### PR TITLE
made translation keys overwritable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment
+    * BUGFIX      #2602 [TranslationBundle]   made translation keys overwritable
     * BUGFIX      #2586 [AdminBundle]         fixed behat tests
     * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview
     * BUGIFX      #2579 [ContentBundle]       Removed smart-content component destroy callback conflict

--- a/src/Sulu/Bundle/TranslateBundle/Command/ExportCommand.php
+++ b/src/Sulu/Bundle/TranslateBundle/Command/ExportCommand.php
@@ -92,6 +92,7 @@ class ExportCommand extends ContainerAwareCommand
         $export = $this->getContainer()->get('sulu_translate.export');
 
         $export->setLocale($locale);
+        $export->setOutput($output);
 
         // Parse format
         switch ($format) {
@@ -120,6 +121,6 @@ class ExportCommand extends ContainerAwareCommand
         }
         $export->execute();
 
-        $output->writeln('Successfully exported translations to file!');
+        $output->writeln('<info>Successfully exported translations to file!</info>');
     }
 }

--- a/src/Sulu/Bundle/TranslateBundle/Translate/Import.php
+++ b/src/Sulu/Bundle/TranslateBundle/Translate/Import.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\TranslateBundle\Translate\Exception\PackageNotFoundException;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
@@ -87,7 +88,7 @@ class Import
     private $backendDomain;
 
     /**
-     * @var Output
+     * @var OutputInterface
      */
     private $output;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2569
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The translation managed by Sulu are made overwritable. The behaviour is the same as with symfony translations, the last translation wins. The translations of bundles get imported in the order the bundles occur in the kernel. The output happens in the order the translations appear in the database. Therefore bundles can overwrite any translations bundles which are registered before them in the kernel.

When a translation key gets overwritten a comment gets written to the console
