### PR TITLE
Added is-published method for route-defaults-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,45 +11,56 @@ CHANGELOG for Sulu
     * BUGFIX      #2632 [ContentBundle]       prevent item select when ordering a column (husky)
     * BUGFIX      #2663 [MediaBundle]         made masonry view work for media with no thumbnail
     * ENHANCEMENT #2665 [Webspace]            Introduced DelegatingFileLoader for webspace configurations
+    * FEATURE     #2669 [RouteBundle]         Added is-published method for route-defaults-provider
 
 * 1.3.0-RC1 (2016-07-22)
     * HOTFIX      #2632 [Content]             Fix usage of document inspector in StructureBridge
     * BUGFIX      #2655 [MediaBundle]         Fixed media selection for none images and selected media list
-    * BUGFIX      #2598 [MediaBundle]         fixed thumbnail rendering in media edit
-    * BUGFIX      #2634 [Rest]                hide exception details on rest-api error in prod environment
+    * BUGFIX      #2598 [MediaBundle]         Fixed thumbnail rendering in media edit
+    * BUGFIX      #2634 [Rest]                Hide exception details on rest-api error in prod environment
     * FEATURE     #2642 [AdminBundle]         Added different badges color support
     * BUGFIX      #2618 [Localization]        Removed the system localizations from LocalizationController
     * BUGFIX      #2640 [ContentBundle]       Fixed reordering for published workspace
-    * BUGFIX      #2611 [HttpCacheBundle]     fill host-placeholder before clearing cache
+    * BUGFIX      #2611 [HttpCacheBundle]     Fill host-placeholder before clearing cache
     * BUGFIX      #2625 [ContentBundle]       Removed force flag for webspace key parameter
     * ENHANCEMENT #2621 [ContentBundle]       Added migration for publishing
     * ENHANCEMENT #2623 [DocumentManager]     Add publishing toolbar buttons to extensions in document manager bundle
     * ENHANCEMENT #2614 [ContentBundle]       Removed unused code and tests
     * BUGFIX      #2603 [ContentBundle]       Fixed resource locator generation for pages with ghost-parent
+<<<<<<< 338dcf15ba150bfc1e147da8bc3715fd762944de
+=======
+    * BUGFIX      #2613 [ContactBundle]       Fixed categories save bug in contacts
+>>>>>>> added is-published method for route-defaults-provider
     * BUGFIX      #2539 [SecurityBundle]      Made TokenStorage dependency for SecuritySubscriber optional
-    * BUGFIX      #2609 [ContentBundle]       fixed excerpt extension save button activation
+    * BUGFIX      #2609 [ContentBundle]       Fixed excerpt extension save button activation
     * ENHANCEMENT #2616 [MediaBundle]         Avoid exception when media is serialized without all data loaded
     * BUGFIX      #2606 [PreviewBundle]       Added cache clear for preview kernel
     * ENHANCEMENT #2608 [TranslateBundle]     removed translation import command and refactored translate bundle
     * BUGFIX      #2590 [CoreBundle]          Clear symfony cache before system collection initialization
     * BUGFIX      #2596 [PreviewBundle]       Fixed preview for prod environment
     * FEATURE     #2515 [ContentBundle]       Added unpublishing functionality for pages
+<<<<<<< 338dcf15ba150bfc1e147da8bc3715fd762944de
     * ENHANCEMENT #2604 [ContentBundle]       fixed publishing on excerpt tab and add excerpt js extension
     * BUGFIX      #2586 [AdminBundle]         fixed behat tests
+=======
+    * ENHANCEMENT #2604 [ContentBundle]       Fixed publishing on excerpt tab and add excerpt js extension
+    * BUGFIX      #2586 [AdminBundle]         Fixed behat tests
+    * BUGFIX      #2588 [ContentBundle]       Made resource locator reload on every rlp.part change
+>>>>>>> added is-published method for route-defaults-provider
     * BUGFIX      #2581 [PreviewBundle]       Deactivated WebProfilerToolbar for preview
     * BUGIFX      #2579 [ContentBundle]       Removed smart-content component destroy callback conflict
     * FEATURE     #2572 [AdminBundle]         Included husky build with autocomplete form mapper validation type
