### PR TITLE
Implemented markup bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2369 [All]                 Install the symfony phpunit bridge again
     * ENHANCEMENT #2356 [PreviewBundle]       Added default error message 
     * BUGFIX      #2354 [ContentBundle]       Fixed javascript error preview is null for new page form 
+    * ENHANCEMENT #2338 [MarkupBundle]        Implemented markup bundle
     * FEATURE     #2333 [PreviewBundle]       Added preview render error templates 
     * ENHANCEMENT #2353 [WebsocketBundle]     Changed configuration to default disable websocket 
     * BUGFIX      #2351 [ContentBundle]       Removed strange condition for data-changed 

--- a/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Markup;
+
+use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
+use Sulu\Component\Content\Repository\Content;
+use Sulu\Component\Content\Repository\ContentRepositoryInterface;
+use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Extends the sulu markup with the "sulu:link" tag.
+ */
+class LinkTag implements TagInterface
+{
+    /**
+     * @var ContentRepositoryInterface
+     */
+    private $contentRepository;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var string
+     */
+    private $environment;
+
+    /**
+     * @param ContentRepositoryInterface $contentRepository
+     * @param RequestStack $requestStack
+     * @param WebspaceManagerInterface $webspaceManager
+     * @param string $environment
+     */
+    public function __construct(
+        ContentRepositoryInterface $contentRepository,
+        RequestStack $requestStack,
+        WebspaceManagerInterface $webspaceManager,
+        $environment
+    ) {
+        $this->contentRepository = $contentRepository;
+        $this->requestStack = $requestStack;
+        $this->webspaceManager = $webspaceManager;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseAll($attributesByTag)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $locale = $request->getLocale();
+
+        $contents = $this->preloadContent($attributesByTag, $locale);
+
+        $result = [];
+        foreach ($attributesByTag as $tag => $attributes) {
+            if (!array_key_exists($attributes['href'], $contents)) {
+                $result[$tag] = array_key_exists('content', $attributes) ? $attributes['content'] :
+                    (array_key_exists('title', $attributes) ? $attributes['title'] : '');
+
+                continue;
+            }
+
+            $content = $contents[$attributes['href']];
+            $url = $content->getUrl();
+            $pageTitle = $content['title'];
+
+            $title = !empty($attributes['title']) ? $attributes['title'] : $pageTitle;
+            $text = !empty($attributes['content']) ? $attributes['content'] : $pageTitle;
+
+            $url = $this->webspaceManager->findUrlByResourceLocator(
+                $url,
+                $this->environment,
+                $locale,
+                $content->getWebspaceKey(),
+                null,
+                $request->getScheme()
+            );
+
+            $result[$tag] = sprintf(
+                '<a href="%s" title="%s"%s>%s</a>',
+                $url,
+                $title,
+                (!empty($attributes['target']) ? ' target="' . $attributes['target'] . '"' : ''),
+                $text
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return content by uuid for given attributes.
+     *
+     * @param array $attributesByTag
+     * @param string $locale
+     *
+     * @return Content[]
+     */
+    private function preloadContent($attributesByTag, $locale)
+    {
+        $uuids = array_map(
+            function ($attributes) {
+                return $attributes['href'];
+            },
+            $attributesByTag
+        );
+
+        $contents = $this->contentRepository->findByUuids(
+            array_unique(array_values($uuids)),
+            $locale,
+            MappingBuilder::create()
+                ->setResolveUrl(true)
+                ->addProperties(['title'])
+                ->setOnlyPublished(true)
+                ->getMapping()
+        );
+
+        $result = [];
+        foreach ($contents as $content) {
+            $result[$content->getId()] = $content;
+        }
+
+        return $result;
+    }
+}

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -131,5 +131,15 @@
 
             <tag name="sulu_route.defaults_provider"/>
         </service>
+
+        <!-- markup -->
+        <service id="sulu_content.markup" class="Sulu\Bundle\ContentBundle\Markup\LinkTag">
+            <argument type="service" id="sulu_content.content_repository"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="string">%kernel.environment%</argument>
+
+            <tag name="sulu_markup.tag" tag="link" type="html"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Markup;
+
+use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Markup\LinkTag;
+use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\Content\Repository\Content;
+use Sulu\Component\Content\Repository\ContentRepositoryInterface;
+use Sulu\Component\Content\Repository\Mapping\Mapping;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class LinkTagTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContentRepositoryInterface
+     */
+    private $contentRepository;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var string
+     */
+    private $environment;
+
+    /**
+     * @var LinkTag
+     */
+    private $linkTag;
+
+    protected function setUp()
+    {
+        $this->contentRepository = $this->prophesize(ContentRepositoryInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+
+        $this->request = $this->prophesize(Request::class);
+        $this->request->getLocale()->willReturn('de');
+        $this->request->getScheme()->willReturn('http');
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
+
+        $this->linkTag = new LinkTag(
+            $this->contentRepository->reveal(),
+            $this->requestStack->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->environment
+        );
+    }
+
+    public function provideParseData()
+    {
+        return [
+            [
+                '<sulu:link href="123-123-123" title="Test-Title">Test-Content</sulu:link>',
+                ['href' => '123-123-123', 'title' => 'Test-Title', 'content' => 'Test-Content'],
+                '<a href="/de/test" title="Test-Title">Test-Content</a>',
+            ],
+            [
+                '<sulu:link href="123-123-123" title="Test-Title"/>',
+                ['href' => '123-123-123', 'title' => 'Test-Title'],
+                '<a href="/de/test" title="Test-Title">Pagetitle</a>',
+            ],
+            [
+                '<sulu:link href="123-123-123" title="Test-Title"></sulu:link>',
+                ['href' => '123-123-123', 'title' => 'Test-Title'],
+                '<a href="/de/test" title="Test-Title">Pagetitle</a>',
+            ],
+            [
+                '<sulu:link href="123-123-123">Test-Content</sulu:link>',
+                ['href' => '123-123-123', 'content' => 'Test-Content'],
+                '<a href="/de/test" title="Pagetitle">Test-Content</a>',
+            ],
+            [
+                '<sulu:link href="123-123-123" title="Test-Title" target="_blank">Test-Content</sulu:link>',
+                ['href' => '123-123-123', 'title' => 'Test-Title', 'target' => '_blank', 'content' => 'Test-Content'],
+                '<a href="/de/test" title="Test-Title" target="_blank">Test-Content</a>',
+            ],
+            [
+                '<sulu:link href="123-123-123" title="Test-Title" target="_self">Test-Content</sulu:link>',
+                ['href' => '123-123-123', 'title' => 'Test-Title', 'target' => '_self', 'content' => 'Test-Content'],
+                '<a href="/de/test" title="Test-Title" target="_self">Test-Content</a>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideParseData
+     */
+    public function testParseAll($tag, $attributes, $expected)
+    {
+        $content = $this->createContent('123-123-123', 'Pagetitle', '/test');
+        $this->contentRepository->findByUuids(['123-123-123'], 'de', Argument::type(Mapping::class))
+            ->willReturn([$content]);
+
+        $this->webspaceManager->findUrlByResourceLocator(
+            $content->getUrl(),
+            $this->environment,
+            $content->getLocale(),
+            $content->getWebspaceKey(),
+            null,
+            'http'
+        )->willReturn('/de' . $content->getUrl());
+
+        $result = $this->linkTag->parseAll([$tag => $attributes]);
+
+        $this->assertEquals([$tag => $expected], $result);
+    }
+
+    public function testParseAllMultipleTags()
+    {
+        $content1 = $this->createContent('123-123-123', '1', '/test-1');
+        $content2 = $this->createContent('312-312-312', '2', '/test-2');
+        $this->contentRepository->findByUuids(['123-123-123', '312-312-312'], 'de', Argument::type(Mapping::class))
+            ->willReturn([$content1, $content2])->shouldBeCalledTimes(1);
+
+        $this->webspaceManager->findUrlByResourceLocator(
+            $content1->getUrl(),
+            $this->environment,
+            $content1->getLocale(),
+            $content1->getWebspaceKey(),
+            null,
+            'http'
+        )->willReturn('/de' . $content1->getUrl());
+
+        $this->webspaceManager->findUrlByResourceLocator(
+            $content2->getUrl(),
+            $this->environment,
+            $content2->getLocale(),
+            $content2->getWebspaceKey(),
+            null,
+            'http'
+        )->willReturn('/de' . $content2->getUrl());
+
+        $tag1 = '<sulu:link href="123-123-123">Test-Content</sulu:link>';
+        $tag2 = '<sulu:link href="123-123-123" title="Test-Title"/>';
+        $tag3 = '<sulu:link href="123-123-123" title="Test-Title">Test-Content</sulu:link>';
+        $tag4 = '<sulu:link href="123-123-123" title="Test-Title" target="_blank">Test-Content</sulu:link>';
+
+        $result = $this->linkTag->parseAll(
+            [
+                $tag1 => ['href' => '123-123-123', 'content' => 'Test-Content'],
+                $tag2 => ['href' => '312-312-312', 'title' => 'Test-Title'],
+                $tag3 => ['href' => '123-123-123', 'title' => 'Test-Title', 'content' => 'Test-Content'],
+                $tag4 => [
+                    'href' => '123-123-123',
+                    'title' => 'Test-Title',
+                    'target' => '_blank',
+                    'content' => 'Test-Content',
+                ],
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                $tag1 => '<a href="/de/test-1" title="1">Test-Content</a>',
+                $tag2 => '<a href="/de/test-2" title="Test-Title">2</a>',
+                $tag3 => '<a href="/de/test-1" title="Test-Title">Test-Content</a>',
+                $tag4 => '<a href="/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+            ],
+            $result
+        );
+    }
+
+    public function testParseAllMultipleTagsMissingContent()
+    {
+        $this->contentRepository->findByUuids(['123-123-123'], 'de', Argument::type(Mapping::class))
+            ->willReturn([])->shouldBeCalledTimes(1);
+
+        $tag1 = '<sulu:link href="123-123-123">Test-Content</sulu:link>';
+        $tag2 = '<sulu:link href="123-123-123" title="Test-Title"/>';
+        $tag3 = '<sulu:link href="123-123-123" title="Test-Title">Test-Content</sulu:link>';
+        $tag4 = '<sulu:link href="123-123-123"/>';
+
+        $result = $this->linkTag->parseAll(
+            [
+                $tag1 => ['href' => '123-123-123', 'content' => 'Test-Content'],
+                $tag2 => ['href' => '123-123-123', 'title' => 'Test-Title'],
+                $tag3 => ['href' => '123-123-123', 'title' => 'Test-Title', 'content' => 'Test-Content'],
+                $tag4 => ['href' => '123-123-123'],
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                $tag1 => 'Test-Content',
+                $tag2 => 'Test-Title',
+                $tag3 => 'Test-Content',
+                $tag4 => '',
+            ],
+            $result
+        );
+    }
+
+    private function createContent($id, $title, $url, $webspaceKey = 'sulu_io', $locale = 'de')
+    {
+        $content = new Content(
+            $locale,
+            $webspaceKey,
+            $id,
+            $url,
+            WorkflowStage::PUBLISHED,
+            1,
+            false,
+            ['title' => $title],
+            []
+        );
+        $content->setUrl($url);
+
+        return $content;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/.gitignore
+++ b/src/Sulu/Bundle/MarkupBundle/.gitignore
@@ -1,0 +1,15 @@
+/Tests/app/cache/*
+/Tests/app/logs/*
+/node_modules/
+/vendor/
+/composer.phar
+/composer.lock
+/.sass-cache/
+*~
+
+# IDEs
+.idea/*
+*.iml
+
+# phpunit
+phpunit.xml

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Collects all parsers for markup.
+ */
+class ParserCompilerPass implements CompilerPassInterface
+{
+    const SERVICE_ID = 'sulu_markup.response_listener';
+    const TAG_NAME = 'sulu_markup.parser';
+    const TYPE_ATTRIBUTE = 'type';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::SERVICE_ID)) {
+            return;
+        }
+
+        $references = [];
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $references[$attributes[self::TYPE_ATTRIBUTE]] = new Reference($id);
+            }
+        }
+
+        if (0 === count($references)) {
+            return;
+        }
+
+        $container->getDefinition(self::SERVICE_ID)->replaceArgument(0, $references);
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Collects all tags for markup.
+ */
+class TagCompilerPass implements CompilerPassInterface
+{
+    const SERVICE_ID = 'sulu_markup.tag.registry';
+    const TAG_NAME = 'sulu_markup.tag';
+    const TAG_ATTRIBUTE = 'tag';
+    const TYPE_ATTRIBUTE = 'type';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::SERVICE_ID)) {
+            return;
+        }
+
+        $references = [];
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $type = $attributes[self::TYPE_ATTRIBUTE];
+                $alias = $attributes[self::TAG_ATTRIBUTE];
+
+                if (!array_key_exists($type, $references)) {
+                    $references[$type] = [];
+                }
+
+                $references[$type][$alias] = new Reference($id);
+            }
+        }
+
+        if (0 === count($references)) {
+            return;
+        }
+
+        $container->getDefinition(self::SERVICE_ID)->replaceArgument(0, $references);
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * Extends the container and initializes the markup bundle.
+ */
+class SuluMarkupExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Listener;
+
+use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Parses content of response and set the replaced html as new content.
+ */
+class MarkupListener
+{
+    /**
+     * @var MarkupParserInterface
+     */
+    private $markupParser;
+
+    /**
+     * @var array
+     */
+    private $mimeTypeFormatMap;
+
+    /**
+     * @param MarkupParserInterface[] $markupParser
+     * @param array $mimeTypeFormatMap
+     */
+    public function __construct(
+        array $markupParser,
+        array $mimeTypeFormatMap = ['text/html' => 'html', 'application/xml' => 'xml', 'text/xml' => 'xml']
+    ) {
+        $this->markupParser = $markupParser;
+        $this->mimeTypeFormatMap = $mimeTypeFormatMap;
+    }
+
+    /**
+     * Parses content of response and set the replaced html as new content.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function replaceMarkup(FilterResponseEvent $event)
+    {
+        $response = $event->getResponse();
+        $mimeType = explode(';', $response->headers->get('Content-Type'))[0];
+        if (!array_key_exists($mimeType, $this->mimeTypeFormatMap)
+            || !array_key_exists($this->mimeTypeFormatMap[$mimeType], $this->markupParser)
+        ) {
+            return;
+        }
+
+        $format = $this->mimeTypeFormatMap[$mimeType];
+
+        $response->setContent($this->markupParser[$format]->parse($response->getContent()));
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MarkupListener.php
@@ -25,20 +25,11 @@ class MarkupListener
     private $markupParser;
 
     /**
-     * @var array
-     */
-    private $mimeTypeFormatMap;
-
-    /**
      * @param MarkupParserInterface[] $markupParser
-     * @param array $mimeTypeFormatMap
      */
-    public function __construct(
-        array $markupParser,
-        array $mimeTypeFormatMap = ['text/html' => 'html', 'application/xml' => 'xml', 'text/xml' => 'xml']
-    ) {
+    public function __construct(array $markupParser)
+    {
         $this->markupParser = $markupParser;
-        $this->mimeTypeFormatMap = $mimeTypeFormatMap;
     }
 
     /**
@@ -48,16 +39,12 @@ class MarkupListener
      */
     public function replaceMarkup(FilterResponseEvent $event)
     {
-        $response = $event->getResponse();
-        $mimeType = explode(';', $response->headers->get('Content-Type'))[0];
-        if (!array_key_exists($mimeType, $this->mimeTypeFormatMap)
-            || !array_key_exists($this->mimeTypeFormatMap[$mimeType], $this->markupParser)
-        ) {
+        $format = $event->getRequest()->getRequestFormat();
+        if (!array_key_exists($format, $this->markupParser)) {
             return;
         }
 
-        $format = $this->mimeTypeFormatMap[$mimeType];
-
+        $response = $event->getResponse();
         $response->setContent($this->markupParser[$format]->parse($response->getContent()));
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup;
+
+use Sulu\Bundle\MarkupBundle\Tag\TagRegistryInterface;
+
+/**
+ * Parses html content and replaces special tags.
+ */
+class HtmlMarkupParser implements MarkupParserInterface
+{
+    const ATTRIBUTE_REGEX = '/(?<name>\b\w+\b)\s*=\s*"(?<value>[^"]*)"/';
+    const CONTENT_REGEX = '/(?:>(?<content>.*)<)/';
+    const TAG_REGEX = '/(?<tag><%s:(?<name>[a-z]*)[^\/>]*(?:\/>|>.*<\/%s:[^\/>]*>))/';
+
+    /**
+     * @var TagRegistryInterface
+     */
+    private $tagRegistry;
+
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * @param TagRegistryInterface $tagRegistry
+     * @param string $namespace
+     */
+    public function __construct(TagRegistryInterface $tagRegistry, $namespace = 'sulu')
+    {
+        $this->tagRegistry = $tagRegistry;
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    public function parse($content)
+    {
+        if (!preg_match_all(sprintf(self::TAG_REGEX, $this->namespace, $this->namespace), $content, $matches)) {
+            return $content;
+        }
+
+        $sortedTags = [];
+        for ($i = 0, $length = count($matches['name']); $i < $length; ++$i) {
+            $tag = $matches['tag'][$i];
+            $name = $matches['name'][$i];
+            if (!array_key_exists($name, $sortedTags)) {
+                $sortedTags[$name] = [];
+            }
+
+            $sortedTags[$name][$tag] = $this->getAttributes($tag);
+        }
+
+        foreach ($sortedTags as $name => $tags) {
+            $tags = $this->tagRegistry->getTag($name, 'html')->parseAll($tags);
+
+            foreach ($tags as $tag => $newTag) {
+                $content = str_replace($tag, $newTag, $content);
+            }
+        }
+
+        return $content;
+    }
+
+    /**
+     * Returns attributes of given html-tag.
+     *
+     * @param string $tag
+     *
+     * @return array
+     */
+    private function getAttributes($tag)
+    {
+        if (!preg_match_all(self::ATTRIBUTE_REGEX, $tag, $matches)) {
+            return [];
+        }
+
+        $attributes = [];
+        for ($i = 0, $length = count($matches['name']); $i < $length; ++$i) {
+            $attributes[$matches['name'][$i]] = $matches['value'][$i];
+        }
+
+        if (preg_match(self::CONTENT_REGEX, $tag, $matches)) {
+            $attributes['content'] = $matches['content'];
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Markup/MarkupParserInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/MarkupParserInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup;
+
+/**
+ * Parses html content and replaces special tags.
+ */
+interface MarkupParserInterface
+{
+    /**
+     * Parses html-document and returns completed html.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    public function parse($content);
+}

--- a/src/Sulu/Bundle/MarkupBundle/Markup/MarkupParserInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/MarkupParserInterface.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\MarkupBundle\Markup;
 
 /**
- * Parses html content and replaces special tags.
+ * Parses response and replaces special tags.
  */
 interface MarkupParserInterface
 {

--- a/src/Sulu/Bundle/MarkupBundle/Markup/MarkupParserInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/MarkupParserInterface.php
@@ -17,7 +17,7 @@ namespace Sulu\Bundle\MarkupBundle\Markup;
 interface MarkupParserInterface
 {
     /**
-     * Parses html-document and returns completed html.
+     * Parses document and returns completed document.
      *
      * @param string $content
      *

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sulu_markup.tag.registry" class="Sulu\Bundle\MarkupBundle\Tag\TagRegistry">
+            <argument type="collection"/>
+        </service>
+
+        <service id="sulu_markup.parser" class="Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser">
+            <argument type="service" id="sulu_markup.tag.registry"/>
+
+            <tag name="sulu_markup.parser" type="html"/>
+        </service>
+
+        <service id="sulu_markup.response_listener" class="Sulu\Bundle\MarkupBundle\Listener\MarkupListener">
+            <argument type="collection"/>
+
+            <tag name="kernel.event_listener" event="kernel.response" method="replaceMarkup" priority="-10"/>
+        </service>
+    </services>
+
+</container>

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle;
+
+use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\ParserCompilerPass;
+use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\TagCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Integrates markup into symfony.
+ */
+class SuluMarkupBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ParserCompilerPass());
+        $container->addCompilerPass(new TagCompilerPass());
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tag;
+
+/**
+ * Represents a single tag which returns new tag for attributes.
+ */
+interface TagInterface
+{
+    /**
+     * Returns new tag with given attributes.
+     *
+     * @param array $attributesByTag attributes array of each tag occurrence.
+     *
+     * @return array Tag array to replace all occurrences.
+     */
+    public function parseAll($attributesByTag);
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tag;
+
+/**
+ * This exception will be raised when a not existing tag was requested.
+ */
+class TagNotFoundException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $tagName;
+
+    /**
+     * @param string $tagName
+     */
+    public function __construct($tagName)
+    {
+        parent::__construct(sprintf('Tag "%s" not found', $tagName));
+
+        $this->tagName = $tagName;
+    }
+
+    /**
+     * Returns tag-name.
+     *
+     * @return string
+     */
+    public function getTagName()
+    {
+        return $this->tagName;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
@@ -22,13 +22,20 @@ class TagNotFoundException extends \Exception
     private $tagName;
 
     /**
-     * @param string $tagName
+     * @var string
      */
-    public function __construct($tagName)
+    private $type;
+
+    /**
+     * @param string $tagName
+     * @param int $type
+     */
+    public function __construct($tagName, $type)
     {
-        parent::__construct(sprintf('Tag "%s" not found', $tagName));
+        parent::__construct(sprintf('Tag "%s" for type "%s" not found', $tagName, $type));
 
         $this->tagName = $tagName;
+        $this->type = $type;
     }
 
     /**
@@ -39,5 +46,15 @@ class TagNotFoundException extends \Exception
     public function getTagName()
     {
         return $this->tagName;
+    }
+
+    /**
+     * Returns type of content.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
@@ -35,7 +35,7 @@ class TagRegistry implements TagRegistryInterface
     public function getTag($name, $type)
     {
         if (!array_key_exists($type, $this->tags) || !array_key_exists($name, $this->tags[$type])) {
-            throw new TagNotFoundException($name);
+            throw new TagNotFoundException($name, $type);
         }
 
         return $this->tags[$type][$name];

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tag;
+
+/**
+ * Container for all tags.
+ */
+class TagRegistry implements TagRegistryInterface
+{
+    /**
+     * @var TagInterface[]
+     */
+    private $tags;
+
+    /**
+     * @param TagInterface[] $tags
+     */
+    public function __construct(array $tags)
+    {
+        $this->tags = $tags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag($name, $type)
+    {
+        if (!array_key_exists($type, $this->tags) || !array_key_exists($name, $this->tags[$type])) {
+            throw new TagNotFoundException($name);
+        }
+
+        return $this->tags[$type][$name];
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistryInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tag;
+
+/**
+ * Container for all tags.
+ */
+interface TagRegistryInterface
+{
+    /**
+     * Returns tag by name.
+     *
+     * @param string $name
+     * @param string $type
+     *
+     * @return TagInterface
+     *
+     * @throws TagNotFoundException
+     */
+    public function getTag($name, $type);
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -69,7 +69,7 @@ class MarkupListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testReplaceMarkup()
     {
-        $this->responseHeaders->get('Content-Type')->willReturn('text/html; charset: UTF-8');
+        $this->request->getRequestFormat()->willReturn('html');
         $this->response->getContent()->willReturn('<html><sulu:link href="123-123-123"/></html>');
 
         $this->markupParser->parse('<html><sulu:link href="123-123-123"/></html>')

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -64,7 +64,7 @@ class MarkupListenerTest extends \PHPUnit_Framework_TestCase
         $this->event->getRequest()->willReturn($this->request->reveal());
         $this->event->getResponse()->willReturn($this->response->reveal());
 
-        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()]);
+        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()], ['text/html' => 'html']);
     }
 
     public function testReplaceMarkup()

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/MarkupListenerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Listener;
+
+use Sulu\Bundle\MarkupBundle\Listener\MarkupListener;
+use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class MarkupListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MarkupParserInterface
+     */
+    private $markupParser;
+
+    /**
+     * @var FilterResponseEvent
+     */
+    private $event;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @var HeaderBag
+     */
+    private $responseHeaders;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var MarkupListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->markupParser = $this->prophesize(MarkupParserInterface::class);
+        $this->event = $this->prophesize(FilterResponseEvent::class);
+
+        $this->request = $this->prophesize(Request::class);
+        $this->response = $this->prophesize(Response::class);
+
+        $this->responseHeaders = $this->prophesize(HeaderBag::class);
+        $this->response->reveal()->headers = $this->responseHeaders->reveal();
+
+        $this->event->getRequest()->willReturn($this->request->reveal());
+        $this->event->getResponse()->willReturn($this->response->reveal());
+
+        $this->listener = new MarkupListener(['html' => $this->markupParser->reveal()]);
+    }
+
+    public function testReplaceMarkup()
+    {
+        $this->responseHeaders->get('Content-Type')->willReturn('text/html; charset: UTF-8');
+        $this->response->getContent()->willReturn('<html><sulu:link href="123-123-123"/></html>');
+
+        $this->markupParser->parse('<html><sulu:link href="123-123-123"/></html>')
+            ->willReturn('<html><a href="/test">Page-Title</a></html>')->shouldBeCalled();
+
+        $this->response->setContent('<html><a href="/test">Page-Title</a></html>')->shouldBeCalled();
+
+        $this->listener->replaceMarkup($this->event->reveal());
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup;
+
+use Prophecy\Argument;
+use Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser;
+use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
+use Sulu\Bundle\MarkupBundle\Tag\TagNotFoundException;
+use Sulu\Bundle\MarkupBundle\Tag\TagRegistryInterface;
+
+class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TagInterface
+     */
+    private $linkTag;
+
+    /**
+     * @var TagInterface
+     */
+    private $mediaTag;
+
+    /**
+     * @var TagRegistryInterface
+     */
+    private $tagRegistry;
+
+    /**
+     * @var HtmlMarkupParser
+     */
+    private $parser;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->linkTag = $this->prophesize(TagInterface::class);
+        $this->mediaTag = $this->prophesize(TagInterface::class);
+        $this->tagRegistry = $this->prophesize(TagRegistryInterface::class);
+        $this->tagRegistry->getTag('link', 'html')->willReturn($this->linkTag->reveal());
+        $this->tagRegistry->getTag('media', 'html')->willReturn($this->mediaTag->reveal());
+        $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test'));
+
+        $this->parser = new HtmlMarkupParser($this->tagRegistry->reveal());
+    }
+
+    public function testParse()
+    {
+        $this->linkTag->parseAll(
+            ['<sulu:link href="123-123-123" title="test" />' => ['href' => '123-123-123', 'title' => 'test']]
+        )->willReturn(
+            ['<sulu:link href="123-123-123" title="test" />' => '<a href="/test" title="test">page title</a>']
+        );
+
+        $response = $this->parser->parse(
+            <<<'EOT'
+<html>
+    <body>
+        <sulu:link href="123-123-123" title="test" />
+    </body>
+</html>
+EOT
+        );
+
+        $this->assertContains('<a href="/test" title="test">page title</a>', $response);
+    }
+
+    public function testParseMultiple()
+    {
+        $this->linkTag->parseAll(
+            [
+                '<sulu:link href="123-123-123" title="test" />' => ['href' => '123-123-123', 'title' => 'test'],
+                '<sulu:link href="312-312-312" title="test" />' => ['href' => '312-312-312', 'title' => 'test'],
+            ]
+        )->willReturn(
+            [
+                '<sulu:link href="123-123-123" title="test" />' => '<a href="/test" title="test">page title</a>',
+                '<sulu:link href="312-312-312" title="test" />' => '<a href="/test-2" title="test">page-2 title</a>',
+            ]
+        );
+
+        $response = $this->parser->parse(
+            <<<'EOT'
+<html>
+    <body>
+        <sulu:link href="123-123-123" title="test" />
+        <sulu:link href="312-312-312" title="test" />
+    </body>
+</html>
+EOT
+        );
+
+        $this->assertContains('<a href="/test" title="test">page title</a>', $response);
+        $this->assertContains('<a href="/test-2" title="test">page-2 title</a>', $response);
+    }
+
+    public function testParseSame()
+    {
+        $this->linkTag->parseAll(
+            ['<sulu:link href="123-123-123" title="test" />' => ['href' => '123-123-123', 'title' => 'test']]
+        )->willReturn(
+            ['<sulu:link href="123-123-123" title="test" />' => '<a href="/test" title="test">page title</a>']
+        )->shouldBeCalledTimes(1);
+
+        $response = $this->parser->parse(
+            <<<'EOT'
+<html>
+    <body>
+        <sulu:link href="123-123-123" title="test" />
+        <sulu:link href="123-123-123" title="test" />
+    </body>
+</html>
+EOT
+        );
+
+        $this->assertEquals(2, preg_match_all('/<a href="\/test" title="test">page title<\/a>/', $response));
+        $this->assertNotContains('<sulu:link href="123-123-123" title="test" />', $response);
+    }
+
+    public function testParseDifferentTags()
+    {
+        $this->linkTag->parseAll(
+            ['<sulu:link href="123-123-123" title="test" />' => ['href' => '123-123-123', 'title' => 'test']]
+        )->willReturn(
+            ['<sulu:link href="123-123-123" title="test" />' => '<a href="/test" title="test">page title</a>']
+        );
+        $this->mediaTag->parseAll(
+            ['<sulu:media src="1" title="test" />' => ['src' => '1', 'title' => 'test']]
+        )->willReturn(
+            ['<sulu:media src="1" title="test" />' => '<img src="/img/test.jpg" title="test"/>']
+        );
+        $this->mediaTag->parseAll(
+            '<sulu:media src="1" title="test" />',
+            ['src' => '1', 'title' => 'test']
+        )->willReturn('<img src="/img/test.jpg" title="test"/>');
+
+        $response = $this->parser->parse(
+            <<<'EOT'
+<html>
+    <body>
+        <sulu:link href="123-123-123" title="test" />
+        <sulu:media src="1" title="test" />
+    </body>
+</html>
+EOT
+        );
+
+        $this->assertContains('<a href="/test" title="test">page title</a>', $response);
+        $this->assertContains('<img src="/img/test.jpg" title="test"/>', $response);
+    }
+
+    public function testParseNonEmptyTag()
+    {
+        $this->linkTag->parseAll(
+            [
+                '<sulu:link href="123-123-123" title="test">link content</sulu:link>' => [
+                    'href' => '123-123-123',
+                    'title' => 'test',
+                    'content' => 'link content',
+                ],
+            ]
+        )->willReturn(
+            ['<sulu:link href="123-123-123" title="test">link content</sulu:link>' => '<a href="/test" title="test">link content</a>']
+        );
+
+        $response = $this->parser->parse(
+            <<<'EOT'
+<html>
+    <body>
+        <sulu:link href="123-123-123" title="test">link content</sulu:link>
+    </body>
+</html>
+EOT
+        );
+
+        $this->assertContains('<a href="/test" title="test">link content</a>', $response);
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -51,7 +51,7 @@ class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
         $this->tagRegistry = $this->prophesize(TagRegistryInterface::class);
         $this->tagRegistry->getTag('link', 'html')->willReturn($this->linkTag->reveal());
         $this->tagRegistry->getTag('media', 'html')->willReturn($this->mediaTag->reveal());
-        $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test'));
+        $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test', 'html'));
 
         $this->parser = new HtmlMarkupParser($this->tagRegistry->reveal());
     }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Tag/TagRegistryTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Tag/TagRegistryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Tag;
+
+use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
+use Sulu\Bundle\MarkupBundle\Tag\TagNotFoundException;
+use Sulu\Bundle\MarkupBundle\Tag\TagRegistry;
+
+class TagRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTag()
+    {
+        $tag = $this->prophesize(TagInterface::class)->reveal();
+        $registry = new TagRegistry(['html' => ['test' => $tag]]);
+
+        $this->assertEquals($tag, $registry->getTag('test', 'html'));
+    }
+
+    public function testGetTagNotFound()
+    {
+        $this->setExpectedException(TagNotFoundException::class);
+
+        $registry = new TagRegistry(['test' => $this->prophesize(TagInterface::class)->reveal()]);
+        $registry->getTag('test-2', 'html');
+    }
+
+    public function testGetTypeNotFound()
+    {
+        $this->setExpectedException(TagNotFoundException::class);
+
+        $registry = new TagRegistry(['test' => $this->prophesize(TagInterface::class)->reveal()]);
+        $registry->getTag('test-2', 'xml');
+    }
+
+    public function testGetTagNoTag()
+    {
+        $this->setExpectedException(TagNotFoundException::class);
+
+        $registry = new TagRegistry([]);
+        $registry->getTag('test-2', 'html');
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../TestBundle/Resources/app/bootstrap.php" colors="true">
+
+    <testsuites>
+        <testsuite name="SuluMarkupBundle Test Suite">
+            <directory suffix="Test.php">./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
+
+</phpunit>

--- a/src/Sulu/Bundle/PreviewBundle/DependencyInjection/SuluPreviewExtension.php
+++ b/src/Sulu/Bundle/PreviewBundle/DependencyInjection/SuluPreviewExtension.php
@@ -11,15 +11,17 @@
 
 namespace Sulu\Bundle\PreviewBundle\DependencyInjection;
 
+use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * Extends the container and initializes the preview budle.
  */
-class SuluPreviewExtension extends Extension
+class SuluPreviewExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -35,5 +37,20 @@ class SuluPreviewExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if (SuluKernel::CONTEXT_ADMIN === $container->getParameter('sulu.context')
+            && $container->hasExtension('framework')
+        ) {
+            $container->prependExtensionConfig(
+                'framework',
+                ['profiler' => ['matcher' => ['service' => 'sulu_markup.preview.profile_matcher']]]
+            );
+        }
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -155,7 +155,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $this->eventDispatcher->dispatch(Events::PRE_RENDER, new PreRenderEvent($attributes));
 
         try {
-            $response = $this->httpKernel->handle($request, HttpKernelInterface::SUB_REQUEST, false);
+            $response = $this->httpKernel->handle($request, HttpKernelInterface::MASTER_REQUEST, false);
         } catch (\Twig_Error $e) {
             throw new TwigException($e, $object, $id, $webspace, $locale);
         }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -146,6 +146,7 @@ class PreviewRenderer implements PreviewRendererInterface
         // Controller arguments
         $defaults['object'] = $object;
         $defaults['preview'] = true;
+        $defaults['_profiler'] = (null !== $this->requestStack->getCurrentRequest());
         $defaults['partial'] = $partial;
         $defaults['_sulu'] = $attributes;
 

--- a/src/Sulu/Bundle/PreviewBundle/Profiler/PreviewProfilerMatcher.php
+++ b/src/Sulu/Bundle/PreviewBundle/Profiler/PreviewProfilerMatcher.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Profiler;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * Disables profiler for websocket preview requests.
+ */
+class PreviewProfilerMatcher implements RequestMatcherInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function matches(Request $request)
+    {
+        return $request->get('_profiler', true);
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -53,6 +53,12 @@
 
             <tag name="sulu.websocket.message.handler" dispatcher="admin" alias="sulu_preview.preview"/>
         </service>
+
+        <!-- disable profiler for websocket-mode -->
+        <service id="sulu_markup.preview.profile_matcher"
+                 class="Sulu\Bundle\PreviewBundle\Profiler\PreviewProfilerMatcher" public="false">
+            <tag name="sulu.context" context="admin"/>
+        </service>
     </services>
 
 </container>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -115,7 +115,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $this->eventDispatcher->dispatch(Events::PRE_RENDER, Argument::type(PreRenderEvent::class))
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
             ->shouldBeCalled()->willReturn(new Response('<title>Hallo</title>'));
 
         $request = new Request();
@@ -141,7 +141,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $this->eventDispatcher->dispatch(Events::PRE_RENDER, Argument::type(PreRenderEvent::class))
             ->shouldNotBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
             ->shouldNotBeCalled();
 
         $request = new Request();
@@ -175,7 +175,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $this->eventDispatcher->dispatch(Events::PRE_RENDER, Argument::type(PreRenderEvent::class))
             ->shouldNotBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
             ->shouldNotBeCalled();
 
         $request = new Request();
@@ -209,7 +209,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
         $this->eventDispatcher->dispatch(Events::PRE_RENDER, Argument::type(PreRenderEvent::class))
             ->shouldBeCalled();
 
-        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::SUB_REQUEST, false)
+        $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
             ->shouldBeCalled()->willThrow(new \Twig_Error_Runtime('Test error'));
 
         $request = new Request();

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Profiler/PreviewProfilerMatcherTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Profiler/PreviewProfilerMatcherTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Tests\Unit\Profiler;
+
+use Sulu\Bundle\PreviewBundle\Profiler\PreviewProfilerMatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+class PreviewProfilerMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function matchesDataProvider()
+    {
+        return [
+            [true, true],
+            [false, false],
+            [null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider matchesDataProvider
+     */
+    public function testMatches($value, $expected)
+    {
+        $matcher = new PreviewProfilerMatcher();
+        $request = new Request([], [], ['_profiler' => $value]);
+
+        $this->assertEquals($expected, $matcher->matches($request));
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -72,7 +73,8 @@ class SecuritySubscriber implements EventSubscriberInterface
             && $document instanceof LocaleBehavior
             && $document instanceof WebspaceBehavior
             && $this->tokenStorage !== null
-            && $this->tokenStorage->getToken() !== null)
+            && $this->tokenStorage->getToken() !== null
+            && $this->tokenStorage->getToken()->getUser() instanceof UserInterface)
         ) {
             return;
         }

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -130,7 +130,7 @@ class ContentRepository implements ContentRepositoryInterface
             throw new ItemNotFoundException();
         }
 
-        return $this->resolveContent($rows->getRows()->current(), $locale, $locales, $webspaceKey, $mapping, $user);
+        return $this->resolveContent($rows->getRows()->current(), $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -150,7 +150,7 @@ class ContentRepository implements ContentRepositoryInterface
         $queryBuilder->where($this->qomFactory->childNode('node', $path));
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
+        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -165,7 +165,7 @@ class ContentRepository implements ContentRepositoryInterface
         );
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
+        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -186,7 +186,7 @@ class ContentRepository implements ContentRepositoryInterface
             ->orderBy($this->qomFactory->propertyValue('node', 'jcr:path'))
             ->where($this->qomFactory->childNode('node', $path));
 
-        while ($path !== $contentPath) {
+        while (PathHelper::getPathDepth($path) > PathHelper::getPathDepth($contentPath)) {
             $path = PathHelper::getParentPath($path);
             $queryBuilder->orWhere($this->qomFactory->childNode('node', $path));
         }
@@ -194,7 +194,7 @@ class ContentRepository implements ContentRepositoryInterface
         $mapping->addProperties(['order']);
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        $result = $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
+        $result = $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
 
         return $this->generateTreeByPath($result);
     }
@@ -218,7 +218,7 @@ class ContentRepository implements ContentRepositoryInterface
         }
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, null, $mapping, $user);
+        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -248,7 +248,7 @@ class ContentRepository implements ContentRepositoryInterface
         }
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, null, $mapping, $user);
+        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -265,7 +265,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
+        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -284,7 +284,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
+        return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -368,7 +368,6 @@ class ContentRepository implements ContentRepositoryInterface
      *
      * @param QueryBuilder $queryBuilder
      * @param string $locale
-     * @param string $webspaceKey
      * @param MappingInterface $mapping
      * @param UserInterface $user
      *
@@ -378,15 +377,14 @@ class ContentRepository implements ContentRepositoryInterface
         QueryBuilder $queryBuilder,
         $locale,
         $locales,
-        $webspaceKey,
         MappingInterface $mapping,
         UserInterface $user = null
     ) {
         return array_values(
             array_filter(
                 array_map(
-                    function (Row $row) use ($mapping, $webspaceKey, $locale, $locales, $user) {
-                        return $this->resolveContent($row, $locale, $locales, $webspaceKey, $mapping, $user);
+                    function (Row $row) use ($mapping, $locale, $locales, $user) {
+                        return $this->resolveContent($row, $locale, $locales, $mapping, $user);
                     },
                     iterator_to_array($queryBuilder->execute())
                 )
@@ -573,7 +571,6 @@ class ContentRepository implements ContentRepositoryInterface
      * @param Row $row
      * @param string $locale
      * @param string $locales
-     * @param string $webspaceKey
      * @param MappingInterface $mapping Includes array of property names.
      * @param UserInterface $user
      *
@@ -583,13 +580,10 @@ class ContentRepository implements ContentRepositoryInterface
         Row $row,
         $locale,
         $locales,
-        $webspaceKey,
         MappingInterface $mapping,
         UserInterface $user = null
     ) {
-        if (!$webspaceKey) {
-            $webspaceKey = $this->nodeHelper->extractWebspaceFromPath($row->getPath());
-        }
+        $webspaceKey = $this->nodeHelper->extractWebspaceFromPath($row->getPath());
 
         $originalLocale = $locale;
         $ghostLocale = $this->localizationFinder->findAvailableLocale(

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -714,7 +714,15 @@ class ContentRepositoryTest extends SuluTestCase
         );
     }
 
-    public function testFindParentsWithSiblingsByUuid()
+    public function provideWebspaceKeys()
+    {
+        return [['sulu_io'], ['test_io']];
+    }
+
+    /**
+     * @dataProvider provideWebspaceKeys
+     */
+    public function testFindParentsWithSiblingsByUuid($webspaceKey)
     {
         $this->initPhpcr();
 
@@ -735,7 +743,7 @@ class ContentRepositoryTest extends SuluTestCase
         $result = $this->contentRepository->findParentsWithSiblingsByUuid(
             $page10->getUuid(),
             'de',
-            'sulu_io',
+            $webspaceKey,
             MappingBuilder::create()->getMapping()
         );
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
@@ -43,7 +43,7 @@ class AdminRequestProcessor implements RequestProcessorInterface
         $attributes['webspaceKey'] = $request->get('webspace');
         $attributes['locale'] = $request->get('locale', $request->get('language'));
 
-        if (null === $attributes['webspaceKey']) {
+        if (empty($attributes['webspaceKey'])) {
             return new RequestAttributes($attributes);
         }
 

--- a/tests/app/Resources/webspaces/test.io.xml
+++ b/tests/app/Resources/webspaces/test.io.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.0.xsd">
+
+    <name>test CMF</name>
+    <key>test_io</key>
+
+    <localizations>
+        <localization language="en" default="true"/>
+    </localizations>
+
+    <theme>
+        <key>default</key>
+        <default-templates>
+            <default-template type="page">default</default-template>
+            <default-template type="homepage">overview</default-template>
+        </default-templates>
+    </theme>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>test CMF AT</name>
+            <key>testcmf_at</key>
+            <resource-locator>
+                <strategy>tree</strategy>
+            </resource-locator>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url>test.lo/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url>test.lo/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="phpcr">
+                    <urls>
+                        <url>test.lo/{localization}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-standard/pull/681
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/218 

#### What's in this PR?

This PR introduces a response-listener which replaces "special" html tags with others. It is extensible via services which gets called with the attributes of the tag to replace.

Inspired by http://www.jochenfroehlich.com/tutorial/typo3-link.html

#### Why?

It should be possible to use html-tags to specify a internal link.

#### Example Usage

~~~html
<html>
    <body>
        <sulu:link href="123-123-123" title="test-title" />
    </body>
</html>
~~~

~~~php
class LinkTag implements TagInterface
{
    /**
     * Returns new tag with given attributes.
     *
     * @param array $attributes attributes array of each tag occurrence.
     *
     * @return array Tag array to replace all occurrences.
     */
    public function parseAll($attributesByTag) {
        $result = [];
        foreach($attributesByTag as $tag => $attributes) {
            $url = ; // load url via uuid from document-manager
            $pageTitle = ...; // load page-title via uuid from document-manager

            $result[$tag] = sprintf('<a href="%s" title="%s">%s</a>', $url, $$pageTitle, $attributes['content']);
        }

        return $result;
    }
}
~~~

Results into:

~~~html
<html>
    <body>
        <a href="/test" title="test-title">Page Title</a>
    </body>
</html>
~~~

#### To Do

- [x] Create a documentation PR
- [x] bundle config and compiler pass