### PR TITLE
Added condition to custom-routes to match only full-matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * HOTFIX      #2378 [ContentBundle]       Fixed writing security to page documents
     * HOTFIX      #2376 [ContentBundle]       Added cleanup for structure reindex provider
+    * HOTFIX      #2384 [WebsiteBundle]       Added condition to custom-routes to match only full-matches
 
 * 1.2.2 (2016-05-09)
     * HOTFIX      #2375 [SecurityBundle]      Fixed visibility of entries in language dropdown

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -145,8 +145,6 @@
 
         <!-- portal loader -->
         <service id="sulu_website.routing.portal_loader" class="%sulu_website.routing.portal_loader.class%">
-            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
-            <argument>%kernel.environment%</argument>
             <tag name="routing.loader"/>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/PortalLoaderTest.php
@@ -15,10 +15,6 @@ use Prophecy\Argument;
 use Sulu\Bundle\WebsiteBundle\Routing\PortalLoader;
 use Sulu\Bundle\WebsiteBundle\Routing\PortalRoute;
 use Sulu\Component\Localization\Localization;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Component\Webspace\Portal;
-use Sulu\Component\Webspace\PortalInformation;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\Routing\Route;
@@ -30,11 +26,6 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
      * @var PortalLoader
      */
     private $portalLoader;
-
-    /**
-     * @var WebspaceManagerInterface
-     */
-    private $webspaceManager;
 
     /**
      * @var LoaderResolverInterface
@@ -51,15 +42,19 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
      */
     private $localizations;
 
+    /**
+     * @var string
+     */
+    private $condition = 'request.get("_sulu").getAttribute("portalInformation").getType() === 1';
+
     public function setUp()
     {
         parent::setUp();
 
-        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->loaderResolver = $this->prophesize(LoaderResolverInterface::class);
         $this->loader = $this->prophesize(LoaderInterface::class);
 
-        $this->portalLoader = new PortalLoader($this->webspaceManager->reveal(), 'dev');
+        $this->portalLoader = new PortalLoader();
         $this->portalLoader->setResolver($this->loaderResolver->reveal());
 
         $de = new Localization();
@@ -75,22 +70,8 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $importedRouteCollection->add('route1', new Route('/example/route1'));
         $importedRouteCollection->add('route2', new Route('/route2'));
 
-        $portal1 = new Portal();
-        $portal1->setKey('sulu_lo');
-        $portal1->setLocalizations($this->localizations);
-
-        $portal2 = new Portal();
-        $portal2->setKey('sulu_com');
-        $portal2->setLocalizations($this->localizations);
-
-        $portalInformations = [
-            new PortalInformation(null, null, $portal1, $this->localizations[0], 'sulu.io/de'),
-            new PortalInformation(null, null, $portal2, $this->localizations[1], 'sulu.com'),
-        ];
-
         $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
         $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
-        $this->webspaceManager->getPortalInformations(Argument::any())->willReturn($portalInformations);
 
         $routeCollection = $this->portalLoader->load('', 'portal');
 
@@ -107,6 +88,8 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
         $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
         $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
+        $this->assertEquals($this->condition, $routeCollection->get('route1')->getCondition());
+        $this->assertEquals($this->condition, $routeCollection->get('route2')->getCondition());
     }
 
     public function testLoadWithCustomUrls()
@@ -115,23 +98,8 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $importedRouteCollection->add('route1', new Route('/example/route1'));
         $importedRouteCollection->add('route2', new Route('/route2'));
 
-        $portal1 = new Portal();
-        $portal1->setKey('sulu_lo');
-        $portal1->setLocalizations($this->localizations);
-
-        $portal2 = new Portal();
-        $portal2->setKey('sulu_com');
-        $portal2->setLocalizations($this->localizations);
-
-        $portalInformations = [
-            new PortalInformation(null, null, $portal1, $this->localizations[0], 'sulu.io/de', null, null, null, true),
-            new PortalInformation(null, null, $portal1, $this->localizations[1], 'sulu.io/en'),
-            new PortalInformation(null, null, $portal2, null, 'sulu.com/*'),
-        ];
-
         $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
         $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
