### PR TITLE
Fixed redirect urls for webspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2290 [WebsiteBundle]       Fixed redirect urls for webspace
     * HOTFIX      #2285 [SecurityBundle]      Made ResettingController translations more configurable
     * HOTFIX      #2291 [ContentBundle]       Fixed wrong spacing between more than two checkboxes
 

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -83,8 +83,9 @@ class ContentRouteProvider implements RouteProviderInterface
         $collection = new RouteCollection();
 
         // no portal information without localization supported
-        if ($this->requestAnalyzer->getCurrentLocalization() === null &&
-            $this->requestAnalyzer->getMatchType() !== RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
+        if ($this->requestAnalyzer->getCurrentLocalization() === null
+            && $this->requestAnalyzer->getMatchType() !== RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
+            && $this->requestAnalyzer->getMatchType() !== RequestAnalyzerInterface::MATCH_TYPE_REDIRECT
         ) {
             return $collection;
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -182,6 +182,96 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $routes);
     }
 
+    public function testGetCollectionForRequestNoLocalizationPartial()
+    {
+        // Set up test
+        $path = '';
+        $prefix = '/de';
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $theme = new Theme();
+        $theme->setKey('theme');
+        $webspace = new Webspace();
+        $webspace->setTheme($theme);
+        $portal->setWebspace($webspace);
+
+        $contentMapper = $this->getContentMapperMock();
+        $requestAnalyzer = $this->getRequestAnalyzerMock(
+            $portal,
+            $path,
+            $prefix,
+            null,
+            RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
+        );
+
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
+
+        $request = $this->getRequestMock($path);
+
+        // Test the route provider
+        $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routes);
+        $this->assertEquals(
+            'SuluWebsiteBundle:Redirect:redirectWebspace',
+            array_values(iterator_to_array($routes->getIterator()))[0]->getDefaults()['_controller']
+        );
+    }
+
+    public function testGetCollectionForRequestNoLocalizationRedirect()
+    {
+        // Set up test
+        $path = '';
+        $prefix = '/de';
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $theme = new Theme();
+        $theme->setKey('theme');
+        $webspace = new Webspace();
+        $webspace->setTheme($theme);
+        $portal->setWebspace($webspace);
+
+        $contentMapper = $this->getContentMapperMock();
+        $requestAnalyzer = $this->getRequestAnalyzerMock(
+            $portal,
+            $path,
+            $prefix,
+            null,
+            RequestAnalyzerInterface::MATCH_TYPE_REDIRECT
+        );
+
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $defaultLocaleProvider->getDefaultLocale()->willReturn(new Localization('de'));
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
+
+        $request = $this->getRequestMock($path);
+
+        // Test the route provider
+        $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routes);
+        $this->assertEquals(
+            'SuluWebsiteBundle:Redirect:redirectWebspace',
+            array_values(iterator_to_array($routes->getIterator()))[0]->getDefaults()['_controller']
+        );
+    }
+
     public function testGetCollectionForRequestSlashOnly()
     {
         // Set up test

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AbstractRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AbstractRequestProcessor.php
@@ -56,13 +56,13 @@ abstract class AbstractRequestProcessor implements RequestProcessorInterface
 
         $attributes['portalUrl'] = $portalInformation->getUrl();
         $attributes['webspace'] = $portalInformation->getWebspace();
+        $attributes['portal'] = $portalInformation->getPortal();
 
         if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
             return new RequestAttributes(array_merge($attributes, $additionalAttributes));
         }
 
         $attributes['localization'] = $portalInformation->getLocalization();
