### PR TITLE
deactivated WebDebugToolbar for preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview
     * FEATURE     #2557 [SecurityBundle]      Set user last login by a listener
     * ENHANCEMENT #2544 [PreviewBundle]       Bugfix for preview in firefox
     * BUGFIX      #2551 [SecurityBundle]      added search fields and search instancename for roles list search

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -3,3 +3,6 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
+
+web_profiler:
+    toolbar: false


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR disables the WebDebugToolbar of Symfony for the preview.

#### Why?

Because #2535 disabled the profiler, which is required for the WebDebugToolbar. This is also causing the 404 errors when opening pages.