### PR TITLE
fixed order in combination with depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.2.7 (2016-07-12)
+    * HOTFIX      #2605 [CategoryBundle]      Fixed order in combination with depth
     * HOTFIX      #2600 [CategoryBundle]      fixed order of categories in content-type
     * HOTFIX      #2585 [CoreBundle]          add fixtures without purging database
     * HOTFIX      #2550 [MediaBundle]         made documents list show description on add

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -142,7 +142,13 @@ class CategoryManager implements CategoryManagerInterface
                         ),
                     ]
                 ),
-                'public.name'
+                'public.name',
+                false,
+                false,
+                '',
+                '',
+                '',
+                false
             );
             $this->fieldDescriptors['locale'] = new DoctrineCaseFieldDescriptor(
                 'locale',

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -297,8 +297,8 @@ class CategoryController extends RestController implements ClassResourceInterfac
         $factory = $this->get('sulu_core.doctrine_list_builder_factory');
 
         $listBuilder = $factory->create(self::$entityName);
-
         $fieldDescriptors = $this->getManager()->getFieldDescriptors($this->getLocale($request));
+        $listBuilder->sort($fieldDescriptors['depth']);
 
         $restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -271,15 +271,18 @@ class CategoryControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
-            '/api/categories?flat=true&sortBy=depth&sortOrder=desc'
+            '/api/categories?flat=true&sortBy=name&sortOrder=asc'
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());
 
-        $response = json_decode($client->getResponse()->getContent());
-        $this->assertEquals(4, count($response->_embedded->categories));
-        $this->assertEquals($this->category4->getId(), $response->_embedded->categories[0]->id);
-        $this->assertEquals('Fourth Category', $response->_embedded->categories[0]->name);
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $categories = $response['_embedded']['categories'];
+        $this->assertEquals(4, count($categories));
+        $this->assertArrayNotHasKey('name', $categories[0]);
+        $this->assertEquals('First Category', $categories[1]['name']);
+        $this->assertEquals('Third Category', $categories[2]['name']);
+        $this->assertEquals('Fourth Category', $categories[3]['name']);
     }
 
     public function testPost()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The depth has to be sorted first for the categories, because all the other sortings must apply later.

#### Why?

Otherwise the datagrid won't properly render it.