### PR TITLE
Autodetect doctrine ORM

### DIFF
--- a/bin/runtests.sh
+++ b/bin/runtests.sh
@@ -75,11 +75,16 @@ for BUNDLE in $BUNDLES; do
     fi
 
     if [[ ! -z "$KERNEL_DIR" ]]; then
+        CONSOLE="env KERNEL_DIR=$OCWD"/"$KERNEL_DIR $OCWD/bin/console"
         comment "Kernel: "$KERNEL_DIR
-        env KERNEL_DIR=$OCWD"/"$KERNEL_DIR $OCWD/bin/console doctrine:schema:update --force
+
+        $CONSOLE container:debug | cut -d' ' -f2 | grep "^doctrine.orm" &> /dev/null \
+            && comment "Doctrine ORM detected" \
+            && $CONSOLE doctrine:schema:update --force
     fi
 
     cd -
+    comment "Running tests"
 
     phpunit --configuration phpunit.travis.xml.dist --stop-on-failure --stop-on-error $BUNDLE_DIR/Tests
 

--- a/src/Sulu/Bundle/LocationBundle/Tests/Functional/Controller/GeolocatorControllerTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Functional/Controller/GeolocatorControllerTest.php
@@ -2,24 +2,18 @@
 
 namespace Sulu\Bundle\LocationBundle\Tests\Functional\Controller;
 
-use Sulu\Bundle\TestBundle\Testing\DatabaseTestCase;
 use Guzzle\Plugin\Mock\MockPlugin;
 use Guzzle\Http\Message\Response;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
-class GeolocatorControllerTest extends DatabaseTestCase
+class GeolocatorControllerTest extends SuluTestCase
 {
     protected $mockPlugin;
     protected $client;
 
     public function setUp()
     {
-        $this->client = $this->createClient(
-            array(),
-            array(
-                'PHP_AUTH_USER' => 'test',
-                'PHP_AUTH_PW' => 'test',
-            )
-        );
+        $this->client = $this->createAuthenticatedClient();
 
         $guzzleClient = $this->client->getContainer()->get('sulu_location.geolocator.guzzle.client');
         $this->mockPlugin = new MockPlugin();

--- a/src/Sulu/Bundle/LocationBundle/Tests/app/AppKernel.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/app/AppKernel.php
@@ -27,6 +27,9 @@ class AppKernel extends Kernel
             new \Sulu\Bundle\LocationBundle\SuluLocationBundle(),
             new \Sulu\Bundle\ContentBundle\SuluContentBundle(),
             new \Sulu\Bundle\SecurityBundle\SuluSecurityBundle(),
+            new \Sulu\Bundle\ContactBundle\SuluContactBundle(),
+            new \Sulu\Bundle\MediaBundle\SuluMediaBundle(),
+            new \Sulu\Bundle\CategoryBundle\SuluCategoryBundle(),
             new \Sulu\Bundle\TagBundle\SuluTagBundle(),
             new \Sulu\Bundle\TestBundle\SuluTestBundle(),
         );

--- a/src/Sulu/Bundle/LocationBundle/Tests/app/config/config.mysql.yml
+++ b/src/Sulu/Bundle/LocationBundle/Tests/app/config/config.mysql.yml
@@ -13,3 +13,4 @@ doctrine:
         auto_mapping: true
         resolve_target_entities:
             Sulu\Component\Security\UserInterface: Sulu\Bundle\TestBundle\Entity\TestUser
+            Sulu\Bundle\SecurityBundle\Entity\RoleInterface: Sulu\Bundle\SecurityBundle\Entity\Role

--- a/src/Sulu/Bundle/LocationBundle/Tests/app/config/config.yml
+++ b/src/Sulu/Bundle/LocationBundle/Tests/app/config/config.yml
@@ -11,10 +11,6 @@ framework:
     profiler:
         enabled: false
 
-fos_rest:
-    routing_loader:
-        default_format: json
-
 monolog:
     handlers:
         main:
@@ -45,8 +41,3 @@ sulu_core:
                 app:
                     path: %kernel.root_dir%/Resources/templates
                     internal: false
-            
-parameters:
-    # Just a dirty hack to get the jms serializer bundle correctly working
-    # schmittjoh/JMSSerializerBundle#270 (comment)
-    jms_serializer.cache_naming_strategy.class: JMS\Serializer\Naming\IdenticalPropertyNamingStrategy


### PR DESCRIPTION
Only (re)initialize the ORM database if the bundle uses the ORM.

Also fixed the location bundle configuration so that it doesn't generate error noise in the test run.
