### PR TITLE
Allow multiple properties when setting just maxOccurs

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
@@ -138,7 +138,10 @@ class ContentTwigExtension extends \Twig_Extension
      */
     public function isMultipleTest($property)
     {
-        return $property->getMinOccurs() > 1 || !is_null($property->getMaxOccurs());
+        return
+            !is_null($property->getMaxOccurs()) ||
+            $property->getMinOccurs() > 1 ||
+            $property->getMinOccurs() < $property->getMaxOccurs();
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
@@ -138,7 +138,7 @@ class ContentTwigExtension extends \Twig_Extension
      */
     public function isMultipleTest($property)
     {
-        return $property->getMinOccurs() > 1;
+        return $property->getMinOccurs() > 1 || !is_null($property->getMaxOccurs());
     }
 
     /**

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -135,7 +135,7 @@ class XmlLoader extends XmlLegacyLoader
         $property->cssClass = $data['cssClass'];
         $property->tags = $data['tags'];
         $property->minOccurs = $data['minOccurs'] !== null ? intval($data['minOccurs']) : 1;
-        $property->maxOccurs = $data['maxOccurs'] ? intval($data['maxOccurs']) : 999;
+        $property->maxOccurs = $data['maxOccurs'] ? intval($data['maxOccurs']) : null;
         $property->parameters = $data['params'];
         $this->mapMeta($property, $data['meta']);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
#### What's in this PR?

Fixes the multiple types issue.
#### Why?
#### Example Usage

``` xml
// Before the fix this line in the webspace xml would have no effect
<property name="name" type="text_line" minOccurs="1" maxOccurs="20">

// This line would create a multiple line, but with a minimum of 2 elements
<property name="name" type="text_line" minOccurs="2" maxOccurs="20">

// After the fix it's also possible to create fields with 0 elements
<property name="name" type="text_line" minOccurs="0" maxOccurs="20">
```
