### PR TITLE
Fixed composer-events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2396                       Fixed composer-events
     * BUGFIX      #2396 [PreviewBundle]       Fixed leaking events of preview
     * BUGFIX      #2389 [MediaBundle]         Removed twice adding of navigation item
     * ENHANCEMENT #2386 [ContentBundle]       Use DocumentManager for NodeController postAction

--- a/src/Sulu/Bundle/MediaBundle/Composer/MediaScriptHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Composer/MediaScriptHandler.php
@@ -11,15 +11,15 @@
 
 namespace Sulu\Bundle\MediaBundle\Composer;
 
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler;
 
 class MediaScriptHandler extends ScriptHandler
 {
     /**
-     * @param $event CommandEvent A instance
+     * @param $event Event A instance
      */
-    public static function initBundle(CommandEvent $event)
+    public static function initBundle(Event $event)
     {
         $options = parent::getOptions($event);
         $consoleDir = isset($options['symfony-bin-dir']) ? $options['symfony-bin-dir'] : $options['symfony-app-dir'];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/93
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes warnings which will be thrown by composer when updating or installing.

#### Why?

Try calling composer install in sulu-standard you will see this warning:

![image](https://cloud.githubusercontent.com/assets/1464615/15326340/e7d57ac6-1c4d-11e6-9068-a2c2853d25b3.png)

````
Deprecation Notice: The callback Sulu\Bundle\MediaBundle\Composer\MediaScriptHandler::initBundle declared at /Users/johannes/Development/sulu/sulu-standard/vendor/sulu/sulu/src/Sulu/Bundle/MediaBundle/Composer/MediaScriptHandler.php accepts a Composer\Script\CommandEvent but post-install-cmd events use a Composer\Script\Event instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes in phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:289
```

