### PR TITLE
Use AutoNameBehavior for CustomUrlDocument

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,25 @@
 
 ## dev-develop
 
+### Indexing title of pages for search
+
+It was possible to define that the title field of a page should be
+indexed as title, although this value was already the default:
+
+```
+<property name="title" type="text_line" mandatory="true">
+    <meta>
+        <title lang="en">Title</title>
+    </meta>
+    <tag name="sulu.search.field" type="string" role="title" />
+</property>
+ ```
+
+ This setting does not work anymore, because the title is now handled
+ separately from the rest of the structure, and the title is not indexed
+ anymore with this tag. Just remove it, and it will be the same as
+ before.
+
 ### Configuration
 
 The configuration of `sulu_content.preview` and `sulu_website.preview_defaults` has been moved to:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,13 @@
 
 ## dev-develop
 
+### TitleBehavior is not localized anymore
+
+If you have implemented your own Documents with an `TitleBehavior`,
+you will recognize that the title in PHPCR is not translated anymore.
+If you still want this Behavior you have to switch to the
+`LocalizedTitleBehavior`.
+
 ### Indexing title of pages for search
 
 It was possible to define that the title field of a page should be

--- a/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
@@ -28,6 +28,7 @@ use Sulu\Component\Content\Document\Structure\Structure;
 use Sulu\Component\Content\Document\Structure\StructureInterface;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ChildrenBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
@@ -53,7 +54,8 @@ class BasePageDocument implements
     OrderBehavior,
     WebspaceBehavior,
     SecurityBehavior,
