### PR TITLE
Added wildcard url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG for Sulu
     * FEATURE     #2201 [All]                 Added collaboration message to all sulu core-bundles
     * ENHANCEMENT #2196 [AdminBundle]         Restructured admin-navigation
     * FEATURE     #2197 [MediaBundle]         Added media field credits
+    * FEATURE     #2203 [WebsiteBundle]       Added host replacer to portal routes to support wildcard-urls 
     * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
     * ENHANCEMENT #2192 [WebsiteBundle]       Added X-Generator HTTP header for Sulu website detection
     * ENHANCEMENT #2125 [All]                 Upgraded to DoctrinePHPCRBundle 1.3

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -22,6 +22,7 @@
                  class="Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu.content.mapper"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument type="string">%kernel.environment%</argument>
 
             <tag name="sulu.context" context="website"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -53,7 +53,6 @@ class PortalLoader extends Loader
         /** @var Route[] $importedRoutes */
         $importedRoutes = $this->import($resource, null);
 
-        $condition = $this->getCondition();
         foreach ($importedRoutes as $importedRouteName => $importedRoute) {
             $this->collection->add(
                 $importedRouteName,
@@ -65,7 +64,7 @@ class PortalLoader extends Loader
                     '{host}',
                     $importedRoute->getSchemes(),
                     $importedRoute->getMethods(),
-                    $condition
+                    $importedRoute->getCondition()
                 )
             );
         }
@@ -79,24 +78,5 @@ class PortalLoader extends Loader
     public function supports($resource, $type = null)
     {
         return $type === 'portal';
-    }
-
-    /**
-     * This condition ensures only existing parameters.
-     *
-     * @return string
-     */
-    private function getCondition()
-    {
-        $conditionParts = [];
-        foreach ($this->webspaceManager->getPortalInformations($this->environment) as $portalInformation) {
-            $conditionParts[] = sprintf(
-                'context.getHost() == \'%s\' and context.getParameter(\'prefix\') == \'%s\'',
-                $portalInformation->getHost(),
-                $portalInformation->getPrefix()
-            );
-        }
-
-        return sprintf('(%s)', implode(') or (', $conditionParts));
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -107,14 +107,6 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
         $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
         $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
-        $this->assertEquals(
-            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'\')',
-            $routeCollection->get('route1')->getCondition()
-        );
-        $this->assertEquals(
-            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'\')',
-            $routeCollection->get('route2')->getCondition()
-        );
     }
 
     public function testLoadWithCustomUrls()
@@ -156,14 +148,6 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
         $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
         $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
-        $this->assertEquals(
-            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/en\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'/*\')',
-            $routeCollection->get('route1')->getCondition()
-        );
-        $this->assertEquals(
-            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/en\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'/*\')',
-            $routeCollection->get('route2')->getCondition()
-        );
     }
 
     public function testLoadPartial()
@@ -205,9 +189,5 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('{prefix}/route', $routeCollection->get('route')->getPath());
         $this->assertEquals('{host}', $routeCollection->get('route')->getHost());
-        $this->assertEquals(
-            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'\')',
-            $routeCollection->get('route')->getCondition()
-        );
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -68,8 +68,7 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
      */
     public function getContentPath($url, $webspaceKey = null, $locale = null, $domain = null, $scheme = 'http')
     {
-        if (
-            $webspaceKey !== null &&
+        if ($webspaceKey !== null &&
             $this->requestAnalyzer
         ) {
             return $this->webspaceManager->findUrlByResourceLocator(

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -14,6 +14,7 @@ use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\Exception\UrlMatchNotFoundException;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -36,13 +37,20 @@ class WebsiteRequestProcessor extends AbstractRequestProcessor
      */
     private $environment;
 
+    /**
+     * @var ReplacerInterface
+     */
+    private $replacer;
+
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
         ContentMapperInterface $contentMapper,
+        ReplacerInterface $replacer,
         $environment
     ) {
         $this->webspaceManager = $webspaceManager;
         $this->contentMapper = $contentMapper;
+        $this->replacer = $replacer;
         $this->environment = $environment;
     }
 
@@ -52,6 +60,14 @@ class WebsiteRequestProcessor extends AbstractRequestProcessor
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
         $url = $request->getHost() . $request->getPathInfo();
+        $urlInfo = parse_url($request->getScheme() . '://' . $url);
+        foreach ($this->webspaceManager->getPortalInformations($this->environment) as $portalInformation) {
+            $portalUrl = $this->replacer->replaceHost($portalInformation->getUrl(), $urlInfo['host']);
+            $portalInformation->setUrl($portalUrl);
+            $portalRedirect = $this->replacer->replaceHost($portalInformation->getRedirect(), $urlInfo['host']);
+            $portalInformation->setRedirect($portalRedirect);
+        }
+
         $portalInformations = $this->webspaceManager->findPortalInformationsByUrl(
             $url,
             $this->environment

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -80,7 +80,7 @@ class WebsiteRequestProcessor extends AbstractRequestProcessor
         usort(
             $portalInformations,
             function (PortalInformation $a, PortalInformation $b) {
-                return $a->getType() > $b->getType();
+                return $a->getPriority() < $b->getPriority();
             }
         );
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -360,7 +360,15 @@ class WebspaceCollectionBuilder
             $replacers[ReplacerInterface::REPLACER_SEGMENT] = $defaultSegment->getKey();
         }
 
-        $urlResult = $this->urlReplacer->cleanup($urlAddress);
+        $urlResult = $this->urlReplacer->cleanup(
+            $urlAddress,
+            [
+                ReplacerInterface::REPLACER_LANGUAGE,
+                ReplacerInterface::REPLACER_COUNTRY,
+                ReplacerInterface::REPLACER_LOCALIZATION,
+                ReplacerInterface::REPLACER_SEGMENT,
+            ]
+        );
         $urlRedirect = $this->generateUrlAddress($urlAddress, $replacers);
 
         if ($this->validateUrlPartialMatch($urlResult, $environment)) {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -235,7 +235,8 @@ class WebspaceCollectionBuilder
                     null,
                     null,
                     false,
-                    $urlAddress
+                    $urlAddress,
+                    1
                 );
             }
 
@@ -250,7 +251,8 @@ class WebspaceCollectionBuilder
                 null,
                 null,
                 false,
-                $urlAddress
+                $urlAddress,
+                1
             );
         }
     }
