### PR TITLE
Added propertyaccessor based multisort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
 
+    * FEATURE     #637 [WebsiteBundle]  Multisort method and Twig filter
     * FEATURE     #585 [ContentBundle]  Added analytics key to webspace configuration
     * BUGFIX      #612 [SnippetBundle]  Introduced snippet pagination
     * BUGFIX      #544 [ContentBundle]  Fixed PHPCR Format Value switches

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -15,6 +15,7 @@
         <parameter key="sulu_website.twig.content.class">Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension</parameter>
         <parameter key="sulu_website.twig.content.memoized.class">Sulu\Bundle\WebsiteBundle\Twig\Content\MemoizedContentTwigExtension</parameter>
         <parameter key="sulu_website.twig.Meta.class">Sulu\Bundle\WebsiteBundle\Twig\Meta\MetaTwigExtension</parameter>
+        <parameter key="sulu_website.twig.util.class">Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension</parameter>
         <parameter key="sulu_website.routing.portal_loader.class">Sulu\Bundle\WebsiteBundle\Routing\PortalLoader</parameter>
         <parameter key="sulu_website.exception.controller.class">Sulu\Bundle\WebsiteBundle\Controller\ExceptionController</parameter>
         <parameter key="sulu_website.resolver.request_analyzer.class">Sulu\Bundle\WebsiteBundle\Resolver\RequestAnalyzerResolver</parameter>
@@ -115,6 +116,11 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.twig.content_path"/>
 
+            <tag name="twig.extension"/>
+        </service>
+
+        <!-- twig extension: util -->
+        <service id="sulu_website.twig.util" class="%sulu_website.twig.util.class%">
             <tag name="twig.extension"/>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Twig\Core;
+
+/**
+ * Twig extension providing generally useful utilities which are available
+ * in the Sulu\Component\Util namespace.
+ */
+class UtilTwigExtension extends \Twig_Extension
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'sulu_util';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('sulu_util_multisort', 'Sulu\Component\Util\SortUtils::multisort'),
+        );
+    }
+}

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -2141,7 +2141,8 @@ class ContentMapper implements ContentMapperInterface
                         'locale' => $locale,
                         'webspaceKey' => $key,
                         'template' => $templateKey,
-                        'parent' => $parent
+                        'parent' => $parent,
+                        'order' => $node->hasProperty('sulu:order') ? $node->getPropertyValue('sulu:order') : null,
                     ),
                     $fieldsData
                 );

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Util;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+/**
+ * Sorting utilities
+ */
+class SortUtils
+{
+    /**
+     * Cannot instantiate this class
+     */
+    final private function __construct()
+    {
+    }
+
+    /**
+     * Sort the given array of arrays/objects using paths.
+     *
+     * e.g.
+     *
+     *      $data = array(
+     *          array('foobar' => 'b'),
+     *          array('foobar' => 'a'),
+     *      );
+     *
+     *      SortUtils::multisort($data, '[foobar]', 'asc');
+     *
+     *      echo $data[0]; // "a"
+     *
+     * You can also use method names:
+     *
+     *      SortUtils::multisort($data, 'getFoobar', 'asc');
+     *
+     * Or sort on multidimensional arrays:
+     *
+     *      SortUtils::multisort($data, 'foobar.bar.getFoobar', 'asc');
+     *
+     * And you can sort on multiple paths:
+     *
+     *      SortUtils::multisort($data, array('foo', 'bar'), 'asc');
+     *
+     * The path is any path accepted by the property access component:
+     *
+     * @link http://symfony.com/doc/current/components/property_access/introduction.html
+     *
+     * @param array $values
+     * @param string|array $path Path or paths on which to sort on
+     * @param string $direction Direction to sort in (either ASC or DESC)
+     *
+     * @return array
+     */
+    public static function multisort($values, $paths, $direction = 'ASC')
+    {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        $values = (array) $values;
+        $paths = (array) $paths;
+
+        usort($values,function ($a, $b) use ($accessor, $paths) {
+            foreach ($paths as $i => $path) {
+                $aOrder = $accessor->getValue($a, $path);
+                $bOrder = $accessor->getValue($b, $path);
+
+                if (is_string($aOrder)) {
+                    $aOrder = strtolower($aOrder);
+                    $bOrder = strtolower($bOrder);
+                }
+
+                if($aOrder == $bOrder) {
+                    if (count($paths) == ($i + 1)) {
+                        return 0;
+                    } else {
+                        continue;
+                    }
+                }
+
+                return ($aOrder < $bOrder) ? -1 : 1;
+            }
+        });
+
+        if (strtoupper($direction) == 'DESC') {
+            $values = array_reverse($values);
+        }
+
+        return $values;
+   }
+}

