### PR TITLE
Added reaction to event-name for configure options

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Search/EventSubscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventSubscriber/StructureSubscriber.php
@@ -32,9 +32,8 @@ class StructureSubscriber implements EventSubscriberInterface
     /**
      * @param SearchManagerInterface $searchManager
      */
-    public function __construct(
-        SearchManagerInterface $searchManager
-    ) {
+    public function __construct(SearchManagerInterface $searchManager)
+    {
         $this->searchManager = $searchManager;
     }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
@@ -59,6 +59,10 @@ class BlameSubscriber implements EventSubscriberInterface
      */
     public function configureOptions(ConfigureOptionsEvent $event)
     {
+        if (!in_array($event->getEventName(), [Events::FIND, Events::PERSIST])) {
+            return;
+        }
+
         $event->getOptions()->setDefaults([
             'user' => null,
         ]);

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -97,6 +97,10 @@ class StructureSubscriber implements EventSubscriberInterface
      */
     public function configureOptions(ConfigureOptionsEvent $event)
     {
+        if (!in_array($event->getEventName(), [Events::FIND, Events::PERSIST])) {
+            return;
+        }
+
         $options = $event->getOptions();
         $options->setDefaults(
             [


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #issuenum |
| Related issues/PRs | https://github.com/sulu-io/sulu-document-manager/pull/69 |
| License | MIT |
| Documentation PR | none |
#### What's in this PR?

Because also for remove the configure options will be called,
