### PR TITLE
Removed published checks from ContentRouteProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2712 [MediaBundle]         Added search to media selection
     * FEATURE     #2726 [PreviewBundle]       Don't allow symfony deprecations anymore
     * FEATURE     #2717 [ContentBundle]       Removed or fixed some publishing translations
+    * ENHANCEMENT #2750 [WebsiteBundle]       Removed published checks from ContentRouteProvider
     * FEATURE     #2704 [All]                 Ignore irrelevant files on composer dist installs
     * FEATURE     #2720 [DocumentManagerBundle] Don't allow symfony deprecations anymore
     * FEATURE     #2727 [RouteBundle]         Don't allow symfony deprecations anymore

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
@@ -15,7 +15,10 @@
         </service>
 
         <service id="sulu_website.provider.content" class="Sulu\Bundle\WebsiteBundle\Routing\ContentRouteProvider">
-            <argument type="service" id="sulu.content.mapper"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <argument type="service" id="sulu.content.rlp.strategy.tree"/>
+            <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.default_locale.provider"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -280,25 +280,6 @@ class ContentMapper implements ContentMapperInterface
     /**
      * {@inheritdoc}
      */
-    public function loadByResourceLocator($resourceLocator, $webspaceKey, $locale, $segmentKey = null)
-    {
-        $uuid = $this->rlpStrategy->loadByResourceLocator(
-            $resourceLocator,
-            $webspaceKey,
-            $locale,
-            $segmentKey
-        );
-
-        $document = $this->loadDocument($uuid, $locale, [
-            'exclude_shadow' => false,
-        ]);
-
-        return $this->documentToStructure($document);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function loadBySql2($sql2, $locale, $webspaceKey, $limit = null)
     {
         $query = $this->documentManager->createQuery($sql2, $locale);

--- a/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
@@ -110,18 +110,6 @@ interface ContentMapperInterface
     public function loadStartPage($webspaceKey, $languageCode);
 
     /**
-     * returns data from given path.
-     *
-     * @param string $resourceLocator Resource locator
-     * @param string $webspaceKey     Key of webspace
-     * @param string $languageCode
-     * @param string $segmentKey
-     *
-     * @return StructureInterface
-     */
-    public function loadByResourceLocator($resourceLocator, $webspaceKey, $languageCode, $segmentKey = null);
-
-    /**
      * returns the content returned by the given sql2 query as structures.
      *
      * @param string $sql2         The query, which returns the content

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -130,31 +130,6 @@ class ContentMapperTest extends SuluTestCase
         $this->assertEquals(1, $content->getChanger());
     }
 
-    public function testLoadByRL()
-    {
-        $data = [
-            'title' => 'Testname',
-            'tags' => [
-                'tag1',
-                'tag2',
-            ],
-            'url' => '/news/test',
-            'article' => 'sulu_io',
-        ];
-
-        $this->save($data, 'overview', 'sulu_io', 'de', 1, true, null, null, StructureInterface::STATE_PUBLISHED);
-
-        $content = $this->mapper->loadByResourceLocator('/news/test', 'sulu_io', 'de');
-
-        $this->assertEquals('Testname', $content->title);
-        $this->assertEquals('sulu_io', $content->article);
-        $this->assertEquals('/news/test', $content->url);
-        $this->assertEquals(['tag1', 'tag2'], $content->tags);
-        $this->assertEquals(StructureInterface::STATE_PUBLISHED, $content->getNodeState());
-        $this->assertEquals(1, $content->getCreator());
-        $this->assertEquals(1, $content->getChanger());
-    }
-
     public function testUpdateNullValue()
     {
         $data = [
@@ -178,7 +153,7 @@ class ContentMapperTest extends SuluTestCase
         $this->save($data, 'overview', 'sulu_io', 'de', 1, false, $structure->getUuid(), null, WorkflowStage::PUBLISHED);
 
         // check read
-        $content = $this->mapper->loadByResourceLocator('/news/test', 'sulu_io', 'de');
+        $content = $this->mapper->load($structure->getUuid(), 'sulu_io', 'de');
 
         $this->assertEquals('Testname', $content->title);
         $this->assertEquals(null, $content->article);
@@ -228,7 +203,7 @@ class ContentMapperTest extends SuluTestCase
         $this->save($data, 'overview', 'sulu_io', 'de', 1, true, $structure->getUuid(), null, WorkflowStage::PUBLISHED);
 
         // check read
-        $content = $this->mapper->loadByResourceLocator('/news/test/test/test', 'sulu_io', 'de');
+        $content = $this->mapper->load($structure->getUuid(), 'sulu_io', 'de');
 
         $this->assertEquals('Testname', $content->title);
         $this->assertEquals('sulu_io', $content->article);
@@ -294,7 +269,7 @@ class ContentMapperTest extends SuluTestCase
         );
 
         // check read
-        $content = $this->mapper->loadByResourceLocator('/news/test/test', 'sulu_io', 'de');
+        $content = $this->mapper->load($structure->getUuid(), 'sulu_io', 'de');
         $this->assertEquals('Testname', $content->title);
 
         // change simple content
@@ -304,7 +279,7 @@ class ContentMapperTest extends SuluTestCase
         $this->save($data, 'overview', 'sulu_io', 'de', 1, true, $structure->getUuid(), null, WorkflowStage::PUBLISHED);
 
         // check read
-        $content = $this->mapper->loadByResourceLocator('/news/asdf/test/test', 'sulu_io', 'de');
+        $content = $this->mapper->load($structure->getUuid(), 'sulu_io', 'de');
         $this->assertEquals('Testname', $content->title);
         $this->assertEquals('sulu_io', $content->article);
         $this->assertEquals('/news/asdf/test/test', $content->url);
@@ -385,24 +360,24 @@ class ContentMapperTest extends SuluTestCase
         $root = $this->save($data[0], 'overview', 'sulu_io', 'de', 1, true, null, null, WorkflowStage::PUBLISHED);
 
         // add a child content
-        $this->save($data[1], 'overview', 'sulu_io', 'de', 1, true, null, $root->getUuid(), WorkflowStage::PUBLISHED);
-        $child = $this->save($data[2], 'overview', 'sulu_io', 'de', 1, true, null, $root->getUuid(), WorkflowStage::PUBLISHED);
-        $this->save($data[3], 'overview', 'sulu_io', 'de', 1, true, null, $child->getUuid(), WorkflowStage::PUBLISHED);
+        $child1 = $this->save($data[1], 'overview', 'sulu_io', 'de', 1, true, null, $root->getUuid(), WorkflowStage::PUBLISHED);
+        $child2 = $this->save($data[2], 'overview', 'sulu_io', 'de', 1, true, null, $root->getUuid(), WorkflowStage::PUBLISHED);
+        $child3 = $this->save($data[3], 'overview', 'sulu_io', 'de', 1, true, null, $child2->getUuid(), WorkflowStage::PUBLISHED);
 
         // check nodes
-        $content = $this->mapper->loadByResourceLocator('/news', 'sulu_io', 'de');
+        $content = $this->mapper->load($root->getUuid(), 'sulu_io', 'de');
         $this->assertEquals('News', $content->title);
         $this->assertTrue($content->getHasChildren());
 
-        $content = $this->mapper->loadByResourceLocator('/news/test-1', 'sulu_io', 'de');
+        $content = $this->mapper->load($child1->getUuid(), 'sulu_io', 'de');
         $this->assertEquals('Testnews-1', $content->title);
         $this->assertFalse($content->getHasChildren());
 
-        $content = $this->mapper->loadByResourceLocator('/news/test-2', 'sulu_io', 'de');
+        $content = $this->mapper->load($child2->getUuid(), 'sulu_io', 'de');
         $this->assertEquals('Testnews-2', $content->title);
         $this->assertTrue($content->getHasChildren());
 
-        $content = $this->mapper->loadByResourceLocator('/news/test-2/test-1', 'sulu_io', 'de');
+        $content = $this->mapper->load($child3->getUuid(), 'sulu_io', 'de');
         $this->assertEquals('Testnews-2-1', $content->title);
         $this->assertFalse($content->getHasChildren());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the published checks from the `ContentRouteProvider`, because it is already searching for the pages in the correct workspace.

#### Why?

Because it is faster and makes the `ContentRouteProvider` slimmer and better understandable.