### PR TITLE
deindex page after unpublishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2692 [PreviewBundle]       Fixed the generation of log and cache directory when context is part of path
+    * BUGFIX      #2697 [ContentBundle]       Deindex page after unpublishing
     * BUGFIX      #2684 [ContentBundle]       Disabled options in toolbar item which are not avialable when editing a page
     * FEATURE     #2559 [CoreBundle]          Renamed parameters.yml to parameters.yml.dist so you can use a local version
     * BUGFIX      #2678 [ContentBundle]       Fixed error caused by draft label when opening a ghost page

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -727,6 +727,18 @@
                 <source>sulu-content.ckeditor.roles-info</source>
                 <target>Die Konfiguration gilt für jeden Text-Editor im System, der von dieser Rolle verwendet wird.</target>
             </trans-unit>
+            <trans-unit id="53" resname="sulu-content.unpublish-confirm-text-no-draft">
+                <source>sulu-content.unpublish-confirm-text-no-draft</source>
+                <target>Soll die Seite wirklich nicht mehr veröffentlicht werden? Dadurch gehen sämtliche Verknüpfungen auf der Website verloren. Dieser Status kann jederzeit ohne Datenverlust geändert werden.</target>
+            </trans-unit>
+            <trans-unit id="54" resname="sulu-content.unpublish-confirm-text-with-draft">
+                <source>sulu-content.unpublish-confirm-text-with-draft</source>
+                <target>Soll die Seite wirklich nicht mehr veröffentlicht werden? Dadurch gehen sämtliche Verknüpfungen auf der Website verloren und die Inhalte  vom aktuellen Entwurf werden unwiderruflich übernommen.</target>
+            </trans-unit>
+            <trans-unit id="55" resname="sulu-content.unpublish-confirm-title">
+                <source>sulu-content.unpublish-confirm-title</source>
+                <target>Nicht mehr veröffentlichen?</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -719,6 +719,18 @@
                 <source>sulu-content.ckeditor.roles-info</source>
                 <target>These settings apply for any text editor throughout the system used by this role.</target>
             </trans-unit>
+            <trans-unit id="53" resname="sulu-content.unpublish-confirm-text-no-draft">
+                <source>sulu-content.unpublish-confirm-text-no-draft</source>
+                <target>Do you really want to unpublish the page? All website links will be lost. This setting can be changed at any time without data loss.</target>
+            </trans-unit>
+            <trans-unit id="54" resname="sulu-content.unpublish-confirm-text-with-draft">
+                <source>sulu-content.unpublish-confirm-text-with-draft</source>
+                <target>Do you really want to unpublish the page? All website links will be lost and all content will be irrevocably transferred from the current draft.</target>
+            </trans-unit>
+            <trans-unit id="55" resname="sulu-content.unpublish-confirm-title">
+                <source>sulu-content.unpublish-confirm-title</source>
+                <target>Set to unpublished?</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
@@ -719,6 +719,18 @@
                 <source>sulu-content.ckeditor.roles-info</source>
                 <target>Cette configuration est valable pour tous les éditeurs de  texte dans le système utilisés par ce rôle.</target>
             </trans-unit>
+            <trans-unit id="53" resname="sulu-content.unpublish-confirm-text-no-draft">
+                <source>sulu-content.unpublish-confirm-text-no-draft</source>
+                <target>Est-ce qu’il ne peut plus publier cette page? Toutes les raccourcis sur la page seront supprimées! Ce statut peut être modifié à tout moment sans perte de données.</target>
+            </trans-unit>
+            <trans-unit id="54" resname="sulu-content.unpublish-confirm-text-with-draft">
+                <source>sulu-content.unpublish-confirm-text-with-draft</source>
+                <target>Est-ce qu’il ne peut plus publier cette page? Toutes les raccourcis sur la page seront supprimées et les teneurs sont adopté de la conception actuelle irrévocable.</target>
+            </trans-unit>
+            <trans-unit id="55" resname="sulu-content.unpublish-confirm-title">
+                <source>sulu-content.unpublish-confirm-title</source>
+                <target>Pas plus publier?</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
@@ -17,6 +17,7 @@ use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\Event\PublishEvent;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\UnpublishEvent;
 
 class StructureSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -108,7 +109,7 @@ class StructureSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->indexPublishedDocument($publishEvent->reveal());
     }
 
-    public function testHandlePreRemove()
+    public function testDeindexRemovedDocument()
     {
         $removeEvent = $this->prophesize(RemoveEvent::class);
 
@@ -117,7 +118,19 @@ class StructureSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->searchManager->deindex($document)->shouldBeCalled();
 
-        $this->subscriber->handlePreRemove($removeEvent->reveal());
+        $this->subscriber->deindexRemovedDocument($removeEvent->reveal());
+    }
+
+    public function testDeindexUnpublishedDocument()
+    {
+        $unpublishEvent = $this->prophesize(UnpublishEvent::class);
+
+        $document = $this->prophesize(StructureBehavior::class);
+        $unpublishEvent->getDocument()->willReturn($document->reveal());
+
+        $this->searchManager->deindex($document)->shouldBeCalled();
+
+        $this->subscriber->deindexUnpublishedDocument($unpublishEvent->reveal());
     }
 
     private function getPersistEventMock($document)

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -126,7 +126,10 @@ class ContentRouteProvider implements RouteProviderInterface
                     $portal->getWebspace()->getKey(),
                     $language
                 );
-                if (
+
+                if (!$content) {
+                    throw new ResourceLocatorNotFoundException();
+                } elseif (
                     preg_match('/\/$/', $resourceLocator)
                     && $this->requestAnalyzer->getResourceLocatorPrefix()
                     && $content->getNodeState() === StructureInterface::STATE_PUBLISHED


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR deindexes the page after it has been unpublished. In addition to that it adds a confirm overlay after a click on the unpublish button.

#### Why?

Because the search index on the website was not updated when a page was unpublished.