### PR TITLE
Use prefer dist in composer install app_veyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
   # install composer and phpunit
   - cd %APPVEYOR_BUILD_FOLDER%
   - php -r "readfile('http://getcomposer.org/installer');" | php
-  - php composer.phar install --no-interaction --no-progress
+  - php composer.phar install --no-interaction --no-progress --prefer-dist
 
 test_script:
    - cd %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
App veyor builds currently hang on `composer install`, noticed that the `zend-search` dependency times out after 300seconds cloning from Github, does not explain the ~50m wait but maybe related, switching to `--prefer-dist` to see if this improves the situation.