### PR TITLE
Don't allow symfony deprecations in HttpCacheBundle anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * FEATURE     #2704 [All]                 Ignore irrelevant files on composer dist installs
     * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
+    * FEATURE     #2722 [HttpCacheBundle]     Don't allow symfony deprecations anymore
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)
     * ENHANCEMENT #2701 [PreviewBundle]       Replaced preview background-images with white background
 

--- a/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
@@ -20,7 +20,6 @@
     <php>
         <server name="KERNEL_DIR" value="Tests/app"/>
         <var name="APP_DB" value="mysql"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Don't allow symfony deprecations in HttpCacheBundle anymore.

#### Why?

Part of the Symfony 3.x compatibility.

#### Considerations

Further additions to the bundle are not allowed to use deprecated code parts from now.