-    LocalizedAuditableBehavior
+    LocalizedAuditableBehavior,
+    LocalizedTitleBehavior
 {
     /**
      * The name of this node.

--- a/src/Sulu/Bundle/ContentBundle/Document/HomeDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/HomeDocument.php
@@ -11,15 +11,13 @@
 
 namespace Sulu\Bundle\ContentBundle\Document;
 
-use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
-
 /**
  * Represents a home page document.
  *
  * The HomeDocument is the immediate child of the webspace node and
  * contains ALL of the webspace pages within its subtree.
  */
-class HomeDocument extends BasePageDocument implements TitleBehavior
+class HomeDocument extends BasePageDocument
 {
     /**
      * {@inheritdoc}

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/blocks.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/blocks.xml
@@ -22,8 +22,6 @@
                 <title lang="en">Title</title>
             </meta>
 
-            <tag name="sulu.search.field" type="string" role="title" />
-
             <tag name="sulu.rlp.part"/>
         </property>
 

--- a/src/Sulu/Bundle/CustomUrlBundle/DependencyInjection/SuluCustomUrlExtension.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/DependencyInjection/SuluCustomUrlExtension.php
@@ -53,7 +53,6 @@ class SuluCustomUrlExtension extends Extension implements PrependExtensionInterf
                             'class' => CustomUrlDocument::class,
                             'phpcr_type' => 'sulu:custom_url',
                             'mapping' => [
-                                'title' => ['property' => 'title'],
                                 'published' => ['property' => 'published'],
                                 'baseDomain' => ['property' => 'baseDomain'],
                                 'domainParts' => ['property' => 'domainParts', 'type' => 'json_array'],

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -291,6 +291,35 @@ class CustomUrlControllerTest extends SuluTestCase
             ],
             [
                 [
+                    'test-11.sulu.io/test-21' => [
+                        'title' => 'Test-1',
+                        'published' => true,
+                        'baseDomain' => '*.sulu.io',
+                        'domainParts' => ['prefix' => 'test-11', 'suffix' => ['test-21']],
+                        'targetDocument' => true,
+                        'targetLocale' => 'de',
+                        'canonical' => true,
+                        'redirect' => true,
+                        'noFollow' => true,
+                        'noIndex' => true,
+                    ],
+                ],
+                [
+                    'title' => 'Test-2',
+                    'published' => true,
+                    'baseDomain' => '*.sulu.io',
+                    'domainParts' => ['prefix' => 'test-12', 'suffix' => ['test-22']],
+                    'targetDocument' => true,
+                    'targetLocale' => 'de',
+                    'canonical' => true,
+                    'redirect' => true,
+                    'noFollow' => true,
+                    'noIndex' => true,
+                ],
+                'test-12.sulu.io/test-22',
+            ],
+            [
+                [
                     'test-1.sulu.io/test-1' => [
                         'title' => 'Test-1',
                         'published' => true,

--- a/src/Sulu/Bundle/SnippetBundle/Document/SnippetDocument.php
+++ b/src/Sulu/Bundle/SnippetBundle/Document/SnippetDocument.php
@@ -17,6 +17,7 @@ use Sulu\Component\Content\Document\Behavior\StructureTypeFilingBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\Structure\Structure;
 use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
@@ -35,7 +36,8 @@ class SnippetDocument implements
     StructureBehavior,
     WorkflowStageBehavior,
     UuidBehavior,
-    PathBehavior
+    PathBehavior,
+    LocalizedTitleBehavior
 {
     private $created;
     private $changed;

--- a/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
+++ b/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
@@ -198,6 +198,8 @@ class ManagedStructure extends Structure
 
     public function bind($data, $clearMissing = true)
     {
+        $this->init();
+
         foreach ($this->structureMetadata->getProperties() as $childName => $child) {
             if (false === $clearMissing && !isset($data[$childName])) {
                 continue;

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -292,6 +292,10 @@ class StructureSubscriber implements EventSubscriberInterface
         $metadata = $this->inspector->getStructureMetadata($document);
 
         foreach ($metadata->getProperties() as $propertyName => $structureProperty) {
+            if ($propertyName === TitleSubscriber::PROPERTY_NAME) {
+                continue;
+            }
+
             $realProperty = $structure->getProperty($propertyName);
             $value = $realProperty->getValue();
 

--- a/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
@@ -10,6 +10,7 @@
 
 namespace Sulu\Component\Content\Document\Subscriber;
 
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
@@ -52,16 +53,29 @@ class TitleSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
 
-        if (!$this->supports($document) || !$event->getLocale()) {
+        if (!$this->supports($document)) {
             return;
         }
 
-        $document->setTitle(
-            $event->getNode()->getPropertyValueWithDefault(
-                $this->propertyEncoder->localizedContentName(self::PROPERTY_NAME, $event->getLocale()),
-                ''
-            )
-        );
+        if ($document instanceof LocalizedTitleBehavior) {
+            if (!$event->getLocale()) {
+                return;
+            }
+
+            $document->setTitle(
+                $event->getNode()->getPropertyValueWithDefault(
+                    $this->propertyEncoder->localizedContentName(static::PROPERTY_NAME, $event->getLocale()),
+                    ''
+                )
+            );
+        } else {
+            $document->setTitle(
+                $event->getNode()->getPropertyValueWithDefault(
+                    $this->propertyEncoder->contentName(static::PROPERTY_NAME),
+                    ''
+                )
+            );
+        }
     }
 
     /**
@@ -73,14 +87,25 @@ class TitleSubscriber implements EventSubscriberInterface
     {
         $document = $event->getDocument();
 
-        if (!$this->supports($document) || !$event->getLocale()) {
+        if (!$this->supports($document)) {
             return;
         }
 
-        $event->getNode()->setProperty(
-            $this->propertyEncoder->localizedContentName(self::PROPERTY_NAME, $event->getLocale()),
-            $document->getTitle()
-        );
+        if ($document instanceof LocalizedTitleBehavior) {
+            if (!$event->getLocale()) {
+                return;
+            }
+
+            $event->getNode()->setProperty(
+                $this->propertyEncoder->localizedContentName(static::PROPERTY_NAME, $event->getLocale()),
+                $document->getTitle()
+            );
+        } else {
+            $event->getNode()->setProperty(
+                $this->propertyEncoder->contentName(static::PROPERTY_NAME),
+                $document->getTitle()
+            );
+        }
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/TitleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/TitleSubscriberTest.php
@@ -1,0 +1,117 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\Content\Document\Subscriber\TitleSubscriber;
+use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+
+class TitleSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var TitleSubscriber
+     */
+    private $titleSubscriber;
+
+    public function setUp()
+    {
+        $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
+        $this->titleSubscriber = new TitleSubscriber($this->propertyEncoder->reveal());
+    }
+
+    public function testSetTitleOnDocument()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $document = $this->prophesize(TitleBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getLocale()->willReturn('de');
+        $event->getNode()->willReturn($node->reveal());
+        $this->propertyEncoder->localizedContentName('title', 'de')->willReturn('i18n:de-title');
+        $node->getPropertyValueWithDefault('i18n:de-title', '')->willReturn('title');
+
+        $document->setTitle('title')->shouldBeCalled();
+
+        $this->titleSubscriber->setTitleOnDocument($event->reveal());
+    }
+
+    public function testSetTitleOnDocumentWithoutLocale()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $document = $this->prophesize(TitleBehavior::class);
+        $event->getDocument()->willReturn($document);
+        $event->getLocale()->willReturn(null);
+
+        $event->getNode()->shouldNotBeCalled();
+
+        $this->titleSubscriber->setTitleOnDocument($event->reveal());
+    }
+
+    public function testSetTitleOnDocumentWithWrongDocument()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $document = new \stdClass();
+        $event->getDocument()->willReturn($document);
+        $event->getLocale()->willReturn('de');
+
+        $event->getNode()->shouldNotBeCalled();
+
+        $this->titleSubscriber->setTitleOnDocument($event->reveal());
+    }
+
+    public function testSetTitleOnNode()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $document = $this->prophesize(TitleBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getLocale()->willReturn('de');
+        $event->getNode()->willReturn($node->reveal());
+        $this->propertyEncoder->localizedContentName('title', 'de')->willReturn('i18n:de-title');
+        $document->getTitle()->willReturn('title');
+
+        $node->setProperty('i18n:de-title', 'title')->shouldBeCalled();
+
+        $this->titleSubscriber->setTitleOnNode($event->reveal());
+    }
+
+    public function testSetTitleOnNodeWithoutLocale()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $document = $this->prophesize(TitleBehavior::class);
+        $event->getDocument()->willReturn($document);
+        $event->getLocale()->willReturn(null);
+
+        $event->getNode()->shouldNotBeCalled();
+
+        $this->titleSubscriber->setTitleOnNode($event->reveal());
+    }
+
+    public function testSetTitleOnNodeWithWrongDocument()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $document = new \stdClass();
+        $event->getDocument()->willReturn($document);
+        $event->getLocale()->willReturn('de');
+
+        $event->getNode()->shouldNotBeCalled();
+
+        $this->titleSubscriber->setTitleOnNode($event->reveal());
+    }
+}

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/TitleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/TitleSubscriberTest.php
@@ -12,6 +12,7 @@ namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
 
 use PHPCR\NodeInterface;
 use Sulu\Component\Content\Document\Subscriber\TitleSubscriber;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
