### PR TITLE
Fixed saving of resource locator without locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2233 [ContentBundle]       Fixed resource locators for saving without locale
     * ENHANCEMENT #2220 [ContentBundle]       Removed routable behavior and moved logic route-subscriber
     * BUGFIX      #2219 [ContentBundle]       Fixed changing template when disabling shadow page
     * ENHANCEMENT #2216 [All]                 Added KernelTestCase::assertHttpStatusCode method

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -144,6 +144,10 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
             return;
         }
 
+        if (!$event->getLocale()) {
+            return;
+        }
+
         if ($document instanceof HomeDocument) {
             return;
         }

--- a/src/Sulu/Component/Content/Tests/Functional/Rlp/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Rlp/Mapper/PhpcrMapperTest.php
@@ -313,11 +313,11 @@ class PhpcrMapperTest extends SuluTestCase
         $session = $this->sessionManager->getSession();
 
         $document2 = $this->createDocument($this->document1, 'content2', '/news');
-        $this->documentManager->persist($document2);
+        $this->documentManager->persist($document2, 'en');
         $document3 = $this->createDocument($document2, 'content3', '/news/news-1');
-        $this->documentManager->persist($document3);
+        $this->documentManager->persist($document3, 'en');
         $document4 = $this->createDocument($document3, 'content4', '/news/news-1/sub-1');
-        $this->documentManager->persist($document4);
+        $this->documentManager->persist($document4, 'en');
         $this->documentManager->flush();
 
         $this->document1->setResourceSegment('/news/news-1/sub-2');

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
@@ -138,9 +138,23 @@ class ResourceSegmentSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->resourceSegmentSubscriber->handlePersistDocument($event->reveal());
     }
 
