### PR TITLE
[FEATURE] New behat step for admin login with default locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * ENHANCEMENT #2432 [SecurityBundle]      New behat step for admin login with default locale
+
 * 1.2.3 (2016-06-01)
     * HOTFIX      #2427 [Hash]                Fixed bug when using non generic visitor in HashSerializeEventSubscriber
     * HOTFIX      #2401 [MediaBundle]         Fixed slow media queries

--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -151,6 +151,15 @@ class SecurityContext extends BaseContext implements SnippetAcceptingContext
     }
 
     /**
+     * @Given I am logged in as an administrator with default locale
+     */
+    public function iAmLoggedInAsAnAdministratorWithDefaultLocale()
+    {
+        $locale = $this->getContainer()->getParameter('locale');
+        $this->logInAsAdministrator($locale);
+    }
+
+    /**
      * @Given I am editing the permission of a user with username :username
      */
     public function iAmEditingThePermissionsOfAUser($username)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

New behat step for admin login with default locale.