### PR TITLE
Fixed analytics with all domains only in created webspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #2290 [WebsiteBundle]       Fixed redirect urls for webspace
+    * HOTFIX      #2294 [WebsiteBundle]       Fixed analytics with all domains only in created webspace
     * HOTFIX      #2285 [SecurityBundle]      Made ResettingController translations more configurable
     * HOTFIX      #2291 [ContentBundle]       Fixed wrong spacing between more than two checkboxes
 

--- a/src/Sulu/Bundle/WebsiteBundle/Entity/AnalyticsRepository.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Entity/AnalyticsRepository.php
@@ -61,20 +61,22 @@ class AnalyticsRepository extends EntityRepository
      * Returns analytics by url.
      *
      * @param string $url
+     * @param string $webspaceKey
      * @param string $environment
      *
      * @return Analytics[]
      */
-    public function findByUrl($url, $environment)
+    public function findByUrl($url, $webspaceKey, $environment)
     {
         $queryBuilder = $this->createQueryBuilder('a')
             ->addSelect('domains')
             ->leftJoin('a.domains', 'domains')
-            ->where('a.allDomains = 1')
-            ->orWhere('domains.url = :url AND domains.environment = :environment');
+            ->where('a.allDomains = 1 OR (domains.url = :url AND domains.environment = :environment)')
+            ->andWhere('a.webspaceKey = :webspaceKey');
 
         $query = $queryBuilder->getQuery();
         $query->setParameter('url', $url);
+        $query->setParameter('webspaceKey', $webspaceKey);
         $query->setParameter('environment', $environment);
 
         return $query->getResult();

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -66,7 +66,11 @@ class AppendAnalyticsListener
         }
 
         $portalUrl = $this->requestAnalyzer->getAttribute('urlExpression');
-        $analytics = $this->analyticsRepository->findByUrl($portalUrl, $this->environment);
+        $analytics = $this->analyticsRepository->findByUrl(
+            $portalUrl,
+            $this->requestAnalyzer->getPortalInformation()->getWebspaceKey(),
+            $this->environment
+        );
 
         $content = $this->engine->render('SuluWebsiteBundle:Analytics:website.html.twig', ['analytics' => $analytics]);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
@@ -7,6 +7,7 @@
             name="Sulu\Bundle\WebsiteBundle\Entity\Analytics">
         <indexes>
             <index columns="all_domains"/>
+            <index columns="webspace_key"/>
         </indexes>
 
         <id name="id" type="integer" column="id">

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Entity/AnalyticsRepositoryTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Entity/AnalyticsRepositoryTest.php
@@ -101,20 +101,53 @@ class AnalyticsRepositoryTest extends BaseFunctional
             ]
         );
 
-        $result = $this->analyticsRepository->findByUrl('www.sulu.io/{localization}', 'prod');
+        $result = $this->analyticsRepository->findByUrl('www.sulu.io/{localization}', 'sulu_io', 'prod');
         $this->assertCount(2, $result);
 
         $this->assertEquals('test-1', $result[0]->getTitle());
         $this->assertEquals('test-2', $result[1]->getTitle());
 
-        $result = $this->analyticsRepository->findByUrl('www.sulu.io/{localization}', 'dev');
+        $result = $this->analyticsRepository->findByUrl('www.sulu.io/{localization}', 'sulu_io', 'dev');
         $this->assertCount(1, $result);
 
         $this->assertEquals('test-2', $result[0]->getTitle());
 
-        $result = $this->analyticsRepository->findByUrl('www.sulu.ud', 'stage');
+        $result = $this->analyticsRepository->findByUrl('www.sulu.ud', 'sulu_io', 'stage');
         $this->assertCount(1, $result);
 
+        $this->assertEquals('test-2', $result[0]->getTitle());
+    }
+
+    public function testFindByUrlDifferentWebspaces()
+    {
+        $this->purgeDatabase();
+        $this->create(
+            'sulu_io',
+            [
+                'title' => 'test-1',
+                'type' => 'google',
+                'content' => 'UA123-123',
+                'allDomains' => true,
+                'domains' => [],
+            ]
+        );
+        $this->create(
+            'test_io',
+            [
+                'title' => 'test-2',
+                'type' => 'google',
+                'content' => 'UA123-123',
+                'allDomains' => true,
+                'domains' => [],
+            ]
+        );
+
+        $result = $this->analyticsRepository->findByUrl('www.sulu.io/{localization}', 'sulu_io', 'prod');
+        $this->assertCount(1, $result);
+        $this->assertEquals('test-1', $result[0]->getTitle());
+
+        $result = $this->analyticsRepository->findByUrl('www.sulu.io/{localization}', 'test_io', 'prod');
+        $this->assertCount(1, $result);
         $this->assertEquals('test-2', $result[0]->getTitle());
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -68,10 +68,11 @@ class AppendAnalyticsListenerTest extends \PHPUnit_Framework_TestCase
         $portalInformation = $this->prophesize(PortalInformation::class);
         $portalInformation->getUrlExpression()->willReturn('sulu.lo/{localization}');
         $portalInformation->getType()->willReturn(RequestAnalyzerInterface::MATCH_TYPE_FULL);
+        $portalInformation->getWebspaceKey()->willReturn('sulu_io');
         $requestAnalyzer->getPortalInformation()->willReturn($portalInformation->reveal());
         $requestAnalyzer->getAttribute('urlExpression')->willReturn('sulu.lo/{localization}');
 
-        $analyticsRepository->findByUrl('sulu.lo/{localization}', 'prod')->willReturn(['test' => 1]);
+        $analyticsRepository->findByUrl('sulu.lo/{localization}', 'sulu_io', 'prod')->willReturn(['test' => 1]);
         $listener = new AppendAnalyticsListener(
             $engine->reveal(),
             $requestAnalyzer->reveal(),
@@ -105,10 +106,11 @@ class AppendAnalyticsListenerTest extends \PHPUnit_Framework_TestCase
         $portalInformation = $this->prophesize(PortalInformation::class);
         $portalInformation->getUrlExpression()->willReturn('*.sulu.lo/*');
         $portalInformation->getType()->willReturn(RequestAnalyzerInterface::MATCH_TYPE_WILDCARD);
+        $portalInformation->getWebspaceKey()->willReturn('sulu_io');
         $requestAnalyzer->getPortalInformation()->willReturn($portalInformation->reveal());
         $requestAnalyzer->getAttribute('urlExpression')->willReturn('1.sulu.lo/2');
 
-        $analyticsRepository->findByUrl('1.sulu.lo/2', 'prod')->willReturn(['test' => 1]);
+        $analyticsRepository->findByUrl('1.sulu.lo/2', 'sulu_io', 'prod')->willReturn(['test' => 1]);
         $listener = new AppendAnalyticsListener(
             $engine->reveal(),
             $requestAnalyzer->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2293
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the fact that analytics with `allDomains=true` appears on all webspaces.