### PR TITLE
Fixed bug with ordering by a concatenated field in DoctrineListBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #XXXX [Rest]            Fixed sorting of concatenated fields
     * FEATURE     #1522 [SecurityBundle]  Created OrderByTrait for Repositories to sort by given array data
                                           `[field.name => order]` 
     * ENHANCEMENT #1522 [SecurityBundle]  Added sorting option for findUserByAccount in UserRepository 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * BUGFIX      #XXXX [Rest]            Fixed sorting of concatenated fields
+    * BUGFIX      #1531 [Rest]            Fixed sorting of concatenated fields
     * FEATURE     #1522 [SecurityBundle]  Created OrderByTrait for Repositories to sort by given array data
                                           `[field.name => order]` 
     * ENHANCEMENT #1522 [SecurityBundle]  Added sorting option for findUserByAccount in UserRepository 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\QueryBuilder;
 use Sulu\Component\Rest\ListBuilder\AbstractFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\AbstractListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\AbstractDoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineConcatenationFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
 use Sulu\Component\Rest\ListBuilder\Event\ListBuilderCreateEvent;
@@ -183,7 +184,11 @@ class DoctrineListBuilder extends AbstractListBuilder
     protected function assignSortFields($queryBuilder)
     {
         foreach ($this->sortFields as $index => $sortField) {
-            $queryBuilder->addOrderBy($sortField->getName(), $this->sortOrders[$index]);
+            $sort = ($sortField instanceof DoctrineConcatenationFieldDescriptor)
+                ? $sortField->getName()
+                : $sortField->getSelect();
+
+            $queryBuilder->addOrderBy($sort, $this->sortOrders[$index]);
         }
     }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -183,7 +183,7 @@ class DoctrineListBuilder extends AbstractListBuilder
     protected function assignSortFields($queryBuilder)
     {
         foreach ($this->sortFields as $index => $sortField) {
-            $queryBuilder->addOrderBy($sortField->getSelect(), $this->sortOrders[$index]);
+            $queryBuilder->addOrderBy($sortField->getName(), $this->sortOrders[$index]);
         }
     }
 

--- a/tests/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/tests/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
 use PHPUnit_Framework_Assert;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineConcatenationFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
 use Sulu\Component\Rest\ListBuilder\Event\ListBuilderCreateEvent;
@@ -236,8 +237,23 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testSort()
     {
-        $alias = 'desc';
-        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', $alias, self::$entityName));
+        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
+
+        $this->queryBuilder->expects($this->exactly(2))->method('addOrderBy')->with(self::$entityName . '.desc', 'ASC');
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSortConcat()
+    {
+        $alias = 'name_desc';
+        $this->doctrineListBuilder->sort(new DoctrineConcatenationFieldDescriptor(
+            [
+                new DoctrineFieldDescriptor('name', 'name', self::$entityName),
+                new DoctrineFieldDescriptor('desc', 'desc', self::$entityName),
+            ],
+            $alias
+        ));
 
         $this->queryBuilder->expects($this->exactly(2))->method('addOrderBy')->with($alias, 'ASC');
 

--- a/tests/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/tests/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -236,9 +236,10 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testSort()
     {
-        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
+        $alias = 'desc';
+        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', $alias, self::$entityName));
 
-        $this->queryBuilder->expects($this->exactly(2))->method('addOrderBy')->with(self::$entityName . '.desc', 'ASC');
+        $this->queryBuilder->expects($this->exactly(2))->method('addOrderBy')->with($alias, 'ASC');
 
         $this->doctrineListBuilder->execute();
     }


### PR DESCRIPTION
Adding a `DoctrineConcatenationFieldDescriptor` to a `DoctrineListBuilder` and then trying to order by in within an admin iterface throws the following exception:
> QueryException: [Syntax Error] line 0, col 597: Error: Expected end of string, got '('

It seems you can only order by *fields* that have been selected in the query.

__Tasks__

- [x] Test coverage
- [x] Update changelog

__Information__

| Q                | A
| ---------------- | ---
| Fixed tickets    | N/A
| BC breaks        | None
| Documentation PR | N/A