### PR TITLE
Throw proper exception when no webspaces is configured

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContentQueryBuilder.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SmartContent/SmartContentQueryBuilder.php
@@ -224,7 +224,7 @@ class SmartContentQueryBuilder extends ContentQueryBuilder
         $includeSubFolders = $this->getConfig('includeSubFolders', false);
         $sqlFunction = $includeSubFolders !== false && $includeSubFolders !== 'false' ? 'ISDESCENDANTNODE' : 'ISCHILDNODE';
 
-        if ($this->webspaceManager->findWebspaceByKey($dataSource) !== null) {
+        if ($this->webspaceManager->hasWebspace($dataSource)) {
             $node = $this->sessionManager->getContentNode($dataSource);
         } else {
             $node = $this->sessionManager->getSession()->getNodeByIdentifier($dataSource);

--- a/src/Sulu/Bundle/ContentBundle/Controller/WebspaceLocalizationController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/WebspaceLocalizationController.php
@@ -36,9 +36,8 @@ class WebspaceLocalizationController extends RestController implements ClassReso
         /** @var WebspaceManagerInterface $webspaceManager */
         $webspaceManager = $this->get('sulu_core.webspace.webspace_manager');
 
-        $webspace = $webspaceManager->findWebspaceByKey($webspaceKey);
-
-        if ($webspace) {
+        if ($webspaceManager->hasWebspace($webspaceKey)) {
+            $webspace = $webspaceManager->findWebspaceByKey($webspaceKey);
             $localizations = new CollectionRepresentation($webspace->getAllLocalizations(), 'localizations');
             $view = $this->view($localizations, 200);
         } else {

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -431,7 +431,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         if ($api) {
             if (isset($filterConfig['dataSource'])) {
-                if ($this->webspaceManager->findWebspaceByKey($filterConfig['dataSource']) !== null) {
+                if ($this->webspaceManager->hasWebspace($filterConfig['dataSource'])) {
                     $node = $this->sessionManager->getContentNode($filterConfig['dataSource']);
                 } else {
                     $node = $this->sessionManager->getSession()->getNodeByIdentifier($filterConfig['dataSource']);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/WebspaceLocalizationControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/WebspaceLocalizationControllerTest.php
@@ -45,6 +45,7 @@ class WebspaceLocalizationControllerTest extends SuluTestCase
         $client->request('GET', '/api/webspace/localizations?webspace=sulu_lo');
         $response = json_decode($client->getResponse()->getContent());
 
+        $this->assertNotNull($response);
         $this->assertEquals(0, $response->code);
         $this->assertEquals('No webspace found for key \'sulu_lo\'', $response->message);
     }

--- a/src/Sulu/Component/Webspace/Analyzer/AdminRequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/AdminRequestAnalyzer.php
@@ -69,10 +69,17 @@ class AdminRequestAnalyzer implements RequestAnalyzerInterface
         // TODO rename to locale
         $locale = $request->get('language');
 
-        if ($webspaceKey !== null) {
-            $this->webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+        if (null !== $webspaceKey) {
+            // todo: we should let the webspace manager throw an exception here as
+            //       here there is a webspace key, and if it doesn't exist, something is wrong. But
+            //       this breaks the existing behavior because the resulting exception is not a REST
+            //       exception and so breaks the REST API tests.
+            if ($this->webspaceManager->hasWebspace($webspaceKey)) {
+                $this->webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+            }
         }
-        if ($this->webspace !== null && $locale !== null) {
+
+        if (null !== $this->webspace && null !== $locale) {
             $this->localization = $this->webspace->getLocalization($locale);
         }
     }

--- a/src/Sulu/Component/Webspace/Exception/UnknownPortalException.php
+++ b/src/Sulu/Component/Webspace/Exception/UnknownPortalException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Exception;
+
+/**
+ * This exception is thrown when an environment in a portal does not exist.
+ */
+class UnknownPortalException extends PortalException
+{
+    public function __construct($portalName)
+    {
+        parent::__construct(
+            sprintf('Portal "%s" is not known.', $portalName)
+        );
+    }
+}

--- a/src/Sulu/Component/Webspace/Exception/UnknownWebspaceException.php
+++ b/src/Sulu/Component/Webspace/Exception/UnknownWebspaceException.php
@@ -11,7 +11,7 @@
 namespace Sulu\Component\Webspace\Exception;
 
 /**
- * This exception is thrown when an environment in a portal does not exist.
+ * This exception is thrown when an environment in a webspace does not exist.
  */
 class UnknownWebspaceException extends \InvalidArgumentException
 {

--- a/src/Sulu/Component/Webspace/Exception/UnknownWebspaceException.php
+++ b/src/Sulu/Component/Webspace/Exception/UnknownWebspaceException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the Sulu CMF.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Exception;
+
+/**
+ * This exception is thrown when an environment in a portal does not exist.
+ */
+class UnknownWebspaceException extends \InvalidArgumentException
+{
+    public function __construct($name)
+    {
+        parent::__construct(
+            sprintf('Webspace "%s" is not known.', $name)
+        );
+    }
+}

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -16,6 +16,8 @@ use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Config\Resource\FileResource;
 use Traversable;
+use Sulu\Component\Webspace\Exception\UnknownWebspaceException;
+use Sulu\Component\Webspace\Exception\UnknownPortalException;
 
 /**
  * A collection of all webspaces and portals in a specific sulu installation.
@@ -77,10 +79,26 @@ class WebspaceCollection implements \IteratorAggregate
      * @param $key string The index of the portal
      *
      * @return Portal
+     * @throws UnknownPortalException
      */
     public function getPortal($key)
     {
-        return array_key_exists($key, $this->portals) ? $this->portals[$key] : null;
+        if (!isset($this->portals[$key])) {
+            throw new UnknownPortalException($key);
+        }
+
+        return $this->portals[$key];
+    }
+
+    /**
+     * Return true if the collection has the named portal
+     *
+     * @param string $name
+     * @return boolean
+     */
+    public function hasPortal($key)
+    {
+        return isset($this->portals[$key]);
     }
 
     /**
@@ -109,10 +127,27 @@ class WebspaceCollection implements \IteratorAggregate
      * @param $key string The key of the webspace
      *
      * @return Webspace
+     *
+     * @throws UnknownWebspaceException
      */
     public function getWebspace($key)
     {
-        return array_key_exists($key, $this->webspaces) ? $this->webspaces[$key] : null;
+        if (!isset($this->webspaces[$key])) {
+            throw new UnknownWebspaceException($key);
+        }
+
+        return $this->webspaces[$key];
+    }
+
+    /**
+     * Return true if the collection has the webspace with the given key
+     *
+     * @param string $name
+     * @return boolean
+     */
+    public function hasWebspace($key)
+    {
+        return isset($this->webspaces[$key]);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -62,13 +62,6 @@ class WebspaceCollectionBuilder
     private $path;
 
     /**
-     * The webspaces for the configured path.
-     *
-     * @var Webspace[]
-     */
-    private $webspaces;
-
-    /**
      * The portals for the configured path.
      *
      * @var Portal[]
@@ -103,7 +96,7 @@ class WebspaceCollectionBuilder
         $collection = new WebspaceCollection();
 
         // reset arrays
-        $this->webspaces = array();
+        $webspaces = array();
         $this->portals = array();
         $this->portalInformations = array();
 
@@ -115,7 +108,7 @@ class WebspaceCollectionBuilder
 
                 /** @var Webspace $webspace */
                 $webspace = $this->loader->load($file->getRealPath());
-                $this->webspaces[] = $webspace;
+                $webspaces[] = $webspace;
 
                 $this->buildPortals($webspace);
             } catch (\InvalidArgumentException $iae) {
@@ -130,7 +123,7 @@ class WebspaceCollectionBuilder
             }
         }
 
-        if (0 === count($this->webspaces)) {
+        if (0 === count($webspaces)) {
             throw new NoValidWebspaceException($this->path);
         }
 
@@ -146,7 +139,7 @@ class WebspaceCollectionBuilder
             );
         }
 
-        $collection->setWebspaces($this->webspaces);
+        $collection->setWebspaces($webspaces);
         $collection->setPortals($this->portals);
         $collection->setPortalInformations($this->portalInformations);
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -62,6 +62,16 @@ class WebspaceManager implements WebspaceManagerInterface
     }
 
     /**
+     * Return true if the webspace with the given key exists.
+     *
+     * @return boolean
+     */
+    public function hasWebspace($key)
+    {
+        return $this->getWebspaceCollection()->hasWebspace($key);
+    }
+
+    /**
      * Returns the portal with the given key.
      *
      * @param string $key The key to search for
@@ -71,6 +81,16 @@ class WebspaceManager implements WebspaceManagerInterface
     public function findPortalByKey($key)
     {
         return $this->getWebspaceCollection()->getPortal($key);
+    }
+
+    /**
+     * Return true if the portal with the given key exists.
+     *
+     * @return boolean
+     */
+    public function hasPortal($key)
+    {
+        return $this->getWebspaceCollection()->hasPortal($key);
     }
 
     /**

--- a/tests/Sulu/Component/Webspace/Manager/WebspaceCollectionTest.php
+++ b/tests/Sulu/Component/Webspace/Manager/WebspaceCollectionTest.php
@@ -102,7 +102,7 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
         $webspace->setNavigation(new Navigation(array(new NavigationContext('main', array()))));
 
         $portals[] = $portal;
-        $webspaces[] = $webspace;
+        $webspaces['default'] = $webspace;
 
         $portalInformations['prod']['www.portal1.com'] = new PortalInformation(
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
@@ -207,5 +207,34 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
     public function testGetPortalInformationsUnknown()
     {
         $this->webspaceCollection->getPortalInformations('unknown');
+    }
+
+    /**
+     * It should throw an exception if a webspace does not exist
+     *
+     * @expectedException Sulu\Component\Webspace\Exception\UnknownWebspaceException
+     */
+    public function testGetUnknownWebspace()
+    {
+        $this->webspaceCollection->getWebspace('unknown');
+    }
+
+    /**
+     * It should throw an exception if a portal does not exist
+     *
+     * @expectedException Sulu\Component\Webspace\Exception\UnknownPortalException
+     */
+    public function testGetUnknownPortal()
+    {
+        $this->webspaceCollection->getPortal('unknown');
+    }
+
+    /**
+     * It should be able to say if a webspace exists or not
+     */
+    public function testHasWebspace()
+    {
+        $this->assertTrue($this->webspaceCollection->hasWebspace('default'));
+        $this->assertFalse($this->webspaceCollection->hasWebspace('asddefault'));
     }
 }

--- a/tests/Sulu/Component/Webspace/Manager/WebspaceManagerTest.php
+++ b/tests/Sulu/Component/Webspace/Manager/WebspaceManagerTest.php
@@ -235,18 +235,6 @@ class WebspaceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
     }
 
-    public function testFindWebspaceByNotExistingKey()
-    {
-        $portal = $this->webspaceManager->findWebspaceByKey('not_existing');
-        $this->assertNull($portal);
-    }
-
-    public function testFindPortalByNotExistingKey()
-    {
-        $portal = $this->webspaceManager->findPortalByKey('not_existing');
-        $this->assertNull($portal);
-    }
-
     public function testFindPortalInformationByUrl()
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.at/test/test/test', 'prod');


### PR DESCRIPTION
This PR changes the behavior of `WebspaceCollection#[getWebspace|getPortal` to throw Exceptions instead of returning NULL. By extension this changes the behavior of `WebspaceManager#[findWebspaceByKey|findPortalByKey]`.

`hasPortal` and `hasWebspace` methods have been added to both classes and code that depended on the NULL behavior has been adpted accordingly.

This will prevent `call to member function on NULL` fatal errors.
Fixes : https://github.com/sulu-io/sulu/issues/1166
