### PR TITLE
Added params to smart-content-item-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * FEATURE     #2704 [All]                 Ignore irrelevant files on composer dist installs
+    * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
     * ENHANCEMENT #2701 [PreviewBundle]       Replaced preview background-images with white background
 
 * 1.3.0-RC2 (2016-07-28)

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/smart-content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/smart-content/main.js
@@ -110,6 +110,7 @@ define(['services/husky/util'], function(util) {
             includeSubFoldersParameter: 'includeSubFolders',
             categoriesParameter: 'categories',
             categoryOperatorParameter: 'categoryOperator',
+            paramsParameter: 'params',
             tagsParameter: 'tags',
             tagOperatorParameter: 'tagOperator',
             sortByParameter: 'sortBy',
@@ -1165,6 +1166,7 @@ define(['services/husky/util'], function(util) {
             data[this.options.categoriesParameter] = this.overlayData.categories || [];
             data[this.options.categoryOperatorParameter] = this.overlayData.categoryOperator ||
                 this.options.preSelectedCategoryOperator;
+            data[this.options.paramsParameter] = JSON.stringify(this.options.property.params);
 
             // min source must be selected
             if (JSON.stringify(data) !== JSON.stringify(this.URI.data)) {

--- a/src/Sulu/Component/Content/Compat/PropertyParameter.php
+++ b/src/Sulu/Component/Content/Compat/PropertyParameter.php
@@ -16,7 +16,7 @@ use JMS\Serializer\Annotation\Type;
 /**
  * Represents a parameter of a property.
  */
-class PropertyParameter
+class PropertyParameter implements \JsonSerializable
 {
     /**
      * @var string
@@ -150,5 +150,16 @@ class PropertyParameter
         } else {
             return '';
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'value' => $this->getValue(),
+            'type' => $this->getType(),
+        ];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/10
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the ability to react on property-params for admin items request.
