### PR TITLE
Copy templates script handler

### DIFF
--- a/src/Sulu/Component/Composer/ScriptHandler.php
+++ b/src/Sulu/Component/Composer/ScriptHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Sulu\Component\Composer;
+
+use Composer\Script\Event;
+
+class ScriptHandler
+{
+    /**
+     * Asks if the new directory structure should be used, installs the structure if needed.
+     *
+     * @param CommandEvent $event
+     */
+    public static function copyDefaultTemplates(Event $event)
+    {
+        $io = $event->getIO();
+        if (false === $io->askConfirmation('<question>Would you like to install the default templates? [Y/n]</> ', true)) {
+            return;
+        }
+
+        $dirs = [
+            getcwd() . '/app/Resources/pages',
+            getcwd() . '/app/Resources/snippets',
+            getcwd() . '/app/Resources/webspaces',
+        ];
+
+        foreach ($dirs as $dir) {
+            $iterator = new \DirectoryIterator($dir);
+
+            foreach ($iterator as $file) {
+                if (false === $file->isFile()) {
+                    continue;
+                }
+
+                if ($file->getExtension() != 'dist') {
+                    continue;
+                }
+
+                $destFilename = substr($file->getPathname(), 0, -5);
+
+                if (file_exists($destFilename)) {
+                    $confirmed = $io->askConfirmation(sprintf('<question>File "%s" already exists, overwrite? [y/N]</> ', $destFilename), false);
+
+                    if (false === $confirmed) {
+                        $event->getIO()->write(sprintf(' <info>[ ]</> %s', $destFilename));
+                        continue;
+                    }
+                }
+                copy($file->getPathname(), $destFilename);
+                $event->getIO()->write(sprintf(' <info>[+]</> %s', $destFilename));
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes https://github.com/sulu-io/sulu-standard/issues/622 |
| Related issues/PRs | https://github.com/sulu-io/sulu-standard/issues/622 |
| License | MIT |
| Documentation PR | sulu-io/sulu-docs#prnum |
#### What's in this PR?

This PR introduces a composer hook to copy the default templates.
#### Why?

Because otherwise the user needs to do this manually each time they install Sulu, which is bad DX.
#### Example Usage

![sulu_composer_copy](https://cloud.githubusercontent.com/assets/530801/13737923/ebefea82-e9b8-11e5-9592-90db1f966bc4.png)
#### To Do
- [ ] Create a documentation PR.
- [ ] Make path to templates configurable (not required if this were in sulu-standard).
- [ ] Would need an associated PR on sulu-standard adding the hook to composer.json
- [ ] Tests
#### Notes

I am not sure if this is the correct place for this hook. It might be that it is more appropriate in `sulu-standard`, but if so, I would not know where to place it.
