### PR TITLE
Add Twig blocks to be able to use inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * FEATURE     #2748 [AdminBundle]         Added Twig blocks to be able to use inheritance 
+
 * 1.3.0-RC3 (2016-08-08)
     * BUGFIX      #2760 [MediaBundle]         Added missing locale to media move action
     * ENHANCEMENT #2759 [ContentBundle]       Fixed ok button translation for smart content overlay

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/index.html.dist.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/index.html.dist.twig
@@ -12,7 +12,9 @@
 
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
+        {% block stylesheets %}
         <link rel="stylesheet" href="/bundles/suluadmin/dist/app.min.1470641403671.css">
+        {% endblock stylesheets %}
     </head>
     <body>
         <div class="spinner initial-loader">
@@ -67,6 +69,8 @@
             var CKEDITOR_BASEPATH = '/bundles/suluadmin/js/vendor/husky/vendor/ckeditor/';
         </script>
 
+        {% block javascripts %}
         <script data-main="/bundles/suluadmin/dist/app.min.1470641403671" src="/bundles/suluadmin/js/vendor/husky/husky.min.js?v=1470641403671"></script>
+        {% endblock javascripts %}
     </body>
 </html>

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/index.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/index.html.twig
@@ -12,10 +12,12 @@
 
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
+        {% block stylesheets %}
         <!-- build:css app.min.css -->
         <link rel="stylesheet" type="text/css" href="/bundles/suluadmin/js/vendor/husky/husky.min.css"/>
         <link rel="stylesheet" type="text/css" href="/bundles/suluadmin/css/main.css"/>
         <!-- endbuild -->
+        {% endblock stylesheets %}
     </head>
     <body>
         <div class="spinner initial-loader">
@@ -70,8 +72,10 @@
             var CKEDITOR_BASEPATH = '/bundles/suluadmin/js/vendor/husky/vendor/ckeditor/';
         </script>
 
+        {% block javascripts %}
         <!-- build:js app.min.js -->
         <script data-main="/bundles/suluadmin/js/main" src="/bundles/suluadmin/js/vendor/husky/husky.js"></script>
         <!-- endbuild -->
+        {% endblock javascripts %}
     </body>
 </html>

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Security/login.html.dist.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Security/login.html.dist.twig
@@ -13,9 +13,11 @@
 
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
+    {% block stylesheets %}
     <link rel="stylesheet" href="/bundles/suluadmin/dist/login.min.1470641403671.css">
 
     <link rel="stylesheet" type="text/css" href="/bundles/suluadmin/css/main.css"/>
+    {% endblock stylesheets %}
 </head>
 <body>
     <div id="main" class="login">
@@ -45,6 +47,8 @@
         {% endautoescape %}
     </script>
 
+    {% block javascripts %}
     <script data-main="/bundles/suluadmin/dist/login.min.1470641403671" src="/bundles/suluadmin/js/vendor/husky/husky.min.js?v=1470641403671"></script>
+    {% endblock javascripts %}
 </body>
 </html>

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Security/login.html.twig
@@ -13,11 +13,13 @@
 
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
+    {% block stylesheets %}
     <!-- build:css login.min.css -->
     <link rel="stylesheet" type="text/css" href="/bundles/suluadmin/js/vendor/husky/husky.min.css"/>
     <!-- endbuild -->
 
     <link rel="stylesheet" type="text/css" href="/bundles/suluadmin/css/main.css"/>
+    {% endblock stylesheets %}
 </head>
 <body>
     <div id="main" class="login">
@@ -47,8 +49,10 @@
         {% endautoescape %}
     </script>
 
+    {% block javascripts %}
     <!-- build:js login.min.js -->
     <script data-main="/bundles/suluadmin/js/login" src="/bundles/suluadmin/js/vendor/husky/husky.js"></script>
     <!-- endbuild -->
+    {% endblock javascripts %}
 </body>
 </html>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | n/a
| Related issues/PRs | n/a
| License | MIT
| Documentation PR | n/a
#### What's in this PR?

Added Twig block tags to allow better inheritance

#### Why?

It allows to add additional stylesheets and javascript without the need to copy the whole twig templates in the AdminBundle.

#### Example Usage

See http://twig.sensiolabs.org/doc/tags/extends.html

#### BC Breaks/Deprecations

None, tested the grunt build, which works fine.


