### PR TITLE
Made --router and --env optional when running the console commands server:run and server:start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2305 [WebsiteBundle]       Fixed handling of non-default formats in error pages
     * ENHANCEMENT #2341 [MediaBundle]         Added category to medias
     * ENHANCEMENT #2323 [WebsiteBundle]       Added TWIG-Extension to check if parent nav-item is active
+    * ENHANCEMENT #2377 [CoreBundle]          Made --router and --env optional when running the console commands server:run, server:start, server:stop and server:status
 
 * 1.2.2 (2016-05-09)
     * HOTFIX      #2375 [SecurityBundle]      Fixed visibility of entries in language dropdown

--- a/src/Sulu/Bundle/CoreBundle/Command/DetermineServerInfoTrait.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/DetermineServerInfoTrait.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+trait DetermineServerInfoTrait
+{
+    /**
+     * @return ContainerInterface
+     *
+     * @throws \LogicException
+     */
+    abstract protected function getContainer();
+
+    /**
+     * Determine the absolute file path for the router script, using the
+     * environment to choose a standard script if no custom router script is
+     * specified.
+     *
+     * @param string|null  $router  File path of the custom router script, if
+     *                              set by the user; otherwise null
+     * @param string       $context The context of the application kernel
+     * @param SymfonyStyle $io      An SymfonyStyle instance
+     *
+     * @return bool|string The absolute file path of the router script, or false
+     *                     on failure
+     */
+    private function determineRouterScript($router, $context, SymfonyStyle $io)
+    {
+        if (null === $router) {
+            $router = $this
+                ->getContainer()
+                ->get('kernel')
+                ->locateResource(sprintf(
+                    '@SuluCoreBundle/Resources/config/router_%s.php',
+                    $context
+                ))
+            ;
+        }
+
+        if (false === $path = realpath($router)) {
+            $io->error(sprintf('The given router script "%s" does not exist.', $router));
+
+            return false;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Determine the web server port that should be used.
+     *
+     * @param string|null  $port    The port, if set by the user; otherwise null
+     * @param string       $context The context of the application kernel
+     *
+     * @return string The web server port to use
+     */
+    private function determinePort($port, $context)
+    {
+        if (null === $port) {
+            return 'website' === $context ? '8001' : '8000';
+        }
+
+        return $port;
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Command/ServerRunCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/ServerRunCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ServerRunCommand as BaseServerRunCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ServerRunCommand extends BaseServerRunCommand
+{
+    use DetermineServerInfoTrait;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        // We'll determine the port dynamically
+        $this->getDefinition()->getOption('port')->setDefault(null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $context = $this->getContainer()->getParameter('sulu.context');
+        $io = new SymfonyStyle($input, $cliOutput = $output);
+
+        if (false === $router = $this->determineRouterScript($input->getOption('router'), $context, $io)) {
+            return 1;
+        }
+
+        $port = $this->determinePort($input->getOption('port'), $context);
+
+        $input->setOption('router', $router);
+        $input->setOption('port', $port);
+
+        return parent::execute($input, $output);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Command/ServerStartCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/ServerStartCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ServerStartCommand as BaseServerStartCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ServerStartCommand extends BaseServerStartCommand
+{
+    use DetermineServerInfoTrait;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        // We'll determine the port dynamically
+        $this->getDefinition()->getOption('port')->setDefault(null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $context = $this->getContainer()->getParameter('sulu.context');
+        $io = new SymfonyStyle($input, $cliOutput = $output);
+
+        if (false === $router = $this->determineRouterScript($input->getOption('router'), $context, $io)) {
+            return 1;
+        }
+
+        $port = $this->determinePort($input->getOption('port'), $context);
+
+        $input->setOption('router', $router);
+        $input->setOption('port', $port);
+
+        return parent::execute($input, $output);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Command/ServerStatusCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/ServerStatusCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ServerStatusCommand as BaseServerStatusCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ServerStatusCommand extends BaseServerStatusCommand
+{
+    use DetermineServerInfoTrait;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->addOption('port', 'p', InputOption::VALUE_REQUIRED, 'Address port number');
+
+        $this->getDefinition()->getArgument('address')->setDefault('127.0.0.1');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $context = $this->getContainer()->getParameter('sulu.context');
+
+        $port = $this->determinePort($input->getOption('port'), $context);
+
+        $address = $input->getArgument('address');
+
+        if (false === strpos($address, ':')) {
+            $address = $address . ':' . $port;
+        }
+
+        $input->setOption('port', $port);
+        $input->setArgument('address', $address);
+
+        return parent::execute($input, $output);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Command/ServerStopCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/ServerStopCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ServerStopCommand as BaseServerStopCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ServerStopCommand extends BaseServerStopCommand
+{
+    use DetermineServerInfoTrait;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        // We'll determine the port dynamically
+        $this->getDefinition()->getOption('port')->setDefault(null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $context = $this->getContainer()->getParameter('sulu.context');
+
+        $port = $this->determinePort($input->getOption('port'), $context);
+
+        $input->setOption('port', $port);
+
+        return parent::execute($input, $output);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/router_admin.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/router_admin.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/*
+ * This file implements rewrite rules for PHP built-in web server.
+ *
+ * See: http://www.php.net/manual/en/features.commandline.webserver.php
+ */
+
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'dev');
+
+if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
+    return false;
+}
+
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'admin.php';
+
+require 'admin.php';

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/router_website.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/router_website.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/*
+ * This file implements rewrite rules for PHP built-in web server.
+ *
+ * See: http://www.php.net/manual/en/features.commandline.webserver.php
+ */
+
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'dev');
+
+if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
+    return false;
+}
+
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'website.php';
+
+require 'website.php';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2069, fixes #2070
| Related issues/PRs | -
| License | MIT
| Documentation PR | to do

#### What's in this PR?

This PR simplifies running Sulu with PHP's built-in server. Running the server is as simple as:

~~~
$ app/console server:start
$ app/webconsole server:start
~~~

The servers for the admin and the website are started on the ports 8000 respectively 8001.

#### Why?

Currently, a user has to pass the correct values in the `--router`, `--env` and `--port` options of the server:run and server:start commands. This makes getting started with Sulu harder than necessary.