### PR TITLE
added twig-function to check if navigation-item is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #2278 [TestBundle]          Cache result of Sulu intitializer rather than using a fixture
     * BUGFIX      #2305 [WebsiteBundle]       Fixed handling of non-default formats in error pages
     * ENHANCEMENT #2341 [MediaBundle]         Added category to medias
+    * ENHANCEMENT #2323 [WebsiteBundle]       Added TWIG-Extension to check if parent nav-item is active
 
 * 1.2.1 (2016-04-26)
     * HOTFIX      #2334 [ContactBundle]       Fixed account-contact search

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Navigation\NavigationTwigExtension;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
@@ -9,11 +18,21 @@ class NavigationTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function activeElementProvider()
     {
         return [
-            [true, '/news', '/news/item'],
+            [false, '/', '/news/item'],
+            [true, '/news/item', '/news/item'],
+            [true, '/news/item', '/news'],
+            [true, '/news/item', '/'],
+            [false, '/news/item-1', '/news/item'],
+            [false, '/news', '/news/item'],
             [false, '/news', '/product/item'],
+            [false, '/news', '/news-1'],
+            [false, '/news', '/news-1/item'],
         ];
     }
 
+    /**
+     * @dataProvider activeElementProvider
+     */
     public function testActiveElement($expected, $requestPath, $itemPath)
     {
         $extension = new NavigationTwigExtension(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
@@ -27,6 +27,7 @@ class NavigationTwigExtensionTest extends \PHPUnit_Framework_TestCase
             [false, '/news', '/product/item'],
             [false, '/news', '/news-1'],
             [false, '/news', '/news-1/item'],
+            [true, '/', '/'],
         ];
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
@@ -21,7 +21,7 @@ class NavigationTwigExtensionTest extends \PHPUnit_Framework_TestCase
             [false, '/', '/news/item'],
             [true, '/news/item', '/news/item'],
             [true, '/news/item', '/news'],
-            [true, '/news/item', '/'],
+            [false, '/news/item', '/'],
             [false, '/news/item-1', '/news/item'],
             [false, '/news', '/news/item'],
             [false, '/news', '/product/item'],

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
@@ -43,4 +43,3 @@ class NavigationTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $extension->navigationIsActiveFunction($requestPath, $itemPath));
     }
 }
-

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/NavigationTwigExtensionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
+use Sulu\Bundle\WebsiteBundle\Twig\Navigation\NavigationTwigExtension;
+use Sulu\Component\Content\Mapper\ContentMapperInterface;
+
+class NavigationTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function activeElementProvider()
+    {
+        return [
+            [true, '/news', '/news/item'],
+            [false, '/news', '/product/item'],
+        ];
+    }
+
+    public function testActiveElement($expected, $requestPath, $itemPath)
+    {
+        $extension = new NavigationTwigExtension(
+            $this->prophesize(ContentMapperInterface::class)->reveal(),
+            $this->prophesize(NavigationMapperInterface::class)->reveal()
+        );
+
+        $this->assertEquals($expected, $extension->navigationIsActiveFunction($requestPath, $itemPath));
+    }
+}
+

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -82,6 +82,17 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
     {
         return $this->memoizeCache->memoize([$this->extension, 'breadcrumbFunction'], $this->lifeTime);
     }
+    
+    /**
+     * @param string $requestUrl
+     * @param string $itemUrl
+     *
+     * @return bool
+     */
+    public function isActiveNavElementFunction($requestUrl, $itemUrl)
+    {
+        return $this->memoizeCache->memoize([$this->extension, 'isActiveNavElementFunction'], $this->lifeTime);
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -84,12 +84,9 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
     }
 
     /**
-     * @param string $requestUrl
-     * @param string $itemUrl
-     *
-     * @return bool
+     * {@inheritdoc}
      */
-    public function isActiveNavElementFunction($requestUrl, $itemUrl)
+    public function navigationIsActiveFunction($requestUrl, $itemUrl)
     {
         return $this->memoizeCache->memoize([$this->extension, 'navigationIsActiveFunction'], $this->lifeTime);
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -82,7 +82,7 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
     {
         return $this->memoizeCache->memoize([$this->extension, 'breadcrumbFunction'], $this->lifeTime);
     }
-    
+
     /**
      * @param string $requestUrl
      * @param string $itemUrl
@@ -91,7 +91,7 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
      */
     public function isActiveNavElementFunction($requestUrl, $itemUrl)
     {
-        return $this->memoizeCache->memoize([$this->extension, 'isActiveNavElementFunction'], $this->lifeTime);
+        return $this->memoizeCache->memoize([$this->extension, 'navigationIsActiveFunction'], $this->lifeTime);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -56,7 +56,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
             new \Twig_SimpleFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
             new \Twig_SimpleFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
             new \Twig_SimpleFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
-            new \Twig_SimpleFunction('sulu_is_active_nav_element', [$this, 'isActiveNavElementFunction']),
+            new \Twig_SimpleFunction('sulu_navigation_is_active', [$this, 'navigationIsActiveFunction']),
         ];
     }
 
