### PR TITLE
Made Travis build only on master, develop and test/* branches on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ sudo: false
 
 language: php
 
+branches:
+  only:
+    - master
+    - develop
+    - /^test\/.*$/
+
 php:
   - 5.5
   - 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2119 [All]                 Made Travis build only on master, develop and test/* branches on push
     * ENHANCEMENT #2122 [All]                 Disable xdebug on Travis to speed up composer and tests
     * ENHANCEMENT #2120 [All]                 Change bundle tests to use their own phpunit config and move `SYMFONY_DEPRECATIONS_HELPER` var into
     * ENHANCEMENT #2121 [All]                 Cache composer cache dir and prefer dist downloads on Travis


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no, improvement
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Travis is now restricted to build only on `master`, `develop` and `test/*` branches on push. On PR builds are still made every time, when pushed if a PR exists.

#### Why?

Pull requests from branches in the Sulu repository itself are creating doubled Travis builds and so blocking four build workers instead of 2. Given the long test duration, this is unnecessary.

##### Why `test/*` branches?

If there are something you really want to test through Travis without creating a PR, name the branch `test/whatever` and push. If you want to create a pull request later, simply rename the branch, according to Sulu standards.
