### PR TITLE
Removed lazy analyzing of the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG for Sulu
     * HOTFIX      #2294 [WebsiteBundle]       Fixed analytics with all domains only in created webspace
     * HOTFIX      #2285 [SecurityBundle]      Made ResettingController translations more configurable
     * HOTFIX      #2291 [ContentBundle]       Fixed wrong spacing between more than two checkboxes
+    * ENHANCEMENT #2288 [WebsiteBundle]       Fixed overriding request attributes and set them on the request
 
 * 1.2.0 (2016-04-11)
     * BUGFIX      #2280 [ContentBundle]       Removed scrollbar from categories in overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #2331 [AdminBundle]         Fixed admin-controller to return correct system
+    * HOTFIX      #2330 [WebsiteBundle]       Removed lazy analyzing of the request
     * HOTFIX      #2321 [WebsiteBundle]       Fixed request-analyze for not existing current request
     * HOTFIX      #2319 [ContactBundle]       Validate unknown vat-number as valid
     * HOTFIX      #2306 [WebsiteBundle]       Fixed partial rendering using query parameter

--- a/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
@@ -89,6 +89,8 @@ class PreviewRenderer
         // get controller and invoke action
         $request = new Request($query, $request, [], $cookies);
         $request->attributes->set('_controller', $content->getController());
+        $request->query->set('webspace', $content->getWebspaceKey());
+        $request->query->set('locale', $content->getLanguageCode());
         $controller = $this->controllerResolver->getController($request);
 
         // prepare locale for translator and request

