### PR TITLE
Add Google Tag Manager to the webspace analytics settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG for Sulu
     * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
     * FEATURE     #2721 [GeneratorBundle]     Don't allow symfony deprecations anymore
     * FEATURE     #2728 [WebsocketBundle]     Don't allow symfony deprecations anymore
+    * FEATURE     #2643 [WebsiteBundle]       Add Google Tag Manager to the webspace analytics settings
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
     * FEATURE     #2722 [HttpCacheBundle]     Don't allow symfony deprecations anymore
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,17 @@ To make it easier to migrate data the country in the address entity is now nulla
 ALTER TABLE co_addresses CHANGE idCountries idCountries INT DEFAULT NULL;
 ```
 
+### Databases
+
+#### ORM
+
+The mapping structure of analytic settings have changed.
+Use the following command to update:
+
+```bash
+app/console doctrine:schema:update --force
+```
+
 ## 1.3.0-RC2
 
 ### SearchController

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
@@ -17,7 +17,7 @@
         <field name="webspaceKey" type="string" column="webspace_key" length="255"/>
         <field name="allDomains" type="boolean" column="all_domains"/>
         <field name="content" type="json_array" column="content"/>
-        <field name="type" type="string" column="type" length="6"/>
+        <field name="type" type="string" column="type" length="60"/>
 
         <many-to-many target-entity="Sulu\Bundle\WebsiteBundle\Entity\Domain" field="domains">
             <join-table name="we_analytics_domains">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/public/js/components/webspace/settings/analytics/overlay/main.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/public/js/components/webspace/settings/analytics/overlay/main.js
@@ -34,6 +34,13 @@ define([
                     inputTemplate: input
                 },
                 {
+                    id: 'google_tag_manager',
+                    title: 'website.webspace.settings.type.google_tag_manager',
+                    input: 'input',
+                    labels: ['website.webspace.settings.key'],
+                    inputTemplate: input
+                },
+                {
                     id: 'piwik',
                     title: 'website.webspace.settings.type.piwik',
                     input: 'input',

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/translations/sulu/backend.de.xlf
@@ -48,7 +48,7 @@
             </trans-unit>
             <trans-unit id="5" resname="website.webspace.settings.type.google">
                 <source>website.webspace.settings.type.google</source>
-                <target>Google</target>
+                <target>Google Analytics</target>
             </trans-unit>
             <trans-unit id="6" resname="website.webspace.settings.type.piwik">
                 <source>website.webspace.settings.type.piwik</source>
@@ -81,6 +81,10 @@
             <trans-unit id="13" resname="website.webspace.settings.site-id">
                 <source>website.webspace.settings.site-id</source>
                 <target>Site-ID</target>
+            </trans-unit>
+            <trans-unit id="14" resname="website.webspace.settings.type.google_tag_manager">
+                <source>website.webspace.settings.type.google_tag_manager</source>
+                <target>Google Tag Manager</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/translations/sulu/backend.en.xlf
@@ -48,7 +48,7 @@
             </trans-unit>
             <trans-unit id="5" resname="website.webspace.settings.type.google">
                 <source>website.webspace.settings.type.google</source>
-                <target>Google</target>
+                <target>Google Analytics</target>
             </trans-unit>
             <trans-unit id="6" resname="website.webspace.settings.type.piwik">
                 <source>website.webspace.settings.type.piwik</source>
@@ -81,6 +81,10 @@
             <trans-unit id="13" resname="website.webspace.settings.site-id">
                 <source>website.webspace.settings.site-id</source>
                 <target>Site-ID</target>
+            </trans-unit>
+            <trans-unit id="14" resname="website.webspace.settings.type.google_tag_manager">
+                <source>website.webspace.settings.type.google_tag_manager</source>
+                <target>Google Tag Manager</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/translations/sulu/backend.fr.xlf
@@ -48,7 +48,7 @@
             </trans-unit>
             <trans-unit id="5" resname="website.webspace.settings.type.google">
                 <source>website.webspace.settings.type.google</source>
-                <target>Google</target>
+                <target>Google Analytics</target>
             </trans-unit>
             <trans-unit id="6" resname="website.webspace.settings.type.piwik">
                 <source>website.webspace.settings.type.piwik</source>
@@ -81,6 +81,10 @@
             <trans-unit id="13" resname="website.webspace.settings.site-id">
                 <source>website.webspace.settings.site-id</source>
                 <target>Site-ID</target>
+            </trans-unit>
+            <trans-unit id="14" resname="website.webspace.settings.type.google_tag_manager">
+                <source>website.webspace.settings.type.google_tag_manager</source>
+                <target>Google Tag Manager</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/type/google_tag_manager.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/type/google_tag_manager.html.twig
@@ -1,0 +1,9 @@
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id={{ analytics.content }}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ analytics.content }}');</script>
+<!-- End Google Tag Manager -->

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
@@ -68,6 +68,15 @@ class AnalyticsManagerTest extends BaseFunctional
             ]
         );
         $this->entities[] = $this->create(
+            'sulu_io',
+            [
+                'title' => 'test-4',
+                'type' => 'google_tag_manager',
+                'content' => 'GTM-XXXX',
+                'domains' => [['url' => 'www.sulu.io', 'environment' => 'prod']],
+            ]
+        );
+        $this->entities[] = $this->create(
             'test_io',
             [
                 'title' => 'test piwik',
@@ -84,10 +93,11 @@ class AnalyticsManagerTest extends BaseFunctional
     public function testFindAll()
     {
         $result = $this->analyticsManager->findAll('sulu_io');
-        $this->assertCount(3, $result);
+        $this->assertCount(4, $result);
         $this->assertEquals('test-1', $result[0]->getTitle());
         $this->assertEquals('test-2', $result[1]->getTitle());
         $this->assertEquals('test-3', $result[2]->getTitle());
+        $this->assertEquals('test-4', $result[3]->getTitle());
 
         $result = $this->analyticsManager->findAll('test_io');
         $this->assertCount(1, $result);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/AnalyticsControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/AnalyticsControllerTest.php
@@ -57,7 +57,7 @@ class AnalyticsControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $items = $response['_embedded']['analytics'];
-        $this->assertCount(3, $items);
+        $this->assertCount(4, $items);
         $this->assertEquals('test-1', $items[0]['title']);
         $this->assertEquals('google', $items[0]['type']);
         $this->assertEquals('UA123-123', $items[0]['content']);
@@ -82,6 +82,13 @@ class AnalyticsControllerTest extends SuluTestCase
         $this->assertEquals('stage', $items[2]['domains'][0]['environment']);
         $this->assertEquals('{localization}.google.at', $items[2]['domains'][1]['url']);
         $this->assertEquals('prod', $items[2]['domains'][1]['environment']);
+
+        $this->assertEquals('test-4', $items[3]['title']);
+        $this->assertEquals('google_tag_manager', $items[3]['type']);
+        $this->assertEquals('GTM-XXXX', $items[3]['content']);
+        $this->assertCount(1, $items[3]['domains']);
+        $this->assertEquals('www.sulu.io', $items[3]['domains'][0]['url']);
+        $this->assertEquals('prod', $items[3]['domains'][0]['environment']);
     }
 
     public function testGet()
@@ -164,7 +171,7 @@ class AnalyticsControllerTest extends SuluTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('DELETE', '/api/webspaces/test_io/analytics/' . $this->entities[3]->getId());
+        $client->request('DELETE', '/api/webspaces/test_io/analytics/' . $this->entities[4]->getId());
         $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request('GET', '/api/webspaces/test_io/analytics');
@@ -182,6 +189,7 @@ class AnalyticsControllerTest extends SuluTestCase
             $this->entities[0]->getId(),
             $this->entities[1]->getId(),
             $this->entities[2]->getId(),
+            $this->entities[3]->getId(),
         ];
 
         $client->request('DELETE', '/api/webspaces/sulu_io/analytics?ids=' . implode(',', $ids));
@@ -227,6 +235,15 @@ class AnalyticsControllerTest extends SuluTestCase
                     ['url' => 'www.google.at', 'environment' => 'stage'],
                     ['url' => '{localization}.google.at', 'environment' => 'prod'],
                 ],
+            ]
+        );
+        $this->entities[] = $this->analyticsManager->create(
+            'sulu_io',
+            [
+                'title' => 'test-4',
+                'type' => 'google_tag_manager',
+                'content' => 'GTM-XXXX',
+                'domains' => [['url' => 'www.sulu.io', 'environment' => 'prod']],
             ]
         );
         $this->entities[] = $this->analyticsManager->create(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | n/a
| Related issues/PRs | n/a
| License | MIT
| Documentation PR | sulu/sulu-docs#239

#### What's in this PR?

Add Google Tag Manager script to the webspace analytics settings.

#### Why?

Because it's easier and more failsafe if Sulu supports the GTM code directly instead of using the custom type.

#### BC considerations

I renamed the translation of the google type to "Google Analytics" to be more clear and added `google_tag_manager` for the GTM type. Through the small width of the type field a database schema update is needed.

#### To Do

- [x] Create a documentation PR

