### PR TITLE
Enhanced custom-route creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #1980 [MediaBundle]         Sort assets by created date descending in lists
     * BUGFIX      #2193 [ContentBundle]       Ignore required properties on homepages during initialization.
     * BUGFIX      #2199 [SnippetBundle]       Fixed syntax mistake in snippet-controller
+    * ENHANCEMENT #2204 [WebsiteBundle]       Enhanced custom-route creation 
     * BUGFIX      #2190 [WebsiteBundle]       Fixed wrong translator locale by decorating translator
     * ENHANCEMENT #2192 [WebsiteBundle]       Added X-Generator HTTP header for Sulu website detection
     * ENHANCEMENT #2125 [All]                 Upgraded to DoctrinePHPCRBundle 1.3

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,22 @@
 
 ## dev-develop
 
+### Custom-Routes
+
+The naming of the custom-routes with `type: portal` has changed. You can use now the configured name 
+and pass the host and prefix in the parameter. The current parameter will be populated in the variable
+`request.routeParameters`.
+
+__before:__
+```
+{{ path(request.portalUrl ~'.'~ request.locale ~ '.website_search') }}
+```
+
+__after:__
+```
+{{ path('website_search', request.routeParameters) }}
+```
+
 ### Twig function `sulu_resolve_user`
 
 This twig function returns now the user. To get the related contact use following code snippet:

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -73,6 +73,10 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
                 'get' => $requestAnalyzer->getGetParameters(),
                 'post' => $requestAnalyzer->getPostParameters(),
                 'analyticsKey' => $requestAnalyzer->getAnalyticsKey(),
+                'routeParameters' => [
+                    'host' => $requestAnalyzer->getPortalInformation()->getHost(),
+                    'prefix' => $requestAnalyzer->getPortalInformation()->getPrefix(),
+                ],
             ],
         ];
     }
