### PR TITLE
Fixed escaping of seo tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2229 [WebsiteBundle]       Fixed escaping of seo tags
     * ENHANCEMENT #2220 [ContentBundle]       Removed routable behavior and moved logic route-subscriber
     * ENHANCEMENT #2216 [All]                 Added KernelTestCase::assertHttpStatusCode method
     * BUGFIX      #2217 [MediaBundle]         Fixed ui-bugs in media-collections

--- a/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
@@ -91,7 +91,7 @@ class StructureProvider implements LocalizedReindexProviderInterface
                 }
             }
             $newDocuments[] = $document;
-        };
+        }
 
         return $newDocuments;
     }

--- a/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/ExtensionContainerSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/ExtensionContainerSubscriber.php
@@ -46,4 +46,3 @@ class ExtensionContainerSubscriber implements EventSubscriberInterface
         }
     }
 }
-;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
@@ -407,6 +407,45 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
                     'noFollow' => false,
                 ],
             ],
+            [
+                [
+                    'title' => '"SEO title"',
+                    'description' => '"SEO description"',
+                    'keywords' => '"SEO keywords"',
+                ],
+                [],
+                [
+                    'en' => '/url-en',
+                ],
+                'en',
+                'en',
+                null,
+                [
+                    '<title>&quot;SEO title&quot;</title>',
+                    '<meta name="description" content="&quot;SEO description&quot;"/>',
+                    '<meta name="keywords" content="&quot;SEO keywords&quot;"/>',
+                ],
+            ],
+            [
+                [
+                    'description' => '"SEO description"',
+                    'keywords' => '"SEO keywords"',
+                ],
+                [
+                    'title' => '"Content title"',
+                ],
+                [
+                    'en' => '/url-en',
+                ],
+                'en',
+                'en',
+                null,
+                [
+                    '<title>&quot;Content title&quot;</title>',
+                    '<meta name="description" content="&quot;SEO description&quot;"/>',
+                    '<meta name="keywords" content="&quot;SEO keywords&quot;"/>',
+                ],
+            ],
         ];
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -118,11 +118,11 @@ class SeoTwigExtension extends \Twig_Extension
         $titleHtml = '<title>%s</title>';
 
         if (isset($seoExtension['title']) && $seoExtension['title'] !== '') {
-            return sprintf($titleHtml, $seoExtension['title']);
+            return sprintf($titleHtml, htmlentities($seoExtension['title']));
         }
 
         if (isset($content['title'])) {
-            return sprintf($titleHtml . PHP_EOL, $content['title']);
+            return sprintf($titleHtml . PHP_EOL, htmlentities($content['title']));
         }
 
         return '';
@@ -175,7 +175,7 @@ class SeoTwigExtension extends \Twig_Extension
      */
     private function renderMetaTag($name, $content)
     {
-        return sprintf('<meta name="%s" content="%s"/>' . PHP_EOL, $name, $content);
+        return sprintf('<meta name="%s" content="%s"/>' . PHP_EOL, $name, htmlentities($content));
     }
 
     /**

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -842,7 +842,7 @@ class ContentMapper implements ContentMapperInterface
 
                     $result[] = $item;
                 }
-            };
+            }
         }
 
         return $result;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/2228
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the escaping of seo html tags.

#### Why?

if you use quotes in your seo-title or other fields the generated HTML is not valid.
