### PR TITLE
Add host and prefix automatically in twig url generation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,22 @@
 
 ## dev-develop
 
+### Twig variable `request.routeParameters` removed
+
+The `request.routeParameters` variable has been removed because it is not longer required when generate an url.
+
+**Before**
+
+```twig
+{{ path('client_website.search', request.routeParameters) }}
+```
+
+**After**
+
+```twig
+{{ path('client_website.search') }}
+```
+
 ### TitleBehavior is not localized anymore
 
 If you have implemented your own Documents with an `TitleBehavior`,

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -66,10 +66,6 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
                 'get' => $requestAnalyzer->getGetParameters(),
                 'post' => $requestAnalyzer->getPostParameters(),
                 'analyticsKey' => $requestAnalyzer->getAnalyticsKey(),
-                'routeParameters' => [
-                    'host' => $requestAnalyzer->getPortalInformation()->getHost(),
-                    'prefix' => $requestAnalyzer->getPortalInformation()->getPrefix(),
-                ],
             ],
         ];
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -164,6 +164,12 @@
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>
         </service>
 
+        <service id="sulu_website.routing.request_listener" class="Sulu\Bundle\WebsiteBundle\Routing\RequestListener">
+            <argument type="service" id="router"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onRequest" />
+        </service>
+
         <!-- exception controller -->
         <service id="sulu_website.exception.controller" class="%sulu_website.exception.controller.class%">
             <argument type="service" id="twig" />

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Routing;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Routing\RouterInterface;
+
+class RequestListener
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @param RouterInterface $router
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     */
+    public function __construct(
+        RouterInterface $router,
+        RequestAnalyzerInterface $requestAnalyzer
+    ) {
+        $this->router = $router;
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onRequest(GetResponseEvent $event)
+    {
+        $context = $this->router->getContext();
+        $portalInformation = $this->requestAnalyzer->getPortalInformation();
+
+        if ($portalInformation) {
+            if (!$context->hasParameter('prefix')) {
+                $context->setParameter('prefix', $portalInformation->getPrefix());
+            }
+            if (!$context->hasParameter('host')) {
+                $context->setParameter('host', $portalInformation->getHost());
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -31,10 +31,8 @@ class RequestListener
      * @param RouterInterface $router
      * @param RequestAnalyzerInterface $requestAnalyzer
      */
-    public function __construct(
-        RouterInterface $router,
-        RequestAnalyzerInterface $requestAnalyzer
-    ) {
+    public function __construct(RouterInterface $router, RequestAnalyzerInterface $requestAnalyzer)
+    {
         $this->router = $router;
         $this->requestAnalyzer = $requestAnalyzer;
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -129,10 +129,6 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
                     'get' => ['p' => 1],
                     'post' => [],
                     'analyticsKey' => 'analyticsKey',
-                    'routeParameters' => [
-                        'host' => 'sulu.lo',
-                        'prefix' => 'de_at',
-                    ],
                 ],
             ],
             $result

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/RequestListenerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Routing;
+
+use Sulu\Bundle\WebsiteBundle\Routing\RequestListener;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouterInterface;
+
+class RequestListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var PortalInformation
+     */
+    private $portalInformation;
+
+    /**
+     * @var RequestContext
+     */
+    private $requestContext;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->router = $this->prophesize(RouterInterface::class);
+        $this->portalInformation = $this->prophesize(PortalInformation::class);
+        $this->requestContext = $this->prophesize(RequestContext::class);
+        $this->event = $this->prophesize(GetResponseEvent::class);
+    }
+
+    public function testRequestAnalyzer()
+    {
+        $this->portalInformation->getPrefix()->willReturn('test/');
+        $this->portalInformation->getHost()->willReturn('sulu.io');
+        $this->requestAnalyzer->getPortalInformation()->willReturn($this->portalInformation);
+
+        $this->requestContext->hasParameter('prefix')->willReturn(false);
+        $this->requestContext->hasParameter('host')->willReturn(false);
+
+        $this->requestContext->setParameter('prefix', 'test/')->shouldBeCalled();
+        $this->requestContext->setParameter('host', 'sulu.io')->shouldBeCalled();
+
+        $this->router->getContext()->willReturn($this->requestContext);
+
+        $requestListener = new RequestListener($this->router->reveal(), $this->requestAnalyzer->reveal());
+        $requestListener->onRequest($this->event->reveal());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The `request.routeParameters` is not required for using `path` or `url` in a twig template.

#### Why?

When you render your own template and have no `request.routeParameters` you needed to call the request analyzer or create a twig extension which will load from the current request routeParameters.

#### Example Usage

```twig
{{ path('client_website.search') }}
{{ url('client_website.search') }}
```