@@ -83,24 +87,28 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
     public function resolveForPreview($webspaceKey, $locale)
     {
         // take first portal url
-        $portalInformation = $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale(
+        $portalInformations = $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale(
             $webspaceKey,
             $locale,
             $this->environment
         );
-        $portalUrl = array_keys($portalInformation)[0];
+        $portalInformation = array_values($portalInformations)[0];
 
         return [
             'request' => [
                 'webspaceKey' => $webspaceKey,
                 'locale' => $locale,
                 'defaultLocale' => $locale,
-                'portalUrl' => $portalUrl,
+                'portalUrl' => $portalInformation->getUrl(),
                 'resourceLocatorPrefix' => '',
                 'resourceLocator' => '',
                 'get' => $this->requestStack->getCurrentRequest()->query->all(),
                 'post' => $this->requestStack->getCurrentRequest()->request->all(),
                 'analyticsKey' => $this->previewDefaults['analyticsKey'],
+                'routeParameters' => [
+                    'host' => $portalInformation->getHost(),
+                    'prefix' => ltrim($portalInformation->getPrefix(), '/'),
+                ],
             ],
         ];
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -11,10 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
-use Sulu\Component\Localization\Localization;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -53,10 +50,24 @@ class PortalLoader extends Loader
     {
         $this->collection = new RouteCollection();
 
+        /** @var Route[] $importedRoutes */
         $importedRoutes = $this->import($resource, null);
 
+        $condition = $this->getCondition();
         foreach ($importedRoutes as $importedRouteName => $importedRoute) {
-            $this->generatePortalRoutes($importedRoute, $importedRouteName);
+            $this->collection->add(
+                $importedRouteName,
+                new PortalRoute(
+                    '{prefix}' . $importedRoute->getPath(),
+                    $importedRoute->getDefaults(),
+                    array_merge(['prefix' => '.*', 'host' => '.+'], $importedRoute->getRequirements()),
+                    $importedRoute->getOptions(),
+                    '{host}',
+                    $importedRoute->getSchemes(),
+                    $importedRoute->getMethods(),
+                    $condition
+                )
+            );
         }
 
         return $this->collection;
@@ -71,134 +82,21 @@ class PortalLoader extends Loader
     }
 
     /**
-     * @param $importedRoute
-     * @param $importedRouteName
+     * This condition ensures only existing parameters.
+     *
+     * @return string
      */
-    private function generatePortalRoutes(Route $importedRoute, $importedRouteName)
+    private function getCondition()
     {
-        $portalInformationCollection = $this->webspaceManager->getPortalInformations($this->environment);
-        foreach ($portalInformationCollection as $portalInformation) {
-            if (false === strpos($portalInformation->getUrl(), '*')) {
-                $route = $this->createRoute($importedRoute, $portalInformation, $importedRouteName);
-
-                // deprecated only for backward-compatibility of route names
-                $this->collection->add(sprintf('%s.%s', $portalInformation->getUrl(), $importedRouteName), $route);
-                $this->collection->add(
-                    sprintf(
-                        '%s.%s.%s',
-                        $portalInformation->getUrl(),
-                        $portalInformation->getLocale(),
-                        $importedRouteName
-                    ),
-                    $route
-                );
-                continue;
-            }
-
-            foreach ($portalInformation->getPortal()->getLocalizations() as $localization) {
-                $route = $this->createLocalizedRoute(
-                    $importedRoute,
-                    $portalInformation,
-                    $portalInformationCollection,
-                    $localization,
-                    $importedRouteName
-                );
-                $this->collection->add(
-                    sprintf(
-                        '%s.%s.%s',
-                        $portalInformation->getUrl(),
-                        $localization->getLocalization(),
-                        $importedRouteName
-                    ),
-                    $route
-                );
-            }
-        }
-    }
-
-    /**
-     * Create a localized route.
-     *
-     * @param Route $importedRoute
-     * @param PortalInformation $portalInformation
-     * @param array $portalInformationCollection
-     * @param Localization $localization
-     * @param string $importedRouteName
-     *
-     * @return Route
-     */
-    private function createLocalizedRoute(
-        Route $importedRoute,
-        PortalInformation $portalInformation,
-        array $portalInformationCollection,
-        Localization $localization,
-        $importedRouteName
-    ) {
-        $currentPortalInformation = $portalInformation;
-        if (strpos($portalInformation->getUrl(), '*')) {
-            $currentPortalInformation = $this->getPortalInformation($localization, $portalInformationCollection);
-        }
-
-        return $this->createRoute($importedRoute, $currentPortalInformation, $importedRouteName);
-    }
-
-    /**
-     * Create a route.
-     *
-     * @param Route $importedRoute
-     * @param PortalInformation $portalInformation
-     * @param string $importedRouteName
-     *
-     * @return Route
-     */
-    private function createRoute(Route $importedRoute, PortalInformation $portalInformation, $importedRouteName)
-    {
-        $route = clone $importedRoute;
-        $route->setHost($portalInformation->getHost());
-        $route->setPath($portalInformation->getPrefix() . $route->getPath());
-
-        if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_PARTIAL) {
-            $route->setDefaults(
-                [
-                    '_controller' => 'SuluWebsiteBundle:Redirect:redirectToRoute',
-                    'route' => sprintf(
-                        '%s.%s.%s',
-                        $portalInformation->getRedirect(),
-                        $portalInformation->getLocale(),
-                        $importedRouteName
-                    ),
-                    'permanent' => true,
-                ]
+        $conditionParts = [];
+        foreach ($this->webspaceManager->getPortalInformations($this->environment) as $portalInformation) {
+            $conditionParts[] = sprintf(
+                'context.getHost() == \'%s\' and context.getParameter(\'prefix\') == \'%s\'',
+                $portalInformation->getHost(),
+                $portalInformation->getPrefix()
             );
         }
 
-        return $route;
-    }
-
-    /**
-     * Returns main portal-information for given locale.
-     * If no main exists it returns the first portal-information which has the given locale.
-     *
-     * @param Localization $localization
-     * @param PortalInformation[] $portalInformationCollection
-     *
-     * @return PortalInformation
-     */
-    private function getPortalInformation(Localization $localization, array $portalInformationCollection)
-    {
-        $result = null;
-        foreach ($portalInformationCollection as $portalInformation) {
-            if ($portalInformation->getLocale() === $localization->getLocalization()) {
-                if ($portalInformation->isMain()) {
-                    // if a main exists return always this
-                    return $portalInformation;
-                } elseif ($result === null) {
-                    // otherwise return first portal-information which has the given locale
-                    $result = $portalInformation;
-                }
-            }
-        }
-
-        return $result;
+        return sprintf('(%s)', implode(') or (', $conditionParts));
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalRoute.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalRoute.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Routing;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Extends symfony route to avoid // in the url.
+ */
+class PortalRoute extends Route
+{
+    /**
+     * Trims leading slash to avoid "//".
+     *
+     * @return mixed
+     */
+    public function getPath()
+    {
+        return ltrim(parent::getPath(), '/');
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -14,6 +14,7 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -97,6 +98,10 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
         $localization->setLanguage('de');
         $localization->setCountry('at');
 
+        $portalInformation = $this->prophesize(PortalInformation::class);
+        $portalInformation->getHost()->willReturn('sulu.lo');
+        $portalInformation->getPrefix()->willReturn('de_at');
+
         $requestAnalyzer = $this->prophesize(RequestAnalyzer::class);
         $requestAnalyzer->getWebspace()->willReturn($webspace);
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
@@ -107,6 +112,7 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
         $requestAnalyzer->getPostParameters()->willReturn([]);
         $requestAnalyzer->getPortal()->willReturn($portal);
         $requestAnalyzer->getAnalyticsKey()->willReturn('analyticsKey');
+        $requestAnalyzer->getPortalInformation()->willReturn($portalInformation->reveal());
 
         $result = $this->resolver->resolve($requestAnalyzer->reveal());
         $this->assertEquals(
@@ -121,6 +127,10 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
                     'get' => ['p' => 1],
                     'post' => [],
                     'analyticsKey' => 'analyticsKey',
+                    'routeParameters' => [
+                        'host' => 'sulu.lo',
+                        'prefix' => 'de_at',
+                    ],
                 ],
             ],
             $result
@@ -129,8 +139,13 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveForPreview()
     {
+        $portalInformation = $this->prophesize(PortalInformation::class);
+        $portalInformation->getUrl()->willReturn('sulu.io/de');
+        $portalInformation->getHost()->willReturn('sulu.lo');
+        $portalInformation->getPrefix()->willReturn('de');
+
         $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale('sulu_io', 'de', 'dev')
-            ->willReturn(['sulu.io/de' => []]);
+            ->willReturn(['sulu.io/de' => $portalInformation->reveal()]);
 
         $request = new \Symfony\Component\HttpFoundation\Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);
@@ -148,6 +163,10 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
                     'get' => [],
                     'post' => [],
                     'analyticsKey' => 'UA-SULU-Test',
+                    'routeParameters' => [
+                        'host' => 'sulu.lo',
+                        'prefix' => 'de',
+                    ],
                 ],
             ],
             $result
@@ -156,8 +175,13 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveForPreviewWithRequestParameter()
     {
+        $portalInformation = $this->prophesize(PortalInformation::class);
+        $portalInformation->getUrl()->willReturn('sulu.io/de');
+        $portalInformation->getHost()->willReturn('sulu.lo');
+        $portalInformation->getPrefix()->willReturn('de');
+
         $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale('sulu_io', 'de', 'dev')
-            ->willReturn(['sulu.io/de' => []]);
+            ->willReturn(['sulu.io/de' => $portalInformation->reveal()]);
 
         $request = new \Symfony\Component\HttpFoundation\Request(['test' => 1], ['test' => 2]);
         $this->requestStack->getCurrentRequest()->willReturn($request);
@@ -175,6 +199,10 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
                     'get' => ['test' => 1],
                     'post' => ['test' => 2],
                     'analyticsKey' => 'UA-SULU-Test',
+                    'routeParameters' => [
+                        'host' => 'sulu.lo',
+                        'prefix' => 'de',
+                    ],
                 ],
             ],
             $result

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Routing;
 
 use Prophecy\Argument;
 use Sulu\Bundle\WebsiteBundle\Routing\PortalLoader;
+use Sulu\Bundle\WebsiteBundle\Routing\PortalRoute;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -93,26 +94,27 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routeCollection = $this->portalLoader->load('', 'portal');
 
-        $this->assertCount(8, $routeCollection);
+        $this->assertCount(2, $routeCollection);
 
         $routes = $routeCollection->getIterator();
-        $this->assertArrayHasKey('sulu.io/de.route1', $routes);
-        $this->assertArrayHasKey('sulu.io/de.de.route1', $routes);
-        $this->assertArrayHasKey('sulu.io/de.route2', $routes);
-        $this->assertArrayHasKey('sulu.io/de.de.route2', $routes);
-        $this->assertArrayHasKey('sulu.com.route1', $routes);
-        $this->assertArrayHasKey('sulu.com.en.route1', $routes);
-        $this->assertArrayHasKey('sulu.com.route2', $routes);
-        $this->assertArrayHasKey('sulu.com.en.route2', $routes);
+        $this->assertArrayHasKey('route1', $routes);
+        $this->assertArrayHasKey('route2', $routes);
 
-        $this->assertEquals('/de/example/route1', $routeCollection->get('sulu.io/de.route1')->getPath());
-        $this->assertEquals('/de/example/route1', $routeCollection->get('sulu.io/de.de.route1')->getPath());
-        $this->assertEquals('/de/route2', $routeCollection->get('sulu.io/de.route2')->getPath());
-        $this->assertEquals('/de/route2', $routeCollection->get('sulu.io/de.de.route2')->getPath());
-        $this->assertEquals('/example/route1', $routeCollection->get('sulu.com.route1')->getPath());
-        $this->assertEquals('/example/route1', $routeCollection->get('sulu.com.en.route1')->getPath());
-        $this->assertEquals('/route2', $routeCollection->get('sulu.com.route2')->getPath());
-        $this->assertEquals('/route2', $routeCollection->get('sulu.com.en.route2')->getPath());
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route1'));
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route2'));
+
+        $this->assertEquals('{prefix}/example/route1', $routeCollection->get('route1')->getPath());
+        $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
+        $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
+        $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
+        $this->assertEquals(
+            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'\')',
+            $routeCollection->get('route1')->getCondition()
+        );
+        $this->assertEquals(
+            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'\')',
+            $routeCollection->get('route2')->getCondition()
+        );
     }
 
     public function testLoadWithCustomUrls()
@@ -141,18 +143,27 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routeCollection = $this->portalLoader->load('', 'portal');
 
-        $this->assertCount(12, $routeCollection);
+        $this->assertCount(2, $routeCollection);
 
         $routes = $routeCollection->getIterator();
-        $this->assertArrayHasKey('sulu.com/*.de.route1', $routes);
-        $this->assertArrayHasKey('sulu.com/*.en.route1', $routes);
-        $this->assertArrayHasKey('sulu.com/*.de.route2', $routes);
-        $this->assertArrayHasKey('sulu.com/*.en.route2', $routes);
+        $this->assertArrayHasKey('route1', $routes);
+        $this->assertArrayHasKey('route2', $routes);
 
-        $this->assertEquals('/de/example/route1', $routeCollection->get('sulu.com/*.de.route1')->getPath());
-        $this->assertEquals('/en/example/route1', $routeCollection->get('sulu.com/*.en.route1')->getPath());
-        $this->assertEquals('/de/route2', $routeCollection->get('sulu.com/*.de.route2')->getPath());
-        $this->assertEquals('/en/route2', $routeCollection->get('sulu.com/*.en.route2')->getPath());
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route1'));
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route2'));
+
+        $this->assertEquals('{prefix}/example/route1', $routeCollection->get('route1')->getPath());
+        $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
+        $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
+        $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
+        $this->assertEquals(
+            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/en\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'/*\')',
+            $routeCollection->get('route1')->getCondition()
+        );
+        $this->assertEquals(
+            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/en\') or (context.getHost() == \'sulu.com\' and context.getParameter(\'prefix\') == \'/*\')',
+            $routeCollection->get('route2')->getCondition()
+        );
     }
 
     public function testLoadPartial()
