### PR TITLE
Assert http status code method for tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2216 [All]                 Added KernelTestCase::assertHttpStatusCode method
     * ENHANCEMENT #2214 [WebsiteBundle]       Added website default locale providers
     * ENHANCEMENT #2208 [AdminBundle]         Added require-js url args to avoid wrong cache hits
     * ENHANCEMENT #2206 [WebsiteBundle]       Added security contexts to webspace settings

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -178,7 +178,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('First Category', $response->name);
         $this->assertEquals('first-category-key', $response->key);
@@ -197,7 +197,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/101230'
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(0, $response->code);
@@ -212,7 +212,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -240,7 +240,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories?flat=true&parent=' . $this->category1->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(1, count($response->_embedded->categories));
@@ -258,7 +258,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories?flat=true&depth=1'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(1, count($response->_embedded->categories));
@@ -274,7 +274,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories?flat=true&sortBy=depth&sortOrder=desc'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(4, count($response->_embedded->categories));
@@ -305,7 +305,7 @@ class CategoryControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('New Category', $response->name);
@@ -321,7 +321,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $response->id
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('New Category', $response->name);
@@ -355,7 +355,7 @@ class CategoryControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Modified Category', $response->name);
@@ -372,7 +372,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Modified Category', $response->name);
@@ -395,7 +395,7 @@ class CategoryControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Imagine this is chinese', $response->name);
 
@@ -404,7 +404,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId() . '?locale=cn'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Imagine this is chinese', $response->name);
 
@@ -413,7 +413,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('First Category', $response->name);
     }
@@ -434,7 +434,7 @@ class CategoryControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testPatch()
@@ -448,7 +448,7 @@ class CategoryControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals($this->category1->getId(), $response->id);
         $this->assertEquals('Name changed through patch', $response->name);
@@ -458,7 +458,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals($this->category1->getId(), $response->id);
         $this->assertEquals('Name changed through patch', $response->name);
@@ -475,7 +475,7 @@ class CategoryControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(1, $response->code);
     }
@@ -488,7 +488,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $this->category2->getId()
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createAuthenticatedClient();
         $client->request(
@@ -496,7 +496,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories' . $this->category2->getId()
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteOfParent()
@@ -507,7 +507,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId()
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createAuthenticatedClient();
         $client->request(
@@ -515,7 +515,7 @@ class CategoryControllerTest extends SuluTestCase
             '/api/categories'
         );
 
-        //$this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(1, count($response->_embedded->categories));
         $this->assertEquals($this->category2->getId(), $response->_embedded->categories[0]->id);
@@ -531,7 +531,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertCount(1, $response->_embedded->categories);
         $this->assertEquals($this->category3->getId(), $response->_embedded->categories[0]->id);
     }
@@ -548,7 +548,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(2, count($response->_embedded->categories));
         $this->assertEquals($this->category4->getId(), $response->_embedded->categories[0]->id);
         $this->assertEquals($this->category3->getId(), $response->_embedded->categories[1]->id);
@@ -583,7 +583,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('en', $response->locale);
         $this->assertEquals('en', $response->defaultLocale);
@@ -596,7 +596,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('en_us', $response->locale);
         $this->assertEquals('en', $response->defaultLocale);
@@ -614,7 +614,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertCount(4, $response->_embedded->categories);
         $this->assertEquals('de', $response->_embedded->categories[0]->locale);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
@@ -79,7 +79,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -100,7 +100,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -119,7 +119,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -140,7 +140,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -160,7 +160,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -179,7 +179,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -198,7 +198,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -222,7 +222,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $this->assertEquals(2002, $result['code']);
     }
 
@@ -238,7 +238,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -257,7 +257,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -281,7 +281,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $this->assertEquals(2001, $result['code']);
     }
 
@@ -298,7 +298,7 @@ class KeywordControllerTest extends SuluTestCase
         );
 
         $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($keyword1, $result['keyword']);
         $this->assertEquals($locale, $result['locale']);
@@ -315,7 +315,7 @@ class KeywordControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId() . '/keywords/' . $first['id']
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
         $this->assertNull($this->entityManager->find(Keyword::class, $first['id']));
     }
 
@@ -329,7 +329,7 @@ class KeywordControllerTest extends SuluTestCase
             '/api/categories/' . $this->category1->getId() . '/keywords/' . $first['id']
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
         $this->assertNotNull($this->entityManager->find(Keyword::class, $first['id']));
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -317,7 +317,7 @@ class AccountControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('Company', $response->name);
         $this->assertEquals('http://www.company.example', $response->urls[0]->url);
@@ -362,7 +362,7 @@ class AccountControllerTest extends SuluTestCase
             '/api/accounts/11230'
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(0, $response->code);
@@ -381,7 +381,7 @@ class AccountControllerTest extends SuluTestCase
         $client->request('GET', '/api/accounts/' . $account->getId() . '/contacts?flat=true');
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(0, $response->total);
         $this->assertCount(0, $response->_embedded->contacts);
@@ -729,7 +729,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertContains('15', $response->message);
 
@@ -758,7 +758,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertContains('16', $response->message);
 
@@ -787,7 +787,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertContains('17', $response->message);
 
@@ -818,7 +818,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertContains('18', $response->message);
 
@@ -836,7 +836,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertContains('19', $response->message);
     }
@@ -861,7 +861,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertTrue(isset($response->message));
     }
@@ -893,7 +893,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertTrue(isset($response->message));
     }
@@ -925,7 +925,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertTrue(isset($response->message));
     }
@@ -959,7 +959,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertTrue(isset($response->message));
     }
@@ -984,7 +984,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertTrue(isset($response->message));
     }
@@ -1018,7 +1018,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertTrue(isset($response->message));
     }
@@ -1177,10 +1177,8 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        //$this->assertEquals(200, $client->getResponse()->getStatusCode());
-
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
 
@@ -1281,7 +1279,7 @@ class AccountControllerTest extends SuluTestCase
             '/api/accounts/' . $this->account->getId()
         );
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
 
@@ -1395,14 +1393,14 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/accounts/' . $this->account->getId()
         );
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
 
@@ -1426,7 +1424,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteById()
@@ -1434,7 +1432,7 @@ class AccountControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/accounts/' . $this->account->getId());
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
     }
 
     public function testAccountAddresses()
@@ -1442,7 +1440,7 @@ class AccountControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/api/accounts/' . $this->account->getId() . '/addresses');
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $address = $response->_embedded->addresses[0];
@@ -1450,7 +1448,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals('1', $address->number);
 
         $client->request('GET', '/api/accounts/' . $this->account->getId() . '/addresses?flat=true');
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals(1, $response->total);
@@ -1471,7 +1469,7 @@ class AccountControllerTest extends SuluTestCase
                 'removeContacts' => 'false',
             ]
         );
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         // check if contacts are still there
         $client->request('GET', '/api/contacts?flat=true');
@@ -1506,7 +1504,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
         // check if contacts are still there
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/contacts?flat=true');
         $response = json_decode($client->getResponse()->getContent());
@@ -1518,7 +1516,7 @@ class AccountControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/accounts/4711');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/accounts?flat=true');
         $response = json_decode($client->getResponse()->getContent());
@@ -1575,7 +1573,7 @@ class AccountControllerTest extends SuluTestCase
 
         // asserts
 
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         // return full number of contacts related to account
@@ -1615,7 +1613,7 @@ class AccountControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/api/accounts/' . $this->account->getId() . '/deleteinfo');
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -1648,7 +1646,7 @@ class AccountControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/api/accounts/' . $this->account->getId() . '/deleteinfo');
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         // deletion not allowed if children existent
@@ -1662,10 +1660,10 @@ class AccountControllerTest extends SuluTestCase
     {
         $client = $this->createAuthenticatedClient();
         $client->request('GET', '/api/accounts/4711/deleteinfo');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/accounts/' . $this->account->getId() . '/deleteinfo');
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
     }
 
     public function testPutRemovedParentAccount()
@@ -1767,7 +1765,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
         $this->assertEquals($this->account->getId(), $response->parent->id);
