### PR TITLE
Fixes ghost children loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #2347 [ContentBundle]       Fixed ghost children loading
+
 * 1.2.1 (2016-04-27)
     * HOTFIX      #2340 [ContactBundle]       Fixed listing of contacts with Sulu user
     * HOTFIX      #2334 [ContactBundle]       Fixed account-contact search

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -633,7 +633,7 @@ class ContentRepository implements ContentRepositoryInterface
         }
 
         $content = new Content(
-            $locale,
+            $originalLocale,
             $webspaceKey,
             $row->getValue('uuid'),
             $this->resolvePath($row, $webspaceKey),

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -213,8 +213,15 @@ class ContentRepositoryTest extends SuluTestCase
 
         $this->assertCount(3, $result);
 
+        $this->assertEquals('de', $result[0]->getLocale());
         $this->assertEquals('test-1', $result[0]['title']);
+        $this->assertEquals('ghost', $result[0]->getLocalizationType()->getName());
+        $this->assertEquals('en', $result[0]->getLocalizationType()->getValue());
+        $this->assertEquals('de', $result[1]->getLocale());
+        $this->assertNull($result[1]->getLocalizationType());
         $this->assertEquals('test-2', $result[1]['title']);
+        $this->assertEquals('de', $result[2]->getLocale());
+        $this->assertNull($result[2]->getLocalizationType());
         $this->assertEquals('test-3', $result[2]['title']);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2318
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes loading of ghost-children loading by returning original locale when loading a ghost.

#### Why?

This locale will be used to generate the children locale.