@@ -41,6 +42,21 @@ class TitleSubscriberTest extends \PHPUnit_Framework_TestCase
         $document = $this->prophesize(TitleBehavior::class);
         $node = $this->prophesize(NodeInterface::class);
         $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $this->propertyEncoder->contentName('title')->willReturn('title');
+        $node->getPropertyValueWithDefault('title', '')->willReturn('title');
+
+        $document->setTitle('title')->shouldBeCalled();
+
+        $this->titleSubscriber->setTitleOnDocument($event->reveal());
+    }
+
+    public function testSetTitleOnDocumentLocalized()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $document = $this->prophesize(LocalizedTitleBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $event->getDocument()->willReturn($document->reveal());
         $event->getLocale()->willReturn('de');
         $event->getNode()->willReturn($node->reveal());
         $this->propertyEncoder->localizedContentName('title', 'de')->willReturn('i18n:de-title');
@@ -51,10 +67,10 @@ class TitleSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->titleSubscriber->setTitleOnDocument($event->reveal());
     }
 
-    public function testSetTitleOnDocumentWithoutLocale()
+    public function testSetTitleOnDocumentLocalizedWithoutLocale()
     {
         $event = $this->prophesize(HydrateEvent::class);
-        $document = $this->prophesize(TitleBehavior::class);
+        $document = $this->prophesize(LocalizedTitleBehavior::class);
         $event->getDocument()->willReturn($document);
         $event->getLocale()->willReturn(null);
 
@@ -80,6 +96,22 @@ class TitleSubscriberTest extends \PHPUnit_Framework_TestCase
         $event = $this->prophesize(PersistEvent::class);
         $document = $this->prophesize(TitleBehavior::class);
         $node = $this->prophesize(NodeInterface::class);
+        $event->getDocument()->willReturn($document);
+        $event->getLocale()->willReturn(null);
+        $event->getNode()->willReturn($node->reveal());
+        $this->propertyEncoder->contentName('title')->willReturn('title');
+        $document->getTitle()->willReturn('title');
+
+        $node->setProperty('title', 'title')->shouldBeCalled();
+
+        $this->titleSubscriber->setTitleOnNode($event->reveal());
+    }
+
+    public function testSetTitleOnNodeLocalized()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $document = $this->prophesize(LocalizedTitleBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
         $event->getDocument()->willReturn($document->reveal());
         $event->getLocale()->willReturn('de');
         $event->getNode()->willReturn($node->reveal());
@@ -91,10 +123,10 @@ class TitleSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->titleSubscriber->setTitleOnNode($event->reveal());
     }
 