-        $attributes['portal'] = $portalInformation->getPortal();
         $attributes['segment'] = $portalInformation->getSegment();
 
         list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -213,6 +213,7 @@ class WebspaceCollectionBuilder
                 $this->buildUrlRedirect(
                     $portal->getWebspace(),
                     $environment,
+                    $portal,
                     $urlAddress,
                     $urlRedirect,
                     $urlAnalyticsKey,
@@ -242,6 +243,7 @@ class WebspaceCollectionBuilder
     /**
      * @param Webspace $webspace
      * @param Environment $environment
+     * @param Portal $portal
      * @param string $urlAddress
      * @param string $urlRedirect
      * @param string $urlAnalyticsKey
@@ -250,6 +252,7 @@ class WebspaceCollectionBuilder
     private function buildUrlRedirect(
         Webspace $webspace,
         Environment $environment,
+        Portal $portal,
         $urlAddress,
         $urlRedirect,
         $urlAnalyticsKey,
@@ -258,7 +261,7 @@ class WebspaceCollectionBuilder
         $this->portalInformations[$environment->getType()][$urlAddress] = new PortalInformation(
             RequestAnalyzerInterface::MATCH_TYPE_REDIRECT,
             $webspace,
-            null,
+            $portal,
             null,
             $urlAddress,
             null,

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -111,10 +111,6 @@ class WebspaceManager implements WebspaceManagerInterface
         return array_filter(
             $this->getWebspaceCollection()->getPortalInformations($environment),
             function (PortalInformation $portalInformation) use ($url) {
-                if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
-                    return $url === $portalInformation->getUrl();
-                }
-
                 return $this->matchUrl($url, $portalInformation->getUrl());
             }
         );

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -360,6 +360,106 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
     }
 
+    public function testFindPortalInformationsByUrl()
+    {
+        $portalInformations = $this->webspaceManager->findPortalInformationsByUrl('sulu.at/test/test/test', 'prod');
+        $portalInformation = reset($portalInformations);
+        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocalization());
+        $this->assertNull($portalInformation->getSegment());
+
+        /** @var Webspace $webspace */
+        $webspace = $portalInformation->getWebspace();
+
+        $this->assertEquals('Sulu CMF', $webspace->getName());
+        $this->assertEquals('sulu_io', $webspace->getKey());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertCount(2, $webspace->getLocalizations());
+        $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
+        $this->assertEquals('auto', $webspace->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $webspace->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $webspace->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $webspace->getLocalizations()[1]->getShadow());
+        $this->assertEquals('sulu', $webspace->getTheme()->getKey());
+
+        /** @var Portal $portal */
+        $portal = $portalInformation->getPortal();
+
+        $this->assertEquals('Sulu CMF AT', $portal->getName());
+        $this->assertEquals('sulucmf_at', $portal->getKey());
+
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
+
+        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
+
+        $this->assertCount(3, $portal->getEnvironments());
+
+        $environmentProd = $portal->getEnvironment('prod');
+        $this->assertEquals('prod', $environmentProd->getType());
+        $this->assertCount(2, $environmentProd->getUrls());
+        $this->assertEquals('sulu.at', $environmentProd->getUrls()[0]->getUrl());
+        $this->assertEquals('www.sulu.at', $environmentProd->getUrls()[1]->getUrl());
+
+        $environmentDev = $portal->getEnvironment('dev');
+        $this->assertEquals('dev', $environmentDev->getType());
+        $this->assertCount(1, $environmentDev->getUrls());
+        $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
+
+        $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.lo', 'dev');
+        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocalization());
+        $this->assertNull($portalInformation->getSegment());
+
+        /* @var Portal $portal */
+        /** @var Webspace $webspace */
+        $webspace = $portalInformation->getWebspace();
+
+        $this->assertEquals('Sulu CMF', $webspace->getName());
+        $this->assertEquals('sulu_io', $webspace->getKey());
+        $this->assertEquals('sulu_io', $webspace->getSecurity()->getSystem());
+        $this->assertCount(2, $webspace->getLocalizations());
+        $this->assertEquals('en', $webspace->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $webspace->getLocalizations()[0]->getCountry());
+        $this->assertEquals('auto', $webspace->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $webspace->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $webspace->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $webspace->getLocalizations()[1]->getShadow());
+        $this->assertEquals('sulu', $webspace->getTheme()->getKey());
+
+        $portal = $portalInformation->getPortal();
+
+        $this->assertEquals('Sulu CMF AT', $portal->getName());
+        $this->assertEquals('sulucmf_at', $portal->getKey());
+
+        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
+
+        $this->assertEquals(2, count($portal->getLocalizations()));
+        $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
+        $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[0]->getShadow());
+        $this->assertEquals('de', $portal->getLocalizations()[1]->getLanguage());
+        $this->assertEquals('at', $portal->getLocalizations()[1]->getCountry());
+        $this->assertEquals('', $portal->getLocalizations()[1]->getShadow());
+
+        $this->assertEquals(3, count($portal->getEnvironments()));
+
+        $environmentProd = $portal->getEnvironment('prod');
+        $this->assertEquals('prod', $environmentProd->getType());
+        $this->assertCount(2, $environmentProd->getUrls());
+        $this->assertEquals('sulu.at', $environmentProd->getUrls()[0]->getUrl());
+        $this->assertEquals('www.sulu.at', $environmentProd->getUrls()[1]->getUrl());
+
+        $environmentDev = $portal->getEnvironment('dev');
+        $this->assertEquals('dev', $environmentDev->getType());
+        $this->assertCount(1, $environmentDev->getUrls());
+        $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
+    }
+
     public function provideFindPortalInformationByUrl()
     {
         return [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the redirect handling of the website routing for following configuration:

```xml
<environment type="dev">
    <urls>
        <url>sulu.lo/{localization}</url>
        <url redirect="sulu.lo">{host}</url>
    </urls>
    <custom-urls>
        <custom-url>*.sulu.lo</custom-url>
    </custom-urls>
</environment>
```