### PR TITLE
Cache jackrabbit download in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ php:
 cache:
   directories:
     - $HOME/.composer/cache
+    - downloads
 
 env:
   global:
     - JACKRABBIT_VERSION=2.12.0
 
 before_script:
-  - wget http://archive.apache.org/dist/jackrabbit/$JACKRABBIT_VERSION/jackrabbit-standalone-$JACKRABBIT_VERSION.jar
-  - java -jar jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
+  - if [ ! -d downloads ]; then mkdir downloads; fi
+  - if [ ! -f downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar ]; then cd downloads; wget http://archive.apache.org/dist/jackrabbit/$JACKRABBIT_VERSION/jackrabbit-standalone-$JACKRABBIT_VERSION.jar; cd -; fi
+  - java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
   - phpenv config-rm xdebug.ini
   - composer self-update
   - composer install  --prefer-dist --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,3 @@ script:
 notifications:
   slack:
     secure: "Gd3/1e0pBKvJv1UhWpBkWijJpmSWlarg6uPBJO0h4z1IpkZjd++jOjhmOQ7n+yMfuapQuJTcVOK0yIWu7orJoGAKFkBlMEIrLk1xMAG9phjjMLUO0FWgcQ3eVW5mTyfMBtClz4OL5wXckw17ohtXHDK8qnI0Hz9Qj8Rqgf2OZhM="
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2269 [WebsiteBundle]       Added query string to redirect for internal links
+    * ENHANCEMENT #2189 [Travis]              Cache jackrabbit download
     * BUGFIX      #2267 [CategoryBundle]      Fixed collaboration component
     * BUGFIX      #2255 [WebsocketBundle]     Introduced own websocket app to avoid connecting to port 8843
     * BUGFIX      #2258 [WebsiteBundle]       Added validation of analytic type

--- a/bin/runtests
+++ b/bin/runtests
@@ -259,7 +259,7 @@ function jackrabbit_restart()
 
     $process = new Process(sprintf(
         'java -jar %s --repo %s/jackrabbit > jackrabbit_process.log &',
-        $jackrabbitJar->getFilename(), dirname($jackrabbitJar->getPathname())
+        $jackrabbitJar->getPathname(), dirname(dirname($jackrabbitJar->getPathname()))
     ));
     $process->start();
     while (false === jackrabbit_is_up()) {
@@ -279,7 +279,7 @@ function jackrabbit_is_up()
 function jackrabbit_pid()
 {
     $jackrabbitJar = jackrabbit_get_path();
-    $process = exec_cmd('pgrep -f -n "java \-jar ' . basename($jackrabbitJar) . '"', false, false);
+    $process = exec_cmd('pgrep -f -n "java \-jar .*' . basename($jackrabbitJar) . '"', false, false);
 
     // no process found
     if ($process->getExitCode() == 1) {
@@ -292,7 +292,7 @@ function jackrabbit_pid()
 function jackrabbit_get_path()
 {
     static $jackrabbit = null;
-    $jackrabbitPath = realpath(__DIR__ . '/../');
+    $jackrabbitPath = realpath(__DIR__ . '/../downloads');
 
     if (!$jackrabbit) {
         $finder = Finder::create()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

This PR will try and cache the jackrabbit-stanalone.jar file, which is around 70M andis downloaded everytime the build runs.

#### Why?

Because jackrabbit can take some time to download


