### PR TITLE
[HOTFIX] Fix usage of document inspector in StructureBridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #2632 [Content]             Fix usage of document inspector in StructureBridge
+
 * 1.2.7 (2016-07-15)
     * HOTFIX      #2617 [ContactBundle]         Setting default country by country-code instead of id
     * HOTFIX      #2612 [CategoryBundle]        Added sort criteria for fallback test

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -301,6 +301,9 @@ class StructureBridge implements StructureInterface
         return $children;
     }
 
+    /**
+     * @return $this
+     */
     public function getParent()
     {
         return $this->documentToStructure($this->inspector->getParent($this->getDocument()));
@@ -613,7 +616,7 @@ class StructureBridge implements StructureInterface
     /**
      * Magic getter.
      *
-     * @deprecated Do not use magic getters. Use ArrayAccess instead.
+     * @deprecated Do not use magic getters. Use ArrayAccess instead
      */
     public function __get($name)
     {
@@ -698,6 +701,11 @@ class StructureBridge implements StructureInterface
         );
     }
 
+    /**
+     * @param StructureBehavior $document The document to convert
+     *
+     * @return $this
+     */
     protected function documentToStructure(StructureBehavior $document)
     {
         return new $this(

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -303,7 +303,7 @@ class StructureBridge implements StructureInterface
 
     public function getParent()
     {
-        return $this->documentToStructure($this->documentInspector->getParent($this->getDocument()));
+        return $this->documentToStructure($this->inspector->getParent($this->getDocument()));
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes, hotfix
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2631 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fixes the wrong acces of `documentInspector` instead of `inspector.