@@ -185,32 +196,18 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
 
         $routeCollection = $this->portalLoader->load('', 'portal');
 
-        $this->assertCount(4, $routeCollection);
+        $this->assertCount(1, $routeCollection);
 
         $routes = $routeCollection->getIterator();
-        $this->assertArrayHasKey('sulu.io.route', $routes);
-        $this->assertArrayHasKey('sulu.io.de.route', $routes);
-        $this->assertArrayHasKey('sulu.io/de.route', $routes);
-        $this->assertArrayHasKey('sulu.io/de.de.route', $routes);
-        $this->assertEquals('/route', $routeCollection->get('sulu.io.route')->getPath());
-        $this->assertEquals('/route', $routeCollection->get('sulu.io.de.route')->getPath());
-        $this->assertEquals('/de/route', $routeCollection->get('sulu.io/de.route')->getPath());
-        $this->assertEquals('/de/route', $routeCollection->get('sulu.io/de.de.route')->getPath());
+        $this->assertArrayHasKey('route', $routes);
+
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route'));
+
+        $this->assertEquals('{prefix}/route', $routeCollection->get('route')->getPath());
+        $this->assertEquals('{host}', $routeCollection->get('route')->getHost());
         $this->assertEquals(
-            [
-                '_controller' => 'SuluWebsiteBundle:Redirect:redirectToRoute',
-                'route' => 'sulu.io/de.de.route',
-                'permanent' => true,
-            ],
-            $routeCollection->get('sulu.io.route')->getDefaults()
-        );
-        $this->assertEquals(
-            [
-                '_controller' => 'SuluWebsiteBundle:Redirect:redirectToRoute',
-                'route' => 'sulu.io/de.de.route',
-                'permanent' => true,
-            ],
-            $routeCollection->get('sulu.io.de.route')->getDefaults()
+            '(context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'/de\') or (context.getHost() == \'sulu.io\' and context.getParameter(\'prefix\') == \'\')',
+            $routeCollection->get('route')->getCondition()
         );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes see UPGRADE
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu-io/sulu-standard/pull/655
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the way to define custom-routes.

#### Why?

Currently you have to know how the name of the route has been build `{portalurl}.{locale}.{custom-route-name}`. This is quite complicated and hard to maintain.

To simplify this i have changed the way routes are generated. 2 parameters (`host` and `prefix`) will be applied automatically by sulu to generate the route successfully for all portals.

#### Example Usage

~~~yml
website_search:
    path: /search
    defaults:
        _controller: "ClientWebsiteBundle:Search:query"
~~~

~~~twig
{{ path('website_search', request.routeParameter) }}
~~~

See related sulu-standard PR.

#### BC Breaks/Deprecations

The name of the routes has changed. See UPGRADE.

#### To Do

- [x] Upgrade
- [x] Tests

