### PR TITLE
fill host-placeholder before clearing cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2611 [HttpCacheBundle]     fill host-placeholder before clearing cache
     * BUGFIX      #2625 [ContentBundle]       Removed force flag for webspace key parameter
     * ENHANCEMENT #2621 [ContentBundle]       Added migration for publishing
     * ENHANCEMENT #2614 [ContentBundle]       Removed unused code and tests

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/structure-cache-handlers.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/structure-cache-handlers.xml
@@ -27,6 +27,8 @@
         <service id="sulu_http_cache.handler.paths" class="%sulu_http_cache.handler.paths.class%">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_http_cache.proxy_client"/>
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument>%kernel.environment%</argument>
             <tag name="sulu_http_cache.handler" alias="paths" />
         </service>

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -12,17 +12,56 @@
 namespace Sulu\Bundle\HttpCacheBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Psr\Log\LoggerInterface;
 use Sulu\Bundle\HttpCacheBundle\DependencyInjection\SuluHttpCacheExtension;
+use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Url\ReplacerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
 {
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var ContentTypeManagerInterface
+     */
+    private $contentTypeManager;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var ReplacerInterface
+     */
+    private $replacer;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function setUp()
     {
         parent::setUp();
+
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->replacer = $this->prophesize(ReplacerInterface::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
+
         $this->container->setParameter('kernel.environment', 'test');
-        $this->container->set('sulu_core.webspace.webspace_manager', $this->getMock('Sulu\Component\Webspace\Manager\WebspaceManagerInterface'));
-        $this->container->set('sulu.content.type_manager', $this->getMock('Sulu\Component\Content\ContentTypeManagerInterface'));
-        $this->container->set('logger', $this->getMock('Psr\Log\LoggerInterface'));
+        $this->container->set('sulu_core.webspace.webspace_manager', $this->webspaceManager->reveal());
+        $this->container->set('sulu.content.type_manager', $this->contentTypeManager->reveal());
+        $this->container->set('request_stack', $this->requestStack->reveal());
+        $this->container->set('sulu_core.webspace.webspace_manager.url_replacer', $this->replacer->reveal());
+        $this->container->set('logger', $this->logger->reveal());
     }
 
     protected function getContainerExtensions()

--- a/src/Sulu/Component/HttpCache/Tests/Unit/Handler/PathsHandlerTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/Handler/PathsHandlerTest.php
@@ -11,10 +11,15 @@
 
 namespace Sulu\Component\HttpCache\Tests\Unit\Handler;
 
+use FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface;
 use Prophecy\Argument;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\HttpCache\Handler\PathsHandler;
 use Sulu\Component\HttpCache\HandlerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Url\ReplacerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class PathsHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -43,18 +48,31 @@ class PathsHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private $webspaceKey = 'sulu_io';
 
+    /**
+     * @var string
+     */
+    private $host = 'sulu.io';
+
     public function setUp()
     {
         parent::setUp();
 
-        $this->structure = $this->prophesize('Sulu\Component\Content\Compat\StructureInterface');
+        $this->structure = $this->prophesize(StructureInterface::class);
 
-        $this->webspaceManager = $this->prophesize('Sulu\Component\Webspace\Manager\WebspaceManagerInterface');
-        $this->proxyClient = $this->prophesize('FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface');
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->proxyClient = $this->prophesize(PurgeInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->request = $this->prophesize(Request::class);
+        $this->replacer = $this->prophesize(ReplacerInterface::class);
+
+        $this->request->getHost()->willReturn($this->host);
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
 
         $this->handler = new PathsHandler(
             $this->webspaceManager->reveal(),
             $this->proxyClient->reveal(),
+            $this->requestStack->reveal(),
+            $this->replacer->reveal(),
             $this->env
         );
     }
@@ -63,21 +81,32 @@ class PathsHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->structure->hasTag('sulu.rlp')->willReturn(false);
         $this->webspaceManager->findUrlsByResourceLocator(Argument::any())->shouldNotBeCalled();
+        $this->replacer->replaceHost(Argument::any())->shouldNotBeCalled();
         $this->handler->invalidateStructure($this->structure->reveal());
         $this->handler->flush();
     }
 
-    public function testInvalidateStructureoRlpNull()
+    public function testInvalidateStructureRlpNull()
     {
         $this->structure->hasTag('sulu.rlp')->willReturn(true);
         $this->structure->getPropertyValueByTagName('sulu.rlp')->willReturn(null);
         $this->webspaceManager->findUrlsByResourceLocator(Argument::any())->shouldNotBeCalled();
+        $this->replacer->replaceHost(Argument::any())->shouldNotBeCalled();
         $this->handler->invalidateStructure($this->structure->reveal());
         $this->handler->flush();
     }
 
-    public function testInvalidate()
+    public function testInvalidateRequestNull()
     {
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->handler = new PathsHandler(
+            $this->webspaceManager->reveal(),
+            $this->proxyClient->reveal(),
+            $this->requestStack->reveal(),
+            $this->replacer->reveal(),
+            $this->env
+        );
+
         $this->structure->hasTag('sulu.rlp')->willReturn(true);
         $this->structure->getPropertyValueByTagName('sulu.rlp')->willReturn('/path/to');
         $this->structure->getLanguageCode()->willReturn($this->languageCode);
@@ -94,12 +123,50 @@ class PathsHandlerTest extends \PHPUnit_Framework_TestCase
             $this->languageCode,
             $this->webspaceKey
         )->willReturn($urls);
+        $this->webspaceManager->findUrlsByResourceLocator(Argument::any())->shouldNotBeCalled();
+
+        $this->replacer->replaceHost(Argument::any())->shouldNotBeCalled();
 
         $this->proxyClient->purge($urls[0])->shouldBeCalled();
         $this->proxyClient->purge($urls[1])->shouldBeCalled();
         $this->proxyClient->flush()->shouldBeCalled();
 
+        $this->handler->invalidateStructure($this->structure->reveal());
+        $this->handler->flush();
+    }
+
+    public function testInvalidate()
+    {
+        $this->structure->hasTag('sulu.rlp')->willReturn(true);
+        $this->structure->getPropertyValueByTagName('sulu.rlp')->willReturn('/path/to');
+        $this->structure->getLanguageCode()->willReturn($this->languageCode);
+        $this->structure->getWebspaceKey()->willReturn($this->webspaceKey);
+
+        $genericUrls = [
+            '{host}/path/to/1',
+            '{host}/path/to/2',
+        ];
+
+        $concreteUrls = [
+            'sulu.io/path/to/1',
+            'sulu.io/path/to/2',
+        ];
+
+        $this->webspaceManager->findUrlsByResourceLocator(
+            '/path/to',
+            $this->env,
+            $this->languageCode,
+            $this->webspaceKey
+        )->willReturn($genericUrls);
         $this->webspaceManager->findUrlsByResourceLocator(Argument::any())->shouldNotBeCalled();
+
+        $this->replacer->replaceHost($genericUrls[0], $this->host)->willReturn($concreteUrls[0]);
+        $this->replacer->replaceHost($genericUrls[1], $this->host)->willReturn($concreteUrls[1]);
+        $this->replacer->replaceHost(Argument::any())->shouldNotBeCalled();
+
+        $this->proxyClient->purge($concreteUrls[0])->shouldBeCalled();
+        $this->proxyClient->purge($concreteUrls[1])->shouldBeCalled();
+        $this->proxyClient->flush()->shouldBeCalled();
 
         $this->handler->invalidateStructure($this->structure->reveal());
         $this->handler->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2531
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR (partially) fixes cache-clearing on page-publishing when using a host-placeholder in webspace.xml.

The misbehaviour is fixed by storing the host of the request on a publish request and fill the host-placeholder of the url with the stored host when clearing cache.
This method does not fix the problem on multi-host portals.

