### PR TITLE
Fixed RequestAnalyzer to be usable with ESI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG for Sulu
     * FEATURE     #2333 [PreviewBundle]       Added preview render error templates 
     * ENHANCEMENT #2353 [WebsocketBundle]     Changed configuration to default disable websocket 
     * BUGFIX      #2351 [ContentBundle]       Removed strange condition for data-changed 
+    * BUGFIX      #2352 [CoreBundle]          Fixed RequestAnalyzer for use with ESI
     * FEATURE     #2349 [RouteBundle]         Added route-bundle 
     * FEATURE     #2299 [PreviewBundle]       Implemented preview bundle 
     * ENHANCEMENT #2289 [ContentBundle]       Added display options support to date content type

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -9,6 +9,15 @@
             <argument type="collection"/>
         </service>
 
+        <service id="sulu_core.request_processor.parameter"
+                 class="Sulu\Component\Webspace\Analyzer\Attributes\ParameterRequestProcessor">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument>%kernel.environment%</argument>
+
+            <tag name="sulu.context" context="website"/>
+            <tag name="sulu.request_attributes" priority="128"/>
+        </service>
+
         <service id="sulu_core.request_processor.admin"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\AdminRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -27,6 +36,12 @@
 
             <tag name="sulu.context" context="website"/>
             <tag name="sulu.request_attributes" priority="0"/>
+        </service>
+
+        <service id="sulu_core.request_processor.portal_information"
+                 class="Sulu\Component\Webspace\Analyzer\Attributes\PortalInformationRequestProcessor">
+            <tag name="sulu.context" context="website"/>
+            <tag name="sulu.request_attributes" priority="-128"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/routing.xml
@@ -93,7 +93,7 @@
             <tag name="sulu.context" context="website"/>
             <tag name="router" priority="30"/>
         </service>
-        
+
         <service id="sulu_custom_urls.request_processor"
                  class="Sulu\Bundle\CustomUrlBundle\Request\CustomUrlRequestProcessor">
             <argument type="service" id="sulu_custom_urls.manager"/>
@@ -102,7 +102,7 @@
             <argument type="string">%kernel.environment%</argument>
 
             <tag name="sulu.context" context="website"/>
