### PR TITLE
disabled require-timeout

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/public/js/main.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/public/js/main.js
@@ -8,6 +8,7 @@
  */
 
 require.config({
+    waitSeconds: 0,
     paths: {
         suluadmin: '../../suluadmin/js',
 


### PR DESCRIPTION
Running `/admin` for the first time often causes a blank page due to require load timeout. 

```
Uncaught Error: Load timeout for modules: text!/admin/bundles_unnormalized2,text!/admin/bundles
http://requirejs.org/docs/errors.html#timeout 
```

This may scare away first-time users. I use a Vagrant setup with shared-folders on Virtualbox which has lousy performance and just won't make it within the 7 seconds default timeout of require.
