### PR TITLE
Added security checks to DoctrineListBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #2306 [WebsiteBundle]       Fixed partial rendering using query parameter
+    * HOTFIX      #2312 [Rest]                Added security checks to DoctrineListBuilder
     * HOTFIX      #2303 [ContactBundle]       Fixed contact media search
     * HOTFIX      #2304 [ContactBundle]       Fixed styling of options dropdown and fixed url-input dropdown
     * HOTFIX      #2290 [WebsiteBundle]       Fixed redirect urls for webspace

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -29,6 +29,7 @@
         <service id="sulu_core.doctrine_list_builder_factory" class="%sulu_core.doctrine_list_builder_factory.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument>%sulu_security.permissions%</argument>
         </service>
 
         <service id="sulu_core.rest.datetime_handler" class="%sulu_core.rest.datetime_handler.class%">

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Rest\ListBuilder;
 
 use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\General\PropertyMetadata;
+use Sulu\Component\Security\Authentication\UserInterface;
 
 abstract class AbstractListBuilder implements ListBuilderInterface
 {
@@ -83,6 +84,16 @@ abstract class AbstractListBuilder implements ListBuilderInterface
      * @var ExpressionInterface[]
      */
     protected $expressions = [];
+
+    /**
+     * @var UserInterface
+     */
+    protected $user;
+
+    /**
+     * @var string
+     */
+    protected $permission;
 
     /**
      * {@inheritdoc}
@@ -245,6 +256,15 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     public function getCurrentPage()
     {
         return $this->page;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPermissionCheck(UserInterface $user, $permission)
+    {
+        $this->user = $user;
+        $this->permission = $permission;
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
@@ -30,13 +30,20 @@ class DoctrineListBuilderFactory
     private $em;
 
     /**
+     * @var array
+     */
+    private $permissions;
+
+    /**
      * @param EntityManager $em
      * @param EventDispatcherInterface $eventDispatcher
+     * @param array $permissions
      */
-    public function __construct(EntityManager $em, EventDispatcherInterface $eventDispatcher)
+    public function __construct(EntityManager $em, EventDispatcherInterface $eventDispatcher, array $permissions)
     {
         $this->em = $em;
         $this->eventDispatcher = $eventDispatcher;
+        $this->permissions = $permissions;
     }
 
     /**
@@ -48,6 +55,6 @@ class DoctrineListBuilderFactory
      */
     public function create($entityName)
     {
-        return new DoctrineListBuilder($this->em, $entityName, $this->eventDispatcher);
+        return new DoctrineListBuilder($this->em, $entityName, $this->eventDispatcher, $this->permissions);
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Rest\ListBuilder;
 
 use Sulu\Component\Rest\ListBuilder\Expression\ConjunctionExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
  * This interface defines the the ListBuilder functionality, for the creation of REST list responses.
@@ -153,6 +154,16 @@ interface ListBuilderInterface
      * @return int
      */
     public function getCurrentPage();
+
+    /**
+     * Sets the permission check for the ListBuilder.
+     *
+     * @param UserInterface $user The user for which the permission must be granted
+     * @param int $permission A value from the PermissionTypes
+     *
+     * @return ListBuilderInterface
+     */
+    public function setPermissionCheck(UserInterface $user, $permission);
 
     /**
      * Defines a constraint for the rows to return.

--- a/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/SecuredEntityRepositoryTrait.php
@@ -43,7 +43,6 @@ trait SecuredEntityRepositoryTrait
             'accessControl.entityClass = :entityClass AND accessControl.entityId = ' . $entityAlias . '.id'
         );
         $queryBuilder->leftJoin('accessControl.role', 'role');
-        // TODO remove hard coded permission value
         $queryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) = :permission OR accessControl.permissions IS NULL'
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2310
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/214

#### What's in this PR?

This PR adds the method `setPermissionCheck` taking a user and a permission type to the `DoctrineListBuilder`, in order to only return the values the given user has the given permission type for. This does not happen automatically, but the method has to be called manually in the controller.

#### Example Usage

~~~php
$listBuilder = $factory->create($this->container->getParameter('sulu.model.contact.class'));
$restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
$listBuilder->setPermissionCheck($this->getUser(), PermissionTypes::VIEW);
$result =$listBuilder->execute();
~~~

#### To Do

- [x] Create a documentation PR

