### PR TITLE
Added a WebsiteSearchController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2678 [ContentBundle]       Fixed error caused by draft label when opening a ghost page
     * BUGFIX      #2668 [ContentBundle]       Fixed resource locator generation for pages with unpublished parents
     * BUGFIX      #2675 [ContactBundle]       Fixed findGetAll-method of ContactRepository
+    * ENHANCEMENT #2674 [SearchBundle]        Added a WebsiteSearchController
     * BUGFIX      #2524 [ContactBundle]       Fixed contact-serialization for smart-content
     * BUGFIX      #2632 [ContentBundle]       prevent item select when ordering a column (husky)
     * BUGFIX      #2663 [MediaBundle]         made masonry view work for media with no thumbnail

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,22 @@
 
 ## dev-develop
 
+### SearchController
+
+The `SearchController` has been moved from sulu-standard to sulu. Therefore the
+new template type `search` has been introduced. Just define the twig template
+you want to use for the search in your webspace configuration:
+
+```xml
+<templates>
+    <template type="search">ClientWebsiteBundle:views:query.html.twig</template>
+</templates>
+```
+
+The name of the route also changed from `website_search` to
+`sulu_search.website_search`, because the controller is located in the
+SuluSearchBundle now.
+
 ### Webspace Configuration
 
 The configuration schema for webspaces has changed. Instead of

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SearchBundle\Controller;
+
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
+use Sulu\Component\Rest\RequestParametersTrait;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This controller handles the search for the website.
+ */
+class WebsiteSearchController
+{
+    use RequestParametersTrait;
+
+    /**
+     * @var SearchManagerInterface
+     */
+    private $searchManager;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var ParameterResolverInterface
+     */
+    private $parameterResolver;
+
+    /**
+     * @var EngineInterface
+     */
+    private $engine;
+
+    /**
+     * @param SearchManagerInterface $searchManager
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     * @param ParameterResolverInterface $parameterResolver
+     * @param EngineInterface $engine
+     */
+    public function __construct(
+        SearchManagerInterface $searchManager,
+        RequestAnalyzerInterface $requestAnalyzer,
+        ParameterResolverInterface $parameterResolver,
+        EngineInterface $engine
+    ) {
+        $this->searchManager = $searchManager;
+        $this->requestAnalyzer = $requestAnalyzer;
+        $this->parameterResolver = $parameterResolver;
+        $this->engine = $engine;
+    }
+
+    /**
+     * Returns the search results for the given query.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function queryAction(Request $request)
+    {
+        $query = $this->getRequestParameter($request, 'q', true);
+
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $webspace = $this->requestAnalyzer->getWebspace();
+
+        $queryString = '';
+        if (strlen($query) < 3) {
+            $queryString .= '+("' . self::escapeDoubleQuotes($query) . '") ';
+        } else {
+            $queryValues = explode(' ', $query);
+            foreach ($queryValues as $queryValue) {
+                if (strlen($queryValue) > 2) {
+                    $queryString .= '+("' . self::escapeDoubleQuotes($queryValue) . '" OR ' .
+                        preg_replace('/([^\pL\s\d])/u', '?', $queryValue) . '* OR ' .
+                        preg_replace('/([^\pL\s\d])/u', '', $queryValue) . '~) ';
+                } else {
+                    $queryString .= '+("' . self::escapeDoubleQuotes($queryValue) . '") ';
+                }
+            }
+        }
+
+        $hits = $this->searchManager
+            ->createSearch($queryString)
+            ->locale($locale)
+            ->index('page_' . $webspace->getKey() . '_published')
+            ->execute();
+
+        return $this->engine->renderResponse(
+            $webspace->getTemplate('search'),
+            $this->parameterResolver->resolve(
+                ['query' => $query, 'hits' => $hits],
+                $this->requestAnalyzer
+            )
+        );
+    }
+
+    /**
+     * Returns the string with escaped quotes.
+     *
+     * @param string $query
+     *
+     * @return string
+     */
+    private static function escapeDoubleQuotes($query)
+    {
+        return str_replace('"', '\\"', $query);
+    }
+}

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        http://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="sulu_search.website_search" path="/search">
+        <default key="_controller">sulu_search.controller.website_search:queryAction</default>
+    </route>
+</routes>

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -21,6 +21,14 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
+        <service id="sulu_search.controller.website_search" class="Sulu\Bundle\SearchBundle\Controller\WebsiteSearchController">
+            <argument type="service" id="massive_search.search_manager"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="sulu_website.resolver.parameter"/>
+            <argument type="service" id="templating"/>
+            <tag name="sulu.context" context="website"/>
+        </service>
+
         <service id="sulu_search.index_configuration_provider" class="Sulu\Bundle\SearchBundle\Search\Configuration\IndexConfigurationProvider">
             <argument>%sulu_search.indexes%</argument>
         </service>

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SearchBundle\Tests\Unit\Controller;
+
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Massive\Bundle\SearchBundle\Search\SearchQueryBuilder;
+use Sulu\Bundle\SearchBundle\Controller\WebsiteSearchController;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class WebsiteSearchControllerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SearchManagerInterface
+     */
+    private $searchManager;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var ParameterResolverInterface
+     */
+    private $parameterResolver;
+
+    /**
+     * @var EngineInterface
+     */
+    private $engine;
+
+    /**
+     * @var WebsiteSearchController
+     */
+    private $websiteSearchController;
+
+    public function setUp()
+    {
+        $this->searchManager = $this->prophesize(SearchManagerInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
+        $this->engine = $this->prophesize(EngineInterface::class);
+
+        $this->websiteSearchController = new WebsiteSearchController(
+            $this->searchManager->reveal(),
+            $this->requestAnalyzer->reveal(),
+            $this->parameterResolver->reveal(),
+            $this->engine->reveal()
+        );
+    }
+
+    public function testQueryAction()
+    {
+        $request = new Request(['q' => 'Test']);
+
+        $localization = new Localization();
+        $localization->setLanguage('en');
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+        $webspace->addTemplate('search', 'search.html.twig');
+
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);
+        $this->searchManager->createSearch('+("Test" OR Test* OR Test~) ')->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->locale('en')->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->index('page_sulu_published')->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->execute()->willReturn([]);
+
+        $this->parameterResolver->resolve(
+            ['query' => 'Test', 'hits' => []],
+            $this->requestAnalyzer->reveal()
+        )->willReturn(['query' => 'Test', 'hits' => []]);
+
+        $this->engine->renderResponse(
+            'search.html.twig',
+            ['query' => 'Test', 'hits' => []]
+        )->willReturn(new Response());
+
+        $this->assertInstanceOf(Response::class, $this->websiteSearchController->queryAction($request));
+    }
+}

--- a/src/Sulu/Component/Webspace/Exception/PortalException.php
+++ b/src/Sulu/Component/Webspace/Exception/PortalException.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\Webspace\Exception;
 
+use Sulu\Component\Webspace\Portal;
+
 /**
  * General class for all webspace exceptions.
  */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu-standard/issues/593
| Related issues/PRs | based on https://github.com/sulu/sulu/pull/2665, prerequesite for https://github.com/sulu/sulu-standard/pull/728 https://github.com/sulu/sulu-minimal/pull/10
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR introduces the `WebsiteSearchController`, which can be used on the website. The file is basically copied from sulu-standard.

#### Why?

Because the `ClientWebsiteBundle` should not contain such basic logic. It is now also required, because there are multiple sulu editions now (standard and minimal, ...)

#### BC Breaks/Deprecations

The name of the route changed from `website_search` to `sulu_search.website_search`.

#### To Do

- [ ] Create a documentation PR
