### PR TITLE
clear cache before system collection initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2590 [CoreBundle]          Clear symfony cache before system collection initialization
     * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment
     * BUGFIX      #2586 [AdminBundle]         fixed behat tests
     * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview

--- a/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Build;
+
+/**
+ * Builder for loading the fictures.
+ */
+class CacheBuilder extends SuluBuilder
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'cache';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        $options = [
+            '--no-optional-warmers' => true,
+            '--no-debug' => true,
+            '--no-interaction' => true,
+        ];
+
+        $this->execCommand('Deleting symfony cache', 'cache:clear', $options);
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
@@ -8,6 +8,7 @@
         <parameter key="sulu_core.build.builder.phpcr.class">Sulu\Bundle\CoreBundle\Build\PhpcrBuilder</parameter>
         <parameter key="sulu_core.build.builder.phpcr_migrations.class">Sulu\Bundle\CoreBundle\Build\PhpcrMigrationsBuilder</parameter>
         <parameter key="sulu_core.build.builder.fixtures.class">Sulu\Bundle\CoreBundle\Build\FixturesBuilder</parameter>
+        <parameter key="sulu_core.build.builder.cache.class">Sulu\Bundle\CoreBundle\Build\CacheBuilder</parameter>
         <parameter key="sulu_core.build.builder.node_order.class">Sulu\Bundle\CoreBundle\Build\NodeOrderBuilder</parameter>
     </parameters>
 
@@ -22,6 +23,10 @@
         </service>
 
         <service id="sulu_core.build.builder.fixtures" class="%sulu_core.build.builder.fixtures.class%">
+            <tag name="massive_build.builder" />
+        </service>
+
+        <service id="sulu_core.build.builder.cache" class="%sulu_core.build.builder.cache.class%">
             <tag name="massive_build.builder" />
         </service>
 

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
@@ -49,7 +49,7 @@ class SystemCollectionBuilder implements BuilderInterface, ContainerAwareInterfa
      */
     public function getDependencies()
     {
-        return ['database', 'fixtures'];
+        return ['cache', 'database', 'fixtures'];
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR implements a CacheBuilder for the MassiveBuildBundle which clears the symfony cache.
The CacheBuilder is set as dependency of the SystemCollectionBuilder. (see next paragraph)

#### Why?

The SystemCollectionBuilder is used to initialize the system collections. When executing the sulu:build command with the --destroy flag, the database is removed, but the cache is not cleared. The SystemCollectionBuilder does not recognize that the collections are removed from the database, because they are still present in the cache. Therefore the system collections are not recreated and missing after executing sulu:build with the --destroy flag.

The implemented CacheBuilder is set as dependency of the SystemCollectionBundle. This ensures, that the cache does not contain invalid data, at the time the SystemCollectionBundle is executed.

