### PR TITLE
Don't allow symfony deprecations in MarkupBundle anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)
+    * FEATURE     #2723 [MarkupBundle]        Don't allow symfony deprecations anymore
     * ENHANCEMENT #2701 [PreviewBundle]       Replaced preview background-images with white background
 
 * 1.3.0-RC2 (2016-07-28)

--- a/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/MarkupBundle/phpunit.xml.dist
@@ -17,8 +17,4 @@
         </whitelist>
     </filter>
 
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    </php>
-
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Don't allow symfony deprecations in MarkupBundle anymore.

#### Why?

Part of the Symfony 3.x compatibility.

#### Considerations

Further additions to the bundle are not allowed to use deprecated code parts from now.
