### PR TITLE
Add last login listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #2557 [SecurityBundle]      Set user last login by a listener
     * ENHANCEMENT #2540 [AdminBundle]         Removed deprecation notices
     * BUGFIX      #2536 [AdminBundle]         changed icon markup in search component (husky)
     * BUGFIX      #2534 [ContactBundle]       Fixed static usage of media repository

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/LastLoginListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/LastLoginListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\BaseUser;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+/**
+ * Listener to set the last login field.
+ */
+class LastLoginListener implements EventSubscriberInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * LastLoginListener constructor.
+     *
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Subscribe the login events.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            SecurityEvents::INTERACTIVE_LOGIN => 'onSecurityInteractiveLogin',
+        ];
+    }
+
+    /**
+     * @param InteractiveLoginEvent $event
+     */
+    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
+    {
+        $user = $event->getAuthenticationToken()->getUser();
+        $this->updateLastLogin($user);
+    }
+
+    /**
+     * Update the users last login.
+     *
+     * @param UserInterface $user
+     */
+    protected function updateLastLogin($user)
+    {
+        if ($user instanceof BaseUser) {
+            $user->setLastLogin(new \DateTime());
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/checker.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/checker.xml
@@ -18,5 +18,10 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
         </service>
+
+        <service id="sulu_security.last_login_listener" class="Sulu\Bundle\SecurityBundle\EventListener\LastLoginListener">
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add last login listener.

#### Why?

To set the last login automatically when the user logged in.