### PR TITLE
Replace deprecated security.context with security.token_storage service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2483 [All]                 Replace security.context with security.token_storage service
     * ENHANCEMENT #2479 [ContentBundle]       Removed restore history route function
     * ENHANCEMENT #2462 [All]                 Removed unnecessary NodeInterface definitions in tests
     * ENHANCEMENT #2461 [PreviewBundle]       Added function that avoid navigating in the preview

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -248,7 +248,7 @@ class ResettingController extends Controller
     private function loginUser(UserInterface $user, $request)
     {
         $token = new UsernamePasswordToken($user, null, 'admin', $user->getRoles());
-        $this->get('security.context')->setToken($token); //now the user is logged in
+        $this->get('security.token_storage')->setToken($token); //now the user is logged in
 
         //now dispatch the login event
         $event = new InteractiveLoginEvent($request, $token);

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/UserManagerCompilerPass.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/UserManagerCompilerPass.php
@@ -23,7 +23,7 @@ class UserManagerCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('security.context')) {
+        if ($container->hasDefinition('security.token_storage')) {
             $container->setDefinition(
                 'sulu_security.user_manager',
                 new Definition(

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -36,7 +36,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * handles snippets.
@@ -66,9 +66,9 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private $snippetRepository;
 
     /**
-     * @var SecurityContext
+     * @var TokenStorageInterface
      */
-    private $securityContext;
+    private $tokenStorage;
 
     /**
      * @var UrlGeneratorInterface
@@ -100,7 +100,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         ContentMapper $contentMapper,
         StructureManagerInterface $structureManager,
         SnippetRepository $snippetRepository,
-        SecurityContext $securityContext,
+        TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $urlGenerator,
         DefaultSnippetManagerInterface $defaultSnippetManager,
         DocumentManager $documentManager,
@@ -111,7 +111,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         $this->contentMapper = $contentMapper;
         $this->structureManager = $structureManager;
         $this->snippetRepository = $snippetRepository;
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->urlGenerator = $urlGenerator;
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->documentManager = $documentManager;
@@ -375,7 +375,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     */
    private function getUser()
    {
-       $token = $this->securityContext->getToken();
+       $token = $this->tokenStorage->getToken();
 
        if (null === $token) {
            throw new \InvalidArgumentException('No user is set');

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -24,7 +24,7 @@
             <argument type="service" id="sulu.content.mapper" />
             <argument type="service" id="sulu.content.structure_manager" />
             <argument type="service" id="sulu_snippet.repository" />
-            <argument type="service" id="security.context" on-invalid="ignore"/>
+            <argument type="service" id="security.token_storage" on-invalid="ignore"/>
             <argument type="service" id="router" />
             <argument type="service" id="sulu_snippet.default_snippet.manager" />
             <argument type="service" id="sulu_document_manager.document_manager" />

--- a/src/Sulu/Component/Persistence/Tests/Functional/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Functional/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
@@ -99,7 +99,7 @@ class UserBlameSubscriberIntegrationTest extends SuluTestCase
 
     private function createExternalUser()
     {
-        $context = $this->getContainer()->get('security.token_storage');
+        $tokenStorage = $this->getContainer()->get('security.token_storage');
         $token = new UsernamePasswordToken('test', 'test', 'test_provider', []);
         $user = new SymfonyUser('test', 'test');
         $token->setUser($user);

--- a/src/Sulu/Component/Persistence/Tests/Functional/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Functional/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
@@ -33,7 +33,7 @@ class UserBlameSubscriberIntegrationTest extends SuluTestCase
 
     public function testUserBlame()
     {
-        $context = $this->getContainer()->get('security.context');
+        $tokenStorage = $this->getContainer()->get('security.token_storage');
         $token = new UsernamePasswordToken('test', 'test', 'test_provider', []);
         $user = new User();
         $user->setUsername('dantleech');
@@ -49,7 +49,7 @@ class UserBlameSubscriberIntegrationTest extends SuluTestCase
         $this->getEntityManager()->flush();
         $token->setUser($user);
 
-        $context->setToken($token);
+        $tokenStorage->setToken($token);
         $contact = new Contact();
         $contact->setFirstName('Max');
         $contact->setLastName('Mustermann');
@@ -99,10 +99,10 @@ class UserBlameSubscriberIntegrationTest extends SuluTestCase
 
     private function createExternalUser()
     {
-        $context = $this->getContainer()->get('security.context');
+        $context = $this->getContainer()->get('security.token_storage');
         $token = new UsernamePasswordToken('test', 'test', 'test_provider', []);
         $user = new SymfonyUser('test', 'test');
         $token->setUser($user);
-        $context->setToken($token);
+        $tokenStorage->setToken($token);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | not sure
| Deprecations? | no
| License | MIT

#### What's in this PR?

Replace `security.context` with `security.token_storage`

#### Why?

The `security.context` service is deprecated.

