### PR TITLE
Introduced own websocket app to avoid connecting to port 8843

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2255 [WebsocketBundle]     Introduced own websocket app to avoid connecting to port 8843
     * BUGFIX      #2251 [MediaBundle]         Fixed filter media by symstem-collection and type
     * BUGFIX      #2252 [ContentBundle]       Fixed webspace in permission check
     * BUGFIX      #2244 [AdminBundle]         Fixed login with enter for Safari and IE

--- a/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
@@ -77,8 +77,17 @@ class PreviewRenderer
         $webspace = $this->webspaceManager->findWebspaceByKey($content->getWebspaceKey());
         $this->activeTheme->setName($webspace->getTheme()->getKey());
 
+        $query = [];
+        $request = [];
+        $cookies = [];
+        if ($currentRequest !== null) {
+            $query = $currentRequest->query->all();
+            $request = $currentRequest->request->all();
+            $cookies = $currentRequest->cookies->all();
+        }
+
         // get controller and invoke action
-        $request = new Request($currentRequest->query->all(), $currentRequest->request->all(), [], $currentRequest->cookies->all());
+        $request = new Request($query, $request, [], $cookies);
         $request->attributes->set('_controller', $content->getController());
         $controller = $this->controllerResolver->getController($request);
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
@@ -92,6 +92,59 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('TEST', $result);
     }
+
+    public function testRenderWithoutCurrentRequest()
+    {
+        $activeTheme = $this->prophesize(ActiveTheme::class);
+        $controllerResolver = $this->prophesize(ControllerResolver::class);
+        $webspaceManager = $this->prophesize(WebspaceManager::class);
+        $requestStack = $this->prophesize(RequestStack::class);
+        $structure = $this->prophesize(PageBridge::class);
+        $translator = $this->prophesize(TranslatorInterface::class);
+
+        $webspaceManager->findWebspaceByKey('sulu_io')->willReturn($this->getWebspace());
+
+        $structure->getController()->willReturn('TestController:test');
+        $structure->getLanguageCode()->willReturn('de_at');
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+
+        $controllerResolver->getController(Argument::type(Request::class))
+            ->will(
+                function () {
+                    return [new TestController(), 'testAction'];
+                }
+            );
+
+        $requestStack->getCurrentRequest()->willReturn(null);
+        $requestStack->push(
+            Argument::that(
+                function (Request $newRequest) {
+                    $this->assertEquals([], $newRequest->query->all());
+                    $this->assertEquals([], $newRequest->request->all());
+                    $this->assertEquals([], $newRequest->cookies->all());
+
+                    return true;
+                }
+            )
+        )->shouldBeCalledTimes(1);
+        $requestStack->pop()->shouldBeCalled();
+
+        $translator->getLocale()->willReturn('de');
+        $translator->setLocale('de_at')->shouldBeCalled();
+        $translator->setLocale('de')->shouldBeCalled();
+
+        $renderer = new PreviewRenderer(
+            $activeTheme->reveal(),
+            $controllerResolver->reveal(),
+            $webspaceManager->reveal(),
+            $requestStack->reveal(),
+            $translator->reveal()
+        );
+
+        $result = $renderer->render($structure->reveal());
+
+        $this->assertEquals('TEST', $result);
+    }
 }
 
 class TestController

