### PR TITLE
SecuritySubscribers tokenStorage should default to null

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
@@ -40,7 +40,7 @@ class SecuritySubscriber implements EventSubscriberInterface
 
     public function __construct(
         AccessControlManagerInterface $accessControlManager,
-        TokenStorageInterface $tokenStorage
+        TokenStorageInterface $tokenStorage = null
     ) {
         $this->accessControlManager = $accessControlManager;
         $this->tokenStorage = $tokenStorage;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Set default value for `tokenStorage` to null

#### Why?

Service definition sets the `tokenStorage` to null if invalid. Resulting in an uncatched exception