### PR TITLE
Only load structures if they are not null

### DIFF
--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -884,7 +884,10 @@ class ContentMapper implements ContentMapperInterface
 
         foreach ($result->getNodes() as $node) {
             try {
-                $structures[] = $this->loadByNode($node, $languageCode, $webspaceKey);
+                $structure = $this->loadByNode($node, $languageCode, $webspaceKey);
+                if (null !== $structure) {
+                    $structures[] = $structure;
+                }
             } catch (TemplateNotFoundException $ex) {
                 // ignore pages without valid template
             }


### PR DESCRIPTION
The current behavior will return NULL if a node is a shadow page, but when loading structures for iteration we do not want `null` values.

**Tasks:**
- [ ] gather feedback for my changes

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | ? |
| Fixed tickets |  |
| BC Breaks |  |
| Doc |  |
