### PR TITLE
fixed request listener for sub requests

### DIFF
--- a/src/Sulu/Component/Webspace/EventListener/RequestListener.php
+++ b/src/Sulu/Component/Webspace/EventListener/RequestListener.php
@@ -31,6 +31,8 @@ class RequestListener
 
     public function onKernelRequest(GetResponseEvent $event)
     {
-        $this->requestAnalyzer->analyze($event->getRequest());
+        if ($event->isMasterRequest()) {
+            $this->requestAnalyzer->analyze($event->getRequest());
+        }
     }
 }


### PR DESCRIPTION
Hotfix for esi subrequests. The subrequests changed the language of the page, so that the language changed in the middle.

Don't forget to also merge into develop.

**Tasks:**
- [ ] test coverage
- [ ] gather feedback for my changes
- [ ] submit changes to the documentation

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | yes |
| Fixed tickets | fixes #617 |
| BC Breaks | Subrequests aren't analyzed |
| Doc | none |