-            <tag name="sulu.request_attributes"/>
+            <tag name="sulu.request_attributes" priority="32"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
@@ -78,11 +78,6 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
         if (!$exists) {
             $customUrlManager->findRouteByUrl($route, $webspaceKey)->willReturn(null);
         } else {
-            if (!$noConcretePortal) {
-                $request->setLocale('de')->shouldBeCalled();
-                $request->setRequestFormat('html')->shouldBeCalled();
-            }
-
             $routeDocument = $this->prophesize(RouteDocument::class);
             $routeDocument->isHistory()->willReturn($history);
             $routeDocument->getPath()->willReturn('/cmf/sulu_io/custom-urls/routes/' . $route);
@@ -103,9 +98,6 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
                     $target = $this->prophesize(PageDocument::class);
                     $target->getWorkflowStage()->willReturn($workflowStage);
                     $customUrl->getTargetDocument()->willReturn($target->reveal());
-                    if ($workflowStage === WorkflowStage::PUBLISHED && $published && !$noConcretePortal) {
-                        $request->setLocale('de')->shouldBeCalled();
-                    }
                 } else {
                     $customUrl->getTargetDocument()->willReturn(null);
                 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -57,6 +57,7 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
         return [
             'request' => [
                 'webspaceKey' => $requestAnalyzer->getWebspace()->getKey(),
+                'portalKey' => $requestAnalyzer->getPortal()->getKey(),
                 'defaultLocale' => $defaultLocale,
                 'locale' => $requestAnalyzer->getCurrentLocalization()->getLocalization(),
                 'portalUrl' => $requestAnalyzer->getPortalUrl(),

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -89,6 +89,7 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
         $webspace->setKey('sulu_io');
 
         $portal = new Portal();
+        $portal->setKey('sulu_io_portal');
         $locale = new Localization();
         $locale->setLanguage('de');
         $locale->setDefault(true);
@@ -119,6 +120,7 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
             [
                 'request' => [
                     'webspaceKey' => 'sulu_io',
+                    'portalKey' => 'sulu_io_portal',
                     'locale' => 'de_at',
                     'defaultLocale' => 'de',
                     'portalUrl' => 'sulu.io/de',

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Analyzer\Attributes;
+
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Takes the parameters from the requests, and tries to find a suiting portal. It checks for the parameters _locale and
+ * _portal. Based on these it will load the best matching portal information, and uses it to analyze the request.
+ */
+class ParameterRequestProcessor implements RequestProcessorInterface
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var string
+     */
+    private $environment;
+
+    public function __construct(
+        WebspaceManagerInterface $webspaceManager,
+        $environment
+    ) {
+        $this->webspaceManager = $webspaceManager;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Request $request, RequestAttributes $requestAttributes)
+    {
+        if (!$request->get('_locale') && !$request->get('_portal')) {
+            return new RequestAttributes();
+        }
+
+        $portalInformations = $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale(
+            $request->get('_portal'),
+            $request->get('_locale'),
+            $this->environment
+        );
+
+        if (!$portalInformations) {
+            return new RequestAttributes();
+        }
+
+        return new RequestAttributes(
+            [
+                'portalInformation' => reset($portalInformations),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(RequestAttributes $attributes)
+    {
+        return true;
+    }
+}

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -16,33 +16,25 @@ use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Base class for request processors.
- * Provides functionality to process a single portal-information.
+ * Adds more information about the Portal if the portalInformation attribute has already been set.
  */
-abstract class AbstractRequestProcessor implements RequestProcessorInterface
+class PortalInformationRequestProcessor implements RequestProcessorInterface
 {
     /**
-     * Returns the request attributes for given portal information.
-     *
-     * @param Request $request
-     * @param PortalInformation $portalInformation
-     * @param array $additionalAttributes
-     *
-     * @return RequestAttributes
+     * {@inheritdoc}
      */
-    protected function processPortalInformation(
-        Request $request,
-        PortalInformation $portalInformation,
-        $additionalAttributes = []
-    ) {
-        $attributes = ['requestUri' => $request->getUri()];
+    public function process(Request $request, RequestAttributes $requestAttributes)
+    {
+        $portalInformation = $requestAttributes->getAttribute('portalInformation');
 
-        if ($portalInformation === null) {
-            return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+        if (!$portalInformation instanceof PortalInformation) {
+            return new RequestAttributes();
         }
 
+        $attributes = ['requestUri' => $request->getUri()];
+
         if (null !== $localization = $portalInformation->getLocalization()) {
-            $request->setLocale($portalInformation->getLocalization()->getLocalization());
+            $request->setLocale($localization->getLocalization());
         }
 
         $attributes['portalInformation'] = $portalInformation;
@@ -59,7 +51,7 @@ abstract class AbstractRequestProcessor implements RequestProcessorInterface
         $attributes['portal'] = $portalInformation->getPortal();
 
         if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
-            return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+            return new RequestAttributes($attributes);
         }
 
         $attributes['localization'] = $portalInformation->getLocalization();
@@ -70,6 +62,7 @@ abstract class AbstractRequestProcessor implements RequestProcessorInterface
             $request
         );
 
+        $attributes['urlExpression'] = $portalInformation->getUrlExpression();
         $attributes['resourceLocator'] = $resourceLocator;
         $attributes['format'] = $format;
 
@@ -84,7 +77,15 @@ abstract class AbstractRequestProcessor implements RequestProcessorInterface
             $request->setRequestFormat($format);
         }
 
-        return new RequestAttributes(array_merge($attributes, $additionalAttributes));
+        return new RequestAttributes($attributes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(RequestAttributes $attributes)
+    {
+        return true;
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
@@ -51,6 +51,6 @@ class RequestAttributes
      */
     public function merge(RequestAttributes $requestAttributes)
     {
-        return new self(array_merge($this->attributes, $requestAttributes->attributes));
+        return new self(array_merge($requestAttributes->attributes, $this->attributes));
     }
 }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Extracts attributes from request for the sulu-website.
  */
-class WebsiteRequestProcessor extends AbstractRequestProcessor
+class WebsiteRequestProcessor implements RequestProcessorInterface
 {
     /**
      * @var WebspaceManagerInterface
@@ -91,11 +91,7 @@ class WebsiteRequestProcessor extends AbstractRequestProcessor
         /** @var PortalInformation $portalInformation */
         $portalInformation = reset($portalInformations);
 
-        return $this->processPortalInformation(
-            $request,
-            $portalInformation,
-            ['urlExpression' => $portalInformation->getUrlExpression()]
-        );
+        return new RequestAttributes(['portalInformation' => $portalInformation]);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -47,8 +47,8 @@ class RequestAnalyzer implements RequestAnalyzerInterface
         }
 
         $attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme()]);
-        foreach ($this->requestProcessors as $provider) {
-            $attributes = $attributes->merge($provider->process($request, $attributes));
+        foreach ($this->requestProcessors as $requestProcessor) {
+            $attributes = $attributes->merge($requestProcessor->process($request, $attributes));
         }
 
         $request->attributes->set('_sulu', $attributes);

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -125,6 +125,21 @@ class WebspaceManager implements WebspaceManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function findPortalInformationsByPortalKeyAndLocale($portalKey, $locale, $environment)
+    {
+        return array_filter(
+            $this->getWebspaceCollection()->getPortalInformations($environment),
+            function (PortalInformation $portalInformation) use ($portalKey, $locale) {
+                return $portalInformation->getPortal()
+                    && $portalInformation->getPortal()->getKey() === $portalKey
+                    && $portalInformation->getLocale() === $locale;
+            }
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findUrlsByResourceLocator(
         $resourceLocator,
         $environment,

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -66,9 +66,20 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
      * @param string $locale The locale which the portal should match
      * @param string $environment The environment in which the url should be searched
      *
-     * @return \Sulu\Component\Webspace\PortalInformation[]
+     * @return PortalInformation[]
      */
     public function findPortalInformationsByWebspaceKeyAndLocale($webspaceKey, $locale, $environment);
+
+    /**
+     * Returns all portal which matches the given portal-key and locale.
+     *
+     * @param string $portalKey The portal-key which the portal should match
+     * @param string $locale The locale which the portal should match
+     * @param string $environment The environment in which the url should be searched
+     *
+     * @return PortalInformation[]
+     */
+    public function findPortalInformationsByPortalKeyAndLocale($portalKey, $locale, $environment);
 
     /**
      * Returns all possible urls for resourcelocator.

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+
+use Sulu\Component\Webspace\Analyzer\Attributes\ParameterRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\HttpFoundation\Request;
+
+class ParameterRequestProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var ParameterRequestProcessor
+     */
+    private $parameterRequestProcessor;
+
+    public function setUp()
+    {
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+
+        $this->parameterRequestProcessor = new ParameterRequestProcessor(
+            $this->webspaceManager->reveal(),
+            'dev'
+        );
+    }
+
+    public function testProcess()
+    {
+        $request = new Request(['_portal' => 'sulu_io', '_locale' => 'de']);
+
+        $portalInformation = new PortalInformation(1);
+
+        $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale('sulu_io', 'de', 'dev')
+            ->willReturn([$portalInformation]);
+
+        $requestAttributes = $this->parameterRequestProcessor->process($request, new RequestAttributes());
+
+        $this->assertEquals($portalInformation, $requestAttributes->getAttribute('portalInformation'));
+    }
+
+    public function testProcessWithoutLocale()
+    {
+        $request = new Request(['_portal' => 'sulu_io']);
+
+        $this->assertEquals(
+            new RequestAttributes(),
+            $this->parameterRequestProcessor->process($request, new RequestAttributes())
+        );
+    }
+
+    public function testProcessWithoutPortal()
+    {
+        $request = new Request(['_locale' => 'sulu_io']);
+
+        $this->assertEquals(
+            new RequestAttributes(),
+            $this->parameterRequestProcessor->process($request, new RequestAttributes())
+        );
+    }
+
+    public function testValidate()
+    {
+        $this->assertTrue($this->parameterRequestProcessor->validate(new RequestAttributes()));
+    }
+}

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\PortalInformationRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PortalInformationRequestProcessor
+     */
+    private $provider;
+
+    public function setUp()
+    {
+        $this->provider = new PortalInformationRequestProcessor();
+    }
+
+    /**
+     * @dataProvider provideProcess
+     */
+    public function testProcess($config, $expected = [])
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+
+        $portal = new Portal();
+        $portal->setKey('sulu');
+
+        $localization = new Localization();
+        $localization->setCountry('at');
+        $localization->setLanguage('de');
+
+        $portalInformation = new PortalInformation(
+            $config['match_type'],
+            $webspace,
+            $portal,
+            $localization,
+            $config['portal_url'],
+            null,
+            $config['redirect'],
+            null,
+            false,
+            $config['url_expression']
+        );
+
+        $request = $this->getMock(Request::class);
+        $request->request = new ParameterBag(['post' => 1]);
+        $request->query = new ParameterBag(['get' => 1]);
+        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
+        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request->expects($this->once())->method('setLocale')->with($localization->getLocalization());
+
+        $attributes = $this->provider->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertEquals('de_at', $attributes->getAttribute('localization'));
+        $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
+        $this->assertEquals('sulu', $attributes->getAttribute('portal')->getKey());
+        $this->assertNull($attributes->getAttribute('segment'));
+
+        $this->assertEquals($expected['portal_url'], $attributes->getAttribute('portalUrl'));
+        $this->assertEquals($expected['redirect'], $attributes->getAttribute('redirect'));
+        $this->assertEquals($expected['resource_locator'], $attributes->getAttribute('resourceLocator'));
+        $this->assertEquals($expected['resource_locator_prefix'], $attributes->getAttribute('resourceLocatorPrefix'));
+        $this->assertEquals($expected['url_expression'], $attributes->getAttribute('urlExpression'));
+        $this->assertEquals(['post' => 1], $attributes->getAttribute('postParameter'));
+        $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
+    }
+
+    /**
+     * @dataProvider provideProcessWithFormat
+     */
+    public function testProcessWithFormat($config, $expected = [])
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+
+        $portal = new Portal();
+        $portal->setKey('sulu');
+
+        $localization = new Localization();
+        $localization->setCountry('at');
+        $localization->setLanguage('de');
+
+        $portalInformation = new PortalInformation(
+            $config['match_type'],
+            $webspace,
+            $portal,
+            $localization,
+            $config['portal_url'],
+            null,
+            $config['redirect']
+        );
+
+        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request->request = new ParameterBag(['post' => 1]);
+        $request->query = new ParameterBag(['get' => 1]);
+        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
+        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue($config['path_info']));
+        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request->expects($this->once())->method('setLocale')->with($localization->getLocalization());
+        if ($expected['format']) {
+            $request->expects($this->once())->method('setRequestFormat')->with($expected['format']);
+        }
+
+        $attributes = $this->provider->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertEquals('de_at', $attributes->getAttribute('localization'));
+        $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
+        $this->assertEquals('sulu', $attributes->getAttribute('portal')->getKey());
+        $this->assertNull($attributes->getAttribute('segment'));
+
+        $this->assertEquals($expected['portal_url'], $attributes->getAttribute('portalUrl'));
+        $this->assertEquals($expected['redirect'], $attributes->getAttribute('redirect'));
+        $this->assertEquals($expected['resource_locator'], $attributes->getAttribute('resourceLocator'));
+        $this->assertEquals($expected['resource_locator_prefix'], $attributes->getAttribute('resourceLocatorPrefix'));
+        $this->assertEquals($expected['format'], $attributes->getAttribute('format'));
+        $this->assertEquals(['post' => 1], $attributes->getAttribute('postParameter'));
+        $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
+    }
+
+    public function testValidate()
+    {
+        $this->assertTrue($this->provider->validate(new RequestAttributes()));
+    }
+
+    public function provideProcess()
+    {
+        return [
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'path_info' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo',
+                    'path_info' => '/test/path/to',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                    'redirect' => 'sulu.lo/test',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+                [
+                    'redirect' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'portal_url' => 'sulu.lo',
+                    'url_expression' => 'sulu.lo/{localization}',
+                ],
+            ],
+        ];
+    }
+
+    public function provideProcessWithFormat()
+    {
+        return [
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to.html',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => 'html',
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo',
+                    'path_info' => '/test/path/to.rss',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
+                    'redirect' => 'sulu.lo/test',
+                ],
+                [
+                    'redirect' => 'sulu.lo/test',
+                    'resource_locator_prefix' => '',
+                    'resource_locator' => '/test/path/to',
+                    'portal_url' => 'sulu.lo',
+                    'format' => 'rss',
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => null,
+                ],
+            ],
+            [
+                [
+                    'portal_url' => 'sulu.lo/test',
+                    'path_info' => '/test/path/to/test.min.css',
+                    'match_type' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+                    'redirect' => '',
+                ],
+                [
+                    'redirect' => null,
+                    'resource_locator_prefix' => '/test',
+                    'resource_locator' => '/path/to/test',
+                    'portal_url' => 'sulu.lo/test',
+                    'format' => 'css',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/RequestAttributesTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/RequestAttributesTest.php
@@ -55,7 +55,7 @@ class RequestAttributesTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($result2, $instance2);
         $this->assertNotSame($result2, $instance3);
 
-        $this->assertEquals(2, $result2->getAttribute('test1'));
+        $this->assertEquals(1, $result2->getAttribute('test1'));
         $this->assertEquals(3, $result2->getAttribute('test2'));
         $this->assertEquals(null, $result2->getAttribute('test3'));
     }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -496,6 +496,21 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('de_at', $portalInformation->getLocale());
     }
 
+    public function testFindPortalInformationsByPortalKeyAndLocale()
+    {
+        $portalInformations = $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale(
+            'sulucmf_at',
+            'de_at',
+            'dev'
+        );
+
+        $this->assertCount(1, $portalInformations);
+
+        $portalInformation = reset($portalInformations);
+        $this->assertEquals('sulucmf_at', $portalInformation->getPortal()->getKey());
+        $this->assertEquals('de_at', $portalInformation->getLocale());
+    }
+
     public function testFindPortalInformationByUrlWithSegment()
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('en.massiveart.us/w/about-us', 'prod');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/220

#### What's in this PR?

This PR introduces another `RequestProcessor`, the `ParameterRequestProcessor`, which takes the information for portals from the `_locale` and `_request` parameters from the request. These take precedence over the other methods to analyze the request.

#### Why?

This is necessary because ESI requests can't be properly handled otherwise. So if there is a twig line like the following:

```jinja
{{ render(controller('ClientWebsiteBundle:Search:query')) }}
```

It's not working properly, because the underlying controller needs values from the `RequestAnalyzer`. This worked before 1.2, but was also not correct, it simply took the values from the master request. That also means that it would have failed if only the ESI request was sent.

#### Example Usage

The above example would now look like that:

~~~jinja
{{ render(controller('ClientWebsiteBundle:Search:query', {q: 'Test', _portal: 'sulu_io'})) }}
~~~

#### To Do

- [x] Create a documentation PR
- [x] Test in production

