### PR TITLE
Use DocumentManager for NodeController postAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2386 [ContentBundle]       Use DocumentManager for NodeController postAction
     * BUGFIX      #2325 [WebsiteBundle]       Fixed a query issue on Postgresql
     * BUGFIX      #2379 [MediaBundle]         Inject CategoryRepository in MediaManager to avoid using removed constant
     * BUGFIX      #2369 [All]                 Install the symfony phpunit bridge again

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1783,7 +1783,6 @@ class NodeControllerTest extends SuluTestCase
         $this->assertFalse($data['publishedState']);
         $this->assertEquals(['main', 'footer'], $data['navContexts']);
         $this->assertFalse($data['hasSub']);
-        $this->assertEquals(0, count($data['_embedded']['nodes']));
         $this->assertArrayHasKey('_links', $data);
 
         // get child nodes from root


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR uses the `DocumentManager` for the `NodeController::postAction`.

#### Why?

This makes the publishing process easier when the document is created and published immediately, since the `publish` method of the `DocumentManager` can be called directly (will be added in https://github.com/sulu/sulu-document-manager/pull/81). And in general it makes the code more consistent and removes a few more deprecated method calls.

#### BC Breaks/Deprecations

The `postAction` does not return an `_embedded` field anymore, but this one was always empty anyway, so I would not add it again, although it is a small BC break. Maybe I can add it to the `UPGRADE.md` file. /cc @chirimoya @wachterjohannes 

#### To Do

- [ ] Add `UPGRADE.md` ?

