### PR TITLE
Fixed media-selection sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2440 [MediaBundle]         Fixed media-selection sorting
     * ENHANCEMENT #2432 [SecurityBundle]      New behat step for admin login with default locale
 
 * 1.2.3 (2016-06-01)

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -587,8 +587,8 @@ class MediaControllerTest extends SuluTestCase
         $this->assertEquals(2, $response->total);
         $this->assertCount(2, $medias);
 
-        $this->assertContains(['id' => $media1->getId(), 'name' => 'photo1.jpeg'], $medias);
-        $this->assertContains(['id' => $media2->getId(), 'name' => 'photo2.jpeg'], $medias);
+        $this->assertEquals(['id' => $media1->getId(), 'name' => 'photo1.jpeg'], $medias[1]);
+        $this->assertEquals(['id' => $media2->getId(), 'name' => 'photo2.jpeg'], $medias[0]);
     }
 
     public function testCgetSearch()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu-standard#694
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the sorting of the media-selection caused by refactoring of the media api to field descriptors.

#### Why?

The media-api doesn't return the assets with the sorting of given ids.