### PR TITLE
setting default country by code instead of id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.2.7 (2016-07-15)
+    * HOTFIX      #2617 [ContactBundle]         Setting default country by country-code instead of id
     * HOTFIX      #2612 [CategoryBundle]        Added sort criteria for fallback test
     * HOTFIX      #2610 [DocumentManagerBundle] Fixed serialization of concrete locales
     * HOTFIX      #2605 [CategoryBundle]        Fixed order in combination with depth

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## 1.2.7
+
+### Default Country
+
+The default country for addresses in the ContactBundle is set by the ISO 3166 country-code
+instead the of database-id now.
+
 ## 1.2.4
 
 ### ContactRepository

--- a/src/Sulu/Bundle/ContactBundle/Controller/TemplateController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/TemplateController.php
@@ -208,7 +208,7 @@ class TemplateController extends RestController
         $countryEntity = 'SuluContactBundle:Country';
         $defaults['country'] = $this->getDoctrine()
             ->getRepository($countryEntity)
-            ->find($config['country']);
+            ->findOneByCode($config['country']);
 
         return $defaults;
     }

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -55,7 +55,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('addressType')->defaultValue('1')->end()
                         ->scalarNode('urlType')->defaultValue('1')->end()
                         ->scalarNode('faxType')->defaultValue('1')->end()
-                        ->scalarNode('country')->defaultValue('15')->end()
+                        ->scalarNode('country')->defaultValue('AT')->end()
                     ->end()
                 ->end()
                 ->arrayNode('form')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR sets the default country in the contact-bundle by the country-code instead of the auto-generated id. 

#### Why?

The id column of the country is not immutable. When reloading fixtures without reseting auto-increment values, the id of the countries can change. This can lead to non existing default-countries.

