### PR TITLE
added load by sql2 function to content mapper

### DIFF
--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -322,12 +322,23 @@ class ContentMapper extends ContainerAware implements ContentMapperInterface
         return $this->loadByNode($contentNode, $languageCode, $webspaceKey);
     }
 
-    public function loadBySql2($sql2, $languageCode, $webspaceKey)
+    /**
+     * returns the content returned by the given sql2 query as structures
+     * @param string $sql2 The query, which returns the content
+     * @param string $languageCode The language code
+     * @param string $webspaceKey The webspace key
+     * @param int $limit Limits the number of returned rows
+     * @return StructureInterface[]
+     */
+    public function loadBySql2($sql2, $languageCode, $webspaceKey, $limit = null)
     {
         $structures = array();
 
         $queryManager = $this->getSession()->getWorkspace()->getQueryManager();
         $query = $queryManager->createQuery($sql2, 'JCR-SQL2');
+        if ($limit) {
+            $query->setLimit($limit);
+        }
         $result = $query->execute();
 
         foreach ($result->getNodes() as $node) {

--- a/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
@@ -109,9 +109,10 @@ interface ContentMapperInterface
      * @param string $sql2 The query, which returns the content
      * @param string $languageCode The language code
      * @param string $webspaceKey The webspace key
+     * @param int $limit Limits the number of returned rows
      * @return StructureInterface[]
      */
-    public function loadBySql2($sql2, $languageCode, $webspaceKey);
+    public function loadBySql2($sql2, $languageCode, $webspaceKey, $limit = null);
 
     /**
      * deletes content with subcontent in given webspace

--- a/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
+++ b/tests/Sulu/Component/Content/Mapper/ContentMapperTest.php
@@ -1185,9 +1185,12 @@ class ContentMapperTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareTreeTestData();
 
-        // get root children
         $result = $this->mapper->loadBySql2('SELECT * FROM [sulu:content]', 'en', 'default');
 
         $this->assertEquals(5, sizeof($result));
+
+        $result = $this->mapper->loadBySql2('SELECT * FROM [sulu:content]', 'en', 'default', 2);
+
+        $this->assertEquals(2, sizeof($result));
     }
 }


### PR DESCRIPTION
Added a new function, which takes a sql2-query and returns the delivered nodes as structures
- [x] test coverage
- [x] finish the code
- [x] gather feedback for my changes

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Tests pass? | yes |
| Fixed tickets | no |
| Doc | none |