-    public function testSetTitleOnNodeWithoutLocale()
+    public function testSetTitleOnNodeLocalizedWithoutLocale()
     {
         $event = $this->prophesize(PersistEvent::class);
-        $document = $this->prophesize(TitleBehavior::class);
+        $document = $this->prophesize(LocalizedTitleBehavior::class);
         $event->getDocument()->willReturn($document);
         $event->getLocale()->willReturn(null);
 

--- a/src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
+++ b/src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
@@ -17,6 +17,7 @@ use Sulu\Component\DocumentManager\Behavior\Audit\TimestampBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 
 /**
  * Contains information about custom-urls and the relations to the routes.
@@ -27,7 +28,8 @@ class CustomUrlDocument implements
     TimestampBehavior,
     BlameBehavior,
     ParentBehavior,
-    LocaleBehavior
+    LocaleBehavior,
+    TitleBehavior
 {
     /**
      * @var string

--- a/src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
+++ b/src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
@@ -17,7 +17,7 @@ use Sulu\Component\DocumentManager\Behavior\Audit\TimestampBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
-use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
 
 /**
  * Contains information about custom-urls and the relations to the routes.
@@ -29,7 +29,7 @@ class CustomUrlDocument implements
     BlameBehavior,
     ParentBehavior,
     LocaleBehavior,
-    TitleBehavior
+    AutoNameBehavior
 {
     /**
      * @var string

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -275,6 +275,9 @@ class CustomUrlManager implements CustomUrlManagerInterface
      */
     private function bind(CustomUrlDocument $document, $data, $locale)
     {
+        $document->setTitle($data['title']);
+        unset($data['title']);
+
         $metadata = $this->metadataFactory->getMetadataForAlias('custom_url');
 
         $accessor = PropertyAccess::createPropertyAccessor();

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -10,8 +10,6 @@
 
 namespace Sulu\Component\CustomUrl\Manager;
 
-use Ferrandini\Urlizer;
-use PHPCR\ItemExistsException;
 use PHPCR\Util\PathHelper;
 use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
 use Sulu\Component\CustomUrl\Document\RouteDocument;
@@ -19,6 +17,7 @@ use Sulu\Component\CustomUrl\Repository\CustomUrlRepository;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
+use Sulu\Component\DocumentManager\Exception\NodeNameAlreadyExistsException;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\PathBuilder;
 use Sulu\Component\HttpCache\HandlerInvalidatePathInterface;
@@ -82,12 +81,12 @@ class CustomUrlManager implements CustomUrlManagerInterface
                 $locale,
                 [
                     'parent_path' => $this->getItemsPath($webspaceKey),
-                    'node_name' => Urlizer::urlize($document->getTitle()),
                     'load_ghost_content' => true,
+                    'auto_rename' => false,
                 ]
 
             );
-        } catch (ItemExistsException $ex) {
+        } catch (NodeNameAlreadyExistsException $ex) {
             throw new TitleAlreadyExistsException($document->getTitle());
         }
 
