### PR TITLE
Allow query parameters in request

### DIFF
--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -122,10 +122,7 @@ class RequestAnalyzer implements RequestAnalyzerInterface
                 $request->setLocale($portalInformation->getLocalization()->getLocalization());
                 // get the path and set it on the request
                 $this->setCurrentResourceLocator(
-                    substr(
-                        $request->getHost() . $request->getRequestUri(),
-                        strlen($portalInformation->getUrl())
-                    )
+                    $this->getResourceLocatorFromRequest($portalInformation, $request)
                 );
 
                 // get the resource locator prefix and set it
@@ -297,5 +294,15 @@ class RequestAnalyzer implements RequestAnalyzerInterface
     protected function setCurrentResourceLocatorPrefix($resourceLocatorPrefix)
     {
         $this->resourceLocatorPrefix = $resourceLocatorPrefix;
+    }
+
+    private function getResourceLocatorFromRequest($portalInformation, $request)
+    {
+        $res = substr(
+            $request->getHost() . $request->getPathInfo(),
+            strlen($portalInformation->getUrl())
+        );
+
+        return $res;
     }
 }

--- a/tests/Sulu/Component/Webspace/Analyzer/RequestAnalyzerTest.php
+++ b/tests/Sulu/Component/Webspace/Analyzer/RequestAnalyzerTest.php
@@ -71,7 +71,44 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testAnalyze()
+    public function provideAnalyze()
+    {
+        return array(
+            array(
+                array(
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ),
+                array(
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                ),
+            ),
+            array(
+                array(
+                    'portal_url' => 'sulu.lo',
+                    'path_info' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                    'redirect' => 'sulu.lo/test',
+                ),
+                array(
+                    'redirect' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'portal_url' => 'sulu.lo',
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideAnalyze
+     */
+    public function testAnalyze($config, $expected = array())
     {
         $webspace = new Webspace();
         $webspace->setKey('sulu');
@@ -84,20 +121,20 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
 
         $portalInformation = new PortalInformation(
-            RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            $config['match_type'],
             $webspace,
             $portal,
             $localization,
-            'sulu.lo/test',
+            $config['portal_url'],
             null,
-            null
+            $config['redirect']
         );
 
         $this->prepareWebspaceManager($portalInformation);
 
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
-        $request->expects($this->any())->method('getRequestUri')->will($this->returnValue('/test/path/to'));
+        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->once())->method('setLocale')->with('de_at');
         $this->requestAnalyzer->analyze($request);
 
@@ -105,48 +142,10 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentWebspace()->getKey());
         $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentPortal()->getKey());
         $this->assertEquals(null, $this->requestAnalyzer->getCurrentSegment());
-        $this->assertEquals('sulu.lo/test', $this->requestAnalyzer->getCurrentPortalUrl());
-        $this->assertEquals('/path/to', $this->requestAnalyzer->getCurrentResourceLocator());
-        $this->assertEquals('/test', $this->requestAnalyzer->getCurrentResourceLocatorPrefix());
-    }
-
-    public function testAnalyzePartialMatch()
-    {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu');
-
-        $portal = new Portal();
-        $portal->setKey('sulu');
-
-        $localization = new Localization();
-        $localization->setCountry('at');
-        $localization->setLanguage('de');
-
-        $portalInformation = new PortalInformation(
-            RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
-            $webspace,
-            $portal,
-            $localization,
-            'sulu.lo',
-            null,
-            'sulu.lo/test'
-        );
-
-        $this->prepareWebspaceManager($portalInformation);
-
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
-        $request->expects($this->any())->method('getRequestUri')->will($this->returnValue('/test/path/to'));
-        $this->requestAnalyzer->analyze($request);
-
-        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentWebspace()->getKey());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getCurrentPortal()->getKey());
-        $this->assertEquals(null, $this->requestAnalyzer->getCurrentSegment());
-        $this->assertEquals('sulu.lo', $this->requestAnalyzer->getCurrentPortalUrl());
-        $this->assertEquals('sulu.lo/test', $this->requestAnalyzer->getCurrentRedirect());
-        $this->assertEquals('/test/path/to', $this->requestAnalyzer->getCurrentResourceLocator());
-        $this->assertEquals('', $this->requestAnalyzer->getCurrentResourceLocatorPrefix());
+        $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getCurrentPortalUrl());
+        $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getCurrentRedirect());
+        $this->assertEquals($expected['resource_locator'], $this->requestAnalyzer->getCurrentResourceLocator());
+        $this->assertEquals($expected['resource_locator_prefix'], $this->requestAnalyzer->getCurrentResourceLocatorPrefix());
     }
 
     /**


### PR DESCRIPTION
- This PR enables query parameters to be used in the request
- It also tidies up the unit test

**Tasks:**
- [x] test coverage
- [x] gather feedback for my changes

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | yes |
| Fixed tickets | #171 |
| BC Breaks | none |
| Doc | n/a |
