### PR TITLE
Don't allow symfony deprecations in WebsocketBundle anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG for Sulu
     * FEATURE     #2720 [DocumentManagerBundle] Don't allow symfony deprecations anymore
     * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
     * FEATURE     #2721 [GeneratorBundle]     Don't allow symfony deprecations anymore
+    * FEATURE     #2728 [WebsocketBundle]     Don't allow symfony deprecations anymore
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
     * FEATURE     #2722 [HttpCacheBundle]     Don't allow symfony deprecations anymore
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)

--- a/src/Sulu/Bundle/WebsocketBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/WebsocketBundle/phpunit.xml.dist
@@ -20,7 +20,6 @@
     <php>
         <server name="KERNEL_DIR" value="Tests/app"/>
         <var name="APP_DB" value="mysql"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Don't allow symfony deprecations in WebsocketBundle anymore.

#### Why?

Part of the Symfony 3.x compatibility.

#### Considerations

Further additions to the bundle are not allowed to use deprecated code parts from now.
