### PR TITLE
Fixed error-template always from default-theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2481 [WebsiteBundle]       Fixed handling of non-default formats in error pages 
     * HOTFIX      #2467 [MediaBundle]         Fixed media-selection-overlay missing locale
     * HOTFIX      #2460 [MediaBundle]         Fixed deprecation of getEntityManager in MediaPreviewController
     * HOTFIX      #2454 [MediaBundle]         Fixed inset image scale image-size 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG for Sulu
     * HOTFIX      #2440 [MediaBundle]         Fixed media-selection sorting
     * HOTFIX      #2441 [ContentBundle]       Fixed block to handle non html text correctly
     * ENHANCEMENT #2432 [SecurityBundle]      New behat step for admin login with default locale
+    * HOTFIX      #2430 [WebsiteBundle]       Fixed error-template always from default-theme
 
 * 1.2.3 (2016-06-01)
     * HOTFIX      #2427 [Hash]                Fixed bug when using non generic visitor in HashSerializeEventSubscriber

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -61,7 +61,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private $viewHandler;
 
     /**
-     * @Var SnippetRepository
+     * @var SnippetRepository
      */
     private $snippetRepository;
 

--- a/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CatalogueControllerTest.php
+++ b/src/Sulu/Bundle/TranslateBundle/Tests/Functional/Controller/CatalogueControllerTest.php
@@ -23,7 +23,7 @@ class CatalogueControllerTest extends SuluTestCase
     private $package;
 
     /**
-     * @Var Catalogue
+     * @var Catalogue
      */
     private $catalogue;
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -169,7 +169,7 @@
 
         <!-- exception controller -->
         <service id="sulu_website.exception.controller" class="%sulu_website.exception.controller.class%">
-            <argument type="service" id="twig" />
+            <argument type="service" id="templating" />
             <argument>%kernel.debug%</argument>
             <argument type="service" id="sulu_website.resolver.parameter" />
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -172,7 +172,6 @@
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
             <argument type="service" id="sulu_website.resolver.parameter" />