+    public function testPersistDocumentWithoutLocale()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $document = $this->prophesize(ResourceSegmentBehavior::class);
+        $document->willImplement(StructureBehavior::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getLocale()->willReturn(null)->shouldBeCalled();
+        $this->rlpStrategy->save($document->reveal(), Argument::any())->shouldNotBeCalled();
+
+        $this->resourceSegmentSubscriber->handlePersistRoute($event->reveal());
+    }
+
     public function testPersistRoute()
     {
         $event = $this->prophesize(PersistEvent::class);
+        $event->getLocale()->willReturn('de');
 
         $this->document->getRedirectType()->willReturn(RedirectType::NONE);
         $event->getDocument()->willReturn($this->document->reveal());
@@ -152,6 +166,7 @@ class ResourceSegmentSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testPersistRouteForRedirect()
     {
         $event = $this->prophesize(PersistEvent::class);
+        $event->getLocale()->willReturn('de');
 
         $this->document->getRedirectType()->willReturn(RedirectType::INTERNAL);
         $event->getDocument()->willReturn($this->document->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the permission tab for pages. If the user changes the permissions on the page, the request erred, because the `ResourceSegmentSubscriber` couldn't handle the persist call without a locale.

#### Why?

This PR fixes the bug for the permission tab with pages. It was failing with the following message:

```
{"code":0,"message":"Invalid path '\/cmf\/sulu_io\/routes\/'","errors":[{"message":"Invalid path '\/cmf\/sulu_io\/routes\/'","code":0,"trace":[{"namespace":"","short_class":"","class":"","type":"","function":"","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/phpcr\/phpcr-utils\/src\/PHPCR\/Util\/PathHelper.php","line":325,"args":[]},{"namespace":"PHPCR\\Util","short_class":"PathHelper","class":"PHPCR\\Util\\PathHelper","type":"::","function":"error","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/phpcr\/phpcr-utils\/src\/PHPCR\/Util\/PathHelper.php","line":55,"args":[["string","Invalid path '\/cmf\/sulu_io\/routes\/'"],["boolean",true]]},{"namespace":"PHPCR\\Util","short_class":"PathHelper","class":"PHPCR\\Util\\PathHelper","type":"::","function":"assertValidAbsolutePath","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/phpcr\/phpcr-utils\/src\/PHPCR\/Util\/PathHelper.php","line":170,"args":[["string","\/cmf\/sulu_io\/routes\/"],["boolean",false],["boolean",true]]},{"namespace":"PHPCR\\Util","short_class":"PathHelper","class":"PHPCR\\Util\\PathHelper","type":"::","function":"normalizePath","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/jackalope\/jackalope\/src\/Jackalope\/ObjectManager.php","line":190,"args":[["string","\/cmf\/sulu_io\/routes\/"]]},{"namespace":"Jackalope","short_class":"ObjectManager","class":"Jackalope\\ObjectManager","type":"->","function":"getNodeByPath","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/jackalope\/jackalope\/src\/Jackalope\/Session.php","line":273,"args":[["string","\/cmf\/sulu_io\/routes\/"]]},{"namespace":"Jackalope","short_class":"Session","class":"Jackalope\\Session","type":"->","function":"getNode","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/PHPCR\/SessionManager\/SessionManager.php","line":47,"args":[["string","\/cmf\/sulu_io\/routes\/"]]},{"namespace":"Sulu\\Component\\PHPCR\\SessionManager","short_class":"SessionManager","class":"Sulu\\Component\\PHPCR\\SessionManager\\SessionManager","type":"->","function":"getRouteNode","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Content\/Types\/Rlp\/Mapper\/PhpcrMapper.php","line":459,"args":[["string","sulu_io"],["null"],["null"]]},{"namespace":"Sulu\\Component\\Content\\Types\\Rlp\\Mapper","short_class":"PhpcrMapper","class":"Sulu\\Component\\Content\\Types\\Rlp\\Mapper\\PhpcrMapper","type":"->","function":"getWebspaceRouteNode","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Content\/Types\/Rlp\/Mapper\/PhpcrMapper.php","line":298,"args":[["string","sulu_io"],["null"],["null"]]},{"namespace":"Sulu\\Component\\Content\\Types\\Rlp\\Mapper","short_class":"PhpcrMapper","class":"Sulu\\Component\\Content\\Types\\Rlp\\Mapper\\PhpcrMapper","type":"->","function":"unique","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Content\/Types\/Rlp\/Strategy\/RlpStrategy.php","line":278,"args":[["string","\/test"],["string","sulu_io"],["null"],["null"]]},{"namespace":"Sulu\\Component\\Content\\Types\\Rlp\\Strategy","short_class":"RlpStrategy","class":"Sulu\\Component\\Content\\Types\\Rlp\\Strategy\\RlpStrategy","type":"->","function":"isValid","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Content\/Types\/Rlp\/Strategy\/RlpStrategy.php","line":146,"args":[["string","\/test"],["string","sulu_io"],["null"]]},{"namespace":"Sulu\\Component\\Content\\Types\\Rlp\\Strategy","short_class":"RlpStrategy","class":"Sulu\\Component\\Content\\Types\\Rlp\\Strategy\\RlpStrategy","type":"->","function":"save","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Content\/Document\/Subscriber\/ResourceSegmentSubscriber.php","line":204,"args":[["object","Sulu\\Bundle\\ContentBundle\\Document\\PageDocument"],["null"]]},{"namespace":"Sulu\\Component\\Content\\Document\\Subscriber","short_class":"ResourceSegmentSubscriber","class":"Sulu\\Component\\Content\\Document\\Subscriber\\ResourceSegmentSubscriber","type":"->","function":"persistRoute","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Content\/Document\/Subscriber\/ResourceSegmentSubscriber.php","line":155,"args":[["object","Sulu\\Bundle\\ContentBundle\\Document\\PageDocument"]]},{"namespace":"Sulu\\Component\\Content\\Document\\Subscriber","short_class":"ResourceSegmentSubscriber","class":"Sulu\\Component\\Content\\Document\\Subscriber\\ResourceSegmentSubscriber","type":"->","function":"handlePersistRoute","args":[["object","Sulu\\Component\\DocumentManager\\Event\\PersistEvent"],["string","sulu_document_manager.persist"],["object","Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher"]]},{"namespace":"","short_class":"","class":"","type":"","function":"call_user_func","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/app\/cache\/admin\/dev\/classes.php","line":1853,"args":[["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ResourceSegmentSubscriber"],["string","handlePersistRoute"]]],["object","Sulu\\Component\\DocumentManager\\Event\\PersistEvent"],["string","sulu_document_manager.persist"],["object","Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher"]]},{"namespace":"Symfony\\Component\\EventDispatcher","short_class":"EventDispatcher","class":"Symfony\\Component\\EventDispatcher\\EventDispatcher","type":"->","function":"doDispatch","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/app\/cache\/admin\/dev\/classes.php","line":1771,"args":[["array",[["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Core\\RegistratorSubscriber"],["string","handleNodeFromRegistry"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\BasePathSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Mapping\\ParentSubscriber"],["string","handleSetParentNodeFromDocument"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\AliasFilingSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\ExplicitSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\StructureTypeFilingSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\AutoNameSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Core\\RegistratorSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Mapping\\LocaleSubscriber"],["string","handleLocale"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\StructureSubscriber"],["string","handlePersistStructureType"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\StructureSubscriber"],["string","handlePersistStagedProperties"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ShadowLocaleSubscriber"],["string","handlePersistUpdateUrl"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\RedirectTypeSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ShadowLocaleSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ResourceSegmentSubscriber"],["string","handlePersistDocument"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\TitleSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ExtensionSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\RouteSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\StructureSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\WorkflowStageSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ShadowCopyPropertiesSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\OrderSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\SecuritySubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\WebspaceSubscriber"],["string","handleWebspace"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\Compat\\ContentMapperSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\BlameSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Audit\\TimestampSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Mapping\\NodeNameSubscriber"],["string","handleNodeName"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Mapping\\UuidSubscriber"],["string","handleUuid"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Mapping\\ParentSubscriber"],["string","handleChangeParent"]]],["array",[["object","Sulu\\Component\\CustomUrl\\Document\\Subscriber\\CustomUrlSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\CustomUrl\\Document\\Subscriber\\InvalidateSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Bundle\\ContentBundle\\Search\\EventSubscriber\\StructureSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Core\\MappingSubscriber"],["string","handlePersist"]]],["array",[["object","Sulu\\Component\\Content\\Document\\Subscriber\\ResourceSegmentSubscriber"],["string","handlePersistRoute"]]],["array",[["object","Sulu\\Component\\DocumentManager\\Subscriber\\Core\\RegistratorSubscriber"],["string","handleEndPersist"]]]]],["string","sulu_document_manager.persist"],["object","Sulu\\Component\\DocumentManager\\Event\\PersistEvent"]]},{"namespace":"Symfony\\Component\\EventDispatcher","short_class":"EventDispatcher","class":"Symfony\\Component\\EventDispatcher\\EventDispatcher","type":"->","function":"dispatch","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/document-manager\/lib\/DocumentManager.php","line":69,"args":[["string","sulu_document_manager.persist"],["object","Sulu\\Component\\DocumentManager\\Event\\PersistEvent"]]},{"namespace":"Sulu\\Component\\DocumentManager","short_class":"DocumentManager","class":"Sulu\\Component\\DocumentManager\\DocumentManager","type":"->","function":"persist","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Security\/Authorization\/AccessControl\/PhpcrAccessControlProvider.php","line":58,"args":[["object","Sulu\\Bundle\\ContentBundle\\Document\\PageDocument"]]},{"namespace":"Sulu\\Component\\Security\\Authorization\\AccessControl","short_class":"PhpcrAccessControlProvider","class":"Sulu\\Component\\Security\\Authorization\\AccessControl\\PhpcrAccessControlProvider","type":"->","function":"setPermissions","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Component\/Security\/Authorization\/AccessControl\/AccessControlManager.php","line":60,"args":[["string","Sulu\\Component\\Content\\Document\\Behavior\\SecurityBehavior"],["string","abc61dd6-e5d0-4587-b42e-6b7372a3a6f2"],["array",{"1":["array",{"view":["boolean",true],"add":["boolean",true],"edit":["boolean",true],"delete":["boolean",false],"live":["boolean",true],"archive":["boolean",true],"security":["boolean",true]}]}]]},{"namespace":"Sulu\\Component\\Security\\Authorization\\AccessControl","short_class":"AccessControlManager","class":"Sulu\\Component\\Security\\Authorization\\AccessControl\\AccessControlManager","type":"->","function":"setPermissions","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/sulu\/sulu\/src\/Sulu\/Bundle\/SecurityBundle\/Controller\/PermissionController.php","line":125,"args":[["string","Sulu\\Component\\Content\\Document\\Behavior\\SecurityBehavior"],["string","abc61dd6-e5d0-4587-b42e-6b7372a3a6f2"],["array",{"1":["array",{"view":["boolean",true],"add":["boolean",true],"edit":["boolean",true],"delete":["boolean",false],"live":["boolean",true],"archive":["boolean",true],"security":["boolean",true]}]}]]},{"namespace":"Sulu\\Bundle\\SecurityBundle\\Controller","short_class":"PermissionController","class":"Sulu\\Bundle\\SecurityBundle\\Controller\\PermissionController","type":"->","function":"postAction","args":[["object","Symfony\\Component\\HttpFoundation\\Request"]]},{"namespace":"","short_class":"","class":"","type":"","function":"call_user_func_array","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/app\/bootstrap.php.cache","line":3205,"args":[["array",[["object","Sulu\\Bundle\\SecurityBundle\\Controller\\PermissionController"],["string","postAction"]]],["array",[["object","Symfony\\Component\\HttpFoundation\\Request"]]]]},{"namespace":"Symfony\\Component\\HttpKernel","short_class":"HttpKernel","class":"Symfony\\Component\\HttpKernel\\HttpKernel","type":"->","function":"handleRaw","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/app\/bootstrap.php.cache","line":3167,"args":[["object","Symfony\\Component\\HttpFoundation\\Request"],["string","1"]]},{"namespace":"Symfony\\Component\\HttpKernel","short_class":"HttpKernel","class":"Symfony\\Component\\HttpKernel\\HttpKernel","type":"->","function":"handle","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/app\/bootstrap.php.cache","line":3318,"args":[["object","Symfony\\Component\\HttpFoundation\\Request"],["string","1"],["boolean",true]]},{"namespace":"Symfony\\Component\\HttpKernel\\DependencyInjection","short_class":"ContainerAwareHttpKernel","class":"Symfony\\Component\\HttpKernel\\DependencyInjection\\ContainerAwareHttpKernel","type":"->","function":"handle","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/app\/bootstrap.php.cache","line":2509,"args":[["object","Symfony\\Component\\HttpFoundation\\Request"],["string","1"],["boolean",true]]},{"namespace":"Symfony\\Component\\HttpKernel","short_class":"Kernel","class":"Symfony\\Component\\HttpKernel\\Kernel","type":"->","function":"handle","file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/web\/admin.php","line":54,"args":[["object","Symfony\\Component\\HttpFoundation\\Request"]]}],"class":"PHPCR\\RepositoryException","statusCode":500,"headers":[],"file":"\/Users\/daniel\/Development\/massiveart\/sulu-standard\/vendor\/phpcr\/phpcr-utils\/src\/PHPCR\/Util\/PathHelper.php","line":325}]}
```