### PR TITLE
Don't allow symfony deprecations in GeneratorBundle anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * FEATURE     #2704 [All]                 Ignore irrelevant files on composer dist installs
     * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
+    * FEATURE     #2721 [GeneratorBundle]     Don't allow symfony deprecations anymore
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)
     * ENHANCEMENT #2701 [PreviewBundle]       Replaced preview background-images with white background

--- a/src/Sulu/Bundle/GeneratorBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/GeneratorBundle/phpunit.xml.dist
@@ -19,7 +19,6 @@
 
     <php>
         <server name="KERNEL_DIR" value="Tests/app"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Don't allow symfony deprecations in GeneratorBundle anymore.

#### Why?

Part of the Symfony 3.x compatibility.

#### Considerations

Although there are no tests yet, further additions and tests to the bundle are not allowed to use deprecated code parts from now.
