### PR TITLE
Fixed portal redirect when using subfolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2486 [WebsiteBundle]       Fixed portal redirect when using subfolder
     * ENHANCEMENT #2483 [All]                 Replace security.context with security.token_storage service
     * ENHANCEMENT #2479 [ContentBundle]       Removed restore history route function
     * ENHANCEMENT #2462 [All]                 Removed unnecessary NodeInterface definitions in tests

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
@@ -32,7 +32,8 @@ class RedirectController extends Controller
     {
         $url = $this->resolveRedirectUrl(
             $request->get('redirect'),
-            $request->getUri()
+            $request->getUri(),
+            $request->get('_sulu')->getAttribute('resourceLocatorPrefix')
         );
 
         return new RedirectResponse($url, 301, ['Cache-Control' => 'private']);
@@ -80,10 +81,11 @@ class RedirectController extends Controller
      *
      * @param string $redirectUrl Redirect webspace URI
      * @param string $requestUri The actual incoming request URI
+     * @param string $resourceLocatorPrefix The prefix of the actual portal
      *
      * @return string URL to redirect to
      */
-    private function resolveRedirectUrl($redirectUrl, $requestUri)
+    private function resolveRedirectUrl($redirectUrl, $requestUri, $resourceLocatorPrefix)
     {
         $redirectInfo = $this->parseUrl($redirectUrl);
         $requestInfo = $this->parseUrl($requestUri);
@@ -98,8 +100,7 @@ class RedirectController extends Controller
             $url .= ':' . $requestInfo['port'];
         }
 
-        if (
-            isset($redirectInfo['path'])
+        if (isset($redirectInfo['path'])
             && (
                 // if requested url not starting with redirectUrl it need to be added
                 !isset($requestInfo['path'])
@@ -109,8 +110,13 @@ class RedirectController extends Controller
             $url .= $redirectInfo['path'];
         }
 
-        if (isset($requestInfo['path'])) {
-            $url .= $requestInfo['path'];
+        if (isset($requestInfo['path']) && $resourceLocatorPrefix !== $requestInfo['path']) {
+            $path = $requestInfo['path'];
+            if (0 === strpos($path, $resourceLocatorPrefix)) {
+                $path = substr($path, strlen($resourceLocatorPrefix));
+            }
+
+            $url .= $path;
             $url = rtrim($url, '/');
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/RedirectControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/RedirectControllerTest.php
@@ -10,6 +10,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,7 +30,7 @@ class RedirectControllerTest extends \PHPUnit_Framework_TestCase
         $this->controller = new RedirectController();
     }
 
-    private function getRequestMock($requestUrl, $portalUrl, $redirectUrl = null)
+    private function getRequestMock($requestUrl, $portalUrl, $redirectUrl = null, $prefix = '')
     {
         $request = $this->getMockBuilder(Request::class)->getMock();
         $request->expects($this->any())->method('get')->will(
@@ -37,6 +38,7 @@ class RedirectControllerTest extends \PHPUnit_Framework_TestCase
                 [
                     ['url', null, false, $portalUrl],
                     ['redirect', null, false, $redirectUrl],
+                    ['_sulu', null, false, new RequestAttributes(['resourceLocatorPrefix' => $prefix])],
                 ]
             )
         );
@@ -61,15 +63,17 @@ class RedirectControllerTest extends \PHPUnit_Framework_TestCase
             ['sulu-redirect.lo/', 'sulu-redirect.lo', 'sulu.lo', 'http://sulu.lo'],
             ['http://sulu.lo:8002/', 'sulu.lo', 'sulu.lo/en', 'http://sulu.lo:8002/en'],
             ['http://sulu.lo/articles', 'sulu.lo/en', 'sulu.lo/de', 'http://sulu.lo/de/articles'],
+            ['http://sulu.lo/events', 'sulu.lo/events', 'sulu.lo/events/de', 'http://sulu.lo/events/de', '/events'],
+            ['http://sulu.lo/events/articles', 'sulu.lo/events', 'sulu.lo/events/de', 'http://sulu.lo/events/de/articles', '/events'],
         ];
     }
 
     /**
      * @dataProvider provideRedirectAction
      */
-    public function testRedirectAction($requestUri, $portalUrl, $redirectUrl, $expectedTargetUrl)
+    public function testRedirectAction($requestUri, $portalUrl, $redirectUrl, $expectedTargetUrl, $prefix = '')
     {
-        $request = $this->getRequestMock($requestUri, $portalUrl, $redirectUrl);
+        $request = $this->getRequestMock($requestUri, $portalUrl, $redirectUrl, $prefix);
 
         $response = $this->controller->redirectWebspaceAction($request);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #1068
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the redirect if the portal is placed into a subfolder.
