### PR TITLE
Integrated custom-urls into analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2157 [CustomUrlBundle]     Fixed route-validation in request processor
     * ENHANCEMENT #1288 [CoreBundle]          Introduced lazy initialization of request attributes
     * ENHANCEMENT #2132 [Test]                Removed external classes from and refactored functional test class hierarchy
+    * FEATURE     #1288 [CustomUrlBundle]     Integrated custom-urls into analytics
     * FEATURE     #1288 [All]                 Added deep-links for selection content-types
     * BUGFIX      #2131 [WebsiteBundle]       Fixed 'getTheme' error in ExceptionController
     * ENHANCEMENT #2131 [CoreBundle]          Added request attributes to extract data from request

--- a/src/Sulu/Bundle/ContentBundle/EventListener/WebspaceSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/EventListener/WebspaceSerializeEventSubscriber.php
@@ -18,6 +18,7 @@ use JMS\Serializer\JsonSerializationVisitor;
 use Sulu\Component\Webspace\Environment;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Url\WebspaceUrlProviderInterface;
 use Sulu\Component\Webspace\Webspace;
 
 /**
@@ -31,13 +32,22 @@ class WebspaceSerializeEventSubscriber implements EventSubscriberInterface
     private $webspaceManager;
 
     /**
+     * @var WebspaceUrlProviderInterface
+     */
+    private $webspaceUrlProvider;
+
+    /**
      * @var string
      */
     private $environment;
 
-    public function __construct(WebspaceManagerInterface $webspaceManager, $environment)
-    {
+    public function __construct(
+        WebspaceManagerInterface $webspaceManager,
+        WebspaceUrlProviderInterface $webspaceUrlProvider,
+        $environment
+    ) {
         $this->webspaceManager = $webspaceManager;
+        $this->webspaceUrlProvider = $webspaceUrlProvider;
         $this->environment = $environment;
     }
 
@@ -99,11 +109,7 @@ class WebspaceSerializeEventSubscriber implements EventSubscriberInterface
      */
     private function appendUrls(Webspace $webspace, Context $context, JsonSerializationVisitor $visitor)
     {
-        $urls = [];
-        foreach ($webspace->getPortals() as $portal) {
-            $environment = $portal->getEnvironment($this->environment);
-            $urls = array_merge($urls, $environment->getUrls());
-        }
+        $urls = $this->webspaceUrlProvider->getUrls($webspace, $this->environment);
         $urls = $context->accept($urls);
         $visitor->addData('urls', $urls);
     }

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -47,6 +47,7 @@
         <service id="sulu_content.webspace.serializer.event_subscriber"
                  class="Sulu\Bundle\ContentBundle\EventListener\WebspaceSerializeEventSubscriber">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="service" id="sulu_core.webspace.url_provider"/>
             <argument type="string">%kernel.environment%</argument>
 
             <tag name="jms_serializer.event_subscriber" />

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/EventListener/WebspaceSerializeEventSubscriberTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/EventListener/WebspaceSerializeEventSubscriberTest.php
@@ -21,14 +21,16 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Url\WebspaceUrlProviderInterface;
 use Sulu\Component\Webspace\Webspace;
 
 class WebspaceSerializeEventSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSubscribedEvents()
     {
+        $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), 'prod');
+        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
 
         $events = $subscriber->getSubscribedEvents();
 
@@ -46,8 +48,9 @@ class WebspaceSerializeEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testAppendPortalInformation()
     {
+        $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), 'prod');
+        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
 
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn('sulu_io');
@@ -81,26 +84,12 @@ class WebspaceSerializeEventSubscriberTest extends \PHPUnit_Framework_TestCase
             new Url('*.sulu.io'),
         ];
 
