### PR TITLE
Removed force flag for webspace key parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2625 [ContentBundle]       Removed force flag for webspace key parameter
     * ENHANCEMENT #2614 [ContentBundle]       Removed unused code and tests
     * BUGFIX      #2603 [ContentBundle]       Fixed resource locator generation for pages with ghost-parent
     * BUGFIX      #2539 [SecurityBundle]      Made TokenStorage dependency for SecuritySubscriber optional

--- a/src/Sulu/Bundle/ContentBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/SmartContentItemController.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Sulu.
  *
@@ -40,7 +41,7 @@ class SmartContentItemController extends RestController
         $filters['excluded'] = [$this->getRequestParameter($request, 'excluded', true)];
         $filters = array_filter($filters);
         $options = [
-            'webspaceKey' => $this->getRequestParameter($request, 'webspace', true),
+            'webspaceKey' => $this->getRequestParameter($request, 'webspace'),
             'locale' => $this->getRequestParameter($request, 'locale', true),
         ];
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Removed force flag for webspace key parameter.

#### Why?

Media data provider do not need any webspace key and it causes problems outside webspace.