### PR TITLE
fixed publishing for the settings tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2751 [ContentBundle]       Fixed publishing for the settings tab
     * ENHANCEMENT #2687 [ContentBundle]       Made move- and copy-overlay width responsive
     * BUGFIX      #2708 [CategoryBundle]      Fixed locale bug for category keywords
     * BUGFIX      #2736 [ContentBundle]       Made column-navigation load even when selected item is not accessible

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
@@ -890,6 +890,9 @@ define([
                             icon: 'floppy-o',
                             title: 'public.save',
                             disabled: true,
+                            callback: function() {
+                                this.sandbox.emit('sulu.toolbar.save', 'publish');
+                            }.bind(this),
                             dropdownItems: saveDropdown
                         }
                     };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the publish action to the button in the settings tab.

#### Why?

Because when the page is saved as as shadow it should also be published, although there is only a single button.