### PR TITLE
Removed double wildcard for custom-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2244 [AdminBundle]         Fixed login with enter for Safari and IE
+    * BUGFIX      #2245 [CustomUrlBundle]     Removed double wildcard for custom-url
     * BUGFIX      #2238 [ContentBundle]       Fixed URL in SEO tab
     * BUGFIX      #2237 [MediaBundle]         Added locale to request for adding new media version
     * BUGFIX      #2236 [ContentBundle]       Fixed preview js errors

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -223,24 +223,6 @@ class WebspaceCollectionBuilder
 
         foreach ($environment->getCustomUrls() as $customUrl) {
             $urlAddress = $customUrl->getUrl();
-
-            if (strpos('*', $urlAddress) >= 0) {
-                $this->portalInformations[$environment->getType()][$urlAddress] = new PortalInformation(
-                    RequestAnalyzerInterface::MATCH_TYPE_WILDCARD,
-                    $portal->getWebspace(),
-                    $portal,
-                    null,
-                    $urlAddress,
-                    null,
-                    null,
-                    null,
-                    false,
-                    $urlAddress,
-                    1
-                );
-            }
-
-            $urlAddress = rtrim($urlAddress, '/') . '/*';
             $this->portalInformations[$environment->getType()][$urlAddress] = new PortalInformation(
                 RequestAnalyzerInterface::MATCH_TYPE_WILDCARD,
                 $portal->getWebspace(),

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -229,4 +229,32 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
         $this->assertEquals('www.sulu.at', $prod->getMainUrl()->getUrl());
         $this->assertEquals('sulu.at', $main->getMainUrl()->getUrl());
     }
+
+    public function testBuildWithCustomUrl()
+    {
+        $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
+            $this->loader,
+            new Replacer(),
+            $this->logger,
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/custom-url'
+        );
+
+        $webspaceCollection = $webspaceCollectionBuilder->build();
+
+        $webspace = $webspaceCollection->getWebspaces()[0];
+        $this->assertEquals('sulu_io', $webspace->getKey());
+
+        $dev = $webspace->getPortals()[0]->getEnvironment('dev');
+        $prod = $webspace->getPortals()[0]->getEnvironment('prod');
+        $stage = $webspace->getPortals()[0]->getEnvironment('stage');
+
+        $this->assertCount(1, $dev->getCustomUrls());
+        $this->assertCount(1, $stage->getCustomUrls());
+        $this->assertCount(2, $prod->getCustomUrls());
+
+        $this->assertEquals('dev.sulu.lo/*', $dev->getCustomUrls()[0]->getUrl());
+        $this->assertEquals('stage.sulu.lo/*', $stage->getCustomUrls()[0]->getUrl());
+        $this->assertEquals('sulu.lo/*', $prod->getCustomUrls()[0]->getUrl());
+        $this->assertEquals('*.sulu.lo', $prod->getCustomUrls()[1]->getUrl());
+    }
 }

--- a/tests/Resources/DataFixtures/Webspace/custom-url/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/custom-url/sulu.io.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.0.xsd">
+
+    <name>sulu.io</name>
+    <key>sulu_io</key>
+
+    <localizations>
+        <localization language="en" default="true"/>
+        <localization language="de"/>
+    </localizations>
+
+    <theme>
+        <key>default</key>
+        <default-templates>
+            <default-template type="page">default</default-template>
+            <default-template type="homepage">overview</default-template>
+        </default-templates>
+
+        <error-templates>
+            <error-template default="true">ClientWebsiteBundle:views:error.html.twig</error-template>
+            <error-template code="404">ClientWebsiteBundle:views:error404.html.twig</error-template>
+        </error-templates>
+    </theme>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="de">Hauptnavigation</title>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>sulu.io</name>
+            <key>sulu_io</key>
+            <resource-locator>
+                <strategy>tree</strategy>
+            </resource-locator>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                    <custom-urls>
+                        <custom-url>sulu.lo/*</custom-url>
+                        <custom-url>*.sulu.lo</custom-url>
+                    </custom-urls>
+                </environment>
+                <environment type="stage">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                    <custom-urls>
+                        <custom-url>stage.sulu.lo/*</custom-url>
+                    </custom-urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                    <custom-urls>
+                        <custom-url>dev.sulu.lo/*</custom-url>
+                    </custom-urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the generation of double wildcards for custom-urls.

#### Why?

It cannot be selected in the base-domain dropdown and custom-urls without wildcard will not be accepted by webspace validation. Therefor it has no additional value. 