### PR TITLE
Disabled options in toolbar item which are not available when editing a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2684 [ContentBundle]       Disabled options in toolbar item which are not avialable when editing a page
     * FEATURE     #2559 [CoreBundle]          Renamed parameters.yml to parameters.yml.dist so you can use a local version
     * BUGFIX      #2678 [ContentBundle]       Fixed error caused by draft label when opening a ghost page
     * BUGFIX      #2668 [ContentBundle]       Fixed resource locator generation for pages with unpublished parents

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
@@ -66,7 +66,7 @@ define([
             return data.url === '/';
         },
 
-        setSaveToolbarItems = function(item, value) {
+        setToolbarItems = function(item, value) {
             this.sandbox.emit('sulu.header.toolbar.item.' + (!!value ? 'enable' : 'disable'), item, false);
         },
 
@@ -782,9 +782,12 @@ define([
                 savePublish = !saved,
                 publish = !!saved && !this.data.publishedState;
 
-            setSaveToolbarItems.call(this, 'saveDraft', saveDraft);
-            setSaveToolbarItems.call(this, 'savePublish', savePublish);
-            setSaveToolbarItems.call(this, 'publish', publish);
+            setToolbarItems.call(this, 'saveDraft', saveDraft);
+            setToolbarItems.call(this, 'savePublish', savePublish);
+            setToolbarItems.call(this, 'publish', publish);
+
+            setToolbarItems.call(this, 'unpublish', !!this.data.published);
+            setToolbarItems.call(this, '')
 
             if (!!saveDraft || !!savePublish || !!publish) {
                 this.sandbox.emit('sulu.header.toolbar.item.enable', 'save', false);
@@ -897,6 +900,7 @@ define([
                 if (SecurityChecker.hasPermission(this.data, 'delete') && !isHomeDocument(this.data)) {
                     editDropdown.delete = {
                         options: {
+                            disabled: !this.data.id,
                             callback: function() {
                                 this.sandbox.emit('sulu.content.content.delete', this.data.id);
                             }.bind(this)
@@ -908,6 +912,7 @@ define([
                     editDropdown.copyLocale = {
                         options: {
                             title: this.sandbox.translate('toolbar.copy-locale'),
+                            disabled: !this.data.id,
                             callback: function() {
                                 CopyLocale.startCopyLocalesOverlay.call(this).then(function(newLocales) {
                                     this.content.attributes.concreteLanguages = _.uniq(this.data.concreteLanguages.concat(newLocales));
@@ -923,6 +928,7 @@ define([
                     editDropdown.unpublish = {
                         options: {
                             title: this.sandbox.translate('sulu-document-manager.unpublish'),
+                            disabled: !this.data.published,
                             callback: function() {
                                 this.sandbox.emit('sulu.header.toolbar.item.loading', 'edit');
                                 ContentManager.unpublish(this.data.id, this.options.language)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2667
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR displays the `unpublish` option in the toolbar of a page only if the page has already been published. Also, it only shows the `delete` and `copyLocale` action if the page is not in add mode.

#### Why?

Because these operations were executed on a click, and lead to errors in certain situations. These errors were happening when:

* Clicking delete on a adding page form
* Trying to copy a locale on a adding page form
* Unpublish a page which has not been published yet (was not throwing an error, but might be confusing)