### PR TITLE
Fix DBAL MySQL tests (ORM + Jackalope). Introduce Sqlite + Postgres to matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: false
 
 language: php
 
-php:
-  - 5.5
-  - 7.0
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -14,19 +10,52 @@ cache:
 env:
   global:
     - JACKRABBIT_VERSION=2.12.0
+    - SYMFONY__PHPCR__TRANSPORT=doctrinedbal
+    - TEST_FLAGS=""
+    - SYMFONY__DATABASE__DRIVER=pdo_mysql
+
+matrix:
+  include:
+    - php: 5.5
+    - php: 7.0
+      env: 
+        - SYMFONY__PHPCR__TRANSPORT=jackrabbit
+        # restart jackrabbit after each suite see: https://github.com/sulu-io/sulu/issues/2137
+        - TEST_FLAGS="--jackrabbit-restart"
+
+# Sqlite support: https://github.com/sulu/sulu/issues/2048
+# Postgres support: https://github.com/sulu/sulu/issues/2241
+#
+#    - php: 7.0
+#      env:
+#        - SYMFONY__DATABASE__DRIVER=pdo_sqlite
+#        - SYMFONY__DATABASE__PATH=test.sqlite
+#    - php: 7.0
+#      env: 
+#        - SYMFONY__DATABASE__DRIVER=pdo_pgsql
+#        - SYMFONY__DATABASE__USER=postgres
+#        - SYMFONY__DATABASE__PASSWORD=postgres
+#  fast_finish: true # do not wait for allowed failures, as they do not affect the build.
 
 before_script:
   - if [ ! -d downloads ]; then mkdir downloads; fi
-  - if [ ! -f downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar ]; then cd downloads; wget http://archive.apache.org/dist/jackrabbit/$JACKRABBIT_VERSION/jackrabbit-standalone-$JACKRABBIT_VERSION.jar; cd -; fi
-  - java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
+  - |
+    if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then 
+        if [ ! -f downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar ]; then 
+            cd downloads
+            wget http://archive.apache.org/dist/jackrabbit/$JACKRABBIT_VERSION/jackrabbit-standalone-$JACKRABBIT_VERSION.jar
+            cd -
+        fi
+        java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
+    fi
+  # the content tests are intensive and there are memory leaks, this is more pronounced with the Jackalope DBAL PHPCR implementation.
+  - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - composer self-update
   - composer install  --prefer-dist --no-interaction
 
 script: 
-  # launch with the "r" flag in order to restart jackrabbit after each suite
-  # see: https://github.com/sulu-io/sulu/issues/2137
-  - time ./bin/runtests -i -a -r
+  - time ./bin/runtests -i -a $TEST_FLAGS
 
 notifications:
   slack:

