### PR TITLE
Fixed bug when using non generic visitor in HashSerializeEventSubscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2427 [Hash]                Fixed bug when using non generic visitor in HashSerializeEventSubscriber
     * HOTFIX      #2401 [MediaBundle]         Fixed slow media queries
     * HOTFIX      #2415 [ContactBundle]       Fixed account contacts api response
     * HOTFIX      #2401 [MediaBundle]         Fixed search in media bundle

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,11 +2,8 @@
 <phpunit bootstrap="./tests/bootstrap.php" colors="true">
 
     <testsuites>
-        <testsuite name="unit">
-            <directory suffix="Test.php">./src/Sulu/Component/*/Tests/Unit</directory>
-        </testsuite>
-        <testsuite name="functional">
-            <directory suffix="Test.php">./src/Sulu/Component/*/Tests/Functional</directory>
+        <testsuite name="components">
+            <directory suffix="Test.php">./src/Sulu/Component/*/Tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/public/js/components/accounts/edit/main.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/public/js/components/accounts/edit/main.js
@@ -133,7 +133,7 @@ define([
         saveTab: function() {
             var promise = $.Deferred();
             this.sandbox.once('sulu.tab.saved', function(savedData, updateData) {
-                if (!!updateData){
+                if (!!updateData) {
                     this.changeData(savedData)
                 }
                 promise.resolve(savedData);

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
@@ -64,7 +64,9 @@ class Configuration implements ConfigurationInterface
                             ->fixXmlConfig('server')
                             ->children()
                                 ->arrayNode('servers')
-                                    ->beforeNormalization()->ifString()->then(function ($v) { return preg_split('/\s*,\s*/', $v); })->end()
+                                    ->beforeNormalization()->ifString()->then(function ($v) {
+                                        return preg_split('/\s*,\s*/', $v);
+                                    })->end()
                                     ->useAttributeAsKey('name')
                                     ->isRequired()
                                     ->requiresAtLeastOneElement()

--- a/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
+++ b/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
@@ -12,6 +12,7 @@ namespace Sulu\Component\Hash\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\GenericSerializationVisitor;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Hash\HasherInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
@@ -57,6 +58,10 @@ class HashSerializeEventSubscriber implements EventSubscriberInterface
         }
 
         if (!$object instanceof AuditableInterface && !$object instanceof LocalizedAuditableBehavior) {
+            return;
+        }
+
+        if (!$event->getVisitor() instanceof GenericSerializationVisitor) {
             return;
         }
 

--- a/src/Sulu/Component/Hash/Tests/Serializer/Subscriber/HashSerializeEventSubscriberTest.php
+++ b/src/Sulu/Component/Hash/Tests/Serializer/Subscriber/HashSerializeEventSubscriberTest.php
@@ -11,7 +11,9 @@
 namespace Sulu\Component\Hash\Tests\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\GenericSerializationVisitor;
 use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\XmlSerializationVisitor;
 use Prophecy\Argument;
 use Sulu\Component\Hash\HasherInterface;
 use Sulu\Component\Hash\Serializer\Subscriber\HashSerializeEventSubscriber;
@@ -30,7 +32,7 @@ class HashSerializeEventSubscriberTest extends \PHPUnit_Framework_TestCase
     private $hashSerializeEventSubscriber;
 
     /**
-     * @var JsonVisitorInterface
+     * @var GenericSerializationVisitor
      */
     private $visitor;
 
@@ -63,6 +65,18 @@ class HashSerializeEventSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->objectEvent->getObject()->willReturn($object);
 
         $this->visitor->addData('_hash', Argument::any())->shouldNotBeCalled();
+        $this->hashSerializeEventSubscriber->onPostSerialize($this->objectEvent->reveal());
+    }
+
+    public function testOnNonGenericSerialization()
+    {
+        $xmlVisitor = $this->prophesize(XmlSerializationVisitor::class);
+        $object = $this->prophesize(AuditableInterface::class);
+        $this->objectEvent->getObject()->willReturn($object);
+        $this->objectEvent->getVisitor()->willReturn($xmlVisitor->reveal());
+
+        $this->hasher->hash()->shouldNotBeCalled();
+
         $this->hashSerializeEventSubscriber->onPostSerialize($this->objectEvent->reveal());
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/DoctrineRestHelperTest.php
@@ -45,6 +45,7 @@ class DoctrineRestHelperTest extends \PHPUnit_Framework_TestCase
         $entities->expects($this->once())->method('getIterator')->willReturn(new \ArrayIterator([null, null]));
         $entities->expects($this->exactly(2))->method('add');
 
-        $this->restHelper->processSubEntities($entities, [], function () {});
+        $this->restHelper->processSubEntities($entities, [], function () {
+        });
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -96,8 +96,10 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
         $this->queryBuilder->setMaxResults(Argument::any())->willReturn($this->queryBuilder->reveal());
         $this->queryBuilder->getQuery()->willReturn($this->query);
 
-        $this->queryBuilder->distinct(false)->should(function () {});
-        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->should(function () {});
+        $this->queryBuilder->distinct(false)->should(function () {
+        });
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->should(function () {
+        });
         $this->queryBuilder->addOrderBy(Argument::cetera())->shouldBeCalled();
 
         $this->query->expects($this->any())->method('getArrayResult')->willReturn($this->idResult);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

HashSerializeEventSubscriber called addData for every Visitor, even though it's only supported by GenericVisitor instances.

#### Why?

Because that was a bug ;)