@@ -1897,7 +1895,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
@@ -1905,7 +1903,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany 222', $response->name);
         $this->assertObjectNotHasAttribute('parent', $response);
@@ -2014,7 +2012,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(false, $response->addresses[0]->primaryAddress);
         $this->assertEquals(true, $response->addresses[1]->primaryAddress);
@@ -2145,7 +2143,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         usort($response->addresses, $this->sortAddressesPrimaryLast());
 
         $this->assertEquals(false, $response->addresses[0]->primaryAddress);
@@ -2158,7 +2156,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         usort($response->addresses, $this->sortAddressesPrimaryLast());
 
         $this->assertEquals(false, $response->addresses[0]->primaryAddress);
@@ -2187,7 +2185,7 @@ class AccountControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(2, $response->total);
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountMediaControllerTest.php
@@ -355,7 +355,7 @@ class AccountMediaControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request(
             'GET',
@@ -375,7 +375,7 @@ class AccountMediaControllerTest extends SuluTestCase
             '/api/accounts/' . $this->account->getId() . '/medias/' . $this->media2->getId()
         );
 
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request(
             'GET',
@@ -394,7 +394,7 @@ class AccountMediaControllerTest extends SuluTestCase
             '/api/accounts/' . $this->account->getId() . '/medias/99'
         );
 
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request(
             'GET',

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -518,7 +518,7 @@ class ContactControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('Erika', $response->firstName);
         $this->assertEquals('Mustermann', $response->lastName);
@@ -831,7 +831,7 @@ class ContactControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(
             'The "Sulu\Bundle\ContactBundle\Entity\Contact"-entity requires a "contact"-argument',
             $response->message
@@ -890,7 +890,7 @@ class ContactControllerTest extends SuluTestCase
         $client = $this->createTestClient();
         $client->request('GET', '/api/contacts?flat=true&search=Nothing&searchFields=fullName');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals(0, $response->total);
@@ -910,7 +910,7 @@ class ContactControllerTest extends SuluTestCase
         $client = $this->createTestClient();
         $client->request('GET', '/api/contacts?flat=true&search=Erika&searchFields=fullName&fields=fullName');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals(1, $response->total);
@@ -1546,7 +1546,7 @@ class ContactControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testGetList()
@@ -1659,12 +1659,12 @@ class ContactControllerTest extends SuluTestCase
         $client = $this->createTestClient();
         $client->request('DELETE', '/api/contacts/' . $this->contact->getId());
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createTestClient();
         $client->request('GET', '/api/contacts/' . $this->contact->getId());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteNotExisting()
@@ -1672,7 +1672,7 @@ class ContactControllerTest extends SuluTestCase
         $client = $this->createTestClient();
         $client->request('DELETE', '/api/contacts/4711');
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/contacts?flat=true');
         $response = json_decode($client->getResponse()->getContent());

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
@@ -350,7 +350,7 @@ class ContactMediaControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request(
             'GET',
@@ -370,7 +370,7 @@ class ContactMediaControllerTest extends SuluTestCase
             '/api/contacts/' . $this->contact->getId() . '/medias/' . $this->media2->getId()
         );
 
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request(
             'GET',
@@ -389,7 +389,7 @@ class ContactMediaControllerTest extends SuluTestCase
             '/api/contacts/' . $this->contact->getId() . '/medias/99'
         );
 
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request(
             'GET',

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -102,7 +102,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('Testtitle', $response->title);
@@ -150,7 +150,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data1);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $uuid = $response->id;
 
@@ -159,7 +159,7 @@ class NodeControllerTest extends SuluTestCase
             '/api/nodes?parent=' . $uuid . '&webspace=sulu_io&language=en',
             $data2
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('test-1', $response->title);
@@ -201,10 +201,10 @@ class NodeControllerTest extends SuluTestCase
         ];
 
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
     }
 
     public function testGet()
@@ -238,7 +238,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('seo', $response['ext']);
@@ -262,7 +262,7 @@ class NodeControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/api/nodes/not-existing-id?language=en');
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testGetLocalized()
@@ -495,10 +495,10 @@ class NodeControllerTest extends SuluTestCase
         $data = $this->setUpContent($data);
 
         $client->request('DELETE', '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en');
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en');
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteReferencedNode()
@@ -529,7 +529,7 @@ class NodeControllerTest extends SuluTestCase
         $linkData = $this->setupContent($linkData);
 
         $client->request('DELETE', '/api/nodes/' . $deleteData[0]['id'] . '?webspace=sulu_io&language=en');
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
     }
 
     public function testDeleteReferencedNodeWithForce()
@@ -560,10 +560,10 @@ class NodeControllerTest extends SuluTestCase
         $linkData = $this->setupContent($linkData);
 
         $client->request('DELETE', '/api/nodes/' . $deleteData[0]['id'] . '?webspace=sulu_io&language=en&force=true');
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/nodes/' . $deleteData[0]['id'] . '?webspace=sulu_io&language=en');
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testPut()
@@ -605,7 +605,7 @@ class NodeControllerTest extends SuluTestCase
             $data[0]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals($data[0]['title'], $response->title);
@@ -622,7 +622,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals(2, $response->total);
@@ -648,7 +648,7 @@ class NodeControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $data = [
             'template' => 'default',
@@ -664,14 +664,14 @@ class NodeControllerTest extends SuluTestCase
             $data
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals($data['title'], $response->title);
 
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals($data['title'], $response->title);
@@ -682,7 +682,7 @@ class NodeControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('PUT', '/api/nodes/not-existing-id?language=de', []);
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testPutWithTemplateChange()
@@ -708,7 +708,7 @@ class NodeControllerTest extends SuluTestCase
             $data[0]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('default', $response->template);
@@ -716,7 +716,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('default', $response->template);
@@ -854,7 +854,7 @@ class NodeControllerTest extends SuluTestCase
             array_merge(['_hash' => $response['_hash']], $data)
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
     }
 
     public function testPutWithInvalidHash()
@@ -877,7 +877,7 @@ class NodeControllerTest extends SuluTestCase
             array_merge(['_hash' => md5('wrong-hash')], $data)
         );
 
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(1102, $response['code']);
 
@@ -887,7 +887,7 @@ class NodeControllerTest extends SuluTestCase
             array_merge(['_hash' => md5('wrong-hash')], $data)
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
     }
 
     public function testPutWithAlreadyExistingUrl()
@@ -900,11 +900,11 @@ class NodeControllerTest extends SuluTestCase
             'url' => '/test',
         ];
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $data['url'] = '/test2';
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $data['url'] = '/test';
@@ -913,7 +913,7 @@ class NodeControllerTest extends SuluTestCase
             '/api/nodes/' . $response['id'] . '?webspace=sulu_io&language=en&state=2',
             $data
         );
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(1103, $response['code']);
     }
@@ -925,7 +925,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -937,7 +937,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get subitems (remove /admin for test environment)
         $client->request('GET', str_replace('/admin', '', $items[1]->_links->children->href));
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -949,7 +949,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get subitems (remove /admin for test environment)
         $client->request('GET', str_replace('/admin', '', $items[1]->_links->children->href));
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -969,7 +969,7 @@ class NodeControllerTest extends SuluTestCase
         );
 
         $response = $client->getResponse()->getContent();
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         // check if tree is correctly loaded till the given id
@@ -1001,7 +1001,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1015,7 +1015,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=2&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1035,7 +1035,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=3&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1058,7 +1058,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from subNode
         $client->request('GET', '/api/nodes?depth=3&webspace=sulu_io&language=en&parent=' . $data[3]['id']);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1075,7 +1075,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&flat=false&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1091,7 +1091,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=2&flat=false&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1117,7 +1117,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=3&flat=false&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1149,7 +1149,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from subNode
         $client->request('GET', '/api/nodes?depth=3&flat=false&webspace=sulu_io&language=en&parent=' . $data[3]['id']);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $items = $response->_embedded->nodes;
 
@@ -1256,7 +1256,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes/' . $data[4]['id'] . '?breadcrumb=true&webspace=sulu_io&language=en');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertEquals($data[4]['title'], $response['title']);
@@ -1273,7 +1273,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes/' . $data[4]['id'] . '?breadcrumb=false&webspace=sulu_io&language=en');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertEquals($data[4]['title'], $response['title']);
@@ -1314,7 +1314,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en&complete=false');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('id', $response);
@@ -1346,7 +1346,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
         $items = $response['_embedded']['nodes'];
 
