### PR TITLE
Fixed generation of log and cache directoy when context is part of path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2692 [PreviewBundle]       Fixed the generation of log and cache directory when context is part of path
     * BUGFIX      #2684 [ContentBundle]       Disabled options in toolbar item which are not avialable when editing a page
     * FEATURE     #2559 [CoreBundle]          Renamed parameters.yml to parameters.yml.dist so you can use a local version
     * BUGFIX      #2678 [ContentBundle]       Fixed error caused by draft label when opening a ghost page

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -54,7 +54,14 @@ class PreviewKernel extends \WebsiteKernel
      */
     public function getLogDir()
     {
-        return str_replace($this->getContext(), static::CONTEXT_PREVIEW, parent::getLogDir());
+        $context = $this->getContext();
+        $this->setContext(static::CONTEXT_PREVIEW);
+
+        $logDirectory = parent::getLogDir();
+
+        $this->setContext($context);
+
+        return $logDirectory;
     }
 
     /**
@@ -62,6 +69,13 @@ class PreviewKernel extends \WebsiteKernel
      */
     public function getCacheDir()
     {
-        return str_replace($this->getContext(), static::CONTEXT_PREVIEW, parent::getCacheDir());
+        $context = $this->getContext();
+        $this->setContext(static::CONTEXT_PREVIEW);
+
+        $cacheDirectory = parent::getCacheDir();
+
+        $this->setContext($context);
+
+        return $cacheDirectory;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the logic to generate the cache and log directory. Now the context will be switched for these functions, so that the directory is generated correctly.

#### Why?

Because if the absolute path contained the context at multiple places it was replaced everywhere, leading to wrong paths.