### PR TITLE
Remove symfony deprecations in CoreBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * FEATURE     #2799 [MediaBundle]         Implemented tiles view for navigating through collections
     * FEATURE     #2765 [MediaBundle]         Implemented new masonry-design for media
+    * ENHANCEMENT #2743 [CoreBundle]          Remove symfony deprecations and don't allow them anymore
 
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -12,16 +12,16 @@
     </parameters>
 
     <services>
-        <service id="sulu_core.rest_helper" class="%sulu_core.rest_helper.class%" scope="request">
+        <service id="sulu_core.rest_helper" class="%sulu_core.rest_helper.class%">
             <argument type="service" id="sulu_core.list_rest_helper"/>
         </service>
 
-        <service id="sulu_core.doctrine_rest_helper" class="%sulu_core.doctrine_rest_helper.class%" scope="request">
+        <service id="sulu_core.doctrine_rest_helper" class="%sulu_core.doctrine_rest_helper.class%">
             <argument type="service" id="sulu_core.list_rest_helper"/>
         </service>
 
-        <service id="sulu_core.list_rest_helper" class="%sulu_core.list_rest_helper.class%" scope="request">
-            <argument type="service" id="request"/>
+        <service id="sulu_core.list_rest_helper" class="%sulu_core.list_rest_helper.class%">
+            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="sulu_core.rest.exception_wrapper_handler" class="Sulu\Component\Rest\ExceptionWrapperHandler">

--- a/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/CoreBundle/phpunit.xml.dist
@@ -17,8 +17,4 @@
         </whitelist>
     </filter>
 
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    </php>
-
 </phpunit>

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -95,6 +95,11 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
      */
     private $requestHashChecker;
 
+    /**
+     * @var ListRestHelper
+     */
+    private $listRestHelper;
+
     public function __construct(
         ViewHandler $viewHandler,
         ContentMapper $contentMapper,
@@ -105,7 +110,8 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         DefaultSnippetManagerInterface $defaultSnippetManager,
         DocumentManager $documentManager,
         FormFactory $formFactory,
-        RequestHashChecker $requestHashChecker
+        RequestHashChecker $requestHashChecker,
+        ListRestHelper $listRestHelper
     ) {
         $this->viewHandler = $viewHandler;
         $this->contentMapper = $contentMapper;
@@ -117,6 +123,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         $this->documentManager = $documentManager;
         $this->formFactory = $formFactory;
         $this->requestHashChecker = $requestHashChecker;
+        $this->listRestHelper = $listRestHelper;
     }
 
     /**
@@ -129,7 +136,6 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     public function cgetAction(Request $request)
     {
         $locale = $this->getLocale($request);
-        $listRestHelper = new ListRestHelper($request);
 
         // if the type parameter is falsy, assign NULL to $type
         $type = $request->query->get('type', null) ?: null;
@@ -144,19 +150,19 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
             $snippets = $this->snippetRepository->getSnippets(
                 $locale,
                 $type,
-                $listRestHelper->getOffset(),
-                $listRestHelper->getLimit(),
-                $listRestHelper->getSearchPattern(),
-                $listRestHelper->getSortColumn(),
-                $listRestHelper->getSortOrder()
+                $this->listRestHelper->getOffset(),
+                $this->listRestHelper->getLimit(),
+                $this->listRestHelper->getSearchPattern(),
+                $this->listRestHelper->getSortColumn(),
+                $this->listRestHelper->getSortOrder()
             );
 
             $total = $this->snippetRepository->getSnippetsAmount(
                 $locale,
                 $type,
-                $listRestHelper->getSearchPattern(),
-                $listRestHelper->getSortColumn(),
-                $listRestHelper->getSortOrder()
+                $this->listRestHelper->getSearchPattern(),
+                $this->listRestHelper->getSortColumn(),
+                $this->listRestHelper->getSortOrder()
             );
         }
 
@@ -165,8 +171,8 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
             'snippets',
             'get_snippets',
             $request->query->all(),
-            $listRestHelper->getPage(),
-            $listRestHelper->getLimit(),
+            $this->listRestHelper->getPage(),
+            $this->listRestHelper->getLimit(),
             $total
         );
 

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -30,6 +30,7 @@
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="form.factory" />
             <argument type="service" id="sulu_hash.request_hash_checker"/>
+            <argument type="service" id="sulu_core.list_rest_helper"/>
 
             <tag name="sulu.context" context="admin"/>
         </service>

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * This is an service helper for ListResources accessed
@@ -26,17 +27,17 @@ class ListRestHelper implements ListRestHelperInterface
      *
      * @var Request
      */
-    protected $request;
+    protected $requestStack;
 
     /**
-     * The constructor takes the request as an argument, which
+     * The constructor takes the request stack as an argument, which
      * is injected by the service container.
      *
-     * @param Request $request
+     * @param RequestStack $requestStack
      */
-    public function __construct(Request $request)
+    public function __construct(RequestStack $requestStack)
     {
-        $this->request = $request;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -46,7 +47,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     protected function getRequest()
     {
-        return $this->request;
+        return $this->requestStack->getCurrentRequest();
     }
 
     /**

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
@@ -11,20 +11,20 @@
 
 namespace Sulu\Component\Rest\Tests\Unit\ListBuilder;
 
-use Doctrine\Common\Persistence\ObjectManager;
 use Sulu\Component\Rest\ListBuilder\ListRestHelper;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class ListRestHelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ObjectManager
+     * @var RequestStack
      */
-    protected $em;
+    protected $requestStack;
 
     public function setUp()
     {
-        $this->em = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->requestStack = $this->prophesize(RequestStack::class);
     }
 
     public static function dataFieldsProvider()
@@ -98,7 +98,8 @@ class ListRestHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFields($request)
     {
-        $helper = new ListRestHelper($request, $this->em);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+        $helper = new ListRestHelper($this->requestStack->reveal());
 
         $this->assertEquals(explode(',', $request->get('fields')), $helper->getFields());
         $this->assertEquals($request->get('sortBy'), $helper->getSortColumn());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove symfony deprecations in `CoreBundle` and don't allow them anymore.

#### Why?

Part of the Symfony 3.x compatibility.

#### Considerations

Further additions to the bundle are not allowed to use deprecated code parts from now.
