### PR TITLE
hotfix Workaround for DoctrinePHPCRBundle regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+
+    * HOTFIX #559 [CoreBundle]    Workaround upstream reg. in DoctrinePHPCRBundle, which causes
+                                  eager validation of workspace existence.
+
 * 0.11.1 (2014-11-13)
 
     * HOTFIX #543 [SearchBundle]  Fixed re-index command

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -38,6 +38,11 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         if (isset($config['phpcr'])) {
             $phpcrConfig = $config['phpcr'];
 
+            // TODO: Workaround for issue: https://github.com/doctrine/DoctrinePHPCRBundle/issues/178
+            if (!isset($phpcrConfig['backend']['check_login_on_server'])) {
+                $phpcrConfig['backend']['check_login_on_server'] = false;
+            }
+
             foreach ($container->getExtensions() as $name => $extension) {
                 $prependConfig = array();
                 switch ($name) {


### PR DESCRIPTION
Fixes issue with non-existing workspace creation: https://github.com/sulu-cmf/sulu-standard/issues/378

Workaround for regression in the DocintrePHPCRBundle: https://github.com/doctrine/DoctrinePHPCRBundle/issues/178

Note this can also be manually set:

```
# app/config/phpcr.yml
parameters:
    phpcr_backend:
        type: jackrabbit
        url: http://localhost:8080/server/
        check_login_on_server: false # << fixes the problem
    phpcr_workspace: defaultasda
    phpcr_user: admin
    phpcr_pass: admin
```
