### PR TITLE
Fixed TestUserProvider for inheritance of contact. Created ContactRepositoryInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2498 [TestBundle]          Fixed TestUserProvider to create accounts with repository to support
+                                              sulu inheritance
     * BUGFIX      #2389 [MediaBundle]         Removed twice adding of navigation item
     * HOTFIX      #2481 [WebsiteBundle]       Fixed handling of non-default formats in error pages 
     * HOTFIX      #2467 [MediaBundle]         Fixed media-selection-overlay missing locale

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## dev-master
+
+### ContactRepository
+
+A Interface for the ContactRepository has been created. Due to the refactoring
+the function `appendJoins` has been changed from public to protected.
+Therefore this function cannot be called anymore.
+
 ## 1.2.1
 
 ### UserRepository

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ContactBundle\Entity;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Contact\Model\ContactRepositoryInterface;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryTrait;
@@ -21,20 +22,16 @@ use Sulu\Component\SmartContent\Orm\DataProviderRepositoryTrait;
 /**
  * Repository for the contacts, implementing some additional functions for querying objects.
  */
-class ContactRepository extends EntityRepository implements DataProviderRepositoryInterface
+class ContactRepository extends EntityRepository implements DataProviderRepositoryInterface, ContactRepositoryInterface
 {
     use DataProviderRepositoryTrait;
 
     /**
-     * find a contact by id.
-     *
-     * @param $id
-     *
-     * @return mixed|null
+     * {@inheritdoc}
      */
     public function findById($id)
     {
-        // create basic query
+        // Create basic query
         $qb = $this->createQueryBuilder('u')
             ->leftJoin('u.accountContacts', 'accountContacts')
             ->leftJoin('accountContacts.account', 'account')
@@ -99,11 +96,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     }
 
     /**
-     * find a contacts by ids.
-     *
-     * @param $ids
-     *
-     * @return mixed|null
+     * {@inheritdoc}
      */
     public function findByIds($ids)
     {
@@ -111,7 +104,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             return [];
         }
 
-        // create basic query
+        // Create basic query
         $qb = $this->createQueryBuilder('u')
             ->leftJoin('u.accountContacts', 'accountContacts')
             ->leftJoin('accountContacts.account', 'account')
@@ -174,15 +167,11 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     }
 
     /**
-     * find a contact by id and load additional infos to delete referenced entities.
-     *
-     * @param $id
-     *
-     * @return mixed|null
+     * {@inheritdoc}
      */
     public function findByIdAndDelete($id)
     {
-        // create basic query
+        // Create basic query
         $qb = $this->createQueryBuilder('u')
             ->leftJoin('u.accountContacts', 'accountContacts')
             ->leftJoin('accountContacts.account', 'account')
@@ -255,18 +244,11 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     }
 
     /**
-     * Searches Entities by where clauses, pagination and sorted.
-     *
-     * @param int|null $limit Page size for Pagination
-     * @param int|null $offset Offset for Pagination
-     * @param array|null $sorting Columns to sort
-     * @param array|null $where Where clauses
-     *
-     * @return array Results
+     * {@inheritdoc}
      */
     public function findGetAll($limit = null, $offset = null, $sorting = null, $where = [])
     {
-        // create basic query
+        // Create basic query
         $qb = $this->createQueryBuilder('u')
             ->leftJoin('u.emails', 'emails')
             ->leftJoin('u.phones', 'phones')
@@ -285,7 +267,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
         $qb = $this->addSorting($qb, $sorting, 'u');
         $qb = $this->addPagination($qb, $offset, $limit);
 
-        // if needed add where statements
+        // If needed add where statements
         if (is_array($where) && count($where) > 0) {
             $qb = $this->addWhere($qb, $where);
         }
@@ -296,14 +278,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     }
 
     /**
-     * Searches for contacts with a specific account and the ability to exclude a certain contacts.
-     *
-     * @param $accountId
-     * @param null $excludeContactId
-     * @param bool $arrayResult
-     * @param bool $onlyFetchMainAccounts Defines if only main relations should be returned
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function findByAccountId(
         $accountId,
@@ -313,7 +288,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     ) {
         $qb = $this->createQueryBuilder('c');
 
-        // only fetch main accounts
+        // Only fetch main accounts
         if ($onlyFetchMainAccounts) {
             $qb->join('c.accountContacts', 'accountContacts', 'WITH', 'accountContacts.main = true');
         } else {
@@ -347,7 +322,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
      */
     private function addSorting($qb, $sorting, $prefix = 'u')
     {
-        // add order by
+        // Add order by
         foreach ($sorting as $k => $d) {
             $qb->addOrderBy($prefix . '.' . $k, $d);
         }
@@ -366,7 +341,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
      */
     private function addPagination($qb, $offset, $limit)
     {
-        // add pagination
+        // Add pagination
         $qb->setFirstResult($offset);
         $qb->setMaxResults($limit);
 
@@ -395,19 +370,12 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     }
 
     /**
-     * finds a contact based on criteria and one email and one phone
-     * also joins account.
-     *
-     * @param $where
-     * @param $email
-     * @param $phone
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
     public function findByCriteriaEmailAndPhone($where, $email = null, $phone = null)
     {
 
-        // create basic query
+        // Create basic query
         $qb = $this->createQueryBuilder('contact')
             ->leftJoin('contact.accountContacts', 'accountContacts')
             ->leftJoin('accountContacts.account', 'account')
@@ -446,15 +414,11 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     }
 
     /**
-     * find a contact by id.
-     *
-     * @param $id
-     *
-     * @return mixed|null
+     * {@inheritdoc}
      */
     public function findContactWithAccountsById($id)
     {
-        // create basic query
+        // Create basic query
         $qb = $this->createQueryBuilder('c')
             ->leftJoin('c.accountContacts', 'accountContacts')
             ->leftJoin('accountContacts.account', 'account')
@@ -478,7 +442,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     /**
      * {@inheritdoc}
      */
-    public function appendJoins(QueryBuilder $queryBuilder, $alias, $locale)
+    protected function appendJoins(QueryBuilder $queryBuilder, $alias, $locale)
     {
         $queryBuilder->addSelect('emails')
             ->addSelect('emailType')

--- a/src/Sulu/Bundle/TestBundle/Resources/config/test_user_provider.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/config/test_user_provider.xml
@@ -8,6 +8,8 @@
     <services>
         <service id="test_user_provider" class="%sulu.test_user_provider.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="sulu.repository.contact"/>
+            <argument type="service" id="sulu.repository.user"/>
         </service>
         <service id="test_voter" class="%sulu.test_voter.class%" public="false">
             <tag name="security.voter"/>

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -47,13 +47,15 @@ class TestUserProvider implements UserProviderInterface
 
     /**
      * @param EntityManager $entityManager
+     * @param ContactRepositoryInterface $contactRepository
+     * @param UserRepositoryInterface $userRepository
      */
     public function __construct(
-        EntityManager $em,
+        EntityManager $entityManager,
         ContactRepositoryInterface $contactRepository,
         UserRepositoryInterface $userRepository
     ) {
-        $this->entityManager = $em;
+        $this->entityManager = $entityManager;
         $this->contactRepository = $contactRepository;
         $this->userRepository = $userRepository;
     }
@@ -67,9 +69,7 @@ class TestUserProvider implements UserProviderInterface
             return $this->user;
         }
 
-        $user = $this->entityManager
-            ->getRepository('Sulu\Bundle\SecurityBundle\Entity\User')
-            ->findOneByUsername('test');
+        $user = $this->userRepository->findOneByUsername('test');
 
         if (!$user) {
             $contact = $this->contactRepository->createNew();
@@ -141,11 +141,13 @@ class TestUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return $class === 'Sulu\Bundle\CoreBundle\Entity\TestUser';
+        return $class instanceof UserInterface;
     }
 
     /**
      * Sets the standard credentials for the user.
+     *
+     * @param UserInterface $user
      */
     private function setCredentials(UserInterface $user)
     {

--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserProvider.php
@@ -12,8 +12,9 @@
 namespace Sulu\Bundle\TestBundle\Testing;
 
 use Doctrine\ORM\EntityManager;
-use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Component\Contact\Model\ContactRepositoryInterface;
+use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -35,11 +36,26 @@ class TestUserProvider implements UserProviderInterface
     private $entityManager;
 
     /**
+     * @var ContactRepositoryInterface
+     */
+    private $contactRepository;
+
+    /**
+     * @var UserRepositoryInterface
+     */
+    private $userRepository;
+
+    /**
      * @param EntityManager $entityManager
      */
-    public function __construct(EntityManager $em)
-    {
+    public function __construct(
+        EntityManager $em,
+        ContactRepositoryInterface $contactRepository,
+        UserRepositoryInterface $userRepository
+    ) {
         $this->entityManager = $em;
+        $this->contactRepository = $contactRepository;
+        $this->userRepository = $userRepository;
     }
 
     /**
@@ -56,12 +72,12 @@ class TestUserProvider implements UserProviderInterface
             ->findOneByUsername('test');
 
         if (!$user) {
-            $contact = new Contact();
+            $contact = $this->contactRepository->createNew();
             $contact->setFirstName('Max');
             $contact->setLastName('Mustermann');
             $this->entityManager->persist($contact);
 
-            $user = new User();
+            $user = $this->userRepository->createNew();
             $this->setCredentials($user);
             $user->setSalt('');
             $user->setLocale('en');

--- a/src/Sulu/Component/Contact/Model/ContactRepositoryInterface.php
+++ b/src/Sulu/Component/Contact/Model/ContactRepositoryInterface.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Contact\Model;
+
+use Sulu\Component\Persistence\Repository\RepositoryInterface;
+
+/**
+ * Repository for the contacts, implementing some additional functions for querying objects.
+ */
+interface ContactRepositoryInterface extends RepositoryInterface
+{
+    /**
+     * Find a contact by id.
+     *
+     * @param int $id
+     *
+     * @return ContactInterface|null
+     */
+    public function findById($id);
+
+    /**
+     * Find a contacts by ids.
+     *
+     * @param int[] $ids
+     *
+     * @return ContactInterface[]
+     */
+    public function findByIds($ids);
+
+    /**
+     * Find a contact by id and load additional infos to delete referenced entities.
+     *
+     * @param int $id
+     *
+     * @return ContactInterface|null
+     */
+    public function findByIdAndDelete($id);
+
+    /**
+     * Searches Entities by where clauses, pagination and sorted.
+     *
+     * @param int|null $limit Page size for Pagination
+     * @param int|null $offset Offset for Pagination
+     * @param array|null $sorting Columns to sort
+     * @param array|null $where Where clauses
+     *
+     * @return array
+     */
+    public function findGetAll($limit = null, $offset = null, $sorting = null, $where = []);
+
+    /**
+     * Searches for contacts with a specific account and the ability to exclude a certain contacts.
+     *
+     * @param int $accountId
+     * @param null|int $excludeContactId
+     * @param bool $arrayResult
+     * @param bool $onlyFetchMainAccounts Defines if only main relations should be returned
+     *
+     * @return ContactInterface[]|array
+     */
+    public function findByAccountId(
+        $accountId,
+        $excludeContactId = null,
+        $arrayResult = true,
+        $onlyFetchMainAccounts = true
+    );
+
+    /**
+     * Finds a contact based on criteria and one email and one phone
+     * also joins account.
+     *
+     * @param array $where
+     * @param string $email
+     * @param string $phone
+     *
+     * @return ContactInterface|null
+     */
+    public function findByCriteriaEmailAndPhone($where, $email = null, $phone = null);
+
+    /**
+     * Find a contact by id.
+     *
+     * @param int $id
+     *
+     * @return ContactInterface|null
+     */
+    public function findContactWithAccountsById($id);
+}

--- a/src/Sulu/Component/Security/Authentication/UserRepositoryInterface.php
+++ b/src/Sulu/Component/Security/Authentication/UserRepositoryInterface.php
@@ -29,9 +29,9 @@ interface UserRepositoryInterface extends RepositoryInterface
     public function findUserById($id);
 
     /**
-     * @param $id
+     * @param int $id
      *
-     * @return mixed
+     * @return UserInterface
      *
      * @throws NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

TestUserProvider was creating Contact and User by calling `new Contact()` and `new User()`. That way it was not possible to use the UserTestProvider in projects that were extending Contact and/or User.
Now the UserRepositories and ContactRepositories `createNew()` Function is used for creating a User and Contact.

#### BC Breaks/Deprecations

A Interface for the ContactRepository has been created. Due to the refactoring
the function `appendJoins` has been changed from public to protected.
Therefore this function cannot be called anymore.
