### PR TITLE
delete routes using the DocumentManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2520 [ContentBundle]       Delete routes using the DocumentManager
     * ENHANCEMENT #2518 [ContentBundle]       Moved parent from BasePageDocument to PageDocument
     * ENHANCEMENT #2507 [SearchBundle]        Changed search adapter to fit new features of MassiveSearchBundle (limit + offset)
     * ENHANCEMENT #2508 [DocumentManager]     Set default structure-type if non given

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeResourcelocatorController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeResourcelocatorController.php
@@ -12,8 +12,8 @@
 namespace Sulu\Bundle\ContentBundle\Controller;
 
 use FOS\RestBundle\Routing\ClassResourceInterface;
-use PHPCR\SessionInterface;
 use Sulu\Bundle\ContentBundle\Repository\ResourceLocatorRepositoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Rest\RestController;
 
@@ -78,7 +78,7 @@ class NodeResourcelocatorController extends RestController implements ClassResou
         $path = $this->getRequestParameter($this->getRequest(), 'path', true);
 
         $this->getResourceLocatorRepository()->delete($path, $webspaceKey, $languageCode);
-        $this->getSession()->save();
+        $this->getDocumentManager()->flush();
 
         return $this->handleView($this->view());
     }
@@ -105,10 +105,10 @@ class NodeResourcelocatorController extends RestController implements ClassResou
     }
 
     /**
-     * @return SessionInterface
+     * @return DocumentManagerInterface
      */
-    private function getSession()
+    private function getDocumentManager()
     {
-        return $this->get('doctrine_phpcr.default_session');
+        return $this->get('sulu_document_manager.document_manager');
     }
 }

--- a/src/Sulu/Component/Content/Types/Rlp/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/Rlp/Mapper/PhpcrMapper.php
@@ -15,7 +15,6 @@ use DateTime;
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
-use PHPCR\SessionInterface;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
@@ -336,40 +335,12 @@ class PhpcrMapper extends RlpMapper
             );
         }
 
-        $session = $this->sessionManager->getSession();
-        $routeNode = $session->getNode($this->getPath($path, $webspaceKey, $languageCode, $segmentKey));
-        $this->deleteByNode($routeNode, $session, $webspaceKey, $languageCode, $segmentKey);
-    }
+        $routeDocument = $this->documentManager->find(
+            $this->getPath($path, $webspaceKey, $languageCode, $segmentKey),
+            $languageCode
+        );
 
-    /**
-     * {@inheritdoc}
-     */
-    private function deleteByNode(
-        NodeInterface $node,
-        SessionInterface $session,
-        $webspaceKey,
-        $languageCode,
-        $segmentKey = null
-    ) {
-        if ($node->getPropertyValue('sulu:history') !== true) {
-            // search for history nodes
-            $this->iterateRouteNodes(
-                $node,
-                function ($resourceLocator, NodeInterface $historyNode) use (
-                    $session,
-                    $webspaceKey,
-                    $languageCode,
-                    $segmentKey
-                ) {
-                    // delete history nodes
-                    $this->deleteByNode($historyNode, $session, $webspaceKey, $languageCode, $segmentKey);
-                },
-                $webspaceKey,
-                $languageCode,
-                $segmentKey
-            );
-        }
-        $node->remove();
+        $this->documentManager->remove($routeDocument);
     }
 
     /**
@@ -414,7 +385,6 @@ class PhpcrMapper extends RlpMapper
      */
     private function getWebspaceRouteNode($webspaceKey, $languageCode, $segmentKey)
     {
-        // trailing slash
         return $this->sessionManager->getRouteNode($webspaceKey, $languageCode, $segmentKey);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | prerequesite of #2361 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR uses the `DocumentManager` to delete routes instead of deleting them manually using the session.

#### Why?

1. Because the logic is already implemented in the `RouteSubscriber`, and does not need to be duplicated in the `PhpcrMapper`.
2. Because the `DocumentManager` uses the correct session, when publishing is introduced (#2361).
