### PR TITLE
fixed error caused by draft label when opening a ghost page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2678 [ContentBundle]       Fixed error caused by draft label when opening a ghost page
     * BUGFIX      #2668 [ContentBundle]       Fixed resource locator generation for pages with unpublished parents
     * BUGFIX      #2524 [ContactBundle]       Fixed contact-serialization for smart-content
     * BUGFIX      #2632 [ContentBundle]       prevent item select when ordering a column (husky)

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
@@ -1025,7 +1025,7 @@ define([
         showDraftLabel: function() {
             this.sandbox.emit('sulu.header.tabs.label.hide');
 
-            if (!this.data.id || !!this.data.publishedState) {
+            if (!this.data.id || !!this.data.publishedState || !this.data.published) {
                 return;
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The if statement for showing the draft label was adjusted.

#### Why?

The draft label was also started when a ghost page opened, because the early return wasn't executed. This leaded to a request for the changer, which didn't exist, and therefore threw an error.