### PR TITLE
Fixed syntax mistake in snippet-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2199 [SnippetBundle]       Fixed syntax mistake in snippet-controller
     * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
     * ENHANCEMENT #2192 [WebsiteBundle]       Added X-Generator HTTP header for Sulu website detection
     * ENHANCEMENT #2125 [All]                 Upgraded to DoctrinePHPCRBundle 1.3

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -457,7 +457,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
                 );
                 $data['structures'][] = $content->toArray();
             } else {
-                $data['other'] = $reference->getPath();
+                $data['other'][] = $reference->getParent()->getPath();
             }
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a mistake in the snippet-controller which creates a wrong response when snippet is referenced.

#### Why?

The response contains only the path to one "other" reference. This is not correct because of a typo in the SnippetController (missing append operator)