### PR TITLE
Fix all calls to phpunits deprecated getMock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
     - php: 7.0
       env: 
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG for Sulu
     * FEATURE     #2716 [ContentBundle]       Added params to smart-content-item-controller
     * FEATURE     #2721 [GeneratorBundle]     Don't allow symfony deprecations anymore
     * FEATURE     #2728 [WebsocketBundle]     Don't allow symfony deprecations anymore
+    * ENHANCEMENT #2744 [All]                 Fix all calls to phpunits deprecated getMock and test against PHP 5.6/7.0
     * BUGFIX      #2695 [MediaBundle]         Removed Paginator from CollectionRepository (mysql 5.7)
     * FEATURE     #2722 [HttpCacheBundle]     Don't allow symfony deprecations anymore
     * BUGFIX      #2695 [CategoryBundle]      Removed hasChildren field descriptor in categories (mysql 5.7)

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "massive/build-bundle": "0.2.*",
         "matthiasnoback/symfony-config-test": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.3",
-        "phpunit/phpunit": ">=4.8.0",
+        "phpunit/phpunit": "^5.4",
         "symfony/phpunit-bridge": "~2.8",
         "sensio/framework-extra-bundle": "~3.0",
         "symfony/monolog-bundle": "2.4.*",

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/Compiler/HandlerPassTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/Compiler/HandlerPassTest.php
@@ -105,7 +105,7 @@ class HandlerPassTest extends AbstractCompilerPassTestCase
         }
 
         foreach ($services as $service) {
-            $definition = new Definition($this->getMock($handlerClass));
+            $definition = new Definition($this->createMock($handlerClass));
             $definition->addTag('sulu_http_cache.handler', ['alias' => $service['alias']]);
             $this->setDefinition($service['service'], $definition);
         }

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
@@ -22,10 +22,10 @@ class LocationContentTypeTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->nodeRepository = $this->getMock('Sulu\Bundle\ContentBundle\Repository\NodeRepositoryInterface');
-        $this->phpcrNode = $this->getMock('PHPCR\NodeInterface');
-        $this->suluProperty = $this->getMock('Sulu\Component\Content\Compat\PropertyInterface');
-        $this->mapManager = $this->getMock('Sulu\Bundle\LocationBundle\Map\MapManager');
+        $this->nodeRepository = $this->createMock('Sulu\Bundle\ContentBundle\Repository\NodeRepositoryInterface');
+        $this->phpcrNode = $this->createMock('PHPCR\NodeInterface');
+        $this->suluProperty = $this->createMock('Sulu\Component\Content\Compat\PropertyInterface');
+        $this->mapManager = $this->createMock('Sulu\Bundle\LocationBundle\Map\MapManager');
         $this->locationContent = new LocationContentType(
             $this->nodeRepository,
             'Foo:bar.html.twig',

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorManagerTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorManagerTest.php
@@ -20,8 +20,8 @@ class GeolocatorManagerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->geolocator = $this->getMock('Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->geolocator = $this->createMock('Sulu\Bundle\LocationBundle\Geolocator\GeolocatorInterface');
 
         $this->manager = new GeolocatorManager($this->container);
     }

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorResponseTest.php
@@ -20,7 +20,7 @@ class GeolocatorResponseTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->response = new GeolocatorResponse();
-        $this->location = $this->getMock('Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation');
+        $this->location = $this->createMock('Sulu\Bundle\LocationBundle\Geolocator\GeolocatorLocation');
     }
 
     public function testToArray()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -54,7 +54,7 @@ class SearchIntegrationTest extends SuluTestCase
         $this->webspaceDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $mediaEntity = new Media();
