### PR TITLE
FEATURE #553 [SnippetBundle] Possiblity to show all snippet types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ CHANGELOG for Sulu
     * HOTFIX      #559 [CoreBundle]    Workaround upstream reg. in DoctrinePHPCRBundle, which causes 
                                        eager validation of workspace existence.
     * ENHANCEMENT #523 [All]           Refactored and improved functional tests
- 
+    * FEATURE #553 [SnippetBundle] Possiblity to show all snippet types by not providing any
+        snippetType parameters in the ContentType
+
 * 0.11.1 (2014-11-13)
 
     * HOTFIX      #543 [SearchBundle]  Fixed re-index command

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,16 @@
+UPGRADE log
+===========
+
+dev-develop
+-----------
+
+### SnippetBundle 
+
+Not specifying a snippetType in the snippets content type will allow a choice
+from ALL snippet types instead of only the default snippet type. Therefore you
+must explicitly declare the snippet type in a parameter or accept the new
+behavior of showing all snippet types. 
+
+See the
+[documentation](https://github.com/sulu-cmf/docs/blob/master/developer-documentation/300-webspaces/snippets.md)
+for more details.

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -36,11 +36,6 @@ class SnippetContent extends ComplexContentType
     protected $template;
 
     /**
-     * @var string
-     */
-    protected $defaultSnippetType;
-
-    /**
      * @var StructureResolverInterface
      */
     protected $structureResolver;
@@ -51,13 +46,11 @@ class SnippetContent extends ComplexContentType
     public function __construct(
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver,
-        $template,
-        $defaultSnippetType
+        $template
     ) {
         $this->contentMapper = $contentMapper;
         $this->structureResolver = $structureResolver;
         $this->template = $template;
-        $this->defaultSnippetType = $defaultSnippetType;
     }
 
     /**
@@ -179,7 +172,6 @@ class SnippetContent extends ComplexContentType
     public function getDefaultParams()
     {
         return array(
-            'defaultSnippetType' => $this->defaultSnippetType
         );
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -88,7 +88,8 @@ class SnippetController
     {
         $this->initEnv($request);
 
-        $type = $request->query->get('type', null);
+        // if the type parameter is falsy, assign NULL to $type
+        $type = $request->query->get('type', null) ? : null;
         $uuidsString = $request->get('ids');
 
         if ($uuidsString) {

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -12,7 +12,6 @@
             <argument type="service" id="sulu.content.mapper" />
             <argument type="service" id="sulu_website.resolver.structure" />
             <argument>%sulu_snippet.content-type.template%</argument>
-            <argument>%sulu.content.structure.default_type.snippet%</argument>
 
             <tag name="sulu.content.type" alias="snippet"/>
         </service>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/public/js/components/snippet-content/main.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/public/js/components/snippet-content/main.js
@@ -467,6 +467,8 @@ define([], function() {
                 this.options.snippetType
             ].join('');
 
+            console.log(this.options.snippetType);
+
             if (newURIGetAll !== this.URIGetAll.str) {
                 this.URIGetAll.str = newURIGetAll;
                 this.URIGetAll.hasChanged = true;

--- a/src/Sulu/Bundle/SnippetBundle/Resources/views/Template/content-types/snippet.html.twig
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/views/Template/content-types/snippet.html.twig
@@ -10,6 +10,8 @@
      data-language="{{ languageCode }}"
      data-url-get="{{ path('get_snippet') }}"
      data-url-all="{{ path('get_snippets') }}"
-     data-snippet-type="{{ property.params.snippetType is defined ? property.params.snippetType : params.defaultSnippetType}}"
+     {% if property.params.snippetType is defined %}
+         data-snippet-type="{{ property.params.snippetType }}"
+     {% endif %}
      >
  </div>


### PR DESCRIPTION
Default behavior when no snippet type is selected is now to show all snipet types.

_Tasks:__
- [ ] gather feedback for my changes

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | ywa |
| Fixed tickets | #553 |
| BC Breaks | Default behavior is now to allow selection of all snippet types (instead of falling back to restricting on the default snippet type) |
| Doc | https://github.com/sulu-cmf/docs/pull/12 |
