### PR TITLE
Fixed RequestAnalyzer to be usable with ESI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * ENHANCEMENT #2346 [ResourceBundle]    Added fixtures for de_CH
-    * ENHANCEMENT #2346 [AdminBundle]       Use always users locale for globalize culture
+    * ENHANCEMENT #2346 [ResourceBundle]      Added fixtures for de_CH
+    * ENHANCEMENT #2346 [AdminBundle]         Use always users locale for globalize culture
+    * HOTFIX      #2344 [WebsiteBundle]       Fixed request analyzer for use with ESI
 
 * 1.2.1 (2016-04-27)
     * HOTFIX      #2340 [ContactBundle]       Fixed listing of contacts with Sulu user

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -9,6 +9,15 @@
             <argument type="collection"/>
         </service>
 
+        <service id="sulu_core.request_processor.parameter"
+                 class="Sulu\Component\Webspace\Analyzer\Attributes\ParameterRequestProcessor">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument>%kernel.environment%</argument>
+
+            <tag name="sulu.context" context="website"/>
+            <tag name="sulu.request_attributes" priority="128"/>
+        </service>
+
         <service id="sulu_core.request_processor.admin"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\AdminRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -37,5 +37,11 @@
             <tag name="sulu.context" context="website"/>
             <tag name="sulu.request_attributes" priority="0"/>
         </service>
+
+        <service id="sulu_core.request_processor.portal_information"
+                 class="Sulu\Component\Webspace\Analyzer\Attributes\PortalInformationRequestProcessor">
+            <tag name="sulu.context" context="website"/>
+            <tag name="sulu.request_attributes" priority="-128"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -15,7 +15,7 @@ use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\CustomUrl\Generator\GeneratorInterface;
 use Sulu\Component\CustomUrl\Manager\CustomUrlManagerInterface;
 use Sulu\Component\Localization\Localization;
-use Sulu\Component\Webspace\Analyzer\Attributes\AbstractRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\AbstractPortalInformationRequestProcessor;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Set localization in case of custom-url route.
  */
