### PR TITLE
Added media field credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #2204 [WebsiteBundle]       Enhanced custom-route creation 
     * FEATURE     #2201 [All]                 Added collaboration message to all sulu core-bundles
     * ENHANCEMENT #2196 [AdminBundle]         Restructured admin-navigation
+    * FEATURE     #2197 [MediaBundle]         Added media field credits
     * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
     * ENHANCEMENT #2192 [WebsiteBundle]       Added X-Generator HTTP header for Sulu website detection
     * ENHANCEMENT #2125 [All]                 Upgraded to DoctrinePHPCRBundle 1.3

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -302,6 +302,37 @@ class Media extends ApiWrapper
     }
 
     /**
+     * @param string $credits
+     *
+     * @return $this
+     */
+    public function setCredits($credits)
+    {
+        $this->getMeta(true)->setCredits($credits);
+
+        return $this;
+    }
+
+    /**
+     * Returns copyright for media.
+     *
+     * @VirtualProperty
+     * @SerializedName("credits")
+     *
+     * @return string
+     *
+     * @throws FileVersionNotFoundException
+     */
+    public function getCredits()
+    {
+        if (!$this->getLocalizedMeta()) {
+            return;
+        }
+
+        return $this->getLocalizedMeta()->getCredits();
+    }
+
+    /**
      * @param int $version
      *
      * @return $this

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -56,6 +56,7 @@ class AbstractMediaController extends RestController
             'title' => $request->get('title', $fallback ? $this->getTitleFromUpload($request, 'fileVersion') : null),
             'description' => $request->get('description'),
             'copyright' => $request->get('copyright'),
+            'credits' => $request->get('credits'),
             'changer' => $request->get('changer'),
             'creator' => $request->get('creator'),
             'changed' => $request->get('changed'),

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMeta.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMeta.php
@@ -39,6 +39,11 @@ class FileVersionMeta
     /**
      * @var string
      */
