### PR TITLE
Website Test Case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2492 [TestBundle]          Added website test case.
     * ENHANCEMENT #2483 [All]                 Replace security.context with security.token_storage service
     * ENHANCEMENT #2464 [All]                 Moved configuration from installation folder to sulu-core
     * ENHANCEMENT #2479 [ContentBundle]       Removed restore history route function

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -248,8 +248,9 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         /**
-         * Just a dirty hack to get the jms serializer bundle correctly working
-         * https://github.com/schmittjoh/JMSSerializerBundle/pull/270#issuecomment-21171800
+         * Just a dirty hack to get the jms serializer bundle correctly working.
+         *
+         * @link https://github.com/schmittjoh/JMSSerializerBundle/pull/270#issuecomment-21171800
          */
         $container->setAlias('jms_serializer.cache_naming_strategy', 'sulu_core.serialize_caching_strategy');
 

--- a/src/Sulu/Bundle/TestBundle/Testing/WebsiteTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/WebsiteTestCase.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\TestBundle\Testing;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+
+/**
+ * WebTestCase is the base class for website functional tests.
+ */
+abstract class WebsiteTestCase extends BaseWebTestCase
+{
+    /**
+     * Attempts to guess the WebsiteKernel location.
+     *
+     * When the WebsiteKernel is located, the file is required.
+     *
+     * @return string The WebsiteKernel class name
+     *
+     * @throws \RuntimeException
+     */
+    protected static function getKernelClass()
+    {
+        if (isset($_SERVER['KERNEL_DIR'])) {
+            $dir = $_SERVER['KERNEL_DIR'];
+
+            if (!is_dir($dir)) {
+                $phpUnitDir = static::getPhpUnitXmlDir();
+                if (is_dir("$phpUnitDir/$dir")) {
+                    $dir = "$phpUnitDir/$dir";
+                }
+            }
+        } else {
+            $dir = static::getPhpUnitXmlDir();
+        }
+
+        $file = $dir . DIRECTORY_SEPARATOR . 'WebsiteKernel.php';
+
+        if (!file_exists($file)) {
+            throw new \RuntimeException('Either set KERNEL_DIR in your phpunit.xml according to https://symfony.com/doc/current/book/testing.html#your-first-functional-test or override the WebsiteTestCase::createKernel() method.');
+        }
+
+        require_once $file;
+
+        return 'WebsiteKernel';
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Added website test case.

#### Why?

Easier website test setup

#### Example Usage

~~~php

namespace AppBundle\Tests\Controller;

use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;

class DefaultControllerTest extends WebsiteTestCase
{
    public function testIndex()
    {
        $client = static::createClient();

        $crawler = $client->request('GET', '/hello-world');

        $this->assertContains('Hello World', $client->getResponse()->getContent());
    }
}
~~~
