### PR TITLE
Do not throw exception if fixture path not exists

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Command/SuluFixtureLoadCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/SuluFixtureLoadCommand.php
@@ -72,10 +72,12 @@ EOT
         );
 
         if (!file_exists($fixturePath)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Fixture path "%s" does not exist',
+            $this->output->writeln(sprintf(
+                'Sulu fixtures path "%s" does not exist, skipping.',
                 $fixturePath
             ));
+
+            return 0;
         }
 
         $dirHandle = opendir($fixturePath);


### PR DESCRIPTION
This means we can remove the fixtures directory from Sulu-standard.
