### PR TITLE
Fixed domain problem with different webspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2273 [ContentBundle]       Fixed link generation for internal link type without webspace
+    * BUGFIX      #2274 [WebsiteBundle]       Fixed sulu-content-path with different webspace
     * BUGFIX      #2269 [WebsiteBundle]       Added query string to redirect for internal links
     * ENHANCEMENT #2189 [Travis]              Cache jackrabbit download
     * BUGFIX      #2272 [ContentBundle]       Fixed ordering of pages for columns including ghosts

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -77,6 +77,10 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
         $locale = $locale ?: $this->requestAnalyzer->getCurrentLocalization()->getLocale();
 
         if ($webspaceKey !== null) {
+            if (!$this->webspaceManager->findWebspaceByKey($webspaceKey)->hasDomain($domain, $this->environment)) {
+                $domain = null;
+            }
+
             $url = $this->webspaceManager->findUrlByResourceLocator(
                 $url,
                 $this->environment,

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -12,6 +12,8 @@
 namespace Sulu\Component\Webspace\Tests\Unit;
 
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Environment;
+use Sulu\Component\Webspace\Url;
 use Sulu\Component\Webspace\Webspace;
 
 class WebspaceTest extends \PHPUnit_Framework_TestCase
@@ -154,5 +156,27 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->webspace->getLocalization('en_us');
         $this->assertEquals(null, $result);
+    }
+
+    public function testHasDomain()
+    {
+        $environment = $this->prophesize(Environment::class);
+        $environment->getUrls()->willReturn([new Url('sulu.lo')]);
+        $this->portal->getEnvironment('prod')->willReturn($environment->reveal());
+        $this->webspace->addPortal($this->portal->reveal());
+
+        $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod'));
+        $this->assertFalse($this->webspace->hasDomain('1.sulu.lo', 'prod'));
+    }
+
+    public function testHasDomainWildcard()
+    {
+        $environment = $this->prophesize(Environment::class);
+        $environment->getUrls()->willReturn([new Url('{host}')]);
+        $this->portal->getEnvironment('prod')->willReturn($environment->reveal());
+        $this->webspace->addPortal($this->portal->reveal());
+
+        $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod'));
+        $this->assertTrue($this->webspace->hasDomain('1.sulu.lo', 'prod'));
     }
 }

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -396,6 +396,30 @@ class Webspace implements ArrayableInterface
     }
 
     /**
+     * Returns false if domain not exists in webspace.
+     *
+     * @param string $domain
+     * @param string $environment
+     *
+     * @return bool
+     *
+     * @throws Exception\EnvironmentNotFoundException
+     */
+    public function hasDomain($domain, $environment)
+    {
+        foreach ($this->getPortals() as $portal) {
+            foreach ($portal->getEnvironment($environment)->getUrls() as $url) {
+                $host = parse_url('//' . $url->getUrl())['host'];
+                if ($host === $domain || $host === '{host}') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function toArray($depth = null)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

If a different webspace is passed to default domain has to be checked if it exists in the webspace otherwise you get null for the url.