### PR TITLE
Website default locale provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2214 [WebsiteBundle]       Added website default locale providers
     * ENHANCEMENT #2208 [AdminBundle]         Added require-js url args to avoid wrong cache hits
     * ENHANCEMENT #2206 [WebsiteBundle]       Added security contexts to webspace settings
     * ENHANCEMENT #2206 [SnippetBundle]       Added security contexts to webspace settings

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
@@ -35,7 +35,7 @@ class RedirectController extends Controller
             $request->getUri()
         );
 
-        return new RedirectResponse($url, 301);
+        return new RedirectResponse($url, 301, ['Cache-Control' => 'private']);
     }
 
     /**
@@ -47,7 +47,7 @@ class RedirectController extends Controller
      */
     public function redirectAction(Request $request)
     {
-        return new RedirectResponse($request->get('url'), 301);
+        return new RedirectResponse($request->get('url'), 301, ['Cache-Control' => 'private']);
     }
 
     /**
@@ -70,7 +70,8 @@ class RedirectController extends Controller
 
         return new RedirectResponse(
             $this->container->get('router')->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL),
-            $permanent ? 301 : 302
+            $permanent ? 301 : 302,
+            ['Cache-Control' => 'private']
         );
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -61,6 +61,12 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+            ->end()
+            ->arrayNode('default_locale')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('provider_service_id')->defaultValue('sulu_website.default_locale.portal_provider')->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -59,6 +59,9 @@ class SuluWebsiteExtension extends Extension
 
         if (SuluKernel::CONTEXT_WEBSITE == $container->getParameter('sulu.context')) {
             $loader->load('website.xml');
+
+            // default local provider
+            $container->setAlias('sulu_website.default_locale.provider', $config['default_locale']['provider_service_id']);
         }
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/DefaultLocaleProviderInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/DefaultLocaleProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Locale;
+
+use Sulu\Component\Localization\Localization;
+
+/**
+ * Interface to provide default locale.
+ */
+interface DefaultLocaleProviderInterface
+{
+    /**
+     * Return default locale.
+     *
+     * @return Localization
+     */
+    public function getDefaultLocale();
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Locale;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+/**
+ * Implements logic to provide the default locale based on the portal configuration.
+ */
+class PortalDefaultLocaleProvider implements DefaultLocaleProviderInterface
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     */
+    public function __construct(RequestAnalyzerInterface $requestAnalyzer)
+    {
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultLocale()
+    {
+        return $this->requestAnalyzer->getPortal()->getDefaultLocalization();
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Locale;
+
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Implements logic to provide the default locale based on the request preferred language.
+ */
+class RequestDefaultLocaleProvider implements DefaultLocaleProviderInterface
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestAnalyzerInterface $requestAnalyzer, RequestStack $requestStack)
+    {
+        $this->requestAnalyzer = $requestAnalyzer;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultLocale()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            return $this->requestAnalyzer->getPortal()->getDefaultLocalization();
+        }
+
+        $defaultLocalization = $this->requestAnalyzer->getPortal()->getDefaultLocalization()->getLocale(Localization::LCID);
+        $localizations = [$defaultLocalization];
+
+        foreach ($this->requestAnalyzer->getPortal()->getLocalizations() as $localization) {
+            if ($localization->getLocale(Localization::LCID) !== $defaultLocalization) {
+                $localizations[] = $localization->getLocale(Localization::LCID);
+            }
+        }
+
+        $preferredLocale = $this->requestStack->getCurrentRequest()->getPreferredLanguage($localizations);
+
+        foreach ($this->requestAnalyzer->getPortal()->getLocalizations() as $localization) {
+            if ($localization->getLocale(Localization::LCID) === $preferredLocale) {
+                return $localization;
+            }
+        }
+
+        return $this->requestAnalyzer->getPortal()->getDefaultLocalization();
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
@@ -20,7 +20,20 @@
         <service id="sulu_website.provider.content" class="Sulu\Bundle\WebsiteBundle\Routing\ContentRouteProvider">
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_website.default_locale.provider"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
 
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_website.default_locale.portal_provider" class="Sulu\Bundle\WebsiteBundle\Locale\PortalDefaultLocaleProvider">
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_website.default_locale.request_provider" class="Sulu\Bundle\WebsiteBundle\Locale\RequestDefaultLocaleProvider">
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="request_stack"/>
             <tag name="sulu.context" context="website"/>
         </service>
 
@@ -41,7 +54,7 @@
             <tag name="sulu.context" context="website"/>
         </service>
 
-        <service id="sulu_website.generator.event_subscriber"
+        <service id="sulu_website.event_subscriber.generator"
                  class="Sulu\Bundle\WebsiteBundle\EventSubscriber\GeneratorEventSubscriber">
             <argument>%sulu.version%</argument>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Locale;
+
+use Sulu\Bundle\WebsiteBundle\Locale\PortalDefaultLocaleProvider;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Portal;
+
+class PortalDefaultLocaleProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDefaultLocale()
+    {
+        $portal = $this->prophesize(Portal::class);
+        $portal->getDefaultLocalization()->willReturn(new Localization('de', 'at'));
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getPortal()->willReturn($portal->reveal());
+
+        $portalDefaultLocaleProvider = new PortalDefaultLocaleProvider($requestAnalyzer->reveal());
+
+        $defaultLocale = $portalDefaultLocaleProvider->getDefaultLocale();
+
+        $this->assertEquals('de-AT', $defaultLocale->getLocale(Localization::ISO6391));
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Locale;
+
+use Sulu\Bundle\WebsiteBundle\Locale\DefaultLocaleProviderInterface;
+use Sulu\Bundle\WebsiteBundle\Locale\RequestDefaultLocaleProvider;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Portal;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RequestDefaultLocaleProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Portal
+     */
+    private $portal;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var DefaultLocaleProviderInterface
+     */
+    private $defaultLocaleProvider;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->portal = $this->prophesize(Portal::class);
+        $this->portal->getDefaultLocalization()->willReturn(new Localization('de', 'at'));
+
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal());
+
+        $this->requestStack = $this->prophesize(RequestStack::class);
+
+        $this->defaultLocaleProvider = new RequestDefaultLocaleProvider(
+            $this->requestAnalyzer->reveal(),
+            $this->requestStack->reveal()
+        );
+    }
+
+    public function testGetDefaultLocale()
+    {
+        $this->portal->getLocalizations()->willReturn([
+            new Localization('de', 'de'),
+            new Localization('en'),
+        ]);
+
+        $request = $this->prophesize(Request::class);
+        $request->getPreferredLanguage(['de_AT', 'de_DE', 'en'])->shouldBeCalled()->willReturn('en');
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+
+        $defaultLocale = $this->defaultLocaleProvider->getDefaultLocale();
+        $this->assertEquals('en', $defaultLocale->getLocale(Localization::ISO6391));
+    }
+
+    public function testGetDefaultLocaleWithoutRequest()
+    {
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $defaultLocale = $this->defaultLocaleProvider->getDefaultLocale();
+        $this->assertEquals('de-AT', $defaultLocale->getLocale(Localization::ISO6391));
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Routing;
 
+use Sulu\Bundle\WebsiteBundle\Locale\DefaultLocaleProviderInterface;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
@@ -21,6 +22,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Theme;
+use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Sulu\Component\Webspace\Webspace;
 
 class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
@@ -47,7 +49,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -79,7 +89,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -111,7 +129,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -138,7 +164,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix);
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -178,7 +212,19 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de', 'at'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+        $urlReplacer->replaceCountry('sulu.lo/de', 'at')->shouldBeCalled()->willReturn('sulu.lo/de');
+        $urlReplacer->replaceLanguage('sulu.lo/de', 'de')->shouldBeCalled()->willReturn('sulu.lo/de');
+        $urlReplacer->replaceLocalization('sulu.lo/de', 'de-at')->shouldBeCalled()->willReturn('sulu.lo/de');
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -214,7 +260,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -244,17 +298,29 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $portal,
             $path,
             $prefix,
-            new Localization(),
+            null,
             RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
             'sulu.lo',
-            'sulu.lo/en-us'
+            'sulu.lo/{localization}'
         );
         $requestAnalyzer->expects($this->any())->method('getAttribute')->will($this->returnValue(null));
 
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue(null));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de', 'at'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+        $urlReplacer->replaceCountry('sulu.lo/{localization}', 'at')->shouldBeCalled()->willReturn('sulu.lo/{localization}');
+        $urlReplacer->replaceLanguage('sulu.lo/{localization}', 'de')->shouldBeCalled()->willReturn('sulu.lo/{localization}');
+        $urlReplacer->replaceLocalization('sulu.lo/{localization}', 'de-at')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -265,7 +331,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $route = $routes->getIterator()->current();
         $this->assertEquals('SuluWebsiteBundle:Redirect:redirectWebspace', $route->getDefaults()['_controller']);
         $this->assertEquals('sulu.lo', $route->getDefaults()['url']);
