### PR TITLE
Added DistributionBundle with Composer hooks for installing .dist files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "symfony/monolog-bundle": "2.4.*",
         "twig/twig": "~1.11",
         "zendframework/zend-stdlib": "~2.3",
-        "zendframework/zendsearch": "@dev"
+        "zendframework/zendsearch": "@dev",
+        "composer/composer": "@alpha"
     },
     "replace": {
         "sulu/media-bundle": "self.version",
@@ -82,9 +83,9 @@
         "psr-0": {
             "Sulu\\": "src/"
         },
-        "exclude-from-classmap": [ 
+        "exclude-from-classmap": [
             "src/Sulu/Component/*/Tests/",
-            "src/Sulu/Bundle/*/Tests/" 
+            "src/Sulu/Bundle/*/Tests/"
         ]
     },
     "autoload-dev": {

--- a/src/Sulu/Bundle/DistributionBundle/Composer/ScriptHandler.php
+++ b/src/Sulu/Bundle/DistributionBundle/Composer/ScriptHandler.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DistributionBundle\Composer;
+
+use Composer\Script\Event;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Contains hooks executed during Composer updates/installs.
+ */
+class ScriptHandler
+{
+    private static $options = [
+        'symfony-app-dir' => 'app',
+        'sulu-dist-install' => true,
+    ];
+
+    /**
+     * Copies ".dist" files to the local Sulu installation if they don't exist
+     * already.
+     *
+     * @param Event $event The Composer event.
+     */
+    public static function installDistFiles(Event $event)
+    {
+        $options = self::getOptions($event);
+
+        if (!$options['sulu-dist-install']) {
+            return;
+        }
+
+        $filesystem = new Filesystem();
+        $resourceDir = $options['symfony-app-dir'] . '/Resources';
+
+        if (!$filesystem->exists($resourceDir . '/webspaces/sulu.io.xml')) {
+            $filesystem->copy(
+                $resourceDir . '/webspaces/sulu.io.xml.dist',
+                $resourceDir . '/webspaces/sulu.io.xml'
+            );
+        }
+
+        if (!$filesystem->exists($resourceDir . '/pages/default.xml')) {
+            $filesystem->copy(
+                $resourceDir . '/pages/default.xml.dist',
+                $resourceDir . '/pages/default.xml'
+            );
+        }
+
+        if (!$filesystem->exists($resourceDir . '/pages/overview.xml')) {
+            $filesystem->copy(
+                $resourceDir . '/pages/overview.xml.dist',
+                $resourceDir . '/pages/overview.xml'
+            );
+        }
+
+        if (!$filesystem->exists($resourceDir . '/snippets/default.xml')) {
+            $filesystem->copy(
+                $resourceDir . '/snippets/default.xml.dist',
+                $resourceDir . '/snippets/default.xml'
+            );
+        }
+    }
+
+    private static function getOptions(Event $event)
+    {
+        return array_replace(static::$options, $event->getComposer()->getPackage()->getExtra());
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/pages/default.xml.dist
+++ b/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/pages/default.xml.dist
@@ -1,0 +1,1 @@
+default pages

--- a/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/pages/overview.xml.dist
+++ b/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/pages/overview.xml.dist
@@ -1,0 +1,1 @@
+overview

--- a/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/snippets/default.xml.dist
+++ b/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/snippets/default.xml.dist
@@ -1,0 +1,1 @@
+default snippets

--- a/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/webspaces/sulu.io.xml.dist
+++ b/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/Fixtures/app/Resources/webspaces/sulu.io.xml.dist
@@ -1,0 +1,1 @@
+default webspaces

--- a/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/ScriptHandlerTest.php
+++ b/src/Sulu/Bundle/DistributionBundle/Tests/Unit/Composer/ScriptHandlerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DistributionBundle\Tests\Unit\Composer;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Composer\Package\RootPackageInterface;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+use Sulu\Bundle\DistributionBundle\Composer\ScriptHandler;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ScriptHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    private $tempDir;
+
+    private $resourceDir;
+
+    private $previousWd;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|Composer
+     */
+    private $composer;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|IOInterface
+     */
+    private $io;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|RootPackageInterface
+     */
+    private $rootPackage;
+
+    /**
+     * @var Event
+     */
+    private $event;
+
+    protected function setUp()
+    {
+        $this->tempDir = self::makeTempDir(__CLASS__);
+        $this->previousWd = getcwd();
+        $this->composer = $this->getMockBuilder('Composer\Composer')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->io = $this->getMock('Composer\IO\IOInterface');
+        $this->rootPackage = $this->getMock('Composer\Package\RootPackageInterface');
+        $this->event = new Event(ScriptEvents::POST_INSTALL_CMD, $this->composer, $this->io);
+
+        $this->composer->expects($this->any())
+            ->method('getPackage')
+            ->willReturn($this->rootPackage);
+
+        $filesystem = new Filesystem();
+        $filesystem->mirror(__DIR__ . '/Fixtures/app', $this->tempDir . '/app');
+
+        chdir($this->tempDir);
+    }
+
+    protected function tearDown()
+    {
+        // Change back, otherwise deleting fails on Windows
+        chdir($this->previousWd);
+
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->tempDir);
+    }
+
+    public function testCopyDistFilesIfNotPresent()
+    {
+        $this->rootPackage->expects($this->any())
+            ->method('getExtra')
+            ->willReturn([]);
+
+        ScriptHandler::installDistFiles($this->event);
+
+        $this->assertFileExists($this->tempDir . '/app/Resources/pages/default.xml');
+        $this->assertFileExists($this->tempDir . '/app/Resources/pages/overview.xml');
+        $this->assertFileExists($this->tempDir . '/app/Resources/snippets/default.xml');
+        $this->assertFileExists($this->tempDir . '/app/Resources/webspaces/sulu.io.xml');
+
+        $this->assertFileEquals(
+            $this->tempDir . '/app/Resources/pages/default.xml',
+            $this->tempDir . '/app/Resources/pages/default.xml.dist'
+        );
+        $this->assertFileEquals(
+            $this->tempDir . '/app/Resources/pages/overview.xml',
+            $this->tempDir . '/app/Resources/pages/overview.xml.dist'
+        );
+        $this->assertFileEquals(
+            $this->tempDir . '/app/Resources/snippets/default.xml',
+            $this->tempDir . '/app/Resources/snippets/default.xml.dist'
+        );
+        $this->assertFileEquals(
+            $this->tempDir . '/app/Resources/webspaces/sulu.io.xml',
+            $this->tempDir . '/app/Resources/webspaces/sulu.io.xml.dist'
+        );
+    }
+
+    public function testKeepExistingFiles()
+    {
+        $this->rootPackage->expects($this->any())
+            ->method('getExtra')
+            ->willReturn([]);
+
+        file_put_contents($this->tempDir . '/app/Resources/pages/overview.xml', 'custom overview');
+        file_put_contents($this->tempDir . '/app/Resources/webspaces/sulu.io.xml', 'custom webspaces');
+
+        ScriptHandler::installDistFiles($this->event);
+
+        $this->assertFileExists($this->tempDir . '/app/Resources/pages/default.xml');
+        $this->assertFileExists($this->tempDir . '/app/Resources/pages/overview.xml');
+        $this->assertFileExists($this->tempDir . '/app/Resources/snippets/default.xml');
+        $this->assertFileExists($this->tempDir . '/app/Resources/webspaces/sulu.io.xml');
+
+        $this->assertFileEquals(
+            $this->tempDir . '/app/Resources/pages/default.xml',
+            $this->tempDir . '/app/Resources/pages/default.xml.dist'
+        );
+        $this->assertFileEquals(
+            $this->tempDir . '/app/Resources/snippets/default.xml',
+            $this->tempDir . '/app/Resources/snippets/default.xml.dist'
+        );
+
+        $this->assertEquals('custom overview', file_get_contents($this->tempDir . '/app/Resources/pages/overview.xml'));
+        $this->assertEquals('custom webspaces', file_get_contents($this->tempDir . '/app/Resources/webspaces/sulu.io.xml'));
+    }
+
+    public function testCopyDistFilesToCustomAppDirectoryIfPresent()
+    {
+        $this->rootPackage->expects($this->any())
+            ->method('getExtra')
+            ->willReturn([
+                'symfony-app-dir' => 'foobar',
+            ]);
+
+        $filesystem = new Filesystem();
+        $filesystem->mirror(__DIR__ . '/Fixtures/app', $this->tempDir . '/foobar');
+
+        ScriptHandler::installDistFiles($this->event);
+
+        $this->assertFileExists($this->tempDir . '/foobar/Resources/pages/default.xml');
+        $this->assertFileExists($this->tempDir . '/foobar/Resources/pages/overview.xml');
+        $this->assertFileExists($this->tempDir . '/foobar/Resources/snippets/default.xml');
+        $this->assertFileExists($this->tempDir . '/foobar/Resources/webspaces/sulu.io.xml');
+    }
+
+    public function testDoNotCopyDistFilesIfDisabled()
+    {
+        $this->rootPackage->expects($this->any())
+            ->method('getExtra')
+            ->willReturn([
+                'sulu-dist-install' => false,
+            ]);
+
+        ScriptHandler::installDistFiles($this->event);
+
+        $this->assertFileNotExists($this->tempDir . '/app/Resources/pages/default.xml');
+        $this->assertFileNotExists($this->tempDir . '/app/Resources/pages/overview.xml');
+        $this->assertFileNotExists($this->tempDir . '/app/Resources/snippets/default.xml');
+        $this->assertFileNotExists($this->tempDir . '/app/Resources/webspaces/sulu.io.xml');
+    }
+
+    public static function makeTempDir($className)
+    {
+        if (false !== ($pos = strrpos($className, '\\'))) {
+            $namespace = substr($className, strpos($className, '/')) . '/';
+            $shortClass = substr($className, $pos + 1);
+        } else {
+            $namespace = '/';
+            $shortClass = $className;
+        }
+
+        // Usage of realpath() is important if the temporary directory is a
+        // symlink to another directory (e.g. /var => /private/var on some Macs)
+        // We want to know the real path to avoid comparison failures with
+        // code that uses real paths only
+        $systemTempDir = str_replace(DIRECTORY_SEPARATOR, '/', realpath(sys_get_temp_dir()));
+        $basePath = $systemTempDir . '/' . $namespace . '/' . $shortClass;
+
+        while (false === @mkdir($tempDir = $basePath . rand(10000, 99999), 0777, true)) {
+            // Run until we are able to create a directory
+        }
+
+        return $tempDir;
+    }
+}


### PR DESCRIPTION
This PR adds hooks that can be referenced in the composer.json file of Sulu Standard in order to get rid of [manually installing .dist files when setting up a project](http://docs.sulu.io/en/latest/book/getting-started/setup.html).

| Q                | A
| ---------------- | ---
| Fixed tickets    | partially sulu-io/sulu-standard#622
| Related PRs      | -
| BC breaks        | -
| Documentation PR | follows later