### PR TITLE
add fixtures without purging database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.2.7 (2016-07-12)
+    * HOTFIX      #2585 [CoreBundle]          add fixtures without purging database
     * HOTFIX      #2550 [MediaBundle]         made documents list show description on add
     * HOTFIX      #2547 [AdminBundle]         Included husky build which fixes the ie11 rendering issue of dropdowns
     * HOTFIX      #2547 [AdminBundle]         Included husky build which fixes globalizing bug

--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadDefaultTypes.php
@@ -27,91 +27,84 @@ class LoadDefaultTypes extends AbstractFixture implements OrderedFixtureInterfac
      */
     public function load(ObjectManager $manager)
     {
-        $phoneType1 = new PhoneType();
-        $phoneType1->setId(1);
-
-        // force id = 1
-        $metadata = $manager->getClassMetaData(get_class($phoneType1));
+        // phone types
+        $metadata = $manager->getClassMetaData(PhoneType::class);
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
+        $phoneType1 = new PhoneType();
+        $phoneType1->setId(1);
+        $phoneType1 = $manager->merge($phoneType1);
         $phoneType1->setName('phone.work');
-        $manager->persist($phoneType1);
 
         $phoneType2 = new PhoneType();
         $phoneType2->setId(2);
+        $phoneType2 = $manager->merge($phoneType2);
         $phoneType2->setName('phone.home');
-        $manager->persist($phoneType2);
 
         $phoneType3 = new PhoneType();
         $phoneType3->setId(3);
+        $phoneType3 = $manager->merge($phoneType3);
         $phoneType3->setName('phone.mobile');
-        $manager->persist($phoneType3);
+
+        // email types
+        $metadata = $manager->getClassMetaData(EmailType::class);
+        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
         $emailType1 = new EmailType();
         $emailType1->setId(1);
-
-        // force id = 1
-        $metadata = $manager->getClassMetaData(get_class($emailType1));
-        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
-
+        $emailType1 = $manager->merge($emailType1);
         $emailType1->setName('email.work');
-        $manager->persist($emailType1);
 
         $this->addReference('email.type.work', $emailType1);
 
         $emailType2 = new EmailType();
         $emailType2->setId(2);
+        $emailType2 = $manager->merge($emailType2);
         $emailType2->setName('email.home');
-        $manager->persist($emailType2);
 
         $this->addReference('email.type.home', $emailType2);
 
-        $addressType1 = new AddressType();
-        $addressType1->setId(1);
-
-        // force id = 1
-        $metadata = $manager->getClassMetaData(get_class($addressType1));
+        // address types
+        $metadata = $manager->getClassMetaData(AddressType::class);
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
+        $addressType1 = new AddressType();
+        $addressType1->setId(1);
+        $addressType1 = $manager->merge($addressType1);
         $addressType1->setName('address.work');
-        $manager->persist($addressType1);
 
         $addressType2 = new AddressType();
         $addressType2->setId(2);
+        $addressType2 = $manager->merge($addressType2);
         $addressType2->setName('address.home');
-        $manager->persist($addressType2);
+
+        // url types
+        $metadata = $manager->getClassMetaData(UrlType::class);
+        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
         $urlType1 = new UrlType();
         $urlType1->setId(1);
-
-        // force id = 1
-        $metadata = $manager->getClassMetaData(get_class($urlType1));
-        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
-
+        $urlType1 = $manager->merge($urlType1);
         $urlType1->setName('url.work');
-        $manager->persist($urlType1);
 
         $urlType2 = new UrlType();
         $urlType2->setId(2);
+        $urlType2 = $manager->merge($urlType2);
         $urlType2->setName('url.home');
-        $manager->persist($urlType2);
 
-        $manager->flush();
+        // fax types
+        $metadata = $manager->getClassMetaData(FaxType::class);
+        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
         $faxType1 = new FaxType();
         $faxType1->setId(1);
-
-        // force id = 1
-        $metadata = $manager->getClassMetaData(get_class($faxType1));
-        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
-
+        $faxType1 = $manager->merge($faxType1);
         $faxType1->setName('fax.work');
-        $manager->persist($faxType1);
 
         $faxType2 = new FaxType();
         $faxType2->setId(2);
+        $faxType2 = $manager->merge($faxType2);
         $faxType2->setName('fax.home');
-        $manager->persist($faxType2);
 
         $manager->flush();
     }