-        $this->webspaceManager->getPortalInformations(Argument::any())->willReturn($portalInformations);
 
         $routeCollection = $this->portalLoader->load('', 'portal');
 
@@ -148,35 +116,17 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{prefix}/route2', $routeCollection->get('route2')->getPath());
         $this->assertEquals('{host}', $routeCollection->get('route1')->getHost());
         $this->assertEquals('{host}', $routeCollection->get('route2')->getHost());
+        $this->assertEquals($this->condition, $routeCollection->get('route1')->getCondition());
+        $this->assertEquals($this->condition, $routeCollection->get('route2')->getCondition());
     }
 
-    public function testLoadPartial()
+    public function testLoadSingleRoute()
     {
         $importedRouteCollection = new RouteCollection();
         $importedRouteCollection->add('route', new Route('/route'));
 
-        $portal = new Portal();
-        $portal->setKey('sulu_lo');
-
-        $localization = new Localization();
-        $localization->setLanguage('de');
-
-        $portalInformations = [
-            new PortalInformation(null, null, $portal, $localization, 'sulu.io/de'),
-            new PortalInformation(
-                RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
-                null,
-                $portal,
-                $localization,
-                'sulu.io',
-                null,
-                'sulu.io/de'
-            ),
-        ];
-
         $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
         $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
-        $this->webspaceManager->getPortalInformations(Argument::any())->willReturn($portalInformations);
 
         $routeCollection = $this->portalLoader->load('', 'portal');
 
@@ -189,5 +139,60 @@ class PortalLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('{prefix}/route', $routeCollection->get('route')->getPath());
         $this->assertEquals('{host}', $routeCollection->get('route')->getHost());
+        $this->assertEquals($this->condition, $routeCollection->get('route')->getCondition());
+    }
+
+    public function testLoadSingleRouteWithHost()
+    {
+        $route = new Route('/route');
+        $route->setHost('sulu.io');
+
+        $importedRouteCollection = new RouteCollection();
+        $importedRouteCollection->add('route', $route);
+
+        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
+        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+
+        $routeCollection = $this->portalLoader->load('', 'portal');
+
+        $this->assertCount(1, $routeCollection);
+
+        $routes = $routeCollection->getIterator();
+        $this->assertArrayHasKey('route', $routes);
+
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route'));
+
+        $this->assertEquals('{prefix}/route', $routeCollection->get('route')->getPath());
+        $this->assertEquals('sulu.io', $routeCollection->get('route')->getHost());
+        $this->assertEquals($this->condition, $routeCollection->get('route')->getCondition());
+    }
+
+    public function testLoadSingleRouteWithCondition()
+    {
+        $route = new Route('/route');
+        $route->setHost('sulu.io');
+        $route->setCondition('request.get("test") === "sulu.io"');
+
+        $importedRouteCollection = new RouteCollection();
+        $importedRouteCollection->add('route', $route);
+
+        $this->loaderResolver->resolve(Argument::any(), Argument::any())->willReturn($this->loader->reveal());
+        $this->loader->load(Argument::any(), Argument::any())->willReturn($importedRouteCollection);
+
+        $routeCollection = $this->portalLoader->load('', 'portal');
+
+        $this->assertCount(1, $routeCollection);
+
+        $routes = $routeCollection->getIterator();
+        $this->assertArrayHasKey('route', $routes);
+
+        $this->assertInstanceOf(PortalRoute::class, $routeCollection->get('route'));
+
+        $this->assertEquals('{prefix}/route', $routeCollection->get('route')->getPath());
+        $this->assertEquals('sulu.io', $routeCollection->get('route')->getHost());
+        $this->assertEquals(
+            $this->condition . ' and (request.get("test") === "sulu.io")',
+            $routeCollection->get('route')->getCondition()
+        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2383
| Related issues/PRs | https://github.com/sulu/sulu/issues/2385
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the condition for for custom-routs which only matches for `RequestAnalyzerInterface::MATCH_TYPE_FULL`. All the other will not match and automatically redirected by `ContentRouteProvider`.

#### Why?

After refactoring of Custom-Route generation there was a bug which also matches `RequestAnalyzerInterface::MATCH_TYPE_PARTIAL` or `RequestAnalyzerInterface::MATCH_TYPE_REDIRECT`. Which causes an exception when following this route.