### PR TITLE
Changed search adapter (to fit MassiveSearchBundle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2507 [SearchBundle]        Changed search adapter to fit new features of MassiveSearchBundle (limit + offset)
     * ENHANCEMENT #2500 [MediaBundle]         Refactored handling of post data for media
     * ENHANCEMENT #2497 [MediaBundle]         Implemented MediaInterface for inheritance
     * BUGFIX      #2504 [WebsiteBundle]       Fixed http-cache clear if var dir exists

--- a/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
@@ -116,7 +116,7 @@ class SearchController
 
         $time = microtime(true) - $startTime;
 
-        $adapter = new ArrayAdapter($query->execute());
+        $adapter = new ArrayAdapter(iterator_to_array($query->execute()));
         $pager = new Pagerfanta($adapter);
         $pager->setMaxPerPage($limit);
         $pager->setCurrentPage($page);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2360 
| Related issues/PRs | [#79 from MassiveSearchBundle](https://github.com/massiveart/MassiveSearchBundle/pull/79)
| License | MIT

#### What's in this PR?

This PR is required after merging PR #79 from the MassiveSearchBundle which adds functionality for limit and offset. Fixes the expected result, which must be an array