--- a/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PreviewRenderer.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContentBundle\Preview;
 
 use Liip\ThemeBundle\ActiveTheme;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -47,18 +48,25 @@ class PreviewRenderer
      */
     private $translator;
 
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
     public function __construct(
         ActiveTheme $activeTheme,
         ControllerResolverInterface $controllerResolver,
         WebspaceManagerInterface $webspaceManager,
         RequestStack $requestStack,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        RequestAnalyzerInterface $requestAnalyzer
     ) {
         $this->activeTheme = $activeTheme;
         $this->controllerResolver = $controllerResolver;
         $this->webspaceManager = $webspaceManager;
         $this->requestStack = $requestStack;
         $this->translator = $translator;
+        $this->requestAnalyzer = $requestAnalyzer;
     }
 
     /**
@@ -97,6 +105,8 @@ class PreviewRenderer
         $request->setLocale($content->getLanguageCode());
         $localeBefore = $this->translator->getLocale();
         $this->translator->setLocale($content->getLanguageCode());
+
+        $this->requestAnalyzer->analyze($request);
 
         $this->requestStack->push($request);
         /** @var Response $response */

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/preview.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/preview.xml
@@ -34,6 +34,7 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="translator"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
         </service>
         <service id="sulu_content.preview.crawler" class="%sulu_content.preview.crawler.class%" public="false"/>
         <service id="sulu_content.preview" class="%sulu_content.preview.class%">

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
@@ -66,7 +66,13 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $requestStack->push(
             Argument::that(
                 function (Request $newRequest) use ($request) {
-                    $this->assertEquals($request->query->all(), $newRequest->query->all());
+                    $this->assertEquals(
+                        array_merge(
+                            ['webspace' => 'sulu_io', 'locale' => 'de_at'],
+                            $request->query->all()
+                        ),
+                        $newRequest->query->all()
+                    );
                     $this->assertEquals($request->request->all(), $newRequest->request->all());
                     $this->assertEquals($request->cookies->all(), $newRequest->cookies->all());
 
@@ -119,7 +125,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $requestStack->push(
             Argument::that(
                 function (Request $newRequest) {
-                    $this->assertEquals([], $newRequest->query->all());
+                    $this->assertEquals(['webspace' => 'sulu_io', 'locale' => 'de_at'], $newRequest->query->all());
                     $this->assertEquals([], $newRequest->request->all());
                     $this->assertEquals([], $newRequest->cookies->all());
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/PreviewRendererTest.php
@@ -15,7 +15,8 @@ use Liip\ThemeBundle\ActiveTheme;
 use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Preview\PreviewRenderer;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
-use Sulu\Component\Webspace\Manager\WebspaceManager;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Theme;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver;
@@ -26,44 +27,100 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class PreviewRendererTest extends \PHPUnit_Framework_TestCase
 {
-    private function getWebspace()
+    /**
+     * @var ActiveTheme
+     */
+    private $activeTheme;
+
+    /**
+     * @var ControllerResolver
+     */
+    private $controllerResolver;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var Webspace
+     */
+    private $webspace;
+
+    /**
+     * @var PageBridge
+     */
+    private $structure;
+
+    /**
+     * @var PreviewRenderer
+     */
+    private $previewRenderer;
+
+    public function setUp()
     {
-        $webspace = new Webspace();
-        $webspace->setName('test');
+        $this->activeTheme = $this->prophesize(ActiveTheme::class);
+        $this->controllerResolver = $this->prophesize(ControllerResolver::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
 
-        $theme = new Theme();
-        $theme->setKey('default');
-        $webspace->setTheme($theme);
-
-        return $webspace;
-    }
-
-    public function testRender()
-    {
-        $request = new Request(['test' => 1], ['test' => 2], [], ['test' => 3]);
-
-        $activeTheme = $this->prophesize(ActiveTheme::class);
-        $controllerResolver = $this->prophesize(ControllerResolver::class);
-        $webspaceManager = $this->prophesize(WebspaceManager::class);
-        $requestStack = $this->prophesize(RequestStack::class);
-        $structure = $this->prophesize(PageBridge::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
-
-        $webspaceManager->findWebspaceByKey('sulu_io')->willReturn($this->getWebspace());
-
-        $structure->getController()->willReturn('TestController:test');
-        $structure->getLanguageCode()->willReturn('de_at');
-        $structure->getWebspaceKey()->willReturn('sulu_io');
-
-        $controllerResolver->getController(Argument::type(Request::class))
+        $this->controllerResolver->getController(Argument::type(Request::class))
             ->will(
                 function () {
                     return [new TestController(), 'testAction'];
                 }
             );
 
-        $requestStack->getCurrentRequest()->willReturn($request);
-        $requestStack->push(
+        $this->webspace = new Webspace();
+        $this->webspace->setName('test');
+        $theme = new Theme();
+        $theme->setKey('default');
+        $this->webspace->setTheme($theme);
+
+        $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($this->webspace);
+
+        $this->structure = $this->prophesize(PageBridge::class);
+        $this->structure->getController()->willReturn('TestController:test');
+        $this->structure->getLanguageCode()->willReturn('de_at');
+        $this->structure->getWebspaceKey()->willReturn('sulu_io');
+
+        $this->translator->getLocale()->willReturn('de');
+        $this->translator->setLocale('de_at')->shouldBeCalled();
+        $this->translator->setLocale('de')->shouldBeCalled();
+
+        $this->previewRenderer = new PreviewRenderer(
+            $this->activeTheme->reveal(),
+            $this->controllerResolver->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->requestStack->reveal(),
+            $this->translator->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    public function testRender()
+    {
+        $request = new Request(['test' => 1], ['test' => 2], [], ['test' => 3]);
+
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+        $this->requestStack->push(
             Argument::that(
                 function (Request $newRequest) use ($request) {
                     $this->assertEquals(
@@ -80,49 +137,17 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
                 }
             )
         )->shouldBeCalledTimes(1);
-        $requestStack->pop()->shouldBeCalled();
+        $this->requestStack->pop()->shouldBeCalled();
 
-        $translator->getLocale()->willReturn('de');
-        $translator->setLocale('de_at')->shouldBeCalled();
-        $translator->setLocale('de')->shouldBeCalled();
-
-        $renderer = new PreviewRenderer(
-            $activeTheme->reveal(),
-            $controllerResolver->reveal(),
-            $webspaceManager->reveal(),
-            $requestStack->reveal(),
-            $translator->reveal()
-        );
-
-        $result = $renderer->render($structure->reveal());
+        $result = $this->previewRenderer->render($this->structure->reveal());
 
         $this->assertEquals('TEST', $result);
     }
 
     public function testRenderWithoutCurrentRequest()
     {
-        $activeTheme = $this->prophesize(ActiveTheme::class);
-        $controllerResolver = $this->prophesize(ControllerResolver::class);
-        $webspaceManager = $this->prophesize(WebspaceManager::class);
-        $requestStack = $this->prophesize(RequestStack::class);
-        $structure = $this->prophesize(PageBridge::class);
-        $translator = $this->prophesize(TranslatorInterface::class);
-
-        $webspaceManager->findWebspaceByKey('sulu_io')->willReturn($this->getWebspace());
-
-        $structure->getController()->willReturn('TestController:test');
-        $structure->getLanguageCode()->willReturn('de_at');
-        $structure->getWebspaceKey()->willReturn('sulu_io');
-
-        $controllerResolver->getController(Argument::type(Request::class))
-            ->will(
-                function () {
-                    return [new TestController(), 'testAction'];
-                }
-            );
-
-        $requestStack->getCurrentRequest()->willReturn(null);
-        $requestStack->push(
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->requestStack->push(
             Argument::that(
                 function (Request $newRequest) {
                     $this->assertEquals(['webspace' => 'sulu_io', 'locale' => 'de_at'], $newRequest->query->all());
@@ -133,21 +158,9 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
                 }
             )
         )->shouldBeCalledTimes(1);
-        $requestStack->pop()->shouldBeCalled();
+        $this->requestStack->pop()->shouldBeCalled();
 
-        $translator->getLocale()->willReturn('de');
-        $translator->setLocale('de_at')->shouldBeCalled();
-        $translator->setLocale('de')->shouldBeCalled();
-
-        $renderer = new PreviewRenderer(
-            $activeTheme->reveal(),
-            $controllerResolver->reveal(),
-            $webspaceManager->reveal(),
-            $requestStack->reveal(),
-            $translator->reveal()
-        );
-
-        $result = $renderer->render($structure->reveal());
+        $result = $this->previewRenderer->render($this->structure->reveal());
 
         $this->assertEquals('TEST', $result);
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
@@ -1,11 +1,15 @@
 sulu_media.website.image.proxy:
     path: %sulu_media.format_cache.media_proxy_path%
-    defaults: { _controller: SuluMediaBundle:MediaStream:getImage }
+    defaults:
+        _controller: SuluMediaBundle:MediaStream:getImage
+        _requestAnalyzer: false
     requirements:
         slug: .*
 
 sulu_media.website.media.download:
     path: %sulu_media.media_manager.media_download_path%
-    defaults: { _controller: SuluMediaBundle:MediaStream:download }
+    defaults:
+        _controller: SuluMediaBundle:MediaStream:download
+        _requestAnalyzer: false
     requirements:
         slug: .*

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/SnippetTwigExtensionTest.php
@@ -18,6 +18,8 @@ use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class SnippetTwigExtensionTest extends SuluTestCase
 {
@@ -41,6 +43,11 @@ class SnippetTwigExtensionTest extends SuluTestCase
      */
     private $extension;
 
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
     protected function setUp()
     {
         $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');
@@ -50,20 +57,23 @@ class SnippetTwigExtensionTest extends SuluTestCase
         $webspace = $this->getContainer()->get('sulu_core.webspace.webspace_manager')->findWebspaceByKey('sulu_io');
         $localization = $webspace->getLocalization('en');
 
-        $attributes = new \ReflectionProperty($this->requestAnalyzer, 'attributes');
-        $attributes->setAccessible(true);
-
-        $attributes->setValue(
-            $this->requestAnalyzer,
-            new RequestAttributes(
-                [
-                    'webspaceKey' => $webspace->getKey(),
-                    'webspace' => $webspace,
-                    'locale' => $localization->getLocalization(),
-                    'localization' => $localization,
-                ]
-            )
+        $request = new Request(
+            [],
+            [],
+            [
+                '_sulu' => new RequestAttributes(
+                    [
+                        'webspaceKey' => $webspace->getKey(),
+                        'webspace' => $webspace,
+                        'locale' => $localization->getLocalization(),
+                        'localization' => $localization,
+                    ]
+                ),
+            ]
         );
+
+        $this->requestStack = $this->getContainer()->get('request_stack');
+        $this->requestStack->push($request);
 
         $this->initPhpcr();
 

--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -12,20 +12,13 @@
 namespace Sulu\Bundle\WebsiteBundle\DataCollector;
 
 use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 class SuluCollector extends DataCollector
 {
-    protected $requestAnalyzer;
-
-    public function __construct(RequestAnalyzerInterface $requestAnalyzer)
-    {
-        $this->requestAnalyzer = $requestAnalyzer;
-    }
-
     public function data($key)
     {
         return $this->data[$key];
@@ -33,15 +26,20 @@ class SuluCollector extends DataCollector
 
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        $requestAnalyzer = $this->requestAnalyzer;
+        if (!$request->attributes->has('_sulu')) {
+            return;
+        }
 
-        $webspace = $requestAnalyzer->getWebspace();
-        $portal = $requestAnalyzer->getPortal();
-        $segment = $requestAnalyzer->getSegment();
+        /** @var RequestAttributes $requestAttributes */
+        $requestAttributes = $request->attributes->get('_sulu');
 
-        $this->data['match_type'] = $requestAnalyzer->getMatchType();
-        $this->data['redirect'] = $requestAnalyzer->getRedirect();
-        $this->data['portal_url'] = $requestAnalyzer->getPortalUrl();
+        $webspace = $requestAttributes->getAttribute('webspace');
+        $portal = $requestAttributes->getAttribute('portal');
+        $segment = $requestAttributes->getAttribute('segment');
+
+        $this->data['match_type'] = $requestAttributes->getAttribute('matchType');
+        $this->data['redirect'] = $requestAttributes->getAttribute('redirect');
+        $this->data['portal_url'] = $requestAttributes->getAttribute('portalUrl');
 
         if ($webspace) {
             $this->data['webspace'] = $webspace->toArray();
@@ -55,9 +53,9 @@ class SuluCollector extends DataCollector
             $this->data['segment'] = $segment->toArray();
         }
 
-        $this->data['localization'] = $requestAnalyzer->getCurrentLocalization();
-        $this->data['resource_locator'] = $requestAnalyzer->getResourceLocator();
-        $this->data['resource_locator_prefix'] = $requestAnalyzer->getResourceLocatorPrefix();
+        $this->data['localization'] = $requestAttributes->getAttribute('localization');
+        $this->data['resource_locator'] = $requestAttributes->getAttribute('resourceLocator');
+        $this->data['resource_locator_prefix'] = $requestAttributes->getAttribute('resourceLocatorPrefix');
 
         $structure = null;
         if ($request->attributes->has('_route_params')) {

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/DeregisterDefaultRouteListenerCompilerPass.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/DeregisterDefaultRouteListenerCompilerPass.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Removes the `kernel.event_subscriber` tag from the default route listener. This is necessary because it is decorated
+ * by the `sulu_website.router_listener` service, which adds the analyzing of the request done by Sulu to this listener.
+ */
+class DeregisterDefaultRouteListenerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $container->getDefinition('router_listener')->clearTag('kernel.event_subscriber');
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\EventListener;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\RouterListener as BaseRouterListener;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * This listener replaces the default RouterListener delivered by Symfony and adds the analyzing of the request as
+ * required by Sulu. Validating the result can be deactivated by passing `false` to the `_requestAnalyzer` default in
+ * the route.
+ */
+class RouterListener implements EventSubscriberInterface
+{
+    const REQUEST_ANALYZER = '_requestAnalyzer';
+
+    /**
+     * @var BaseRouterListener
+     */
+    private $baseRouteListener;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function __construct(BaseRouterListener $baseRouterListener, RequestAnalyzerInterface $requestAnalyzer)
+    {
+        $this->baseRouteListener = $baseRouterListener;
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    /**
+     * Analyzes the request before passing the event to the default RouterListener from symfony and validates the result
+     * afterwards.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        // This call is required in all cases, because the default router needs our webspace information
+        // Would be nice to also only call this if the _requestAnalyzer attribute is set, but it's set on the next line
+        $this->requestAnalyzer->analyze($request);
+        $this->baseRouteListener->onKernelRequest($event);
+        if ($request->attributes->get(static::REQUEST_ANALYZER, true) !== false) {
+            $this->requestAnalyzer->validate($request);
+        }
+    }
+
+    /**
+     * Simply pass the event to the route listener, because we have nothing to add here.
+     *
+     * @param FinishRequestEvent $event
+     */
+    public function onKernelFinishRequest(FinishRequestEvent $event)
+    {
+        $this->baseRouteListener->onKernelFinishRequest($event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', 32]],
+            KernelEvents::FINISH_REQUEST => [['onKernelFinishRequest', 0]],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -191,5 +191,13 @@
             <argument type="service" id="sulu_website.translator.request_analyzer.inner"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
         </service>
+
+        <service id="sulu_website.router_listener"
+                 class="Sulu\Bundle\WebsiteBundle\EventListener\RouterListener"
+                 decorates="router_listener">
+            <argument type="service" id="sulu_website.router_listener.inner"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
@@ -11,8 +11,6 @@
     <services>
         <!-- request analyzer data collector -->
         <service id="sulu_website.data_collector.sulu_collector" class="%sulu_website.data_collector.sulu_collector.class%">
-            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
-
             <tag name="data_collector" template="SuluWebsiteBundle:Profiler:layout" id="sulu"/>
             <tag name="sulu.context" context="website"/>
         </service>

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle;
 
+use Sulu\Bundle\WebsiteBundle\DependencyInjection\Compiler\DeregisterDefaultRouteListenerCompilerPass;
 use Sulu\Component\Util\SuluVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,5 +26,6 @@ class SuluWebsiteBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new SuluVersionPass());
+        $container->addCompilerPass(new DeregisterDefaultRouteListenerCompilerPass());
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollectorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollectorTest.php
@@ -12,51 +12,72 @@
 namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\DataCollector;
 
 use Sulu\Bundle\WebsiteBundle\DataCollector\SuluCollector;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Segment;
+use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class SuluCollectorTest extends \PHPUnit_Framework_TestCase
 {
-    protected $requestAnalyzer;
+    /**
+     * @var Request
+     */
     protected $request;
+
+    /**
+     * @var Response
+     */
     protected $response;
+
+    /**
+     * @var SuluCollector
+     */
+    private $suluCollector;
 
     public function setUp()
     {
-        parent::setUp();
-        $this->requestAnalyzer = $this->prophesize('Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface');
         $this->request = new Request();
-        $this->response = $this->prophesize('Symfony\Component\HttpFoundation\Response');
-        $this->portal = $this->prophesize('Sulu\Component\Webspace\Portal');
-        $this->webspace = $this->prophesize('Sulu\Component\Webspace\Webspace');
-        $this->segment = $this->prophesize('Sulu\Component\Webspace\Segment');
-        $this->structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $this->response = $this->prophesize(Response::class);
 
-        $this->dataCollector = new SuluCollector($this->requestAnalyzer->reveal());
+        $this->suluCollector = new SuluCollector();
     }
 
     public function testCollectorNoComplexObjects()
     {
-        $this->dataCollector->collect($this->request, $this->response->reveal());
+        $this->suluCollector->collect($this->request, $this->response->reveal());
     }
 
     public function testCollector()
     {
-        $this->requestAnalyzer->getPortal()->willReturn($this->portal);
-        $this->requestAnalyzer->getWebspace()->willReturn($this->webspace);
-        $this->requestAnalyzer->getSegment()->willReturn($this->segment);
-        $this->requestAnalyzer->getMatchType()->willReturn('match');
-        $this->requestAnalyzer->getRedirect()->willReturn('red');
-        $this->requestAnalyzer->getPortalUrl()->willReturn('/foo');
+        $structure = $this->prophesize(PageBridge::class);
 
-        $this->requestAnalyzer->getCurrentLocalization()->willReturn('de_de');
-        $this->requestAnalyzer->getResourceLocator()->willReturn('/asd');
-        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/asd/');
-        $this->request->attributes->set('_route_params', ['structure' => $this->structure->reveal()]);
+        $webspace = $this->prophesize(Webspace::class);
+        $portal = $this->prophesize(Portal::class);
+        $segment = $this->prophesize(Segment::class);
 
-        $this->dataCollector->collect($this->request, $this->response->reveal());
+        $this->request->attributes->set('_sulu', new RequestAttributes(
+            [
+                'webspace' => $webspace->reveal(),
+                'portal' => $portal->reveal(),
+                'segment' => $segment->reveal(),
+                'matchType' => 'match',
+                'redirect' => 'red',
+                'portalUrl' => '/foo',
+                'localization' => 'de_de',
+                'resourceLocator' => '/asd',
+                'resourceLocatorPrefix' => '/asd/',
+            ]
+        ));
 
-        $this->portal->toArray()->shouldHaveBeenCalled();
-        $this->webspace->toArray()->shouldHaveBeenCalled();
-        $this->segment->toArray()->shouldHaveBeenCalled();
+        $this->request->attributes->set('_route_params', ['structure' => $structure->reveal()]);
+
+        $webspace->toArray()->shouldBeCalled();
+        $portal->toArray()->shouldBeCalled();
+        $segment->toArray()->shouldBeCalled();
+
+        $this->suluCollector->collect($this->request, $this->response->reveal());
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/RouterListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/RouterListenerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Unit\Sulu\Bundle\WebsiteBundle\EventListener;
+
+use Sulu\Bundle\WebsiteBundle\EventListener\RouterListener;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\RouterListener as BaseRouteListener;
+
+class RouterListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var BaseRouteListener
+     */
+    private $baseRouteListener;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var RouterListener
+     */
+    private $routerListener;
+
+    /**
+     * @var GetResponseEvent
+     */
+    private $event;
+
+    public function setUp()
+    {
+        $this->baseRouteListener = $this->prophesize(BaseRouteListener::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->routerListener = new RouterListener($this->baseRouteListener->reveal(), $this->requestAnalyzer->reveal());
+
+        $this->event = $this->prophesize(GetResponseEvent::class);
+    }
+
+    public function testAnalyzeRequest()
+    {
+        $request = new Request([], [], ['_requestAnalyzer' => true]);
+        $this->event->getRequest()->willReturn($request);
+
+        $this->requestAnalyzer->analyze($request)->shouldBeCalled();
+        $this->requestAnalyzer->validate($request)->shouldBeCalled();
+
+        $this->routerListener->onKernelRequest($this->event->reveal());
+    }
+
+    public function testAnalyzeRequestDisabled()
+    {
+        $request = new Request([], [], ['_requestAnalyzer' => false]);
+        $this->event->getRequest()->willReturn($request);
+
+        $this->requestAnalyzer->analyze($request)->shouldBeCalled();
+        $this->requestAnalyzer->validate($request)->shouldNotBeCalled();
+
+        $this->routerListener->onKernelRequest($this->event->reveal());
+    }
+
+    public function testAnalyzeRequestDefault()
+    {
+        $request = new Request();
+        $this->event->getRequest()->willReturn($request);
+
+        $this->requestAnalyzer->analyze($request)->shouldBeCalled();
+        $this->requestAnalyzer->validate($request)->shouldBeCalled();
+
+        $this->routerListener->onKernelRequest($this->event->reveal());
+    }
+}

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -31,11 +31,6 @@ class RequestAnalyzer implements RequestAnalyzerInterface
      */
     private $requestStack;
 
-    /**
-     * @var RequestAttributes
-     */
-    private $attributes;
-
     public function __construct(RequestStack $requestStack, array $requestProcessors)
     {
         $this->requestStack = $requestStack;
@@ -47,14 +42,16 @@ class RequestAnalyzer implements RequestAnalyzerInterface
      */
     public function analyze(Request $request)
     {
-        $this->attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme()]);
+        $attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme()]);
         foreach ($this->requestProcessors as $provider) {
-            $this->attributes = $this->attributes->merge($provider->process($request, $this->attributes));
+            $attributes = $attributes->merge($provider->process($request, $attributes));
         }
 
         foreach ($this->requestProcessors as $provider) {
-            $provider->validate($this->attributes);
+            $provider->validate($attributes);
         }
+
+        $request->attributes->set('_sulu', $attributes);
     }
 
     /**
@@ -64,18 +61,17 @@ class RequestAnalyzer implements RequestAnalyzerInterface
      */
     protected function getAttributes()
     {
-        if (null !== $this->attributes) {
-            return $this->attributes;
-        }
-
         $request = $this->requestStack->getCurrentRequest();
-        if (!$request) {
+        
+        if (null === $request) {
             return new RequestAttributes();
         }
+        
+        if (null === $request->attributes->get('_sulu')) {
+            $this->analyze($this->requestStack->getCurrentRequest());
+        }
 
-        $this->analyze($request);
-
-        return $this->attributes;
+        return $this->requestStack->getCurrentRequest()->attributes->get('_sulu');
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
@@ -56,10 +56,15 @@ interface RequestAnalyzerInterface
      * Analyzes the current request, and saves the values for portal, language, country and segment for further usage.
      *
      * @param Request $request The request to analyze
-     *
-     * @return
      */
     public function analyze(Request $request);
+
+    /**
+     * Validates the data written on the given request and throws exceptions in case something is wrong or missing.
+     *
+     * @param Request $request
+     */
+    public function validate(Request $request);
 
     /**
      * Returns the current match type for this request.

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -15,6 +15,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use Prophecy\Argument;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -207,13 +208,29 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
 
         $this->prepareWebspaceManager($portalInformation);
 
+        $requestBag = $this->prophesize(ParameterBag::class);
+        $requestBag->all()->willReturn(['post' => 1]);
+        $queryBag = $this->prophesize(ParameterBag::class);
+        $queryBag->all()->willReturn(['get' => 1]);
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
+        $request->request = $requestBag->reveal();
+        $request->query = $queryBag->reveal();
+        $request->attributes = $attributesBag->reveal();
+
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->any())->method('getScheme')->willReturn('http');
         $request->expects($this->once())->method('setLocale')->with('de_at');
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
@@ -257,9 +274,22 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
 
         $requestFormat = false;
 
+        $requestBag = $this->prophesize(ParameterBag::class);
+        $requestBag->all()->willReturn(['post' => 1]);
+        $queryBag = $this->prophesize(ParameterBag::class);
+        $queryBag->all()->willReturn(['get' => 1]);
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
+        $request->request = $requestBag->reveal();
+        $request->query = $queryBag->reveal();
+        $request->attributes = $attributesBag->reveal();
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->once())->method('setLocale')->with('de_at');
@@ -283,6 +313,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
             )
         );
 
+        $this->requestStack->getCurrentRequest()->willReturn($request);
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
@@ -346,13 +377,14 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
+        $request->attributes = new ParameterBag();
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
         $request->expects($this->any())->method('getScheme')->willReturn('http');
         $request->expects($this->once())->method('setLocale')->with('de_at');
 
         // this request will be analyzed only once
-        $this->requestStack->getCurrentRequest()->willReturn($request)->shouldBeCalledTimes(1);
+        $this->requestStack->getCurrentRequest()->willReturn($request)->shouldBeCalled();
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
         $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -214,6 +214,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $queryBag->all()->willReturn(['get' => 1]);
         $attributesBag = $this->prophesize(ParameterBag::class);
         $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->has('_sulu')->willReturn(true);
         $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
             function ($arguments) use ($attributesBag) {
                 $attributesBag->get('_sulu')->willReturn($arguments[1]);
@@ -279,6 +280,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $queryBag = $this->prophesize(ParameterBag::class);
         $queryBag->all()->willReturn(['get' => 1]);
         $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->has('_sulu')->willReturn(true);
         $attributesBag->get('_sulu')->willReturn(null);
         $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
             function ($arguments) use ($attributesBag) {
@@ -343,8 +345,10 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
+        $request->attributes = new ParameterBag();
 
         $this->requestAnalyzer->analyze($request);
+        $this->requestAnalyzer->validate($request);
     }
 
     /**
@@ -385,6 +389,9 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
 
         // this request will be analyzed only once
         $this->requestStack->getCurrentRequest()->willReturn($request)->shouldBeCalled();
+
+        $this->requestAnalyzer->analyze($request);
+        $this->requestAnalyzer->validate($request);
 
         $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocalization());
         $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -15,6 +15,7 @@ use Prophecy\Argument;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestProcessorInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -24,6 +25,10 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalled();
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalled()->willReturn(new RequestAttributes());
@@ -39,6 +44,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalled()->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalledTimes(1)->willReturn(new RequestAttributes(['test' => 1]));
@@ -56,6 +70,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalledTimes(1)->willReturn(new RequestAttributes(['test' => 1]));
@@ -77,6 +100,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
 
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
+
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalledTimes(1)->willReturn(new RequestAttributes(['test' => 1]));
         $provider->validate(Argument::type(RequestAttributes::class))->shouldBeCalled()->willReturn(true);
@@ -94,6 +126,15 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getHost()->willReturn('www.sulu.io');
         $request->getScheme()->willReturn('https');
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
 
         $requestStack = $this->prophesize(RequestStack::class);
         $requestStack->getCurrentRequest()->willReturn($request->reveal());
@@ -144,6 +185,16 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->prophesize(RequestProcessorInterface::class);
         $request = $this->prophesize(Request::class);
+
+        $attributesBag = $this->prophesize(ParameterBag::class);
+        $attributesBag->get('_sulu')->willReturn(null);
+        $attributesBag->set('_sulu', Argument::type(RequestAttributes::class))->shouldBeCalledTimes(1)->will(
+            function ($arguments) use ($attributesBag) {
+                $attributesBag->get('_sulu')->willReturn($arguments[1]);
+            }
+        );
+        $request->reveal()->attributes = $attributesBag->reveal();
+
         $provider->process($request->reveal(), Argument::type(RequestAttributes::class))
             ->shouldBeCalled()->willReturn(new RequestAttributes($attributes));
         $provider->validate(Argument::type(RequestAttributes::class))->shouldBeCalled()->willReturn(true);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | includes changes from https://github.com/sulu/sulu/pull/2322, prerequisite of https://github.com/sulu/sulu/pull/2324
| License | MIT
| Documentation PR | TODO (check)

#### What's in this PR?

This PR reintroduces the `RequestListener`, which will call the `RequestAnalyzer`. This change somehow discards what was changed in https://github.com/sulu/sulu/pull/2153. Instead of lazily loading, which caused circular referencing issues in the DIC, the request analyzer can now be deactivated for single routes.

Also includes a backport which has only been merged to develop.

#### Why?

Because we were having circular referencing issues with the lazy loading of the `RequestAnalyzer`.

#### To Do

- [ ] Create a documentation PR

