### PR TITLE
Fixed hreflang-tag for homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2362 [Website]           Fixed hreflang-tag for homepage
     * ENHANCEMENT #2346 [ResourceBundle]    Added fixtures for de_CH
     * ENHANCEMENT #2346 [AdminBundle]       Use always users locale for globalize culture
 

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -141,7 +141,7 @@ class RequestAnalyzer implements RequestAnalyzerInterface
      */
     public function getResourceLocator()
     {
-        return $this->getAttribute('resourceLocator');
+        return $this->getAttribute('resourceLocator', false);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -163,7 +163,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
             [['redirect' => 1], 'getRedirect', 1],
             [[], 'getRedirect', null],
             [['resourceLocator' => 1], 'getResourceLocator', 1],
-            [[], 'getResourceLocator', null],
+            [[], 'getResourceLocator', false],
             [['resourceLocatorPrefix' => 1], 'getResourceLocatorPrefix', 1],
             [[], 'getResourceLocatorPrefix', null],
             [['postParameter' => 1], 'getPostParameters', 1],
@@ -195,6 +195,6 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $requestAnalyzer->analyze($request);
         $requestAnalyzer->validate($request);
 
-        $this->assertEquals($expected, $requestAnalyzer->{$method}());
+        $this->assertSame($expected, $requestAnalyzer->{$method}());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the default value to `false` for `getResourceLocator` in the `RequestAnalyzer`.

#### Why?

False was returned before refactoring the `RequestAnalyzer` and will be needed to render the `hreflang` tag for the homepage see following file: https://github.com/sulu/sulu/blob/develop/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php#L205
