### PR TITLE
[ENHANCEMENT] Making MassiveBuild an optional dependency

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
@@ -8,7 +8,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CoreBundle\Command;
+namespace Sulu\Bundle\CoreBundle\CommandOptional;
 
 use Massive\Bundle\BuildBundle\Command\BuildCommand;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -59,7 +59,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         if ($container->hasExtension('massive_build')) {
             $container->prependExtensionConfig('massive_build', array(
-                'command_class' => 'Sulu\Bundle\CoreBundle\Command\SuluBuildCommand'
+                'command_class' => 'Sulu\Bundle\CoreBundle\CommandOptional\SuluBuildCommand'
             ));
         }
     }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-   <parameters>
-       <parameter key="sulu.core.build.builder.database.class">Sulu\Bundle\CoreBundle\Build\DatabaseBuilder</parameter>
-       <parameter key="sulu.core.build.builder.phpcr.class">Sulu\Bundle\CoreBundle\Build\PhpcrBuilder</parameter>
-       <parameter key="sulu.core.build.builder.fixtures.class">Sulu\Bundle\CoreBundle\Build\FixturesBuilder</parameter>
-       <parameter key="sulu.core.build.builder.node_order.class">Sulu\Bundle\CoreBundle\Build\NodeOrderBuilder</parameter>
-   </parameters>
+    <parameters>
+        <parameter key="sulu_core.build.builder.database.class">Sulu\Bundle\CoreBundle\Build\DatabaseBuilder</parameter>
+        <parameter key="sulu_core.build.builder.phpcr.class">Sulu\Bundle\CoreBundle\Build\PhpcrBuilder</parameter>
+        <parameter key="sulu_core.build.builder.fixtures.class">Sulu\Bundle\CoreBundle\Build\FixturesBuilder</parameter>
+        <parameter key="sulu.core.build.builder.node_order.class">Sulu\Bundle\CoreBundle\Build\NodeOrderBuilder</parameter>
+    </parameters>
 
     <services>
 
-        <service id="sulu.core.build.builder.database" class="%sulu.core.build.builder.database.class%">
+        <service id="sulu_core.build.builder.database" class="%sulu_core.build.builder.database.class%">
             <tag name="massive_build.builder" />
         </service>
 
-        <service id="sulu.core.build.builder.phpcr" class="%sulu.core.build.builder.phpcr.class%">
+        <service id="sulu_core.build.builder.phpcr" class="%sulu_core.build.builder.phpcr.class%">
             <tag name="massive_build.builder" />
         </service>
 
-        <service id="sulu.core.build.builder.fixtures" class="%sulu.core.build.builder.fixtures.class%">
+        <service id="sulu_core.build.builder.fixtures" class="%sulu_core.build.builder.fixtures.class%">
             <tag name="massive_build.builder" />
         </service>
 


### PR DESCRIPTION
Currently the massive build bundle is a hard dependency for CoreBundle because the Command extends the MassiveBuild command.

This PR makes the `sulu:build` command a service and only loads it if the MA BuildBundle is present.

Havn't tested this yet properly, so its still WIP.
