### PR TITLE
Change vars visibility to make AdminController extendable

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -30,77 +30,77 @@ class AdminController
     /**
      * @var AuthorizationCheckerInterface
      */
-    private $authorizationChecker;
+    protected $authorizationChecker;
 
     /**
      * @var UrlGeneratorInterface
      */
-    private $urlGenerator;
+    protected $urlGenerator;
 
     /**
      * @var TokenStorageInterface
      */
-    private $tokenStorage;
+    protected $tokenStorage;
 
     /**
      * @var AdminPool
      */
-    private $adminPool;
+    protected $adminPool;
 
     /**
      * @var JsConfigPool
      */
-    private $jsConfigPool;
+    protected $jsConfigPool;
 
     /**
      * @var SerializerInterface
      */
-    private $serializer;
+    protected $serializer;
 
     /**
      * @var EngineInterface
      */
-    private $engine;
+    protected $engine;
 
     /**
      * @var string
      */
-    private $environment;
+    protected $environment;
 
     /**
      * @var string
      */
-    private $adminName;
+    protected $adminName;
 
     /**
      * @var array
      */
-    private $locales;
+    protected $locales;
 
     /**
      * @var string
      */
-    private $suluVersion;
+    protected $suluVersion;
 
     /**
      * @var array
      */
-    private $translatedLocales;
+    protected $translatedLocales;
 
     /**
      * @var array
      */
-    private $translations;
+    protected $translations;
 
     /**
      * @var string
      */
-    private $fallbackLocale;
+    protected $fallbackLocale;
 
     /**
      * @var LocalizationManagerInterface
      */
-    private $localizationManager;
+    protected $localizationManager;
 
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
#### What's in this PR?

This PR change the visibility for variables to "protected" in the AdminController to let developers extend the class.
#### Why?

Right now extending the AdminController is almost useless as all variables are private
