### PR TITLE
added sort criteria for category fallback test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.2.7 (2016-07-12)
+    * HOTFIX      #2612 [CategoryBundle]        Added sort criteria for fallback test
     * HOTFIX      #2610 [DocumentManagerBundle] Fixed serialization of concrete locales
     * HOTFIX      #2605 [CategoryBundle]        Fixed order in combination with depth
     * HOTFIX      #2600 [CategoryBundle]        fixed order of categories in content-type

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -612,7 +612,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $client->request(
             'GET',
-            '/api/categories?locale=de&flat=true'
+            '/api/categories?locale=de&flat=true&sortBy=name'
         );
 
         $response = json_decode($client->getResponse()->getContent());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR sorts the categories for the fallback test.

#### Why?

To have predictable results (appveyor was failing)