### PR TITLE
Fixed partial rendering using query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2306 [WebsiteBundle]       Fixed partial rendering using query parameter
     * HOTFIX      #2290 [WebsiteBundle]       Fixed redirect urls for webspace
     * HOTFIX      #2294 [WebsiteBundle]       Fixed detecting webspaces for URLs with same priority
     * HOTFIX      #2294 [WebsiteBundle]       Fixed analytics with all domains only in created webspace

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -302,6 +302,7 @@ class ContentRouteProvider implements RouteProviderInterface
             $request->getPathInfo(), [
                 '_controller' => $content->getController(),
                 'structure' => $content,
+                'partial' => $request->get('partial', 'false') === 'true',
             ]
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -24,6 +24,7 @@ use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Theme;
 use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpFoundation\Request;
 
 class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -59,7 +60,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -99,7 +100,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -139,13 +140,58 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
+        $defaults = $routes->getIterator()->current()->getDefaults();
 
         $this->assertCount(1, $routes);
-        $this->assertEquals(1, $routes->getIterator()->current()->getDefaults()['structure']->getUuid());
+        $this->assertEquals(1, $defaults['structure']->getUuid());
+        $this->assertEquals(false, $defaults['partial']);
+    }
+
+    public function testGetCollectionForRequestWithPartialFlag()
+    {
+        // Set up test
+        $path = '';
+        $prefix = '/de';
+        $uuid = 1;
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $theme = new Theme();
+        $theme->setKey('theme');
+        $webspace = new Webspace();
+        $webspace->setTheme($theme);
+        $portal->setWebspace($webspace);
+        $localization = new Localization();
+        $localization->setLanguage('de');
+
+        $structure = $this->getStructureMock($uuid);
+        $requestAnalyzer = $this->getRequestAnalyzerMock($portal, $path, $prefix, $localization);
+
+        $contentMapper = $this->getContentMapperMock();
+        $contentMapper->expects($this->any())->method('loadByResourceLocator')->will($this->returnValue($structure));
+
+        $defaultLocaleProvider = $this->prophesize(DefaultLocaleProviderInterface::class);
+        $urlReplacer = $this->prophesize(ReplacerInterface::class);
+
+        $portalRouteProvider = new ContentRouteProvider(
+            $contentMapper,
+            $requestAnalyzer,
+            $defaultLocaleProvider->reveal(),
+            $urlReplacer->reveal()
+        );
+
+        $request = new Request(['partial' => 'true'], [], [], [], [], ['REQUEST_URI' => $path]);
+
+        // Test the route provider
+        $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
+        $defaults = $routes->getIterator()->current()->getDefaults();
+
+        $this->assertCount(1, $routes);
+        $this->assertEquals(1, $defaults['structure']->getUuid());
+        $this->assertEquals(true, $defaults['partial']);
     }
 
     public function testGetCollectionForRequestNoLocalization()
@@ -174,7 +220,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -215,7 +261,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -260,7 +306,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -316,7 +362,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -360,7 +406,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -412,7 +458,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -457,7 +503,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -506,7 +552,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -561,7 +607,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -615,7 +661,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path, 'test1=value1');
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path, 'QUERY_STRING' => 'test1=value1']);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -669,7 +715,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -724,7 +770,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -779,7 +825,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -831,7 +877,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
             $urlReplacer->reveal()
         );
 
-        $request = $this->getRequestMock($path);
+        $request = new Request([], [], [], [], [], ['REQUEST_URI' => $path]);
 
         // Test the route provider
         $routes = $portalRouteProvider->getRouteCollectionForRequest($request);
@@ -932,20 +978,5 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         return $contentMapper;
-    }
-
-    /**
-     * @param string $path
-     * @param string $queryString
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getRequestMock($path, $queryString = null)
-    {
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request', ['getRequestUri', 'getQueryString']);
-        $request->expects($this->any())->method('getRequestUri')->will($this->returnValue($path));
-        $request->expects($this->any())->method('getQueryString')->will($this->returnValue($queryString));
-
-        return $request;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces the possibility to render only the content block of a page using the `partial=true` query string.

#### Why?

Because this behavior was already there and is required by some existing projects.