### PR TITLE
fixed error with non-visible permissions types in matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2523 [SecurityBundle]      Fixed error with non-visible permission types in matrix
     * ENHANCEMENT #2518 [ContentBundle]       Moved parent from BasePageDocument to PageDocument
     * ENHANCEMENT #2507 [SearchBundle]        Changed search adapter to fit new features of MassiveSearchBundle (limit + offset)
     * ENHANCEMENT #2508 [DocumentManager]     Set default structure-type if non given

--- a/src/Sulu/Bundle/SecurityBundle/Resources/public/js/components/permission-tab/components/form/main.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/public/js/components/permission-tab/components/form/main.js
@@ -65,7 +65,7 @@ define(['config', 'sulusecurity/collections/roles'], function(Config, Roles) {
 
                     // set the data for all available roles
                     this.sandbox.util.each(roles, function(index, role) {
-                        var data = {}, matrixRoleData = [];
+                        var permissionRoleData = {}, matrixRoleData = [];
 
                         // set the captions and values for the matrix
                         verticalCaptions.push(role.name);
@@ -74,7 +74,7 @@ define(['config', 'sulusecurity/collections/roles'], function(Config, Roles) {
 
                         // initialize the data
                         this.sandbox.util.each(permissionTypes, function(index, permission) {
-                            data[permission.value] = false;
+                            permissionRoleData[permission.value] = false;
                         }.bind(this));
 
                         // set the data from the permissions
@@ -83,8 +83,7 @@ define(['config', 'sulusecurity/collections/roles'], function(Config, Roles) {
                             this.sandbox.util.each(
                                 permissionResponseData.permissions[role.id],
                                 function(index, value) {
-                                    data[index] = value;
-                                    matrixRoleData.push(value);
+                                    setPermissionTypeData(permissionRoleData, matrixRoleData, index, value);
                                 }
                             );
                         } else {
@@ -96,12 +95,11 @@ define(['config', 'sulusecurity/collections/roles'], function(Config, Roles) {
                             );
 
                             this.sandbox.util.each(contextPermissions, function (index, value) {
-                                data[index] = value;
-                                matrixRoleData.push(value);
+                                setPermissionTypeData(permissionRoleData, matrixRoleData, index, value);
                             });
                         }
 
-                        permissionData.permissions[role.id] = data;
+                        permissionData.permissions[role.id] = permissionRoleData;
                         matrixData[index] = matrixRoleData;
                     }.bind(this));
 
@@ -141,6 +139,13 @@ define(['config', 'sulusecurity/collections/roles'], function(Config, Roles) {
                     setPermission.call(this, data.section, value.value, data.activated);
                 });
             }
+        },
+
+        setPermissionTypeData = function (permissionRoleData, matrixRoleData, index, value) {
+            if (!!permissionRoleData.hasOwnProperty(index)) {
+                matrixRoleData.push(value);
+            }
+            permissionRoleData[index] = value;
         },
 
         setPermission = function(section, value, activated) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | prerequesite for #2361 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the assignment of data to the internal arrays of the permission tab component.

#### Why?

Because the non-visible permission types in the matrix were always overridden with false.

#### Steps to reproduce

1. Navigate to `Settings > User Roles`
2. Create a new role with the following media permission:
![image](https://cloud.githubusercontent.com/assets/405874/16492697/f076b76e-3ee2-11e6-8b08-0ccafc675f4e.png)
3. Navigate to `Media` and select a collection without permissions
4. Click the lock to open the permission overlay
5. Add the live permission and click ok
6. Open the overlay again and see that the live permission is missing