### PR TITLE
Multiple Document Managers (document_context)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "imagine/imagine": "~0.6.1",
         "liip/theme-bundle": "1.3.*",
         "massive/search-bundle": "0.13.*",
-        "sulu/document-manager": "0.6.*",
+        "sulu/document-manager": "dev-document_context",
         "sensio/framework-extra-bundle": "3.0.*",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "symfony-cmf/routing-bundle": "1.2.*",

--- a/src/Sulu/Bundle/ContentBundle/Command/CleanupHistoryCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/CleanupHistoryCommand.php
@@ -74,7 +74,7 @@ EOT
         $basePath = $input->getOption('base-path');
         $dryRun = $input->getOption('dry-run');
 
-        $this->session = $this->getContainer()->get('doctrine_phpcr')->getManager()->getPhpcrSession();
+        $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->output = $output;
 

--- a/src/Sulu/Bundle/ContentBundle/Command/ContentLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ContentLocaleCopyCommand.php
@@ -93,7 +93,7 @@ EOT
         $overwrite = $input->getOption('overwrite');
         $dryRun = $input->getOption('dry-run');
 
-        $this->session = $this->getContainer()->get('doctrine_phpcr')->getManager()->getPhpcrSession();
+        $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
         $this->queryManager = $this->session->getWorkspace()->getQueryManager();
         $this->languageNamespace = $this->getContainer()->getParameter('sulu.content.language.namespace');
         $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');

