### PR TITLE
Added cache clear for preview kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2606 [PreviewBundle]       Added cache clear for preview kernel
     * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment
     * BUGFIX      #2586 [AdminBundle]         fixed behat tests
     * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview

--- a/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
+++ b/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Command;
+
+use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
+use Sulu\Component\HttpKernel\SuluKernel;
+use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand as BaseCacheClearCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class CacheClearCommand extends BaseCacheClearCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $nullOutput = new NullOutput();
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var KernelInterface $kernel */
+        $kernel = $this->getContainer()->get('kernel');
+        $context = $this->getContainer()->getParameter('sulu.context');
+
+        $io->comment(sprintf('Clearing the <info>%s cache</info> for the <info>%s</info> environment with debug <info>%s</info>',
+            $context, $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+        parent::execute($input, $nullOutput);
+
+        $io->success(sprintf('%s cache for the "%s" environment (debug=%s) was successfully cleared.',
+            ucfirst($context), $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+        if (SuluKernel::CONTEXT_ADMIN === $context) {
+            /** @var KernelFactoryInterface $kernelFactory */
+            $kernelFactory = $this->getContainer()->get('sulu_preview.preview.kernel_factory');
+            $previewKernel = $kernelFactory->create($kernel->getEnvironment());
+
+            // set preview container
+            $this->setContainer($previewKernel->getContainer());
+
+            $io->comment(sprintf('Clearing the <info>preview cache</info> for the <info>%s</info> environment with debug <info>%s</info>',
+                $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+            parent::execute($input, $nullOutput);
+
+            $io->success(sprintf('Preview cache for the "%s" environment (debug=%s) was successfully cleared.',
+                $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        }
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2606 |
| Related issues/PRs | none |
| License | MIT |
| Documentation PR | none |
#### What's in this PR?

Clear preview cache when admin cache is cleared.
#### Why?

Because the preview kernel has now his own cache directory.