-class CustomUrlRequestProcessor extends AbstractRequestProcessor
+class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcessor
 {
     /**
      * @var CustomUrlManagerInterface

--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -15,8 +15,8 @@ use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\CustomUrl\Generator\GeneratorInterface;
 use Sulu\Component\CustomUrl\Manager\CustomUrlManagerInterface;
 use Sulu\Component\Localization\Localization;
-use Sulu\Component\Webspace\Analyzer\Attributes\AbstractPortalInformationRequestProcessor;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestProcessorInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Set localization in case of custom-url route.
  */
-class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcessor
+class CustomUrlRequestProcessor implements RequestProcessorInterface
 {
     /**
      * @var CustomUrlManagerInterface
@@ -68,10 +68,7 @@ class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcesso
         if (substr($url, -5, 5) === '.html') {
             $url = substr($url, 0, -5);
         }
-        $portalInformations = $this->webspaceManager->findPortalInformationsByUrl(
-            $url,
-            $this->environment
-        );
+        $portalInformations = $this->webspaceManager->findPortalInformationsByUrl($url, $this->environment);
 
         if (count($portalInformations) === 0) {
             return new RequestAttributes();
@@ -91,7 +88,7 @@ class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcesso
             }
 
             if (null !== $attributes = $this->matchCustomUrl($url, $portalInformation, $request)) {
-                return $attributes;
+                return new RequestAttributes($attributes);
             }
         }
 
@@ -124,14 +121,10 @@ class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcesso
         );
 
         if (!$routeDocument) {
-            return;
+            return [];
         } elseif ($routeDocument->isHistory()) {
             // redirect happen => no portal is needed
-            return $this->processPortalInformation(
-                $request,
-                $portalInformation,
-                ['customUrlRoute' => $routeDocument]
-            );
+            return ['customUrlRoute' => $routeDocument];
         }
 
         $customUrlDocument = $this->customUrlManager->findByUrl(
@@ -146,15 +139,10 @@ class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcesso
             || $customUrlDocument->getTargetDocument()->getWorkflowStage() !== WorkflowStage::PUBLISHED
         ) {
             // error happen because this custom-url is not published => no portal is needed
-            return $this->processPortalInformation(
-                $request,
-                $portalInformation,
-                ['customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument]
-            );
+            return ['customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument];
         }
 
         $localization = $this->parse($customUrlDocument->getTargetLocale());
-        $request->setLocale($localization->getLocalization());
 
         $portalInformations = $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale(
             $portalInformation->getWebspace()->getKey(),
@@ -163,26 +151,19 @@ class CustomUrlRequestProcessor extends AbstractPortalInformationRequestProcesso
         );
 
         if (0 === count($portalInformations)) {
-            return $this->processPortalInformation(
-                $request,
-                $portalInformation,
-                ['customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument]
-            );
+            return ['customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument];
         }
 
-        return $this->processPortalInformation(
-            $request,
-            reset($portalInformations),
-            [
-                'localization' => $localization,
-                'customUrlRoute' => $routeDocument,
-                'customUrl' => $customUrlDocument,
-                'urlExpression' => $this->generator->generate(
-                    $customUrlDocument->getBaseDomain(),
-                    $customUrlDocument->getDomainParts()
-                ),
-            ]
-        );
+        return [
+            'portalInformation' => $portalInformation,
+            'localization' => $localization,
+            'customUrlRoute' => $routeDocument,
+            'customUrl' => $customUrlDocument,
+            'urlExpression' => $this->generator->generate(
+                $customUrlDocument->getBaseDomain(),
+                $customUrlDocument->getDomainParts()
+            ),
+        ];
     }
 
     /**

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
@@ -93,7 +93,7 @@
             <tag name="sulu.context" context="website"/>
             <tag name="router" priority="30"/>
         </service>
-        
+
         <service id="sulu_custom_urls.request_processor"
                  class="Sulu\Bundle\CustomUrlBundle\Request\CustomUrlRequestProcessor">
             <argument type="service" id="sulu_custom_urls.manager"/>
@@ -102,7 +102,7 @@
             <argument type="string">%kernel.environment%</argument>
 
             <tag name="sulu.context" context="website"/>
-            <tag name="sulu.request_attributes"/>
+            <tag name="sulu.request_attributes" priority="32"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
@@ -78,11 +78,6 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
         if (!$exists) {
             $customUrlManager->findRouteByUrl($route, $webspaceKey)->willReturn(null);
         } else {
-            if (!$noConcretePortal) {
-                $request->setLocale('de')->shouldBeCalled();
-                $request->setRequestFormat('html')->shouldBeCalled();
-            }
-
             $routeDocument = $this->prophesize(RouteDocument::class);
             $routeDocument->isHistory()->willReturn($history);
             $routeDocument->getPath()->willReturn('/cmf/sulu_io/custom-urls/routes/' . $route);
@@ -103,9 +98,6 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
                     $target = $this->prophesize(PageDocument::class);
                     $target->getWorkflowStage()->willReturn($workflowStage);
                     $customUrl->getTargetDocument()->willReturn($target->reveal());
-                    if ($workflowStage === WorkflowStage::PUBLISHED && $published && !$noConcretePortal) {
-                        $request->setLocale('de')->shouldBeCalled();
-                    }
                 } else {
                     $customUrl->getTargetDocument()->willReturn(null);
                 }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AbstractPortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AbstractPortalInformationRequestProcessor.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
  * Base class for request processors.
  * Provides functionality to process a single portal-information.
  */
-abstract class AbstractRequestProcessor implements RequestProcessorInterface
+abstract class AbstractPortalInformationRequestProcessor implements RequestProcessorInterface
 {
     /**
      * Returns the request attributes for given portal information.

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Analyzer\Attributes;
+
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Takes the parameters from the requests, and tries to find a suiting portal. It checks for the parameters _locale and
+ * _portal. Based on these it will load the best matching portal information, and uses it to analyze the request.
+ */
+class ParameterRequestProcessor extends AbstractPortalInformationRequestProcessor
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var string
+     */
+    private $environment;
+
+    public function __construct(
+        WebspaceManagerInterface $webspaceManager,
+        $environment
+    ) {
+        $this->webspaceManager = $webspaceManager;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Request $request, RequestAttributes $requestAttributes)
+    {
+        if (!$request->get('_locale') && !$request->get('_portal')) {
+            return new RequestAttributes();
+        }
+
+        $portalInformations = $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale(
+            $request->get('_portal'),
+            $request->get('_locale'),
+            $this->environment
+        );
+
+        if (!$portalInformations) {
+            return new RequestAttributes();
+        }
+
+        return $this->processPortalInformation($request, reset($portalInformations));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(RequestAttributes $attributes)
+    {
+        return true;
+    }
+}

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
  * Takes the parameters from the requests, and tries to find a suiting portal. It checks for the parameters _locale and
  * _portal. Based on these it will load the best matching portal information, and uses it to analyze the request.
  */
-class ParameterRequestProcessor extends AbstractPortalInformationRequestProcessor
+class ParameterRequestProcessor implements RequestProcessorInterface
 {
     /**
      * @var WebspaceManagerInterface
@@ -57,7 +57,11 @@ class ParameterRequestProcessor extends AbstractPortalInformationRequestProcesso
             return new RequestAttributes();
         }
 
-        return $this->processPortalInformation($request, reset($portalInformations));
+        return new RequestAttributes(
+            [
+                'portalInformation' => reset($portalInformations),
+            ]
+        );
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -16,30 +16,22 @@ use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Base class for request processors.
- * Provides functionality to process a single portal-information.
+ * Adds more information about the Portal if the portalInformation attribute has already been set.
  */
-abstract class AbstractPortalInformationRequestProcessor implements RequestProcessorInterface
+class PortalInformationRequestProcessor implements RequestProcessorInterface
 {
     /**
-     * Returns the request attributes for given portal information.
-     *
-     * @param Request $request
-     * @param PortalInformation $portalInformation
-     * @param array $additionalAttributes
-     *
-     * @return RequestAttributes
+     * {@inheritdoc}
      */
-    protected function processPortalInformation(
-        Request $request,
-        PortalInformation $portalInformation,
-        $additionalAttributes = []
-    ) {
-        $attributes = ['requestUri' => $request->getUri()];
+    public function process(Request $request, RequestAttributes $requestAttributes)
+    {
+        $portalInformation = $requestAttributes->getAttribute('portalInformation');
 
-        if ($portalInformation === null) {
-            return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+        if (!$portalInformation instanceof PortalInformation) {
+            return new RequestAttributes();
         }
+
+        $attributes = ['requestUri' => $request->getUri()];
 
         if (null !== $localization = $portalInformation->getLocalization()) {
             $request->setLocale($portalInformation->getLocalization()->getLocalization());
@@ -59,7 +51,7 @@ abstract class AbstractPortalInformationRequestProcessor implements RequestProce
         $attributes['portal'] = $portalInformation->getPortal();
 
         if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
-            return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+            return new RequestAttributes($attributes);
         }
 
         $attributes['localization'] = $portalInformation->getLocalization();
@@ -70,6 +62,7 @@ abstract class AbstractPortalInformationRequestProcessor implements RequestProce
             $request
         );
 
+        $attributes['urlExpression'] = $portalInformation->getUrlExpression();
         $attributes['resourceLocator'] = $resourceLocator;
         $attributes['format'] = $format;
 
@@ -84,7 +77,15 @@ abstract class AbstractPortalInformationRequestProcessor implements RequestProce
             $request->setRequestFormat($format);
         }
 
-        return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+        return new RequestAttributes($attributes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(RequestAttributes $attributes)
+    {
+        return true;
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
@@ -51,6 +51,6 @@ class RequestAttributes
      */
     public function merge(RequestAttributes $requestAttributes)
     {
-        return new self(array_merge($this->attributes, $requestAttributes->attributes));
+        return new self(array_merge($requestAttributes->attributes, $this->attributes));
     }
 }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Extracts attributes from request for the sulu-website.
  */
-class WebsiteRequestProcessor extends AbstractPortalInformationRequestProcessor
+class WebsiteRequestProcessor implements RequestProcessorInterface
 {
     /**
      * @var WebspaceManagerInterface
@@ -91,11 +91,7 @@ class WebsiteRequestProcessor extends AbstractPortalInformationRequestProcessor
         /** @var PortalInformation $portalInformation */
         $portalInformation = reset($portalInformations);
 
-        return $this->processPortalInformation(
-            $request,
-            $portalInformation,
-            ['urlExpression' => $portalInformation->getUrlExpression()]
-        );
+        return new RequestAttributes(['portalInformation' => $portalInformation]);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Extracts attributes from request for the sulu-website.
  */
-class WebsiteRequestProcessor extends AbstractRequestProcessor
+class WebsiteRequestProcessor extends AbstractPortalInformationRequestProcessor
 {
     /**
      * @var WebspaceManagerInterface

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -43,8 +43,8 @@ class RequestAnalyzer implements RequestAnalyzerInterface
     public function analyze(Request $request)
     {
         $attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme()]);
-        foreach ($this->requestProcessors as $provider) {
-            $attributes = $attributes->merge($provider->process($request, $attributes));
+        foreach ($this->requestProcessors as $requestProcessor) {
+            $attributes = $attributes->merge($requestProcessor->process($request, $attributes));
         }
 
         $request->attributes->set('_sulu', $attributes);

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -133,6 +133,21 @@ class WebspaceManager implements WebspaceManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function findPortalInformationsByPortalKeyAndLocale($portalKey, $locale, $environment)
+    {
+        return array_filter(
+            $this->getWebspaceCollection()->getPortalInformations($environment),
+            function (PortalInformation $portalInformation) use ($portalKey, $locale) {
+                return $portalInformation->getPortal()
+                    && $portalInformation->getPortal()->getKey() === $portalKey
+                    && $portalInformation->getLocale() === $locale;
+            }
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findUrlsByResourceLocator(
         $resourceLocator,
         $environment,

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -71,6 +71,17 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
     public function findPortalInformationsByWebspaceKeyAndLocale($webspaceKey, $locale, $environment);
 
     /**
+     * Returns all portal which matches the given portal-key and locale.
+     *
+     * @param string $portalKey The portal-key which the portal should match
+     * @param string $locale The locale which the portal should match
+     * @param string $environment The environment in which the url should be searched
+     *
+     * @return \Sulu\Component\Webspace\PortalInformation[]
+     */
+    public function findPortalInformationsByPortalKeyAndLocale($portalKey, $locale, $environment);
+
+    /**
      * Returns all possible urls for resourcelocator.
      *
      * @param string $resourceLocator

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+
+use Sulu\Component\Webspace\Analyzer\Attributes\ParameterRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\HttpFoundation\Request;
+
+class ParameterRequestProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var ParameterRequestProcessor
+     */
+    private $parameterRequestProcessor;
+
+    public function setUp()
+    {
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+
+        $this->parameterRequestProcessor = new ParameterRequestProcessor(
+            $this->webspaceManager->reveal(),
+            'dev'
+        );
+    }
+
+    public function testProcess()
+    {
+        $request = new Request(['_portal' => 'sulu_io', '_locale' => 'de']);
+
+        $portalInformation = new PortalInformation(1);
+
+        $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale('sulu_io', 'de', 'dev')
+            ->willReturn([$portalInformation]);
+
+        $requestAttributes = $this->parameterRequestProcessor->process($request, new RequestAttributes());
+
+        $this->assertEquals($portalInformation, $requestAttributes->getAttribute('portalInformation'));
+    }
+
+    public function testProcessWithoutLocale()
+    {
+        $request = new Request(['_portal' => 'sulu_io']);
+
+        $this->assertEquals(
+            new RequestAttributes(),
+            $this->parameterRequestProcessor->process($request, new RequestAttributes())
+        );
+    }
+
+    public function testProcessWithoutPortal()
+    {
+        $request = new Request(['_locale' => 'sulu_io']);
+
+        $this->assertEquals(
+            new RequestAttributes(),
+            $this->parameterRequestProcessor->process($request, new RequestAttributes())
+        );
+    }
+
+    public function testValidate()
+    {
+        $this->assertTrue($this->parameterRequestProcessor->validate(new RequestAttributes()));
+    }
+}

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\PortalInformationRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PortalInformationRequestProcessor
+     */
+    private $provider;
+
+    public function setUp()
+    {
+        $this->provider = new PortalInformationRequestProcessor();
+    }
+
+    /**
+     * @dataProvider provideProcess
+     */
+    public function testProcess($config, $expected = [])
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+
+        $portal = new Portal();
+        $portal->setKey('sulu');
+
+        $localization = new Localization();
+        $localization->setCountry('at');
+        $localization->setLanguage('de');
+
+        $portalInformation = new PortalInformation(
+            $config['match_type'],
+            $webspace,
+            $portal,
+            $localization,
+            $config['portal_url'],
+            null,
+            $config['redirect'],
+            null,
+            false,
+            $config['url_expression']
+        );
+
+        $request = $this->getMock(Request::class);
+        $request->request = new ParameterBag(['post' => 1]);
+        $request->query = new ParameterBag(['get' => 1]);
+        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
+        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request->expects($this->once())->method('setLocale')->with($localization->getLocalization());
+
+        $attributes = $this->provider->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertEquals('de_at', $attributes->getAttribute('localization'));
+        $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
+        $this->assertEquals('sulu', $attributes->getAttribute('portal')->getKey());
+        $this->assertNull($attributes->getAttribute('segment'));
+
+        $this->assertEquals($expected['portal_url'], $attributes->getAttribute('portalUrl'));
+        $this->assertEquals($expected['redirect'], $attributes->getAttribute('redirect'));
+        $this->assertEquals($expected['resource_locator'], $attributes->getAttribute('resourceLocator'));
+        $this->assertEquals($expected['resource_locator_prefix'], $attributes->getAttribute('resourceLocatorPrefix'));
+        $this->assertEquals($expected['url_expression'], $attributes->getAttribute('urlExpression'));
+        $this->assertEquals(['post' => 1], $attributes->getAttribute('postParameter'));
+        $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
+    }
+
+    /**
+     * @dataProvider provideProcessWithFormat
+     */
+    public function testProcessWithFormat($config, $expected = [])
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+
+        $portal = new Portal();
+        $portal->setKey('sulu');
+
+        $localization = new Localization();
+        $localization->setCountry('at');
+        $localization->setLanguage('de');
+
+        $portalInformation = new PortalInformation(
+            $config['match_type'],
+            $webspace,
+            $portal,
+            $localization,
+            $config['portal_url'],
+            null,
+            $config['redirect']
+        );
+
+        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request->request = new ParameterBag(['post' => 1]);
+        $request->query = new ParameterBag(['get' => 1]);
+        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
+        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request->expects($this->once())->method('setLocale')->with($localization->getLocalization());
+        if ($expected['format']) {
+            $request->expects($this->once())->method('setRequestFormat')->with($expected['format']);
+        }
+
+        $attributes = $this->provider->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertEquals('de_at', $attributes->getAttribute('localization'));
+        $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
+        $this->assertEquals('sulu', $attributes->getAttribute('portal')->getKey());
+        $this->assertNull($attributes->getAttribute('segment'));
+
+        $this->assertEquals($expected['portal_url'], $attributes->getAttribute('portalUrl'));
+        $this->assertEquals($expected['redirect'], $attributes->getAttribute('redirect'));
+        $this->assertEquals($expected['resource_locator'], $attributes->getAttribute('resourceLocator'));
+        $this->assertEquals($expected['resource_locator_prefix'], $attributes->getAttribute('resourceLocatorPrefix'));
+        $this->assertEquals($expected['format'], $attributes->getAttribute('format'));
+        $this->assertEquals(['post' => 1], $attributes->getAttribute('postParameter'));
+        $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
+    }
+
+    public function testValidate()
+    {
+        $this->assertTrue($this->provider->validate(new RequestAttributes()));
+    }
+
+    public function provideProcess()
+    {
+        return [
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'path_info' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo',
+                    'path_info' => '/test/path/to',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                    'redirect' => 'sulu.lo/test',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+                [
+                    'redirect' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'portal_url' => 'sulu.lo',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+            ],
+        ];
+    }
+
+    public function provideProcessWithFormat()
+    {
+        return [
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to.html',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => 'html',
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo',
+                    'path_info' => '/test/path/to.rss',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                    'redirect' => 'sulu.lo/test',
+                ],
+                [
+                    'redirect' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'portal_url' => 'sulu.lo',
+                    'format' => 'rss',
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => null,
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to/test.min.css',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to/test',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => 'css',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -505,6 +505,21 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('de_at', $portalInformation->getLocale());
     }
 
+    public function testFindPortalInformationsByPortalKeyAndLocale()
+    {
+        $portalInformations = $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale(
+            'sulucmf_at',
+            'de_at',
+            'dev'
+        );
+
+        $this->assertCount(1, $portalInformations);
+
+        $portalInformation = reset($portalInformations);
+        $this->assertEquals('sulucmf_at', $portalInformation->getPortal()->getKey());
+        $this->assertEquals('de_at', $portalInformation->getLocale());
+    }
+
     public function testFindPortalInformationByUrlWithSegment()
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('en.massiveart.us/w/about-us', 'prod');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | TODO

#### What's in this PR?

This PR introduces another `RequestProcessor`, the `ParameterRequestProcessor`, which takes the information for portals from the `_locale` and `_request` parameters from the request. These take precedence over the other methods to analyze the request.

#### Why?

This is necessary because ESI requests can't be properly handled otherwise. So if there is a twig line like the following:

```jinja
{{ render(controller('ClientWebsiteBundle:Search:query')) }}
```

It's not working properly, because the underlying controller needs values from the `RequestAnalyzer`. This worked before 1.2, but was also not correct, it simply took the values from the master request. That also means that it would have failed if only the ESI request was sent.

#### Example Usage

The above example would now look like that:

~~~jinja
{{ render(controller('ClientWebsiteBundle:Search:query', {q: 'Test', _portal: 'sulu_io'})) }}
~~~

#### To Do

- [ ] Create a documentation PR
- [x] Test in production