@@ -155,10 +155,10 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
      *
      * @return bool
      */
-    public function isActiveNavElementFunction($requestUrl, $itemUrl)
+    public function navigationIsActiveFunction($requestPath, $itemPath)
     {
-        if ($requestUrl !== $itemUrl) {
-            if (substr($requestUrl, 0, strlen($itemUrl)) !== $itemUrl) {
+        if ($requestPath !== $itemPath) {
+            if (substr($requestUrl, 0, strlen($itemUrl) + 1) !== $itemUrl . '/') {
                 return false;
             }
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Navigation;
 
+use PHPCR\Util\PathHelper;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -39,7 +40,8 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
         ContentMapperInterface $contentMapper,
         NavigationMapperInterface $navigationMapper,
         RequestAnalyzerInterface $requestAnalyzer = null
-    ) {
+    )
+    {
         $this->contentMapper = $contentMapper;
         $this->navigationMapper = $navigationMapper;
         $this->requestAnalyzer = $requestAnalyzer;
@@ -150,20 +152,18 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     }
 
     /**
-     * @param string $requestUrl
-     * @param string $itemUrl
+     * @param string $requestPath
+     * @param string $itemPath
      *
      * @return bool
      */
     public function navigationIsActiveFunction($requestPath, $itemPath)
     {
-        if ($requestPath !== $itemPath) {
-            if (substr($requestUrl, 0, strlen($itemUrl) + 1) !== $itemUrl . '/') {
-                return false;
-            }
+        if ($requestPath === $itemPath) {
+            return true;
         }
 
-        return true;
+        return preg_match(sprintf('/%s([\/]|$)/', preg_quote($itemPath, '/')), $requestPath);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Navigation;
 
-use PHPCR\Util\PathHelper;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -40,8 +39,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
         ContentMapperInterface $contentMapper,
         NavigationMapperInterface $navigationMapper,
         RequestAnalyzerInterface $requestAnalyzer = null
-    )
-    {
+    ) {
         $this->contentMapper = $contentMapper;
         $this->navigationMapper = $navigationMapper;
         $this->requestAnalyzer = $requestAnalyzer;

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -56,6 +56,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
             new \Twig_SimpleFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
             new \Twig_SimpleFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
             new \Twig_SimpleFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
+            new \Twig_SimpleFunction('sulu_is_active_nav_element', [$this, 'isActiveNavElementFunction']),
         ];
     }
 
@@ -146,6 +147,23 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
             $webspaceKey,
             $locale
         );
+    }
+
+    /**
+     * @param string $requestUrl
+     * @param string $itemUrl
+     *
+     * @return bool
+     */
+    public function isActiveNavElementFunction($requestUrl, $itemUrl)
+    {
+        if ($requestUrl !== $itemUrl) {
+            if (substr($requestUrl, 0, strlen($itemUrl)) !== $itemUrl) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
@@ -74,4 +74,14 @@ interface NavigationTwigExtensionInterface extends \Twig_ExtensionInterface
      * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
      */
     public function breadcrumbFunction($uuid);
+
+    /**
+     * Returns a boolean value to check if navigation item is active.
+     *
+     * @param string $requestUrl
+     * @param string $itemUrl
+     *
+     * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
+     */
+    public function isActiveNavElementFunction($requestUrl, $itemUrl);
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
@@ -83,5 +83,5 @@ interface NavigationTwigExtensionInterface extends \Twig_ExtensionInterface
      *
      * @return \Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem[]
      */
-    public function isActiveNavElementFunction($requestUrl, $itemUrl);
+    public function navigationIsActiveFunction($requestUrl, $itemUrl);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #492
| Related issues/PRs | #492
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

I created a twig-function to check which nav-item is active in these cases:
sulu.lo/overview
sulu.lo/overview?q=test
sulu.lo/overview/subpage

with this twig-extension the overview is in all cases the active element.

#### Example Usage

~~~twig
<ul class="nav nav-justified">
    {% for item in sulu_navigation_root_tree('main', 2) %}
        {% set activeNav = sulu_is_active_nav_element(request.resourceLocator, item.url) ? 'nav-item-active' : '' %}
        <li>
            <a href="{{ sulu_content_path(item.url) }}" title="{{ item.title }}">{{ item.title }}</a>
            {{ activeNav }}
        </li>
    {% endfor %}
</ul>
~~~

#### To Do

- [ ] Create a documentation PR

