### PR TITLE
Wrapped website-kernel and append preview-specific configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2534 [ContactBundle]       Fixed static usage of media repository
     * ENHANCEMENT #2533 [RouteBundle]         Added locale to route-defaults
+    * BUGFIX      #2535 [PreviewBundle]       Wrapped website-kernel and append preview-specific configs
     * BUGFIX      #2530 [AdminBundle]         Included husky build which fixes the login translation issue
     * FEATURE     #2528 [AdminBundle]         Added form-abstraction for simple data-mapper forms
     * ENHANCEMENT #2526 [SearchBundle]        Introduced contexts for indexes to restrict selections

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Preview\Renderer;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+/**
+ * Extends website-kernel from sulu-installation and override configuration.
+ */
+class PreviewKernel extends \WebsiteKernel
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        parent::registerContainerConfiguration($loader);
+
+        $loader->load(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview.yml']));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRootDir()
+    {
+        if (null === $this->rootDir) {
+            $reflectionClass = new \ReflectionClass(\WebsiteKernel::class);
+            $this->rootDir = dirname($reflectionClass->getFileName());
+        }
+
+        return $this->rootDir;
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/WebsiteKernelFactory.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/WebsiteKernelFactory.php
@@ -21,13 +21,8 @@ class WebsiteKernelFactory implements KernelFactoryInterface
      */
     public function create($environment)
     {
-        $kernel = new \WebsiteKernel($environment, $environment === 'dev');
+        $kernel = new PreviewKernel($environment, $environment === 'dev');
         $kernel->boot();
-        $container = $kernel->getContainer();
-
-        if ($container->has('profiler')) {
-            $container->get('profiler')->disable();
-        }
 
         return $kernel;
     }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -1,0 +1,5 @@
+framework:
+    session:
+        storage_id: session.storage.mock_file
+    profiler:
+        enabled: false


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces PreviewKernel which wraps the WebsiteKernel and append configuration to disable profiler and session-storage.

#### Why?

If you enable file session-storage there will be an exception because of ini_set