### PR TITLE
use correct default phpcr session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2522 [All]                 Use correct default phpcr session
     * ENHANCEMENT #2518 [ContentBundle]       Moved parent from BasePageDocument to PageDocument
     * ENHANCEMENT #2507 [SearchBundle]        Changed search adapter to fit new features of MassiveSearchBundle (limit + offset)
     * ENHANCEMENT #2508 [DocumentManager]     Set default structure-type if non given

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeResourcelocatorController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeResourcelocatorController.php
@@ -109,6 +109,6 @@ class NodeResourcelocatorController extends RestController implements ClassResou
      */
     private function getSession()
     {
-        return $this->get('doctrine_phpcr.default_session');
+        return $this->get('doctrine_phpcr.session');
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/ResourceLocatorRepositoryTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/ResourceLocatorRepositoryTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Functional\Repository;
 
-use PHPCR\SessionInterface;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
 use Sulu\Bundle\ContentBundle\Repository\ResourceLocatorRepositoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -29,11 +28,6 @@ class ResourceLocatorRepositoryTest extends SuluTestCase
     private $documentManager;
 
     /**
-     * @var SessionInterface
-     */
-    private $session;
-
-    /**
      * @var ResourceLocatorRepositoryInterface
      */
     private $repository;
@@ -42,7 +36,6 @@ class ResourceLocatorRepositoryTest extends SuluTestCase
     {
         $this->initPhpcr();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
         $this->repository = $this->getContainer()->get('sulu_content.rl_repository');
     }
 
@@ -121,7 +114,7 @@ class ResourceLocatorRepositoryTest extends SuluTestCase
         $structure = $this->prepareHistoryTestData();
 
         $this->repository->delete('/test', 'sulu_io', 'en');
-        $this->session->save();
+        $this->documentManager->flush();
         $result = $this->repository->getHistory($structure->getUuid(), 'sulu_io', 'en');
 
         $this->assertEquals(1, count($result['_embedded']['resourcelocators']));

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -138,7 +138,7 @@
 
         <!-- sulu node helper -->
         <service id="sulu.util.node_helper" class="%sulu.util.node_helper.class%">
-            <argument type="service" id="doctrine_phpcr.default_session"/>
+            <argument type="service" id="doctrine_phpcr.session"/>
             <argument>%sulu.content.language.namespace%</argument>
             <argument type="collection">
                 <argument key="base">%sulu.content.node_names.base%</argument>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
@@ -9,7 +9,7 @@
 
     <services>
         <service id="sulu.phpcr.session" class="%sulu.phpcr.session.class%">
-            <argument type="service" id="doctrine_phpcr.default_session"/>
+            <argument type="service" id="doctrine_phpcr.session"/>
             <argument type="collection">
                 <argument key="base">%sulu.content.node_names.base%</argument>
                 <argument key="content">%sulu.content.node_names.content%</argument>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -26,7 +26,7 @@
         </service>
 
         <service id="sulu_document_manager.node_manager" class="Sulu\Component\DocumentManager\NodeManager" public="false">
-            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="doctrine_phpcr.session" />
         </service>
 
         <service id="sulu_document_manager.metadata_factory.base" class="Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory" public="false">
@@ -139,7 +139,7 @@
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session" />
+            <argument type="service" id="doctrine_phpcr.session" />
             <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\WebsiteBundle\Navigation;
 
 use PHPCR\NodeInterface;
-use PHPCR\SessionInterface;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -27,7 +26,6 @@ use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Query\ContentQueryExecutor;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
-use Sulu\Component\Webspace\Navigation;
 
 class NavigationTest extends SuluTestCase
 {
@@ -50,11 +48,6 @@ class NavigationTest extends SuluTestCase
      * @var DocumentManagerInterface
      */
     private $documentManager;
-
-    /**
-     * @var SessionInterface
-     */
-    private $session;
 
     /**
      * @var StructureManagerInterface
@@ -83,7 +76,6 @@ class NavigationTest extends SuluTestCase
         $this->initPhpcr();
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
         $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');
         $this->extensionManager = $this->getContainer()->get('sulu_content.extension.manager');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -96,7 +96,7 @@ class SitemapGeneratorTest extends SuluTestCase
     {
         $this->initPhpcr();
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->webspaceManager = $this->getContainer()->get('sulu_core.webspace.webspace_manager');
         $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -90,7 +90,7 @@ class ContentMapperTest extends SuluTestCase
         $this->extensions = [new TestExtension('test1'), new TestExtension('test2', 'test2')];
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->extensionManager = $this->getContainer()->get('sulu_content.extension.manager');
         $this->contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -77,7 +77,7 @@ class ContentRepositoryTest extends SuluTestCase
 
     public function setUp()
     {
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->propertyEncoder = $this->getContainer()->get('sulu_document_manager.property_encoder');

--- a/src/Sulu/Component/Content/Tests/Functional/Rlp/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Rlp/Mapper/PhpcrMapperTest.php
@@ -69,7 +69,7 @@ class PhpcrMapperTest extends SuluTestCase
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
 
         $this->prepareTestData();

--- a/src/Sulu/Component/Content/Tests/Functional/Rlp/Strategy/TreeStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Rlp/Strategy/TreeStrategyTest.php
@@ -45,7 +45,7 @@ class TreeStrategyTest extends SuluTestCase
         $this->rlpStrategy = $this->getContainer()->get('sulu.content.rlp.strategy.tree');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.default_session');
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
 
         $this->initPhpcr();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | prerequesite for #2361 
| License | MIT
| Documentation PR | none

#### What's in this PR?

`doctrine_phpcr.default_session` is not the default session, but the session actually named "default". `doctrine_phpcr.session` refers to the real default session. This PR changes these occurences.

#### Why?

Because it doesn't work if the session is named different from `default`.