### PR TITLE
Fixed bug when loading smart-content items with passed params

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/SmartContentItemController.php
@@ -84,7 +84,12 @@ class SmartContentItemController extends RestController
     {
         $result = [];
         foreach ($params as $name => $item) {
-            $result[$name] = new PropertyParameter($name, $item['value'], $item['type']);
+            $value = $item['value'];
+            if ($item['type'] === 'collection') {
+                $value = $this->getParams($value);
+            }
+
+            $result[$name] = new PropertyParameter($name, $value, $item['type']);
         }
 
         return $result;

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -292,6 +292,34 @@ class SmartContentItemControllerTest extends SuluTestCase
         );
     }
 
+    public function testGetItemsWithParams()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request(
+            'GET',
+            '/api/items?webspace=sulu_io&locale=en&dataSource=' . $this->team->getUuid() .
+            '&provider=content&excluded=' . $this->johannes->getUuid() .
+            '&params={"max_per_page":{"value":"5","type":"string"},' .
+            '"properties":{"value":{"title":{"value":"title","type":"string"}},"type":"collection"}}'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $result = json_decode($client->getResponse()->getContent(), true);
+        $this->assertEquals(
+            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
+            $result['datasource']
+        );
+        $this->assertEquals(
+            [
+                ['id' => $this->daniel->getUuid(), 'title' => 'Daniel'],
+                ['id' => $this->thomas->getUuid(), 'title' => 'Thomas'],
+            ],
+            $result['_embedded']['items']
+        );
+    }
+
     public function testGetItemsLimit()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The content of this PR fixes the issue that the server responded with 500 when smart-content items were loaded with passed params. Moreover a test was added.