### PR TITLE
Fixed runtests.sh script colors for Mac users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
 
+    * ENHANCEMENT #--- [Tests]          Fixed output colors for Mac users
     * BUGFIX      #571 [CoreBundle]     Fixed build command
     * ENHANCEMENT #556 [MediaBundle]    Enhanced url generation for collections
     * ENHANCEMENT #535 [SecurityBundle] Added SecurityListener and secured Content, Media and Security

--- a/bin/runtests.sh
+++ b/bin/runtests.sh
@@ -3,31 +3,33 @@
 DB=mysql
 OCWD=`pwd`
 BUNDLE=""
+SULU_ORM=${SULU_ORM:-mysql}
+SULU_PHPCR=${SULU_PHPCR:-doctrine_dbal}
 
 function header {
     echo ""
-    echo -e "\e[32m======================================================\e[0m"
+    echo -e "\x1b[32m======================================================\x1b[0m"
     echo $1
-    echo -e "\e[32m======================================================\e[0m"
+    echo -e "\x1b[32m======================================================\x1b[0m"
     echo ""
 }
 
 function info {
-    echo -e "\e[32m"$1"\e[0m"
+    echo -e "\x1b[32m"$1"\x1b[0m"
 
     echo ""
 }
 
 function comment {
-    echo -e "\e[33m"$1"\e[0m"
+    echo -e "\x1b[33m"$1"\x1b[0m"
     echo ""
 }
 
 function error {
     echo ""
-    echo -e "\e[31m======================================================\e[0m"
+    echo -e "\x1b[31m======================================================\x1b[0m"
     echo $1
-    echo -e "\e[31m======================================================\e[0m"
+    echo -e "\x1b[31m======================================================\x1b[0m"
     echo ""
 }
 
@@ -167,13 +169,13 @@ if [[ ! -s /tmp/failed.tests ]]; then
 else
     # There were failures
     echo ""
-    echo -e "\e[31m======================================================\e[0m"
+    echo -e "\x1b[31m======================================================\x1b[0m"
     echo "Oh no, "`cat /tmp/failed.tests | wc -l`" Component(s) failed:"
     echo ""
     for line in `cat /tmp/failed.tests`; do
         comment " - "$line
     done
-    echo -e "\e[31m======================================================\e[0m"
+    echo -e "\x1b[31m======================================================\x1b[0m"
     echo ""
     exit 1
 fi


### PR DESCRIPTION
Fixed the color output for Mac users and added assign default values to the environment variables if they are not set.