--- a/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
@@ -37,7 +37,7 @@ class FixturesBuilder extends SuluBuilder
      */
     public function build()
     {
-        $this->execCommand('Loading ORM fixtures', 'doctrine:fixtures:load', ['--no-interaction' => true, '--append' => false]);
+        $this->execCommand('Loading ORM fixtures', 'doctrine:fixtures:load', ['--no-interaction' => true, '--append' => true]);
         $this->execCommand('Loading SULU fixtures', 'sulu:document:fixtures:load', ['--no-interaction' => true]);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadCollectionTypes.php
@@ -24,40 +24,25 @@ class LoadCollectionTypes extends AbstractFixture implements OrderedFixtureInter
      */
     public function load(ObjectManager $manager)
     {
-        // force id = 1
+        // set id manually
         $metadata = $manager->getClassMetaData(CollectionType::class);
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
-        $defaultCollectionType = $this->createCollectionType(1, 'collection.default', 'Default');
-        $manager->persist($defaultCollectionType);
+        // create or update collectiontype with id 1
+        $defaultCollectionType = new CollectionType();
+        $defaultCollectionType->setId(1);
+        $defaultCollectionType = $manager->merge($defaultCollectionType);
+        $defaultCollectionType->setKey('collection.default');
+        $defaultCollectionType->setName('Default');
 
-        $systemCollectionType = $this->createCollectionType(
-            2,
-            SystemCollectionManagerInterface::COLLECTION_TYPE,
-            'System Collections'
-        );
-        $manager->persist($systemCollectionType);
+        // create or update collectiontype with id 2
+        $systemCollectionType = new CollectionType();
+        $systemCollectionType->setId(2);
+        $systemCollectionType = $manager->merge($systemCollectionType);
+        $systemCollectionType->setKey(SystemCollectionManagerInterface::COLLECTION_TYPE);
+        $systemCollectionType->setName('System Collections');
 
         $manager->flush();
-    }
-
-    /**
-     * Create a collection type with given parameter.
-     *
-     * @param int $id
-     * @param string $key
-     * @param string $name
-     *
-     * @return CollectionType
-     */
-    private function createCollectionType($id, $key, $name)
-    {
-        $collectionType = new CollectionType();
-        $collectionType->setId($id);
-        $collectionType->setKey($key);
-        $collectionType->setName($name);
-
-        return $collectionType;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
+++ b/src/Sulu/Bundle/MediaBundle/DataFixtures/ORM/LoadMediaTypes.php
@@ -23,30 +23,29 @@ class LoadMediaTypes extends AbstractFixture implements OrderedFixtureInterface
      */
     public function load(ObjectManager $manager)
     {
-        $mediaDocument = new MediaType();
-        $mediaDocument->setId(1);
-
-        // force id = 1
-        $metadata = $manager->getClassMetaData(get_class($mediaDocument));
+        // set id manually
+        $metadata = $manager->getClassMetaData(MediaType::class);
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_NONE);
 
+        $mediaDocument = new MediaType();
+        $mediaDocument->setId(1);
+        $mediaDocument = $manager->merge($mediaDocument);
         $mediaDocument->setName('document');
-        $manager->persist($mediaDocument);
 
         $mediaImage = new MediaType();
         $mediaImage->setId(2);
+        $mediaImage = $manager->merge($mediaImage);
         $mediaImage->setName('image');
-        $manager->persist($mediaImage);
 
         $mediaVideo = new MediaType();
         $mediaVideo->setId(3);
+        $mediaVideo = $manager->merge($mediaVideo);
         $mediaVideo->setName('video');
-        $manager->persist($mediaVideo);
 
         $mediaAudio = new MediaType();
         $mediaAudio->setId(4);
+        $mediaAudio = $manager->merge($mediaAudio);
         $mediaAudio->setName('audio');
-        $manager->persist($mediaAudio);
 
         $manager->flush();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2521
| Related issues/PRs | #2521
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the issue of wiped assets on sulu:build commands by implementing the doctrine fixtures non-destructive.

This is done by setting the fixtures append-mode which prevents database purging and adjusting the insert strategy to enable updating the database, if the fixtures are already (partially) present.