### PR TITLE
Fixed overriding request attributes and set them on the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2288 [WebsiteBundle]       Fixed overriding request attributes and set them on the request
     * BUGFIX      #2288 [AdminBundle]         Removed deleting of entire dom tree on tab change
     * ENHANCEMENT #2278 [TestBundle]          Cache result of Sulu intitializer rather than using a fixture
 

--- a/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
@@ -89,6 +89,8 @@ class PreviewRenderer
         // get controller and invoke action
         $request = new Request($query, $request, [], $cookies);
         $request->attributes->set('_controller', $content->getController());
+        $request->query->set('webspace', $content->getWebspaceKey());
+        $request->query->set('locale', $content->getLanguageCode());
         $controller = $this->controllerResolver->getController($request);
 
         // prepare locale for translator and request

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
@@ -66,7 +66,13 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $requestStack->push(
             Argument::that(
                 function (Request $newRequest) use ($request) {
-                    $this->assertEquals($request->query->all(), $newRequest->query->all());
+                    $this->assertEquals(
+                        array_merge(
+                            ['webspace' => 'sulu_io', 'locale' => 'de_at'],
+                            $request->query->all()
+                        ),
+                        $newRequest->query->all()
+                    );
                     $this->assertEquals($request->request->all(), $newRequest->request->all());
                     $this->assertEquals($request->cookies->all(), $newRequest->cookies->all());
 
@@ -119,7 +125,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $requestStack->push(
             Argument::that(
                 function (Request $newRequest) {
-                    $this->assertEquals([], $newRequest->query->all());
+                    $this->assertEquals(['webspace' => 'sulu_io', 'locale' => 'de_at'], $newRequest->query->all());
                     $this->assertEquals([], $newRequest->request->all());
                     $this->assertEquals([], $newRequest->cookies->all());
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/SnippetTwigExtensionTest.php
@@ -18,6 +18,8 @@ use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class SnippetTwigExtensionTest extends SuluTestCase
 {
@@ -41,6 +43,11 @@ class SnippetTwigExtensionTest extends SuluTestCase
      */
     private $extension;
 
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
     protected function setUp()
     {
         $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');
@@ -50,20 +57,23 @@ class SnippetTwigExtensionTest extends SuluTestCase
         $webspace = $this->getContainer()->get('sulu_core.webspace.webspace_manager')->findWebspaceByKey('sulu_io');
         $localization = $webspace->getLocalization('en');
 
-        $attributes = new \ReflectionProperty($this->requestAnalyzer, 'attributes');
-        $attributes->setAccessible(true);
-
-        $attributes->setValue(
-            $this->requestAnalyzer,
-            new RequestAttributes(
-                [
-                    'webspaceKey' => $webspace->getKey(),
-                    'webspace' => $webspace,
-                    'locale' => $localization->getLocalization(),
-                    'localization' => $localization,
-                ]
-            )
+        $request = new Request(
+            [],
+            [],
+            [
+                '_sulu' => new RequestAttributes(
+                    [
+                        'webspaceKey' => $webspace->getKey(),
+                        'webspace' => $webspace,
+                        'locale' => $localization->getLocalization(),
+                        'localization' => $localization,
+                    ]
+                ),
+            ]
         );
+
+        $this->requestStack = $this->getContainer()->get('request_stack');
+        $this->requestStack->push($request);
 
         $this->initPhpcr();
 

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -15,6 +15,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use Prophecy\Argument;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -207,13 +208,29 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
 
         $this->prepareWebspaceManager($portalInformation);
 
+        $requestBag = $this->prophesize(ParameterBag::class);
+        $requestBag->all()->willReturn(['post' => 1]);
+        $queryBag = $this->prophesize(ParameterBag::class);
+        $queryBag->all()->willReturn(['get' => 1]);
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
+        $request->request = $requestBag->reveal();
+        $request->query = $queryBag->reveal();
+        $request->attributes = $attributesBag->reveal();
+
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->any())->method('getScheme')->willReturn('http');
         $request->expects($this->once())->method('setLocale')->with('de_at');
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
@@ -257,9 +274,22 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
 
         $requestFormat = false;
 
+        $requestBag = $this->prophesize(ParameterBag::class);
+        $requestBag->all()->willReturn(['post' => 1]);
+        $queryBag = $this->prophesize(ParameterBag::class);
+        $queryBag->all()->willReturn(['get' => 1]);
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
+        $request->request = $requestBag->reveal();
+        $request->query = $queryBag->reveal();
+        $request->attributes = $attributesBag->reveal();
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->once())->method('setLocale')->with('de_at');
@@ -283,6 +313,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
             )
         );
 
+        $this->requestStack->getCurrentRequest()->willReturn($request);
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -15,6 +15,7 @@ use Prophecy\Argument;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestProcessorInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -24,6 +25,10 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalled();
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalled()->willReturn(new RequestAttributes());
@@ -39,6 +44,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalled()->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalledTimes(1)->willReturn(new RequestAttributes(['test' => 1]));
@@ -56,6 +70,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalledTimes(1)->willReturn(new RequestAttributes(['test' => 1]));
@@ -77,6 +100,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
 
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
+
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalledTimes(1)->willReturn(new RequestAttributes(['test' => 1]));
         $provider->validate(Argument::type(RequestAttributes::class))->shouldBeCalled()->willReturn(true);
@@ -94,6 +126,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getHost()->willReturn('www.sulu.io');
         $request->getScheme()->willReturn('https');
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $requestStack = $this->prophesize(RequestStack::class);
         $requestStack->getCurrentRequest()->willReturn($request->reveal());
@@ -144,6 +185,16 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
+
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalled()->willReturn(new RequestAttributes($attributes));
         $provider->validate(Argument::type(RequestAttributes::class))->shouldBeCalled()->willReturn(true);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR enables the request analyzer to hold attributes per request.

#### Why?

The public values of the request analyzer should never be overriden.