### PR TITLE
removed twice adding of media navigation item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2389 [MediaBundle]         Removed twice adding of navigation item
     * BUGFIX      #2325 [WebsiteBundle]       Fixed a query issue on Postgresql
     * BUGFIX      #2379 [MediaBundle]         Inject CategoryRepository in MediaManager to avoid using removed constant
     * BUGFIX      #2369 [All]                 Install the symfony phpunit bridge again

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -34,7 +34,7 @@ class MediaAdmin extends Admin
         $section->setPosition(20);
 
         if ($this->securityChecker->hasPermission('sulu.media.collections', PermissionTypes::VIEW)) {
-            $media = new DataNavigationItem('navigation.media', '/admin/api/collections?sortBy=title', $section);
+            $media = new DataNavigationItem('navigation.media', '/admin/api/collections?sortBy=title');
             $media->setId('collections-edit');
             $media->setPosition(20);
             $media->setIcon('image');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the second media navigation item in the navigation.

#### Why?

Because with certain permission settings the media navigation item was appearing twice. Actually this should have happend all the time, but the merge mechanism removed one of both items somehow sometimes.

