### PR TITLE
inject CategoryRepositoy in MediaManager to avoid using removed constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2379 [MediaBundle]         Inject CategoryRepository in MediaManager to avoid using removed constant
     * BUGFIX      #2369 [All]                 Install the symfony phpunit bridge again
     * ENHANCEMENT #2356 [PreviewBundle]       Added default error message 
     * BUGFIX      #2354 [ContentBundle]       Fixed javascript error preview is null for new page form 

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\MediaBundle\Media\Manager;
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
 use FFMpeg\FFProbe;
+use Sulu\Bundle\CategoryBundle\Category\CategoryRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionRepository;
@@ -62,6 +63,11 @@ class MediaManager implements MediaManagerInterface
      * @var CollectionRepository
      */
     protected $collectionRepository;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    protected $categoryRepository;
 
     /**
      * @var EntityManager
@@ -160,6 +166,7 @@ class MediaManager implements MediaManagerInterface
         MediaRepositoryInterface $mediaRepository,
         CollectionRepositoryInterface $collectionRepository,
         UserRepositoryInterface $userRepository,
+        CategoryRepositoryInterface $categoryRepository,
         EntityManager $em,
         StorageInterface $storage,
         FileValidatorInterface $validator,
@@ -177,6 +184,7 @@ class MediaManager implements MediaManagerInterface
         $this->mediaRepository = $mediaRepository;
         $this->collectionRepository = $collectionRepository;
         $this->userRepository = $userRepository;
+        $this->categoryRepository = $categoryRepository;
         $this->em = $em;
         $this->storage = $storage;
         $this->validator = $validator;
@@ -596,8 +604,7 @@ class MediaManager implements MediaManagerInterface
 
                         if (is_array($categoryIds) && !empty($categoryIds)) {
                             /** @var CategoryRepositoryInterface $repository */
-                            $repository = $this->em->getRepository(self::ENTITY_NAME_CATEGORY);
-                            $categories = $repository->findCategoryByIds($categoryIds);
+                            $categories = $this->categoryRepository->findCategoryByIds($categoryIds);
 
                             foreach ($categories as $category) {
                                 $media->addCategory($category);

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -94,6 +94,7 @@
             <argument type="service" id="sulu_media.media_repository" />
             <argument type="service" id="sulu_media.collection_repository" />
             <argument type="service" id="sulu.repository.user" />
+            <argument type="service" id="sulu_category.category_repository"/>
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="sulu_media.storage" />
             <argument type="service" id="sulu_media.file_validator" />

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -16,6 +16,7 @@ use FFMpeg\FFProbe;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\CategoryBundle\Category\CategoryRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\File;
@@ -59,6 +60,11 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
      * @var ObjectProphecy
      */
     private $userRepository;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    private $categoryRepository;
 
     /**
      * @var ObjectProphecy
@@ -122,6 +128,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $this->mediaRepository = $this->prophesize(MediaRepositoryInterface::class);
         $this->collectionRepository = $this->prophesize(CollectionRepositoryInterface::class);
         $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
+        $this->categoryRepository = $this->prophesize(CategoryRepositoryInterface::class);
         $this->em = $this->prophesize(EntityManager::class);
         $this->storage = $this->prophesize(StorageInterface::class);
         $this->validator = $this->prophesize(FileValidatorInterface::class);
@@ -138,6 +145,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
             $this->mediaRepository->reveal(),
             $this->collectionRepository->reveal(),
             $this->userRepository->reveal(),
+            $this->categoryRepository->reveal(),
             $this->em->reveal(),
             $this->storage->reveal(),
             $this->validator->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | #2359 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the usage of the entity manager to get the `CollectionRepository` using the entity manager and injects the `CollectionRepository` instead.

#### Why?

#2359 removed some constants, but another usage of this constant was added in the `develop` branch. 