-        $environments = [$this->prophesize(Environment::class), $this->prophesize(Environment::class)];
-        $portals = [$this->prophesize(Portal::class), $this->prophesize(Portal::class)];
-        $portals[0]->getEnvironment('prod')->willReturn($environments[0]->reveal());
-        $portals[1]->getEnvironment('prod')->willReturn($environments[1]->reveal());
-
-        $environments[0]->getUrls()->willReturn([$urls[0], $urls[1]]);
-        $environments[1]->getUrls()->willReturn([$urls[2], $urls[3]]);
+        $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
 
         $webspace = $this->prophesize(Webspace::class);
-        $webspace->getPortals()->willReturn(
-            array_map(
-                function ($portal) {
-                    return $portal->reveal();
-                },
-                $portals
-            )
-        );
-
-        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), 'prod');
+        $webspaceUrlProvider->getUrls($webspace->reveal(), 'prod')->willReturn($urls);
 
         $context = $this->prophesize(Context::class);
         $visitor = $this->prophesize(JsonSerializationVisitor::class);
@@ -147,8 +136,9 @@ class WebspaceSerializeEventSubscriberTest extends \PHPUnit_Framework_TestCase
             )
         );
 
+        $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), 'prod');
+        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
 
         $context = $this->prophesize(Context::class);
         $visitor = $this->prophesize(JsonSerializationVisitor::class);

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/WebspaceUrlProviderCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/WebspaceUrlProviderCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Collects all url provider and combines them in the chain-provider.
+ */
+class WebspaceUrlProviderCompilerPass implements CompilerPassInterface
+{
+    const SERVICE_ID = 'sulu_core.webspace.url_provider';
+    const TAG_NAME = 'sulu.webspace.url_provider';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::SERVICE_ID)) {
+            return;
+        }
+
+        $references = [];
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
+            $references[] = new Reference($id);
+        }
+
+        $container->getDefinition(self::SERVICE_ID)->replaceArgument(0, $references);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -46,5 +46,13 @@
         <service id="sulu_core.webspace.settings_manager" class="Sulu\Component\Webspace\Settings\SettingsManager">
             <argument type="service" id="sulu.phpcr.session"/>
         </service>
+
+        <service id="sulu_core.webspace.url_provider" class="Sulu\Component\Webspace\Url\WebspaceUrlChainProvider">
+            <argument type="collection"/>
+        </service>
+
+        <service id="sulu_core.webspace.url_provider.default" class="Sulu\Component\Webspace\Url\WebspaceUrlProvider">
+            <tag name="sulu.webspace.url_provider"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProv
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RemoveForeignContextServicesPass;
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\ReplacersCompilerPass;
 use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RequestAnalyzerCompilerPass;
+use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\WebspaceUrlProviderCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -34,5 +35,6 @@ class SuluCoreBundle extends Bundle
         $container->addCompilerPass(new ListBuilderMetadataProviderCompilerPass());
         $container->addCompilerPass(new RequestAnalyzerCompilerPass());
         $container->addCompilerPass(new CsvHandlerCompilerPass());
+        $container->addCompilerPass(new WebspaceUrlProviderCompilerPass());
     }
 }

--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CustomUrlBundle\Request;
 
 use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\CustomUrl\Generator\GeneratorInterface;
 use Sulu\Component\CustomUrl\Manager\CustomUrlManagerInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\Attributes\AbstractRequestProcessor;
@@ -32,6 +33,11 @@ class CustomUrlRequestProcessor extends AbstractRequestProcessor
     private $customUrlManager;
 
     /**
+     * @var GeneratorInterface
+     */
+    private $generator;
+
+    /**
      * @var WebspaceManagerInterface
      */
     private $webspaceManager;
@@ -43,10 +49,12 @@ class CustomUrlRequestProcessor extends AbstractRequestProcessor
 
     public function __construct(
         CustomUrlManagerInterface $customUrlManager,
+        GeneratorInterface $generator,
         WebspaceManagerInterface $webspaceManager,
         $environment
     ) {
         $this->customUrlManager = $customUrlManager;
+        $this->generator = $generator;
         $this->webspaceManager = $webspaceManager;
         $this->environment = $environment;
     }
