### PR TITLE
Added cleanup for structure reindex provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #2376 [ContentBundle]       Added cleanup for structure reindex provider
+
 * 1.2.2 (2016-05-09)
     * HOTFIX      #2375 [SecurityBundle]      Fixed visibility of entries in language dropdown
     * ENHANCEMENT #2373 [MediaBundle]         Added batch indexing for medias

--- a/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
@@ -99,6 +99,14 @@ class StructureProvider implements LocalizedReindexProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function cleanUp($classFqn)
+    {
+        $this->documentManager->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getCount($classFqn)
     {
         $query = $this->getQuery($classFqn);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/ReIndex/StructureProviderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/ReIndex/StructureProviderTest.php
@@ -233,4 +233,12 @@ class StructureProviderTest extends \PHPUnit_Framework_TestCase
             $this->structure->reveal(),
         ], $results);
     }
+
+    public function testCleanup()
+    {
+        $classFqn = 'Foo';
+        $this->provider->cleanUp($classFqn);
+
+        $this->documentManager->clear()->shouldBeCalled();
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (momory-usage)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #1762
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/92
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a cleanup method for StructureProvider. This cleanup the document-manager to reduce memory usage.

#### Why?

After a while and enough entities the memory usage raises up to the limit.
