### PR TITLE
Added resource locator strategy to portal configuration

### DIFF
--- a/src/Sulu/Component/Portal/Loader/XmlFileLoader.php
+++ b/src/Sulu/Component/Portal/Loader/XmlFileLoader.php
@@ -68,6 +68,9 @@ class XmlFileLoader extends FileLoader
         $portal->setName($xpath->query('/x:portal/x:name')->item(0)->nodeValue);
         $portal->setKey($xpath->query('/x:portal/x:key')->item(0)->nodeValue);
 
+        // set resource locator
+        $portal->setResourceLocatorStrategy($xpath->query('/x:portal/x:resource-locator/x:strategy')->item(0)->nodeValue);
+
         // add languages
         foreach ($xpath->query('/x:portal/x:languages/x:language') as $languageNode) {
             /** @var \DOMNode $languageNode */

--- a/src/Sulu/Component/Portal/Loader/schema/portal/portal-1.0.xsd
+++ b/src/Sulu/Component/Portal/Loader/schema/portal/portal-1.0.xsd
@@ -9,11 +9,24 @@
         <xs:sequence>
             <xs:element type="xs:string" name="name"/>
             <xs:element type="xs:string" name="key"/>
+            <xs:element type="resourceLocatorType" name="resource-locator"/>
             <xs:element type="languagesType" name="languages"/>
             <xs:element type="themeType" name="theme"/>
             <xs:element type="environmentsType" name="environments"/>
         </xs:sequence>
     </xs:complexType>
+
+    <xs:complexType name="resourceLocatorType">
+        <xs:sequence>
+            <xs:element type="resourceLocatorStrategyType" name="strategy"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:simpleType name="resourceLocatorStrategyType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="tree"/>
+            <xs:enumeration value="short"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="languagesType">
         <xs:sequence>

--- a/src/Sulu/Component/Portal/Portal.php
+++ b/src/Sulu/Component/Portal/Portal.php
@@ -29,6 +29,12 @@ class Portal
     private $key;
 
     /**
+     * The url generation strategy for this portal
+     * @var string
+     */
+    private $resourceLocatorStrategy;
+
+    /**
      * An array of languages
      * @var Language[]
      */
@@ -79,6 +85,22 @@ class Portal
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @param string $resourceLocatorStrategy
+     */
+    public function setResourceLocatorStrategy($resourceLocatorStrategy)
+    {
+        $this->resourceLocatorStrategy = $resourceLocatorStrategy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResourceLocatorStrategy()
+    {
+        return $this->resourceLocatorStrategy;
     }
 
     /**

--- a/src/Sulu/Component/Portal/PortalCollection.php
+++ b/src/Sulu/Component/Portal/PortalCollection.php
@@ -102,6 +102,7 @@ class PortalCollection implements \IteratorAggregate
             $portalData = array();
             $portalData['name'] = $portal->getName();
             $portalData['key'] = $portal->getKey();
+            $portalData['resourceLocator']['strategy'] = $portal->getResourceLocatorStrategy();
 
             foreach ($portal->getLanguages() as $language) {
                 $languageData = array();

--- a/src/Sulu/Component/Portal/Resources/skeleton/PortalCollectionClass.php.twig
+++ b/src/Sulu/Component/Portal/Resources/skeleton/PortalCollectionClass.php.twig
@@ -22,6 +22,7 @@ class {{ cache_class }} extends {{ base_class }}
         $portal = new Portal();
         $portal->setName('{{ portal.name }}');
         $portal->setKey('{{ portal.key }}');
+        $portal->setResourceLocatorStrategy('{{ portal.resourceLocator.strategy }}');
 {% for language in portal.languages %}
 
         // add language

--- a/tests/Resources/DataFixtures/Portal/both/massiveart.xml
+++ b/tests/Resources/DataFixtures/Portal/both/massiveart.xml
@@ -5,6 +5,10 @@
 
     <name>Massive Art</name>
     <key>massiveart</key>
+    
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
 
     <languages>
         <language main="true">en</language>

--- a/tests/Resources/DataFixtures/Portal/both/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Portal/both/sulu.io.xml
@@ -5,6 +5,10 @@
 
     <name>Sulu CMF</name>
     <key>sulu_io</key>
+    
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
 
     <languages>
         <language main="true">en</language>

--- a/tests/Resources/DataFixtures/Portal/both/sulu.io_invalid.xml
+++ b/tests/Resources/DataFixtures/Portal/both/sulu.io_invalid.xml
@@ -5,6 +5,10 @@
 
     <name>Sulu CMF</name>
     <key>sulu_io</key>
+    
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
 
     <languages>
         <language main="true">en</language>

--- a/tests/Resources/DataFixtures/Portal/invalid/massiveart.xml
+++ b/tests/Resources/DataFixtures/Portal/invalid/massiveart.xml
@@ -5,6 +5,10 @@
 
     <name>Massive Art</name>
     <key>massiveart</key>
+    
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
 
     <languages>
         <language main="true">en</language>

--- a/tests/Resources/DataFixtures/Portal/valid/massiveart.xml
+++ b/tests/Resources/DataFixtures/Portal/valid/massiveart.xml
@@ -6,6 +6,10 @@
     <name>Massive Art</name>
     <key>massiveart</key>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <languages>
         <language main="true">en</language>
         <language fallback="true">de</language>

--- a/tests/Resources/DataFixtures/Portal/valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Portal/valid/sulu.io.xml
@@ -6,6 +6,10 @@
     <name>Sulu CMF</name>
     <key>sulu_io</key>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <languages>
         <language main="true">en</language>
         <language fallback="true">de</language>

--- a/tests/Sulu/Component/Portal/Loader/XmlFileLoaderTest.php
+++ b/tests/Sulu/Component/Portal/Loader/XmlFileLoaderTest.php
@@ -32,6 +32,8 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Sulu CMF', $portal->getName());
         $this->assertEquals('sulu_io', $portal->getKey());
 
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
+
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
         $this->assertEquals(true, $portal->getLanguages()[0]->isMain());

--- a/tests/Sulu/Component/Portal/PortalManagerTest.php
+++ b/tests/Sulu/Component/Portal/PortalManagerTest.php
@@ -65,6 +65,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Massive Art', $portal->getName());
         $this->assertEquals('massiveart', $portal->getKey());
 
+        $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
+
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
         $this->assertEquals(true, $portal->getLanguages()[0]->isMain());
@@ -95,6 +97,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Sulu CMF', $portal->getName());
         $this->assertEquals('sulu_io', $portal->getKey());
+
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
@@ -129,6 +133,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Sulu CMF', $portal->getName());
         $this->assertEquals('sulu_io', $portal->getKey());
+
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
@@ -170,6 +176,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Sulu CMF', $portal->getName());
         $this->assertEquals('sulu_io', $portal->getKey());
 
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
+
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
         $this->assertEquals(true, $portal->getLanguages()[0]->isMain());
@@ -200,6 +208,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Sulu CMF', $portal->getName());
         $this->assertEquals('sulu_io', $portal->getKey());
+
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
@@ -260,6 +270,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Massive Art', $portal->getName());
         $this->assertEquals('massiveart', $portal->getKey());
 
+        $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
+
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());
         $this->assertEquals(true, $portal->getLanguages()[0]->isMain());
@@ -290,6 +302,8 @@ class PortalManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Sulu CMF', $portal->getName());
         $this->assertEquals('sulu_io', $portal->getKey());
+
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLanguages()));
         $this->assertEquals('en', $portal->getLanguages()[0]->getCode());


### PR DESCRIPTION
The portal configuration includes now a field for the resource locator strategy, which can be `tree` or `short`
- [x] test coverage
- [x] finish the code
- [ ] gather feedback for my changes

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Tests pass? | yes |
| Fixed tickets | non |
| Doc | none |
