### PR TITLE
fixed reordering for published workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2640 [ContentBundle]       Fixed reordering for published workspace
     * BUGFIX      #2611 [HttpCacheBundle]     fill host-placeholder before clearing cache
     * BUGFIX      #2625 [ContentBundle]       Removed force flag for webspace key parameter
     * ENHANCEMENT #2621 [ContentBundle]       Added migration for publishing

--- a/src/Sulu/Bundle/ContentBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/Subscriber/PublishSubscriber.php
@@ -147,7 +147,7 @@ class PublishSubscriber implements EventSubscriberInterface
      */
     public function reorderNodeInPublicWorkspace(ReorderEvent $event)
     {
-        $node = $event->getNode();
+        $node = $this->getLiveNode($event->getDocument());
 
         $this->nodeHelper->reorder($node, $event->getDestId());
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
@@ -250,9 +250,14 @@ class PublishSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testReorderInPublicWorkspace()
     {
+        $document = $this->prophesize(PathBehavior::class);
+        $document->getPath()->willReturn('/cmf/sulu_io/contents/page');
+
         $event = $this->prophesize(ReorderEvent::class);
         $event->getDestId()->willReturn('uuid');
-        $event->getNode()->willReturn($this->node->reveal());
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->liveSession->getNode('/cmf/sulu_io/contents/page')->willReturn($this->node->reveal());
 
         $parentNode = $this->prophesize(NodeInterface::class);
         $this->node->getParent()->willReturn($parentNode->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes an issue with the reordering in the public workspace. It was reordering the node in the draft workspace.

#### Why?

Because the node should also be reordered on the live workspace. The node is already reordered in another subscriber for the draft workspace.