-    * BUGFIX      #2564 [CustomUrlBundle]     made width of custom url inputs flexible
-    * BUGFIX      #2580 [AdminBundle]         made the navigation adapt on history back
-    * FEATURE     #2565 [AdminBundle]         reseted navigation width after collapse
+    * BUGFIX      #2564 [CustomUrlBundle]     Made width of custom url inputs flexible
+    * BUGFIX      #2580 [AdminBundle]         Made the navigation adapt on history back
+    * FEATURE     #2565 [AdminBundle]         Reseted navigation width after collapse
     * FEATURE     #2557 [SecurityBundle]      Set user last login by a listener
     * ENHANCEMENT #2544 [PreviewBundle]       Bugfix for preview in firefox
-    * BUGFIX      #2551 [SecurityBundle]      added search fields and search instancename for roles list search
-    * BUGFIX      #2556 [ContentBundle]       removed the change content-change event from the texteditor's focusout
-    * BUGFIX      #2558 [CollaborationBundle] made own username show up as collaborator in warning
-    * BUGFIX      #2554 [ContentBundle]       made changing to copied locales possible
+    * BUGFIX      #2551 [SecurityBundle]      Added search fields and search instancename for roles list search
+    * BUGFIX      #2556 [ContentBundle]       Removed the change content-change event from the texteditor's focusout
+    * BUGFIX      #2558 [CollaborationBundle] Made own username show up as collaborator in warning
+    * BUGFIX      #2554 [ContentBundle]       Made changing to copied locales possible
     * ENHANCEMENT #2540 [AdminBundle]         Removed deprecation notices
-    * BUGFIX      #2536 [AdminBundle]         changed icon markup in search component (husky)
+    * BUGFIX      #2536 [AdminBundle]         Changed icon markup in search component (husky)
     * BUGFIX      #2538 [ContentBundle]       Display url in single-internal-link instead of path
     * BUGFIX      #2534 [ContactBundle]       Fixed static usage of media repository
     * FEATURE     #2532 [RouteBundle]         Allow route generation for entity routes

