### PR TITLE
Allow country to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #2621 [ContentBundle]       Added migration for publishing
     * ENHANCEMENT #2623 [DocumentManager]     Add publishing toolbar buttons to extensions in document manager bundle
     * ENHANCEMENT #2614 [ContentBundle]       Removed unused code and tests
+    * ENHANCEMENT #2555 [ContactBundle]       Allow country to be nullable in address entity
     * BUGFIX      #2603 [ContentBundle]       Fixed resource locator generation for pages with ghost-parent
     * BUGFIX      #2613 [ContactBundle]       Fixed categories save bug in contacts
     * BUGFIX      #2539 [SecurityBundle]      Made TokenStorage dependency for SecuritySubscriber optional

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade
 
+## dev-develop
+
+### Address country is nullable
+
+To make it easier to migrate data the country in the address entity is now nullable in sulu.
+
+```sql
+ALTER TABLE co_addresses CHANGE idCountries idCountries INT DEFAULT NULL;
+```
+
 ## 1.3.0-RC2
 
 ### SearchController

--- a/src/Sulu/Bundle/ContactBundle/Entity/Address.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Address.php
@@ -345,7 +345,7 @@ class Address
      *
      * @return Address
      */
-    public function setCountry(\Sulu\Bundle\ContactBundle\Entity\Country $country)
+    public function setCountry(\Sulu\Bundle\ContactBundle\Entity\Country $country = null)
     {
         $this->country = $country;
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Address.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Address.orm.xml
@@ -38,7 +38,7 @@
 
         <many-to-one field="country" target-entity="Sulu\Bundle\ContactBundle\Entity\Country" inversed-by="addresses">
             <join-columns>
-                <join-column name="idCountries" referenced-column-name="id" nullable="false"/>
+                <join-column name="idCountries" referenced-column-name="id" nullable="true"/>
             </join-columns>
         </many-to-one>
     </entity>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Allow country to be nullable.

#### Why?

If you migrate an old system to sulu you have some incomplete address data where the country is not set.