-        $tagManager = $this->getMock('Sulu\Bundle\TagBundle\Tag\TagManagerInterface');
+        $tagManager = $this->createMock('Sulu\Bundle\TagBundle\Tag\TagManagerInterface');
         $this->media = new ApiMedia($mediaEntity, 'de', null, $tagManager);
 
         $this->mediaSelectionContainer = $this->prophesize(MediaSelectionContainer::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -30,7 +30,7 @@ class MediaSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->mediaManager = $this->getMock(MediaManagerInterface::class);
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
 
         $this->mediaSelection = new MediaSelectionContentType(
             $this->mediaManager, 'SuluMediaBundle:Template:image-selection.html.twig'

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
@@ -15,7 +15,7 @@ class DispositionTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetMediaUrlDefaultInline()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
+        $mediaMock = $this->createMock('Sulu\Bundle\MediaBundle\Api\Media');
         $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
         $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
 
@@ -27,7 +27,7 @@ class DispositionTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediaUrlDefaultAttachment()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
+        $mediaMock = $this->createMock('Sulu\Bundle\MediaBundle\Api\Media');
         $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
         $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
 
@@ -39,7 +39,7 @@ class DispositionTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediaUrlOtherMimeTypeDefaultInline()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
+        $mediaMock = $this->createMock('Sulu\Bundle\MediaBundle\Api\Media');
         $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/html');
         $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
 
@@ -51,7 +51,7 @@ class DispositionTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediaUrlOtherMimeTypeDefaultAttachment()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
+        $mediaMock = $this->createMock('Sulu\Bundle\MediaBundle\Api\Media');
         $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/html');
         $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
 
@@ -63,7 +63,7 @@ class DispositionTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediaUrlWithDispositionType()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
+        $mediaMock = $this->createMock('Sulu\Bundle\MediaBundle\Api\Media');
         $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
         $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/SnippetContentTest.php
@@ -64,7 +64,7 @@ class SnippetContentTest extends BaseFunctionalTestCase
         $this->loadFixtures();
 
         $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
-        $this->property = $this->getMock('Sulu\Component\Content\Compat\PropertyInterface');
+        $this->property = $this->createMock('Sulu\Component\Content\Compat\PropertyInterface');
 
         $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
 

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -207,7 +207,7 @@ class TagControllerTest extends SuluTestCase
 
     public function testDeleteById()
     {
-        $mockedEventListener = $this->getMock('stdClass', ['onDelete']);
+        $mockedEventListener = $this->getMockBuilder('stdClass')->setMethods(['onDelete'])->getMock();
         $mockedEventListener->expects($this->once())->method('onDelete');
 
         $client = $this->createAuthenticatedClient();
@@ -252,7 +252,7 @@ class TagControllerTest extends SuluTestCase
 
         $this->em->flush();
 
-        $mockedEventListener = $this->getMock('stdClass', ['onMerge']);
+        $mockedEventListener = $this->getMockBuilder('stdClass')->setMethods(['onMerge'])->getMock();
         $mockedEventListener->expects($this->once())->method('onMerge');
 
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -156,7 +156,7 @@ class SitemapGeneratorTest extends SuluTestCase
             )
         );
 
-        $this->webspaceManager = $this->getMock('Sulu\Component\Webspace\Manager\WebspaceManagerInterface');
+        $this->webspaceManager = $this->createMock('Sulu\Component\Webspace\Manager\WebspaceManagerInterface');
         $this->webspaceManager
             ->expects($this->any())
             ->method('findWebspaceByKey')

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -58,14 +58,10 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->contentTypeManager = $this->getMock(
-            'Sulu\Component\Content\ContentTypeManager',
-            ['get'],
-            [],
-            '',
-            false
-        );
-
+        $this->contentTypeManager = $this->getMockBuilder('Sulu\Component\Content\ContentTypeManager')
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMock();
         $this->blockContentType = new BlockContentType($this->contentTypeManager, 'not in use', 'i18n:');
 
         $this->contentTypeValueMap = [
@@ -126,7 +122,11 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareSingleBlockProperty();
 
-        $this->node = $this->getMock('\Jackalope\Node', ['getPropertyValue', 'hasProperty'], [], '', false);
+        $this->node = $this->getMockBuilder('\Jackalope\Node')
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertyValue', 'hasProperty'])
+            ->getMock();
+
         $data = [
             [
                 'type' => 'type1',
@@ -177,7 +177,10 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareSingleBlockProperty();
 
-        $this->node = $this->getMock('\Jackalope\Node', ['setProperty'], [], '', false);
+        $this->node = $this->getMockBuilder('\Jackalope\Node')
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertyValue', 'setProperty'])
+            ->getMock();
         $result = [];
         $this->node
             ->expects($this->any())
@@ -239,7 +242,11 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareMultipleBlockProperty();
 
-        $this->node = $this->getMock('\Jackalope\Node', ['getPropertyValue', 'hasProperty'], [], '', false);
+        $this->node = $this->getMockBuilder('\Jackalope\Node')
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertyValue', 'hasProperty'])
+            ->getMock();
+
         $data = [
             [
                 'type' => 'type1',
@@ -313,7 +320,10 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareMultipleBlockProperty();
 
-        $this->node = $this->getMock('\Jackalope\Node', ['setProperty'], [], '', false);
+        $this->node = $this->getMockBuilder('\Jackalope\Node')
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertyValue', 'setProperty'])
+            ->getMock();
         $result = [];
         $this->node
             ->expects($this->any())
@@ -397,7 +407,11 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareMultipleBlockProperty();
 
-        $this->node = $this->getMock('\Jackalope\Node', ['getPropertyValue', 'hasProperty'], [], '', false);
+        $this->node = $this->getMockBuilder('\Jackalope\Node')
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertyValue', 'hasProperty'])
+            ->getMock();
+
         $data = [
             [
                 'type' => 'type1',
@@ -458,7 +472,10 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
     {
         $this->prepareMultipleBlockProperty();
 
-        $this->node = $this->getMock('\Jackalope\Node', ['setProperty'], [], '', false);
+        $this->node = $this->getMockBuilder('\Jackalope\Node')
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertyValue', 'setProperty'])
+            ->getMock();
         $result = [];
         $this->node
             ->expects($this->any())

--- a/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -19,7 +19,7 @@ class ContentTypeManagerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $this->manager = new ContentTypeManager($this->container);
 
         $this->manager->mapAliasToServiceId('content_1.alias', 'content_1.service.id');

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/RlpStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/RlpStrategyTest.php
@@ -73,12 +73,10 @@ class RlpStrategyTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->mapper = $this->getMock(
-            'Sulu\Component\Content\Types\Rlp\Mapper\RlpMapper',
-            [],
-            ['test-mapper'],
-            'TestMapper'
-        );
+        $this->mapper = $this->getMockBuilder('Sulu\Component\Content\Types\Rlp\Mapper\RlpMapper')
+            ->setConstructorArgs(['test-mapper'])
+            ->setMockClassName('TestMapper')
+            ->getMock();
         $this->mapper->expects($this->any())
             ->method('unique')
             ->will($this->returnCallback([$this, 'uniqueCallback']));
@@ -100,7 +98,7 @@ class RlpStrategyTest extends \PHPUnit_Framework_TestCase
 
         $structureManager = $this->getMockForAbstractClass('Sulu\Component\Content\Compat\StructureManagerInterface');
         $contentTypeManager = $this->getMockForAbstractClass('Sulu\Component\Content\ContentTypeManagerInterface');
-        $nodeHelper = $this->getMock('Sulu\Component\Util\SuluNodeHelper', [], [], '', false);
+        $nodeHelper = $this->createMock('Sulu\Component\Util\SuluNodeHelper');
         $this->documentInspector = $this->getMockBuilder(DocumentInspector::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeStrategyTest.php
@@ -69,7 +69,7 @@ class TreeStrategyTest extends \PHPUnit_Framework_TestCase
 
         $structureManager = $this->getMockForAbstractClass('Sulu\Component\Content\Compat\StructureManagerInterface');
         $contentTypeManager = $this->getMockForAbstractClass('Sulu\Component\Content\ContentTypeManagerInterface');
-        $nodeHelper = $this->getMock('Sulu\Component\Util\SuluNodeHelper', [], [], '', false);
+        $nodeHelper = $this->createMock('Sulu\Component\Util\SuluNodeHelper');
         $documentInspector = $this->getMockBuilder(DocumentInspector::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
@@ -24,7 +24,7 @@ class ListRestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->em = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->em = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
     }
 
     public static function dataFieldsProvider()

--- a/src/Sulu/Component/Rest/Tests/Unit/Listing/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/Listing/ListRestHelperTest.php
@@ -20,7 +20,7 @@ class ListRestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->em = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->em = $this->createMock('Doctrine\Common\Persistence\ObjectManager');
     }
 
     public function testGetFields()

--- a/src/Sulu/Component/Rest/Tests/Unit/RestControllerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RestControllerTest.php
@@ -30,7 +30,7 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->controller = $this->getMockForAbstractClass('\Sulu\Component\Rest\RestController');
-        $this->mockedObject = $this->getMock('stdClass', ['getId']);
+        $this->mockedObject = $this->getMockBuilder('stdClass')->setMethods(['getId'])->getMock();
         $this->mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
     }
 
@@ -69,7 +69,7 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessPutEmpty()
     {
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add'])->getMock();
         $mock->expects($this->never())->method('delete');
         $mock->expects($this->never())->method('update');
         $mock->expects($this->never())->method('add');
@@ -94,7 +94,7 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessPutWithDelete()
     {
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add'])->getMock();
         $mock->expects($this->once())->method('delete');
         $mock->expects($this->never())->method('update');
         $mock->expects($this->never())->method('add');
@@ -128,7 +128,7 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessPutWithUpdate()
     {
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add'])->getMock();
         $mock->expects($this->never())->method('delete');
         $mock->expects($this->once())->method('update');
         $mock->expects($this->never())->method('add');
@@ -166,7 +166,7 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessPutWithAdd()
     {
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add'])->getMock();
         $mock->expects($this->never())->method('delete');
         $mock->expects($this->never())->method('update');
         $mock->expects($this->once())->method('add');
@@ -273,10 +273,9 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
             ['get', 'getRequest']
         );
 
-        $listHelper = $this->getMock(
-            '\Sulu\Bundle\Rest\Listing\ListRestHelper',
-            ['find', 'getTotalPages', 'getTotalNumberOfElements', 'getLimit', 'getPage']
-        );
+        $listHelper = $this->getMockBuilder('\Sulu\Bundle\Rest\Listing\ListRestHelper')
+            ->setMethods(['find', 'getTotalPages', 'getTotalNumberOfElements', 'getLimit', 'getPage'])
+            ->getMock();
 
         $listHelper->expects($this->any())->method('find')->will($this->returnValue($entities));
         $listHelper->expects($this->any())->method('getTotalPages')->will($this->returnValue(3));
@@ -286,12 +285,12 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
         $controller->expects($this->any())->method('get')->will($this->returnValue($listHelper));
 
-        $request = $this->getMock('\Request', ['getRequestUri', 'getPathInfo']);
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->expects($this->any())->method('getRequestUri')->will($this->returnValue('admin/api/contacts?page=2'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('admin/api/contacts'));
         $controller->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
-        $query = $this->getMock('\Symfony\Component\HttpFoundation\ParameterBag', ['all']);
+        $query = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
         $query->expects($this->any())->method('all')->will($this->returnValue([]));
         $request->query = $query;
 
@@ -354,10 +353,9 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
             ['get', 'getRequest']
         );
 
-        $listHelper = $this->getMock(
-            '\Sulu\Bundle\Rest\Listing\ListRestHelper',
-            ['find', 'getTotalPages', 'getTotalNumberOfElements', 'getLimit', 'getPage']
-        );
+        $listHelper = $this->getMockBuilder('\Sulu\Bundle\Rest\Listing\ListRestHelper')
+            ->setMethods(['find', 'getTotalPages', 'getTotalNumberOfElements', 'getLimit', 'getPage'])
+            ->getMock();
 
         $listHelper->expects($this->any())->method('find')->will($this->returnValue($entities));
         $listHelper->expects($this->any())->method('getTotalPages')->will($this->returnValue(3));
@@ -367,14 +365,14 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
         $controller->expects($this->any())->method('get')->will($this->returnValue($listHelper));
 
-        $request = $this->getMock('\Request', ['getRequestUri', 'getPathInfo']);
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->expects($this->any())->method('getRequestUri')->will(
             $this->returnValue('admin/api/contacts?flat=true&page=2&limit=4&orderBy=lastName&sortOrder=asc')
         );
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('admin/api/contacts'));
         $controller->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
-        $query = $this->getMock('\Symfony\Component\HttpFoundation\ParameterBag', ['all']);
+        $query = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
         $query->expects($this->any())->method('all')->will($this->returnValue([]));
         $request->query = $query;
 
@@ -422,10 +420,9 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
             ['get', 'getRequest']
         );
 
-        $listHelper = $this->getMock(
-            '\Sulu\Bundle\Rest\Listing\ListRestHelper',
-            ['find', 'getTotalPages', 'getTotalNumberOfElements', 'getLimit', 'getPage']
-        );
+        $listHelper = $this->getMockBuilder('\Sulu\Bundle\Rest\Listing\ListRestHelper')
+            ->setMethods(['find', 'getTotalPages', 'getTotalNumberOfElements', 'getLimit', 'getPage'])
+            ->getMock();
 
         $listHelper->expects($this->any())->method('find')->will($this->returnValue($entities));
         $listHelper->expects($this->any())->method('getTotalPages')->will($this->returnValue(3));
@@ -435,12 +432,12 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
 
         $controller->expects($this->any())->method('get')->will($this->returnValue($listHelper));
 
-        $request = $this->getMock('\Request', ['getRequestUri', 'getPathInfo']);
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->expects($this->any())->method('getRequestUri')->will($this->returnValue('admin/api/contacts?page=2'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('admin/api/contacts'));
         $controller->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
-        $query = $this->getMock('\Symfony\Component\HttpFoundation\ParameterBag', ['all']);
+        $query = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
         $query->expects($this->any())->method('all')->will($this->returnValue([]));
         $request->query = $query;
 
@@ -463,10 +460,9 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
             $this->getMockForAbstractClass('\Sulu\Bundle\CoreBundle\Entity\ApiEntity'),
         ];
 
-        $listHelper = $this->getMock(
-            '\Sulu\Bundle\Rest\Listing\ListRestHelper',
-            ['getLimit', 'getPage']
-        );
+        $listHelper = $this->getMockBuilder('\Sulu\Bundle\Rest\Listing\ListRestHelper')
+            ->setMethods(['getLimit', 'getPage'])
+            ->getMock();
 
         $listHelper->expects($this->any())->method('getLimit')->will($this->returnValue(1));
         $listHelper->expects($this->any())->method('getPage')->will($this->returnValue(2));
@@ -481,12 +477,12 @@ class RestControllerTest extends \PHPUnit_Framework_TestCase
             ['get', 'getRequest']
         );
         $controller->expects($this->any())->method('get')->will($this->returnValue($listHelper));
-        $request = $this->getMock('\Request', ['getRequestUri', 'getPathInfo']);
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->expects($this->any())->method('getRequestUri')->will($this->returnValue('/admin/api/contacts'));
         $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('admin/api/contacts'));
         $controller->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
-        $query = $this->getMock('\Symfony\Component\HttpFoundation\ParameterBag', ['all']);
+        $query = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
         $query->expects($this->any())->method('all')->will($this->returnValue([]));
         $request->query = $query;
 

--- a/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
@@ -142,7 +142,7 @@ class RestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testprocessSubEntitiesEmpty()
     {
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add', 'get']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->never())->method('delete');
         $mock->expects($this->never())->method('update');
         $mock->expects($this->never())->method('add');
@@ -169,10 +169,10 @@ class RestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testprocessSubEntitiesWithDelete()
     {
-        $mockedObject = $this->getMock('stdClass', ['getId']);
+        $mockedObject = $this->getMockBuilder('stdClass')->setMethods(['getId'])->getMock();
         $mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add', 'get']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->once())->method('delete');
         $mock->expects($this->never())->method('update');
         $mock->expects($this->never())->method('add');
@@ -208,10 +208,10 @@ class RestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testprocessSubEntitiesWithUpdate()
     {
-        $mockedObject = $this->getMock('stdClass', ['getId']);
+        $mockedObject = $this->getMockBuilder('stdClass')->setMethods(['getId'])->getMock();
         $mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add', 'get']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->never())->method('delete');
         $mock->expects($this->once())->method('update');
         $mock->expects($this->never())->method('add');
@@ -251,7 +251,7 @@ class RestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testprocessSubEntitiesWithAdd()
     {
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add', 'get']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->never())->method('delete');
         $mock->expects($this->never())->method('update');
         $mock->expects($this->once())->method('add');
@@ -289,14 +289,14 @@ class RestHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testCompareEntitiesWithData()
     {
-        $mockedObject = $this->getMock('stdClass', ['getId', 'getValue']);
+        $mockedObject = $this->getMockBuilder('stdClass')->setMethods(['getId', 'getValue'])->getMock();
         $mockedObject->expects($this->any())->method('getId')->will($this->returnValue(1));
         $mockedObject->expects($this->any())->method('getValue')->will($this->returnValue(2));
 
         $mockedObject2 = clone $mockedObject;
         $mockedObject3 = clone $mockedObject;
 
-        $mock = $this->getMock('stdClass', ['delete', 'update', 'add', 'get']);
+        $mock = $this->getMockBuilder('stdClass')->setMethods(['delete', 'update', 'add', 'get'])->getMock();
         $mock->expects($this->once())->method('delete');
         $mock->expects($this->any())->method('update');
         $mock->expects($this->once())->method('add');

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -289,7 +289,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->findPortalInformationsByUrl(Argument::any(), Argument::any())->willReturn(null);
         $this->webspaceManager->getPortalInformations(Argument::any())->willReturn([]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
         $request->attributes = new ParameterBag();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -61,7 +61,7 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             $config['url_expression']
         );
 
-        $request = $this->getMock(Request::class);
+        $request = $this->createMock(Request::class);
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
@@ -113,7 +113,7 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             $config['redirect']
         );
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -105,7 +105,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2, $portalInformation3]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
@@ -170,7 +170,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
@@ -233,7 +233,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
+        $request = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         $request->request = new ParameterBag(['post' => 1]);
         $request->query = new ParameterBag(['get' => 1]);
         $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fixes all the calls to the deprecated `getMock` (deprecated since PHPUnit 5.4.0) with appropriate calls to `createMock` or `getMockBuilder`.

This includes to test Travis with PHP 5.6 instead of 5.5 because I raised the PHPUnit version minimum requirement (`createMock` was introduced in 5.4.0).

#### Why?

Too much warnings of the `getMock` at tests :grin: 