-        $this->assertEquals('sulu.lo/en-us', $route->getDefaults()['redirect']);
+        $this->assertEquals('sulu.lo/de-at', $route->getDefaults()['redirect']);
     }
 
     public function testGetCollectionForNotExistingRequest()
@@ -291,7 +357,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $this->throwException(new ResourceLocatorNotFoundException())
         );
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -328,7 +402,19 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue(null));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de', 'at'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+        $urlReplacer->replaceCountry('sulu.lo', 'at')->shouldBeCalled()->willReturn('sulu.lo');
+        $urlReplacer->replaceLanguage('sulu.lo', 'de')->shouldBeCalled()->willReturn('sulu.lo');
+        $urlReplacer->replaceLocalization('sulu.lo', 'de-at')->shouldBeCalled()->willReturn('sulu.lo');
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -375,7 +461,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -421,7 +515,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -458,13 +560,25 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $localization,
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
             'sulu.lo',
-            'sulu.lo/en-us'
+            'sulu.lo/de-at'
         );
 
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->willReturn($structure);
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de', 'at'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+        $urlReplacer->replaceCountry('sulu.lo/de-at', 'at')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+        $urlReplacer->replaceLanguage('sulu.lo/de-at', 'de')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+        $urlReplacer->replaceLocalization('sulu.lo/de-at', 'de-at')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -501,13 +615,25 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $localization,
             RequestAnalyzerInterface::MATCH_TYPE_FULL,
             'sulu.lo',