@@ -1434,7 +1434,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en&action=move&destination=' . $data[1]['id']
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         // check some properties
@@ -1453,7 +1453,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/123-123?webspace=sulu_io&language=en&action=move&destination=' . $data[1]['id']
         );
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testMoveNonExistingDestination()
@@ -1465,7 +1465,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en&action=move&destination=123-123'
         );
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testCopy()
@@ -1477,7 +1477,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en&action=copy&destination=' . $data[1]['id']
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         // check some properties
@@ -1491,7 +1491,7 @@ class NodeControllerTest extends SuluTestCase
             'GET',
             '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en'
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertEquals($data[0]['id'], $response['id']);
@@ -1511,7 +1511,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/123-123?webspace=sulu_io&language=en&action=copy&destination=' . $data[1]['id']
         );
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testCopyNonExistingDestination()
@@ -1523,7 +1523,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/' . $data[0]['id'] . '?webspace=sulu_io&language=en&action=copy&destination=123-123'
         );
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testOrder()
@@ -1538,7 +1538,7 @@ class NodeControllerTest extends SuluTestCase
                 'position' => 3,
             ]
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         // check some properties
@@ -1555,7 +1555,7 @@ class NodeControllerTest extends SuluTestCase
                 'position' => 1,
             ]
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
         // check some properties
@@ -1567,7 +1567,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
         $items = $response['_embedded']['nodes'];
 
@@ -1602,7 +1602,7 @@ class NodeControllerTest extends SuluTestCase
                 'position' => 1,
             ]
         );
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testOrderNonExistingPosition()
@@ -1626,7 +1626,7 @@ class NodeControllerTest extends SuluTestCase
                 'position' => 42,
             ]
         );
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testNavContexts()
@@ -1657,7 +1657,7 @@ class NodeControllerTest extends SuluTestCase
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
         $items = $response['_embedded']['nodes'];
 
@@ -1690,7 +1690,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/' . $data['id'] . '?action=copy-locale&webspace=sulu_io&language=en&dest=de'
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
@@ -1721,7 +1721,7 @@ class NodeControllerTest extends SuluTestCase
             'POST',
             '/api/nodes/' . $data['id'] . '?action=copy-locale&webspace=sulu_io&language=en&dest=de,de_at'
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeResourcelocatorControllerTest.php
@@ -133,7 +133,7 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             '/api/nodes/resourcelocators/generates?webspace=sulu_io&language=en&template=default',
             ['parts' => ['title' => 'test']]
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals('/test', $response->resourceLocator);
 
@@ -142,7 +142,7 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             '/api/nodes/resourcelocators/generates?parent=' . $this->data[0]['id'] . '&webspace=sulu_io&language=en&template=default',
             ['parts' => ['title' => 'test']]
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals('/products/test', $response->resourceLocator);
 
@@ -151,7 +151,7 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             '/api/nodes/resourcelocators/generates?parent=' . $this->data[1]['id'] . '&webspace=sulu_io&language=en&template=default',
             ['parts' => ['title' => 'test']]
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals('/news/test-2', $response->resourceLocator);
 
@@ -160,7 +160,7 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             '/api/nodes/resourcelocators/generates?parent=' . $this->data[3]['id'] . '&webspace=sulu_io&language=en&template=default',
             ['parts' => ['title' => 'test']]
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals('/news/test-1/test-1', $response->resourceLocator);
     }
@@ -181,7 +181,7 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             'GET',
             '/api/nodes/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $result = (array) json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertEquals(1, count($result['_embedded']['resourcelocators']));
@@ -205,20 +205,20 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             'GET',
             '/api/nodes/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $history = (array) json_decode($this->client->getResponse()->getContent(), true);
 
         $url = $history['_embedded']['resourcelocators'][0]['_links']['delete'];
 
         $url = substr($url, 6);
         $this->client->request('DELETE', $url);
