### PR TITLE
Fixed route-provider when no resource-locator prefix isset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2426 [RouteBundle]         Fixed route-provider when no resource-locator prefix isset
     * BUGFIX      #2418 [ContentBundle]       Removed ContentMapperRequest
     * ENHANCEMENT #2414 [ContentBundle]       Removed save method of ContentMapper
     * BUGFIX      #2367 [ContentBundle]       Fixed copy internal-link into new language

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -42,8 +42,8 @@ class RouteProvider implements RouteProviderInterface
     private $routeDefaultsProvider;
 
     /**
-     * @param RouteRepositoryInterface       $routeRepository
-     * @param RequestAnalyzerInterface       $requestAnalyzer
+     * @param RouteRepositoryInterface $routeRepository
+     * @param RequestAnalyzerInterface $requestAnalyzer
      * @param RouteDefaultsProviderInterface $routeDefaultsProvider
      */
     public function __construct(
@@ -62,12 +62,13 @@ class RouteProvider implements RouteProviderInterface
     public function getRouteCollectionForRequest(Request $request)
     {
         $collection = new RouteCollection();
-        $path = PathHelper::relativizePath(
-            $request->getPathInfo(),
-            $this->requestAnalyzer->getResourceLocatorPrefix()
-        );
+        $path = $request->getPathInfo();
+        $prefix = $this->requestAnalyzer->getResourceLocatorPrefix();
+        if (!empty($prefix)) {
+            $path = PathHelper::relativizePath($path, $prefix);
+        }
 
-        $route = $this->routeRepository->findByPath('/' . $path, $request->getLocale());
+        $route = $this->routeRepository->findByPath('/' . ltrim($path, '/'), $request->getLocale());
         if (!$route || !$this->routeDefaultsProvider->supports($route->getEntityClass())) {
             return $collection;
         }

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -173,4 +173,30 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
             $routes[0]->getDefaults()
         );
     }
+
+    public function testGetRouteCollectionForRequestNoPrefix()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/test');
+        $request->getLocale()->willReturn('de');
+
+        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn(null);
+
+        $routeEntity = $this->prophesize(RouteInterface::class);
+        $routeEntity->getEntityClass()->willReturn('Example');
+        $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->isHistory()->willReturn(false);
+
+        $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
+        $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->getByEntity('Example', '1')->willReturn(['test' => 1]);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(1, $collection);
+        $routes = array_values(iterator_to_array($collection->getIterator()));
+
+        $this->assertEquals('/test', $routes[0]->getPath());
+        $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug for the route-bundle `RouteProvider` which happens when no resource-locator-prefix isset.

#### Why?

The function `PathHelper::relativizePath` cannot handle a null value as second parameter.

