### PR TITLE
Moved resource-locator node from portal to webspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG for Sulu
     * FEATURE     #2726 [PreviewBundle]       Don't allow symfony deprecations anymore
     * FEATURE     #2717 [ContentBundle]       Removed or fixed some publishing translations
     * ENHANCEMENT #2750 [WebsiteBundle]       Removed published checks from ContentRouteProvider
+    * ENHANCEMENT #2729 [Webpace]             Moved resource-locator node from portal to webspace
     * FEATURE     #2704 [All]                 Ignore irrelevant files on composer dist installs
     * FEATURE     #2720 [DocumentManagerBundle] Don't allow symfony deprecations anymore
     * FEATURE     #2727 [RouteBundle]         Don't allow symfony deprecations anymore

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,6 +62,8 @@ After:
 </templates>
 ```
 
+And the `resource-locator` node has moved from `portal` to `webspace`. 
+
 This change only affects the files which use the 1.1 version of the webspace
 schema definition.
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -29,13 +29,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -29,13 +29,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -29,13 +29,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -38,13 +38,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+    
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="fr"/>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/test.io.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/webspaces/test.io.xml
@@ -37,13 +37,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>test CMF AT</name>
             <key>testcmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -35,13 +35,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" default="true" />

--- a/src/Sulu/Bundle/GeneratorBundle/Resources/skeleton/sulu/travis/Tests/app/Resources/webspaces/sulu.io.xml.twig
+++ b/src/Sulu/Bundle/GeneratorBundle/Resources/skeleton/sulu/travis/Tests/app/Resources/webspaces/sulu.io.xml.twig
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>sulu.io</name>
             <key>sulu_io</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" default="true"/>

--- a/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -35,14 +35,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
-
             <localizations>
                 <localization language="de" country="at" default="true" />
                 <localization language="de" />

--- a/src/Sulu/Bundle/PreviewBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -38,13 +38,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="fr"/>

--- a/src/Sulu/Bundle/SearchBundle/Tests/app/Resources/webspaces/sulu.lo.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/app/Resources/webspaces/sulu.lo.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>sulu.io</name>
             <key>sulu_io</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" default="true"/>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en"/>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>sulu.io</name>
             <key>sulu_io</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en"/>

--- a/src/Sulu/Bundle/TagBundle/Tests/app/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/app/Resources/webspaces/sulu.io.xml
@@ -27,13 +27,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/src/Sulu/Bundle/TestBundle/Resources/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/webspaces/sulu.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>sulu.io</name>
             <key>sulu_io</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" default="true"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/sulu_lo.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/sulu_lo.xml
@@ -32,13 +32,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF</name>
             <key>sulucmf</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/test_lo.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/test_lo.xml
@@ -34,13 +34,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>test CMF</name>
             <key>testcmf</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" default="true"/>

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -336,9 +336,6 @@ class XmlFileLoader10 extends BaseXmlFileLoader
 
             $portal->setName($this->xpath->query('x:name', $portalNode)->item(0)->nodeValue);
             $portal->setKey($this->xpath->query('x:key', $portalNode)->item(0)->nodeValue);
-            $portal->setResourceLocatorStrategy(
-                $this->xpath->query('x:resource-locator/x:strategy', $portalNode)->item(0)->nodeValue
-            );
 
             // set localization on portal
             $this->generatePortalLocalizations($portalNode, $portal);

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -27,6 +27,23 @@ class XmlFileLoader11 extends XmlFileLoader10
     /**
      * {@inheritdoc}
      */
+    protected function parseXml($file)
+    {
+        $webspace = parent::parseXml($file);
+
+        $strategyNode = $this->xpath->query('/x:webspace/x:resource-locator/x:strategy')->item(0);
+        if (null !== $strategyNode) {
+            $webspace->setResourceLocatorStrategy($strategyNode->nodeValue);
+        } else {
+            $webspace->setResourceLocatorStrategy('tree');
+        }
+
+        return $webspace;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function generateDefaultTemplates(Webspace $webspace)
     {
         $expected = ['page', 'home'];

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -14,6 +14,7 @@
             <xs:element type="defaultTemplatesType" name="default-templates" minOccurs="1" maxOccurs="1"/>
             <xs:element type="templatesType" name="templates" minOccurs="0" maxOccurs="1"/>
             <xs:element type="navigationType" name="navigation"/>
+            <xs:element type="resource-locatorType" name="resource-locator" maxOccurs="1" minOccurs="0"/>
             <xs:element type="portalsType" name="portals"/>
         </xs:sequence>
     </xs:complexType>
@@ -92,6 +93,12 @@
         </xs:simpleContent>
     </xs:complexType>
 
+    <xs:complexType name="resource-locatorType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="strategy"/>
+        </xs:sequence>
+    </xs:complexType>
+
     <xs:complexType name="portalsType">
         <xs:sequence>
             <xs:element type="portalType" name="portal" maxOccurs="unbounded" minOccurs="0"/>
@@ -101,14 +108,8 @@
         <xs:sequence>
             <xs:element type="xs:string" name="name"/>
             <xs:element type="xs:string" name="key"/>
-            <xs:element type="resource-locatorType" name="resource-locator"/>
             <xs:element type="localizationsType" name="localizations" minOccurs="0" maxOccurs="1"/>
             <xs:element type="environmentsType" name="environments"/>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="resource-locatorType">
-        <xs:sequence>
-            <xs:element type="xs:string" name="strategy"/>
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="defaultTemplatesType">

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -35,13 +35,6 @@ class Portal
     private $key;
 
     /**
-     * The url generation strategy for this portal.
-     *
-     * @var string
-     */
-    private $resourceLocatorStrategy;
-
-    /**
      * An array of localizations.
      *
      * @var Localization[]
@@ -106,22 +99,6 @@ class Portal
     public function getKey()
     {
         return $this->key;
-    }
-
-    /**
-     * @param string $resourceLocatorStrategy
-     */
-    public function setResourceLocatorStrategy($resourceLocatorStrategy)
-    {
-        $this->resourceLocatorStrategy = $resourceLocatorStrategy;
-    }
-
-    /**
-     * @return string
-     */
-    public function getResourceLocatorStrategy()
-    {
-        return $this->resourceLocatorStrategy;
     }
 
     /**
@@ -285,7 +262,6 @@ class Portal
         $res = [];
         $res['name'] = $this->getName();
         $res['key'] = $this->getKey();
-        $res['resourceLocator']['strategy'] = $this->getResourceLocatorStrategy();
 
         $res['localizations'] = [];
 

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -76,6 +76,7 @@ class {{ cache_class }} extends {{ base_class }}
         $navigation = new Navigation();
 {% for context in webspace.navigation.contexts %}        $navigation->addContext(new NavigationContext('{{ context.key }}', {{ _self.renderArray(context.metadata) }}));
 {% endfor %}        $webspace->setNavigation($navigation);
+        $webspace->setResourceLocatorStrategy('{{ webspace.resourceLocator.strategy }}');
 
 {% for portal in webspace.portals %}
 
@@ -83,7 +84,6 @@ class {{ cache_class }} extends {{ base_class }}
         $portal = new Portal();
         $portal->setName('{{ portal.name }}');
         $portal->setKey('{{ portal.key }}');
-        $portal->setResourceLocatorStrategy('{{ portal.resourceLocator.strategy }}');
         $portal->setWebspace($webspace);
 {% for localization in portal.localizations %}
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
@@ -79,8 +79,6 @@ class XmlFileLoader10Test extends WebspaceTestCase
             $webspace->getDefaultTemplates()
         );
 
-        $this->assertEquals('short', $webspace->getPortals()[0]->getResourceLocatorStrategy());
-
         $this->assertEquals(2, count($webspace->getPortals()[0]->getLocalizations()));
         $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $webspace->getPortals()[0]->getLocalizations()[0]->getCountry());

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -78,8 +78,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
             ['page' => 'default', 'homepage' => 'overview', 'home' => 'overview'],
             $webspace->getDefaultTemplates()
         );
-
-        $this->assertEquals('short', $webspace->getPortals()[0]->getResourceLocatorStrategy());
+        $this->assertEquals('short', $webspace->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($webspace->getPortals()[0]->getLocalizations()));
         $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());
@@ -165,7 +164,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
 
         $this->assertEquals('massiveart', $webspace->getTheme());
 
-        $this->assertEquals('tree', $webspace->getPortals()[0]->getResourceLocatorStrategy());
+        $this->assertEquals('tree', $webspace->getResourceLocatorStrategy());
 
         $this->assertEquals(4, count($webspace->getPortals()[0]->getLocalizations()));
         $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());
@@ -214,7 +213,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         );
 
         $this->assertEquals('Massive Art CA', $webspace->getPortals()[1]->getName());
-        $this->assertEquals('tree', $webspace->getPortals()[1]->getResourceLocatorStrategy());
+        $this->assertEquals('tree', $webspace->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($webspace->getPortals()[1]->getLocalizations()));
         $this->assertEquals('en', $webspace->getPortals()[1]->getLocalizations()[0]->getLanguage());
@@ -258,6 +257,14 @@ class XmlFileLoader11Test extends WebspaceTestCase
         );
     }
 
+    public function testLoadNoStrategy()
+    {
+        $webspace = $this->loader->load($this->getResourceDirectory() . '/DataFixtures/Webspace/valid/sulu.io_no_strategy.xml');
+
+        $this->assertEquals('Sulu CMF', $webspace->getName());
+        $this->assertEquals('tree', $webspace->getResourceLocatorStrategy());
+    }
+
     public function testLoadWithoutPortalLocalizations()
     {
         $webspace = $this->loader->load(
@@ -288,7 +295,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
 
         $this->assertEquals('sulu', $webspace->getTheme());
 
-        $this->assertEquals('short', $webspace->getPortals()[0]->getResourceLocatorStrategy());
+        $this->assertEquals('short', $webspace->getResourceLocatorStrategy());
 
         $this->assertEquals(3, count($webspace->getPortals()[0]->getLocalizations()));
         $this->assertEquals('en', $webspace->getPortals()[0]->getLocalizations()[0]->getLanguage());

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionTest.php
@@ -75,8 +75,6 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
         $portal->addLocalization($localizationFrCa);
         $portal->setDefaultLocalization($localizationEnUs);
 
-        $portal->setResourceLocatorStrategy('tree');
-
         $webspace = new Webspace();
         $webspace->addLocalization($localizationEnUs);
         $webspace->addLocalization($localizationFrCa);
@@ -94,6 +92,7 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
         $webspace->addPortal($portal);
         $webspace->setKey('default');
         $webspace->setName('Default');
+        $webspace->setResourceLocatorStrategy('tree');
         $webspace->addPortal($portal);
 
         $webspace->setNavigation(new Navigation([new NavigationContext('main', [])]));
@@ -166,6 +165,7 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($webspace['navigation']['contexts']));
         $this->assertEquals('main', $webspace['navigation']['contexts'][0]['key']);
         $this->assertEquals([], $webspace['navigation']['contexts'][0]['metadata']);
+        $this->assertEquals('tree', $webspace['resourceLocator']['strategy']);
 
         $portal = $webspace['portals'][0];
 
@@ -188,7 +188,6 @@ class WebspaceCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ca', $portal['localizations'][2]['country']);
         $this->assertEquals('fr', $portal['localizations'][2]['language']);
         $this->assertEquals(false, $portal['localizations'][2]['default']);
-        $this->assertEquals('tree', $portal['resourceLocator']['strategy']);
 
         $portalInformation = $collectionArray['portalInformations']['prod']['www.portal1.com'];
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -110,8 +110,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('Massive Art US', $portal->getName());
         $this->assertEquals('massiveart_us', $portal->getKey());
 
-        $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
-
         $this->assertEquals(4, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
@@ -142,8 +140,6 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('Massive Art CA', $portal->getName());
         $this->assertEquals('massiveart_ca', $portal->getKey());
-
-        $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
@@ -198,8 +194,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
 
-        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
-
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
@@ -229,8 +223,6 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
-
-        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
@@ -293,8 +285,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
 
-        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
-
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
@@ -340,8 +330,6 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
-
-        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
@@ -393,8 +381,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
 
-        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
-
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
         $this->assertEquals('us', $portal->getLocalizations()[0]->getCountry());
@@ -440,8 +426,6 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('Sulu CMF AT', $portal->getName());
         $this->assertEquals('sulucmf_at', $portal->getKey());
-
-        $this->assertEquals('short', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(2, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());
@@ -536,8 +520,6 @@ class WebspaceManagerTest extends WebspaceTestCase
 
         $this->assertEquals('Massive Art US', $portal->getName());
         $this->assertEquals('massiveart_us', $portal->getKey());
-
-        $this->assertEquals('tree', $portal->getResourceLocatorStrategy());
 
         $this->assertEquals(4, count($portal->getLocalizations()));
         $this->assertEquals('en', $portal->getLocalizations()[0]->getLanguage());

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalTest.php
@@ -55,9 +55,6 @@ class PortalTest extends \PHPUnit_Framework_TestCase
         $expected = [
             'name' => 'foo',
             'key' => 'bar',
-            'resourceLocator' => [
-                'strategy' => 'hello',
-            ],
             'localizations' => [
                 ['foo'],
             ],
@@ -77,7 +74,6 @@ class PortalTest extends \PHPUnit_Framework_TestCase
 
         $this->portal->addEnvironment($this->environment->reveal());
         $this->portal->addLocalization($this->localization->reveal());
-        $this->portal->setResourceLocatorStrategy($expected['resourceLocator']['strategy']);
         $this->portal->setName($expected['name']);
         $this->portal->setKey($expected['key']);
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -88,6 +88,9 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
             'navigation' => [
                 'contexts' => [],
             ],
+            'resourceLocator' => [
+                'strategy' => 'tree',
+            ],
         ];
 
         $this->security->getSystem()->willReturn($expected['security']['system']);
@@ -114,6 +117,7 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $this->webspace->setTheme($this->theme);
+        $this->webspace->setResourceLocatorStrategy($expected['resourceLocator']['strategy']);
 
         $res = $this->webspace->toArray();
         $this->assertEquals($expected, $res);

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -111,6 +111,13 @@ class Webspace implements ArrayableInterface
     private $defaultTemplates = [];
 
     /**
+     * The url generation strategy for this portal.
+     *
+     * @var string
+     */
+    private $resourceLocatorStrategy;
+
+    /**
      * Sets the key of the webspace.
      *
      * @param string $key
@@ -508,6 +515,26 @@ class Webspace implements ArrayableInterface
     }
 
     /**
+     * Set resource-locator strategy.
+     *
+     * @param string $resourceLocatorStrategy
+     */
+    public function setResourceLocatorStrategy($resourceLocatorStrategy)
+    {
+        $this->resourceLocatorStrategy = $resourceLocatorStrategy;
+    }
+
+    /**
+     * Returns resource-locator strategy.
+     *
+     * @return string
+     */
+    public function getResourceLocatorStrategy()
+    {
+        return $this->resourceLocatorStrategy;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function toArray($depth = null)
@@ -518,6 +545,7 @@ class Webspace implements ArrayableInterface
         $res['localizations'] = [];
         $res['templates'] = $this->getTemplates();
         $res['defaultTemplates'] = $this->getDefaultTemplates();
+        $res['resourceLocator']['strategy'] = $this->getResourceLocatorStrategy();
 
         foreach ($this->getLocalizations() as $localization) {
             $res['localizations'][] = $localization->toArray();

--- a/tests/Resources/DataFixtures/Webspace/custom-url/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/custom-url/sulu.io.xml
@@ -34,13 +34,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>sulu.io</name>
             <key>sulu_io</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <environments>
                 <environment type="prod">

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart.xml
@@ -30,12 +30,13 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us" default="true"/>
@@ -56,9 +57,6 @@
         </portal>
         <portal>
             <name>Massive Art CA</name>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca" default="true"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_invalid_custom_url.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_invalid_custom_url.xml
@@ -47,13 +47,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
             <key>massiveart_us</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>
@@ -76,9 +77,6 @@
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca" default="true"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withIncorrectUrls.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withIncorrectUrls.xml
@@ -43,13 +43,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
             <key>massiveart_us</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>
@@ -75,9 +76,6 @@
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withNotExistingDefault.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withNotExistingDefault.xml
@@ -42,13 +42,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withNotExistingDefaultSegment.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withNotExistingDefaultSegment.xml
@@ -43,13 +43,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withTwoDefaultLocalizations.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withTwoDefaultLocalizations.xml
@@ -42,13 +42,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
             <key>massiveart_us</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>
@@ -72,9 +73,6 @@
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withoutDefaultLocalization.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/massiveart_withoutDefaultLocalization.xml
@@ -42,13 +42,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
             <key>massiveart_us</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>
@@ -72,9 +73,6 @@
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca"/>

--- a/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_multiple_template_types.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_multiple_template_types.xml
@@ -45,13 +45,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/main/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/main/sulu.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/multiple-localization-urls/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/multiple-localization-urls/sulu.io.xml
@@ -29,13 +29,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <environments>
                 <environment type="prod">

--- a/tests/Resources/DataFixtures/Webspace/multiple/massiveart.xml
+++ b/tests/Resources/DataFixtures/Webspace/multiple/massiveart.xml
@@ -42,13 +42,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
             <key>massiveart_us</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>
@@ -72,9 +73,6 @@
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca"/>

--- a/tests/Resources/DataFixtures/Webspace/multiple/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/multiple/sulu.io.xml
@@ -35,13 +35,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/not-valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/not-valid/sulu.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <fuu>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at"/>

--- a/tests/Resources/DataFixtures/Webspace/url-with-trailing-slash/sulu.io_url_with_slash.xml
+++ b/tests/Resources/DataFixtures/Webspace/url-with-trailing-slash/sulu.io_url_with_slash.xml
@@ -35,13 +35,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at_url_with_slash</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/valid/dan.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/dan.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Dan CMF AT</name>
             <key>dancmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/valid/massiveart.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/massiveart.xml
@@ -47,13 +47,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Massive Art US</name>
             <key>massiveart_us</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>
@@ -78,9 +79,6 @@
         <portal>
             <name>Massive Art CA</name>
             <key>massiveart_ca</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="ca" default="true"/>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+    
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="en" country="us"/>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_no_strategy.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_no_strategy.xml
@@ -1,35 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
 <webspace xmlns="http://schemas.sulu.io/webspace/webspace"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
     <name>Sulu CMF</name>
     <key>sulu_io</key>
 
+    <security>
+        <system>sulu_io</system>
+    </security>
+
     <localizations>
-        <localization language="en" shadow="auto">
-            <localization language="en" country="us" shadow="auto"/>
-        </localization>
-        <localization language="de">
-            <localization language="de" country="at"/>
-        </localization>
+        <localization language="en" country="us" shadow="auto"/>
+        <localization language="de" country="at" default="true"/>
     </localizations>
 
-    <theme>default</theme>
+    <theme>sulu</theme>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
 
     <navigation>
         <contexts>
             <context key="main">
                 <meta>
+                    <title lang="de">Hauptnavigation</title>
                     <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+            <context key="footer">
+                <meta>
+                    <title lang="de">Unten</title>
+                    <title lang="en">Footer</title>
                 </meta>
             </context>
         </contexts>
     </navigation>
-
-    <resource-locator>
-        <strategy>tree</strategy>
-    </resource-locator>
 
     <portals>
         <portal>
@@ -37,6 +45,7 @@
             <key>sulucmf_at</key>
 
             <localizations>
+                <localization language="en" country="us"/>
                 <localization language="de" country="at" default="true"/>
             </localizations>
 
@@ -50,15 +59,13 @@
                 <environment type="dev">
                     <urls>
                         <url language="de" country="at">sulu.lo</url>
-                        <url language="de" country="at">localhost</url>
-                        <url redirect="sulu.lo">sulu-redirect.lo</url>
                     </urls>
                 </environment>
-                <environment type="test">
+                <environment type="main">
                     <urls>
                         <url language="de" country="at">sulu.lo</url>
-                        <url language="de" country="at">localhost</url>
-                        <url redirect="sulu.lo">sulu-redirect.lo</url>
+                        <url language="de" country="at" main="true">sulu.at</url>
+                        <url language="de" country="at">at.sulu.de</url>
                     </urls>
                 </environment>
             </environments>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_singleLanguage.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_singleLanguage.xml
@@ -34,13 +34,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_singlelanguage_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <environments>
                 <environment type="prod">

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_withoutPortalLocalization.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_withoutPortalLocalization.xml
@@ -37,13 +37,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_withoutportallocalizations_at</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <environments>
                 <environment type="prod">

--- a/tests/Resources/DataFixtures/Webspace/xdefault/sulu.io_no_xdefault_locale.xml
+++ b/tests/Resources/DataFixtures/Webspace/xdefault/sulu.io_no_xdefault_locale.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>no_xdefault_locale</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/tests/Resources/DataFixtures/Webspace/xdefault/sulu.io_xdefault_locale.xml
+++ b/tests/Resources/DataFixtures/Webspace/xdefault/sulu.io_xdefault_locale.xml
@@ -39,13 +39,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>xdefault_locale</key>
-            <resource-locator>
-                <strategy>short</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>

--- a/tests/app/Resources/webspaces/sulu.io.xml
+++ b/tests/app/Resources/webspaces/sulu.io.xml
@@ -37,13 +37,14 @@
         </contexts>
     </navigation>
 
+    <resource-locator>
+        <strategy>tree</strategy>
+    </resource-locator>
+
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
             <key>sulucmf_at</key>
-            <resource-locator>
-                <strategy>tree</strategy>
-            </resource-locator>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-standard/pull/733 https://github.com/sulu/sulu-minimal/commit/1888b8f82f42c2f3e9a5176b75001a7137ae7126
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/244

#### What's in this PR?

This PR moves the configuration of `resource-locator` `strategy` from portal to webspace.

#### Why?

This will be needed for introducing multiple strategies.