@@ -281,7 +283,8 @@ class WebspaceCollectionBuilder
             $urlRedirect,
             $urlAnalyticsKey,
             $url->isMain(),
-            $url->getUrl()
+            $url->getUrl(),
+            $this->urlReplacer->hasHostReplacer($urlAddress) ? 4 : 9
         );
     }
 
@@ -319,7 +322,8 @@ class WebspaceCollectionBuilder
                     null,
                     $urlAnalyticsKey,
                     $url->isMain(),
-                    $url->getUrl()
+                    $url->getUrl(),
+                    $this->urlReplacer->hasHostReplacer($urlResult) ? 5 : 10
                 );
             }
         } else {
@@ -334,7 +338,8 @@ class WebspaceCollectionBuilder
                 null,
                 $urlAnalyticsKey,
                 $url->isMain(),
-                $url->getUrl()
+                $url->getUrl(),
+                $this->urlReplacer->hasHostReplacer($urlResult) ? 5 : 10
             );
         }
     }
@@ -382,7 +387,8 @@ class WebspaceCollectionBuilder
                 $urlRedirect,
                 $urlAnalyticsKey,
                 false, // partial matches cannot be main
-                $url->getUrl()
+                $url->getUrl(),
+                $this->urlReplacer->hasHostReplacer($urlResult) ? 4 : 9
             );
         }
     }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -94,8 +94,8 @@ class WebspaceManager implements WebspaceManagerInterface
     public function findPortalInformationByUrl($url, $environment)
     {
         $portalInformations = $this->getWebspaceCollection()->getPortalInformations($environment);
-        foreach ($portalInformations as $portalUrl => $portalInformation) {
-            if ($this->matchUrl($url, $portalUrl)) {
+        foreach ($portalInformations as $portalInformation) {
+            if ($this->matchUrl($url, $portalInformation->getUrl())) {
                 return $portalInformation;
             }
         }
@@ -150,10 +150,10 @@ class WebspaceManager implements WebspaceManagerInterface
             $environment,
             [RequestAnalyzerInterface::MATCH_TYPE_FULL]
         );
-        foreach ($portals as $url => $portalInformation) {
+        foreach ($portals as $portalInformation) {
             $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
-            $url = rtrim(sprintf('%s://%s%s', $scheme, $url, $resourceLocator), '/');
+            $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
                 $urls[] = $url;
             }
@@ -182,13 +182,13 @@ class WebspaceManager implements WebspaceManagerInterface
                 RequestAnalyzerInterface::MATCH_TYPE_REDIRECT,
             ]
         );
-        foreach ($portals as $url => $portalInformation) {
+        foreach ($portals as $portalInformation) {
             $sameLocalization = (
                 $portalInformation->getLocalization() === null
                 || $portalInformation->getLocalization()->getLocalization() === $languageCode
             );
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
-            $url = rtrim(sprintf('%s://%s%s', $scheme, $url, $resourceLocator), '/');
+            $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
                 if ($portalInformation->isMain()) {
                     array_unshift($urls, $url);

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -83,6 +83,11 @@ class PortalInformation implements ArrayableInterface
      */
     private $urlExpression;
 
+    /**
+     * @var int
+     */
+    private $priority;
+
     public function __construct(
         $type,
         Webspace $webspace = null,
@@ -93,7 +98,8 @@ class PortalInformation implements ArrayableInterface
         $redirect = null,
         $analyticsKey = null,
         $main = false,
-        $urlExpression = null
+        $urlExpression = null,
+        $priority = 0
     ) {
         $this->setType($type);
         $this->setWebspace($webspace);
@@ -105,6 +111,7 @@ class PortalInformation implements ArrayableInterface
         $this->setAnalyticsKey($analyticsKey);
         $this->setMain($main);
         $this->setUrlExpression($urlExpression);
+        $this->setPriority($priority);
     }
 
     /**
@@ -379,6 +386,22 @@ class PortalInformation implements ArrayableInterface
     }
 
     /**
+     * @return int
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @param int $priority
+     */
+    public function setPriority($priority)
+    {
+        $this->priority = $priority;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function toArray($depth = null)
@@ -388,6 +411,7 @@ class PortalInformation implements ArrayableInterface
         $result['webspace'] = $this->getWebspace()->getKey();
         $result['url'] = $this->getUrl();
         $result['main'] = $this->isMain();
+        $result['priority'] = $this->getPriority();
 
         $portal = $this->getPortal();
         if ($portal) {

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -164,10 +164,11 @@ class {{ cache_class }} extends {{ base_class }}
             false,
 {% endif %}
 {% if portalInformation.urlExpression %}
-            '{{ portalInformation.urlExpression }}'
+            '{{ portalInformation.urlExpression }}',
 {% else %}
-            null
+            null,
 {% endif %}
+            {{ portalInformation.priority }}
         );
 
 {% endfor %}

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalInformationTest.php
@@ -59,6 +59,7 @@ class PortalInformationTest extends \PHPUnit_Framework_TestCase
             'localization' => ['foo'],
             'redirect' => true,
             'main' => false,
+            'priority' => 0,
         ];
 
         $this->portal->getKey()->willReturn($expected['portal']);

--- a/src/Sulu/Component/Webspace/Url/Replacer.php
+++ b/src/Sulu/Component/Webspace/Url/Replacer.php
@@ -111,15 +111,6 @@ class Replacer implements ReplacerInterface
         return str_replace($replacer, $value, $url);
     }
 
-    public function replaceAll($url, $replacers)
-    {
-        foreach ($replacers as $replacer => $value) {
-            $url = $this->replace($url, $replacer, $value);
-        }
-
-        return $url;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Sulu/Component/Webspace/Url/Replacer.php
+++ b/src/Sulu/Component/Webspace/Url/Replacer.php
@@ -20,6 +20,7 @@ class Replacer implements ReplacerInterface
         self::REPLACER_COUNTRY,
         self::REPLACER_LOCALIZATION,
         self::REPLACER_SEGMENT,
+        self::REPLACER_HOST,
     ];
 
     /**
@@ -89,17 +90,46 @@ class Replacer implements ReplacerInterface
     /**
      * {@inheritdoc}
      */
-    public function replace($url, $replacer, $value)
+    public function hasHostReplacer($url)
     {
-        return str_replace($replacer, $value, $url);
+        return $this->hasReplacer($url, self::REPLACER_HOST);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function cleanup($url)
+    public function replaceHost($url, $host)
     {
-        foreach ($this->replacers as $replacer) {
+        return $this->replace($url, self::REPLACER_HOST, $host);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replace($url, $replacer, $value)
+    {
+        return str_replace($replacer, $value, $url);
+    }
+
+    public function replaceAll($url, $replacers)
+    {
+        foreach ($replacers as $replacer => $value) {
+            $url = $this->replace($url, $replacer, $value);
+        }
+
+        return $url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cleanup($url, array $replacers = null)
+    {
+        if (!$replacers) {
+            $replacers = $this->replacers;
+        }
+
+        foreach ($replacers as $replacer) {
             $url = $this->replace($url, $replacer, '');
         }
 

--- a/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
+++ b/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
@@ -19,6 +19,7 @@ interface ReplacerInterface
     const REPLACER_COUNTRY = '{country}';
     const REPLACER_LOCALIZATION = '{localization}';
     const REPLACER_SEGMENT = '{segment}';
+    const REPLACER_HOST = '{host}';
 
     /**
      * Returns true if language replacer exists.
@@ -97,6 +98,25 @@ interface ReplacerInterface
     public function replaceSegment($url, $segment);
 
     /**
+     * Returns true if host replacer exists.
+     *
+     * @param string $url
+     *
+     * @return bool
+     */
+    public function hasHostReplacer($url);
+
+    /**
+     * Replace host with given value.
+     *
+     * @param string $url
+     * @param string $host
+     *
+     * @return string
+     */
+    public function replaceHost($url, $host);
+
+    /**
      * Replace replacer with given value.
      *
      * @param string $url
@@ -111,10 +131,11 @@ interface ReplacerInterface
      * Removes all replacers.
      *
      * @param string $url
+     * @param array $replacers
      *
      * @return string
      */
-    public function cleanup($url);
+    public function cleanup($url, array $replacers = null);
 
     /**
      * Appends localization replacer to url.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu-io/sulu-standard/pull/654 https://github.com/sulu-io/sulu/pull/2204
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/195

#### What's in this PR?

This PR adds the `{host}` placeholder to the urls. This can be used to match every host to a portal.

#### Why?

In some cases its not possible to determine one single host for a portal (see platform.sh) there you get a URL which changes over time.

Also if sulu is used by a single portal this placeholder can be used to simplify the creation of webspaces.

#### Example Usage

~~~php
<environment type="dev">
    <urls>
        <url>{host}/{localization}</url>
    </urls>
</environment>
~~~

#### To Do

- [x] Create a documentation PR
- [x] test
- [x] pretify