--- a/bin/runtests
+++ b/bin/runtests
@@ -50,13 +50,15 @@ $definition->addOption(new InputOption('target', 't', InputOption::VALUE_REQUIRE
 $definition->addOption(new InputOption('all', 'a', InputOption::VALUE_NONE));
 $definition->addOption(new InputOption('jackrabbit-restart', 'r', InputOption::VALUE_NONE));
 $definition->addOption(new InputOption('help', 'h', InputOption::VALUE_NONE));
-$definition->addOption(new InputOption('no-component-tests', 'C', InputOption::VALUE_NONE, null));
-$definition->addOption(new InputOption('no-bundle-tests', 'B', InputOption::VALUE_NONE, null));
+$definition->addOption(new InputOption('no-component-tests', 'C', InputOption::VALUE_NONE));
+$definition->addOption(new InputOption('no-bundle-tests', 'B', InputOption::VALUE_NONE));
+$definition->addOption(new InputOption('verbose', 'v', InputOption::VALUE_NONE));
 $input = new ArgvInput(null, $definition);
 $output = new ConsoleOutput();
 $output->getFormatter()->setStyle('red', new OutputFormatterStyle('red'));
 $failedTests = new \ArrayObject();
-global $output, $input, $failedTests, $termWidth;
+$verbose = $input->getOption('verbose');
+global $output, $input, $failedTests, $termWidth, $verbose;
 
 // Utility methods
 // ===============
@@ -120,6 +122,11 @@ function write($line)
 
 function exec_sf_cmd($cmd, $echo = true, $checkForError = true)
 {
+    global $verbose;
+
+    if ($verbose) {
+        $cmd .= ' --verbose';
+    }
     return exec_cmd(
         'php ' . __DIR__ . '/console ' . $cmd,
         $echo,
@@ -182,14 +189,15 @@ function show_help()
 
 <comment>Options:</>
 
-  -i, --initialize          Execute the initializaction script before running the tests.
-  -f, --flags               Pass flags to PHPUnit.
-  -t, --target              Specify a target bundle.
-  -a, --all                 Run all tests.
-  -r, --restart-jackrabbit  Restart jackrabbit between bundle tests.
-  -h, --help                Show this help.
-  -C, --no-component-tests  Do not run the component tests.
-  -B, --no-bundle-tests     Do not run the bundle tests.
+  -i, --initialize            Execute the initializaction script before running the tests.
+  -f, --flags                 Pass flags to PHPUnit.
+  -t, --target                Specify a target bundle.
+  -a, --all                   Run all tests.
+  -r, --restart-jackrabbit    Restart jackrabbit between bundle tests.
+  -h, --help                  Show this help.
+  -C, --no-component-tests    Do not run the component tests.
+  -B, --no-bundle-tests       Do not run the bundle tests.
+  -v, --verbose               Verbose (pass flag to sub commands).
 EOT
     );
 }
@@ -358,7 +366,7 @@ function run_bundle_tests(\SplFileInfo $phpunitFile)
 
     $flags = $input->getOption('flags');
     $process = exec_cmd(sprintf(
-        'phpunit --colors --configuration %s %s',
+        'phpunit --configuration %s %s',
         $phpunitFile->getPathname(),
         $flags
     ), true, false);
@@ -394,11 +402,14 @@ function init_bundle($phpunitPath)
     }
 
     write_info('Doctrine ORM detected, updating the schema for the bundle.');
+
     exec_cmd(sprintf(
         'php %s %s',
         $console,
         ' doctrine:schema:update --force'
     ));
+
+    exec_sf_cmd('sulu:document:initialize --ansi', false);
 }
 
 function is_everything_ok()
@@ -444,7 +455,7 @@ if ($input->getOption('initialize')) {
     write_header('Initialization');
     init_dbal();
     write_info('Initializing the content repository');
-    exec_sf_cmd('sulu:document:initialize --ansi', false);
+    exec_sf_cmd('sulu:document:initialize --ansi', true);
     if (getenv('SYMFONY__PHPCR__TRANSPORT') === 'doctrine_dbal') {
         init_phpcr_dbal();
     }
@@ -472,7 +483,7 @@ if (false === $input->getOption('no-component-tests') || $input->getOption('all'
     // should explicitly indicate which kernels they are using.
     // https://github.com/sulu-io/sulu/issues/2187
     putenv('KERNEL_DIR=' . __DIR__ . '/../tests/app');
-    $process = exec_cmd('phpunit --color ' . $input->getOption('flags'), true, false);
+    $process = exec_cmd('phpunit ' . $input->getOption('flags'), true, false);
     if ($process->getExitCode() !== 0) {
         $failedTests[] = 'Components';
     }

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "phpcr/phpcr-shell": "~1.0.0@alpha",
         "doctrine/doctrine-bundle": "1.4.*",
         "jackalope/jackalope-jackrabbit": "~1.2.0",
+        "jackalope/jackalope-doctrine-dbal": "~1.2.0",
         "guzzle/plugin-mock": "3.9.*",
         "massive/build-bundle": "0.2.*",
         "matthiasnoback/symfony-config-test": "^1.0",

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\TagBundle\Tests\Functional\Controller;
+namespace Sulu\Bundle\CategoryBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryMeta;
@@ -217,6 +217,10 @@ class CategoryControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $categories = $response->_embedded->categories;
+
+        usort($categories, function ($cat1, $cat2) {
+            return $cat1->id > $cat2->id;
+        });
 
         $this->assertEquals('First Category', $categories[0]->name);
         $this->assertEquals('en', $categories[0]->defaultLocale);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1246,6 +1246,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes/filter?webspace=sulu_io&language=en');
         $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $items = $response['_embedded']['nodes'];
 
         $this->assertEquals('Homepage', $response['title']);

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
@@ -26,7 +26,8 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu.phpcr.session"/>
 
-            <tag name="sulu_document_manager.initializer"/>
+            <!-- This needs to happen after the content repository has been initialized !-->
+            <tag name="sulu_document_manager.initializer" priority="-127"/>
         </service>
 
         <service id="sulu_custom_urls.subscriber"

--- a/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Initializer/WorkspaceInitializer.php
@@ -39,14 +39,10 @@ class WorkspaceInitializer implements InitializerInterface
             $workspace = $connection->getWorkspace();
 
             try {
-                $connection->getRootNode();
-                $output->writeln(sprintf('  [ ] <info>workspace</info>: "%s"', $workspace->getName()));
-            } catch (RepositoryException $e) {
-                // TODO: We should catch the more explicit
-                // WorkspaceNotFoundException but Jackalope doctrine-dbal does
-                // not throw this: https://github.com/jackalope/jackalope-doctrine-dbal/issues/322
                 $workspace->createWorkspace($workspace->getName());
                 $output->writeln(sprintf('  [+] <info>workspace</info>: "%s"', $workspace->getName()));
+            } catch (RepositoryException $e) {
+                $output->writeln(sprintf('  [ ] <info>workspace</info>: "%s"', $workspace->getName()));
             }
         }
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/WorkspaceInitializerTest.php
@@ -74,16 +74,13 @@ class WorkspaceInitializerTest extends \PHPUnit_Framework_TestCase
             $this->session2->reveal(),
         ]);
 
