### PR TITLE
Fixed handling of non-default formats in error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2288 [AdminBundle]         Removed deleting of entire dom tree on tab change
     * ENHANCEMENT #2278 [TestBundle]          Cache result of Sulu intitializer rather than using a fixture
+    * BUGFIX      #2305 [WebsiteBundle]       Fixed handling of non-default formats in error pages
 
 * 1.2.0 (2016-04-11)
     * BUGFIX      #2280 [ContentBundle]       Removed scrollbar from categories in overlay

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -175,7 +175,6 @@
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
             <argument type="service" id="sulu_website.resolver.parameter" />
-            <argument type="service" id="sulu.content.mapper" />
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
+
+use Prophecy\Argument;
+use Sulu\Bundle\WebsiteBundle\Controller\ExceptionController;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Theme;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Request;
+
+class ExceptionControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ExceptionController
+     */
+    private $exceptionController;
+
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
+
+    /**
+     * @var \Twig_ExistsLoaderInterface
+     */
+    private $loader;
+
+    /**
+     * @var ParameterResolverInterface
+     */
+    private $parameterResolver;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function setUp()
+    {
+        $this->twig = $this->prophesize(\Twig_Environment::class);
+        $this->loader = $this->prophesize(\Twig_ExistsLoaderInterface::class);
+        $this->twig->getLoader()->willReturn($this->loader->reveal());
+
+        $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->exceptionController = new ExceptionController(
+            $this->twig->reveal(),
+            false,
+            $this->parameterResolver->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    public static function provideShowAction()
+    {
+        return [
+            ['html', true, 'html'],
+            ['xml', true, 'xml'],
+            ['json', true, 'json'],
+            ['aspx', false, 'html'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideShowAction
+     */
+    public function testShowActionFormat($retrievedFormat, $templateAvailable, $expectedExceptionFormat)
+    {
+        $request = new Request();
+        $request->setRequestFormat($retrievedFormat);
+        $exception = FlattenException::create(new \Exception(), 400);
+
+        $webspace = new Webspace();
+        $theme = new Theme();
+        $theme->addErrorTemplate(400, 'error400.html.twig');
+        $webspace->setTheme($theme);
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->twig->render(Argument::containingString($expectedExceptionFormat), Argument::any())->shouldBeCalled();
+        $this->loader->exists(Argument::any())->willReturn($templateAvailable);
+
+        if ($expectedExceptionFormat === 'html') {
+            $this->parameterResolver->resolve(Argument::cetera())->shouldBeCalled()->willReturn([]);
+        } else {
+            $this->parameterResolver->resolve(Argument::cetera())->shouldNotBeCalled();
+        }
+
+        // Required to leave one ob_level left, test will be marked otherwise as risky by PHPUnit
+        $request->headers->add(['X-Php-Ob-Level' => 1]);
+
+        $this->exceptionController->showAction($request, $exception);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2297
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the handling of error pages. Instead of only replacing the handling for errors in HTML mode, Sulu now takes over handling of all formats Symfony does not support (and of HTML).