### PR TITLE
Upgraded to PhpcrBundle 1.2 and added phpcr-shell to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "require": {
         "cboden/ratchet": "0.3.*",
         "doctrine/orm": "2.4.*",
-        "doctrine/phpcr-bundle": "1.1.*",
-        "doctrine/phpcr-odm": "1.1.*",
+        "doctrine/phpcr-bundle": "~1.2.0",
+        "doctrine/phpcr-odm": "~1.2.0",
         "friendsofsymfony/http-cache": "1.0.*",
         "friendsofsymfony/rest-bundle": "~1.4",
         "guzzle/http": "3.*",
@@ -38,6 +38,7 @@
         "willdurand/hateoas-bundle": "0.3.*"
     },
     "require-dev": {
+        "phpcr/phpcr-shell": "~1.0.0@alpha",
         "doctrine/doctrine-bundle": "1.2.*",
         "doctrine/doctrine-fixtures-bundle": "2.2.*",
         "doctrine/orm": "~2.2,>=2.2.3",


### PR DESCRIPTION
Upgraded to doctrine phpcrbundle 1.2 and added phpcr-shell as a dev dependency:

```
$ php app/console doctrine:phpcr:shell

Welcome to the PHPCRSH shell (1.0.0-alpha6).

At the prompt, type help for some help.

- To list all of the commands type list.
- To list all of the registered command aliases, type aliases.

To exit the shell, type exit.

PHPCRSH >
```
