### PR TITLE
Updated hateoas-bundle to version 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
     - php: 7.0
       env: 
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2710 [All]                 Updated hateoas-bundle to version 1.2
     * BUGFIX      #2692 [AdminBundle]         Made url comparison in navigation use url parts an not characters (husky)
     * BUGFIX      #2738 [ContentBundle]       Fixed using non-existent AbstractKernel
     * ENHANCEMENT #2685 [ContentBundle]       Made internal links and smart content show unpublished nodes

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "stof/doctrine-extensions-bundle": "1.1.*",
         "symfony-cmf/routing-bundle": "1.2.*",
         "symfony/symfony": "~2.8.7",
-        "willdurand/hateoas-bundle": "0.3.*",
+        "willdurand/hateoas-bundle": "^1.2",
         "symfony/swiftmailer-bundle": "~2.3",
         "pagerfanta/pagerfanta": "~1.0",
         "pulse00/ffmpeg-bundle": "^0.6",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/2651 |
| Related issues/PRs | none |
| License | MIT |
| Documentation PR | none |
#### What's in this PR?

The hateoas-bundle dependency was upgraded to 1.2 (from 0.3)