--- a/tests/Sulu/Component/Util/SortUtilsTest.php
+++ b/tests/Sulu/Component/Util/SortUtilsTest.php
@@ -1,0 +1,181 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Util;
+
+use Sulu\Component\Util\SortUtils;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class SortUtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideSortObjects()
+    {
+        return array(
+            // ascending
+            array(
+                array(
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'aaa'),
+                    new FoobarTestClass('aaa', 'aaa'),
+                ),
+                'getField1',
+                'asc',
+                'field1', array('aaa', 'bbb', 'ccc'),
+            ),
+
+            // descending
+            array(
+                array(
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'aaa'),
+                    new FoobarTestClass('aaa', 'aaa'),
+                ),
+                'getField1',
+                'desc',
+                'field1', array('ccc', 'bbb', 'aaa'),
+            ),
+
+            // sort on a different method
+            array(
+                array(
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'bbb'),
+                    new FoobarTestClass('aaa', 'ccc'),
+                ),
+                'getField2',
+                'desc',
+                'field1', array('aaa', 'bbb', 'ccc'),
+            ),
+
+            // sort by two methods
+            array(
+                array(
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'aaa'),
+                    new FoobarTestClass('aaa', 'aaa'),
+                ),
+                array('getField2', 'getField1'),
+                'asc',
+                'field1', array('aaa', 'bbb', 'ccc'),
+            ),
+
+            // check sorting numerical strings
+            array(
+                array(
+                    new FoobarTestClass('15', 'aaa'),
+                    new FoobarTestClass('100', 'bbb'),
+                    new FoobarTestClass('200', 'ccc'),
+                ),
+                'getField1',
+                'asc',
+                'field1', array('15', '100', '200'),
+            ),
+
+            // check array
+            array(
+                array(
+                    array('foo' => 'zzz', 'bar' => 'aaa'),
+                    array('foo' => 'xxx', 'bar' => 'aaa'),
+                    array('foo' => 'yyy', 'bar' => 'aaa'),
+                ),
+                '[foo]',
+                'asc',
+                '[foo]', array('xxx', 'yyy', 'zzz'),
+            ),
+
+            // multi dimensional array
+            array(
+                array(
+                    array('foo' => '1', 'baz' => array('bar' => 'bbb')),
+                    array('foo' => '2', 'baz' => array('bar' => 'aaa')),
+                    array('foo' => '3', 'baz' => array('bar' => 'ccc')),
+                ),
+                '[baz][bar]',
+                'asc',
+                '[foo]', array('2', '1', '3'),
+            ),
+
+            // multi dimensional array missing key
+            array(
+                array(
+                    array('foo' => '1', 'baz' => array('bar' => 'bbb')),
+                    array('foo' => '2', 'baz' => array('sad' => 'aaa')),
+                    array('foo' => '3', 'baz' => array('bad' => 'ccc')),
+                ),
+                '[baz][bar]',
+                'asc',
+                '[foo]', array('3', '2', '1'),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideSortObjects
+     */
+    public function testSortObjects($data, $methodName, $direction, $checkField, $expectedOrder)
+    {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        $res = SortUtils::multisort($data, $methodName, $direction);
+
+        foreach ($expectedOrder as $expected) {
+            $object = array_shift($res);
+            $this->assertEquals($expected, $accessor->getValue($object, $checkField));
+        }
+    }
+
+    public function testSortArrayObject()
+    {
+        $collection = new \ArrayObject(array(
+            new FoobarTestClass('value2', 'value2'),
+            new FoobarTestClass('value1', 'value2'),
+        ));
+
+        $res = SortUtils::multisort($collection, 'getField1');
+
+        $this->assertEquals('value1', $res[0]->field1);
+        $this->assertEquals('value2', $res[0]->field2);
+    }
+
+    /**
+     * @expectedException Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     */
+    public function testSortMissingField()
+    {
+        $collection = new \ArrayObject(array(
+            (object) array('value2', 'value2'),
+            (object) array('value1', 'value2'),
+        ));
+
+        SortUtils::multisort($collection, 'somefink');
+    }
+}
+
+class FoobarTestClass
+{
+    public $field1;
+    public $field2;
+
+    public function __construct($value1, $value2)
+    {
+        $this->field1 = $value1;
+        $this->field2 = $value2;
+    }
+
+    public function getField1()
+    {
+        return $this->field1;
+    }
+
+    public function getField2()
+    {
+        return $this->field2;
+    }
+}


### PR DESCRIPTION
This PR makes two things possible:
- Sorting ANY collection in a Twig template
- Accessing the system property `order` from query results (e.g. smart content results)

``` jinja
      {% for page in content.smartcontent|sulu_util_multisort('[order]', 'asc') %}

          <div class="col-lg-4">
              <h2>
                  <a href="{{ content_path(page.url) }}">{{ page.title }}</a>
              </h2>
              <!-- ... -->
      {% endfor %}
```

The twig function `sulu_util_multisort` sorts arrays or objects, on properties or methods thanks to the [PropertyAcessor](http://symfony.com/doc/current/components/property_access/introduction.html).

The twig extension uses `SortUtil::multisort` function internally

**Tasks:**
- [x] test coverage
- [ ] gather feedback for my changes
- [ ] submit changes to the documentation

**Informations:**

| Q | A |
| --- | --- |
| Tests pass? | yes |
| Fixed tickets | n/a |
| BC Breaks | n/a |
| Doc |  |
