### PR TITLE
bugfix NoderOrderBuilder eagerly instantiates PHPCR session

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Build/NodeOrderBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/NodeOrderBuilder.php
@@ -16,6 +16,7 @@ use Massive\Bundle\BuildBundle\Build\BuilderContext;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Content\Mapper\Subscriber\NodeOrderSubscriber;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Builder for initializing PHPCR
@@ -23,24 +24,18 @@ use Sulu\Component\Content\Mapper\Subscriber\NodeOrderSubscriber;
 class NodeOrderBuilder implements BuilderInterface
 {
     /**
-     * @var SessionManagerInterface
-     */
-    protected $sessionManager;
-
-    /**
-     * @var WebspaceManagerInterface
-     */
-    protected $webspaceManager;
-
-    /**
      * @var BuilderContext
      */
     protected $context;
 
-    public function __construct(SessionManagerInterface $sessionManager, WebspaceManagerInterface $webspaceManager)
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
     {
-        $this->sessionManager = $sessionManager;
-        $this->webspaceManager = $webspaceManager;
+        $this->container = $container;
     }
 
     /**
@@ -72,10 +67,13 @@ class NodeOrderBuilder implements BuilderInterface
      */
     public function build()
     {
-        $webspaceCollection = $this->webspaceManager->getWebspaceCollection();
+        $sessionManager = $this->container->get('sulu.phpcr.session');
+        $webspaceManager = $this->container->get('sulu_core.webspace.webspace_manager');
+
+        $webspaceCollection = $webspaceManager->getWebspaceCollection();
 
         foreach ($webspaceCollection as $webspace) {
-            $contentNode = $this->sessionManager->getContentNode($webspace->getKey());
+            $contentNode = $sessionManager->getContentNode($webspace->getKey());
             $this->traverse($contentNode);
             $this->sessionManager->getSession()->save();
         }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
@@ -25,8 +25,7 @@
         </service>
 
         <service id="sulu.core.build.builder.node_order" class="%sulu.core.build.builder.node_order.class%">
-            <argument type="service" id="sulu.phpcr.session"/>
-            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="service" id="service_container"/>
             <tag name="massive_build.builder" />
         </service>
 


### PR DESCRIPTION
The NodeOrderBuilder eagerly instantiates the PHPCR session causing
an exception when the workspace does not exist.
