### PR TITLE
[Feature] Maintenance manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "phpunit/phpunit": "4.0.*",
         "phpspec/prophecy-phpunit": "~1.0",
         "sulu/test-bundle": "dev-develop",
+        "matthiasnoback/symfony-dependency-injection-test": "~0.7.1",
         "jackalope/jackalope-doctrine-dbal": "1.1.*"
     },
     "suggest": {

--- a/src/Sulu/Bundle/CoreBundle/Command/MaintenanceCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/MaintenanceCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Sulu\Component\Maintainence\MaintainenceManager;
+use Symfony\Component\Console\Input\InputOption;
+use Sulu\Component\Maintenance\MaintenanceManager;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MaintenanceCommand extends ContainerAwareCommand
+{
+    public function configure()
+    {
+        $this->setName('sulu:content:maintain');
+        $this->setDescription('Maintain the Sulu content repository');
+        $this->addArgument('name', InputArgument::OPTIONAL, 'Name of maintainer to run (optional)');
+        $this->addOption('list', null, InputOption::VALUE_NONE, 'List maintainers');
+        $this->setHelp(<<<EOT
+The %command.full_name% command executes maintenance services which assure the
+consistency of the Sulu content repository.
+EOT
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $maintenanceManager = $this->getContainer()->get('sulu.maintenance_manager');
+        $listMaintainers = $input->getOption('list');
+        $maintainerName = $input->getArgument('name');
+
+        if (true === $listMaintainers) {
+            $this->listMaintainers($output, $maintenanceManager);
+            return 0;
+        }
+
+        if ($maintainerName) {
+            $maintainers = array($maintenanceManager->getMaintainer($maintainerName));
+        } else {
+            $maintainers = $maintenanceManager->getMaintainers();
+        }
+
+        foreach ($maintainers as $maintainer) {
+            if ($maintainer instanceof ContainerAwareInterface) {
+                $maintainer->setContainer($this->getContainer());
+            }
+
+            $maintainer->maintain($output);
+        }
+    }
+
+    private function listMaintainers(OutputInterface $output, MaintenanceManager $manager)
+    {
+        $table = new Table($output);
+        $table->setHeaders(array('Name'));
+
+        foreach ($manager->getMaintainers() as $maintainer) {
+            $table->addRow(array($maintainer->getName()));
+        }
+
+        $table->render();
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/MaintainerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/MaintainerPass.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class MaintainerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sulu.maintainence_manager')) {
+            return;
+        }
+
+        $maintainenceManager = $container->getDefinition('sulu.maintainence_manager');
+
+        $ids = $container->findTaggedServiceIds('sulu.maintainer');
+        foreach (array_keys($ids) as $id) {
+            $maintainenceManager->addMethodCall(
+                'registerMaintainer',
+                array(new Reference($id))
+            );
+        }
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -57,6 +57,8 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             }
         }
 
+        // note with the next iteration of massive build bundle we can remove this
+        // as it will allow the definition of explicit build targets with options
         if ($container->hasExtension('massive_build')) {
             $container->prependExtensionConfig('massive_build', array(
                 'command_class' => 'Sulu\Bundle\CoreBundle\Command\SuluBuildCommand'
@@ -102,6 +104,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         $loader->load('rest.xml');
         $loader->load('build.xml');
+        $loader->load('maintenance.xml');
     }
 
     /**

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/maintenance.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/maintenance.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sulu.maintenance_manager.class">Sulu\Component\Maintenance\MaintenanceManager</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="sulu.maintenance_manager" class="%sulu.maintenance_manager.class%" />
+
+    </services>
+
+</container>
+

--- a/src/Sulu/Component/Maintenance/MaintainerInterface.php
+++ b/src/Sulu/Component/Maintenance/MaintainerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sulu\Component\Maintenance;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Interface to be implemented by classes which maintain the
+ * data in the databases (PHPCR or conventional).
+ */
+interface MaintainerInterface
+{
+    /**
+     * Perform the maintenance task
+     *
+     * @param OutputInterface $output
+     */
+    public function maintain(OutputInterface $output);
+
+    /**
+     * Return the name for this matinainer
+     *
+     * @return string
+     */
+    public function getName();
+
+}

--- a/src/Sulu/Component/Maintenance/MaintenanceManager.php
+++ b/src/Sulu/Component/Maintenance/MaintenanceManager.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sulu\Component\Maintenance;
+
+use Sulu\Component\Maintainence\MaintainerInterface;
+
+/**
+ * This class manages maintainence classes
+ */
+class MaintenanceManager
+{
+    protected $maintainers = array();
+
+    /**
+     * Register a maintainer
+     *
+     * @param MaintainerInterface
+     */
+    public function registerMaintainer(MaintainerInterface $maintainer)
+    {
+        if (isset($this->maintainers[$maintainer->getName()])) {
+            throw new \InvalidArgumentException(sprintf(
+                'There already exists a maintainer with the name "%s" when trying to add maintainer of class "%s"',
+                $maintainer->getName(), get_class($maintainer)
+            ));
+        }
+
+        $this->maintainers[$maintainer->getName()] = $maintainer;
+    }
+
+    /**
+     * Return all maintainers
+     */
+    public function getMaintainers()
+    {
+        return $this->maintainers;
+    }
+
+    /**
+     * Return maintainer with given name
+     */
+    public function getMaintainer($name)
+    {
+        if (!isset($this->maintainers[$name])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Trying to get unknown maintainer with name "%s", known maintainers are "%s"',
+                $name, implode(', ', array_keys($this->maintainers))
+            ));
+        }
+
+        return $this->maintainers[$name];
+    }
+}

--- a/tests/Sulu/Bundle/CoreBundle/Command/MaintainenceCommandTest.php
+++ b/tests/Sulu/Bundle/CoreBundle/Command/MaintainenceCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Prophecy\PhpUnit\ProphecyTestCase;
+use Prophecy\Argument;
+
+class MaintainenceCommandTest extends ProphecyTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->manager = $this->prophesize('Sulu\Component\Maintenance\MaintenanceManager');
+        $this->maintainer1 = $this->prophesize('Sulu\Component\Maintenance\MaintainerInterface');
+        $this->maintainer1->getName()->willReturn('maintainer-1');
+
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container->get('sulu.maintenance_manager')->willReturn($this->manager);
+
+        $this->manager->getMaintainer('maintainer-1')->willReturn($this->maintainer1);
+        $this->manager->getMaintainers()->willReturn(array(
+            $this->maintainer1->reveal()
+        ));
+
+        $this->command = new MaintenanceCommand();
+        $this->command->setContainer($this->container->reveal());
+        $this->tester = new CommandTester($this->command);
+    }
+
+    public function testList()
+    {
+        $this->tester->execute(array(
+            '--list' => true
+        ));
+    }
+
+    public function testMaintainByName()
+    {
+        $this->manager->getMaintainer('maintainer-1')->shouldBeCalled();
+        $this->maintainer1->maintain(Argument::type('Symfony\Component\Console\Output\OutputInterface'))->shouldBeCalled();
+        $this->tester->execute(array(
+            'name' => 'maintainer-1',
+        ));
+    }
+
+
+    public function testMaintainAll()
+    {
+        $this->manager->getMaintainers()->shouldBeCalled();
+        $this->maintainer1->maintain(Argument::type('Symfony\Component\Console\Output\OutputInterface'))->shouldBeCalled();
+        $this->tester->execute(array());
+    }
+}