-            'sulu.lo/en-us'
+            'sulu.lo/de-at'
         );
 
         $contentMapper = $this->getContentMapperMock();
         $contentMapper->expects($this->any())->method('loadByResourceLocator')->willReturn($structure);
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de', 'at'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+        $urlReplacer->replaceCountry('sulu.lo/de-at', 'at')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+        $urlReplacer->replaceLanguage('sulu.lo/de-at', 'de')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+        $urlReplacer->replaceLocalization('sulu.lo/de-at', 'de-at')->shouldBeCalled()->willReturn('sulu.lo/de-at');
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 
@@ -551,7 +677,15 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $this->throwException(new ResourceLocatorMovedException('/new-test', '123-123-123'))
         );
 
-        $portalRouteProvider = new ContentRouteProvider($contentMapper, $requestAnalyzer);
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
 
         $request = $this->getRequestMock($path);
 

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -19,6 +19,11 @@ use Sulu\Component\Util\ArrayableInterface;
  */
 class Localization implements \JsonSerializable, ArrayableInterface
 {
+    const UNDERSCORE = 'de_at';
+    const DASH = 'de-at';
+    const ISO6391 = 'de-AT';
+    const LCID = 'de_AT';
+
     /**
      * The language of the localization.
      *
@@ -172,12 +177,51 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @return string
      * @VirtualProperty
+     *
+     * @deprecated use getLocale instead
      */
     public function getLocalization($delimiter = '_')
     {
+        @trigger_error(__method__ . '() is deprecated since version 1.2 and will be removed in 2.0. Use getLocale() instead.', E_USER_DEPRECATED);
+
         $localization = $this->getLanguage();
         if ($this->getCountry() != null) {
             $localization .= $delimiter . $this->getCountry();
+        }
+
+        return $localization;
+    }
+
+    /**
+     * Returns the localization code, which is a combination of the language and the country in a specific format.
+     *
+     * @param string $format requested localization format
+     *
+     * @return string
+     * @VirtualProperty
+     */
+    public function getLocale($format = self::UNDERSCORE)
+    {
+        $localization = strtolower($this->getLanguage());
+
+        if (null != $this->getCountry()) {
+            $country = strtolower($this->getCountry());
+            $delimiter = '-';
+
+            switch ($format) {
+                case self::UNDERSCORE:
+                    $delimiter = '_';
+                    break;
+                case self::ISO6391:
+                    $country = strtoupper($country);
+                    break;
+                case self::LCID:
+                    $delimiter = '_';
+                    $country = strtoupper($country);
+                    break;
+            }
+
+            $localization .= $delimiter . $country;
         }
 
         return $localization;

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -356,7 +356,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
         $res = [];
         $res['country'] = $this->getCountry();
         $res['language'] = $this->getLanguage();
-        $res['localization'] = $this->getLocalization();
+        $res['localization'] = $this->getLocale();
         $res['default'] = $this->isDefault();
         $res['xDefault'] = $this->isXDefault();
         $res['children'] = [];

--- a/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
+++ b/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
@@ -20,17 +20,18 @@ class LocalizationTest extends \PHPUnit_Framework_TestCase
      */
     private $localization;
 
-    public function testToArray()
+    public function setUp()
     {
-        $this->localization = new Localization();
-        $this->localization->setLanguage('fr');
-        $this->localization->setCountry('at');
+        $this->localization = new Localization('de', 'at');
         $this->localization->setDefault(true);
         $this->localization->setXDefault(true);
+    }
 
+    public function testToArray()
+    {
         $expected = [
-            'language' => 'fr',
-            'localization' => 'fr_at',
+            'language' => 'de',
+            'localization' => 'de_at',
             'country' => 'at',
             'default' => true,
             'xDefault' => true,
@@ -39,5 +40,13 @@ class LocalizationTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $this->localization->toArray());
+    }
+
+    public function testGetLocale()
+    {
+        $this->assertEquals('de_at', $this->localization->getLocale(Localization::UNDERSCORE));
+        $this->assertEquals('de-at', $this->localization->getLocale(Localization::DASH));
+        $this->assertEquals('de-AT', $this->localization->getLocale(Localization::ISO6391));
+        $this->assertEquals('de_AT', $this->localization->getLocale(Localization::LCID));
     }
 }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -353,11 +353,7 @@ class WebspaceCollectionBuilder
         $urlAnalyticsKey,
         Url $url
     ) {
-        $replacers = [
-            ReplacerInterface::REPLACER_LANGUAGE => $portal->getDefaultLocalization()->getLanguage(),
-            ReplacerInterface::REPLACER_COUNTRY => $portal->getDefaultLocalization()->getCountry(),
-            ReplacerInterface::REPLACER_LOCALIZATION => $portal->getDefaultLocalization()->getLocalization('-'),
-        ];
+        $replacers = [];
 
         $defaultSegment = $portal->getWebspace()->getDefaultSegment();
         if ($defaultSegment) {
@@ -372,7 +368,7 @@ class WebspaceCollectionBuilder
                 RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
                 $portal->getWebspace(),
                 $portal,
-                $portal->getDefaultLocalization(),
+                null,
                 $urlResult,
                 $portal->getWebspace()->getDefaultSegment(),
                 $urlRedirect,

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -148,11 +148,7 @@ class WebspaceManager implements WebspaceManagerInterface
         $urls = [];
         $portals = $this->getWebspaceCollection()->getPortalInformations(
             $environment,
-            [
-                RequestAnalyzerInterface::MATCH_TYPE_FULL,
-                RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
-                RequestAnalyzerInterface::MATCH_TYPE_REDIRECT,
-            ]
+            [RequestAnalyzerInterface::MATCH_TYPE_FULL]
         );
         foreach ($portals as $url => $portalInformation) {
             $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;

--- a/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/EnvironmentTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Environment\Tests\Unit;
+namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Prophecy\Argument;
 use Sulu\Component\Webspace\Environment;

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -153,11 +153,11 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
             $devPortalInformationValues['massiveart-us.lo/fr-ca/s']
         );
         $this->assertEquals(
-            ['type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, 'locale' => 'fr_ca', 'redirect' => 'massiveart-ca.lo/fr-ca/s'],
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, 'redirect' => 'massiveart-ca.lo/{localization}/s'],
             $devPortalInformationValues['massiveart-ca.lo']
         );
         $this->assertEquals(
-            ['type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, 'locale' => 'en_us', 'redirect' => 'massiveart-us.lo/en-us/s'],
+            ['type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL, 'redirect' => 'massiveart-us.lo/{localization}/s'],
             $devPortalInformationValues['massiveart-us.lo']
         );
         $this->assertEquals(

--- a/src/Sulu/Component/Webspace/Tests/Unit/SegmentTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/SegmentTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Segment\Tests\Unit;
+namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Sulu\Component\Webspace\Segment;
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/ThemeTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/ThemeTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Theme\Tests\Unit;
+namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Sulu\Component\Webspace\Theme;
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Url\Tests\Unit;
+namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Sulu\Component\Webspace\Url;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Fixed tickets | fixes #1661 |
| License | MIT |
| Documentation PR | sulu/sulu-docs/pull/196 |
#### What's in this PR?

Adds the possibility to have different default-locale providers.
#### Why?

Currently a partial request match e.g. http://sulu.io/ is redirect to the default language e.g. http://sulu.io/en which is configured in the portal settings. This PR adds the posibitly to have different default-locale providers. Out of the box, sulu will support portal configuration and request preferred language.
#### Change default locale provider to request preferred language

``` yaml
sulu_website:
    default_locale:
        provider_service_id: sulu_website.default_locale.request_provider
```
#### To Do
- [x] Create a documentation PR
- [x] Tests
- [x] Changelog
