### PR TITLE
hide exception details on rest-api error in prod environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2634 [Rest]                hide exception details on rest-api error in prod environment
     * BUGFIX      #2618 [Localization]        Removed the system localizations from LocalizationController
     * BUGFIX      #2640 [ContentBundle]       Fixed reordering for published workspace
     * BUGFIX      #2611 [HttpCacheBundle]     fill host-placeholder before clearing cache

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -24,7 +24,9 @@
             <argument type="service" id="request"/>
         </service>
 
-        <service id="sulu_core.rest.exception_wrapper_handler" class="Sulu\Component\Rest\ExceptionWrapperHandler"/>
+        <service id="sulu_core.rest.exception_wrapper_handler" class="Sulu\Component\Rest\ExceptionWrapperHandler">
+            <argument>%kernel.environment%</argument>
+        </service>
 
         <service id="sulu_core.doctrine_list_builder_factory" class="%sulu_core.doctrine_list_builder_factory.class%">
             <argument type="service" id="doctrine.orm.entity_manager"/>

--- a/src/Sulu/Component/Rest/ExceptionWrapperHandler.php
+++ b/src/Sulu/Component/Rest/ExceptionWrapperHandler.php
@@ -20,12 +20,28 @@ use FOS\RestBundle\View\ExceptionWrapperHandlerInterface;
 class ExceptionWrapperHandler implements ExceptionWrapperHandlerInterface
 {
     /**
+     * @var string
+     */
+    private $environment;
+
+    /**
+     * @param string $environment - kernel environment, dev, prod, etc
+     */
+    public function __construct($environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function wrap($data)
     {
         $data['status_code'] = $data['exception']->getCode();
-        $data['errors'] = [$data['exception']];
+
+        if (in_array($this->environment, ['dev', 'test'])) {
+            $data['errors'] = [$data['exception']];
+        }
 
         return new ExceptionWrapper($data);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR hides the exception details, if an error occurs on a rest-api request in prod environment.
The exception details are still visible in the response in dev and test environment.

#### Why?

The exception details should not be visible if an error occurs in prod environment.