@@ -157,7 +165,15 @@ class CustomUrlRequestProcessor extends AbstractRequestProcessor
         return $this->processPortalInformation(
             $request,
             reset($portalInformations),
-            ['localization' => $localization, 'customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument]
+            [
+                'localization' => $localization,
+                'customUrlRoute' => $routeDocument,
+                'customUrl' => $customUrlDocument,
+                'urlExpression' => $this->generator->generate(
+                    $customUrlDocument->getBaseDomain(),
+                    $customUrlDocument->getDomainParts()
+                ),
+            ]
         );
     }
 

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
@@ -50,5 +50,10 @@
         <service id="sulu_custom_urls.domain_generator" class="Sulu\Component\CustomUrl\Generator\Generator">
             <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
         </service>
+
+        <service id="sulu_custom_urls.url_provider" class="Sulu\Component\CustomUrl\WebspaceCustomUrlProvider">
+            <argument type="service" id="sulu_custom_urls.manager"/>
+            <tag name="sulu.webspace.url_provider"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
@@ -97,6 +97,7 @@
         <service id="sulu_custom_urls.request_processor"
                  class="Sulu\Bundle\CustomUrlBundle\Request\CustomUrlRequestProcessor">
             <argument type="service" id="sulu_custom_urls.manager"/>
+            <argument type="service" id="sulu_custom_urls.domain_generator"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="string">%kernel.environment%</argument>
 

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\CustomUrlBundle\Request\CustomUrlRequestProcessor;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
 use Sulu\Component\CustomUrl\Document\RouteDocument;
+use Sulu\Component\CustomUrl\Generator\Generator;
 use Sulu\Component\CustomUrl\Manager\CustomUrlManager;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
@@ -89,6 +90,8 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
             } else {
                 $customUrl = $this->prophesize(CustomUrlDocument::class);
                 $customUrl->isPublished()->willReturn($published);
+                $customUrl->getBaseDomain()->willReturn('sulu.lo/*');
+                $customUrl->getDomainParts()->willReturn(['prefix' => '', 'suffix' => ['test-1']]);
                 $customUrl->getTargetLocale()->willReturn('de');
                 $customUrlManager->findByUrl($route, $webspaceKey, 'de')->willReturn($customUrl->reveal());
 
@@ -132,7 +135,14 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $webspaceManager->findPortalInformationsByWebspaceKeyAndLocale('sulu_io', 'de', 'prod')
             ->willReturn([$portalInformation]);
 
-        $processor = new CustomUrlRequestProcessor($customUrlManager->reveal(), $webspaceManager->reveal(), 'prod');
+        $generator = $this->prophesize(Generator::class);
+
+        $processor = new CustomUrlRequestProcessor(
+            $customUrlManager->reveal(),
+            $generator->reveal(),
+            $webspaceManager->reveal(),
+            'prod'
+        );
         $processor->process($request->reveal(), $requestAttributes);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -65,10 +65,8 @@ class AppendAnalyticsListener
             return;
         }
 