--- a/src/Sulu/Bundle/ContentBundle/DocumentManager/ContentInitializer.php
+++ b/src/Sulu/Bundle/ContentBundle/DocumentManager/ContentInitializer.php
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ContentInitializer implements InitializerInterface
 {
     /**
-     * @var DocumentRegistry
+     * @var ConnectionRegistry
      */
     private $registry;
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
@@ -8,7 +8,6 @@
                  class="Sulu\Component\Content\Document\Subscriber\StructureSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
             <argument type="service" id="sulu.content.type_manager" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_content.compat.structure.legacy_property_factory" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
@@ -26,10 +25,8 @@
         <service id="sulu_resource_segment.document.subscriber.resource_segment"
                  class="Sulu\Component\Content\Document\Subscriber\ResourceSegmentSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu.content.rlp.strategy.tree" />
-            <argument type="service" id="sulu_document_manager.document_inspector"/>
-            <tag name="sulu_document_manager.event_subscriber" />
+            <tag name="sulu_document_manager.event_subscriber" manager="default"/>
         </service>
 
         <service id="sulu_document_manager.document.subscriber.workflow_stage"
@@ -41,8 +38,6 @@
         <service id="sulu_document_manager.document.subscriber.shadow_locale"
                  class="Sulu\Component\Content\Document\Subscriber\ShadowLocaleSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
@@ -55,15 +50,12 @@
         <service id="sulu_document_manager.document.subscriber.title"
                  class="Sulu\Component\Content\Document\Subscriber\TitleSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.document.subscriber.fallback_localization"
                  class="Sulu\Component\Content\Document\Subscriber\FallbackLocalizationSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <argument type="service" id="sulu.content.localization_finder" />
 
             <tag name="sulu_document_manager.event_subscriber" />
@@ -73,7 +65,6 @@
                  class="Sulu\Component\Content\Document\Subscriber\ExtensionSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
             <argument type="service" id="sulu_content.extension.manager" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_document_manager.namespace_registry" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
@@ -119,7 +110,6 @@
         <!-- Compat -->
         <service id="sulu_document_manager.document.subscriber.compat.content_mapper"
                  class="Sulu\Component\Content\Document\Subscriber\Compat\ContentMapperSubscriber">
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sulu.content.mapper" />
             <argument type="service" id="sulu.util.node_helper" />
@@ -129,8 +119,6 @@
 
         <service id="sulu_document_manager.subscriber.behavior.remove_content"
                  class="Sulu\Component\Content\Document\Subscriber\StructureRemoveSubscriber">
-            <argument type="service" id="sulu_document_manager.document_manager" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_document_manager.metadata_factory" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeResourcelocatorControllerTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Controller;
 
-use PHPCR\SessionInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 
@@ -20,11 +19,6 @@ use Symfony\Bundle\FrameworkBundle\Client;
  */
 class NodeResourcelocatorControllerTest extends SuluTestCase
 {
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
     /**
      * @var Client
      */
@@ -37,7 +31,6 @@ class NodeResourcelocatorControllerTest extends SuluTestCase
 
     protected function setUp()
     {
-        $this->session = $this->getContainer()->get('doctrine')->getConnection();
         $this->purgeDatabase();
         $this->initPhpcr();
         $this->data = $this->prepareRepositoryContent();

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Document/PageDocumentSerializationTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Document/PageDocumentSerializationTest.php
@@ -51,16 +51,13 @@ class PageDocumentSerializationTest extends SuluTestCase
 
     /**
      * It can serialize content that contains objects.
-     *
-     * NOTE: We do not persist so that we can use any type
-     *       of content - persisting would cause the content
-     *       to be validated.
      */
     public function testSerialization()
     {
         $internalLink = $this->createPage([
             'title' => 'Hello',
         ]);
+        $this->manager->persist($internalLink, 'de');
 
         $page = $this->createPage([
             'title' => 'Foobar',
@@ -71,6 +68,8 @@ class PageDocumentSerializationTest extends SuluTestCase
             ],
             'integer' => 1234,
         ]);
+        $page->setResourceSegment('/bar');
+        $this->manager->persist($page, 'de');
 
         $result = $this->serializer->serialize($page, 'json');
 
@@ -135,10 +134,6 @@ class PageDocumentSerializationTest extends SuluTestCase
     private function createPage($data)
     {
         $page = new PageDocument();
-
-        $uuidReflection = new \ReflectionProperty(PageDocument::class, 'uuid');
-        $uuidReflection->setAccessible(true);
-        $uuidReflection->setValue($page, 1);
 
         $page->setTitle($data['title']);
         $page->setParent($this->parent);

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -33,39 +33,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend(ContainerBuilder $container)
     {
-        // process the configuration of SuluCoreExtension
-        $configs = $container->getExtensionConfig($this->getAlias());
-        $parameterBag = $container->getParameterBag();
-        $configs = $parameterBag->resolveValue($configs);
-        $config = $this->processConfiguration(new Configuration(), $configs);
-
-        if (isset($config['phpcr'])) {
-            $phpcrConfig = $config['phpcr'];
-
-            // TODO: Workaround for issue: https://github.com/doctrine/DoctrinePHPCRBundle/issues/178
-            if (!isset($phpcrConfig['backend']['check_login_on_server'])) {
-                $phpcrConfig['backend']['check_login_on_server'] = false;
-            }
-
-            foreach (array_keys($container->getExtensions()) as $name) {
-                $prependConfig = [];
-                switch ($name) {
-                    case 'doctrine_phpcr':
-                        $prependConfig = [
-                            'session' => $phpcrConfig,
-                            'odm' => [],
-                        ];
-                        break;
-                    case 'cmf_core':
-                        break;
-                }
-
-                if ($prependConfig) {
-                    $container->prependExtensionConfig($name, $prependConfig);
-                }
-            }
-        }
-
         if ($container->hasExtension('massive_build')) {
             $container->prependExtensionConfig('massive_build', [
                 'command_class' => 'Sulu\Bundle\CoreBundle\CommandOptional\SuluBuildCommand',

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -45,7 +45,6 @@
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="form.factory" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_document_manager.property_encoder" />
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_content.extension.manager"/>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspectorFactory.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspectorFactory.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Bridge;
+
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentInspectorFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerContext;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+
+/**
+ * Creates document inspector instances for a given document manager context.
+ */
+class DocumentInspectorFactory implements DocumentInspectorFactoryInterface
+{
+    /**
+     * @var NamespaceRegistry
+     */
+    private $namespaceRegistry;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $structureFactory;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var PathSegmentRegistry
+     */
+    private $pathSegmentRegistry;
+
+    /**
+     * @var DocumentInspector[]
+     */
+    private $inspector = [];
+
+    public function __construct(
+        PathSegmentRegistry $pathSegmentRegistry,
+        NamespaceRegistry $namespaceRegistry,
+        MetadataFactoryInterface $metadataFactory,
+        StructureMetadataFactoryInterface $structureFactory,
+        PropertyEncoder $encoder,
+        WebspaceManagerInterface $webspaceManager
+    ) {
+        $this->pathSegmentRegistry = $pathSegmentRegistry;
+        $this->namespaceRegistry = $namespaceRegistry;
+        $this->metadataFactory = $metadataFactory;
+        $this->structureFactory = $structureFactory;
+        $this->encoder = $encoder;
+        $this->webspaceManager = $webspaceManager;
+        $this->pathSegmentRegistry = $pathSegmentRegistry;
+    }
+
+    /**
+     * Create a new instance of the inspector.
+     *
+     * {@inheritdoc}
+     */
+    public function getInspector(DocumentManagerContext $context)
+    {
+        $hash = spl_object_hash($context);
+
+        if (isset($this->inspector[$hash])) {
+            return $this->inspector[$hash];
+        }
+
+        $inspector = new DocumentInspector(
+            $context->getRegistry(),
+            $this->pathSegmentRegistry,
+            $this->namespaceRegistry,
+            $context->getProxyFactory(),
+            $this->metadataFactory,
+            $this->structureFactory,
+            $this->encoder,
+            $this->webspaceManager
+        );
+
+        $this->inspector[$hash] = $inspector;
+
+        return $inspector;
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentManagerRegistry.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentManagerRegistry.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Bridge;
+
+use Sulu\Component\DocumentManager\DocumentManagerRegistryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Container based document manager registry.
+ */
+class DocumentManagerRegistry implements DocumentManagerRegistryInterface
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * @var array
+     */
+    private $contexts;
+
+    /**
+     * @var string
+     */
+    private $defaultName;
+
+    /**
+     * @param ContainerInterface $container Dependency injection container
+     * @param array $contexts Associative array of manager names => service IDs
+     * @param string Default document manager name
+     */
+    public function __construct(
+        ContainerInterface $container,
+        array $contexts,
+        $defaultName
+    ) {
+        $this->container = $container;
+        $this->defaultName = $defaultName;
+        $this->contexts = $contexts;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultManagerName()
+    {
+        return $this->defaultName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagerNames()
+    {
+        return array_keys($this->contexts);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getManager($name = null)
+    {
+        return $this->getContext($name)->getManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContext($name = null)
+    {
+        $name = $name ?: $this->defaultName;
+
+        if (!isset($this->contexts[$name])) {
+            throw new \RuntimeException(sprintf(
+                'Manager with name "%s" does not exist. Valid manager names: "%s"',
+                $name, implode('", "', array_keys($this->contexts))
+            ));
+        }
+
+        return $this->container->get($this->contexts[$name]);
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/SubscriberPass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/SubscriberPass.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Compiler pass to register document manager subscribers.
+ *
+ * Subscriber tags may indicate to which document manager they
+ * should be associated.
+ */
+class SubscriberPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $managers = $container->getParameter('sulu_document_manager.managers');
+        $baseDispatcherId = 'sulu_document_manager.event_dispatcher';
+        $dispatcherIds = [];
+
+        foreach ($managers as $manager) {
+            $dispatcherId = $baseDispatcherId . '.' . $manager;
+
+            if (!$container->hasDefinition($dispatcherId) && !$container->hasAlias($dispatcherId)) {
+                throw new \RuntimeException(sprintf(
+                    'No event dispatcher with ID "%s" found, it should have been created by the DocumentManagerExtension',
+                    $dispatcherId
+                ));
+            }
+
+            $dispatcherIds[] = $dispatcherId;
+        }
+
+        foreach ($container->findTaggedServiceIds('sulu_document_manager.event_subscriber') as $subscriberId => $attributes) {
+            $subscriber = $container->getDefinition($subscriberId);
+
+            if (!$subscriber->isPublic()) {
+                throw new InvalidArgumentException(sprintf('The service "%s" must be public as event subscribers are lazy-loaded.', $subscriberId));
+            }
+
+            if ($subscriber->isAbstract()) {
+                throw new InvalidArgumentException(sprintf('The service "%s" must not be abstract as event subscribers are lazy-loaded.', $subscriberId));
+            }
+
+            // We must assume that the class value has been correctly filled, even if the service is created by a factory
+            $class = $container->getParameterBag()->resolveValue($subscriber->getClass());
+
+            $reflClass = new \ReflectionClass($class);
+            $interface = EventSubscriberInterface::class;
+
+            if (!$reflClass->implementsInterface($interface)) {
+                throw new InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $subscriberId, $interface));
+            }
+
+            $validKeys = ['manager'];
+
+            // throw a good exception if the specified manager does not exist.
+            if ($diff = array_diff(array_keys($attributes[0]), $validKeys)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Subscriber "%s" has invalid tag keys: "%s", valid keys: "%s"',
+                    $subscriberId,
+                    implode('", "', $diff),
+                    implode('", "', $validKeys)
+                ));
+            }
+
+            // build the list of event dispatcher IDs to which this subscriber should be added.
+            // note that the "manager" attribute may be a comma-separated list of manager names.
+            $targetDispatcherIds = $dispatcherIds;
+            if (isset($attributes[0]['manager'])) {
+                $targetDispatcherIds = [];
+                $documentManagerNames = array_unique(explode(',', $attributes[0]['manager']));
+
+                foreach ($documentManagerNames as $documentManagerName) {
+                    if (!in_array($documentManagerName, $managers)) {
+                        throw new InvalidArgumentException(sprintf(
+                            'Unknown document manager "%s" specified for event subscriber "%s". Known document managers: "%s"',
+                            $documentManagerName, $subscriberId, implode('", "', $managers)
+                        ));
+                    }
+
+                    $dispatcherId = $baseDispatcherId . '.' . $documentManagerName;
+                    $targetDispatcherIds[] = $dispatcherId;
+                }
+            }
+
+            foreach ($targetDispatcherIds as $dispatcherId) {
+                $dispatcher = $container->findDefinition($dispatcherId);
+                $dispatcher->addMethodCall('addSubscriberService', [$subscriberId, $class]);
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('namespace')
-                ->useAttributeAsKey('role')
+                    ->useAttributeAsKey('role')
                     ->defaultValue([
                         'extension_localized' => 'i18n',
                         'system' => 'sulu',
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             ->scalarNode('class')
-                                ->info('Fully qualified class name for mapped object')
+                               ->info('Fully qualified class name for mapped object')
                                 ->isRequired()
                             ->end()
                             ->scalarNode('phpcr_type')
@@ -70,7 +70,42 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-            ->end();
+                ->scalarNode('default_manager')
+                    ->info('Name of the default document manager')
+                    ->defaultValue('default')
+                ->end()
+                ->arrayNode('sessions')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->children()
+                            ->arrayNode('backend')
+                                ->children()
+                                    ->scalarNode('type')->end()
+                                    ->scalarNode('url')->end()
+                                ->end()
+                            ->end()
+                            ->scalarNode('workspace')->end()
+                            ->scalarNode('username')->defaultValue('admin')->end()
+                            ->scalarNode('password')->defaultValue('admin')->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('managers')
+                    ->useAttributeAsKey('name')
+                    ->defaultValue([
+                        'default' => [
+                            'session' => 'default',
+                        ],
+                    ])
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('session')
+                                ->info('PHPCR session name')
+                                ->isRequired()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end();
 
         return $treeBuilder;
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -11,16 +11,47 @@
 
 namespace Sulu\Bundle\DocumentManagerBundle\DependencyInjection;
 
+use Sulu\Component\DocumentManager\DocumentManager;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
 
 class SuluDocumentManagerExtension extends Extension implements PrependExtensionInterface
 {
     public function prepend(ContainerBuilder $container)
     {
+        // process the configuration of SuluCoreExtension
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $parameterBag = $container->getParameterBag();
+        $configs = $parameterBag->resolveValue($configs);
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        foreach ($config['sessions'] as &$session) {
+            // Do not automatically "login" workspaces upon repository instantiation.
+            // This allows "admin" commands to be executed (f.e. for creating workspaces).
+            // NOTE: we may be able to remove this when we upgrade to DoctrinePhpcrBundle 1.3
+            if (isset($session['backend'])) {
+                $session['backend']['check_login_on_server'] = false;
+            }
+        }
+
+        if ($container->hasExtension('doctrine_phpcr')) {
+            $container->prependExtensionConfig(
+                'doctrine_phpcr', 
+                [
+                    'odm' => [],
+                    'session' => [
+                        'sessions' => $config['sessions'],
+                    ],
+                ]
+            );
+        }
+
         if ($container->hasExtension('jms_serializer')) {
             $container->prependExtensionConfig(
                 'jms_serializer',
@@ -58,23 +89,84 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
         $config = $this->processConfiguration($configuration, $configs);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
-        $this->configureDocumentManager($config, $container);
         $this->configurePathSegmentRegistry($config, $container);
-
         $loader->load('core.xml');
         $loader->load('behaviors.xml');
         $loader->load('serializer.xml');
         $loader->load('command.xml');
         $loader->load('data_fixtures.xml');
+        $this->configureDocumentManagers($config, $container);
     }
 
-    private function configureDocumentManager($config, ContainerBuilder $container)
+    private function configureDocumentManagers(array $config, ContainerBuilder $container)
     {
+        // set the default document manager
+        $defaultManager = $config['default_manager'];
+        $container->setParameter('sulu_document_manager.default_manager', $defaultManager);
+
+        // let the container know what the manager names are (required for
+        // example in the SubscriberPass).
+        $container->setParameter('sulu_document_manager.managers', array_keys($config['managers']));
+
+        // create the document manager services.
+        $contextMap = [];
         $debug = $config['debug'];
+        foreach ($config['managers'] as $name => $manager) {
+            // create a concrete event dispatcher for the document manager from
+            // the abstract service.  choose either the debug or "standard"
+            // dispatcher based on the "debug" flag.
+            $abstractDispatcherId = $debug ? 
+                'sulu_document_manager.abstract_event_dispatcher.debug' : 
+                'sulu_document_manager.abstract_event_dispatcher.standard';
 
-        $dispatcherId = $debug ? 'sulu_document_manager.event_dispatcher.debug' : 'sulu_document_manager.event_dispatcher.standard';
-        $container->setAlias('sulu_document_manager.event_dispatcher', $dispatcherId);
+            $dispatcherId = sprintf('sulu_document_manager.event_dispatcher.%s', $name);
+            $dispatcherDef = new DefinitionDecorator($abstractDispatcherId);
+            $dispatcherDef->setPublic(false);
+            $container->setDefinition($dispatcherId, $dispatcherDef);
 
+            // create the concrete document context instance from the abstract
+            // service using the correct PHPCR session and the event dispatcher
+            // defined above.
+            $phpcrSessionId = sprintf('doctrine_phpcr.%s_session', $manager['session']);
+            $contextId = sprintf('sulu_document_manager.context.%s', $name);
+            $contextDef = new DefinitionDecorator('sulu_document_manager.abstract_document_manager_context');
+            $contextDef->replaceArgument(0, $name);
+            $contextDef->replaceArgument(1, new Reference($phpcrSessionId));
+            $contextDef->replaceArgument(2, new Reference($dispatcherId));
+            $container->setDefinition($contextId, $contextDef);
+
+            // define the document manager for the above context.
+            $managerId = sprintf('sulu_document_manager.document_manager.%s', $name);
+            $managerDef = new Definition(DocumentManager::class);
+            $managerDef->setFactory([ new Reference($contextId), 'getManager' ]);
+            $container->setDefinition($managerId, $managerDef);
+
+            $contextMap[$name] = $contextId;
+        }
+
+        // set the document manager service map on the document manager registry.
+        $registryDef = $container->getDefinition('sulu_document_manager.registry');
+        $registryDef->replaceArgument(1, $contextMap);
+
+        // create aliases to the default services.
+        $container->setAlias(
+            'sulu_document_manager.document_manager',
+            'sulu_document_manager.document_manager.' . $defaultManager
+        );
+        $container->setAlias(
+            'sulu_document_manager.context',
+            'sulu_document_manager.context.' . $defaultManager
+        );
+        $container->setAlias(
+            'sulu_document_manager.event_dispatcher',
+            'sulu_document_manager.event_dispatcher.' . $defaultManager
+        );
+
+        // set the metadata mapping configuration into the container (it is then
+        // subsequently used by the MetadataSubscriber).
+        //
+        // NOTE: It would potentially be cleaner to directly set these configuration
+        //       values on the service definition(s) themselves.
         $realMapping = [];
         foreach ($config['mapping'] as $alias => $mapping) {
             $realMapping[] = array_merge([

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -8,10 +8,8 @@
         <!-- Behavior Subscribers !-->
         <service id="sulu_document_manager.subscriber.behavior.auto_name"
                  class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <argument type="service" id="sulu_document_manager.slugifier" />
             <argument type="service" id="sulu_document_manager.name_resolver" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
             <argument type="service" id="sulu_document_manager.document_strategy" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
@@ -19,7 +17,6 @@
         <service id="sulu_document_manager.subscriber.behavior.path.explicit"
                  class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\ExplicitSubscriber">
             <argument type="service" id="sulu_document_manager.document_strategy" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
@@ -54,7 +51,6 @@
         <service id="sulu_document_manager.suscriber.behavior.parent"
                  class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ParentSubscriber">
             <argument type="service" id="sulu_document_manager.proxy_factory" />
-            <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_document_manager.document_manager" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
@@ -65,28 +61,20 @@
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <service id="sulu_document_manager.subscriber.behavior.path"
-                 class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\PathSubscriber">
-            <argument type="service" id="sulu_document_manager.document_inspector" />
+        <service id="sulu_document_manager.subscriber.behavior.path" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\PathSubscriber">
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <service id="sulu_document_manager.subscriber.behavior.filing"
-                 class="Sulu\Component\Content\Document\Subscriber\StructureTypeFilingSubscriber">
-            <argument type="service" id="sulu_document_manager.node_manager" />
+        <service id="sulu_document_manager.subscriber.behavior.filing" class="Sulu\Component\Content\Document\Subscriber\StructureTypeFilingSubscriber">
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <service id="sulu_document_manager.subscriber.behavior.alias"
-                 class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber">
-            <argument type="service" id="sulu_document_manager.node_manager" />
+        <service id="sulu_document_manager.subscriber.behavior.alias" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber">
             <argument type="service" id="sulu_document_manager.metadata_factory.base" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <service id="sulu_document_manager.subscriber.behavior.base_path"
-                 class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\BasePathSubscriber">
-            <argument type="service" id="sulu_document_manager.node_manager" />
+        <service id="sulu_document_manager.subscriber.behavior.base_path" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\BasePathSubscriber">
             <argument>/%sulu.content.node_names.base%</argument>
             <tag name="sulu_document_manager.event_subscriber" />
         </service>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -5,28 +5,31 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- Core -->
-        <service id="sulu_document_manager.event_dispatcher.debug" class="Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher" public="false">
+        <service id="sulu_document_manager.abstract_event_dispatcher.debug" class="Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher" abstract="true">
             <argument type="service" id="service_container" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="sulu_document_manager" />
         </service>
 
-        <service id="sulu_document_manager.event_dispatcher.standard" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher" public="false">
+        <service id="sulu_document_manager.abstract_event_dispatcher.standard" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher" abstract="true">
             <argument type="service" id="service_container" />
         </service>
 
-        <service id="sulu_document_manager.document_manager" class="Sulu\Component\DocumentManager\DocumentManager">
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
+        <service id="sulu_document_manager.registry" class="Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentManagerRegistry">
+            <argument type="service" id="service_container" />
+            <argument type="collection"/>
+            <argument>%sulu_document_manager.default_manager%</argument>
         </service>
 
-        <service id="sulu_document_manager.document_registry" class="Sulu\Component\DocumentManager\DocumentRegistry" public="false">
+        <service id="sulu_document_manager.abstract_document_manager_context" class="Sulu\Component\DocumentManager\DocumentManagerContext" abstract="true">
+            <argument /> <!-- name -->
+            <argument /> <!-- the PHPCR session -->
+            <argument /> <!-- the event dispatcher -->
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
+            <argument type="service" id="sulu_document_manager.proxy_manager.factory.ghost"/>
+            <argument type="service" id="sulu_document_manager.document_inspector_factory" />
             <argument>%sulu.content.language.default%</argument>
-        </service>
-
-        <service id="sulu_document_manager.node_manager" class="Sulu\Component\DocumentManager\NodeManager" public="false">
-            <argument type="service" id="doctrine_phpcr.default_session" />
         </service>
 
         <service id="sulu_document_manager.metadata_factory.base" class="Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory" public="false">
@@ -66,23 +69,29 @@
             <argument type="service" id="sulu_document_manager.path_segment_registry" />
         </service>
 
-        <service id="sulu_document_manager.document_inspector" class="Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector">
-            <argument type="service" id="sulu_document_manager.document_registry" />
+        <service id="sulu_document_manager.document_inspector_factory" class="Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspectorFactory" public="false">
             <argument type="service" id="sulu_document_manager.path_segment_registry" />
             <argument type="service" id="sulu_document_manager.namespace_registry" />
-            <argument type="service" id="sulu_document_manager.proxy_factory" />
             <argument type="service" id="sulu_document_manager.metadata_factory" />
             <argument type="service" id="sulu_content.structure.factory" />
             <argument type="service" id="sulu_document_manager.property_encoder" />
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
         </service>
 
-        <!-- Proxy manager -->
+        <service id="sulu_document_manager.document_inspector" class="Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector">
+            <factory service="sulu_document_manager.document_manager" method="getInspector" />
+        </service>
+
+        <service id="sulu_document_manager.node_manager" class="Sulu\Component\DocumentManager\NodeManager">
+            <factory service="sulu_document_manager.context" method="getNodeManager" />
+        </service>
+
+        <service id="sulu_document_manager.document_registry" class="Sulu\Component\DocumentManager\DocumentRegistry">
+            <factory service="sulu_document_manager.context" method="getRegistry" />
+        </service>
+
         <service id="sulu_document_manager.proxy_factory" class="Sulu\Component\DocumentManager\ProxyFactory">
-            <argument type="service" id="sulu_document_manager.proxy_manager.factory.ghost" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <factory service="sulu_document_manager.context" method="getProxyFactor" />
         </service>
 
         <service id="sulu_document_manager.proxy_manager.configuration" class="ProxyManager\Configuration" public="false">
@@ -120,48 +129,34 @@
         </service>
 
         <service id="sulu_document_manager.subscriber.core.registrator" class="Sulu\Component\DocumentManager\Subscriber\Core\RegistratorSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.reorder" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\ReorderSubscriber">
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <argument type="service" id="sulu_document_manager.document_registry" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <!-- PHPCR subscribers -->
         <service id="sulu_document_manager.subscriber.phpcr.find" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber">
             <argument type="service" id="sulu_document_manager.metadata_factory" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.general" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
-            <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.remove" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber">
-            <argument type="service" id="sulu_document_manager.document_registry" />
-            <argument type="service" id="sulu_document_manager.node_manager" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.core.mapping" class="Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber">
             <argument type="service" id="sulu_document_manager.metadata_factory" />
             <argument type="service" id="sulu_document_manager.property_encoder" />
-            <argument type="service" id="sulu_document_manager.proxy_factory"/>
-            <argument type="service" id="sulu_document_manager.document_registry"/>
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -12,8 +12,8 @@
 namespace Sulu\Bundle\DocumentManagerBundle;
 
 use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\InitializerPass;
+use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\SubscriberPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SuluDocumentManagerBundle extends Bundle
@@ -22,10 +22,6 @@ class SuluDocumentManagerBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new InitializerPass());
-        $container->addCompilerPass(new RegisterListenersPass(
-            'sulu_document_manager.event_dispatcher',
-            'sulu_document_manager.event_listener',
-            'sulu_document_manager.event_subscriber'
-        ));
+        $container->addCompilerPass(new SubscriberPass());
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Functional/Bridge/DocumentManagerRegistryTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Functional/Bridge/DocumentManagerRegistryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Functional\Bridge;
+
+use Sulu\Bundle\ContentBundle\Document\PageDocument;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class DocumentManagerRegistryTest extends SuluTestCase
+{
+    private $registry;
+
+    public function setUp()
+    {
+        $this->registry = $this->getContainer()->get('sulu_document_manager.registry');
+        $this->getContainer()->get('sulu_document_manager.initializer')->initialize(null, true);
+    }
+
+    /**
+     * It should be able to write to both the default and "live" workspace as configured
+     * in the TestBundle.
+     */
+    public function testWriteToDifferentSessions()
+    {
+        $defaultManager = $this->registry->getManager('default');
+        $liveManager = $this->registry->getManager('live');
+
+        $pageDocument = new PageDocument();
+        $pageDocument->setStructureType('default');
+        $pageDocument->setTitle('Draft');
+        $pageDocument->setResourceSegment('/hai');
+
+        $defaultManager->persist($pageDocument, 'de', [
+            'path' => '/cmf/sulu_io/contents/home',
+        ]);
+
+        $defaultManager->flush();
+
+        $pageDocument->setResourceSegment('/hoo');
+        $liveManager->persist($pageDocument, 'de', [
+            'path' => '/cmf/sulu_io/contents/home',
+            'auto_create' => true,
+        ]);
+        $liveManager->flush();
+
+        $defaultManager->persist($pageDocument, 'de', [
+            'path' => '/cmf/sulu_io/contents/home',
+        ]);
+
+        $defaultManager->flush();
+
+        $pageDocument->setTitle('Live');
+        $pageDocument->setResourceSegment('/boo');
+        $liveManager->persist($pageDocument, 'de', [
+            'path' => '/cmf/sulu_io/contents/home',
+        ]);
+        $liveManager->flush();
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorFactoryTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentInspectorFactoryTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Bridge;
+
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspectorFactory;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerContext;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+
+class DocumentInspectorFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var PathSegmentRegistry
+     */
+    private $pathRegistry;
+
+    /**
+     * @var NamespaceRegistry
+     */
+    private $namespaceRegistry;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var StructureMetadataFactory
+     */
+    private $structureFactory;
+
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var WebspaceManager
+     */
+    private $webspaceManager;
+
+    /**
+     * @var DocumentInspectorFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->pathRegistry = $this->prophesize(PathSegmentRegistry::class);
+        $this->namespaceRegistry = $this->prophesize(NamespaceRegistry::class);
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->structureFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->proxyFactory = $this->prophesize(ProxyFactory::class);
+        $this->encoder = $this->prophesize(PropertyEncoder::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->context1 = $this->prophesize(DocumentManagerContext::class);
+        $this->context2 = $this->prophesize(DocumentManagerContext::class);
+
+        $this->context1->getProxyFactory()->willReturn($this->proxyFactory->reveal());
+        $this->context1->getRegistry()->willReturn($this->documentRegistry->reveal());
+        $this->context2->getProxyFactory()->willReturn($this->proxyFactory->reveal());
+        $this->context2->getRegistry()->willReturn($this->documentRegistry->reveal());
+
+        $this->factory = new DocumentInspectorFactory(
+            $this->pathRegistry->reveal(),
+            $this->namespaceRegistry->reveal(),
+            $this->metadataFactory->reveal(),
+            $this->structureFactory->reveal(),
+            $this->encoder->reveal(),
+            $this->webspaceManager->reveal()
+        );
+    }
+
+    /**
+     * It should return a document inspector.
+     * It should always return the same instance for the same context.
+     */
+    public function testGetInspector()
+    {
+        $inspector = $this->factory->getInspector($this->context1->reveal());
+
+        $this->assertInstanceOf(
+            DocumentInspector::class,
+            $inspector
+        );
+
+        $this->assertSame(
+            $inspector,
+            $this->factory->getInspector($this->context1->reveal())
+        );
+    }
+
+    /**
+     * It should return a different document inspector for each context.
+     */
+    public function testGetInspectorDifferentContexts()
+    {
+        $inspector1 = $this->factory->getInspector($this->context1->reveal());
+        $inspector2 = $this->factory->getInspector($this->context2->reveal());
+
+        $this->assertNotSame(
+            $inspector1,
+            $inspector2
+        );
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentManagerRegistryTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Bridge/DocumentManagerRegistryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Bridge;
+
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentManagerRegistry;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sulu\Component\DocumentManager\DocumentManagerContext;
+
+class DocumentManagerRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DocumentManagerRegistry
+     */
+    private $registry;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var DocumentManagerContext
+     */
+    private $context;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->registry = new DocumentManagerRegistry(
+            $this->container->reveal(),
+            [
+                'default' => 'document_context.1.id',
+                'staging' => 'document_context.2.id',
+                'live' => 'document_context.3.id',
+            ],
+            'default'
+        );
+
+        $this->context = $this->prophesize(DocumentManagerContext::class);
+        $this->manager = $this->prophesize(DocumentManagerInterface::class);
+    }
+
+    /**
+     * It should return the default document manager name.
+     */
+    public function testGetDefaultName()
+    {
+        $name = $this->registry->getDefaultManagerName();
+        $this->assertEquals('default', $name);
+    }
+
+    /**
+     * It should return the default document managre if no argument given.
+     */
+    public function testGetDefaultContext()
+    {
+        $this->container->get('document_context.1.id')->willReturn($this->context->reveal());
+        $context = $this->registry->getContext();
+        $this->assertSame(
+            $this->context->reveal(),
+            $context
+        );
+    }
+
+    /**
+     * It should return the named document context.
+     */
+    public function testNamedDocumentContext()
+    {
+        $this->container->get('document_context.2.id')->willReturn($this->context->reveal());
+        $context = $this->registry->getContext('staging');
+        $this->assertSame(
+            $this->context->reveal(),
+            $context
+        );
+    }
+
+    /**
+     * It should return the named document manager
+     */
+    public function testGetNamedDocumentManager()
+    {
+        $this->container->get('document_context.2.id')->willReturn($this->context->reveal());
+        $this->context->getManager()->willReturn($this->manager->reveal());
+        $manager = $this->registry->getManager('staging');
+        $this->assertSame(
+            $this->manager->reveal(),
+            $manager
+        );
+
+    }
+
+    /**
+     * It should throw an exception if the named document manager does not exist.
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Manager with name "foo_foo" does not exist.
+     */
+    public function testNotExist()
+    {
+        $this->registry->getManager('foo_foo');
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/InitializeCommandTest.php
@@ -23,12 +23,12 @@ use Symfony\Component\Console\Tester\CommandTester;
 class InitializeCommandTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var mixed
+     * @var QuestionHelper
      */
     private $questionHelper;
 
     /**
-     * @var mixed
+     * @var Initializer
      */
     private $initializer;
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DependencyInjection/Compiler/SubscriberPassTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DependencyInjection/Compiler/SubscriberPassTest.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Sulu\Bundle\DocumentManagerBundle\DependencyInjection\Compiler\SubscriberPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SubscriberPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EventSubscriberInterface
+     */
+    private $subscriber1;
+
+    /**
+     * @var EventSubscriberInterface
+     */
+    private $subscriber2;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher1;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher2;
+
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * @var SubscriberPass
+     */
+    private $pass;
+
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->subscriber1 = $this->prophesize(EventSubscriberInterface::class);
+        $this->subscriber2 = $this->prophesize(EventSubscriberInterface::class);
+
+        $this->dispatcher1 = $this->container->register('sulu_document_manager.event_dispatcher.default', EventDispatcherInterface::class);
+        $this->dispatcher2 = $this->container->register('sulu_document_manager.event_dispatcher.prod', EventDispatcherInterface::class);
+        $this->pass = new SubscriberPass();
+        $this->container->setParameter('sulu_document_manager.managers', ['default', 'prod']);
+    }
+
+    /**
+     * It should throw an exception if the subscriber is not public.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The service "subscriber_1" must be public as event subscribers are lazy-loaded
+     */
+    public function testDispatcherNotPublic()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+        $subscriberDef1->setPublic(false);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the subscriber is abstract.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The service "subscriber_1" must not be abstract as event subscribers are lazy-loaded.
+     */
+    public function testDispatcherAbstract()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+        $subscriberDef1->setAbstract(true);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the subscriber does not implement the event subscriber interface.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Service "subscriber_1" must implement interface "Symfony\Component\EventDispatcher\EventSubscriberInterface"
+     */
+    public function testDispatcherNotImplementing()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', 'stdClass');
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the event subscriber specifies a non-existant manager.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown document manager "not-existing" specified for event subscriber "subscriber_1". Known document managers: "default", "prod"
+     */
+    public function testNonExistingManager()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'not-existing']);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should throw an exception if the tag has invalid keys.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Subscriber "subscriber_1" has invalid tag keys: "bar", valid keys: "manager"
+     */
+    public function testInvalidKeys()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['bar' => 'foo']);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * It should add subscribers to specific event dispatchers.
+     */
+    public function testSpecificDispatchers()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default']);
+
+        $subscriberDef2 = $this->container->register('subscriber_2', get_class($this->subscriber2->reveal()));
+        $subscriberDef2->addTag('sulu_document_manager.event_subscriber', ['manager' => 'prod']);
+
+        $this->pass->process($this->container);
+
+        $calls = $this->dispatcher1->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+
+        $calls = $this->dispatcher2->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_2',
+                get_class($this->subscriber2->reveal()),
+            ],
+        ]);
+    }
+
+    /**
+     * It should allow a comma-separated list of managers.
+     */
+    public function testSpecificDispatchersCommaSeparated()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber', ['manager' => 'default,prod']);
+
+        $this->pass->process($this->container);
+
+        $calls = $this->dispatcher1->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+
+        $calls = $this->dispatcher2->getMethodCalls();
+
+        $this->assertCount(1, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+    }
+
+    /**
+     * It should add to all managers if no manager is specified.
+     */
+    public function testAllManagers()
+    {
+        $subscriberDef1 = $this->container->register('subscriber_1', get_class($this->subscriber1->reveal()));
+        $subscriberDef1->addTag('sulu_document_manager.event_subscriber');
+
+        $subscriberDef2 = $this->container->register('subscriber_2', get_class($this->subscriber2->reveal()));
+        $subscriberDef2->addTag('sulu_document_manager.event_subscriber');
+
+        $this->pass->process($this->container);
+
+        $calls = $this->dispatcher1->getMethodCalls();
+
+        $this->assertCount(2, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+        $this->assertEquals($calls[1], [
+            'addSubscriberService',
+            [
+                'subscriber_2',
+                get_class($this->subscriber2->reveal()),
+            ],
+        ]);
+
+        $calls = $this->dispatcher2->getMethodCalls();
+
+        $this->assertCount(2, $calls);
+        $this->assertEquals($calls[0], [
+            'addSubscriberService',
+            [
+                'subscriber_1',
+                get_class($this->subscriber1->reveal()),
+            ],
+        ]);
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/InitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/InitializerTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * TODO: Test purge.
+ */
 class InitializerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/app/AppKernel.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/app/AppKernel.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
+
+class AppKernel extends SuluTestKernel
+{
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/app/Resources/pages/default.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
+          >
+
+    <key>default</key>
+
+    <view>ClientWebsiteBundle:templates:animals</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <meta>
+        <title lang="de">Tiers</title>
+        <title lang="en">Animals</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Tier</title>
+                <title lang="en">Animals</title>
+            </meta>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="de">Adresse</title>
+                <title lang="en">Resourcelocator</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+    </properties>
+</template>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/app/Resources/webspaces/sulu_io.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/app/Resources/webspaces/sulu_io.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.0.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu_io</key>
+
+    <localizations>
+        <localization language="de"/>
+    </localizations>
+
+    <theme>
+        <key>default</key>
+        <default-templates>
+            <default-template type="page">default</default-template>
+            <default-template type="homepage">default</default-template>
+        </default-templates>
+    </theme>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="de">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF</name>
+            <key>sulu_io</key>
+            <resource-locator>
+                <strategy>tree</strategy>
+            </resource-locator>
+
+            <localizations>
+                <localization language="de" default="true"/>
+            </localizations>
+
+            <environments>
+                <environment type="test">
+                    <urls>
+                        <url language="de">sulu.lo</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>
+

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml
@@ -1,16 +1,17 @@
 parameters:
-    database.driver:   pdo_mysql
-    database.host:     localhost
-    database.path:     ~
-    database.user:     root
-    database.name:     sulu_test
-    database.port:     ~
+    database.driver: pdo_mysql
+    database.host: localhost
+    database.user: root
+    database.path: ~
+    database.name: sulu_test
+    database.path: ~
+    database.port: ~
     database.password: ~
-    database.version:  5.5
+    database.version: 5.5
 
-    phpcr.transport:   jackrabbit
+    phpcr.transport: jackrabbit
     phpcr.backend_url: http://localhost:8080/server/
-    phpcr.username:    admin
-    phpcr.password:    admin
-    phpcr.workspace:   test
-
+    phpcr.username: admin
+    phpcr.password: admin
+    phpcr.workspace.live: live
+    phpcr.workspace.default: test

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -54,14 +54,6 @@ sulu_core:
         en: English
     translations: ['de', 'en']
     fallback_locale: 'en'
-    phpcr:
-        backend:
-            type: "%phpcr.transport%"
-            url:  "%phpcr.backend_url%"
-            check_login_on_server: false
-        workspace: "%phpcr.workspace%"
-        username: "%phpcr.username%"
-        password: "%phpcr.password%"
 
 sulu_content:
     search:
@@ -126,6 +118,26 @@ sulu_test:
 
 sulu_document_manager:
     debug: false
+    sessions:
+        default:
+            backend:
+                type: "%phpcr.transport%"
+                url:  "%phpcr.backend_url%"
+            username: "%phpcr.username%"
+            password: "%phpcr.password%"
+            workspace: "%phpcr.workspace.default%"
+        live:
+            backend:
+                type: "%phpcr.transport%"
+                url:  "%phpcr.backend_url%"
+            username: "%phpcr.username%"
+            password: "%phpcr.password%"
+            workspace: "%phpcr.workspace.live%"
+    managers:
+        default:
+            session: default
+        live:
+            session: live
     mapping:
         page:
             class: Sulu\Bundle\ContentBundle\Document\PageDocument

--- a/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
@@ -23,6 +23,8 @@ use Sulu\Component\Content\Document\WorkflowStage;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Security\Core\Tests\Authentication\Token\TestUser;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use PHPCR\NoSuchWorkspaceException;
 
 /**
  * Base test case for functional tests in Sulu.
@@ -62,20 +64,7 @@ abstract class SuluTestCase extends KernelTestCase
     public function tearDown()
     {
         parent::tearDown();
-        // close the doctrine connection
-        foreach ($this->getContainer()->get('doctrine')->getConnections() as $connection) {
-            $connection->close();
-        }
-
-        // close the jackalope connections - can be removed when
-        // https://github.com/sulu/sulu/pull/2125 is merged.
-        // this has a negligble impact on memory usage in anycase.
-        foreach ($this->getContainer()->get('doctrine_phpcr')->getConnections() as $connection) {
-            try {
-                $connection->logout();
-            } catch (\Exception $e) {
-            }
-        }
+        $this->getEntityManager()->getConnection()->close();
     }
 
     /**
@@ -138,34 +127,38 @@ abstract class SuluTestCase extends KernelTestCase
 
     /**
      * Initialize / reset the Sulu PHPCR environment.
-     *
-     * NOTE: We could use the document initializer here rather than manually creating
-     *       the webspace nodes, but it currently adds more overhead and offers
-     *       no control over *which* webspaces are created, see
-     *       https://github.com/sulu-io/sulu/pull/2063 for a solution.
      */
-    protected function initPhpcr()
+    protected function initPhpcr(HttpKernelInterface $kernel = null)
     {
-        /** @var SessionInterface $session */
-        $session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
+        $container = $kernel ? $kernel->getContainer() : $this->getContainer();
 
-        if ($session->nodeExists('/cmf')) {
-            NodeHelper::purgeWorkspace($session);
-            $session->save();
+        /** @var SessionInterface $session */
+        $registry = $container->get('doctrine_phpcr');
+
+        foreach ($registry->getConnections() as $session) {
+            try {
+                NodeHelper::purgeWorkspace($session);
+                $session->save();
+            } catch (NoSuchWorkspaceException $e) {
+            }
         }
 
         if (!$this->importer) {
-            $this->importer = new PHPCRImporter($session);
+            $this->importer = new PHPCRImporter($this->getContainer()->get('doctrine_phpcr')->getConnection());
         }
+
+        $connections = $registry->getConnections();
+        $connectionsKey = serialize(array_keys($connections));
 
         // initialize the content repository.  in order to speed things up, for
         // each process, we dump the initial state to an XML file and restore
         // it thereafter.
         $initializerDump = __DIR__ . '/../Resources/app/cache/initial.xml';
-        if (true === self::$workspaceInitialized) {
-            $session->importXml('/', $initializerDump, ImportUUIDBehaviorInterface::IMPORT_UUID_COLLISION_THROW);
-            $session->save();
-
+        if (self::$workspaceInitialized && $connectionsKey === self::$workspaceInitialized) {
+            foreach ($connections as $session) {
+                $session->importXml('/', $initializerDump, ImportUUIDBehaviorInterface::IMPORT_UUID_COLLISION_THROW);
+                $session->save();
+            }
             return;
         }
 
@@ -173,11 +166,11 @@ abstract class SuluTestCase extends KernelTestCase
         if (!$filesystem->exists(dirname($initializerDump))) {
             $filesystem->mkdir(dirname($initializerDump));
         }
-        $this->getContainer()->get('sulu_document_manager.initializer')->initialize();
+        $container->get('sulu_document_manager.initializer')->initialize();
         $handle = fopen($initializerDump, 'w');
-        $session->exportSystemView('/cmf', $handle, false, false);
+        $registry->getConnection()->exportSystemView('/cmf', $handle, false, false);
         fclose($handle);
-        self::$workspaceInitialized = true;
+        self::$workspaceInitialized = $connectionsKey;
     }
 
     /**

--- a/src/Sulu/Component/Content/Document/Subscriber/ExtensionSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ExtensionSubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Extension\ManagedExtensionContainer;
@@ -28,11 +27,6 @@ class ExtensionSubscriber implements EventSubscriberInterface
      * @var ExtensionManagerInterface
      */
     private $extensionManager;
-
-    /**
-     * @var DocumentInspector
-     */
-    private $inspector;
 
     /**
      * @var NamespaceRegistry
@@ -54,13 +48,11 @@ class ExtensionSubscriber implements EventSubscriberInterface
     public function __construct(
         PropertyEncoder $encoder,
         ExtensionManagerInterface $extensionManager,
-        DocumentInspector $inspector,
         // these two dependencies should absolutely not be necessary
         NamespaceRegistry $namespaceRegistry
     ) {
         $this->encoder = $encoder;
         $this->extensionManager = $extensionManager;
-        $this->inspector = $inspector;
         $this->namespaceRegistry = $namespaceRegistry;
     }
 
@@ -110,7 +102,7 @@ class ExtensionSubscriber implements EventSubscriberInterface
         $node = $event->getNode();
         $extensionsData = $document->getExtensionsData();
 
-        $webspaceName = $this->inspector->getWebspace($document);
+        $webspaceName = $event->getManager()->getInspector()->getWebspace($document);
         $prefix = $this->namespaceRegistry->getPrefix('extension_localized');
 
         $extensions = $this->extensionManager->getExtensions($structureType);
@@ -140,8 +132,9 @@ class ExtensionSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
         $node = $event->getNode();
-        $locale = $this->inspector->getLocale($document);
-        $webspaceName = $this->inspector->getWebspace($document);
+        $inspector = $event->getManager()->getInspector();
+        $locale = $inspector->getLocale($document);
+        $webspaceName = $inspector->getWebspace($document);
         $structureType = $document->getStructureType();
 
         if (null === $structureType) {

--- a/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
@@ -32,29 +32,15 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
     private $encoder;
 
     /**
-     * @var DocumentInspector
-     */
-    private $inspector;
-
-    /**
-     * @var DocumentRegistry
-     */
-    private $documentRegistry;
-
-    /**
      * @var LocalizationFinderInterface
      */
     private $localizationFinder;
 
     public function __construct(
         PropertyEncoder $encoder,
-        DocumentInspector $inspector,
-        DocumentRegistry $documentRegistry,
         LocalizationFinderInterface $localizationFinder
     ) {
         $this->encoder = $encoder;
-        $this->inspector = $inspector;
-        $this->documentRegistry = $documentRegistry;
         $this->localizationFinder = $localizationFinder;
     }
 
@@ -89,20 +75,23 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $newLocale = $this->getAvailableLocalization($document, $locale);
+        $context = $event->getContext();
+
+        $newLocale = $this->getAvailableLocalization($context->getInspector(), $context->getRegistry(), $document, $locale);
         $event->setLocale($newLocale);
 
         if ($newLocale === $locale) {
             return;
         }
 
+        $registry = $context->getRegistry();
         if ($event->getOption('load_ghost_content', true) === true) {
-            $this->documentRegistry->updateLocale($document, $newLocale, $locale);
+            $registry->updateLocale($document, $newLocale, $locale);
 
             return;
         }
 
-        $this->documentRegistry->updateLocale($document, $locale, $locale);
+        $registry->updateLocale($document, $locale, $locale);
     }
 
     /**
@@ -113,9 +102,9 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
      *
      * @return string
      */
-    public function getAvailableLocalization(StructureBehavior $document, $locale)
+    private function getAvailableLocalization(DocumentInspector $inspector, DocumentRegistry $registry, StructureBehavior $document, $locale)
     {
-        $availableLocales = $this->inspector->getLocales($document);
+        $availableLocales = $inspector->getLocales($document);
 
         if (in_array($locale, $availableLocales)) {
             return $locale;
@@ -125,7 +114,7 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
 
         if ($document instanceof WebspaceBehavior) {
             $fallbackLocale = $this->localizationFinder->findAvailableLocale(
-                $this->inspector->getWebspace($document),
+                $inspector->getWebspace($document),
                 $availableLocales,
                 $locale
             );
@@ -136,7 +125,7 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
         }
 
         if (!$fallbackLocale) {
-            $fallbackLocale = $this->documentRegistry->getDefaultLocale();
+            $fallbackLocale = $registry->getDefaultLocale();
         }
 
         return $fallbackLocale;

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\OrderBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
@@ -27,13 +26,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class OrderSubscriber implements EventSubscriberInterface
 {
     const FIELD = 'order';
-
-    private $inspector;
-
-    public function __construct(DocumentInspector $inspector)
-    {
-        $this->inspector = $inspector;
-    }
 
     /**
      * {@inheritdoc}
@@ -99,14 +91,15 @@ class OrderSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $parentDocument = $this->inspector->getParent($document);
+        $inspector = $event->getManager()->getInspector();
+        $parentDocument = $inspector->getParent($document);
 
         if (null === $parentDocument) {
             return;
         }
 
         $count = 0;
-        foreach ($this->inspector->getChildren($parentDocument) as $childDocument) {
+        foreach ($inspector->getChildren($parentDocument) as $childDocument) {
             if (!$childDocument instanceof OrderBehavior) {
                 continue;
             }

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -32,11 +32,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class ResourceSegmentSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var DocumentInspector
-     */
-    private $documentInspector;
-
-    /**
      * @var PropertyEncoder
      */
     private $encoder;
@@ -48,11 +43,9 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
 
     public function __construct(
         PropertyEncoder $encoder,
-        DocumentInspector $documentInspector,
         RlpStrategyInterface $rlpStrategy
     ) {
         $this->encoder = $encoder;
-        $this->documentInspector = $documentInspector;
         $this->rlpStrategy = $rlpStrategy;
     }
 
@@ -98,9 +91,11 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $inspector = $event->getManager()->getInspector();
+
         $node = $event->getNode();
-        $property = $this->getResourceSegmentProperty($document);
-        $originalLocale = $this->documentInspector->getOriginalLocale($document);
+        $property = $this->getResourceSegmentProperty($inspector, $document);
+        $originalLocale = $inspector->getOriginalLocale($document);
         $segment = $node->getPropertyValueWithDefault(
             $this->encoder->localizedSystemName(
                 $property->getName(),
@@ -126,7 +121,7 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $property = $this->getResourceSegmentProperty($document);
+        $property = $this->getResourceSegmentProperty($event->getManager()->getInspector(), $document);
         $this->persistDocument($document, $property);
     }
 
@@ -166,9 +161,9 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
      *
      * @return PropertyMetadata
      */
-    private function getResourceSegmentProperty($document)
+    private function getResourceSegmentProperty(DocumentInspector $inspector, $document)
     {
-        $structure = $this->documentInspector->getStructureMetadata($document);
+        $structure = $inspector->getStructureMetadata($document);
         $property = $structure->getPropertyByTagName('sulu.rlp');
 
         if (!$property) {

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -15,7 +15,6 @@ use PHPCR\NodeInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
-use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
@@ -29,28 +28,14 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
     const SHADOW_LOCALE_FIELD = 'shadow-base';
 
     /**
-     * @var DocumentInspector
-     */
-    private $inspector;
-
-    /**
-     * @var DocumentRegistry
-     */
-    private $registry;
-
-    /**
      * @var PropertyEncoder
      */
     private $encoder;
 
     public function __construct(
-        PropertyEncoder $encoder,
-        DocumentInspector $inspector,
-        DocumentRegistry $registry
+        PropertyEncoder $encoder
     ) {
         $this->encoder = $encoder;
-        $this->inspector = $inspector;
-        $this->registry = $registry;
     }
 
     /**
@@ -134,7 +119,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
 
         $shadowLocale = $this->getShadowLocale($node, $locale);
         $document->setShadowLocale($shadowLocale);
-        $this->registry->updateLocale($document, $shadowLocale, $locale);
+        $event->getContext()->getRegistry()->updateLocale($document, $shadowLocale, $locale);
         $event->setLocale($shadowLocale);
     }
 
@@ -154,7 +139,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
         }
 
         if ($document->isShadowLocaleEnabled()) {
-            $this->validateShadow($document);
+            $this->validateShadow($event->getManager()->getInspector(), $document);
         }
 
         $event->getNode()->setProperty(
@@ -188,7 +173,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
         }
 
         $node = $event->getNode();
-        $structure = $this->inspector->getStructureMetadata($document);
+        $structure = $event->getManager()->getInspector()->getStructureMetadata($document);
 
         if (false === $structure->hasPropertyWithTagName('sulu.rlp')) {
             return;
@@ -238,7 +223,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
         );
     }
 
-    private function validateShadow(ShadowLocaleBehavior $document)
+    private function validateShadow(DocumentInspector $inspector, ShadowLocaleBehavior $document)
     {
         if ($document->getLocale() === $document->getShadowLocale()) {
             throw new \RuntimeException(sprintf(
@@ -247,14 +232,14 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
             ));
         }
 
-        $locales = $this->inspector->getConcreteLocales($document);
+        $locales = $inspector->getConcreteLocales($document);
         if (!in_array($document->getShadowLocale(), $locales)) {
-            $this->inspector->getNode($document)->revert();
+            $inspector->getNode($document)->revert();
             throw new \RuntimeException(sprintf(
                 'Attempting to create shadow for "%s" on a non-concrete locale "%s" for document at "%s". Concrete languages are "%s"',
                 $document->getLocale(),
                 $document->getShadowLocale(),
-                $this->inspector->getPath($document),
+                $inspector->getPath($document),
                 implode('", "', $locales)
             ));
         }

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -40,11 +40,6 @@ class StructureSubscriber implements EventSubscriberInterface
     private $contentTypeManager;
 
     /**
-     * @var DocumentInspector
-     */
-    private $inspector;
-
-    /**
      * @var LegacyPropertyFactory
      */
     private $legacyPropertyFactory;
@@ -63,12 +58,10 @@ class StructureSubscriber implements EventSubscriberInterface
     public function __construct(
         PropertyEncoder $encoder,
         ContentTypeManagerInterface $contentTypeManager,
-        DocumentInspector $inspector,
         LegacyPropertyFactory $legacyPropertyFactory
     ) {
         $this->encoder = $encoder;
         $this->contentTypeManager = $contentTypeManager;
-        $this->inspector = $inspector;
         $this->legacyPropertyFactory = $legacyPropertyFactory;
     }
 
@@ -128,7 +121,7 @@ class StructureSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $structureMetadata = $this->inspector->getStructureMetadata($document);
+        $structureMetadata = $event->getManager()->getInspector()->getStructureMetadata($document);
 
         $structure = $document->getStructure();
         if ($structure instanceof ManagedStructure) {
@@ -163,18 +156,20 @@ class StructureSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $inspector = $event->getManager()->getInspector();
+
         $node = $event->getNode();
         $propertyName = $this->getStructureTypePropertyName($document, $event->getLocale());
         $structureType = $node->getPropertyValueWithDefault($propertyName, null);
         $document->setStructureType($structureType);
 
         if (false === $event->getOption('load_ghost_content', false)) {
-            if ($this->inspector->getLocalizationState($document) === LocalizationState::GHOST) {
+            if ($inspector->getLocalizationState($document) === LocalizationState::GHOST) {
                 $structureType = null;
             }
         }
 
-        $container = $this->getStructure($document, $structureType);
+        $container = $this->getStructure($inspector, $document, $structureType);
 
         // Set the property container
         $event->getAccessor()->set(
@@ -207,7 +202,8 @@ class StructureSubscriber implements EventSubscriberInterface
         $locale = $event->getLocale();
         $options = $event->getOptions();
 
-        $this->mapContentToNode($document, $node, $locale, $options['ignore_required']);
+        $inspector = $event->getManager()->getInspector();
+        $this->mapContentToNode($inspector, $document, $node, $locale, $options['ignore_required']);
 
         $node->setProperty(
             $this->getStructureTypePropertyName($document, $locale),
@@ -235,12 +231,12 @@ class StructureSubscriber implements EventSubscriberInterface
      *
      * @return ManagedStructure
      */
-    private function createStructure($document)
+    private function createStructure($inspector, $document)
     {
         return new ManagedStructure(
             $this->contentTypeManager,
             $this->legacyPropertyFactory,
-            $this->inspector,
+            $inspector,
             $document
         );
     }
@@ -255,11 +251,11 @@ class StructureSubscriber implements EventSubscriberInterface
      *
      * @throws MandatoryPropertyException
      */
-    private function mapContentToNode($document, NodeInterface $node, $locale, $ignoreRequired)
+    private function mapContentToNode(DocumentInspector $inspector, $document, NodeInterface $node, $locale, $ignoreRequired)
     {
         $structure = $document->getStructure();
-        $webspaceName = $this->inspector->getWebspace($document);
-        $metadata = $this->inspector->getStructureMetadata($document);
+        $webspaceName = $inspector->getWebspace($document);
+        $metadata = $inspector->getStructureMetadata($document);
 
         foreach ($metadata->getProperties() as $propertyName => $structureProperty) {
             $realProperty = $structure->getProperty($propertyName);
@@ -316,10 +312,10 @@ class StructureSubscriber implements EventSubscriberInterface
      *
      * @return StructureInterface
      */
-    private function getStructure($document, $structureType)
+    private function getStructure(DocumentInspector $inspector, $document, $structureType)
     {
         if ($structureType) {
-            return $this->createStructure($document);
+            return $this->createStructure($inspector, $document);
         }
 
         if ($document->getStructure()) {

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureTypeFilingSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureTypeFilingSubscriber.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Content\Document\Subscriber;
 
 use Sulu\Component\Content\Document\Behavior\StructureTypeFilingBehavior;
+use Sulu\Component\DocumentManager\Event\AbstractEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AbstractFilingSubscriber;
@@ -42,7 +43,7 @@ class StructureTypeFilingSubscriber extends AbstractFilingSubscriber
         if ($event->hasParentNode()) {
             $currentPath = $event->getParentNode()->getPath();
         }
-        $parentName = $this->getParentName($document);
+        $parentName = $this->getParentName($event);
 
         return sprintf('%s/%s', $currentPath, $parentName);
     }
@@ -58,8 +59,10 @@ class StructureTypeFilingSubscriber extends AbstractFilingSubscriber
     /**
      * {@inheritdoc}
      */
-    protected function getParentName($document)
+    protected function getParentName(AbstractEvent $event)
     {
+        $document = $event->getDocument();
+
         return $document->getStructureType();
     }
 }

--- a/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
@@ -23,21 +23,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class TitleSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var DocumentInspector
-     */
-    private $inspector;
-
-    /**
      * @var PropertyEncoder
      */
     private $encoder;
 
     public function __construct(
-        PropertyEncoder $encoder,
-        DocumentInspector $inspector
+        PropertyEncoder $encoder
     ) {
         $this->encoder = $encoder;
-        $this->inspector = $inspector;
     }
 
     /**
@@ -63,7 +56,8 @@ class TitleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $title = $this->getTitle($document);
+        $inspector = $event->getManager()->getInspector();
+        $title = $this->getTitle($inspector, $document);
 
         $document->setTitle($title);
     }
@@ -81,7 +75,7 @@ class TitleSubscriber implements EventSubscriberInterface
 
         $title = $document->getTitle();
 
-        $structure = $this->inspector->getStructureMetadata($document);
+        $structure = $event->getManager()->getInspector()->getStructureMetadata($document);
         if (!$structure->hasProperty('title')) {
             return;
         }
@@ -90,18 +84,18 @@ class TitleSubscriber implements EventSubscriberInterface
         $this->handleHydrate($event);
     }
 
-    private function getTitle($document)
+    private function getTitle(DocumentInspector $inspector, $document)
     {
-        if (!$this->hasTitle($document)) {
+        if (!$this->hasTitle($inspector, $document)) {
             return 'Document has no "title" property in content';
         }
 
         return $document->getStructure()->getProperty('title')->getValue();
     }
 
-    private function hasTitle($document)
+    private function hasTitle(DocumentInspector $inspector, $document)
     {
-        $structure = $this->inspector->getStructureMetadata($document);
+        $structure = $inspector->getStructureMetadata($document);
 
         return $structure->hasProperty('title');
     }

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Events;
@@ -21,21 +20,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class WebspaceSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var DocumentInspector
-     */
-    private $inspector;
-
-    /**
      * @var PropertyEncoder
      */
     private $encoder;
 
     public function __construct(
-        PropertyEncoder $encoder,
-        DocumentInspector $inspector
+        PropertyEncoder $encoder
     ) {
         $this->encoder = $encoder;
-        $this->inspector = $inspector;
     }
 
     /**
@@ -61,7 +53,7 @@ class WebspaceSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $webspaceName = $this->inspector->getWebspace($document);
+        $webspaceName = $event->getManager()->getInspector()->getWebspace($document);
         $event->getAccessor()->set('webspaceName', $webspaceName);
     }
 }

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -19,7 +19,6 @@ use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
 use PHPCR\Util\PathHelper;
 use Sulu\Bundle\ContentBundle\Document\HomeDocument;
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
 use Sulu\Component\Content\BreadcrumbItem;
 use Sulu\Component\Content\Compat\Property as LegacyProperty;
@@ -113,11 +112,6 @@ class ContentMapper implements ContentMapperInterface
     private $formFactory;
 
     /**
-     * @var DocumentInspector
-     */
-    private $inspector;
-
-    /**
      * @var PropertyEncoder
      */
     private $encoder;
@@ -131,7 +125,6 @@ class ContentMapper implements ContentMapperInterface
         DocumentManager $documentManager,
         WebspaceManagerInterface $webspaceManager,
         FormFactoryInterface $formFactory,
-        DocumentInspector $inspector,
         PropertyEncoder $encoder,
         StructureManagerInterface $structureManager,
         ExtensionManagerInterface $extensionManager,
@@ -148,13 +141,13 @@ class ContentMapper implements ContentMapperInterface
         $this->webspaceManager = $webspaceManager;
         $this->documentManager = $documentManager;
         $this->formFactory = $formFactory;
-        $this->inspector = $inspector;
         $this->encoder = $encoder;
         $this->namespaceRegistry = $namespaceRegistry;
         $this->rlpStrategy = $rlpStrategy;
 
         // deprecated
         $this->eventDispatcher = $eventDispatcher;
+        $this->inspector = $documentManager->getInspector();
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ExtensionSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ExtensionSubscriberTest.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Document\Subscriber\ExtensionSubscriber;
 use Sulu\Component\Content\Extension\ExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
@@ -66,19 +67,22 @@ class ExtensionSubscriberTest extends SubscriberTestCase
         $this->extension = $this->prophesize(ExtensionInterface::class);
         $this->node = $this->prophesize(NodeInterface::class);
         $this->documentAccessor = $this->prophesize(DocumentAccessor::class);
+        $this->manager = $this->prophesize(DocumentManagerInterface::class);
 
         $this->subscriber = new ExtensionSubscriber(
             $this->encoder->reveal(),
             $this->extensionManager->reveal(),
-            $this->inspector->reveal(),
             $this->namespaceRegistry->reveal()
         );
 
         $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
         $this->hydrateEvent->getLocale()->willReturn('de');
         $this->hydrateEvent->getAccessor()->willReturn($this->documentAccessor->reveal());
+        $this->hydrateEvent->getManager()->willReturn($this->manager->reveal());
         $this->persistEvent->getNode()->willReturn($this->node->reveal());
         $this->persistEvent->getLocale()->willReturn('de');
+        $this->persistEvent->getManager()->willReturn($this->manager->reveal());
+        $this->manager->getInspector()->willReturn($this->inspector->reveal());
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -80,8 +80,6 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
 
         $this->subscriber = new FallbackLocalizationSubscriber(
             $this->encoder->reveal(),
-            $this->inspector->reveal(),
-            $this->registry->reveal(),
             new LocalizationFinder($this->webspaceManager->reveal())
         );
 
@@ -90,6 +88,9 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->hydrateEvent->getLocale()->willReturn(self::FIX_LOCALE);
         $this->webspaceManager->findWebspaceByKey(self::FIX_WEBSPACE)->willReturn($this->webspace);
         $this->registry->getDefaultLocale()->willReturn('de');
+
+        $this->context->getInspector()->willReturn($this->inspector->reveal());
+        $this->context->getRegistry()->willReturn($this->registry->reveal());
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/OrderSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/OrderSubscriberTest.php
@@ -31,9 +31,10 @@ class OrderSubscriberTest extends SubscriberTestCase
         parent::setUp();
 
         $this->inspector = $this->prophesize(DocumentInspector::class);
-        $this->subscriber = new OrderSubscriber($this->inspector->reveal());
+        $this->subscriber = new OrderSubscriber();
         $this->persistEvent->getDocument()->willReturn(new TestOrderDocument(null));
         $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->manager->getInspector()->willReturn($this->inspector->reveal());
     }
 
     /**
@@ -58,6 +59,7 @@ class OrderSubscriberTest extends SubscriberTestCase
         ]);
 
         $reorderEvent = $this->prophesize(ReorderEvent::class);
+        $reorderEvent->getManager()->willReturn($this->manager->reveal());
         $reorderEvent->getDocument()->willReturn($document);
 
         $this->subscriber->handleReorder($reorderEvent->reveal());
@@ -75,6 +77,7 @@ class OrderSubscriberTest extends SubscriberTestCase
         $document = new \stdClass();
 
         $reorderEvent = $this->prophesize(ReorderEvent::class);
+        $reorderEvent->getManager()->willReturn($this->manager->reveal());
         $reorderEvent->getDocument()->willReturn($document);
 
         $this->subscriber->handleReorder($reorderEvent->reveal());
@@ -90,6 +93,7 @@ class OrderSubscriberTest extends SubscriberTestCase
 
         $reorderEvent = $this->prophesize(ReorderEvent::class);
         $reorderEvent->getDocument()->willReturn($document->reveal());
+        $reorderEvent->getManager()->willReturn($this->manager->reveal());
         $this->inspector->getParent($document->reveal())->willReturn(null);
 
         $this->subscriber->handleReorder($reorderEvent->reveal());

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
@@ -23,6 +23,7 @@ use Sulu\Component\Content\Document\Subscriber\ResourceSegmentSubscriber;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\Content\Types\Rlp\Strategy\RlpStrategyInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\PropertyEncoder;
@@ -74,7 +75,6 @@ class ResourceSegmentSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->resourceSegmentSubscriber = new ResourceSegmentSubscriber(
             $this->encoder->reveal(),
-            $this->documentInspector->reveal(),
             $this->rlpStrategy->reveal()
         );
     }
@@ -87,6 +87,9 @@ class ResourceSegmentSubscriberTest extends \PHPUnit_Framework_TestCase
         $localizedPropertyName = sprintf('i18n:%s-%s', $locale, $propertyName);
 
         $event = $this->prophesize(AbstractMappingEvent::class);
+        $manager = $this->prophesize(DocumentManagerInterface::class);
+        $manager->getInspector()->willReturn($this->documentInspector->reveal());
+        $event->getManager()->willReturn($manager->reveal());
 
         $event->getDocument()->willReturn($this->document->reveal());
 
@@ -116,6 +119,9 @@ class ResourceSegmentSubscriberTest extends \PHPUnit_Framework_TestCase
         $localizedPropertyName = sprintf('i18n:%s-%s', $locale, $propertyName);
 
         $event = $this->prophesize(PersistEvent::class);
+        $manager = $this->prophesize(DocumentManagerInterface::class);
+        $manager->getInspector()->willReturn($this->documentInspector->reveal());
+        $event->getManager()->willReturn($manager->reveal());
 
         $event->getDocument()->willReturn($this->document->reveal());
 

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
@@ -98,15 +98,16 @@ class StructureSubscriberTest extends SubscriberTestCase
         $this->propertyFactory = $this->prophesize(LegacyPropertyFactory::class);
         $this->document = $this->prophesize(StructureBehavior::class);
         $this->inspector = $this->prophesize(DocumentInspector::class);
+        $this->manager->getInspector()->willReturn($this->inspector->reveal());
 
         $this->document->getStructureType()->willReturn('foobar');
         $this->inspector->getStructureMetadata(Argument::any())->willReturn($this->structureMetadata);
         $this->persistEvent->getLocale()->willReturn('en');
+        $this->persistEvent->getManager()->willReturn($this->manager->reveal());
 
         $this->subscriber = new StructureSubscriber(
             $this->encoder->reveal(),
             $this->contentTypeManager->reveal(),
-            $this->inspector->reveal(),
             $this->propertyFactory->reveal()
         );
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureTypeFilingSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureTypeFilingSubscriberTest.php
@@ -17,10 +17,12 @@ use Sulu\Component\Content\Document\Behavior\StructureTypeFilingBehavior;
 use Sulu\Component\Content\Document\Subscriber\StructureTypeFilingSubscriber;
 use Sulu\Component\DocumentManager\Behavior\Path\BasePathBehavior;
 use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\DocumentManagerContext;
 
 class StructureTypeFilingSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -74,6 +76,11 @@ class StructureTypeFilingSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private $subscriber;
 
+    /**
+     * @var array
+     */
+    private $options;
+
     public function setUp()
     {
         $this->persistEvent = $this->prophesize(PersistEvent::class);
@@ -86,10 +93,14 @@ class StructureTypeFilingSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
         $this->metadata = $this->prophesize(Metadata::class);
         $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->manager = $this->prophesize(DocumentManagerInterface::class);
+        $this->context = $this->prophesize(DocumentManagerContext::class);
 
-        $this->subscriber = new StructureTypeFilingSubscriber(
-            $this->nodeManager->reveal()
-        );
+        $this->subscriber = new StructureTypeFilingSubscriber();
+
+        $this->context->getNodeManager()->willReturn($this->nodeManager->reveal());
+        $this->persistEvent->getManager()->willReturn($this->manager->reveal());
+        $this->persistEvent->getNodeManager()->willReturn($this->nodeManager->reveal());
     }
 
     /**
@@ -97,6 +108,7 @@ class StructureTypeFilingSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testPersistNotImplementing()
     {
+        $this->persistEvent->getOptions()->willReturn([]);
         $this->persistEvent->getDocument()->willReturn($this->notImplementing);
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
@@ -116,6 +128,7 @@ class StructureTypeFilingSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->persistEvent->hasParentNode()->shouldBeCalled();
         $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
         $this->documentManager->find('/test', 'fr')->willReturn($this->parentDocument);
+        $this->persistEvent->getOptions()->willReturn([]);
 
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SubscriberTestCase.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SubscriberTestCase.php
@@ -13,9 +13,12 @@ namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
 
 use PHPCR\NodeInterface;
 use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\FlushEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\DocumentManagerContext;
 
 class SubscriberTestCase extends \PHPUnit_Framework_TestCase
 {
@@ -28,6 +31,11 @@ class SubscriberTestCase extends \PHPUnit_Framework_TestCase
      * @var HydrateEvent
      */
     protected $hydrateEvent;
+
+    /**
+     * @var FlushEvent
+     */
+    protected $flushEvent;
 
     /**
      * @var \stdClass
@@ -54,10 +62,13 @@ class SubscriberTestCase extends \PHPUnit_Framework_TestCase
      */
     protected $parentNode;
 
+    protected $manager;
+
     public function setUp()
     {
         $this->persistEvent = $this->prophesize(PersistEvent::class);
         $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->flushEvent = $this->prophesize(FlushEvent::class);
         $this->notImplementing = new \stdClass();
         $this->encoder = $this->prophesize(PropertyEncoder::class);
         $this->node = $this->prophesize(NodeInterface::class);
@@ -66,5 +77,15 @@ class SubscriberTestCase extends \PHPUnit_Framework_TestCase
         $this->persistEvent->getNode()->willReturn($this->node);
         $this->persistEvent->getAccessor()->willReturn($this->accessor);
         $this->hydrateEvent->getAccessor()->willReturn($this->accessor);
+        $this->manager = $this->prophesize(DocumentManagerInterface::class);
+        $this->context = $this->prophesize(DocumentManagerContext::class);
+
+        $this->context->getManager()->willReturn($this->manager->reveal());
+        $this->hydrateEvent->getManager()->willReturn($this->manager->reveal());
+        $this->persistEvent->getManager()->willReturn($this->manager->reveal());
+        $this->flushEvent->getManager()->willReturn($this->manager->reveal());
+        $this->hydrateEvent->getContext()->willReturn($this->context->reveal());
+        $this->persistEvent->getContext()->willReturn($this->context->reveal());
+        $this->flushEvent->getContext()->willReturn($this->context->reveal());
     }
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WebspaceSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WebspaceSubscriberTest.php
@@ -31,13 +31,14 @@ class WebspaceSubscriberTest extends SubscriberTestCase
         parent::setUp();
 
         $this->inspector = $this->prophesize(DocumentInspector::class);
-        $this->subscriber = new WebspaceSubscriber($this->encoder->reveal(), $this->inspector->reveal());
+        $this->subscriber = new WebspaceSubscriber($this->encoder->reveal());
     }
 
     public function testHandleWebspace()
     {
         $document = $this->prophesize(WebspaceBehavior::class);
         $this->persistEvent->getDocument()->willReturn($document);
+        $this->manager->getInspector()->willReturn($this->inspector->reveal());
 
         $this->inspector->getWebspace($document->reveal())->willReturn('example');
         $this->accessor->set('webspaceName', 'example')->shouldBeCalled();

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Document/Subscriber/CustomUrlSubscriberTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Document/Subscriber/CustomUrlSubscriberTest.php
@@ -150,7 +150,7 @@ class CustomUrlSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace);
 
         $this->documentManager->find('/cmf/sulu_io/custom-urls/routes/sulu.lo/test-3', 'de')
-            ->willThrow(new DocumentNotFoundException());
+            ->willThrow(new DocumentNotFoundException('test'));
         $this->documentManager->create('custom_url_route')->willReturn($routeDocument3->reveal());
         $routeDocument3->setTargetDocument($document->reveal())->shouldBeCalled();
         $routeDocument3->setLocale('de')->shouldBeCalled();


### PR DESCRIPTION
This PR introduces the possiblity to have multiple document managers and access them via. a `DocumentManagerRegistry`.

This allows us to access more than one PHPCR workspace or backend in the same request.

WARNING: This is using a POC branch of the document manager, and as such most of the code in this PR is liable to change if we implement a different strategy in the document manager.

See DocumentManager PR for more details: https://github.com/sulu-io/sulu-document-manager/pull/66

Notes

- We move the PHPCR configuration out of the `SuluCoreBundle` to the `DocumentManagerBundle`.