### PR TITLE
added unpublishing functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment
+    * FEATURE     #2515 [ContentBundle]       Added unpublishing functionality for pages
     * BUGFIX      #2586 [AdminBundle]         fixed behat tests
     * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview
     * BUGIFX      #2579 [ContentBundle]       Removed smart-content component destroy callback conflict

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -724,7 +724,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
     public function postTriggerAction($uuid, Request $request)
     {
         // extract parameter
-        $webspace = $this->getWebspace($request);
         $action = $this->getRequestParameter($request, 'action', true);
         $language = $this->getLanguage($request);
         $userId = $this->getUser()->getId();
@@ -756,15 +755,24 @@ class NodeController extends RestController implements ClassResourceInterface, S
                     break;
                 case 'order':
                     $position = (int) $this->getRequestParameter($request, 'position', true);
+                    $webspace = $this->getWebspace($request);
 
                     // call repository method
                     $data = $repository->orderAt($uuid, $position, $webspace, $language, $userId);
                     break;
                 case 'copy-locale':
                     $destLocale = $this->getRequestParameter($request, 'dest', true);
+                    $webspace = $this->getWebspace($request);
 
                     // call repository method
                     $data = $repository->copyLocale($uuid, $userId, $webspace, $language, explode(',', $destLocale));
+                    break;
+                case 'unpublish':
+                    $document = $this->getDocumentManager()->find($uuid, $language);
+                    $this->getDocumentManager()->unpublish($document, $language);
+                    $this->getDocumentManager()->flush();
+
+                    $data = $this->getDocumentManager()->find($uuid, $language);
                     break;
                 default:
                     throw new RestException('Unrecognized action: ' . $action);

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/services/content-manager.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/services/content-manager.js
@@ -47,6 +47,25 @@ define(['jquery'], function ($) {
                     error: errorCallback
                 }
             );
+        },
+
+        unpublish: function(id, locale) {
+            var deferred = $.Deferred();
+            $.ajax(
+                [baseUrl, '/', id, '?', 'action=unpublish&language=' + locale].join(''),
+                {
+                    method: 'POST',
+                    contentType: 'application/json; charset=utf-8',
+                    success: function(response) {
+                        deferred.resolve(response);
+                    },
+                    error: function(xhr) {
+                        deferred.reject(xhr);
+                    }
+                }
+            );
+
+            return deferred.promise();
         }
     }
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -699,6 +699,14 @@
                 <source>sulu-content.draft-label</source>
                 <target><![CDATA[Du arbeitest an einem Entwurf, zuletzt gespeichert: %(changed)s von <b>%(user)s</b>]]></target>
             </trans-unit>
+            <trans-unit id="46" resname="sulu-content.unpublish">
+                <source>sulu-content.unpublish</source>
+                <target>Veröffentlichung widerrufen</target>
+            </trans-unit>
+            <trans-unit id="47" resname="labels.error.content-unpublish-desc">
+                <source>labels.error.content-unpublish-desc</source>
+                <target>Veröffentlichung der Seite konnte nicht widerrufen werden.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -691,6 +691,14 @@
                 <source>sulu-content.draft-label</source>
                 <target><![CDATA[You are working on a draft, last saved: %(changed)s by <b>%(user)s</b>]]></target>
             </trans-unit>
+            <trans-unit id="46" resname="sulu-content.unpublish">
+                <source>sulu-content.unpublish</source>
+                <target>Unpublish</target>
+            </trans-unit>
+            <trans-unit id="47" resname="labels.error.content-unpublish-desc">
+                <source>labels.error.content-unpublish-desc</source>
+                <target>Page could not be unpublished.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
@@ -691,6 +691,14 @@
                 <source>sulu-content.draft-label</source>
                 <target><![CDATA[Tu travailles à une ébauche sauvegarder en dernier par <b>%(user)s</b> à %(changed)s.]]></target>
             </trans-unit>
+            <trans-unit id="46" resname="sulu-content.unpublish">
+                <source>sulu-content.unpublish</source>
+                <target>Annuler publication</target>
+            </trans-unit>
+            <trans-unit id="47" resname="labels.error.content-unpublish-desc">
+                <source>labels.error.content-unpublish-desc</source>
+                <target>La publication de la page n’a pas pu être anullée.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
@@ -25,6 +25,7 @@ use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\Event\UnpublishEvent;
 use Sulu\Component\DocumentManager\NodeHelperInterface;
 
 class PublishSubscriberTest extends \PHPUnit_Framework_TestCase
@@ -269,7 +270,7 @@ class PublishSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->publishSubscriber->reorderNodeInPublicWorkspace($event->reveal());
     }
 
-    public function testSetNodeFromPublicWorkspace()
+    public function testSetNodeFromPublicWorkspaceForPublishing()
     {
         $document = $this->prophesize(PathBehavior::class);
         $document->getPath()->willReturn('/cmf/sulu');
@@ -281,7 +282,22 @@ class PublishSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $event->setNode($this->node->reveal())->shouldBeCalled();
 
-        $this->publishSubscriber->setNodeFromPublicWorkspace($event->reveal());
+        $this->publishSubscriber->setNodeFromPublicWorkspaceForPublishing($event->reveal());
+    }
+
+    public function testSetNodeFromPublicWorkspaceForUnpublishing()
+    {
+        $document = $this->prophesize(PathBehavior::class);
+        $document->getPath()->willReturn('/cmf/sulu');
+
+        $event = $this->prophesize(UnpublishEvent::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->liveSession->getNode('/cmf/sulu')->willReturn($this->node->reveal());
+
+        $event->setNode($this->node->reveal())->shouldBeCalled();
+
+        $this->publishSubscriber->setNodeFromPublicWorkspaceForUnpublishing($event->reveal());
     }
 
     public function testFlushPublicWorkspace()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2028 
| Related issues/PRs | based on #2361, https://github.com/sulu/sulu-document-manager/pull/92
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the possibility to unpublish a page. When a page is unpublished, the content in its language is deleted in the live workspace, and the state is set to test and the published date is reset to null in the draft workspace.

#### Why?

Because it should be possible to remove a page from the live workspace without deleting it entirely.

#### To Do

- [ ] French translation
- [x] ~~Caching~~ (#2537)
