### PR TITLE
fixed serialization of concrete locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@ CHANGELOG for Sulu
 ==================
 
 * 1.2.7 (2016-07-12)
-    * HOTFIX      #2605 [CategoryBundle]      Fixed order in combination with depth
-    * HOTFIX      #2600 [CategoryBundle]      fixed order of categories in content-type
-    * HOTFIX      #2585 [CoreBundle]          add fixtures without purging database
-    * HOTFIX      #2550 [MediaBundle]         made documents list show description on add
-    * HOTFIX      #2547 [AdminBundle]         Included husky build which fixes the ie11 rendering issue of dropdowns
-    * HOTFIX      #2547 [AdminBundle]         Included husky build which fixes globalizing bug
-    * BUGFIX            [WebsiteBundle]       Fixed a query issue on Postgresql
+    * HOTFIX      #2610 [DocumentManagerBundle] Fixed serialization of concrete locales
+    * HOTFIX      #2605 [CategoryBundle]        Fixed order in combination with depth
+    * HOTFIX      #2600 [CategoryBundle]        fixed order of categories in content-type
+    * HOTFIX      #2585 [CoreBundle]            add fixtures without purging database
+    * HOTFIX      #2550 [MediaBundle]           made documents list show description on add
+    * HOTFIX      #2547 [AdminBundle]           Included husky build which fixes the ie11 rendering issue of dropdowns
+    * HOTFIX      #2547 [AdminBundle]           Included husky build which fixes globalizing bug
+    * BUGFIX            [WebsiteBundle]         Fixed a query issue on Postgresql
 
 * 1.2.6 (2016-07-05)
     * BUGFIX      #2530 [AdminBundle]         Included husky build which fixes the login translation issue

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -224,7 +224,7 @@ class DocumentInspector extends BaseDocumentInspector
             $locales = array_diff($locales, $this->getShadowLocales($document));
         }
 
-        return $locales;
+        return array_values($locales);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR |none

#### What's in this PR?

This PR avoids that the `DocumentInspector::getConcreteLocales` method returns an array which indexes do not start with 0.

#### Why?

Because if it starts with something different than 0, the serializer will turn it into an object instead array.