--- a/src/Sulu/Bundle/WebsocketBundle/App/WebsocketApp.php
+++ b/src/Sulu/Bundle/WebsocketBundle/App/WebsocketApp.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsocketBundle\App;
+
+use Ratchet\ComponentInterface;
+use Ratchet\Http\HttpServer;
+use Ratchet\Http\HttpServerInterface;
+use Ratchet\Http\OriginCheck;
+use Ratchet\Http\Router;
+use Ratchet\MessageComponentInterface;
+use Ratchet\Server\IoServer;
+use Ratchet\Wamp\WampServer;
+use Ratchet\Wamp\WampServerInterface;
+use Ratchet\WebSocket\WsServer;
+use React\EventLoop\Factory as LoopFactory;
+use React\EventLoop\LoopInterface;
+use React\Socket\Server as Reactor;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * This class was inspired by Ratchet\App but was decoupled from it because of trying to connect to 8843.
+ */
+class WebsocketApp
+{
+    /**
+     * @var \Symfony\Component\Routing\RouteCollection
+     */
+    public $routes;
+
+    /**
+     * @var \Ratchet\Server\IoServer
+     */
+    protected $_server;
+
+    /**
+     * The Host passed in construct used for same origin policy.
+     *
+     * @var string
+     */
+    protected $httpHost;
+
+    /***
+     * The port the socket is listening
+     * @var int
+     */
+    protected $port;
+
+    /**
+     * @var int
+     */
+    protected $_routeCounter = 0;
+
+    /**
+     * @param string $httpHost HTTP hostname clients intend to connect to. MUST match JS `new WebSocket('ws://$httpHost');`
+     * @param int $port Port to listen on. If 80, assuming production, Flash on 843 otherwise expecting Flash to be proxied through 8843
+     * @param string $address IP address to bind to. Default is localhost/proxy only. '0.0.0.0' for any machine.
+     * @param LoopInterface $loop Specific React\EventLoop to bind the application to. null will create one for you.
+     */
+    public function __construct(
+        $httpHost = 'localhost',
+        $port = 8080,
+        $address = '127.0.0.1',
+        LoopInterface $loop = null
+    ) {
+        if (3 !== strlen('✓')) {
+            throw new \DomainException(
+                'Bad encoding, length of unicode character ✓ should be 3. Ensure charset UTF-8 and check ini val mbstring.func_autoload'
+            );
+        }
+
+        if (null === $loop) {
+            $loop = LoopFactory::create();
+        }
+
+        $this->httpHost = $httpHost;
+        $this->port = $port;
+
+        $socket = new Reactor($loop);
+        $socket->listen($port, $address);
+
+        $this->routes = new RouteCollection();
+        $this->_server = new IoServer(
+            new HttpServer(new Router(new UrlMatcher($this->routes, new RequestContext()))),
+            $socket,
+            $loop
+        );
+    }
+
+    /**
+     * Add an endpoint/application to the server.
+     *
+     * @param string $path The URI the client will connect to
+     * @param ComponentInterface $controller Your application to server for the route. If not specified, assumed to be for a WebSocket
+     * @param array $allowedOrigins An array of hosts allowed to connect (same host by default), ['*'] for any
+     * @param string $httpHost Override the $httpHost variable provided in the __construct
+     *
+     * @return ComponentInterface|WsServer
+     */
+    public function route($path, ComponentInterface $controller, array $allowedOrigins = [], $httpHost = null)
+    {
+        if ($controller instanceof HttpServerInterface || $controller instanceof WsServer) {
+            $decorated = $controller;
+        } elseif ($controller instanceof WampServerInterface) {
+            $decorated = new WsServer(new WampServer($controller));
+        } elseif ($controller instanceof MessageComponentInterface) {
+            $decorated = new WsServer($controller);
+        } else {
+            $decorated = $controller;
+        }
+
+        if ($httpHost === null) {
+            $httpHost = $this->httpHost;
+        }
+
+        $allowedOrigins = array_values($allowedOrigins);
+        if (0 === count($allowedOrigins)) {
+            $allowedOrigins[] = $httpHost;
+        }
+        if ('*' !== $allowedOrigins[0]) {
+            $decorated = new OriginCheck($decorated, $allowedOrigins);
+        }
+
+        $this->routes->add(
+            'rr-' . ++$this->_routeCounter,
+            new Route($path, ['_controller' => $decorated], ['Origin' => $this->httpHost], [], $httpHost)
+        );
+
+        return $decorated;
+    }
+
+    /**
+     * Run the server by entering the event loop.
+     */
+    public function run()
+    {
+        $this->_server->run();
+    }
+}

--- a/src/Sulu/Component/Websocket/RatchetAppManager.php
+++ b/src/Sulu/Component/Websocket/RatchetAppManager.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Websocket;
 
 use Ratchet\App;
 use React\EventLoop\LoopInterface;
+use Sulu\Bundle\WebsocketBundle\App\WebsocketApp;
 
 /**
  * Class manages ratchet websocket apps.
@@ -50,7 +51,7 @@ class RatchetAppManager implements AppManagerInterface
     /**
      * Ratchet app.
      *
-     * @var App
+     * @var WebsocketApp
      */
     private $ratchetApp;
 
@@ -98,7 +99,7 @@ class RatchetAppManager implements AppManagerInterface
      */
     public function run()
     {
-        $this->ratchetApp = new App($this->getHttpHost(), $this->getPort(), $this->getIpAddress(), $this->loop);
+        $this->ratchetApp = new WebsocketApp($this->getHttpHost(), $this->getPort(), $this->getIpAddress(), $this->loop);
 
         foreach ($this->apps as $app) {
             // TODO introduce session config for this: $sessionApp = new SessionProvider($app['app'], $this->sessionHandler);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/201

#### What's in this PR?

This PR fixes a problem when two websockets are running on the same server.

#### Why?

The websocket - component from ratchet try to connect to the port 8843 for each websocket server. this cannot be disabled or the port cannot be changed.
