### PR TITLE
Fixed issue when applying same field descriptor multiple times to sort of list builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2388 [Rest]                Fixed bug when applying same sortfield multiple times
     * HOTFIX      #2378 [ContentBundle]       Fixed writing security to page documents
 
 * 1.2.2 (2016-05-09)

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -216,8 +216,19 @@ abstract class AbstractListBuilder implements ListBuilderInterface
      */
     public function sort(FieldDescriptorInterface $fieldDescriptor, $order = self::SORTORDER_ASC)
     {
-        $this->sortFields[] = $fieldDescriptor;
-        $this->sortOrders[] = $order;
+        // Do not continue if filter is not sortable.
+        if (!$fieldDescriptor->getSortable()) {
+            return;
+        }
+
+        $existingIndex = $this->retrieveIndexOfFieldDescriptor($fieldDescriptor, $this->sortFields);
+        if ($existingIndex !== false) {
+            $this->sortOrders[$existingIndex] = $order;
+        } else {
+            // Else add to list of sort-fields.
+            $this->sortFields[] = $fieldDescriptor;
+            $this->sortOrders[] = $order;
+        }
 
         return $this;
     }
@@ -329,5 +340,27 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     public function addExpression(ExpressionInterface $expression)
     {
         $this->expressions[] = $expression;
+    }
+
+    /**
+     * Returns index of given FieldDescriptor in given array of descriptors.
+     * If no match is found, false will be returned.
+     *
+     * @param FieldDescriptorInterface $currentFieldDescriptor
+     * @param FieldDescriptorInterface[] $fieldDescriptorArray
+     *
+     * @return bool|int|string
+     */
+    protected function retrieveIndexOfFieldDescriptor(
+        FieldDescriptorInterface $currentFieldDescriptor,
+        array $fieldDescriptorArray
+    ) {
+        foreach ($fieldDescriptorArray as $index => $fieldDescriptor) {
+            if ($currentFieldDescriptor->compare($fieldDescriptor)) {
+                return $index;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -216,12 +216,8 @@ abstract class AbstractListBuilder implements ListBuilderInterface
      */
     public function sort(FieldDescriptorInterface $fieldDescriptor, $order = self::SORTORDER_ASC)
     {
-        // Do not continue if filter is not sortable.
-        if (!$fieldDescriptor->getSortable()) {
-            return;
-        }
-
         $existingIndex = $this->retrieveIndexOfFieldDescriptor($fieldDescriptor, $this->sortFields);
+
         if ($existingIndex !== false) {
             $this->sortOrders[$existingIndex] = $order;
         } else {
@@ -346,17 +342,17 @@ abstract class AbstractListBuilder implements ListBuilderInterface
      * Returns index of given FieldDescriptor in given array of descriptors.
      * If no match is found, false will be returned.
      *
-     * @param FieldDescriptorInterface $currentFieldDescriptor
-     * @param FieldDescriptorInterface[] $fieldDescriptorArray
+     * @param FieldDescriptorInterface $fieldDescriptor
+     * @param FieldDescriptorInterface[] $fieldDescriptors
      *
      * @return bool|int|string
      */
     protected function retrieveIndexOfFieldDescriptor(
-        FieldDescriptorInterface $currentFieldDescriptor,
-        array $fieldDescriptorArray
+        FieldDescriptorInterface $fieldDescriptor,
+        array $fieldDescriptors
     ) {
-        foreach ($fieldDescriptorArray as $index => $fieldDescriptor) {
-            if ($currentFieldDescriptor->compare($fieldDescriptor)) {
+        foreach ($fieldDescriptors as $index => $other) {
+            if ($fieldDescriptor->compare($other)) {
                 return $index;
             }
         }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor;
 
 use JMS\Serializer\Annotation\ExclusionPolicy;
+use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 
 /**
  * This class defines the necessary information for a field to resolve it within a Doctrine Query for the ListBuilder.
@@ -56,7 +57,18 @@ class DoctrineFieldDescriptor extends AbstractDoctrineFieldDescriptor
         $editable = false,
         $cssClass = ''
     ) {
-        parent::__construct($name, $translation, $disabled, $default, $type, $width, $minWidth, $sortable, $editable, $cssClass);
+        parent::__construct(
+            $name,
+            $translation,
+            $disabled,
+            $default,
+            $type,
+            $width,
+            $minWidth,
+            $sortable,
+            $editable,
+            $cssClass
+        );
 
         $this->fieldName = $fieldName;
         $this->entityName = $entityName;
@@ -99,5 +111,18 @@ class DoctrineFieldDescriptor extends AbstractDoctrineFieldDescriptor
     public function getJoins()
     {
         return $this->joins;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compare(FieldDescriptorInterface $other)
+    {
+        if (!$other instanceof DoctrineFieldDescriptor) {
+            return false;
+        }
+
+        return $this->getEntityName() === $other->getEntityName()
+            && $this->getFieldName() === $other->getFieldName();
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineFieldDescriptor.php
@@ -118,7 +118,7 @@ class DoctrineFieldDescriptor extends AbstractDoctrineFieldDescriptor
      */
     public function compare(FieldDescriptorInterface $other)
     {
-        if (!$other instanceof DoctrineFieldDescriptor) {
+        if (!$other instanceof self) {
             return false;
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
@@ -116,11 +116,11 @@ class DoctrineIdentityFieldDescriptor extends AbstractDoctrineFieldDescriptor
      */
     public function compare(FieldDescriptorInterface $other)
     {
-        if (!$other instanceof DoctrineIdentityFieldDescriptor) {
+        if (!$other instanceof self) {
             return false;
         }
 
         return $this->getEntityName() === $other->getEntityName()
-        && $this->getFieldName() === $other->getFieldName();
+            && $this->getFieldName() === $other->getFieldName();
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineIdentityFieldDescriptor.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor;
 
 use JMS\Serializer\Annotation\ExclusionPolicy;
+use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 
 /**
  * This class defines the necessary information for a field to resolve it within a Doctrine Query for the ListBuilder.
@@ -108,5 +109,18 @@ class DoctrineIdentityFieldDescriptor extends AbstractDoctrineFieldDescriptor
     public function getJoins()
     {
         return $this->joins;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compare(FieldDescriptorInterface $other)
+    {
+        if (!$other instanceof DoctrineIdentityFieldDescriptor) {
+            return false;
+        }
+
+        return $this->getEntityName() === $other->getEntityName()
+        && $this->getFieldName() === $other->getFieldName();
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
@@ -226,4 +226,17 @@ class FieldDescriptor implements FieldDescriptorInterface
     {
         $this->metadata = $metadata;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compare(FieldDescriptorInterface $other)
+    {
+        if (!$other instanceof FieldDescriptor) {
+            return false;
+        }
+
+        return $this->getName() === $other->getName()
+            && $this->getType() === $other->getType();
+    }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
@@ -232,7 +232,7 @@ class FieldDescriptor implements FieldDescriptorInterface
      */
     public function compare(FieldDescriptorInterface $other)
     {
-        if (!$other instanceof FieldDescriptor) {
+        if (!$other instanceof self) {
             return false;
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
@@ -81,4 +81,13 @@ interface FieldDescriptorInterface
      * @return PropertyMetadata
      */
     public function getMetadata();
+
+    /**
+     * Compares current instance of FieldDescriptor with another instance.
+     *
+     * @param FieldDescriptorInterface $other
+     *
+     * @return bool
+     */
+    public function compare(FieldDescriptorInterface $other);
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -409,6 +409,38 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
         $this->doctrineListBuilder->execute();
     }
 
+    /**
+     * Test if multiple calls to sort with same field descriptor will lead to multiple order by calls.
+     */
+    public function testSortWithMultipleSort()
+    {
+        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('SuluCoreBundle:Example.desc AS desc')]);
+
+        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
+        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
+
+        $this->queryBuilder->addSelect('SuluCoreBundle:Example.desc AS desc')->shouldBeCalledTimes(1);
+        $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalledTimes(2);
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    /**
+     * Test if sort is correnctly overwritten, when field descriptor is provided multiple times.
+     */
+    public function testChangeSortOrder()
+    {
+        $this->queryBuilder->getDQLPart('select')->willReturn([new Select('SuluCoreBundle:Example.desc AS desc')]);
+
+        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName), 'ASC');
+        $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName), 'DESC');
+
+        $this->queryBuilder->addSelect('SuluCoreBundle:Example.desc AS desc')->shouldBeCalledTimes(1);
+        $this->queryBuilder->addOrderBy('desc', 'DESC')->shouldBeCalledTimes(2);
+
+        $this->doctrineListBuilder->execute();
+    }
+
     public function testSortWithoutDefault()
     {
         // when no sort is applied, results should be orderd by id by default


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | none 
| Related issues/PRs | none 
| License | MIT
| Documentation PR | none 

#### What's in this PR?

Fixing issue when applying same FieldDescriptor multiple times.

#### Why?

In order to be able to change a given sorting, you can now overwrite the sort-order of the field descriptor.
Until now this would lead to an exception. (This happens since Sulu 1.2)

#### BC Breaks/Deprecations

The interface of `FieldDescriptor` has been extended by a function `compare(FieldDescriptorInterface $other)` which needs to be implemented by all FieldDescriptors (outside of the sulu project)