### PR TITLE
ignore ghost page parent when generating resource locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2603 [ContentBundle]       Fixed resource locator generation for pages with ghost-parent
     * BUGFIX      #2539 [SecurityBundle]      Made TokenStorage dependency for SecuritySubscriber optional
     * BUGFIX      #2606 [PreviewBundle]       Added cache clear for preview kernel
     * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -70,6 +70,8 @@
         <service id="sulu_content.rl_repository" class="%sulu_content.rl_repository.class%">
             <argument type="service" id="sulu.content.rlp.strategy.tree"/>
             <argument type="service" id="sulu.content.structure_manager"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector" />
         </service>
 
         <!-- structure extension -->


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2433
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR fixes the bug which occured when generating resource locator paths for new pages with a ghost-page parent (See #2433).
The misbehaviour is fixed by using the first ancestor of the new page which is not a ghost-page for path generation.

