### PR TITLE
Fixed escape path to avoid unvalid queries

### DIFF
--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -147,7 +147,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         $locales = $this->getLocalesByWebspaceKey($webspaceKey);
         $queryBuilder = $this->getQueryBuilder($locale, $locales, $user);
-        $queryBuilder->where($this->qomFactory->childNode('node', $path));
+        $queryBuilder->where($this->qomFactory->childNode('node', '"' . $path . '"'));
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
         return $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $webspaceKey, $mapping, $user);
@@ -161,7 +161,7 @@ class ContentRepository implements ContentRepositoryInterface
         $locales = $this->getLocalesByWebspaceKey($webspaceKey);
         $queryBuilder = $this->getQueryBuilder($locale, $locales, $user);
         $queryBuilder->where(
-            $this->qomFactory->childNode('node', $this->sessionManager->getContentPath($webspaceKey))
+            $this->qomFactory->childNode('node', '"' . $this->sessionManager->getContentPath($webspaceKey) . '"')
         );
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
@@ -184,11 +184,11 @@ class ContentRepository implements ContentRepositoryInterface
         $locales = $this->getLocalesByWebspaceKey($webspaceKey);
         $queryBuilder = $this->getQueryBuilder($locale, $locales, $user)
             ->orderBy($this->qomFactory->propertyValue('node', 'jcr:path'))
-            ->where($this->qomFactory->childNode('node', $path));
+            ->where($this->qomFactory->childNode('node', '"' . $path . '"'));
 
         while ($path !== $contentPath) {
             $path = PathHelper::getParentPath($path);
-            $queryBuilder->orWhere($this->qomFactory->childNode('node', $path));
+            $queryBuilder->orWhere($this->qomFactory->childNode('node', '"' . $path . '"'));
         }
 
         $mapping->addProperties(['order']);
@@ -213,7 +213,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         foreach ($paths as $path) {
             $queryBuilder->orWhere(
-                $this->qomFactory->sameNode('node', $path)
+                $this->qomFactory->sameNode('node', '"' . $path . '"')
             );
         }
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
@@ -260,8 +260,8 @@ class ContentRepository implements ContentRepositoryInterface
 
         $locales = $this->getLocalesByWebspaceKey($webspaceKey);
         $queryBuilder = $this->getQueryBuilder($locale, $locales, $user)
-            ->where($this->qomFactory->descendantNode('node', $contentPath))
-            ->orWhere($this->qomFactory->sameNode('node', $contentPath));
+            ->where($this->qomFactory->descendantNode('node', '"' . $contentPath . '"'))
+            ->orWhere($this->qomFactory->sameNode('node', '"' . $contentPath . '"'));
 
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
@@ -279,8 +279,8 @@ class ContentRepository implements ContentRepositoryInterface
 
         $locales = $this->getLocalesByPortalKey($portalKey);
         $queryBuilder = $this->getQueryBuilder($locale, $locales, $user)
-            ->where($this->qomFactory->descendantNode('node', $contentPath))
-            ->orWhere($this->qomFactory->sameNode('node', $contentPath));
+            ->where($this->qomFactory->descendantNode('node', '"' . $contentPath . '"'))
+            ->orWhere($this->qomFactory->sameNode('node', '"' . $contentPath . '"'));
 
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
@@ -633,7 +633,7 @@ class ContentRepository implements ContentRepositoryInterface
         }
 
         $content = new Content(
-            $originalLocale,
+            $locale,
             $webspaceKey,
             $row->getValue('uuid'),
             $this->resolvePath($row, $webspaceKey),
@@ -842,7 +842,7 @@ class ContentRepository implements ContentRepositoryInterface
         $queryBuilder
             ->select('node', 'jcr:uuid', 'uuid')
             ->from($this->qomFactory->selector('node', 'nt:unstructured'))
-            ->where($this->qomFactory->childNode('node', $row->getPath()))
+            ->where($this->qomFactory->childNode('node', '"' . $row->getPath() . '"'))
             ->setMaxResults(1);
 
         $result = $queryBuilder->execute();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/jackalope/jackalope-jackrabbit/issues/134
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a quite strange behavior of jackrabbit. There you can create nodes with the name "/test-10e" but if you use this path in a query you get an:

````
message: "HTTP 400: Query: SELECT node.[jcr:uuid] AS uuid FROM [nt:unstructured] AS node WHERE ISCHILDNODE(node, [/test-10e])
````

To fix it all queries which uses the path will be "enclosed" with `"`

#### Why?

If you have a page with a (node-name) including 10e you cannot open the column view.