### PR TITLE
Added column definitions to resource-bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * HOTFIX      #2378 [ContentBundle]       Fixed writing security to page documents
     * HOTFIX      #2376 [ContentBundle]       Added cleanup for structure reindex provider
+    * HOTFIX      #2382 [ResourceBundle]      Added column definitions to resource-bundle
 
 * 1.2.2 (2016-05-09)
     * HOTFIX      #2375 [SecurityBundle]      Fixed visibility of entries in language dropdown

--- a/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/Condition.orm.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/Condition.orm.xml
@@ -7,10 +7,10 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="field" type="string" length="255" nullable="false"/>
-        <field name="operator" type="string" length="255" nullable="false"/>
-        <field name="type" type="integer" nullable="false"/>
-        <field name="value" type="json_array" nullable="false"/>
+        <field name="field" column="field" type="string" length="255" nullable="false"/>
+        <field name="operator" column="operator" type="string" length="255" nullable="false"/>
+        <field name="type" column="type" type="integer" nullable="false"/>
+        <field name="value" column="value" type="json_array" nullable="false"/>
 
         <many-to-one target-entity="Sulu\Bundle\ResourceBundle\Entity\ConditionGroup" field="conditionGroup"
                      inversed-by="conditions">

--- a/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/Filter.orm.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/Filter.orm.xml
@@ -12,8 +12,8 @@
         <field name="conjunction" type="string" length="10" column="conjunction" nullable="true"/>
         <field name="context" type="string" column="context" length="255" nullable="false"/>
         <field name="private" type="boolean" column="private" nullable="false"/>
-        <field name="created" type="datetime" length="255"/>
-        <field name="changed" type="datetime" length="255"/>
+        <field name="created" column="created" type="datetime" length="255"/>
+        <field name="changed" column="changed" type="datetime" length="255"/>
 
         <one-to-many target-entity="Sulu\Bundle\ResourceBundle\Entity\FilterTranslation" mapped-by="filter"
                      field="translations">

--- a/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/FilterTranslation.orm.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/FilterTranslation.orm.xml
@@ -6,10 +6,10 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="name" type="string" length="255" nullable="true"/>
-        <field name="locale" type="string" length="10"/>
-        <field name="shortDescription" type="text" nullable="true"/>
-        <field name="longDescription" type="text" nullable="true"/>
+        <field name="name" column="name" type="string" length="255" nullable="true"/>
+        <field name="locale" column="locale" type="string" length="10"/>
+        <field name="shortDescription" column="shortDescription" type="text" nullable="true"/>
+        <field name="longDescription" column="longDescription" type="text" nullable="true"/>
 
         <many-to-one target-entity="Sulu\Bundle\ResourceBundle\Entity\Filter" field="filter"
                      inversed-by="translations">

--- a/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/OperatorTranslation.orm.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/OperatorTranslation.orm.xml
@@ -6,10 +6,10 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="name" type="string" length="255" nullable="true"/>
-        <field name="locale" type="string" length="10" nullable="false"/>
-        <field name="shortDescription" type="text" nullable="true"/>
-        <field name="longDescription" type="text" nullable="true"/>
+        <field name="name" column="name" type="string" length="255" nullable="true"/>
+        <field name="locale" column="locale" type="string" length="10"/>
+        <field name="shortDescription" column="shortDescription" type="text" nullable="true"/>
+        <field name="longDescription" column="longDescription" type="text" nullable="true"/>
 
         <many-to-one target-entity="Sulu\Bundle\ResourceBundle\Entity\Operator" field="operator"
                      inversed-by="translations">

--- a/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/OperatorValueTranslation.orm.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Resources/config/doctrine/OperatorValueTranslation.orm.xml
@@ -6,10 +6,10 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="name" type="string" length="255" nullable="true"/>
-        <field name="locale" type="string" length="10"/>
-        <field name="shortDescription" type="text" nullable="true"/>
-        <field name="longDescription" type="text" nullable="true"/>
+        <field name="name" column="name" type="string" length="255" nullable="true"/>
+        <field name="locale" column="locale" type="string" length="10"/>
+        <field name="shortDescription" column="shortDescription" type="text" nullable="true"/>
+        <field name="longDescription" column="longDescription" type="text" nullable="true"/>
 
         <many-to-one target-entity="Sulu\Bundle\ResourceBundle\Entity\OperatorValue" field="operatorValue"
                      inversed-by="translations">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (it avoids a propably bug)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-standard/pull/693
| License | MIT
| Documentation PR | none 

#### What's in this PR?

This PR adds column definitions for doctrine-orm entities. To avoid dropping of columns when naming-strategy will be changed. 

#### Why?

Doctrine drops columns which name is generated and recreate it if the naming-strategy was changed.
