### PR TITLE
fixed writing security for page documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #2378 [ContentBundle]       Fixed writing security to page documents
+
 * 1.2.2 (2016-05-09)
     * HOTFIX      #2375 [SecurityBundle]      Fixed visibility of entries in language dropdown
     * ENHANCEMENT #2373 [MediaBundle]         Added batch indexing for medias

--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -73,7 +73,8 @@ class SecuritySubscriber implements EventSubscriberInterface
         $node = $event->getNode();
 
         foreach ($document->getPermissions() as $roleId => $permission) {
-            $node->setProperty('sec:role-' . $roleId, $permission); // TODO use PropertyEncoder, once it is refactored
+            // TODO use PropertyEncoder, once it is refactored
+            $node->setProperty('sec:role-' . $roleId, $this->getAllowedPermissions($permission));
         }
     }
 
@@ -104,5 +105,24 @@ class SecuritySubscriber implements EventSubscriberInterface
         }
 
         $document->setPermissions($permissions);
+    }
+
+    /**
+     * Extracts the keys of the allowed permissions into an own array.
+     *
+     * @param $permissions
+     *
+     * @return array
+     */
+    private function getAllowedPermissions($permissions)
+    {
+        $allowedPermissions = [];
+        foreach ($permissions as $permission => $allowed) {
+            if ($allowed) {
+                $allowedPermissions[] = $permission;
+            }
+        }
+
+        return $allowedPermissions;
     }
 }

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -669,7 +669,17 @@ class ContentRepositoryTest extends SuluTestCase
         $user = $this->prophesize(UserInterface::class);
         $user->getRoleObjects()->willReturn([$role1->reveal(), $role2->reveal()]);
 
-        $page = $this->createPage('test-1', 'de', [], null, [1 => 'edit', 2 => 'view archive', 3 => 'add']);
+        $page = $this->createPage(
+            'test-1',
+            'de',
+            [],
+            null,
+            [
+                1 => ['edit' => true],
+                2 => ['view' => true, 'archive' => true],
+                3 => ['add' => true],
+            ]
+        );
 
         $result = $this->contentRepository->find(
             $page->getUuid(),

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -35,7 +35,7 @@ class SecuritySubscriberTest extends SubscriberTestCase
         /** @var SecurityBehavior $document */
         $document = $this->prophesize(SecurityBehavior::class);
         $document->getPermissions()->willReturn(
-            [1 => ['view', 'add', 'edit']]
+            [1 => ['view' => true, 'add' => true, 'edit' => true, 'delete' => false]]
         );
 
         $this->persistEvent->getDocument()->willReturn($document);

--- a/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
@@ -47,13 +47,8 @@ class PhpcrAccessControlProvider implements AccessControlProviderInterface
      */
     public function setPermissions($type, $identifier, $permissions)
     {
-        $allowedPermissions = [];
-        foreach ($permissions as $roleId => $rolePermissions) {
-            $allowedPermissions[$roleId] = $this->getAllowedPermissions($rolePermissions);
-        }
-
         $document = $this->documentManager->find($identifier, null, ['rehydrate' => false]);
-        $document->setPermissions($allowedPermissions);
+        $document->setPermissions($permissions);
 
         $this->documentManager->persist($document);
         $this->documentManager->flush();
@@ -92,24 +87,5 @@ class PhpcrAccessControlProvider implements AccessControlProviderInterface
         }
 
         return $class->implementsInterface(SecurityBehavior::class);
-    }
-
-    /**
-     * Extracts the keys of the allowed permissions into an own array.
-     *
-     * @param $permissions
-     *
-     * @return array
-     */
-    private function getAllowedPermissions($permissions)
-    {
-        $allowedPermissions = [];
-        foreach ($permissions as $permission => $allowed) {
-            if ($allowed) {
-                $allowedPermissions[] = $permission;
-            }
-        }
-
-        return $allowedPermissions;
     }
 }

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/PhpcrAccessControlProviderTest.php
@@ -45,7 +45,7 @@ class PhpcrAccessControlProviderTest extends \PHPUnit_Framework_TestCase
         $document->willImplement(SecurityBehavior::class);
 
         $this->documentManager->find('1', null, ['rehydrate' => false])->willReturn($document);
-        $document->setPermissions(['role' => ['view']])->shouldBeCalled();
+        $document->setPermissions(['role' => ['view' => true, 'edit' => false]])->shouldBeCalled();
         $this->documentManager->persist($document)->shouldBeCalled();
         $this->documentManager->flush()->shouldBeCalled();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This content repairs the saving of document security.

#### Why?

There was a bug concerning documents with security. If the document had some security set, and was save another time using the content tab in the Sulu-Admin, the `sec:*` properties in the node contained boolean values instead of the permission strings. This lead to a not properly working Sulu-Admin (the document was not editable anymore, because the wrong permissions were used to evaluate that)