### PR TITLE
Fixed domain switching in sulu-content path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2269 [WebsiteBundle]       Fixed domain switching in sulu-content path
     * BUGFIX      #2267 [CategoryBundle]      Fixed collaboration component
     * BUGFIX      #2255 [WebsocketBundle]     Introduced own websocket app to avoid connecting to port 8843
     * BUGFIX      #2258 [WebsiteBundle]       Added validation of analytic type

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## dev-develop
 
+### sulu_content_path
+
+The twig function `sulu_content_path('/path')` now always returning the full-qualified-domain
+`http://www.sulu.io/de/path`.
+
 ### Custom-Routes
 
 The naming of the custom-routes with `type: portal` has changed. You can use now the configured name 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -66,24 +66,30 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
     /**
      * {@inheritdoc}
      */
-    public function getContentPath($url, $webspaceKey = null, $locale = null, $domain = null, $scheme = 'http')
+    public function getContentPath($url, $webspaceKey = null, $locale = null, $domain = null, $scheme = null)
     {
-        if ($webspaceKey !== null &&
-            $this->requestAnalyzer
-        ) {
-            return $this->webspaceManager->findUrlByResourceLocator(
+        if (!$this->requestAnalyzer) {
+            return $url;
+        }
+
+        $domain = $domain ?: $this->requestAnalyzer->getAttribute('host');
+        $scheme = $scheme ?: $this->requestAnalyzer->getAttribute('scheme');
+        $locale = $locale ?: $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+
+        if ($webspaceKey !== null) {
+            $url = $this->webspaceManager->findUrlByResourceLocator(
                 $url,
                 $this->environment,
-                $locale ?: $this->requestAnalyzer->getCurrentLocalization()->getLocalization(),
+                $locale,
                 $webspaceKey,
                 $domain,
                 $scheme
             );
-        } elseif (strpos($url, '/') === 0 && $this->requestAnalyzer) {
-            return $this->webspaceManager->findUrlByResourceLocator(
+        } elseif (strpos($url, '/') === 0) {
+            $url = $this->webspaceManager->findUrlByResourceLocator(
                 $url,
                 $this->environment,
-                $locale ?: $this->requestAnalyzer->getCurrentLocalization()->getLocalization(),
+                $locale,
                 $this->requestAnalyzer->getWebspace()->getKey(),
                 $domain,
                 $scheme

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -47,7 +47,7 @@ class RequestAnalyzer implements RequestAnalyzerInterface
      */
     public function analyze(Request $request)
     {
-        $this->attributes = new RequestAttributes();
+        $this->attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme()]);
         foreach ($this->requestProcessors as $provider) {
             $this->attributes = $this->attributes->merge($provider->process($request, $this->attributes));
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2266
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the `sulu_content_path` twig function.

#### Why?

After changing the behavior and always returning the full-qualified-domain the domain and scheme switches if the url is not the main of the portal or the scheme was not passed to the function.

