### PR TITLE
fixed security checker to work with commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * 0.12.0 (2014-11-25)
 
+    * BUGFIX      #614 [SecurityBundle] Fixed the security for command lines
     * HOTFIX      #594 [WebsiteBundle]  Fixed sitemap alternate link bugs
     * BUGFIX      #609 [All]            Allows null value for security subject and fixed snippet internal links bug
     * ENHANCEMENT #577 [All]            Applied security to navigation items and content tabs

--- a/src/Sulu/Bundle/SecurityBundle/Permission/SecurityChecker.php
+++ b/src/Sulu/Bundle/SecurityBundle/Permission/SecurityChecker.php
@@ -35,7 +35,9 @@ class SecurityChecker extends AbstractSecurityChecker
      */
     public function hasPermission($subject, $permission, $locale = null)
     {
-        if (!$subject) {
+        if (!$subject || !$this->securityContext->getToken()) {
+            // if there is no subject the operation is allowed, since we have nothing to check against
+            // if there is no token we are not behind a firewall, so the action is also allowed (e.g. command execution)
             return true;
         }
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Command;
+
+use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CreateUserCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    public function setUp()
+    {
+        $application = new Application($this->getContainer()->get('kernel'));
+
+        $loadFixturesCommand = new LoadDataFixturesDoctrineCommand();
+        $loadFixturesCommand->setApplication($application);
+        $loadFixturesCommandTester = new CommandTester($loadFixturesCommand);
+        $loadFixturesCommandTester->execute(array(), array('interactive' => false));
+
+        $createUserCommand = new CreateUserCommand();
+        $createUserCommand->setApplication($application);
+        $this->tester = new CommandTester($createUserCommand);
+    }
+
+    public function testExecute()
+    {
+        $this->tester->execute(
+            array(
+                'username' => 'sulu',
+                'firstName' => 'Sulu',
+                'lastName' => 'Hikaru',
+                'email' => 'sulu.hikaru@startrek.com',
+                'locale' => 'en',
+                'password' => 'sulu'
+            ),
+            array('interactive' => false)
+        );
+
+        $this->assertEquals("Created user sulu\n", $this->tester->getDisplay());
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Permission/SecurityCheckerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Permission/SecurityCheckerTest.php
@@ -31,6 +31,7 @@ class SecurityCheckerTest extends ProphecyTestCase
         parent::setUp();
 
         $this->securityContext = $this->prophesize('Symfony\Component\Security\Core\SecurityContextInterface');
+        $this->securityContext->getToken()->willReturn(true); // stands for a valid token
         $this->securityChecker = new SecurityChecker($this->securityContext->reveal());
     }
 
@@ -96,5 +97,13 @@ class SecurityCheckerTest extends ProphecyTestCase
         )->willReturn(false);
 
         $this->securityChecker->checkPermission('sulu.media.collection', 'view');
+    }
+
+    public function testIsGrantedWithoutToken()
+    {
+        $this->securityContext->getToken()->willReturn(null);
+        $this->securityContext->isGranted(Argument::any(), Argument::any())->willReturn(false);
+
+        $this->assertTrue($this->securityChecker->checkPermission('sulu.media.collection', 'view'));
     }
 }


### PR DESCRIPTION
Grants access, if there is no firewall at all, which is the case in the cli context.

For that there is a check, if there is a token. If there is no firewall, there won't be a token. If we are behind a firewall but not logged in, there is the `AnonymousToken`, so the permissions will be correctly checked.

**Tasks:**
- [ ] test coverage
- [ ] gather feedback for my changes
- [ ] submit changes to the documentation

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | yes |
| Fixed tickets | none |
| BC Breaks | Security does not apply to console commands anymore |
| Doc | none |
