### PR TITLE
Fixed inset image scale image-size 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2454 [MediaBundle]         Fixed inset image scale image-size 0
     * HOTFIX      #2440 [MediaBundle]         Fixed media-selection sorting
     * HOTFIX      #2441 [ContentBundle]       Fixed block to handle non html text correctly
     * ENHANCEMENT #2432 [SecurityBundle]      New behat step for admin login with default locale

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Command/ScaleCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Command/ScaleCommand.php
@@ -29,7 +29,7 @@ class ScaleCommand implements CommandInterface
             'mode' => $image::THUMBNAIL_OUTBOUND,
         ], $parameters);
 
-        list($newWidth, $newHeight) = $this->getHeightWidth($parameters, $image->getSize());
+        list($newWidth, $newHeight) = $this->getHeightWidth($parameters, $image->getSize(), $parameters['mode']);
 
         $image = $image->thumbnail(new Box($newWidth, $newHeight), $parameters['mode']);
     }
@@ -40,7 +40,7 @@ class ScaleCommand implements CommandInterface
      *
      * @return array
      */
-    protected function getHeightWidth($parameters, $size)
+    protected function getHeightWidth($parameters, $size, $mode)
     {
         $newWidth = $parameters['x'];
         $newHeight = $parameters['y'];
@@ -64,7 +64,7 @@ class ScaleCommand implements CommandInterface
         // if image is smaller keep ratio
         // e.g. when a square image is requested (200x200) and the original image is smaller (150x100)
         //      it still returns a squared image (100x100)
-        if ($parameters['forceRatio']) {
+        if ($mode === ImageInterface::THUMBNAIL_OUTBOUND && $parameters['forceRatio']) {
             if ($newWidth > $size->getWidth()) {
                 list($newHeight, $newWidth) = $this->getSizeInSameRatio(
                     $newHeight,
@@ -99,6 +99,13 @@ class ScaleCommand implements CommandInterface
         }
 
         $size2 = $originalSize;
+
+        if ($size1 < 1) {
+            $size1 = 1;
+        }
+        if ($size2 < 1) {
+            $size2 = 1;
+        }
 
         return [$size1, $size2];
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Command/ScaleCommandTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Command/ScaleCommandTest.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Command;
 
+use Imagine\Image\ImageInterface;
+
 /**
  * Class ScaleCommandTest
  * Test the scale command service.
@@ -94,6 +96,53 @@ class ScaleCommandTest extends AbstractCommandTest
                 // Tested Result
                 'width' => 700,
                 'height' => 500,
+            ],
+            [
+                // Command Options
+                'options' => [
+                    'mode' => ImageInterface::THUMBNAIL_INSET,
+                    'x' => 200,
+                    'y' => 200,
+                ],
+                // Tested Result
+                'width' => 200,
+                'height' => 4,
+                // Source image
+                'imageHeight' => 6,
+                'imageWidth' => 300,
+            ],
+            [
+                // Command Options
+                'options' => [
+                    'mode' => ImageInterface::THUMBNAIL_INSET,
+                    'x' => 600,
+                    'y' => 600,
+                ],
+                // Tested Result
+                'width' => 600,
+                'height' => 429,
+            ],
+            [
+                // Command Options
+                'options' => [
+                    'mode' => ImageInterface::THUMBNAIL_INSET,
+                    'x' => 1000,
+                    'y' => 1000,
+                ],
+                // Tested Result
+                'width' => 700,
+                'height' => 500,
+            ],
+            [
+                // Command Options
+                'options' => [
+                    'mode' => ImageInterface::THUMBNAIL_INSET,
+                    'x' => 300,
+                    'y' => 300,
+                ],
+                // Tested Result
+                'width' => 300,
+                'height' => 214,
             ],
         ];
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2447 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the problem mentioned in the issue.

#### How?

The `forceRatio` would be disabled for inset image scale. This makes no sense because the inset command wont keep ratios and this make problems with calculating the image size.