### PR TITLE
Install the symfony phpunit bridge again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2369 [All]                 Install the symfony phpunit bridge again
     * ENHANCEMENT #2356 [PreviewBundle]       Added default error message 
     * BUGFIX      #2354 [ContentBundle]       Fixed javascript error preview is null for new page form 
     * FEATURE     #2333 [PreviewBundle]       Added preview render error templates 

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "matthiasnoback/symfony-config-test": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.3",
         "phpunit/phpunit": ">=4.8.0",
+        "symfony/phpunit-bridge": "~2.8",
         "sensio/framework-extra-bundle": "~3.0",
         "symfony/monolog-bundle": "2.4.*",
         "twig/twig": "~1.11",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | (yes)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Install the symfony phpunit bridge again to get the count of deprecation notices in the phpunit tests.

#### Why?

The phpunit bridge was unintentionally removed with #2242 when the `symfony-cmf/testing` was removed. I never checked if the bridge was a direct dev dependency of sulu.