### PR TITLE
Fixed filter media by symstem-collection and type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2251 [MediaBundle]         Fixed filter media by symstem-collection and type
     * BUGFIX      #2244 [AdminBundle]         Fixed login with enter for Safari and IE
     * BUGFIX      #2245 [CustomUrlBundle]     Removed double wildcard for custom-url
     * BUGFIX      #2242 [MediaBundle]         Fixed leaking events after uploading new media version

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -313,8 +313,10 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         }
 
         if (!$systemCollections) {
-            $queryBuilder->leftJoin('collection.type', 'type');
-            $queryBuilder->andWhere('type.key != \'' . SystemCollectionManagerInterface::COLLECTION_TYPE . '\'');
+            $queryBuilder->leftJoin('collection.type', 'collectionType');
+            $queryBuilder->andWhere(
+                sprintf('collectionType.key != \'%s\'', SystemCollectionManagerInterface::COLLECTION_TYPE)
+            );
         }
 
         if (!empty($types)) {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -414,6 +414,15 @@ class MediaRepositoryTest extends SuluTestCase
         $this->assertCount(1, $this->mediaRepository->findMedia(['systemCollections' => false]));
     }
 
+    public function testFindMediaWithSystemCollectionsAndTypes()
+    {
+        $this->createMedia('test-1', 'test-1');
+        $this->createMedia('test-2', 'test-2', 'image', 2);
+
+        $this->assertCount(2, $this->mediaRepository->findMedia());
+        $this->assertCount(1, $this->mediaRepository->findMedia(['systemCollections' => false, 'types' => ['image']]));
+    }
+
     public function testFindMediaByIds()
     {
         $media1 = $this->createMedia('test-1', 'test-1', 'video');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the alias of system-collection type in the media-repository.

#### Why?

If you filter for system-collections and types you will get an error becaus the same alias is used twice.
