### PR TITLE
Use Doctrine DBAL as default PHPCR-Backend for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2370 [TestBundle]          Use Doctrine DBAL as default PHPCR-Backend
     * BUGFIX      #2369 [All]                 Install the symfony phpunit bridge again
     * ENHANCEMENT #2356 [PreviewBundle]       Added default error message 
     * BUGFIX      #2354 [ContentBundle]       Fixed javascript error preview is null for new page form 

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml
@@ -8,7 +8,7 @@ parameters:
     database.password: ~
     database.version:  5.5
 
-    phpcr.transport:   jackrabbit
+    phpcr.transport:   doctrinedbal
     phpcr.backend_url: http://localhost:8080/server/
     phpcr.username:    admin
     phpcr.password:    admin


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#222

#### What's in this PR?

Changes the default PHPCR-Backend for the tests to Doctrine DBAL instead of jackrabbit, thus first timers who quickly want to run the tests don't have to hussle with Jackrabbit.

#### Why?

For me it was relative easy to get Jackrabbit installed with the bash snippet extracted from `.travis.yml`, but anyone new to the project, doesn't know how to download Jackrabbit to the correct location. And the docs were misleading since the `bin/jacrabbit.sh` script was removed.