### PR TITLE
[ContentBundle] Prefix contentbundle template path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG for Sulu
 
 * 0.10.2
 
-    * HOTFIX #509 [SuluContentBundle] Fixed cached data bug in smart-content
+    * HOTFIX #509 [ContentBundle] Fixed cached data bug in smart-content
+    * ENHANCEMENT #523 [ContentBundle] Prefix contentbundle template path
 
 * 0.10.1 (2014-11-04)
 

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -14,14 +14,38 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 /**
  * This is the class that loads and manages your bundle configuration
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class SuluContentExtension extends Extension
+class SuluContentExtension extends Extension implements PrependExtensionInterface
 {
+    public function prepend(ContainerBuilder $container)
+    {
+        $extensions = $container->getExtensions();
+
+        if (isset($extensions['sulu_core'])) {
+            $prepend = array(
+                'content' => array(
+                    'structure' => array(
+                        'paths' => array(
+                            'sulu_content_bundle' => array(
+                                'path' => __DIR__ . '/../Content/templates',
+                                'type' => 'page',
+                                'internal' => true,
+                            ),
+                        ),
+                    ),
+                ),
+            );
+
+            $container->prependExtensionConfig('sulu_core', $prepend);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/config/config.yml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/config/config.yml
@@ -44,9 +44,6 @@ sulu_core:
                      path: %kernel.root_dir%/Resources/snippets
                      internal: false
                      type: snippet
-                 bundle:
-                     path: %kernel.root_dir%/../../Content/templates
-                     internal: true
     webspace:
         request_analyzer:
             enabled: true

--- a/tests/app/config/config.yml
+++ b/tests/app/config/config.yml
@@ -44,9 +44,6 @@ sulu_core:
                      path: %kernel.root_dir%/Resources/snippets
                      internal: false
                      type: snippet
-                 bundle:
-                     path: %kernel.root_dir%/../../Content/templates
-                     internal: true
     webspace:
         request_analyzer:
             enabled: true


### PR DESCRIPTION
This PR automatically adds the _internal_ content bundle templates directory to the `sulu_core` configuration.

This removes the need to define `structures.content.paths.xxx.path: %kernel.root_dir%/vendor/foo/bar/bar/bar/Content/templates`
