### PR TITLE
fixed preview for prod environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment
     * BUGFIX      #2586 [AdminBundle]         fixed behat tests
     * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview
     * BUGIFX      #2579 [ContentBundle]       Removed smart-content component destroy callback conflict

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -18,12 +18,20 @@ use Symfony\Component\Config\Loader\LoaderInterface;
  */
 class PreviewKernel extends \WebsiteKernel
 {
+    const CONTEXT_PREVIEW = 'preview';
+
     /**
      * {@inheritdoc}
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         parent::registerContainerConfiguration($loader);
+
+        if (in_array($this->getEnvironment(), ['dev', 'test'])) {
+            $loader->load(
+                implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview_dev.yml'])
+            );
+        }
 
         $loader->load(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview.yml']));
     }
@@ -39,5 +47,21 @@ class PreviewKernel extends \WebsiteKernel
         }
 
         return $this->rootDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogDir()
+    {
+        return str_replace($this->getContext(), static::CONTEXT_PREVIEW, parent::getLogDir());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheDir()
+    {
+        return str_replace($this->getContext(), static::CONTEXT_PREVIEW, parent::getCacheDir());
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -3,6 +3,3 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
-
-web_profiler:
-    toolbar: false

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview_dev.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview_dev.yml
@@ -1,0 +1,2 @@
+web_profiler:
+    toolbar: false


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a `config_preview_dev.yml` file, which is only loaded in the dev environment, and disables the debug toolbar.

#### Why?

This configuration was previously in a file which was loaded also in a `prod` environment, and this caused an error, because the `web_profiler` extension is not available there.