### PR TITLE
Fixed sulu-content-path for webspaces with different domains for locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * HOTFIX      #2362 [Website]             Fixed hreflang-tag for homepage
     * BUGFIX      #2364 [CoreBundle]          DependencyInjection: Throw exception when locales/translations are misconfigured
     * BUGFIX      #2364 [ResourceBundle]      Moved fixtures from de_CH to de_ch
+    * HOTFIX      #2363 [WebsiteBundle]       Fixed sulu-content-path for webspaces with different domains for locales
     * ENHANCEMENT #2346 [ResourceBundle]      Added fixtures for de_CH
     * ENHANCEMENT #2346 [AdminBundle]         Use always users locale for globalize culture
     * HOTFIX      #2347 [ContentBundle]       Fixed ghost children loading

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -71,7 +71,6 @@
 
         <!-- twig extension: content path -->
         <service id="sulu_website.twig.content_path" class="%sulu_website.twig.content_path.class%">
-            <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%kernel.environment%</argument>
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Twig;
+
+use Prophecy\Argument;
+use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathTwigExtension;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var Webspace
+     */
+    private $suluWebspace;
+
+    /**
+     * @var Webspace
+     */
+    private $testWebspace;
+
+    /**
+     * @var string
+     */
+    private $environment = 'prod';
+
+    /**
+     * @var ContentPathTwigExtension
+     */
+    private $extension;
+
+    protected function setUp()
+    {
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->suluWebspace = $this->prophesize(Webspace::class);
+        $this->suluWebspace->getKey()->willReturn('sulu_io');
+        $this->suluWebspace->hasDomain('www.sulu.io', $this->environment)->willReturn(true);
+        $this->suluWebspace->hasDomain('www.test.io', $this->environment)->willReturn(false);
+
+        $this->testWebspace = $this->prophesize(Webspace::class);
+        $this->testWebspace->getKey()->willReturn('test_io');
+        $this->testWebspace->hasDomain('www.test.io', $this->environment)->willReturn(true);
+        $this->testWebspace->hasDomain('www.sulu.io', $this->environment)->willReturn(false);
+
+        $this->requestAnalyzer->getAttribute('scheme')->willReturn('http');
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+        $this->requestAnalyzer->getWebspace()->willReturn($this->suluWebspace->reveal());
+
+        $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn($this->suluWebspace->reveal());
+        $this->webspaceManager->findWebspaceByKey('test_io')->willReturn($this->testWebspace->reveal());
+
+        $this->extension = new ContentPathTwigExtension(
+            $this->webspaceManager->reveal(),
+            $this->environment,
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    public function testGetContentPath()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'http'
+        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
+    }
+
+    public function testGetContentPathWithWebspaceKey()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'test_io',
+            'www.test.io',
+            'http'
+        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test', 'test_io'));
+    }
+
+    public function testGetContentPathWithWebspaceKeyNotFoundForDomain()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'test_io',
+            'www.test.io',
+            'http'
+        )->willReturn(null)->shouldBeCalledTimes(1);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'test_io',
+            null,
+            'http'
+        )->willReturn('www.test.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.test.io/de/test', $this->extension->getContentPath('/test', 'test_io'));
+    }
+
+    public function testGetContentPathWithWebspaceKeyHostNotWebspace()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.xy.io');
+        $this->testWebspace->hasDomain('www.xy.io', $this->environment)->willReturn(false);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'test_io',
+            null,
+            'http'
+        )->willReturn('www.test.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.test.io/de/test', $this->extension->getContentPath('/test', 'test_io'));
+    }
+
+    public function testGetContentPathWithWebspaceKeyAndDomain()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'en',
+            'test_io',
+            'www.test.io',
+            'http'
+        )->willReturn(null)->shouldBeCalledTimes(1);
+
+        $this->assertEquals(
+            '/test',
+            $this->extension->getContentPath('/test', 'test_io', 'en', 'www.test.io')
+        );
+    }
+
+    public function testGetContentPathExternalUrl()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->webspaceManager->findUrlByResourceLocator(
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any()
+        )->shouldNotBeCalled();
+
+        $this->assertEquals(
+            'http://www.google.at',
+            $this->extension->getContentPath('http://www.google.at')
+        );
+        $this->assertEquals(
+            'http://www.google.at',
+            $this->extension->getContentPath('http://www.google.at', 'test_io')
+        );
+        $this->assertEquals(
+            'http://www.google.at',
+            $this->extension->getContentPath('http://www.google.at', 'test_io', 'en')
+        );
+        $this->assertEquals(
+            'http://www.google.at',
+            $this->extension->getContentPath('http://www.google.at', 'test_io', 'en', 'www.test.io')
+        );
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathInterface.php
@@ -19,7 +19,7 @@ interface ContentPathInterface
     /**
      * Generates real url for given content.
      *
-     * @param string $url
+     * @param string $route
      * @param string $webspaceKey
      * @param string $locale
      * @param string $domain
@@ -27,7 +27,7 @@ interface ContentPathInterface
      *
      * @return string
      */
-    public function getContentPath($url, $webspaceKey = null, $locale = null, $domain = null, $scheme = 'http');
+    public function getContentPath($route, $webspaceKey = null, $locale = null, $domain = null, $scheme = 'http');
 
     /**
      * Generates real root url.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2358
| Related issues/PRs | none
| License | MIT
| Documentation PR | non

#### What's in this PR?

This PR introduces a fallback if a url for for current host does not exists.

If you pass no domain to `sulu_content_path('/test', 'sulu_io', 'en')` but the the domain of `en` is a different one than the current one.

#### Why?

Explained in the linked issue.