-        $this->session1->getRootNode()->willThrow(new RepositoryException('Foo'));
-        $this->session2->getRootNode()->willReturn(true);
-
         $this->session1->getWorkspace()->willReturn($this->workspace1->reveal());
         $this->session2->getWorkspace()->willReturn($this->workspace2->reveal());
 
         $this->workspace1->getName()->willReturn('hello1');
         $this->workspace2->getName()->willReturn('hello2');
-        $this->workspace1->createWorkspace('hello1')->shouldBeCalled();
-        $this->workspace2->createWorkspace('hello2')->shouldNotBeCalled();
+        $this->workspace1->createWorkspace('hello1')->willThrow(new RepositoryException('foo'));
+        $this->workspace2->createWorkspace('hello2')->shouldBeCalled();
 
         $this->initializer->initialize($this->output);
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/Media.php
@@ -172,6 +172,13 @@ class Media implements AuditableInterface
      */
     public function getCollection()
     {
+        if (null === $this->collection) {
+            throw new \RuntimeException(sprintf(
+                'Media entity %d is not associated with a collection',
+                $this->getId()
+            ));
+        }
+
         return $this->collection;
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Entity/MediaTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Entity/MediaTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Entity;
+
+use Sulu\Bundle\MediaBundle\Entity\Media;
+
+class MediaTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Media
+     */
+    private $media;
+
+    public function setUp()
+    {
+        $this->media = new Media();
+    }
+
+    /**
+     * It should throw an exception if the Media is not associated with a collection
+     * and getCollection is called.
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testGetCollectionNull()
+    {
+        $this->media->getCollection();
+    }
+}

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml
@@ -1,6 +1,7 @@
 parameters:
     database.driver:   pdo_mysql
     database.host:     localhost
+    database.path:     ~
     database.user:     root
     database.name:     sulu_test
     database.port:     ~

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -58,6 +58,7 @@ sulu_core:
         backend:
             type: "%phpcr.transport%"
             url:  "%phpcr.backend_url%"
+            check_login_on_server: false
         workspace: "%phpcr.workspace%"
         username: "%phpcr.username%"
         password: "%phpcr.password%"
@@ -106,6 +107,7 @@ doctrine:
         dbname: "%database.name%"
         user: "%database.user%"
         password: "%database.password%"
+        path: "%database.path%"
         server_version: "%database.version%"
         charset:  UTF8
 

--- a/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
@@ -58,7 +58,20 @@ abstract class SuluTestCase extends KernelTestCase
     public function tearDown()
     {
         parent::tearDown();
-        $this->getEntityManager()->getConnection()->close();
+        // close the doctrine connection
+        foreach ($this->getContainer()->get('doctrine')->getConnections() as $connection) {
+            $connection->close();
+        }
+
+        // close the jackalope connections - can be removed when
+        // https://github.com/sulu/sulu/pull/2125 is merged.
+        // this has a negligble impact on memory usage in anycase.
+        foreach ($this->getContainer()->get('doctrine_phpcr')->getConnections() as $connection) {
+            try {
+                $connection->logout();
+            } catch (\Exception $e) {
+            }
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/TranslateBundle/Controller/CodeController.php
+++ b/src/Sulu/Bundle/TranslateBundle/Controller/CodeController.php
@@ -279,8 +279,24 @@ class CodeController extends RestController implements ClassResourceInterface
             $code->setBackend($backend);
             $code->setFrontend($frontend);
             $code->setLength($length);
-            $code->setPackage($em->getReference(self::$packageEntity, $package['id']));
-            $code->setLocation($em->getReference(self::$locationEntity, $location['id']));
+
+            $package = $em->find(self::$packageEntity, $package['id']);
+            $location = $em->find(self::$locationEntity, $location['id']);
+
+            if (null === $package) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Package "%s" not found', $package['id']
+                ));
+            }
+
+            if (null === $location) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Location "%s" not found', $location['id']
+                ));
+            }
+
+            $code->setPackage($package);
+            $code->setLocation($location);
 
             if ($translations != null && count($translations) > 0) {
                 foreach ($translations as $translationData) {

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Translate/ImportTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Translate/ImportTest.php
@@ -324,15 +324,15 @@ class ImportTest extends SuluTestCase
         $this->import->resetPackages();
 
         $packages = $this->em->getRepository('SuluTranslateBundle:Package')->findAll();
-        $this->assertEquals(0, count($packages));
+        $this->assertCount(0, $packages);
 
         $catalogues = $this->em->getRepository('SuluTranslateBundle:Catalogue')->findAll();
         $this->assertEquals(0, count($catalogues));
 
-        $codes = $this->em->getRepository('SuluTranslateBundle:Code')->findAll();
-        $this->assertEquals(0, count($codes));
-
         $translations = $this->em->getRepository('SuluTranslateBundle:Translation')->findAll();
         $this->assertEquals(0, count($translations));
+
+        $codes = $this->em->getRepository('SuluTranslateBundle:Code')->findAll();
+        $this->assertEquals(0, count($codes));
     }
 }

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -1369,7 +1369,7 @@ class ContentMapperTest extends SuluTestCase
 
         $result = $this->mapper->loadBySql2($sql2, 'de', 'sulu_io');
 
-        $this->assertEquals(5, count($result));
+        $this->assertCount(5, $result);
 
         $result = $this->mapper->loadBySql2($sql2, 'de', 'sulu_io', 2);
 

--- a/src/Sulu/Component/CustomUrl/Document/Initializer/CustomUrlInitializer.php
+++ b/src/Sulu/Component/CustomUrl/Document/Initializer/CustomUrlInitializer.php
@@ -60,6 +60,7 @@ class CustomUrlInitializer implements InitializerInterface
     public function initialize(OutputInterface $output)
     {
         $nodeTypeManager = $this->sessionManager->getSession()->getWorkspace()->getNodeTypeManager();
+
         foreach ([new CustomUrlNodeType(), new CustomUrlRouteNodeType()] as $nodeType) {
             $nodeTypeManager->registerNodeType($nodeType, true);
         }

--- a/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
+++ b/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
@@ -32,6 +32,8 @@ class SessionManager implements SessionManagerInterface
     }
 
     /**
+     * @deprecated Use the doctrine_phpcr service to retreive the session
+     *
      * {@inheritdoc}
      */
     public function getSession()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | https://github.com/sulu/sulu/issues/1257
| License | MIT

#### What's in this PR?

This PR will fix the Doctrine DBAL PHPCR tests (for both the ORM and Jackalope). It also (re)introduces sqlite and postgres to the test matrix (as allowed fails).

#### Why?

Because we should test Sulu with the more commonly used DBAL Jackalope implementation and not only
the Jackalope Jackrabbit PHPCR implementation.