-        $analytics = $this->analyticsRepository->findByUrl(
-            $this->requestAnalyzer->getPortalInformation()->getUrlExpression(),
-            $this->environment
-        );
+        $portalUrl = $this->requestAnalyzer->getAttribute('urlExpression');
+        $analytics = $this->analyticsRepository->findByUrl($portalUrl, $this->environment);
 
         $content = $this->engine->render('SuluWebsiteBundle:Analytics:website.html.twig', ['analytics' => $analytics]);
 

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -107,6 +107,14 @@ class CustomUrlManager implements CustomUrlManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function findUrls($webspaceKey)
+    {
+        return $this->customUrlRepository->findUrls($this->getItemsPath($webspaceKey));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function find($uuid, $locale = null)
     {
         return $this->documentManager->find($uuid, $locale, ['load_ghost_content' => true]);

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManagerInterface.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManagerInterface.php
@@ -42,6 +42,15 @@ interface CustomUrlManagerInterface
     public function findList($webspaceKey, $locale);
 
     /**
+     * Returns a list of custom-urls.
+     *
+     * @param string $webspaceKey
+     *
+     * @return string[]
+     */
+    public function findUrls($webspaceKey);
+
+    /**
      * Returns a single custom-url object identified by uuid.
      *
      * @param string $uuid

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
@@ -104,7 +104,7 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($result->isRedirect());
     }
 
-    public function testReadList()
+    public function testFindList()
     {
         $documentManager = $this->prophesize(DocumentManagerInterface::class);
         $customUrlRepository = $this->prophesize(CustomUrlRepository::class);
@@ -131,7 +131,34 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([['title' => 'Test-1'], ['title' => 'Test-2']], $result);
     }
 
-    public function testRead()
+    public function testFindUrls()
+    {
+        $documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $customUrlRepository = $this->prophesize(CustomUrlRepository::class);
+        $metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $pathBuilder = $this->prophesize(PathBuilder::class);
+        $cacheHandler = $this->prophesize(HandlerInvalidatePathInterface::class);
+
+        $pathBuilder->build(['%base%', 'sulu_io', '%custom_urls%', '%custom_urls_items%'])
+            ->willReturn('/cmf/sulu_io/custom_urls/items');
+
+        $manager = new CustomUrlManager(
+            $documentManager->reveal(),
+            $customUrlRepository->reveal(),
+            $metadataFactory->reveal(),
+            $pathBuilder->reveal(),
+            $cacheHandler->reveal()
+        );
+
+        $customUrlRepository->findUrls('/cmf/sulu_io/custom_urls/items')
+            ->willReturn(['1.sulu.lo', '1.sulu.lo/2']);
+
+        $result = $manager->findUrls('sulu_io');
+
+        $this->assertEquals(['1.sulu.lo', '1.sulu.lo/2'], $result);
+    }
+
+    public function testFind()
     {
         $documentManager = $this->prophesize(DocumentManagerInterface::class);
         $customUrlRepository = $this->prophesize(CustomUrlRepository::class);
@@ -155,7 +182,7 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($document->reveal(), $result);
     }
 
-    public function testReadByUrl()
+    public function testFindByUrl()
     {
         $documentManager = $this->prophesize(DocumentManagerInterface::class);
         $customUrlRepository = $this->prophesize(CustomUrlRepository::class);
@@ -186,7 +213,7 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($customUrlDocument->reveal(), $result);
     }
 
-    public function testReadRouteByUrl()
+    public function testFindRouteByUrl()
     {
         $documentManager = $this->prophesize(DocumentManagerInterface::class);
         $customUrlRepository = $this->prophesize(CustomUrlRepository::class);

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/WebspaceCustomUrlProviderTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/WebspaceCustomUrlProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\CustomUrl\Tests\Unit;
+
+use Sulu\Component\CustomUrl\Manager\CustomUrlManagerInterface;
+use Sulu\Component\CustomUrl\WebspaceCustomUrlProvider;
+use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Webspace;
+
+class WebspaceCustomUrlProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUrls()
+    {
+        $customUrlManager = $this->prophesize(CustomUrlManagerInterface::class);
+        $provider = new WebspaceCustomUrlProvider($customUrlManager->reveal());
+
+        $customUrlManager->findUrls('sulu_io')->willReturn(['1.sulu.lo', '1.sulu.lo/2']);
+
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu_io');
+
+        $result = $provider->getUrls($webspace->reveal(), 'prod');
+
+        $this->assertEquals([new Url('1.sulu.lo', 'prod'), new Url('1.sulu.lo/2', 'prod')], $result);
+    }
+}

--- a/src/Sulu/Component/CustomUrl/WebspaceCustomUrlProvider.php
+++ b/src/Sulu/Component/CustomUrl/WebspaceCustomUrlProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\CustomUrl;
+
+use Sulu\Component\CustomUrl\Manager\CustomUrlManagerInterface;
+use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Url\WebspaceUrlProviderInterface;
+use Sulu\Component\Webspace\Webspace;
+
+/**
+ * Returns custom-urls for given webspace.
+ */
+class WebspaceCustomUrlProvider implements WebspaceUrlProviderInterface
+{
+    /**
+     * @var CustomUrlManagerInterface
+     */
+    private $customUrlManager;
+
+    public function __construct(CustomUrlManagerInterface $customUrlManager)
+    {
+        $this->customUrlManager = $customUrlManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUrls(Webspace $webspace, $environment)
+    {
+        $urls = [];
+        foreach ($this->customUrlManager->findUrls($webspace->getKey()) as $customUrl) {
+            $urls[] = new Url($customUrl, $environment);
+        }
+
+        return $urls;
+    }
+}

--- a/src/Sulu/Component/Util/Tests/Unit/WildcardUrlUtilTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/WildcardUrlUtilTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Util\Tests\Unit;
+
+use Sulu\Component\Util\WildcardUrlUtil;
+
+class WildcardUrlUtilTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideMatchData()
+    {
+        return [
+            ['*.sulu.lo', '1.sulu.lo', true],
+            ['*.sulu.lo', '1.sulu.lo/test', true],
+            ['*.sulu.lo', '1.sulu.com', false],
+            ['*.sulu.lo', '1.sulu.com/test', false],
+            ['1.sulu.lo', '1.sulu.lo', true],
+            ['1.sulu.lo', '1.sulu.lo/test', true],
+            ['1.sulu.lo', '1.sulu.com', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchData
+     */
+    public function testMatch($portalUrl, $url, $expected)
+    {
+        $this->assertEquals($expected, WildcardUrlUtil::match($url, $portalUrl));
+    }
+
+    public function provideResolveData()
+    {
+        return [
+            ['*.sulu.lo', '1.sulu.lo', '1.sulu.lo'],
+            ['*.sulu.lo', '1.sulu.lo/test', '1.sulu.lo'],
+            ['*.sulu.lo/*', '1.sulu.lo/test', '1.sulu.lo/test'],
+            ['*.sulu.lo/*', '1.sulu.lo/test/asdf', '1.sulu.lo/test'],
+            ['*.sulu.lo/*/*', '1.sulu.lo/test', null],
+            ['*.sulu.lo/*/*', '1.sulu.lo/test/asdf', '1.sulu.lo/test/asdf'],
+            ['*.sulu.lo/*/*', '1.sulu.lo/test/asdf/qwertz', '1.sulu.lo/test/asdf'],
+            ['*.sulu.lo', 'sulu.lo', null],
+        ];
+    }
+
+    /**
+     * @dataProvider provideResolveData
+     */
+    public function testResolve($portalUrl, $url, $expected)
+    {
+        $this->assertEquals($expected, WildcardUrlUtil::resolve($url, $portalUrl));
+    }
+}

--- a/src/Sulu/Component/Util/WildcardUrlUtil.php
+++ b/src/Sulu/Component/Util/WildcardUrlUtil.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Util;
+
+/**
+ * Utility methods to handle wildcard urls.
+ */
+final class WildcardUrlUtil
+{
+    /**
+     * Cannot instantiate this class.
+     */
+    final private function __construct()
+    {
+    }
+
+    /**
+     * Returns regular expression to match given portal-url.
+     *
+     * @param string $portalUrl
+     *
+     * @return string
+     */
+    private static function getRegularExpression($portalUrl)
+    {
+        $patternUrl = rtrim($portalUrl, '/');
+        $patternUrl = preg_quote($patternUrl);
+        $patternUrl = str_replace(['/', '\*'], ['\/', '([^\/.]+)'], $patternUrl);
+
+        return sprintf('/^%s($|([\/].*)|([.].*))$/', $patternUrl);
+    }
+
+    /**
+     * Matches given url with portal-url.
+     *
+     * @param string $url
+     * @param string $portalUrl
+     *
+     * @return bool
+     */
+    public static function match($url, $portalUrl)
+    {
+        return preg_match(self::getRegularExpression($portalUrl), $url);
+    }
+
+    /**
+     * Replaces wildcards with occurrences in the given url.
+     *
+     * @param string $url
+     * @param string $portalUrl
+     *
+     * @return string
+     */
+    public static function resolve($url, $portalUrl)
+    {
+        $regexp = self::getRegularExpression($portalUrl);
+
+        if (preg_match($regexp, $url, $matches)) {
+            for ($i = 0, $countStar = substr_count($portalUrl, '*'); $i < $countStar; ++$i) {
+                $pos = strpos($portalUrl, '*');
+                if ($pos !== false) {
+                    $portalUrl = substr_replace($portalUrl, $matches[$i + 1], $pos, 1);
+                }
+            }
+
+            return $portalUrl;
+        }
+
+        return;
+    }
+}

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -68,7 +68,14 @@ class WebsiteRequestProcessor extends AbstractRequestProcessor
             }
         );
 
-        return $this->processPortalInformation($request, reset($portalInformations));
+        /** @var PortalInformation $portalInformation */
+        $portalInformation = reset($portalInformations);
+
+        return $this->processPortalInformation(
+            $request,
+            $portalInformation,
+            ['urlExpression' => $portalInformation->getUrlExpression()]
+        );
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Webspace\Manager;
 
 use Psr\Log\LoggerInterface;
+use Sulu\Component\Util\WildcardUrlUtil;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\Dumper\PhpWebspaceCollectionDumper;
 use Sulu\Component\Webspace\Portal;
@@ -369,12 +370,6 @@ class WebspaceManager implements WebspaceManagerInterface
      */
     protected function matchUrl($url, $portalUrl)
     {
-        $patternUrl = rtrim($portalUrl, '/');
-        $patternUrl = preg_quote($patternUrl);
-        $patternUrl = str_replace('/', '\/', $patternUrl);
-        $patternUrl = str_replace('\*', '[^\/.]+', $patternUrl);
-        $regexp = sprintf('/^%s($|([\/].*)|([.].*))$/', $patternUrl);
-
-        return preg_match($regexp, $url);
+        return WildcardUrlUtil::match($url, $portalUrl);
     }
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Url/WebspaceUrlChainProviderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Url/WebspaceUrlChainProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Url;
+
+use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Url\WebspaceUrlChainProvider;
+use Sulu\Component\Webspace\Url\WebspaceUrlProviderInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class WebspaceUrlChainProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUrls()
+    {
+        $webspace = $this->prophesize(Webspace::class);
+
+        $provider1 = $this->prophesize(WebspaceUrlProviderInterface::class);
+        $provider1->getUrls($webspace->reveal(), 'prod')->willReturn([new Url('1.sulu.lo'), new Url('2.sulu.lo')]);
+        $provider2 = $this->prophesize(WebspaceUrlProviderInterface::class);
+        $provider2->getUrls($webspace->reveal(), 'prod')->willReturn([new Url('3.sulu.lo'), new Url('4.sulu.lo')]);
+
+        $provider = new WebspaceUrlChainProvider([$provider1->reveal(), $provider2->reveal()]);
+
+        $this->assertEquals(
+            [new Url('1.sulu.lo'), new Url('2.sulu.lo'), new Url('3.sulu.lo'), new Url('4.sulu.lo')],
+            $provider->getUrls($webspace->reveal(), 'prod')
+        );
+    }
+
+    public function testGetUrlsEmptyChain()
+    {
+        $webspace = $this->prophesize(Webspace::class);
+
+        $provider = new WebspaceUrlChainProvider();
+
+        $this->assertEquals([], $provider->getUrls($webspace->reveal(), 'prod'));
+    }
+}

--- a/src/Sulu/Component/Webspace/Tests/Unit/Url/WebspaceUrlProviderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Url/WebspaceUrlProviderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Url;
+
+use Sulu\Component\Webspace\Environment;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Webspace;
+
+class WebspaceUrlProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUrls()
+    {
+        $urls = [
+            new Url('sulu.lo'),
+            new Url('*.sulu.lo'),
+            new Url('sulu.io'),
+            new Url('*.sulu.io'),
+        ];
+
+        $environments = [$this->prophesize(Environment::class), $this->prophesize(Environment::class)];
+        $portals = [$this->prophesize(Portal::class), $this->prophesize(Portal::class)];
+        $portals[0]->getEnvironment('prod')->willReturn($environments[0]->reveal());
+        $portals[1]->getEnvironment('prod')->willReturn($environments[1]->reveal());
+
+        $environments[0]->getUrls()->willReturn([$urls[0], $urls[1]]);
+        $environments[1]->getUrls()->willReturn([$urls[2], $urls[3]]);
+
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getPortals()->willReturn(
+            array_map(
+                function ($portal) {
+                    return $portal->reveal();
+                },
+                $portals
+            )
+        );
+
+        $provider = new Url\WebspaceUrlProvider();
+        $this->assertEquals($urls, $provider->getUrls($webspace->reveal(), 'prod'));
+    }
+}

--- a/src/Sulu/Component/Webspace/Url.php
+++ b/src/Sulu/Component/Webspace/Url.php
@@ -68,9 +68,10 @@ class Url implements ArrayableInterface
      */
     private $environment;
 
-    public function __construct($url = null)
+    public function __construct($url = null, $environment = null)
     {
         $this->url = $url;
+        $this->environment = $environment;
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Url/WebspaceUrlChainProvider.php
+++ b/src/Sulu/Component/Webspace/Url/WebspaceUrlChainProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Url;
+
+use Sulu\Component\Webspace\Webspace;
+
+/**
+ * Combines multiple url-provider.
+ */
+class WebspaceUrlChainProvider implements WebspaceUrlProviderInterface
+{
+    /**
+     * @var WebspaceUrlProviderInterface[]
+     */
+    private $chain;
+
+    public function __construct(array $chain = [])
+    {
+        $this->chain = $chain;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUrls(Webspace $webspace, $environment)
+    {
+        $urls = [];
+        foreach ($this->chain as $provider) {
+            $urls = array_merge($urls, $provider->getUrls($webspace, $environment));
+        }
+
+        return $urls;
+    }
+}

--- a/src/Sulu/Component/Webspace/Url/WebspaceUrlProvider.php
+++ b/src/Sulu/Component/Webspace/Url/WebspaceUrlProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Url;
+
+use Sulu\Component\Webspace\Webspace;
+
+/**
+ * Returns urls of given webspace.
+ */
+class WebspaceUrlProvider implements WebspaceUrlProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getUrls(Webspace $webspace, $environment)
+    {
+        $urls = [];
+        foreach ($webspace->getPortals() as $portal) {
+            $urls = array_merge($urls, $portal->getEnvironment($environment)->getUrls());
+        }
+
+        return $urls;
+    }
+}

--- a/src/Sulu/Component/Webspace/Url/WebspaceUrlProviderInterface.php
+++ b/src/Sulu/Component/Webspace/Url/WebspaceUrlProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Url;
+
+use Sulu\Component\Webspace\Url;
+use Sulu\Component\Webspace\Webspace;
+
+/**
+ * Provides urls for given webspace.
+ */
+interface WebspaceUrlProviderInterface
+{
+    /**
+     * Returns urls for given webspace.
+     *
+     * @param Webspace $webspace
+     * @param string $environment
+     *
+     * @return Url[]
+     */
+    public function getUrls(Webspace $webspace, $environment);
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | missing feature of PR #1927 and fixes https://github.com/sulu-io/sulu-standard/issues/594
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR integrates the custom-urls into the analytics.

#### Why?

After merging that you can manage own analytic keys for the custom-urls.
