### PR TITLE
fixed find-get-all of contact-repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2675 [ContactBundle]       Fixed findGetAll-method of ContactRepository
     * BUGFIX      #2524 [ContactBundle]       Fixed contact-serialization for smart-content
     * BUGFIX      #2632 [ContentBundle]       prevent item select when ordering a column (husky)
     * BUGFIX      #2663 [MediaBundle]         made masonry view work for media with no thumbnail

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -246,7 +246,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
     /**
      * {@inheritdoc}
      */
-    public function findGetAll($limit = null, $offset = null, $sorting = null, $where = [])
+    public function findGetAll($limit = null, $offset = null, $sorting = [], $where = [])
     {
         // Create basic query
         $qb = $this->createQueryBuilder('u')
@@ -255,7 +255,8 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             ->leftJoin('u.faxes', 'faxes')
             ->leftJoin('u.contactAddresses', 'contactAddresses')
             ->leftJoin('contactAddresses.address', 'addresses')
-            ->leftJoin('u.account', 'account')
+            ->leftJoin('u.accountContacts', 'accountContacts')
+            ->leftJoin('accountContacts.account', 'account')
             ->leftJoin('u.title', 'title')
             ->addSelect('title')
             ->addSelect('emails')
@@ -269,7 +270,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
 
         // If needed add where statements
         if (is_array($where) && count($where) > 0) {
-            $qb = $this->addWhere($qb, $where);
+            $qb = $this->addWhere($qb, $where, 'u');
         }
 
         $query = $qb->getQuery();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Entity/ContactRepositoryTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Entity/ContactRepositoryTest.php
@@ -65,8 +65,8 @@ class ContactRepositoryTest extends SuluTestCase
     private $contactData = [
         ['Max', 'Mustermann', [0, 1, 2], [0, 1, 2]],
         ['Anne', 'Mustermann', [0, 1, 3], [0, 1, 3]],
-        ['Georg', 'Mustermann', [0, 1], [0, 1]],
-        ['Marianne', 'Mustermann', [0, 1, 2], [0, 1, 2]],
+        ['Georg', 'Musterfrau', [0, 1], [0, 1]],
+        ['Marianne', 'Musterfrau', [0, 1, 2], [0, 1, 2]],
         ['Franz-Xaver', 'Gabler', [0], [0]],
         ['Markus', 'Mustermann', [0], [0]],
         ['Erika', 'Mustermann', [0], [0]],
@@ -531,6 +531,38 @@ class ContactRepositoryTest extends SuluTestCase
             $this->assertEquals($ids[$i], $result[$i]->getId());
             $this->assertEquals($expected[$i][0], $result[$i]->getFirstName());
             $this->assertEquals($expected[$i][1], $result[$i]->getLastName());
+        }
+    }
+
+    public function findGetAllProvider()
+    {
+        return [
+            [null, null, [], [], $this->contactData],
+            [3, null, [], [], array_slice($this->contactData, 0, 3)],
+            [3, 2, [], [], array_slice($this->contactData, 2, 3)],
+            [1, 0, [], ['lastName' => 'Gabler'], [$this->contactData[4]]],
+            [1, 0, ['firstName' => 'asc'], [], [$this->contactData[1]]],
+            [null, 0, ['firstName' => 'desc'], ['lastName' => 'Musterfrau'], [$this->contactData[3], $this->contactData[2]]],
+        ];
+    }
+
+    /**
+     * @dataProvider findGetAllProvider
+     *
+     * @param $limit
+     * @param $offset
+     * @param $sorting
+     * @param $where
+     * @param $expected
+     */
+    public function testFindGetAll($limit, $offset, $sorting, $where, $expected)
+    {
+        $repository = $this->em->getRepository(Contact::class);
+        $result = $repository->findGetAll($limit, $offset, $sorting, $where);
+
+        $this->assertEquals(count($expected), count($result));
+        for ($i = 0; $i < count($result); ++$i) {
+            $this->assertEquals($expected[$i][0], $result[$i]['firstName']);
         }
     }
 }

--- a/src/Sulu/Component/Contact/Model/ContactRepositoryInterface.php
+++ b/src/Sulu/Component/Contact/Model/ContactRepositoryInterface.php
@@ -55,7 +55,7 @@ interface ContactRepositoryInterface extends RepositoryInterface
      *
      * @return array
      */
-    public function findGetAll($limit = null, $offset = null, $sorting = null, $where = []);
+    public function findGetAll($limit = null, $offset = null, $sorting = [], $where = []);
 
     /**
      * Searches for contacts with a specific account and the ability to exclude a certain contacts.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2151 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR fixes the warning and error which occured when using the `findGetAll()`-method of the `ContactRepository`-class by adjusting the signature of the method and selecting the correct joint-table.

Also tests for the `findGetAll()`-method are added.