### PR TITLE
Don't allow symfony deprecations in PersistenceBundle anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)
     * ENHANCEMENT #2701 [PreviewBundle]       Replaced preview background-images with white background
+    * FEATURE     #2725 [PersistenceBundle]   Don't allow symfony deprecations anymore
 
 * 1.3.0-RC2 (2016-07-28)
     * BUGFIX      #2692 [PreviewBundle]       Fixed the generation of log and cache directory when context is part of path

--- a/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PersistenceBundle/phpunit.xml.dist
@@ -20,7 +20,6 @@
     <php>
         <server name="KERNEL_DIR" value="Tests/app"/>
         <var name="APP_DB" value="mysql"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Don't allow symfony deprecations in PersistenceBundle anymore.

#### Why?

Part of the Symfony 3.x compatibility.

#### Considerations

Further additions to the bundle are not allowed to use deprecated code parts from now.
