### PR TITLE
Fixed internal link webspace locale bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2271 [ContentBundle]       Fixed internal link webspace locale bug
     * BUGFIX      #2267 [CategoryBundle]      Fixed collaboration component
     * BUGFIX      #2255 [WebsocketBundle]     Introduced own websocket app to avoid connecting to port 8843
     * BUGFIX      #2258 [WebsiteBundle]       Added validation of analytic type

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -895,6 +895,10 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $webspaces = [];
         /** @var Webspace $webspace */
         foreach ($webspaceManager->getWebspaceCollection() as $webspace) {
+            if (null === $webspace->getLocalization($locale)) {
+                continue;
+            }
+
             $paths[] = $sessionManager->getContentPath($webspace->getKey());
             $webspaces[$webspace->getKey()] = $webspace;
         }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1852,6 +1852,76 @@ class NodeControllerTest extends SuluTestCase
         $this->assertArrayHasKey('_permissions', $response);
     }
 
+    public function testCGetWithAllWebspaceNodes()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/nodes?webspace=sulu_io&language=de&fields=title&webspace-nodes=all'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $nodes = $response['_embedded']['nodes'];
+        $this->assertCount(2, $nodes);
+
+        $titles = array_map(
+            function ($node) {
+                return $node['title'];
+            },
+            $nodes
+        );
+        $this->assertContains('Sulu CMF', $titles);
+        $this->assertContains('Test CMF', $titles);
+    }
+
+    public function testCGetWithAllWebspaceNodesDifferentLocales()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/nodes?webspace=sulu_io&language=fr&fields=title&webspace-nodes=all'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $nodes = $response['_embedded']['nodes'];
+        $this->assertCount(1, $nodes);
+
+        $titles = array_map(
+            function ($node) {
+                return $node['title'];
+            },
+            $nodes
+        );
+        $this->assertContains('Sulu CMF', $titles);
+    }
+
+    public function testCGetWithSingleWebspaceNodes()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/nodes?webspace=sulu_io&language=fr&fields=title&webspace-nodes=single'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $nodes = $response['_embedded']['nodes'];
+        $this->assertCount(1, $nodes);
+
+        $titles = array_map(
+            function ($node) {
+                return $node['title'];
+            },
+            $nodes
+        );
+        $this->assertContains('Sulu CMF', $titles);
+    }
+
     private function setUpContent($data)
     {
         /** @var ContentMapperInterface $mapper */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2026
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR hides the webspace in internal-links selection if the webspace is not translated to the selected content locale.

#### Why?

The internal-link selection is broken when you have two webspaces like this:

* sulu.lo with locales de and en
* 1.sulu.lo with locale de

if you open the internal link for sulu.lo in en the internal-link don't work properly.

In the linked issue we have decided to ignore this internal-links in the first step.