@@ -204,11 +203,12 @@ class CustomUrlManager implements CustomUrlManagerInterface
                 $locale,
                 [
                     'parent_path' => PathHelper::getParentPath($document->getPath()),
-                    'node_name' => Urlizer::urlize($document->getTitle()),
                     'load_ghost_content' => true,
+                    'auto_rename' => false,
+                    'auto_name_locale' => $locale,
                 ]
             );
-        } catch (ItemExistsException $ex) {
+        } catch (NodeNameAlreadyExistsException $ex) {
             throw new TitleAlreadyExistsException($document->getTitle());
         }
 

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
@@ -10,7 +10,6 @@
 
 namespace Sulu\Component\CustomUrl\Tests\Unit\Manager;
 
-use PHPCR\ItemExistsException;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
 use Sulu\Component\CustomUrl\Document\CustomUrlDocument;
 use Sulu\Component\CustomUrl\Document\RouteDocument;
@@ -19,6 +18,7 @@ use Sulu\Component\CustomUrl\Manager\RouteNotRemovableException;
 use Sulu\Component\CustomUrl\Manager\TitleAlreadyExistsException;
 use Sulu\Component\CustomUrl\Repository\CustomUrlRepository;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Exception\NodeNameAlreadyExistsException;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\PathBuilder;
@@ -61,7 +61,7 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $documentManager->persist(
             $testDocument,
             'en',
-            ['parent_path' => '/cmf/sulu_io/custom_urls/items', 'node_name' => 'test', 'load_ghost_content' => true]
+            ['parent_path' => '/cmf/sulu_io/custom_urls/items', 'load_ghost_content' => true, 'auto_rename' => false]
         )->shouldBeCalledTimes(1);
         $documentManager->find('123-123-123', 'en', ['load_ghost_content' => true])
             ->willReturn($targetDocument);
@@ -283,7 +283,12 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $documentManager->persist(
             $document,
             'en',
-            ['parent_path' => '/cmf/sulu_io/custom_urls/items', 'node_name' => 'test-1', 'load_ghost_content' => true]
+            [
+                'parent_path' => '/cmf/sulu_io/custom_urls/items',
+                'load_ghost_content' => true,
+                'auto_rename' => false,
+                'auto_name_locale' => 'en',
+            ]
         )->shouldBeCalledTimes(1);
 
         $result = $manager->save(
@@ -346,8 +351,13 @@ class CustomUrlManagerTest extends \PHPUnit_Framework_TestCase
         $documentManager->persist(
             $document,
             'en',
-            ['parent_path' => '/cmf/sulu_io/custom_urls/items', 'node_name' => 'test-1', 'load_ghost_content' => true]
-        )->willThrow(new ItemExistsException());
+            [
+                'parent_path' => '/cmf/sulu_io/custom_urls/items',
+                'load_ghost_content' => true,
+                'auto_rename' => false,
+                'auto_name_locale' => 'en',
+            ]
+        )->willThrow(NodeNameAlreadyExistsException::class);
 
         $this->setExpectedException(TitleAlreadyExistsException::class);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-document-manager/pull/89
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR tries to use the `AutoNameBehavior` for the `CustomUrlDocument`. It was not used until now, because the `AutoNameBehavior` implicitly required the Document to also implement the `StructureBehavior`, which the `CustomUrlDocument` does not.

#### Why?

This is required for #2361, because using the `parent_path` and `node_name` options in the `CustomUrlManager` break the syncing of the structure to the published workspace, which will be introduced in #2361.

#### BC Breaks/Deprecations

The `title` in the page type xml file is now only required for being displayed in the form of the Sulu-Admin. Therefore it is now handled in a different way, so that the indexing for the search doesn't allow anymore to set a search tag on the title property.

#### TODO

- [ ] Move `TitleBehavior` from `DocumentManager` to this repository