### PR TITLE
Fix one where clause to work on Postgresql.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX            [WebsiteBundle]       Fixed a query issue on Postgresql
     * ENHANCEMENT #2279 [Webspace]            Do not hide invalid webspace exceptions.
     * ENHANCEMENT #2288 [WebsiteBundle]       Fixed overriding request attributes and set them on the request
     * BUGFIX      #2288 [AdminBundle]         Removed deleting of entire dom tree on tab change

--- a/src/Sulu/Bundle/WebsiteBundle/Entity/AnalyticsRepository.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Entity/AnalyticsRepository.php
@@ -70,7 +70,7 @@ class AnalyticsRepository extends EntityRepository
         $queryBuilder = $this->createQueryBuilder('a')
             ->addSelect('domains')
             ->leftJoin('a.domains', 'domains')
-            ->where('a.allDomains = 1')
+            ->where('a.allDomains = TRUE')
             ->orWhere('domains.url = :url AND domains.environment = :environment');
 
         $query = $queryBuilder->getQuery();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

A where clause with a boolean field is changed from "field = 1" to "field = TRUE"

#### Why?

When using a boolean field in the where clause, on Postgres you cannot compare with an integer.
Comparing with the constant TRUE should work in both Postgres and MySQL

Without this fix you cannot view the front page of a Sulu installation on Postgres.