### PR TITLE
fixed copying shadow properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #2365                       Fixed missing and wrong method mocks
+    * HOTFIX      #2368 [ContentBundle]       Fixed copying shadow properties
     * HOTFIX      #2362 [Website]             Fixed hreflang-tag for homepage
     * BUGFIX      #2364 [CoreBundle]          DependencyInjection: Throw exception when locales/translations are misconfigured
     * BUGFIX      #2364 [ResourceBundle]      Moved fixtures from de_CH to de_ch

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -47,7 +47,10 @@ class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return [Events::PERSIST => 'handlePersist'];
+        return [
+            // has to happen after MappingSubscriber, because properties to copy have old values otherwise
+            Events::PERSIST => ['handlePersist', -256],
+        ];
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Functional/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Functional\Document\Subscriber;
+
+use PHPCR\SessionInterface;
+use Sulu\Bundle\ContentBundle\Document\HomeDocument;
+use Sulu\Bundle\ContentBundle\Document\PageDocument;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+
+class ShadowCopyPropertiesSubscriberTest extends \Sulu\Bundle\TestBundle\Testing\SuluTestCase
+{
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var HomeDocument
+     */
+    private $homeDocument;
+
+    public function setUp()
+    {
+        $this->initPhpcr();
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+
+        $this->homeDocument = $this->documentManager->find('/cmf/sulu_io/contents', 'en');
+
+        $englishDocument = $this->documentManager->create('page');
+        $englishDocument->setStructureType('default');
+        $englishDocument->setParent($this->homeDocument);
+        $englishDocument->setTitle('English page');
+        $englishDocument->setResourceSegment('/english-page');
+        $this->documentManager->persist($englishDocument, 'en');
+
+        $this->documentManager->flush();
+
+        $germanDocument = $this->documentManager->find($englishDocument->getUuid(), 'de');
+        $germanDocument->setStructureType('default');
+        $germanDocument->setParent($this->homeDocument);
+        $germanDocument->setTitle('Deutsche Seite');
+        $germanDocument->setResourceSegment('/deutsche-seite');
+        $this->documentManager->persist($germanDocument, 'de');
+
+        $this->documentManager->flush();
+
+        $this->documentManager->clear();
+        $this->session->refresh(false);
+    }
+
+    public function testCopyShadowPropertiesToShadow()
+    {
+        /** @var PageDocument $germanDocument */
+        $germanDocument = $this->documentManager->find('/cmf/sulu_io/contents/english-page', 'de');
+        $germanDocument->setShadowLocale('en');
+        $germanDocument->setShadowLocaleEnabled(true);
+
+        $this->documentManager->persist($germanDocument, 'de');
+        $this->documentManager->flush();
+
+        /** @var PageDocument $englishDocument */
+        $englishDocument = $this->documentManager->find('/cmf/sulu_io/contents/english-page', 'en');
+        $englishDocument->setExtensionsData([
+            'excerpt' => [
+                'tags' => ['tag1', 'tag2'],
+            ],
+        ]);
+        $englishDocument->setNavigationContexts(['main']);
+
+        $this->documentManager->persist($englishDocument, 'en');
+
+        $node = $this->session->getNode('/cmf/sulu_io/contents/english-page');
+
+        $this->assertCount(2, $node->getPropertyValue('i18n:en-excerpt-tags'));
+        $this->assertCount(2, $node->getPropertyValue('i18n:de-excerpt-tags'));
+        $this->assertEquals(['main'], $node->getPropertyValue('i18n:en-navContexts'));
+        $this->assertEquals(['main'], $node->getPropertyValue('i18n:de-navContexts'));
+    }
+
+    public function testCopyShadowPropertiesFromShadow()
+    {
+        /** @var PageDocument $englishDocument */
+        $englishDocument = $this->documentManager->find('/cmf/sulu_io/contents/english-page', 'en');
+        $englishDocument->setExtensionsData([
+            'excerpt' => [
+                'tags' => ['tag1', 'tag2'],
+            ],
+        ]);
+        $englishDocument->setNavigationContexts(['main']);
+
+        $this->documentManager->persist($englishDocument, 'en');
+        $this->documentManager->flush();
+
+        $this->documentManager->clear();
+        $this->session->refresh(false);
+
+        /** @var PageDocument $germanDocument */
+        $germanDocument = $this->documentManager->find('/cmf/sulu_io/contents/english-page', 'de');
+        $germanDocument->setShadowLocale('en');
+        $germanDocument->setShadowLocaleEnabled(true);
+
+        $this->documentManager->persist($germanDocument, 'de');
+
+        $node = $this->session->getNode('/cmf/sulu_io/contents/english-page');
+
+        $this->assertCount(2, $node->getPropertyValue('i18n:en-excerpt-tags'));
+        $this->assertCount(2, $node->getPropertyValue('i18n:de-excerpt-tags'));
+        $this->assertEquals(['main'], $node->getPropertyValue('i18n:en-navContexts'));
+        $this->assertEquals(['main'], $node->getPropertyValue('i18n:de-navContexts'));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR corrects the priority of the `ShadowCopySubscriber`.

#### Why?

The `ShadowCopySubscriber` must be called after the `MappingSubscriber`, because otherwise the navigation contexts are not already written on the node and therefore not copied.
