### PR TITLE
Used intl-component to generate countries for location-content-type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2505 [MediaBundle]         Used intl-component to generate countries for location-content-type
     * ENHANCEMENT #2500 [MediaBundle]         Refactored handling of post data for media
     * ENHANCEMENT #2497 [MediaBundle]         Implemented MediaInterface for inheritance
     * BUGFIX      #2504 [WebsiteBundle]       Fixed http-cache clear if var dir exists

--- a/src/Sulu/Bundle/LocationBundle/Content/Types/LocationContentType.php
+++ b/src/Sulu/Bundle/LocationBundle/Content/Types/LocationContentType.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\LocationBundle\Map\MapManager;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
+use Symfony\Component\Intl\Intl;
 
 /**
  * ContentType for TextEditor.
@@ -68,28 +69,14 @@ class LocationContentType extends ComplexContentType
      */
     public function getDefaultParams(PropertyInterface $property = null)
     {
-        // Need a service to provide countries, see: https://github.com/sulu-cmf/SuluContactBundle/issues/121
         return [
-            'countries' => new PropertyParameter(
-                'countries',
-                [
-                    'at' => new PropertyParameter('at', 'Austria'),
-                    'fr' => new PropertyParameter('fr', 'France'),
-                    'ch' => new PropertyParameter('ch', 'Switzerland'),
-                    'de' => new PropertyParameter('de', 'Germany'),
-                    'gb' => new PropertyParameter('gb', 'Great Britain'),
-                ],
-                'collection'
-            ),
+            'countries' => new PropertyParameter('countries', $this->getCountries(), 'collection'),
             'mapProviders' => new PropertyParameter(
                 'mapProviders',
                 $this->mapManager->getProvidersAsArray(),
                 'collection'
             ),
-            'defaultProvider' => new PropertyParameter(
-                'defaultProvider',
-                $this->mapManager->getDefaultProviderName()
-            ),
+            'defaultProvider' => new PropertyParameter('defaultProvider', $this->mapManager->getDefaultProviderName()),
             'geolocatorName' => new PropertyParameter('geolocatorName', $this->geolocatorName),
         ];
     }
@@ -134,5 +121,20 @@ class LocationContentType extends ComplexContentType
         if ($node->hasProperty($property->getName())) {
             $node->getProperty($property->getName())->remove();
         }
+    }
+
+    /**
+     * Returns array of countries with the country-code as array key.
+     *
+     * @return array
+     */
+    private function getCountries()
+    {
+        $countries = [];
+        foreach (Intl::getRegionBundle()->getCountryNames() as $countryCode => $countryName) {
+            $countries[strtolower($countryCode)] = new PropertyParameter(strtolower($countryCode), $countryName);
+        }
+
+        return $countries;
     }
 }

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
@@ -112,7 +112,7 @@ class LocationContentTypeTest extends \PHPUnit_Framework_TestCase
                     'fr' => new PropertyParameter('fr', 'France'),
                     'ch' => new PropertyParameter('ch', 'Switzerland'),
                     'de' => new PropertyParameter('de', 'Germany'),
-                    'gb' => new PropertyParameter('gb', 'Great Britain'),
+                    'gb' => new PropertyParameter('gb', 'United Kingdom'),
                 ],
                 'collection'
             ),
@@ -136,6 +136,13 @@ class LocationContentTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getDefaultProviderName')
             ->will($this->returnValue('leaflet'));
 
-        $this->assertEquals($expected, $this->locationContent->getDefaultParams());
+        $params = $this->locationContent->getDefaultParams();
+
+        $this->assertEquals($expected['mapProviders'], $params['mapProviders']);
+        $this->assertEquals($expected['defaultProvider'], $params['defaultProvider']);
+        $this->assertEquals($expected['geolocatorName'], $params['geolocatorName']);
+        foreach ($expected['countries']->getValue() as $parameter) {
+            $this->assertEquals($parameter, $params['countries']->getValue()[$parameter->getName()]);
+        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the usage for intl-component to generate the dropdown in the content-type overlay.