### PR TITLE
Remove SYMFONY_DEPRECATIONS_HELPER environment from AppVeyor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2738 [ContentBundle]       Fixed using non-existent AbstractKernel
     * ENHANCEMENT #2685 [ContentBundle]       Made internal links and smart content show unpublished nodes
     * BUGFIX      #2661 [ContentBundle]       Fixed ck-editor internal link visualization
+    * BUGFIX      #2745 [All]                 Remove SYMFONY_DEPRECATIONS_HELPER environment from AppVeyor config
     * ENHANCEMENT #2737 [TranslateBundle]     Remove symfony deprecations and don't allow them anymore
     * FEATURE     #2681 [ContentBundle]       Fixed frontend resource locator generation for ghost pages
     * BUGFIX      #2712 [MediaBundle]         Added search to media selection

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ services:
   - mysql
 
 environment:
-  SYMFONY_DEPRECATIONS_HELPER: weak
   JACKRABBIT_VERSION: '2.12.0'
   SYMFONY__DATABASE__PASSWORD: Password12!
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #2106, #2120
| License | MIT
| Documentation PR | -

#### What's in this PR?

Remove `SYMFONY_DEPRECATIONS_HELPER` environment from AppVeyor config, because this is already configured in the individual `phpunit.xml.dist` files, made in #2120.

#### Why?

Was unfortunately added when the `appveyor.yml` was created :smile: 