-            <argument type="service" id="sulu.content.mapper" />
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
+
+use Prophecy\Argument;
+use Sulu\Bundle\WebsiteBundle\Controller\ExceptionController;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Theme;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Request;
+
+class ExceptionControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ExceptionController
+     */
+    private $exceptionController;
+
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
+
+    /**
+     * @var \Twig_ExistsLoaderInterface
+     */
+    private $loader;
+
+    /**
+     * @var ParameterResolverInterface
+     */
+    private $parameterResolver;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function setUp()
+    {
+        $this->twig = $this->prophesize(\Twig_Environment::class);
+        $this->loader = $this->prophesize(\Twig_ExistsLoaderInterface::class);
+        $this->twig->getLoader()->willReturn($this->loader->reveal());
+
+        $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->exceptionController = new ExceptionController(
+            $this->twig->reveal(),
+            false,
+            $this->parameterResolver->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    public static function provideShowAction()
+    {
+        return [
+            ['html', true, 'html'],
+            ['xml', true, 'xml'],
+            ['json', true, 'json'],
+            ['aspx', false, 'html'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideShowAction
+     */
+    public function testShowActionFormat($retrievedFormat, $templateAvailable, $expectedExceptionFormat)
+    {
+        $request = new Request();
+        $request->setRequestFormat($retrievedFormat);
+        $exception = FlattenException::create(new \Exception(), 400);
+
+        $webspace = new Webspace();
+        $theme = new Theme();
+        $theme->addErrorTemplate(400, 'error400.html.twig');
+        $webspace->setTheme($theme);
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->twig->render(Argument::containingString($expectedExceptionFormat), Argument::any())->shouldBeCalled();
+        $this->loader->exists(Argument::any())->willReturn($templateAvailable);
+
+        if ($expectedExceptionFormat === 'html') {
+            $this->parameterResolver->resolve(Argument::cetera())->shouldBeCalled()->willReturn([]);
+        } else {
+            $this->parameterResolver->resolve(Argument::cetera())->shouldNotBeCalled();
+        }
+
+        // Required to leave one ob_level left, test will be marked otherwise as risky by PHPUnit
+        $request->headers->add(['X-Php-Ob-Level' => 1]);
+
+        $this->exceptionController->showAction($request, $exception);
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/ExceptionControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Controller;
+
+use Prophecy\Argument;
+use Sulu\Bundle\WebsiteBundle\Controller\ExceptionController;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Theme;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Templating\EngineInterface;
+
+class ExceptionControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EngineInterface
+     */
+    private $engine;
+
+    /**
+     * @var ParameterResolverInterface
+     */
+    private $parameterResolver;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var FlattenException
+     */
+    private $exception;
+
+    /**
+     * @var Webspace
+     */
+    private $webspace;
+
+    protected function setUp()
+    {
+        $this->engine = $this->prophesize(EngineInterface::class);
+        $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->request = $this->prophesize(Request::class);
+        $this->exception = $this->prophesize(FlattenException::class);
+
+        $this->exception->getStatusCode()->willReturn(500);
+        $this->request->get('showException', Argument::any())->willReturnArgument(1);
+        $this->request->getRequestFormat()->willReturn('html');
+
+        $requestHeader = $this->prophesize(HeaderBag::class);
+        $requestHeader->get('X-Php-Ob-Level', -1)->willReturn(5);
+        $this->request->reveal()->headers = $requestHeader->reveal();
+
+        $this->webspace = $this->prophesize(Webspace::class);
+        $theme = $this->prophesize(Theme::class);
+        $theme->getErrorTemplate(500)->willReturn('error500.html.twig');
+        $this->webspace->getTheme()->willReturn($theme->reveal());
+    }
+
+    protected function getExceptionController($debug = false)
+    {
+        return new ExceptionController(
+            $this->engine->reveal(),
+            $debug,
+            $this->parameterResolver->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    public function testShow()
+    {
+        $exceptionController = $this->getExceptionController();
+
+        $parameters = [
+            'status_code' => 500,
+            'status_text' => 'Internal Server Error',
+            'exception' => $this->exception->reveal(),
+            'currentContent' => '',
+            'webspace' => $this->webspace->reveal(),
+        ];
+
+        $this->requestAnalyzer->getWebspace()->willReturn($this->webspace->reveal());
+        $this->engine->exists('@Twig/Exception/error500.html.twig')->willReturn(true);
+        $this->parameterResolver->resolve(
+            [
+                'status_code' => 500,
+                'status_text' => 'Internal Server Error',
+                'exception' => $this->exception->reveal(),
+                'currentContent' => '',
+            ],
+            $this->requestAnalyzer
+        )->willReturn($parameters);
+        $this->engine->render('error500.html.twig', $parameters)->shouldBeCalled()->willReturn('My Exception Content');
+
+        $response = $exceptionController->showAction($this->request->reveal(), $this->exception->reveal());
+
+        $this->assertEquals('My Exception Content', $response->getContent());
+    }
+
+    public function testShowNoWebspace()
+    {
+        $exceptionController = $this->getExceptionController();
+
+        $this->engine->exists('@Twig/Exception/error500.html.twig')->willReturn(true);
+
+        $this->engine->render('@Twig/Exception/error500.html.twig', Argument::any())
+            ->shouldBeCalled()->willReturn('My Exception Content');
+
+        $response = $exceptionController->showAction($this->request->reveal(), $this->exception->reveal());
+
+        $this->assertEquals('My Exception Content', $response->getContent());
+    }
+
+    public function testShowDebug()
+    {
+        $exceptionController = $this->getExceptionController(true);
+
+        $this->engine->exists('@Twig/Exception/exception_full.html.twig')->willReturn(true);
+
+        $this->engine->render('@Twig/Exception/exception_full.html.twig', Argument::any())
+            ->shouldBeCalled()->willReturn('My Exception Content');
+
+        $response = $exceptionController->showAction($this->request->reveal(), $this->exception->reveal());
+
+        $this->assertEquals('My Exception Content', $response->getContent());
+    }
+}

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -103,7 +103,7 @@ class ContentMapper implements ContentMapperInterface
     private $rlpStrategy;
 
     /**
-     * @Var DocumentManager
+     * @var DocumentManager
      */
     private $documentManager;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #2435 and a bug without ticket
| Related issues/PRs | https://github.com/sulu/sulu/pull/2481
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the fact that the error-template is always taken from the default template.

#### To Do

- [x] Testcases