+    private $credits;
+
+    /**
+     * @var string
+     */
     private $locale;
 
     /**
@@ -126,6 +131,30 @@ class FileVersionMeta
     public function getCopyright()
     {
         return $this->copyright;
+    }
+
+    /**
+     * Set credits.
+     *
+     * @param string $credits
+     *
+     * @return FileVersionMeta
+     */
+    public function setCredits($credits)
+    {
+        $this->credits = $credits;
+
+        return $this;
+    }
+
+    /**
+     * Get credits.
+     *
+     * @return string
+     */
+    public function getCredits()
+    {
+        return $this->credits;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -705,7 +705,8 @@ class MediaManager implements MediaManagerInterface
                 ($attribute === 'tags' && $value !== null) ||
                 ($attribute === 'size' && $value !== null) ||
                 ($attribute === 'description' && $value !== null) ||
-                ($attribute === 'copyright' && $value !== null)
+                ($attribute === 'copyright' && $value !== null) ||
+                ($attribute === 'credits' && $value !== null)
             ) {
                 switch ($attribute) {
                     case 'size':
@@ -719,6 +720,9 @@ class MediaManager implements MediaManagerInterface
                         break;
                     case 'copyright':
                         $media->setCopyright($value);
+                        break;
+                    case 'credits':
+                        $media->setCredits($value);
                         break;
                     case 'version':
                         $media->setVersion($value);

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
@@ -16,6 +16,7 @@
         <field name="title" type="string" column="title" length="255"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="copyright" type="text" column="copyright" nullable="true"/>
+        <field name="credits" type="text" column="credits" nullable="true"/>
         <field name="locale" type="string" column="locale" length="5"/>
 
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="meta">

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/js/components/collections/media-edit-overlay/copyright.html
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/js/components/collections/media-edit-overlay/copyright.html
@@ -9,4 +9,14 @@
             </div>
         </div>
     </div>
+    <div class="grid-row">
+        <div class="grid-col-12">
+            <div class="form-group m-bottom-20">
+                <label for="media-edit-credits"><%= translate('sulu.media.credits-information') %></label>
+                <textarea id="media-edit-credits"
+                          class="form-element"
+                          data-mapper-property="credits"></textarea>
+            </div>
+        </div>
+    </div>
 </form>

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/js/components/collections/media-edit-overlay/main.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/js/components/collections/media-edit-overlay/main.js
@@ -237,7 +237,7 @@ define([
 
             var tabs = [
                 {title: this.sandbox.translate('public.info'), data: $info},
-                {title: this.sandbox.translate('sulu.media.copyright'), data: $copyright}
+                {title: this.sandbox.translate('sulu.media.licence'), data: $copyright}
             ];
 
             if (!!$preview) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/js/models/media.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/js/models/media.js
@@ -23,6 +23,7 @@ define(['mvc/relationalmodel'], function (RelationalModel) {
                 description: '',
                 tags: [],
                 copyright: '',
+                credits: '',
                 versions: {}
             };
         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.de.xlf
@@ -222,6 +222,14 @@
                 <source>sulu.media.copyright</source>
                 <target>Urheberrecht</target>
             </trans-unit>
+            <trans-unit id="243d88cf2f646526337ls55369f11111" resname="sulu.media.licence">
+                <source>sulu.media.licence</source>
+                <target>Lizenz</target>
+            </trans-unit>
+            <trans-unit id="243d88cf2f646526337ls55369f22222" resname="sulu.media.credits-information">
+                <source>sulu.media.credits-information</source>
+                <target>Bildnachweis</target>
+            </trans-unit>
             <trans-unit id="243d88cf2f646526337ls55369f22124" resname="sulu.media.copyright-information">
                 <source>sulu.media.copyright-information</source>
                 <target>Urheberrechtsinformationen</target>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.en.xlf
@@ -222,6 +222,14 @@
                 <source>sulu.media.copyright</source>
                 <target>Copyright</target>
             </trans-unit>
+            <trans-unit id="243d88cf2f646526337ls55369f11111" resname="sulu.media.licence">
+                <source>sulu.media.licence</source>
+                <target>Licence</target>
+            </trans-unit>
+            <trans-unit id="243d88cf2f646526337ls55369f22222" resname="sulu.media.credits-information">
+                <source>sulu.media.credits-information</source>
+                <target>Media credits</target>
+            </trans-unit>
             <trans-unit id="243d88cf2f646526337ls55369f22124" resname="sulu.media.copyright-information">
                 <source>sulu.media.copyright-information</source>
                 <target>Copyright information</target>

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/sulu/backend.fr.xlf
@@ -222,6 +222,14 @@
                 <source>sulu.media.copyright</source>
                 <target>Copyright</target>
             </trans-unit>
+            <trans-unit id="243d88cf2f646526337ls55369f11111" resname="sulu.media.licence">
+                <source>sulu.media.licence</source>
+                <target>Licence</target>
+            </trans-unit>
+            <trans-unit id="243d88cf2f646526337ls55369f22222" resname="sulu.media.credits-information">
+                <source>sulu.media.credits-information</source>
+                <target>Médias credits</target>
+            </trans-unit>
             <trans-unit id="243d88cf2f646526337ls55369f22124" resname="sulu.media.copyright-information">
                 <source>sulu.media.copyright-information</source>
                 <target>Copyright information</target>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -639,6 +639,7 @@ class MediaControllerTest extends SuluTestCase
                 'title' => 'New Image Title',
                 'description' => 'New Image Description',
                 'copyright' => 'My copyright',
+                'credits' => 'My credits',
                 'contentLanguages' => [
                     'en-gb',
                 ],
@@ -667,6 +668,7 @@ class MediaControllerTest extends SuluTestCase
         $this->assertEquals('New Image Title', $response->title);
         $this->assertEquals('New Image Description', $response->description);
         $this->assertEquals('My copyright', $response->copyright);
+        $this->assertEquals('My credits', $response->credits);
         $this->assertNotEmpty($response->url);
         $this->assertNotEmpty($response->thumbnails);
 
@@ -780,6 +782,7 @@ class MediaControllerTest extends SuluTestCase
                 'title' => 'New Image Title',
                 'description' => 'New Image Description',
                 'copyright' => 'My copyright',
+                'credits' => 'My credits',
                 'contentLanguages' => [
                     'en-gb',
                 ],
@@ -809,6 +812,7 @@ class MediaControllerTest extends SuluTestCase
         $this->assertEquals('New Image Title', $response->title);
         $this->assertEquals('New Image Description', $response->description);
         $this->assertEquals('My copyright', $response->copyright);
+        $this->assertEquals('My credits', $response->credits);
         $this->assertEquals(
             [
                 'en-gb',
@@ -844,6 +848,7 @@ class MediaControllerTest extends SuluTestCase
                 'title' => 'Update Title',
                 'description' => 'Update Description',
                 'copyright' => 'My copyright',
+                'credits' => 'My credits',
                 'contentLanguages' => [
                     'en-gb',
                 ],
@@ -867,6 +872,7 @@ class MediaControllerTest extends SuluTestCase
         $this->assertEquals('Update Title', $response->title);
         $this->assertEquals('Update Description', $response->description);
         $this->assertEquals('My copyright', $response->copyright);
+        $this->assertEquals('My credits', $response->credits);
         $this->assertNotEmpty($response->url);
         $this->assertNotEmpty($response->thumbnails);
         $this->assertEquals(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu-io/sulu-standard/pull/652
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a media-credit field.

#### Why?

To differentiate credits from copyright information.