### PR TITLE
moved parent from BasePageDocument to PageDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2518 [ContentBundle]       Moved parent from BasePageDocument to PageDocument
     * ENHANCEMENT #2507 [SearchBundle]        Changed search adapter to fit new features of MassiveSearchBundle (limit + offset)
     * ENHANCEMENT #2508 [DocumentManager]     Set default structure-type if non given
     * ENHANCEMENT #2506 [ContentBundle]       Extracted seo-tab to reuse it in other bundles

--- a/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/BasePageDocument.php
@@ -30,7 +30,6 @@ use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ChildrenBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocalizedTitleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
-use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
@@ -40,7 +39,6 @@ use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
  */
 class BasePageDocument implements
     NodeNameBehavior,
-    ParentBehavior,
     LocalizedStructureBehavior,
     ResourceSegmentBehavior,
     NavigationContextBehavior,
@@ -91,13 +89,6 @@ class BasePageDocument implements
      * @var int
      */
     protected $changer;
-
-    /**
-     * Document's parent.
-     *
-     * @var object
-     */
-    protected $parent;
 
     /**
      * Title of document.
@@ -307,22 +298,6 @@ class BasePageDocument implements
     public function getChanger()
     {
         return $this->changer;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return $this->parent;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setParent($parent)
-    {
-        $this->parent = $parent;
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Document/PageDocument.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/PageDocument.php
@@ -18,4 +18,28 @@ use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
  */
 class PageDocument extends BasePageDocument implements AutoNameBehavior
 {
+    /**
+     * @var object
+     */
+    private $parent;
+
+    /**
+     * Return the parent document for this document.
+     *
+     * @return object
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Set the parent document for this document.
+     *
+     * @param object $parent
+     */
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
 }

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
@@ -12,35 +12,15 @@
 namespace Sulu\Bundle\ContentBundle\Form\Type;
 
 use Sulu\Component\Content\Form\Type\DocumentObjectType;
-use Sulu\Component\DocumentManager\DocumentManager;
-use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 abstract class BasePageDocumentType extends AbstractStructureBehaviorType
 {
-    /**
-     * @var SessionManagerInterface
-     */
-    private $sessionManager;
-
-    /**
-     * @var DocumentManager
-     */
-    private $documentManager;
-
-    public function __construct(SessionManagerInterface $sessionManager, DocumentManager $documentManager)
-    {
-        $this->sessionManager = $sessionManager;
-        $this->documentManager = $documentManager;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -61,7 +41,6 @@ abstract class BasePageDocumentType extends AbstractStructureBehaviorType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('parent', DocumentObjectType::class);
         $builder->add('extensions', TextType::class, ['property_path' => 'extensionsData']);
         $builder->add('resourceSegment', TextType::class);
         $builder->add(
@@ -80,38 +59,5 @@ abstract class BasePageDocumentType extends AbstractStructureBehaviorType
         $builder->add('shadowLocaleEnabled', CheckboxType::class);
         $builder->add('shadowLocale', TextType::class); // TODO: Should be choice of available shadow locales
         $builder->setAttribute('webspace_key', $options['webspace_key']);
-
-        $builder->addEventListener(FormEvents::POST_SUBMIT, [$this, 'postSubmitDocumentParent']);
-    }
-
-    /**
-     * Set the document parent to be the webspace content path
-     * when the document has no parent.
-     *
-     * @param FormEvent $event
-     */
-    public function postSubmitDocumentParent(FormEvent $event)
-    {
-        $document = $event->getData();
-
-        if ($document->getParent()) {
-            return;
-        }
-
-        $form = $event->getForm();
-        $webspaceKey = $form->getConfig()->getAttribute('webspace_key');
-        $parent = $this->documentManager->find($this->sessionManager->getContentPath($webspaceKey));
-
-        if (null === $parent) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Could not determine parent for document with title "%s" in webspace "%s"',
-                    $document->getTitle(),
-                    $webspaceKey
-                )
-            );
-        }
-
-        $document->setParent($parent);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/PageDocumentType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/PageDocumentType.php
@@ -11,13 +11,28 @@
 
 namespace Sulu\Bundle\ContentBundle\Form\Type;
 
+use Sulu\Component\Content\Form\Type\DocumentObjectType;
 use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class PageDocumentType extends BasePageDocumentType
 {
+    /**
+     * @var SessionManagerInterface
+     */
+    private $sessionManager;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
     /**
      * @var MetadataFactory
      */
@@ -28,9 +43,21 @@ class PageDocumentType extends BasePageDocumentType
         DocumentManager $documentManager,
         MetadataFactory $metadataFactory
     ) {
-        parent::__construct($sessionManager, $documentManager);
-
+        $this->sessionManager = $sessionManager;
+        $this->documentManager = $documentManager;
         $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+
+        $builder->add('parent', DocumentObjectType::class);
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, [$this, 'postSubmitDocumentParent']);
     }
 
     /**
@@ -53,5 +80,36 @@ class PageDocumentType extends BasePageDocumentType
     public function getName()
     {
         return 'page';
+    }
+
+    /**
+     * Set the document parent to be the webspace content path
+     * when the document has no parent.
+     *
+     * @param FormEvent $event
+     */
+    public function postSubmitDocumentParent(FormEvent $event)
+    {
+        $document = $event->getData();
+
+        if ($document->getParent()) {
+            return;
+        }
+
+        $form = $event->getForm();
+        $webspaceKey = $form->getConfig()->getAttribute('webspace_key');
+        $parent = $this->documentManager->find($this->sessionManager->getContentPath($webspaceKey));
+
+        if (null === $parent) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Could not determine parent for document with title "%s" in webspace "%s"',
+                    $document->getTitle(),
+                    $webspaceKey
+                )
+            );
+        }
+
+        $document->setParent($parent);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/form.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/form.xml
@@ -21,9 +21,6 @@
         </service>
 
         <service id="dtl_content.form.type.home" class="Sulu\Bundle\ContentBundle\Form\Type\HomeDocumentType">
-            <argument type="service" id="sulu.phpcr.session" />
-            <argument type="service" id="sulu_document_manager.document_manager" />
-
             <tag name="form.type" alias="home" />
         </service>
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
@@ -43,7 +43,6 @@
         <property name="extensions" type="Sulu\Component\Content\Document\Extension\ExtensionContainer" serialized-name="ext" groups="defaultPage,preview"/>
         <property name="structure" type="Sulu\Component\Content\Document\Structure\Structure" groups="preview"/>
         <property name="children" exclude="true" type="Sulu\Component\DocumentManager\Collection\ChildrenCollection"/>
-        <property name="parent" exclude="true"/>
         <property name="suluOrder" type="integer" serialized-name="order" groups="defaultPage,smallPage"/>
         <property name="permissions" exclude="true"/>
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.PageDocument.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.PageDocument.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
     <class name="Sulu\Bundle\ContentBundle\Document\PageDocument">
+        <property name="parent" exclude="true"/>
     </class>
 </serializer>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | prerequesite for #2361 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This content moves the `parent` variable from the `BasePageDocument` to the `PageDocument`, because the `HomeDocument` also inherits from the `BasePageDocument`, although it doesn't have a parent document.

#### Why?

This PR is necessary because the architectural flaw described here prevents #2361 from working correctly.

