### PR TITLE
Template attributes resolver for custom controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #2489 [WebsiteBundle]       Add a template attribute resolver service.
     * ENHANCEMENT #2483 [All]                 Replace security.context with security.token_storage service
     * ENHANCEMENT #2464 [All]                 Moved configuration from installation folder to sulu-core
     * ENHANCEMENT #2479 [ContentBundle]       Removed restore history route function

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -248,8 +248,9 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         /**
-         * Just a dirty hack to get the jms serializer bundle correctly working
-         * https://github.com/schmittjoh/JMSSerializerBundle/pull/270#issuecomment-21171800
+         * Just a dirty hack to get the jms serializer bundle correctly working.
+         *
+         * {@link https://github.com/schmittjoh/JMSSerializerBundle/pull/270#issuecomment-21171800}
          */
         $container->setAlias('jms_serializer.cache_naming_strategy', 'sulu_core.serialize_caching_strategy');
 

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -64,7 +64,8 @@ class RouteProvider implements RouteProviderInterface
         $collection = new RouteCollection();
         $path = $request->getPathInfo();
         $prefix = $this->requestAnalyzer->getResourceLocatorPrefix();
-        if (!empty($prefix)) {
+
+        if (!empty($prefix) && strpos($path, $prefix) === 0) {
             $path = PathHelper::relativizePath($path, $prefix);
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -54,12 +54,19 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
         $defaultLocalization = $requestAnalyzer->getPortal()->getDefaultLocalization();
         $defaultLocale = $defaultLocalization ? $defaultLocalization->getLocalization() : null;
 
+        $currentLocale = null;
+        $currentLocalization = $requestAnalyzer->getCurrentLocalization();
+
+        if ($currentLocalization) {
+            $currentLocale = $currentLocalization->getLocale();
+        }
+
         return [
             'request' => [
                 'webspaceKey' => $requestAnalyzer->getWebspace()->getKey(),
                 'portalKey' => $requestAnalyzer->getPortal()->getKey(),
                 'defaultLocale' => $defaultLocale,
-                'locale' => $requestAnalyzer->getCurrentLocalization()->getLocalization(),
+                'locale' => $currentLocale,
                 'portalUrl' => $requestAnalyzer->getPortalUrl(),
                 'resourceLocatorPrefix' => $requestAnalyzer->getResourceLocatorPrefix(),
                 'resourceLocator' => $requestAnalyzer->getResourceLocator(),

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Resolver;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Resolve all needed template attributes.
+ */
+class TemplateAttributeResolver implements TemplateAttributeResolverInterface
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    protected $requestAnalyzer;
+
+    /**
+     * @var RequestAnalyzerResolverInterface
+     */
+    protected $requestAnalyzerResolver;
+
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    protected $webspaceManager;
+
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @var string
+     */
+    protected $environment;
+
+    /**
+     * TemplateAttributeResolver constructor.
+     *
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     * @param RequestAnalyzerResolverInterface $requestAnalyzerResolver
+     * @param WebspaceManagerInterface $webspaceManager
+     * @param RouterInterface $router
+     * @param RequestStack $requestStack
+     * @param string $environment
+     */
+    public function __construct(
+        RequestAnalyzerInterface $requestAnalyzer,
+        RequestAnalyzerResolverInterface $requestAnalyzerResolver,
+        WebspaceManagerInterface $webspaceManager,
+        RouterInterface $router,
+        RequestStack $requestStack,
+        $environment
+    ) {
+        $this->requestAnalyzer = $requestAnalyzer;
+        $this->requestAnalyzerResolver = $requestAnalyzerResolver;
+        $this->webspaceManager = $webspaceManager;
+        $this->router = $router;
+        $this->requestStack = $requestStack;
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($customParameters = [])
+    {
+        $parameters = array_merge(
+            $this->getDefaultParameters(),
+            $this->requestAnalyzerResolver->resolve($this->requestAnalyzer)
+        );
+
+        // Generate Urls
+        if (!isset($customParameters['urls'])) {
+            $customParameters['urls'] = $this->getUrls();
+        }
+
+        return array_merge(
+            $parameters,
+            $customParameters
+        );
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDefaultParameters()
+    {
+        return [
+            'extension' => [
+                'excerpt' => [
+                ],
+                'seo' => [
+                ],
+            ],
+            'content' => [],
+            'view' => [],
+            'shadowBaseLocale' => null,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function getUrls()
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $urls = [];
+
+        if ($request->get('_route')) {
+            $portalInformations = $this->webspaceManager->getPortalInformations($this->environment);
+            $routeParams = $request->get('_route_params');
+
+            foreach ($portalInformations as $portalInformation) {
+                if (
+                    $portalInformation->getPortalKey() === $this->requestAnalyzer->getPortal()->getKey()
+                    && $portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_FULL
+                ) {
+                    if (isset($routeParams['prefix'])) {
+                        $routeParams['prefix'] = $portalInformation->getPrefix();
+                    }
+
+                    $url = $this->router->generate(
+                        $request->get('_route'),
+                        $routeParams,
+                        true
+                    );
+
+                    $urls[$portalInformation->getLocale()] = $url;
+                }
+            }
+        }
+
+        return $urls;
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolverInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolverInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Resolver;
+
+/**
+ * Interface for template attributes resolver.
+ */
+interface TemplateAttributeResolverInterface
+{
+    /**
+     * Returns all needed template attributes.
+     *
+     * @param array $customParameters
+     *
+     * @return array
+     */
+    public function resolve($customParameters = []);
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -159,6 +159,16 @@
             <argument>%kernel.environment%</argument>
         </service>
 
+        <service id="sulu_website.resolver.template_attribute"
+                 class="Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolver">
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_website.resolver.request_analyzer"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
+            <argument type="service" id="router"/>
+            <argument type="service" id="request_stack"/>
+            <argument>%kernel.environment%</argument>
+        </service>
+
         <service id="sulu_website.resolver.parameter" class="%sulu_website.resolver.parameter.class%">
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolverTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Resolver;
+
+use Sulu\Bundle\WebsiteBundle\Resolver\RequestAnalyzerResolverInterface;
+use Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolver;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Testing the TemplateAttributeResolver class.
+ */
+class TemplateAttributeResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    protected $requestAnalyzer;
+
+    /**
+     * @var RequestAnalyzerResolverInterface
+     */
+    protected $requestAnalyzerResolver;
+
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @var PortalInformation[]
+     */
+    protected $portalInformations;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    protected $webspaceManager;
+
+    /**
+     * @var Portal
+     */
+    protected $portal;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var TemplateAttributeResolver
+     */
+    protected $templateAttributeResolver;
+
+    /**
+     * @var string
+     */
+    protected $environment = 'test';
+
+    public function setUp()
+    {
+        $webspacePortalKey = 'sulu_io';
+
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->requestAnalyzerResolver = $this->prophesize(RequestAnalyzerResolverInterface::class);
+        $this->router = $this->prophesize(RouterInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->request = $this->prophesize(Request::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->portal = $this->prophesize(Portal::class);
+
+        $portalInformationEn = $this->prophesize(PortalInformation::class);
+        $portalInformationEn->getLocale()->willReturn('en');
+        $portalInformationEn->getType()->willReturn(RequestAnalyzerInterface::MATCH_TYPE_FULL);
+        $portalInformationEn->getPrefix()->willReturn('/en');
+        $portalInformationEn->getPortalKey()->willReturn($webspacePortalKey);
+
+        $portalInformationDe = $this->prophesize(PortalInformation::class);
+        $portalInformationDe->getLocale()->willReturn('de');
+        $portalInformationDe->getType()->willReturn(RequestAnalyzerInterface::MATCH_TYPE_FULL);
+        $portalInformationDe->getPrefix()->willReturn('/de');
+        $portalInformationDe->getPortalKey()->willReturn($webspacePortalKey);
+
+        $this->portalInformations = [
+            $portalInformationEn->reveal(),
+            $portalInformationDe->reveal(),
+        ];
+
+        $this->webspaceManager->getPortalInformations($this->environment)->willReturn($this->portalInformations);
+
+        $this->requestStack->getCurrentRequest()->willReturn($this->request);
+        $this->portal->getKey()->willReturn($webspacePortalKey);
+        $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal());
+
+        $this->request->get('_route')->willReturn('test');
+        $this->request->get('_route_params')->willReturn(['host' => 'sulu.io', 'prefix' => '/de']);
+
+        $this->router->generate('test', ['host' => 'sulu.io', 'prefix' => '/de'], true)->willReturn('http://sulu.io/de/test');
+        $this->router->generate('test', ['host' => 'sulu.io', 'prefix' => '/en'], true)->willReturn('http://sulu.io/en/test');
+
+        $this->requestAnalyzerResolver->resolve($this->requestAnalyzer)->willReturn(
+            [
+                'request' => [
+                    'webspaceKey' => $webspacePortalKey,
+                    'locale' => 'en',
+                ],
+            ]
+        );
+
+        $this->templateAttributeResolver = new TemplateAttributeResolver(
+            $this->requestAnalyzer->reveal(),
+            $this->requestAnalyzerResolver->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->router->reveal(),
+            $this->requestStack->reveal(),
+            $this->environment
+        );
+    }
+
+    public function testResolve()
+    {
+        $resolved = $this->templateAttributeResolver->resolve(['custom' => 'test']);
+
+        $this->assertEquals($resolved, [
+            'extension' => [
+                'seo' => [],
+                'excerpt' => [],
+            ],
+            'content' => [],
+            'view' => [],
+            'shadowBaseLocale' => null,
+            'custom' => 'test',
+            'urls' => [
+                'en' => 'http://sulu.io/en/test',
+                'de' => 'http://sulu.io/de/test',
+            ],
+            'request' => [
+                'webspaceKey' => 'sulu_io',
+                'locale' => 'en',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add a template attribute resolver to add sulu specific params to template rendering.

#### Why?

If you render a twig template over a custom controller you use mostly the same master.html.twig. So you need in this action the same template attributes.

#### Example Usage

```php
    /**
     * {@inheritdoc}
     */
    public function render($view, array $parameters = [], Response $response = null)
    {
        return parent::render(
            $view,
            $this->get('sulu_website.resolver.template_attribute')->resolve($parameters),
            $response
        );
    }
```

