### PR TITLE
removed port parameter from ServerStatusCommand because it has been added in Symfony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2455 [CoreBundle]          Fixed ServerStatusCommand for Symfony 2.8.7
     * BUGFIX      #2443 [WebsiteBundle]       Added portal check for portal-routes
     * FEATURE     #2424 [Content]             Add support for XInclude
     * BUGFIX      #2439 [ContentBundle]       Fixed tab visibility for create new page localization

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "sensio/framework-extra-bundle": "3.0.*",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "symfony-cmf/routing-bundle": "1.2.*",
-        "symfony/symfony": "~2.8",
+        "symfony/symfony": "~2.8.7",
         "willdurand/hateoas-bundle": "0.3.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "pagerfanta/pagerfanta": "~1.0",

--- a/src/Sulu/Bundle/CoreBundle/Command/ServerStatusCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/Command/ServerStatusCommand.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\CoreBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ServerStatusCommand as BaseServerStatusCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ServerStatusCommand extends BaseServerStatusCommand
@@ -24,8 +23,8 @@ class ServerStatusCommand extends BaseServerStatusCommand
     {
         parent::configure();
 
-        $this->addOption('port', 'p', InputOption::VALUE_REQUIRED, 'Address port number');
-
+        // We'll determine the port dynamically
+        $this->getDefinition()->getOption('port')->setDefault(null);
         $this->getDefinition()->getArgument('address')->setDefault('127.0.0.1');
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the `port` option from our own `ServerStatusCommand`.

#### Why?

Because the `port` option has now been added to Symfony 2.8.7.