### PR TITLE
Allow route generation for dynamic entity routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2536 [AdminBundle]         changed icon markup in search component (husky)
     * BUGFIX      #2534 [ContactBundle]       Fixed static usage of media repository
+    * FEATURE     #2532 [RouteBundle]         Allow route generation for entity routes
     * ENHANCEMENT #2533 [RouteBundle]         Added locale to route-defaults
     * BUGFIX      #2535 [PreviewBundle]       Wrapped website-kernel and append preview-specific configs
     * BUGFIX      #2530 [AdminBundle]         Included husky build which fixes the login translation issue

--- a/src/Sulu/Bundle/RouteBundle/Entity/RouteRepositoryInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/RouteRepositoryInterface.php
@@ -34,4 +34,13 @@ interface RouteRepositoryInterface
      * @return RouteInterface
      */
     public function findByPath($path, $locale);
+
+    /**
+     * Returns route-entity by id.
+     *
+     * @param int $id
+     *
+     * @return RouteInterface
+     */
+    public function find($id);
 }

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/routing.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/routing.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="sulu.repository.route"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_route.routing.defaults_provider"/>
+            <argument type="service" id="request_stack"/>
 
             <tag name="sulu.context" context="website"/>
         </service>

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -13,10 +13,12 @@ namespace Sulu\Bundle\RouteBundle\Routing;
 
 use PHPCR\Util\PathHelper;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -26,6 +28,8 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class RouteProvider implements RouteProviderInterface
 {
+    const ROUTE_PREFIX = 'sulu_route_';
+
     /**
      * @var RouteRepositoryInterface
      */
@@ -42,18 +46,26 @@ class RouteProvider implements RouteProviderInterface
     private $routeDefaultsProvider;
 
     /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
      * @param RouteRepositoryInterface $routeRepository
      * @param RequestAnalyzerInterface $requestAnalyzer
      * @param RouteDefaultsProviderInterface $routeDefaultsProvider
+     * @param RequestStack $requestStack
      */
     public function __construct(
         RouteRepositoryInterface $routeRepository,
         RequestAnalyzerInterface $requestAnalyzer,
-        RouteDefaultsProviderInterface $routeDefaultsProvider
+        RouteDefaultsProviderInterface $routeDefaultsProvider,
+        RequestStack $requestStack
     ) {
         $this->routeRepository = $routeRepository;
         $this->requestAnalyzer = $requestAnalyzer;
         $this->routeDefaultsProvider = $routeDefaultsProvider;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -70,40 +82,14 @@ class RouteProvider implements RouteProviderInterface
         }
 
         $route = $this->routeRepository->findByPath('/' . ltrim($path, '/'), $request->getLocale());
+
         if (!$route || !$this->routeDefaultsProvider->supports($route->getEntityClass())) {
             return $collection;
         }
 
-        if ($route->isHistory()) {
-            $collection->add(
-                uniqid('sulu_history_route_', true),
-                new Route(
-                    $request->getPathInfo(),
-                    [
-                        '_controller' => 'SuluWebsiteBundle:Redirect:redirect',
-                        'url' => $request->getSchemeAndHttpHost()
-                            . $this->requestAnalyzer->getResourceLocatorPrefix()
-                            . $route->getTarget()->getPath()
-                            . ($request->getQueryString() ? ('?' . $request->getQueryString()) : ''),
-                    ]
-                )
-            );
-
-            return $collection;
-        }
-
-        // TODO move route-name to entity
-
         $collection->add(
-            uniqid('sulu_route_', true),
-            new Route(
-                $request->getPathInfo(),
-                $this->routeDefaultsProvider->getByEntity(
-                    $route->getEntityClass(),
-                    $route->getEntityId(),
-                    $request->getLocale()
-                )
-            )
+            self::ROUTE_PREFIX . $route->getId(),
+            $this->createRoute($route, $request)
         );
 
         return $collection;
@@ -114,7 +100,20 @@ class RouteProvider implements RouteProviderInterface
      */
     public function getRouteByName($name)
     {
-        throw new RouteNotFoundException();
+        if (strpos($name, self::ROUTE_PREFIX) !== 0) {
+            throw new RouteNotFoundException();
+        }
+
+        $routeId = substr($name, strlen(self::ROUTE_PREFIX));
+
+        /** @var RouteInterface $route */
+        $route = $this->routeRepository->find($routeId);
+
+        if (!$route) {
+            throw new RouteNotFoundException();
+        }
+
+        return $this->createRoute($route, $this->requestStack->getCurrentRequest());
     }
 
     /**
@@ -123,5 +122,40 @@ class RouteProvider implements RouteProviderInterface
     public function getRoutesByNames($names)
     {
         return [];
+    }
+
+    /**
+     * Will create a symfony route.
+     *
+     * @param RouteInterface $route
+     * @param Request $request
+     *
+     * @return Route
+     */
+    protected function createRoute(RouteInterface $route, Request $request)
+    {
+        $routePath = $this->requestAnalyzer->getResourceLocatorPrefix() . $route->getPath();
+
+        if ($route->isHistory()) {
+            return new Route(
+                $routePath,
+                [
+                    '_controller' => 'SuluWebsiteBundle:Redirect:redirect',
+                    'url' => $request->getSchemeAndHttpHost()
+                        . $this->requestAnalyzer->getResourceLocatorPrefix()
+                        . $route->getTarget()->getPath()
+                        . ($request->getQueryString() ? ('?' . $request->getQueryString()) : ''),
+                ]
+            );
+        }
+
+        return new Route(
+            $routePath,
+            $this->routeDefaultsProvider->getByEntity(
+                $route->getEntityClass(),
+                $route->getEntityId(),
+                $request->getLocale()
+            )
+        );
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
 use Sulu\Bundle\RouteBundle\Routing\RouteProvider;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class RouteProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -40,18 +41,25 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
      */
     private $defaultsProvider;
 
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
     protected function setUp()
     {
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->defaultsProvider = $this->prophesize(RouteDefaultsProviderInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
 
         $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/de');
 
         $this->routeProvider = new RouteProvider(
             $this->routeRepository->reveal(),
             $this->requestAnalyzer->reveal(),
-            $this->defaultsProvider->reveal()
+            $this->defaultsProvider->reveal(),
+            $this->requestStack->reveal()
         );
     }
 
@@ -95,6 +103,8 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
         $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/test');
         $routeEntity->isHistory()->willReturn(false);
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
@@ -124,6 +134,8 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
         $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/test');
         $routeEntity->getTarget()->willReturn($targetEntity->reveal());
         $routeEntity->isHistory()->willReturn(true);
 
@@ -156,6 +168,8 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
         $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/test');
         $routeEntity->getTarget()->willReturn($targetEntity->reveal());
         $routeEntity->isHistory()->willReturn(true);
 
@@ -185,6 +199,8 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
         $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/test');
         $routeEntity->isHistory()->willReturn(false);
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -127,6 +127,7 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         if ($request->get('_route')) {
             $portalInformations = $this->webspaceManager->getPortalInformations($this->environment);
             $routeParams = $request->get('_route_params');
+            $routeName = $request->get('_route');
 
             foreach ($portalInformations as $portalInformation) {
                 if (
@@ -138,7 +139,7 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
                     }
 
                     $url = $this->router->generate(
-                        $request->get('_route'),
+                        $routeName,
                         $routeParams,
                         true
                     );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This will allow to generate a route by the route service.

#### Why?

Is needed when the template resolver service is used.

#### Example Usage

```php
$this->router->generate('sulu_route_1');
```