### PR TITLE
Removed unneccessary NodeInterface definitions in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2462 [All]                 Removed unnecessary NodeInterface definitions in tests
     * BUGFIX      #2455 [CoreBundle]          Fixed ServerStatusCommand for Symfony 2.8.7
     * BUGFIX      #2443 [WebsiteBundle]       Added portal check for portal-routes
     * FEATURE     #2424 [Content]             Add support for XInclude

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/InternalLink/InternalLinksTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/InternalLink/InternalLinksTest.php
@@ -11,15 +11,13 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Types\InternalLink;
 
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\ContentBundle\Content\Types\InternalLinks;
+use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
-
-//FIXME remove on update to phpunit 3.8, caused by https://github.com/sebastianbergmann/phpunit/issues/604
-interface NodeInterface extends \PHPCR\NodeInterface, \Iterator
-{
-}
 
 /**
  * @group unit
@@ -44,13 +42,13 @@ class InternalLinksTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->contentQuery = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Query\ContentQueryExecutor',
+            ContentQueryExecutorInterface::class,
             [],
             '',
             false
         );
         $this->contentQueryBuilder = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Query\ContentQueryBuilderInterface',
+            ContentQueryBuilderInterface::class,
             [],
             '',
             false
@@ -61,7 +59,7 @@ class InternalLinksTest extends \PHPUnit_Framework_TestCase
     public function testWriteWithNoneExistingUUID()
     {
         $subNode1 = $this->getMockForAbstractClass(
-            'Sulu\Bundle\ContentBundle\Tests\Unit\Content\Types\InternalLink\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -70,7 +68,7 @@ class InternalLinksTest extends \PHPUnit_Framework_TestCase
         );
         $subNode1->expects($this->any())->method('getIdentifier')->will($this->returnValue('123-123-123'));
         $subNode2 = $this->getMockForAbstractClass(
-            'Sulu\Bundle\ContentBundle\Tests\Unit\Content\Types\InternalLink\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -80,7 +78,7 @@ class InternalLinksTest extends \PHPUnit_Framework_TestCase
         $subNode2->expects($this->any())->method('getIdentifier')->will($this->returnValue('123-456-789'));
 
         $node = $this->getMockForAbstractClass(
-            'Sulu\Bundle\ContentBundle\Tests\Unit\Content\Types\InternalLink\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -89,7 +87,7 @@ class InternalLinksTest extends \PHPUnit_Framework_TestCase
         );
 
         $session = $this->getMockForAbstractClass(
-            'PHPCR\SessionInterface',
+            SessionInterface::class,
             [],
             '',
             true,
@@ -103,7 +101,7 @@ class InternalLinksTest extends \PHPUnit_Framework_TestCase
         );
 
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -11,14 +11,12 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types;
 
-use PHPUnit_Framework_TestCase;
+use PHPCR\NodeInterface;
+use Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
 
-//FIXME remove on update to phpunit 3.8, caused by https://github.com/sebastianbergmann/phpunit/issues/604
-interface NodeInterface extends \PHPCR\NodeInterface, \Iterator
-{
-}
-
-class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
+class MediaSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType
@@ -32,9 +30,9 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->mediaManager = $this->getMock('\Sulu\Bundle\MeediaBundle\Media\Manager\MediaManagerInterface');
+        $this->mediaManager = $this->getMock(MediaManagerInterface::class);
 
-        $this->mediaSelection = new \Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType(
+        $this->mediaSelection = new MediaSelectionContentType(
             $this->mediaManager, 'SuluMediaBundle:Template:image-selection.html.twig'
         );
     }
@@ -47,7 +45,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
     public function testWrite()
     {
         $node = $this->getMockForAbstractClass(
-            'Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -57,7 +55,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         );
 
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,
@@ -102,7 +100,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
     public function testWriteWithPassedContainer()
     {
         $node = $this->getMockForAbstractClass(
-            'Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -112,7 +110,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         );
 
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,
@@ -160,7 +158,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';
 
         $node = $this->getMockForAbstractClass(
-            'Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -170,7 +168,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         );
 
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,
@@ -212,7 +210,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';
 
         $node = $this->getMockForAbstractClass(
-            'Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -222,7 +220,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         );
 
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,
@@ -265,7 +263,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         $config = '{"config":{"conf1": 1, "conf2": 2}, "displayOption": "right", "ids": [1,2,3,4]}';
 
         $node = $this->getMockForAbstractClass(
-            'Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types\NodeInterface',
+            NodeInterface::class,
             [],
             '',
             true,
@@ -275,7 +273,7 @@ class MediaSelectionContentTypeTest extends PHPUnit_Framework_TestCase
         );
 
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Two tests were still containing its own implementation from the `PHPCR\NodeInterface`. This was relevant back in the days, because of a bug in PHPUnit (https://github.com/sebastianbergmann/phpunit/issues/604).

#### Why?

IntelliJ also offered the implementations from these tests as suggestions, so you ended up sometimes to use the wrong implementation.