### PR TITLE
Fix doctrine generators when class not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2513 [PersistanceBundle]   Fix doctrine generator commands
     * BUGFIX      #2776 [MediaBundle]         Fixed upload of media without an extension
     * BUGFIX      #2850 [ContentBundle]       Ordered response of template action alphabetically
     * BUGFIX      #2848 [ContentBundle]       Fixed preview serialization to include date and authors

--- a/src/Sulu/Bundle/MediaBundle/Entity/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/Media.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use JMS\Serializer\Annotation\Exclude;
 use Sulu\Component\Security\Authentication\UserInterface;
 
@@ -37,7 +36,7 @@ class Media implements MediaInterface
     protected $changed;
 
     /**
-     * @var Collection
+     * @var ArrayCollection
      */
     protected $files;
 

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -94,6 +94,10 @@ class MetadataSubscriber implements EventSubscriber
      */
     private function setAssociationMappings(ClassMetadataInfo $metadata, Configuration $configuration)
     {
+        if (!class_exists($metadata->getName())) {
+            return;
+        }
+
         foreach (class_parents($metadata->getName()) as $parent) {
             $parentMetadata = new ClassMetadata(
                 $parent,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #1343 
| License | MIT

#### What's in this PR?

It checks if the class exists before calling `class_parents` function.

#### Why?

This will fix problems with the doctrine generators.

![bildschirmfoto 2016-08-26 um 11 29 32](https://cloud.githubusercontent.com/assets/1698337/18000925/b21ee926-6b80-11e6-979c-972c6ecf0f7d.png)

