### PR TITLE
Fixed detecting webspaces for URLs with same priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2294 [WebsiteBundle]       Fixed detecting webspaces for URLs with same priority
     * HOTFIX      #2285 [SecurityBundle]      Made ResettingController translations more configurable
     * HOTFIX      #2291 [ContentBundle]       Fixed wrong spacing between more than two checkboxes
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -80,6 +80,10 @@ class WebsiteRequestProcessor extends AbstractRequestProcessor
         usort(
             $portalInformations,
             function (PortalInformation $a, PortalInformation $b) {
+                if ($a->getPriority() === $b->getPriority()) {
+                    return strlen($a->getUrl()) < strlen($b->getUrl());
+                }
+
                 return $a->getPriority() < $b->getPriority();
             }
         );

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -391,6 +391,67 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sulu.lo', $portalInformation2->getUrl());
     }
 
+    public function testProcessSamePriorityDifferentLength()
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+
+        $portal = new Portal();
+        $portal->setKey('sulu');
+
+        $localization = new Localization();
+        $localization->setCountry('at');
+        $localization->setLanguage('de');
+
+        $portalInformation1 = new PortalInformation(
+            RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            $webspace,
+            $portal,
+            $localization,
+            'sulu.lo/de',
+            null,
+            null,
+            null,
+            false,
+            'sulu.lo/de',
+            5
+        );
+
+        $portalInformation2 = new PortalInformation(
+            RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            $webspace,
+            $portal,
+            $localization,
+            'sulu.lo',
+            null,
+            null,
+            null,
+            false,
+            'sulu.lo',
+            5
+        );
+
+        $this->webspaceManager->findPortalInformationsByUrl(Argument::any(), 'prod')
+            ->willReturn([$portalInformation1, $portalInformation2]);
+        $this->webspaceManager->getPortalInformations('prod')
+            ->willReturn([$portalInformation1, $portalInformation2]);
+
+        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request->request = new ParameterBag(['post' => 1]);
+        $request->query = new ParameterBag(['get' => 1]);
+        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
+        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('/de'));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+
+        $this->replacer->replaceHost(null, 'sulu.lo')->willReturn('sulu.lo');
+        $this->replacer->replaceHost('sulu.lo', 'sulu.lo')->willReturn('sulu.lo');
+        $this->replacer->replaceHost('sulu.lo/de', 'sulu.lo')->willReturn('sulu.lo/de');
+
+        $attributes = $this->provider->process($request, new RequestAttributes());
+
+        $this->assertEquals($portalInformation1, $attributes->getAttribute('portalInformation'));
+    }
+
     public function provideAnalyzeData()
     {
         $portalInformation = $this->prophesize(PortalInformation::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The `usort` callback in the `WebsiteRequestProcessor` was only sorting based on the given priority. But in addition to that, it should also sort based on the length of the matching URL, since it might be possible that multiple `portalInformation`s have the same priority. So the matching portal should be the one with the highest priority and the longest URL.

#### Why?

An environment configuration in the webspace xml like the following did not work as it did in 1.1:

```xml
    <environment type="dev">
        <urls>
            <url>sulu.lo/{localization}</url>
            <url language="en">sulu.lo</url>
        </urls>
    </environment>
```

We would suppose that `sulu.lo` would not end up in a redirect to `sulu.lo/en`, but just shows the english language, and that also all localization variants like `sulu.lo/de`, `sulu.lo/en` and so on are working.

This was not the case, the setup shown before only shows `sulu.lo`, and the other localizations were not working at all. Strange is that it only stopped working if there are also no custom urls defined for this environment. However, I think that's based on the behavior of the `usort` function, which does not guarantee the same sorting in ambiguous situations.

#### BC Breaks/Deprecations

The behavior for the configuration mentioned above changes to the way it was in the 1.1 release.