### PR TITLE
Initialization fixes

### DIFF
--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
@@ -26,7 +26,7 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu.phpcr.session"/>
 
-            <tag name="sulu_document_manager.initializer"/>
+            <tag name="sulu_document_manager.initializer" priority="-127"/>
         </service>
 
         <service id="sulu_custom_urls.subscriber"

--- a/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
@@ -39,13 +39,9 @@ class WorkspaceInitializer implements InitializerInterface
             $workspace = $connection->getWorkspace();
 
             try {
-                $connection->getRootNode();
+                $workspace->createWorkspace($workspace->getName());
                 $output->writeln(sprintf('  [ ] <info>workspace</info>: "%s"', $workspace->getName()));
             } catch (RepositoryException $e) {
-                // TODO: We should catch the more explicit
-                // WorkspaceNotFoundException but Jackalope doctrine-dbal does
-                // not throw this: https://github.com/jackalope/jackalope-doctrine-dbal/issues/322
-                $workspace->createWorkspace($workspace->getName());
                 $output->writeln(sprintf('  [+] <info>workspace</info>: "%s"', $workspace->getName()));
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
| Documentation PR | sulu-io/sulu-docs#prnum |
#### What's in this PR?

This PR adds some DBAL fixes for the `sulu:document:initialization` command.
- Execute custom URL intitialization after workspace creation.
- Create workspace as test to see if workspace exists.
