### PR TITLE
Allow empty clean title for resource-locator generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * HOTFIX      #2401 [MediaBundle]         Fixed slow media queries
     * HOTFIX      #2401 [MediaBundle]         Fixed search in media bundle
+    * HOTFIX      #2400 [ContentBundle]       Allow empty clean title for resource-locator generation
     * HOTFIX      #2381 [ContentBundle]       Fixed auto-name subscriber to rename at the very end of persist
     * HOTFIX      #2388 [Rest]                Fixed bug when applying same sortfield multiple times
     * HOTFIX      #2378 [ContentBundle]       Fixed writing security to page documents

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/RlpStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/RlpStrategyTest.php
@@ -383,4 +383,10 @@ class RlpStrategyTest extends \PHPUnit_Framework_TestCase
         $result = $this->strategy->generateForUuid('test', '123-123-123', 'default', 'de');
         $this->assertEquals('/parent/test', $result);
     }
+
+    public function testGenerateForArabicTitle()
+    {
+        $result = $this->strategy->generate('تیتر متن', '/parent', 'sulu_io', 'de');
+        $this->assertEquals('/parent/', $result);
+    }
 }

--- a/src/Sulu/Component/Content/Types/Rlp/Strategy/RlpStrategy.php
+++ b/src/Sulu/Component/Content/Types/Rlp/Strategy/RlpStrategy.php
@@ -103,8 +103,10 @@ abstract class RlpStrategy implements RlpStrategyInterface
         // cleanup path
         $path = $this->cleaner->cleanup($path, $languageCode);
 
-        // get unique path
-        $path = $this->mapper->getUniquePath($path, $webspaceKey, $languageCode, $segmentKey);
+        if (substr($path, -1, 1) !== '/') {
+            // get unique path
+            $path = $this->mapper->getUniquePath($path, $webspaceKey, $languageCode, $segmentKey);
+        }
 
         return $path;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes sulu/sulu-standard#698 |
| Related issues/PRs | https://github.com/sulu/sulu-document-manager/pull/87 |
| License | MIT |
| Documentation PR | none |
#### What's in this PR?

This PR add the ability to pass empty titles for resource-locator generation. this happens if you pass a title which is cleaned-up empty.
#### Why?

If you type in a title like: arabic `تیتر متن`, hebrew `Εβραϊκή γλώσσα` or mandarin Chinese `官 話` you get an error for generating a resource-locator (beyond level 1) and you cannot save.
