### PR TITLE
Fix using non-existent AbstractKernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2738 [ContentBundle]       Fixed using non-existent AbstractKernel
     * ENHANCEMENT #2685 [ContentBundle]       Made internal links and smart content show unpublished nodes
     * BUGFIX      #2661 [ContentBundle]       Fixed ck-editor internal link visualization
     * FEATURE     #2681 [ContentBundle]       Fixed frontend resource locator generation for ghost pages

--- a/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\HttpKernel\SuluKernel;
 
 /**
  * Provides structures for the MassiveSearch reindex process.
@@ -80,7 +81,7 @@ class StructureProvider implements LocalizedReindexProviderInterface
     {
         $document = $this->documentManager->find($this->inspector->getUuid($object), $locale);
 
-        if ($document instanceof WorkflowStageBehavior && $this->context === \AbstractKernel::CONTEXT_ADMIN) {
+        if ($document instanceof WorkflowStageBehavior && $this->context === SuluKernel::CONTEXT_ADMIN) {
             // set the workflowstage to test, so that the document will be indexed in the index for drafting
             // this change must not be persisted
             // is required because of the expression for the index name uses the workflowstage


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2738
| License | MIT

#### What's in this PR?

Use the SuluKernel instead of relying on the AbstractKernel from the sulu-standard package.
