### PR TITLE
fixed listing of contacts with Sulu users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 CHANGELOG for Sulu
 ==================
 
-* 1.2.1 (2016-04-26)
+* 1.2.1 (2016-04-27)
+    * HOTFIX      #2340 [ContactBundle]       Fixed listing of contacts with Sulu user
     * HOTFIX      #2334 [ContactBundle]       Fixed account-contact search
     * HOTFIX      #2335 [ContentBundle]       Fixed textarea vertical resize
     * HOTFIX      #2331 [AdminBundle]         Fixed admin-controller to return correct system

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -446,7 +446,7 @@ class ContactController extends RestController implements ClassResourceInterface
     protected function getContactsByUserSystem()
     {
         $repo = $this->get('sulu_security.user_repository');
-        $users = $repo->getUserInSystem();
+        $users = $repo->findUserBySystem($this->getParameter('sulu_security.system'));
         $contacts = [];
 
         foreach ($users as $user) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yse
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | #2324 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug introduced in #2324. A method was renamed there, but has not been updated in the `ContactController`.

#### Why?

Because the action `/admin/api/contacts?bySystem=true` was throwing an exception now.