--- a/src/Sulu/Bundle/ContentBundle/Preview/PageRouteDefaultsProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PageRouteDefaultsProvider.php
@@ -78,6 +78,14 @@ class PageRouteDefaultsProvider implements RouteDefaultsProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function isPublished($entityClass, $id, $locale)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function supports($entityClass)
     {
         return HomeDocument::class === $entityClass || PageDocument::class === $entityClass;

--- a/src/Sulu/Bundle/RouteBundle/Routing/Defaults/RouteDefaultsProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/Defaults/RouteDefaultsProvider.php
@@ -49,6 +49,14 @@ class RouteDefaultsProvider implements RouteDefaultsProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function isPublished($entityClass, $id, $locale)
+    {
+        return $this->getDefaultProvider($entityClass)->isPublished($entityClass, $id, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function supports($entityClass)
     {
         return null !== $this->getDefaultProvider($entityClass);

--- a/src/Sulu/Bundle/RouteBundle/Routing/Defaults/RouteDefaultsProviderInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/Defaults/RouteDefaultsProviderInterface.php
@@ -29,6 +29,17 @@ interface RouteDefaultsProviderInterface
     public function getByEntity($entityClass, $id, $locale, $object = null);
 
     /**
+     * Returns true if object is published.
+     *
+     * @param string $entityClass
+     * @param string $id
+     * @param string $locale
+     *
+     * @return bool
+     */
+    public function isPublished($entityClass, $id, $locale);
+
+    /**
      * Returns true if this provider supports given entity-class.
      *
      * @param string $entityClass

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -83,7 +83,14 @@ class RouteProvider implements RouteProviderInterface
 
         $route = $this->routeRepository->findByPath('/' . ltrim($path, '/'), $request->getLocale());
 
-        if (!$route || !$this->routeDefaultsProvider->supports($route->getEntityClass())) {
+        if (!$route
+            || !$this->routeDefaultsProvider->supports($route->getEntityClass())
+            || !$this->routeDefaultsProvider->isPublished(
+                $route->getEntityClass(),
+                $route->getEntityId(),
+                $route->getLocale()
+            )
+        ) {
             return $collection;
         }
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/Defaults/RouteDefaultsProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/Defaults/RouteDefaultsProviderTest.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\RouteBundle\Tests\Unit\Routing\Defaults;
 use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProvider;
 use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
 
-class DefaultsProviderTest extends \PHPUnit_Framework_TestCase
+class RouteDefaultsProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var RouteDefaultsProviderInterface
@@ -57,6 +57,22 @@ class DefaultsProviderTest extends \PHPUnit_Framework_TestCase
         $this->providers[2]->supports('Test')->shouldNotBeCalled()->willReturn(false);
 
         $this->assertTrue($this->defaultsProvider->supports('Test'));
+    }
+
+    public function testIsPublishedFalse()
+    {
+        $this->providers[0]->supports('Test')->shouldBeCalled()->willReturn(true);
+        $this->providers[0]->isPublished('Test', 1, 'de')->shouldBeCalled()->willReturn(false);
+
+        $this->assertFalse($this->defaultsProvider->isPublished('Test', 1, 'de'));
+    }
+
+    public function testIsPublished()
+    {
+        $this->providers[0]->supports('Test')->shouldBeCalled()->willReturn(true);
+        $this->providers[0]->isPublished('Test', 1, 'de')->shouldBeCalled()->willReturn(true);
+
+        $this->assertTrue($this->defaultsProvider->isPublished('Test', 1, 'de'));
     }
 
     public function testGetByEntityFalse()

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -94,6 +94,29 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $collection);
     }
 
+    public function testGetRouteCollectionForRequestUnpublished()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/de/test');
+        $request->getLocale()->willReturn('de');
+
+        $routeEntity = $this->prophesize(RouteInterface::class);
+        $routeEntity->getEntityClass()->willReturn('Example');
+        $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/test');
+        $routeEntity->isHistory()->willReturn(false);
+        $routeEntity->getLocale()->willReturn('de');
+
+        $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
+        $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(false);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(0, $collection);
+    }
+
     public function testGetRouteCollectionForRequest()
     {
         $request = $this->prophesize(Request::class);
@@ -106,9 +129,11 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity->getId()->willReturn(1);
         $routeEntity->getPath()->willReturn('/test');
         $routeEntity->isHistory()->willReturn(false);
+        $routeEntity->getLocale()->willReturn('de');
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
         $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(true);
         $this->defaultsProvider->getByEntity('Example', '1', 'de')->willReturn(['test' => 1]);
 
         $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
@@ -138,9 +163,11 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity->getPath()->willReturn('/test');
         $routeEntity->getTarget()->willReturn($targetEntity->reveal());
         $routeEntity->isHistory()->willReturn(true);
+        $routeEntity->getLocale()->willReturn('de');
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
         $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(true);
 
         $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
 
@@ -172,9 +199,11 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity->getPath()->willReturn('/test');
         $routeEntity->getTarget()->willReturn($targetEntity->reveal());
         $routeEntity->isHistory()->willReturn(true);
+        $routeEntity->getLocale()->willReturn('de');
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
         $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(true);
 
         $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
 
@@ -202,9 +231,11 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $routeEntity->getId()->willReturn(1);
         $routeEntity->getPath()->willReturn('/test');
         $routeEntity->isHistory()->willReturn(false);
+        $routeEntity->getLocale()->willReturn('de');
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
         $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(true);
         $this->defaultsProvider->getByEntity('Example', '1', 'de')->willReturn(['test' => 1]);
 
         $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/7
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the isPublished method to route-defaults provider to allow unpublished state for routable-entities.
