### PR TITLE
Added option to ignore required properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2193 [ContentBundle]       Ignore required properties on homepages during initialization.
     * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
     * ENHANCEMENT #2192 [WebsiteBundle]       Added X-Generator HTTP header for Sulu website detection
     * BUGFIX      #2183 [ContentBundle]       Added missing locale for loading route document

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -102,12 +102,14 @@ class StructureSubscriber implements EventSubscriberInterface
             [
                 'load_ghost_content' => true,
                 'clear_missing_content' => false,
+                'ignore_required' => false,
             ]
         );
         $options->setAllowedTypes(
             [
                 'load_ghost_content' => 'bool',
                 'clear_missing_content' => 'bool',
+                'ignore_required' => 'bool',
             ]
         );
     }
@@ -203,8 +205,9 @@ class StructureSubscriber implements EventSubscriberInterface
 
         $node = $event->getNode();
         $locale = $event->getLocale();
+        $options = $event->getOptions();
 
-        $this->mapContentToNode($document, $node, $locale);
+        $this->mapContentToNode($document, $node, $locale, $options['ignore_required']);
 
         $node->setProperty(
             $this->getStructureTypePropertyName($document, $locale),
@@ -248,10 +251,11 @@ class StructureSubscriber implements EventSubscriberInterface
      * @param mixed $document
      * @param NodeInterface $node
      * @param string $locale
+     * @param bool $ignoreRequired
      *
      * @throws MandatoryPropertyException
      */
-    private function mapContentToNode($document, NodeInterface $node, $locale)
+    private function mapContentToNode($document, NodeInterface $node, $locale, $ignoreRequired)
     {
         $structure = $document->getStructure();
         $webspaceName = $this->inspector->getWebspace($document);
@@ -261,7 +265,7 @@ class StructureSubscriber implements EventSubscriberInterface
             $realProperty = $structure->getProperty($propertyName);
             $value = $realProperty->getValue();
 
-            if ($structureProperty->isRequired() && null === $value) {
+            if (false === $ignoreRequired && $structureProperty->isRequired() && null === $value) {
                 throw new MandatoryPropertyException(
                     sprintf(
                         'Property "%s" in structure "%s" is required but no value was given. Loaded from "%s"',

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -91,9 +91,10 @@ class WebspaceInitializer implements InitializerInterface
             ]);
             $existingLocales = $this->inspector->getLocales($homeDocument);
         } else {
+            $homeType = $webspace->getTheme()->getDefaultTemplate('homepage');
             $homeDocument = new HomeDocument();
             $homeDocument->setTitle('Homepage');
-            $homeDocument->setStructureType($webspace->getTheme()->getDefaultTemplate('homepage'));
+            $homeDocument->setStructureType($homeType);
             $homeDocument->setWorkflowStage(WorkflowStage::PUBLISHED);
             $existingLocales = [];
         }
@@ -104,7 +105,7 @@ class WebspaceInitializer implements InitializerInterface
                 continue;
             }
 
-            $output->writeln(sprintf('  [+] <info>homepage</info>: %s (%s)', $homePath, $webspaceLocale));
+            $output->writeln(sprintf('  [+] <info>homepage</info>: [%s] %s (%s)', $homeType, $homePath, $webspaceLocale));
 
             $routePath = $routesPath . '/' . $webspaceLocale;
             try {
@@ -116,6 +117,7 @@ class WebspaceInitializer implements InitializerInterface
             $this->documentManager->persist($homeDocument, $webspaceLocale, [
                 'path' => $homePath,
                 'auto_create' => true,
+                'ignore_required' => true,
             ]);
 
             $routeDocument->setTargetDocument($homeDocument);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
@@ -126,17 +126,29 @@ class WebspaceInitializerTest extends \PHPUnit_Framework_TestCase
         $this->documentManager->persist(
             Argument::type(HomeDocument::class),
             'de',
-            ['path' => '/cmf/webspace1/contents', 'auto_create' => true]
+            [
+                'path' => '/cmf/webspace1/contents',
+                'auto_create' => true,
+                'ignore_required' => true,
+            ]
         )->shouldBeCalled();
         $this->documentManager->persist(
             Argument::type(HomeDocument::class),
             'en',
-            ['path' => '/cmf/webspace1/contents', 'auto_create' => true]
+            [
+                'path' => '/cmf/webspace1/contents',
+                'auto_create' => true,
+                'ignore_required' => true,
+            ]
         )->shouldBeCalled();
         $this->documentManager->persist(
             Argument::type(HomeDocument::class),
             'de',
-            ['path' => '/cmf/webspace2/contents', 'auto_create' => true]
+            [
+                'path' => '/cmf/webspace2/contents',
+                'auto_create' => true,
+                'ignore_required' => true,
+            ]
         )->shouldBeCalled();
 
         $this->documentManager->persist(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #1951
| License | MIT

#### What's in this PR?

This PR adds a new, undocumented, persist option to ignore require properties in tempates.

#### Why?

Currently the user may define a "home" template that has required fields, in sch a case the initialization will fail.

