### PR TITLE
added query string to redirect for internal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2269 [WebsiteBundle]       Added query string to redirect for internal links
     * BUGFIX      #2267 [CategoryBundle]      Fixed collaboration component
     * BUGFIX      #2255 [WebsocketBundle]     Introduced own websocket app to avoid connecting to port 8843
     * BUGFIX      #2258 [WebsiteBundle]       Added validation of analytic type

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -139,11 +139,17 @@ class ContentRouteProvider implements RouteProviderInterface
                     $content->getNodeState() === StructureInterface::STATE_PUBLISHED
                 ) {
                     // redirect internal link
+                    $redirectUrl = $this->requestAnalyzer->getResourceLocatorPrefix() . $content->getResourceLocator();
+
+                    if ($request->getQueryString()) {
+                        $redirectUrl .= '?' . $request->getQueryString();
+                    }
+
                     $collection->add(
                         $content->getKey() . '_' . uniqid(),
                         $this->getRedirectRoute(
                             $request,
-                            $this->requestAnalyzer->getResourceLocatorPrefix() . $content->getResourceLocator()
+                            $redirectUrl
                         )
                     );
                 } elseif (

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/RedirectControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/RedirectControllerTest.php
@@ -83,6 +83,7 @@ class RedirectControllerTest extends \PHPUnit_Framework_TestCase
             ['sulu.lo/de', 'http://sulu.lo', 'http://sulu.lo/de'],
             ['http://sulu.lo/de', 'http://sulu.lo', 'http://sulu.lo/de'],
             ['http://sulu.lo', 'http://sulu.lo/de/test', 'http://sulu.lo/de/test'],
+            ['sulu.lo/de', 'http://sulu.lo?test1=value1', 'http://sulu.lo/de?test1=value1'],
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2261
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the query string to redirects caused by the internal link node type, as shown in the screenshot:

![image](https://cloud.githubusercontent.com/assets/405874/14376482/15fa317e-fd6a-11e5-936e-6d4268ad387d.png)