--- a/tests/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/MaintainerPassTest.php
+++ b/tests/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/MaintainerPassTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sulu\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\MaintainerPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class MaintainerPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new MaintainerPass());
+    }
+
+    public function testPass()
+    {
+        $managerDefinition = new Definition();
+        $this->setDefinition('sulu.maintainence_manager', $managerDefinition);
+
+        $maintainerDefinition = new Definition();
+        $maintainerDefinition->addTag('sulu.maintainer');
+        $this->setDefinition('some_maintainer', $maintainerDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sulu.maintainence_manager',
+            'registerMaintainer',
+            array(
+                new Reference('some_maintainer')
+            )
+        );
+    }
+}

--- a/tests/Sulu/Component/Maintenance/MaintainenceManagerTest.php
+++ b/tests/Sulu/Component/Maintenance/MaintainenceManagerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sulu\Component\Maintenance;
+
+use Prophecy\PhpUnit\ProphecyTestCase;
+
+class MaintenanceManagerTest extends ProphecyTestCase
+{
+    protected $maintainers = array();
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        for ($i = 1; $i <= 3; $i++) {
+            $this->maintainers[$i] = $this->prophesize('Sulu\Component\Maintainence\MaintainerInterface');
+            $this->maintainers[$i]->getName()->willReturn('maintainer-' . $i);
+        }
+
+        $this->manager = new MaintainenceManager();
+    }
+
+    public function testGetMaintainers()
+    {
+        $this->manager->registerMaintainer($this->maintainers[1]->reveal());
+        $this->manager->registerMaintainer($this->maintainers[2]->reveal());
+        $this->manager->registerMaintainer($this->maintainers[3]->reveal());
+
+        $res = $this->manager->getMaintainers();
+        $this->assertCount(3, $res);
+    }
+
+    public function testGetMaintainer()
+    {
+        $this->manager->registerMaintainer($this->maintainers[1]->reveal());
+        $res = $this->manager->getMaintainer('maintainer-1');
+        $this->assertSame($this->maintainers[1]->reveal(), $res);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetMaintainerNotKnown()
+    {
+        $this->manager->getMaintainer('foobar');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDoubleRegister()
+    {
+        $this->manager->registerMaintainer($this->maintainers[1]->reveal());
+        $this->manager->registerMaintainer($this->maintainers[1]->reveal());
+    }
+}


### PR DESCRIPTION
The Maintainence manager collects Maintainer classes which perform maintainence tasks.

Example maintainers:
- Ensure that node order is syncronized to the tree order
- Ensure that content is indexed in the search bundle

A command is provided to execute the maintainers:

```
$ php app/console sulu:content:maintain
```

This command can be run periodically or when upgrading to ensure the consistency of the database(s).
