### PR TITLE
[HOTFIX] #546 [SearchBundle] Switched to using TestAdapter for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * [UNRELEASED]
 
    * HOTFIX #543 [SearchBundle] Fixed re-index command
+   * HOTFIX #551 [SearchBundle] Switched to test adapter for tests
 
 * 0.11.0 (2014-11-12)
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "imagine/imagine": "~0.6.1",
         "jackalope/jackalope-jackrabbit": "1.1.*",
         "liip/theme-bundle": "1.1.*",
-        "massive/search-bundle": "~0.3.1",
+        "massive/search-bundle": "~0.4",
         "php": ">=5.4",
         "phpspec/prophecy-phpunit": "~1.0",
         "sensio/framework-extra-bundle": "3.0.*",

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/SaveStructureTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/SaveStructureTest.php
@@ -26,7 +26,7 @@ class SaveStructureTest extends BaseTestCase
         $this->indexStructure('About Us', '/about-us');
 
         $searchManager = $this->getSearchManager();
-        $res = $searchManager->createSearch('About*')->locale('de')->index('content')->execute();
+        $res = $searchManager->createSearch('About')->locale('de')->index('content')->execute();
         $this->assertCount(1, $res);
         $hit = $res[0];
         $document = $hit->getDocument();

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/SearchManagerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/SearchManagerTest.php
@@ -20,7 +20,7 @@ class SearchManagerTest extends BaseTestCase
         for ($i = 1; $i <= 2; $i++) {
 
             $this->generateStructureIndex($nbResults);
-            $res = $this->getSearchManager()->createSearch('Structure*')->locale('de')->index('content')->execute();
+            $res = $this->getSearchManager()->createSearch('Structure')->locale('de')->index('content')->execute();
 
             $this->assertCount($nbResults, $res);
         }
@@ -30,9 +30,15 @@ class SearchManagerTest extends BaseTestCase
     {
         $this->generateStructureIndex(4, 'webspace_four');
         $this->generateStructureIndex(2, 'webspace_two');
-        $res = $this->getSearchManager()->createSearch('Structure*')->locale('de')->index('content')->execute();
+        $res = $this->getSearchManager()->createSearch('Structure')->locale('de')->index('content')->execute();
         $this->assertCount(6, $res);
 
+        if (!$this->getContainer()->get('massive_search.adapter') instanceof \Massive\Bundle\SearchBundle\Search\Adapter\ZendLuceneAdapter) {
+            $this->markTestSkipped('Skipping zend lucene specific test');
+            return;
+        }
+
+        // TODO: This should should not be here
         $res = $this->getSearchManager()->createSearch('+webspaceKey:webspace_four Structure*')->locale('de')->index('content')->execute();
         $this->assertCount(4, $res);
     }

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/app/config/config.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/app/config/config.yml
@@ -48,6 +48,4 @@ sulu_core:
                     internal: false
 
 massive_search:
-    adapters:
-        zend_lucene:
-            hide_index_exception: true
+    adapter_id: massive_search.adapter.test

--- a/src/Sulu/Bundle/SearchBundle/composer.json
+++ b/src/Sulu/Bundle/SearchBundle/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "massive/search-bundle": "0.3.*",
+        "massive/search-bundle": "~0.4",
         "sulu/sulu": "dev-develop"
     },
     "require-dev": {


### PR DESCRIPTION
This PR changes the search implementation used by the SearchBundle to the (memory based) TestAdapter so that test stability is not affected by ZendSearch.