-        $this->assertEquals(204, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->request(
             'GET',
             '/api/nodes/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $result = (array) json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertEquals(0, count($result['_embedded']['resourcelocators']));
@@ -242,19 +242,19 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
             '/api/nodes/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
         );
         $node = (array) json_decode($this->client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $history = (array) json_decode($this->client->getResponse()->getContent(), true);
 
         $url = $history['_embedded']['resourcelocators'][0]['_links']['restore'];
         $url = substr($url, 6);
         $this->client->request('PUT', $url);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->client->request(
             'GET',
             '/api/nodes/' . $newsData['id'] . '?webspace=sulu_io&language=en'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $node = (array) json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertEquals('/news', $node['url']);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/PreviewControllerTest.php
@@ -122,7 +122,7 @@ class PreviewControllerTest extends SuluTestCase
         $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=de_at');
         $response = $client->getResponse()->getContent();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertTrue(strpos($response, '<h1 property="title">Hello Hikaru Sulu</h1>') > -1);
     }
 
@@ -147,7 +147,7 @@ class PreviewControllerTest extends SuluTestCase
         $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=de_at');
         $response = $client->getResponse()->getContent();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertTrue(strpos($response, '<h1>Hello Hikaru Sulu</h1>') > -1);
         $this->assertTrue(strpos($response, '<nav>') > -1);
         $this->assertTrue(strpos($response, '</nav>') > -1);
@@ -174,7 +174,7 @@ class PreviewControllerTest extends SuluTestCase
         $client->request('GET', '/content/preview/' . $response->id . '/render?webspace=sulu_io&language=de_at');
         $response = $client->getResponse()->getContent();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertTrue(strpos($response, '<h1>Hello Hikaru Sulu</h1>') > -1);
         $this->assertTrue(preg_match('/^\<p\>This is a fabulous test case!\s*\<\/p\>/', $response) > -1);
         $this->assertTrue(strpos($response, '<nav>') > -1);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -249,7 +249,7 @@ class SmartContentItemControllerTest extends SuluTestCase
             '&provider=content&excluded=' . $this->team->getUuid()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
@@ -276,7 +276,7 @@ class SmartContentItemControllerTest extends SuluTestCase
             '&provider=content&excluded=' . $this->johannes->getUuid()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
@@ -302,7 +302,7 @@ class SmartContentItemControllerTest extends SuluTestCase
             '&provider=content&excluded=' . $this->team->getUuid() . '&limitResult=2'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
@@ -328,7 +328,7 @@ class SmartContentItemControllerTest extends SuluTestCase
             '&provider=content&excluded=' . $this->team->getUuid() . '&limitResult=2&tags[]=' . $this->tag1->getName()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/TemplateControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/TemplateControllerTest.php
@@ -31,7 +31,7 @@ class TemplateControllerTest extends SuluTestCase
         );
         $crawler = $client->request('GET', '/content/template/form/default.html');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(1, $crawler->filter('form#content-form')->count());
 
         // foreach property one textfield

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -118,11 +118,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $response = $client->getResponse();
         $responseData = json_decode($response->getContent(), true);
 
-        $this->assertEquals(
-            $statusCode,
-            $response->getStatusCode(),
-            json_encode($responseData)
-        );
+        $this->assertHttpStatusCode($statusCode, $response);
 
         if ($statusCode !== 200) {
             $this->assertEquals($restErrorCode, $responseData['code']);
@@ -492,11 +488,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $response = $client->getResponse();
         $responseData = json_decode($response->getContent(), true);
 
-        $this->assertEquals(
-            $statusCode,
-            $response->getStatusCode(),
-            array_key_exists('error', $responseData) ? $responseData['error']['message'] : ''
-        );
+        $this->assertHttpStatusCode($statusCode, $response);
 
         if ($statusCode !== 200) {
             $this->assertEquals($restErrorCode, $responseData['code']);
@@ -576,11 +568,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $response = $client->getResponse();
         $responseData = json_decode($response->getContent(), true);
 
-        $this->assertEquals(
-            200,
-            $response->getStatusCode(),
-            array_key_exists('error', $responseData) ? $responseData['error']['message'] : ''
-        );
+        $this->assertHttpStatusCode(200, $response);
 
         foreach ($data as $key => $value) {
             if ($key === 'targetDocument') {
@@ -657,7 +645,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $response = $client->getResponse();
         $responseDataComplete = json_decode($response->getContent(), true);
 
-        $this->assertEquals(200, $response->getStatusCode(), $response);
+        $this->assertHttpStatusCode(200, $response);
 
         foreach ($responseDataComplete['_embedded']['custom-urls'] as $responseData) {
             $data = $items[$responseData['customUrl']];
@@ -692,13 +680,13 @@ class CustomUrlControllerTest extends SuluTestCase
         $client->request('DELETE', '/api/webspaces/sulu_io/custom-urls/' . $uuid);
 
         $response = $client->getResponse();
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertHttpStatusCode(204, $response);
 
         $client = $this->createAuthenticatedClient();
         $client->request('GET', '/api/webspaces/sulu_io/custom-urls/' . $uuid);
 
         $response = $client->getResponse();
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertHttpStatusCode(404, $response);
     }
 
     /**
@@ -731,13 +719,13 @@ class CustomUrlControllerTest extends SuluTestCase
         $client->request('DELETE', '/api/webspaces/sulu_io/custom-urls?ids=' . implode(',', $uuids));
 
         $response = $client->getResponse();
-        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertHttpStatusCode(204, $response);
 
         $client = $this->createAuthenticatedClient();
         $client->request('GET', '/api/webspaces/sulu_io/custom-urls');
 
         $response = $client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
 
         $responseData = json_decode($response->getContent(), true);
         $this->assertCount(1, $responseData['_embedded']['custom-urls']);
@@ -874,7 +862,7 @@ class CustomUrlControllerTest extends SuluTestCase
         );
 
         $response = $client->getResponse();
-        $this->assertEquals($statusCode, $response->getStatusCode());
+        $this->assertHttpStatusCode($statusCode, $response);
 
         if ($restErrorCode) {
             $responseData = json_decode($response->getContent(), true);

--- a/src/Sulu/Bundle/LocationBundle/Tests/Functional/Controller/GeolocatorControllerTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Functional/Controller/GeolocatorControllerTest.php
@@ -42,6 +42,6 @@ class GeolocatorControllerTest extends SuluTestCase
         ]));
 
         $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -207,7 +207,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $style = json_decode(
             json_encode(
@@ -248,7 +248,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response->_embedded->collections);
 
@@ -267,7 +267,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections/10'
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(5005, $response->code);
@@ -306,7 +306,7 @@ class CollectionControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $style = new \stdClass();
         $style->type = 'circle';
@@ -335,7 +335,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -410,7 +410,7 @@ class CollectionControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $style = new \stdClass();
         $style->type = 'circle';
@@ -437,7 +437,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
 
@@ -467,7 +467,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertEquals(2 + $this->getAmountOfSystemCollections(), $response->total);
@@ -493,7 +493,7 @@ class CollectionControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('en', $response->locale);
         $this->assertNotNull($response->id);
@@ -513,7 +513,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -560,7 +560,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -628,7 +628,7 @@ class CollectionControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertTrue(isset($response->message));
     }
 
@@ -654,7 +654,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
@@ -664,7 +664,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $style = new \stdClass();
         $style->type = 'circle';
@@ -688,7 +688,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?locale=en-gb'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -742,14 +742,14 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/collections/' . $this->collection1->getId()
         );
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $style = new \stdClass();
         $style->type = 'circle';
@@ -773,7 +773,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?locale=en'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -833,14 +833,14 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/collections/' . $this->collection1->getId() . '?locale=en-gb'
         );
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $style = new \stdClass();
         $style->type = 'quader';
@@ -870,7 +870,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     /**
@@ -881,7 +881,7 @@ class CollectionControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/collections/' . $this->collection1->getId());
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createAuthenticatedClient();
 
@@ -890,7 +890,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections/' . $this->collection1->getId()
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(5005, $response->code);
@@ -905,7 +905,7 @@ class CollectionControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/collections/404');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/collections?flat=true');
         $response = json_decode($client->getResponse()->getContent());
@@ -990,7 +990,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertEquals(2, $response->total);
@@ -1014,7 +1014,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertEquals(6, $response->total);
@@ -1055,7 +1055,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertEquals(7, $response->total);
@@ -1105,7 +1105,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertCount(2, $response->_embedded->collections);
@@ -1128,7 +1128,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertCount(2, $response->_embedded->collections);
@@ -1172,7 +1172,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotEmpty($response);
         $this->assertCount(2, $response->_embedded->collections);
@@ -1255,7 +1255,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response->title);
         $this->assertNull($response->_embedded->parent);
@@ -1271,7 +1271,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response->title);
         $this->assertNull($response->_embedded->parent);
@@ -1297,7 +1297,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response->title);
         $this->assertNull($response->_embedded->parent);
@@ -1337,7 +1337,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($ids[0], $response->_embedded->parent->id);
 
@@ -1351,7 +1351,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $items = $response->_embedded->collections;
 
         // all items in this response
@@ -1409,7 +1409,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response['title']);
         $this->assertcount(1, $response['_embedded']['collections']);
@@ -1435,7 +1435,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response['title']);
         $this->assertcount(2, $response['_embedded']['collections']);
@@ -1452,7 +1452,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response['title']);
         $this->assertcount(1, $response['_embedded']['collections']);
@@ -1468,7 +1468,7 @@ class CollectionControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($titles[3], $response['title']);
         $this->assertcount(3, $response['_embedded']['collections']);
@@ -1497,7 +1497,7 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(403, $client->getResponse());
     }
 
     public function testPutSystemCollection()
@@ -1519,6 +1519,6 @@ class CollectionControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(403, $client->getResponse());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -346,7 +346,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media/' . $media->getId() . '?locale=en-gb'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
@@ -370,7 +370,7 @@ class MediaControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/media/' . $media->getId() . '?locale=de');
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
@@ -393,7 +393,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -415,7 +415,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?collection=' . $this->collection->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -440,7 +440,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?collection=' . $this->collection->getId() . '&types=image'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -463,7 +463,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?collection=' . $this->collection->getId() . '&types=audio'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -486,7 +486,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?collection=' . $this->collection->getId() . '&types=image,audio'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -511,7 +511,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?ids=' . $media->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -534,7 +534,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?ids=' . $media2->getId() . ',' . $media1->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -558,7 +558,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?flat=true&search=photo%2A'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
@@ -588,7 +588,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media?ids=1232,3123,1234'
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -609,7 +609,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media/11230'
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(5015, $response->code);
@@ -655,7 +655,7 @@ class MediaControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('photo.jpeg', $response->name);
         $this->assertNotNull($response->id);
@@ -713,7 +713,7 @@ class MediaControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($this->mediaDefaultTitle, $response->title);
 
         $this->assertEquals('photo.jpeg', $response->name);
@@ -748,7 +748,7 @@ class MediaControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals('small', $response->title);
 
         $this->assertEquals('small.txt', $response->name);
@@ -796,7 +796,7 @@ class MediaControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($media->getId(), $response->id);
         $this->assertEquals($this->collection->getId(), $response->collection);
         $this->assertEquals(2, $response->version);
@@ -855,7 +855,7 @@ class MediaControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($media->getId(), $response->id);
         $this->assertEquals($this->collection->getId(), $response->collection);
         $this->assertEquals(1, $response->version);
@@ -911,7 +911,7 @@ class MediaControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($media->getId(), $response->id);
         $this->assertEquals($this->mediaDefaultTitle, $response->title);
@@ -943,7 +943,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media/' . $media->getId()
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(5015, $response->code);
@@ -962,7 +962,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/collections/' . $this->collection->getId());
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createAuthenticatedClient();
 
@@ -971,7 +971,7 @@ class MediaControllerTest extends SuluTestCase
             '/api/media/' . $media->getId()
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(5015, $response->code);
@@ -987,7 +987,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/media/404');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/media');
         $response = json_decode($client->getResponse()->getContent());
@@ -1010,14 +1010,14 @@ class MediaControllerTest extends SuluTestCase
         );
         ob_end_clean();
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/media/' . $media->getId()
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -1057,7 +1057,7 @@ class MediaControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($destCollection->getId(), $response['collection']);
         $this->assertEquals($this->mediaDefaultTitle, $response['title']);
     }
@@ -1072,7 +1072,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request('POST', '/api/media/' . $media->getId() . '?action=move&destination=404');
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     /**
@@ -1083,7 +1083,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request('POST', '/api/media/404?action=move&destination=' . $this->collection->getId());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     /**
@@ -1096,7 +1096,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request('POST', '/api/media/' . $media->getId() . '?action=test');
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     /**

--- a/src/Sulu/Bundle/ResourceBundle/Tests/Functional/Controller/FilterControllerTest.php
+++ b/src/Sulu/Bundle/ResourceBundle/Tests/Functional/Controller/FilterControllerTest.php
@@ -143,7 +143,7 @@ class FilterControllerTest extends SuluTestCase
             'GET',
             '/api/filters/' . $this->filter1->getId()
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals($this->filter1->getId(), $response->id);
@@ -192,7 +192,7 @@ class FilterControllerTest extends SuluTestCase
             'GET',
             '/api/filters?context=contact'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertNotEmpty($response);
@@ -205,7 +205,7 @@ class FilterControllerTest extends SuluTestCase
             'GET',
             '/api/filters?flat=true&context=contact'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertNotEmpty($response);
@@ -221,7 +221,7 @@ class FilterControllerTest extends SuluTestCase
             'GET',
             '/api/filters/666'
         );
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
     /**
@@ -232,11 +232,11 @@ class FilterControllerTest extends SuluTestCase
         $filter = $this->createFilterAsArray('newFilter', false, 'contact');
         $this->client->request('POST', '/api/filters', $filter);
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->client->request('GET', '/api/filters/' . $response->id);
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals($filter['conjunction'], $response->conjunction);
         $this->assertEquals($filter['context'], $response->context);
@@ -256,7 +256,7 @@ class FilterControllerTest extends SuluTestCase
     {
         $filter = $this->createFilterAsArray('newFilter', false, 'not defined');
         $this->client->request('POST', '/api/filters', $filter);
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
     }
 
     /**
@@ -270,7 +270,7 @@ class FilterControllerTest extends SuluTestCase
         ];
         $this->client->request('POST', '/api/filters', $filter);
 
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
 
         $filter = [
             'name' => 'name',
@@ -278,7 +278,7 @@ class FilterControllerTest extends SuluTestCase
         ];
         $this->client->request('POST', '/api/filters', $filter);
 
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
 
         $filter = [
             'name' => 'name',
@@ -286,7 +286,7 @@ class FilterControllerTest extends SuluTestCase
         ];
         $this->client->request('POST', '/api/filters', $filter);
 
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
     }
 
     public function createFilterAsArray($name, $conjunction, $context, $partial = false)
@@ -329,11 +329,11 @@ class FilterControllerTest extends SuluTestCase
         $filter = $this->createFilterAsArray('newFilter', 'and', 'account', true);
         $this->client->request('POST', '/api/filters', $filter);
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->client->request('GET', '/api/filters/' . $response->id);
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals($filter['conjunction'], $response->conjunction);
         $this->assertEquals($filter['context'], $response->context);
@@ -378,7 +378,7 @@ class FilterControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals($newName, $response->name);
@@ -431,7 +431,7 @@ class FilterControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals($newName, $response->name);
@@ -473,7 +473,7 @@ class FilterControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals($newName, $response->name);
@@ -504,7 +504,7 @@ class FilterControllerTest extends SuluTestCase
                 'context' => $newContext,
             ]
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals($newName, $response->name);
@@ -519,7 +519,7 @@ class FilterControllerTest extends SuluTestCase
     {
         $this->client->request('PUT', '/api/filters/666', ['code' => 'Missing filter']);
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
         $this->assertEquals(
             'Entity with the type "SuluResourceBundle:Filter" and the id "666" not found.',
             $response->message
@@ -532,10 +532,10 @@ class FilterControllerTest extends SuluTestCase
     public function testDeleteById()
     {
         $this->client->request('DELETE', '/api/filters/' . $this->filter1->getId());
-        $this->assertEquals('204', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->request('GET', '/api/filters/' . $this->filter1->getId());
-        $this->assertEquals('404', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
     /**
@@ -547,10 +547,10 @@ class FilterControllerTest extends SuluTestCase
             '/api/filters?ids=' . $this->filter1->getId() . ',' . $this->filter2->getId() . ',' . $this->filter3->getId(
             )
         );
-        $this->assertEquals('204', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->request('GET', '/api/filters?context=contact');
-        $this->assertEquals('200', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEmpty($response->_embedded->filters);
     }
@@ -561,10 +561,10 @@ class FilterControllerTest extends SuluTestCase
     public function testCDeleteByIdsNotExisting()
     {
         $this->client->request('DELETE', '/api/filters?ids=666,999');
-        $this->assertEquals('204', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->request('GET', '/api/filters?context=contact&flat=true');
-        $this->assertEquals('200', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals(2, count($response->_embedded->filters));
     }
@@ -575,10 +575,10 @@ class FilterControllerTest extends SuluTestCase
     public function testCDeleteByIdsPartialExistent()
     {
         $this->client->request('DELETE', '/api/filters?ids=' . $this->filter1->getId() . ',666');
-        $this->assertEquals('204', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->request('GET', '/api/filters?context=contact&flat=true');
-        $this->assertEquals('200', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals(1, count($response->_embedded->filters));
     }
@@ -589,6 +589,6 @@ class FilterControllerTest extends SuluTestCase
     public function testDeleteByIdNotExisting()
     {
         $this->client->request('GET', '/api/filters/666');
-        $this->assertEquals('404', $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 }

--- a/src/Sulu/Bundle/ResourceBundle/Tests/Functional/Controller/OperatorControllerTest.php
+++ b/src/Sulu/Bundle/ResourceBundle/Tests/Functional/Controller/OperatorControllerTest.php
@@ -135,7 +135,7 @@ class OperatorControllerTest extends SuluTestCase
             'GET',
             '/api/operators'
         );
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent());
 
         $this->assertNotEmpty($response);

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -172,7 +172,7 @@ class SearchControllerTest extends SuluTestCase
         $this->client->request('GET', '/search/query', $params);
 
         $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         unset($result['_links']);
 
@@ -187,7 +187,7 @@ class SearchControllerTest extends SuluTestCase
         $this->client->request('GET', '/search/indexes');
 
         $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
 
         $this->assertEquals('product', $result[0]['indexName']);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/GroupControllerTest.php
@@ -184,7 +184,7 @@ class GroupControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(2, count($response->_embedded->groups));
 
         $client->request(
@@ -192,7 +192,7 @@ class GroupControllerTest extends SuluTestCase
             '/api/groups/' . $this->group1->getId()
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request(
             'GET',
@@ -200,7 +200,7 @@ class GroupControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(1, count($response->_embedded->groups));
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -101,7 +101,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         // asserting response
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($this->user1->getEmail(), $response->email);
 
         // asserting user properties
@@ -131,7 +131,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         // asserting response
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($this->user1->getEmail(), $response->email);
 
         // asserting user properties
@@ -163,7 +163,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         // asserting response
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals('installation.email@sulu.test', $response->email);
 
         // asserting user properties
@@ -195,7 +195,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         // asserting response
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($this->user3->getEmail(), $response->email);
 
         // asserting user properties
@@ -228,7 +228,7 @@ class ResettingControllerTest extends SuluTestCase
             $mailCollector = $client->getProfile()->getCollector('swiftmailer');
             $response = json_decode($client->getResponse()->getContent());
 
-            $this->assertEquals(200, $client->getResponse()->getStatusCode());
+            $this->assertHttpStatusCode(200, $client->getResponse());
             $this->assertEquals($this->user3->getEmail(), $response->email);
             $this->assertEquals(1, $mailCollector->getMessageCount());
         }
@@ -243,7 +243,7 @@ class ResettingControllerTest extends SuluTestCase
         $user = $client->getContainer()->get('doctrine')->getManager()
             ->find('SuluSecurityBundle:User', $this->user3->getId());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(1007, $response->code);
         $this->assertEquals(0, $mailCollector->getMessageCount());
         $this->assertEquals($counter, $user->getPasswordResetTokenEmailsSent());
@@ -260,7 +260,7 @@ class ResettingControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(0, $response->code);
         $this->assertEquals(0, $mailCollector->getMessageCount());
     }
@@ -278,7 +278,7 @@ class ResettingControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(0, $response->code);
         $this->assertEquals(0, $mailCollector->getMessageCount());
     }
@@ -293,7 +293,7 @@ class ResettingControllerTest extends SuluTestCase
         ]);
         $response = json_decode($client->getResponse()->getContent());
         // asserting response
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals($this->user1->getEmail(), $response->email);
 
         // second request should be blocked
@@ -303,7 +303,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $mailCollector = $client->getProfile()->getCollector('swiftmailer');
         // asserting response
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(1003, $response->code);
         $this->assertEquals(0, $mailCollector->getMessageCount());
     }
@@ -321,7 +321,7 @@ class ResettingControllerTest extends SuluTestCase
         $user = $client->getContainer()->get('doctrine')->getManager()
             ->find('SuluSecurityBundle:User', $this->user3->getId());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $encoder = $this->getContainer()->get('security.encoder_factory')->getEncoder($user);
         $this->assertEquals($encoder->encodePassword($newPassword, $user->getSalt()), $user->getPassword());
@@ -340,7 +340,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $user = $this->em->find('SuluSecurityBundle:User', $this->user3->getId());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(1005, $response->code);
         $this->assertEquals($passwordBefore, $user->getPassword());
     }
@@ -357,7 +357,7 @@ class ResettingControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $user = $this->em->find('SuluSecurityBundle:User', $this->user3->getId());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertEquals(1005, $response->code);
         $this->assertEquals($passwordBefore, $user->getPassword());
     }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -474,7 +474,7 @@ class RoleControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $this->assertContains('11230', $response->message);
     }
 
@@ -488,7 +488,7 @@ class RoleControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(2, count($response->_embedded->roles));
 
         $client->request(
@@ -496,7 +496,7 @@ class RoleControllerTest extends SuluTestCase
             '/api/roles/' . $this->role1->getId()
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request(
             'GET',
@@ -504,7 +504,7 @@ class RoleControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals(1, count($response->_embedded->roles));
     }
 
@@ -519,7 +519,7 @@ class RoleControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $this->assertContains('11230', $response->message);
     }
 
@@ -530,7 +530,7 @@ class RoleControllerTest extends SuluTestCase
         $client->request('GET', '/api/roles');
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(2, count($response->_embedded->roles));
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -244,7 +244,7 @@ class UserControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
         $this->assertContains('1120', $response->message);
     }
 
@@ -362,7 +362,7 @@ class UserControllerTest extends SuluTestCase
         );
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertContains('username', $response->message);
     }
 
@@ -393,7 +393,7 @@ class UserControllerTest extends SuluTestCase
         );
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $this->assertContains('email', strtolower($response->message));
         $this->assertEquals(1004, $response->code);
     }
@@ -427,7 +427,7 @@ class UserControllerTest extends SuluTestCase
         );
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals('hikari', $response->username);
         $this->assertEquals('contact.unique@test.com', $response->email);
         $this->assertEquals($this->contact1->getId(), $response->contact->id);
@@ -440,11 +440,11 @@ class UserControllerTest extends SuluTestCase
 
         $client->request('DELETE', '/api/users/' . $this->user1->getId());
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/users/' . $this->user1->getId());
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteNotExisting()
@@ -453,7 +453,7 @@ class UserControllerTest extends SuluTestCase
 
         $client->request('DELETE', '/api/users/11235');
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testPut()
@@ -564,7 +564,7 @@ class UserControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $this->assertEquals('admin', $response->username);
         $this->assertEquals(1001, $response->code);
     }
@@ -601,7 +601,7 @@ class UserControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $this->assertEquals('admin', $response->username);
         $this->assertEquals(1001, $response->code);
     }
@@ -680,7 +680,7 @@ class UserControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(409, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $client->getResponse());
         $this->assertEquals('admin', $response->username);
         $this->assertEquals(1001, $response->code);
     }
@@ -714,7 +714,7 @@ class UserControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
         $this->assertContains('password', $response->message);
     }
 
@@ -729,7 +729,7 @@ class UserControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals($this->user1->getId(), $response->_embedded->users[0]->id);
         $this->assertEquals('admin', $response->_embedded->users[0]->username);
@@ -750,7 +750,7 @@ class UserControllerTest extends SuluTestCase
             '/api/users?contactId=1234'
         );
 
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
     }
 
     public function testGetUserAndRolesWithoutParam()
@@ -946,7 +946,7 @@ class UserControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals(1002, $response->code);
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testPutWithoutPassword()

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -64,7 +64,7 @@ class SnippetControllerTest extends SuluTestCase
 
         $result = $response->getContent();
         $result = json_decode($response->getContent(), true);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $this->assertLinks([
             'self', 'delete', 'update', 'new',
         ], $result);
@@ -105,7 +105,7 @@ class SnippetControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
 
         $result = json_decode($response->getContent(), true);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $this->assertLinks([
             'self', 'first', 'last', 'filter', 'find', 'pagination', 'sortable',
         ], $result);
@@ -129,7 +129,7 @@ class SnippetControllerTest extends SuluTestCase
         );
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         $result = reset($result['_embedded']['snippets']);
         $this->assertEquals($this->hotel1->getUuid(), $result['id']);
@@ -147,7 +147,7 @@ class SnippetControllerTest extends SuluTestCase
         ));
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         $result = $result['_embedded']['snippets'];
         $this->assertCount(2, $result);
@@ -212,7 +212,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('GET', '/snippets?' . $query);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
 
         $result = json_decode($response->getContent(), true);
         $this->assertCount($expectedNbResults, $result['_embedded']['snippets']);
@@ -265,7 +265,7 @@ class SnippetControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
 
         $result = json_decode($response->getContent(), true);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $this->assertLinks([
             'self', 'delete', 'update', 'new',
         ], $result);
@@ -301,7 +301,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('POST', '/snippets?' . $query, $data);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         $this->assertEquals($data['title'], $result['title']);
         $this->assertEquals($params['language'], reset($result['concreteLanguages']));
@@ -327,7 +327,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('POST', '/snippets?' . $query, $data);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         $this->assertEquals($data['title'], $result['title']);
         $this->assertEquals($params['language'], reset($result['concreteLanguages']));
@@ -351,7 +351,7 @@ class SnippetControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
 
         $result = json_decode($response->getContent(), true);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
 
         foreach ($data as $key => $value) {
             $this->assertEquals($data[$key], $value);
@@ -378,7 +378,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('PUT', sprintf('/snippets/%s?%s', $this->hotel1->getUuid(), $query), $data);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         $this->assertLinks([
             'self', 'delete', 'update', 'new',
@@ -404,7 +404,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('PUT', sprintf('/snippets/%s?%s', $this->hotel1->getUuid(), $query), $data);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
         $this->assertEquals(StructureInterface::STATE_TEST, $result['nodeState']);
     }
@@ -420,7 +420,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('POST', '/snippets?language=de', $data);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
 
         $this->client->request(
@@ -429,7 +429,7 @@ class SnippetControllerTest extends SuluTestCase
             array_merge(['_hash' => $result['_hash']], $data)
         );
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
     }
 
     public function testPutWithInvalidHash()
@@ -443,7 +443,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('POST', '/snippets?language=de', $data);
         $response = $this->client->getResponse();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $result = json_decode($response->getContent(), true);
 
         $this->client->request(
@@ -452,7 +452,7 @@ class SnippetControllerTest extends SuluTestCase
             array_merge(['_hash' => 'wrong-hash'], $data)
         );
 
-        $this->assertEquals(409, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(409, $this->client->getResponse());
     }
 
     public function testDeleteReferenced()
@@ -483,7 +483,7 @@ class SnippetControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
         $content = json_decode($response->getContent(), true);
 
-        $this->assertEquals(409, $response->getStatusCode());
+        $this->assertHttpStatusCode(409, $response);
         $this->assertEquals($node->getPath(), $content['other'][0]);
     }
 
@@ -496,7 +496,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->documentManager->flush();
 
         $this->client->request('POST', '/snippets/' . $snippet->getUuid() . '?action=copy-locale&dest=en&language=de');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $newPage = $this->documentManager->find($snippet->getUuid(), 'en');
         $this->assertEquals('Hotel de', $newPage->getTitle());
@@ -509,7 +509,7 @@ class SnippetControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/snippet/fields');
         $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertHttpStatusCode(200, $response);
         $body = $response->getContent();
         $fields = json_decode($body);
         $this->assertNotNull($fields);

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -54,7 +54,7 @@ class TagControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('tag1', $response['name']);
         $this->assertNotContains('creator', array_keys($response));
@@ -100,7 +100,7 @@ class TagControllerTest extends SuluTestCase
             '/api/tags/11230'
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(0, $response->code);
@@ -127,7 +127,7 @@ class TagControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('tag3', $response['name']);
         $this->assertNotContains('creator', array_keys($response));
@@ -143,7 +143,7 @@ class TagControllerTest extends SuluTestCase
             ['name' => 'tag1']
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('A tag with the name "tag1"already exists!', $response->message);
@@ -170,7 +170,7 @@ class TagControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('tag1_new', $response['name']);
         $this->assertNotContains('creator', array_keys($response));
@@ -186,7 +186,7 @@ class TagControllerTest extends SuluTestCase
             ['name' => 'tag1']
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('A tag with the name "tag1"already exists!', $response->message);
@@ -202,7 +202,7 @@ class TagControllerTest extends SuluTestCase
             ['name' => 'tag1_new']
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteById()
@@ -220,13 +220,13 @@ class TagControllerTest extends SuluTestCase
             'DELETE',
             '/api/tags/' . $this->tag1->getId()
         );
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/tags/' . $this->tag1->getId()
         );
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteByNotExistingId()
@@ -237,7 +237,7 @@ class TagControllerTest extends SuluTestCase
             'DELETE',
             '/api/tags/4711'
         );
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testMerge()
@@ -268,32 +268,32 @@ class TagControllerTest extends SuluTestCase
                 $this->tag2->getId(), $tag3->getId(), $tag4->getId(),
             ]), 'dest' => $this->tag1->getId()]
         );
-        $this->assertEquals(303, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(303, $client->getResponse());
         $this->assertEquals('/admin/api/tags/' . $this->tag1->getId(), $client->getResponse()->headers->get('location'));
 
         $client->request(
             'GET',
             '/api/tags/' . $this->tag1->getId()
         );
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/tags/' . $this->tag2->getId()
         );
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/tags/' . $tag3->getId()
         );
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request(
             'GET',
             '/api/tags/' . $tag4->getId()
         );
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testMergeNotExisting()
@@ -305,7 +305,7 @@ class TagControllerTest extends SuluTestCase
             ['src' => 1233, 'dest' => $this->tag1->getId()]
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -334,7 +334,7 @@ class TagControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('tag3', $response[0]->name);
@@ -374,7 +374,7 @@ class TagControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('A tag with the name "tag1"already exists!', $response->message);
@@ -399,7 +399,7 @@ class TagControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('tag11', $response[0]->name);

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CatalogueControllerTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CatalogueControllerTest.php
@@ -79,10 +79,10 @@ class CatalogueControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/catalogues/' . $this->catalogue->getId());
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/catalogues/' . $this->catalogue->getId());
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testDeleteByIdNotExisting()
@@ -90,7 +90,7 @@ class CatalogueControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/catalogues/4711');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/catalogues');
         $response = json_decode($client->getResponse()->getContent());
@@ -102,7 +102,7 @@ class CatalogueControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', '/api/catalogues?flat=true&fields=id,locale&packageId=' . $this->package->getId());
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals($this->catalogue->getId(), $response->_embedded->catalogues[0]->id);
@@ -115,7 +115,7 @@ class CatalogueControllerTest extends SuluTestCase
         $client->request('GET', '/api/catalogues?flat=true&fields=id,locale&packageId=4711');
 
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals('200', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
         $this->assertEquals('0', $response->total);
     }
 

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CodeControllerTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CodeControllerTest.php
@@ -224,7 +224,7 @@ class CodeControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/api/codes');
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(4, $response->total);
         $this->assertEquals(4, count($response->_embedded->codes));
@@ -246,7 +246,7 @@ class CodeControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/api/codes?packageId=' . $this->package1->getId());
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(3, count($response->_embedded->codes));
 
@@ -261,7 +261,7 @@ class CodeControllerTest extends SuluTestCase
 
         $this->client->request('GET', '/api/codes?catalogueId= ' . $this->catalogue2->getId());
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(3, count($response->_embedded->codes));
 
@@ -279,7 +279,7 @@ class CodeControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/api/codes?packageId=5123');
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(0, count($response->_embedded->codes));
         $this->assertEquals(0, $response->total);
@@ -289,7 +289,7 @@ class CodeControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/api/codes?catalogueId=5123');
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(0, count($response->_embedded->codes));
         $this->assertEquals(0, $response->total);
@@ -299,14 +299,14 @@ class CodeControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/api/codes?limit=2&page=1');
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(2, count($response->_embedded->codes));
         $this->assertEquals(2, $response->total);
 
         $this->client->request('GET', '/api/codes?limit=2&page=2');
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals(1, count($response->_embedded->codes));
         $this->assertEquals(1, $response->total);
@@ -316,7 +316,7 @@ class CodeControllerTest extends SuluTestCase
     {
         $this->client->request('GET', '/api/codes?sortBy=id&sortOrder=desc');
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertNotNull($response->_embedded->codes[0]->id);
         $this->assertNotNull($response->_embedded->codes[1]->id);
@@ -499,7 +499,7 @@ class CodeControllerTest extends SuluTestCase
     public function testGetIdNotExisting()
     {
         $this->client->request('GET', '/api/codes/5123');
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
     public function testPost()
@@ -560,7 +560,7 @@ class CodeControllerTest extends SuluTestCase
             '/api/codes',
             $r1
         );
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
 
         $r2 = [
             'code' => 'test.code.5',
@@ -579,7 +579,7 @@ class CodeControllerTest extends SuluTestCase
             $r2
         );
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
 
         $r3 = [
             'code' => 'test.code.6',
@@ -596,7 +596,7 @@ class CodeControllerTest extends SuluTestCase
             $r3
         );
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
 
         $r4 = [
             'code' => 'test.code.7',
@@ -613,7 +613,7 @@ class CodeControllerTest extends SuluTestCase
             $r4
         );
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
 
         $r5 = [
             'code' => 'test.code.8',
@@ -632,7 +632,7 @@ class CodeControllerTest extends SuluTestCase
             $r5
         );
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
     }
 
     public function testPut()
@@ -660,11 +660,11 @@ class CodeControllerTest extends SuluTestCase
             $request
         );
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->client->request('GET', '/api/codes/' . $this->code1->getId());
         $response = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertNotNull($response->id);
         $this->assertEquals($request['code'], $response->code);
@@ -706,7 +706,7 @@ class CodeControllerTest extends SuluTestCase
             '/api/codes/125',
             $request
         );
-        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
     public function testPutNotExistingPackage()
@@ -728,7 +728,7 @@ class CodeControllerTest extends SuluTestCase
             '/api/codes/' . $this->code1->getId(),
             $request
         );
-        $this->assertEquals(500, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(500, $this->client->getResponse());
 
         $this->client->request('GET', '/api/codes/' . $this->code1->getId());
         $response = json_decode($this->client->getResponse()->getContent());
@@ -759,7 +759,7 @@ class CodeControllerTest extends SuluTestCase
             '/api/codes/' . $this->code1->getId(),
             $request
         );
-        $this->assertEquals(500, $this->client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(500, $this->client->getResponse());
 
         $this->client->request('GET', '/api/codes/' . $this->code1->getId());
         $response = json_decode($this->client->getResponse()->getContent());
@@ -776,7 +776,7 @@ class CodeControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/codes/' . $this->code1->getId());
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
     }
 
     public function testDeleteByIdNotExisting()
@@ -784,7 +784,7 @@ class CodeControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/codes/4711');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         $client->request('GET', '/api/codes');
         $response = json_decode($client->getResponse()->getContent());

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/PackageControllerTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/PackageControllerTest.php
@@ -211,7 +211,7 @@ class PackageControllerTest extends SuluTestCase
             []
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
     }
 
     public function testPut()
@@ -302,7 +302,7 @@ class PackageControllerTest extends SuluTestCase
             ['name' => 'Portal']
         );
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testPutNotExistingCatalogue()
@@ -320,7 +320,7 @@ class PackageControllerTest extends SuluTestCase
             ]
         );
 
-        $this->assertEquals(400, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(400, $client->getResponse());
 
         $client->request(
             'GET',
@@ -338,7 +338,7 @@ class PackageControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/packages/' . $this->package1->getId());
-        $this->assertEquals('204', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
     }
 
     public function testDeleteByIdNotExisting()
@@ -346,7 +346,7 @@ class PackageControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/packages/4711');
-        $this->assertEquals('404', $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(404, $client->getResponse());
 
         // there still have to be 3 packages
         $client->request('GET', '/api/packages');

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/TranslationsControllerTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/TranslationsControllerTest.php
@@ -115,7 +115,7 @@ class TranslationsControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request('GET', '/api/catalogues/' . $this->catalogue2->getId() . '/translations');
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(2, $response->total);
         $this->assertEquals(2, count($response->_embedded->translations));
@@ -165,12 +165,12 @@ class TranslationsControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request('PATCH', '/api/catalogues/' . $this->catalogue1->getId() . '/translations', $request);
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createAuthenticatedClient();
         $client->request('GET', '/api/catalogues/' . $this->catalogue1->getId() . '/translations');
         $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(3, $response->total);
         $this->assertEquals(3, count($response->_embedded->translations));

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/AnalyticsControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/AnalyticsControllerTest.php
@@ -41,7 +41,7 @@ class AnalyticsControllerTest extends SuluTestCase
         $client->request('GET', '/api/webspaces/test/analytics');
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEmpty($response['_embedded']['analytics']);
     }
@@ -53,7 +53,7 @@ class AnalyticsControllerTest extends SuluTestCase
         $client->request('GET', '/api/webspaces/sulu_io/analytics');
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $items = $response['_embedded']['analytics'];
         $this->assertCount(3, $items);
@@ -90,7 +90,7 @@ class AnalyticsControllerTest extends SuluTestCase
         $client->request('GET', '/api/webspaces/sulu_io/analytics/' . $this->entities[0]->getId());
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('test-1', $response['title']);
         $this->assertEquals('google', $response['type']);
@@ -116,7 +116,7 @@ class AnalyticsControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotNull($response['id']);
         $this->assertEquals('test-1', $response['title']);
@@ -146,7 +146,7 @@ class AnalyticsControllerTest extends SuluTestCase
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotNull($response['id']);
         $this->assertEquals('test-10', $response['title']);
@@ -164,11 +164,11 @@ class AnalyticsControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
 
         $client->request('DELETE', '/api/webspaces/test_io/analytics/' . $this->entities[3]->getId());
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/webspaces/test_io/analytics');
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEmpty($response['_embedded']['analytics']);
     }
@@ -184,11 +184,11 @@ class AnalyticsControllerTest extends SuluTestCase
         ];
 
         $client->request('DELETE', '/api/webspaces/sulu_io/analytics?ids=' . implode(',', $ids));
-        $this->assertEquals(204, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/webspaces/sulu_io/analytics');
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEmpty($response['_embedded']['analytics']);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

This PR introduces a `->assertHttpStatusCode` method to the base functional test case.

This method will show a *useful* error message when the HTTP code is not expected instead of the current:

```
200 is not equal to 404
```

- Shows the body of the content
- Pretty prints JSON if it is a JSON response
- Limits the number of lines (default to 10)

#### Why?

Because the current way of asserting responses gives no indication as to why the request failed.

#### Example Usage

~~~php
PHPUnit 5.0.3 by Sebastian Bergmann and contributors.

...SSF

Time: 19.26 seconds, Memory: 108.50Mb

There was 1 failure:

1) Sulu\Bundle\TagBundle\Tests\Functional\Controller\CategoryControllerTest::testCGetWithSorting
HTTP status code 500 is not expected 200, showing 10 lines of the response body: {
    "code": 0,
    "message": "An exception occurred while executing 'SELECT c0_.id AS id_0, c0_.category_key AS category_key_1, c0_.default_locale AS default_locale_2, (CASE WHEN c1_.translation IS NOT NULL THEN c1_.translation ELSE c2_.translation END) AS sclr_3, (CASE WHEN c1_.locale IS NOT NULL THEN c1_.locale ELSE c2_.locale END) AS sclr_4, c0_.created AS created_5, c0_.changed AS changed_6, c0_.depth AS depth_7, c3_.id AS id_8, c4_.id AS id_9 FROM ca_categories c0_ LEFT JOIN ca_category_translations c1_ ON c0_.id = c1_.idCategories AND (c1_.locale = 'en') LEFT JOIN ca_category_translations c2_ ON c0_.id = c2_.idCategories AND (c2_.locale = c0_.default_locale) LEFT JOIN ca_categories c3_ ON c0_.idCategoriesParent = c3_.id LEFT JOIN ca_categories c4_ ON c0_.id = c4_.idCategoriesParent WHERE c0_.id IN (?, ?, ?, ?) GROUP BY c0_.id ORDER BY c0_.depth DESC' with params [1261, 1260, 1258, 1259]:\n\nSQLSTATE[42803]: Grouping error: 7 ERROR:  column \"c1_.translation\" must appear in the GROUP BY clause or be used in an aggregate function\nLINE 1: ...0_.default_locale AS default_locale_2, (CASE WHEN c1_.transl...\n                                                             ^",
    "errors": [
        {
            "message": "An exception occurred while executing 'SELECT c0_.id AS id_0, c0_.category_key AS category_key_1, c0_.default_locale AS default_locale_2, (CASE WHEN c1_.translation IS NOT NULL THEN c1_.translation ELSE c2_.translation END) AS sclr_3, (CASE WHEN c1_.locale IS NOT NULL THEN c1_.locale ELSE c2_.locale END) AS sclr_4, c0_.created AS created_5, c0_.changed AS changed_6, c0_.depth AS depth_7, c3_.id AS id_8, c4_.id AS id_9 FROM ca_categories c0_ LEFT JOIN ca_category_translations c1_ ON c0_.id = c1_.idCategories AND (c1_.locale = 'en') LEFT JOIN ca_category_translations c2_ ON c0_.id = c2_.idCategories AND (c2_.locale = c0_.default_locale) LEFT JOIN ca_categories c3_ ON c0_.idCategoriesParent = c3_.id LEFT JOIN ca_categories c4_ ON c0_.id = c4_.idCategoriesParent WHERE c0_.id IN (?, ?, ?, ?) GROUP BY c0_.id ORDER BY c0_.depth DESC' with params [1261, 1260, 1258, 1259]:\n\nSQLSTATE[42803]: Grouping error: 7 ERROR:  column \"c1_.translation\" must appear in the GROUP BY clause or be used in an aggregate function\nLINE 1: ...0_.default_locale AS default_locale_2, (CASE WHEN c1_.transl...\n                                                             ^",
            "code": 0,
            "previous": {
                "message": "SQLSTATE[42803]: Grouping error: 7 ERROR:  column \"c1_.translation\" must appear in the GROUP BY clause or be used in an aggregate function\nLINE 1: ...0_.default_locale AS default_locale_2, (CASE WHEN c1_.transl...\n                                                             ^",
                "code": "42803",
Failed asserting that 500 matches expected 200.

/home/daniel/www/sulu-io/sulu/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php:222
/home/daniel/www/sulu-io/sulu/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php:277

FAILURES!
Tests: 6, Assertions: 22, Failures: 1, Skipped: 2.
~~~
