### PR TITLE
Fixed default snippets for public workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2758 [ContentBundle]       Fixed wrong disabeling of button in block type
     * FEATURE     #2761 [All]                 Added Dutch translation
     * FEATURE     #2748 [AdminBundle]         Added Twig blocks to be able to use inheritance
+    * BUGFIX      #2771 [SnippetBundle]       Fixed default snippets for public workspace
 
 * 1.3.0-RC3 (2016-08-08)
     * BUGFIX      #2760 [MediaBundle]         Added missing locale to media move action

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -51,6 +51,7 @@
         </service>
 
         <service id="sulu_core.webspace.settings_manager" class="Sulu\Component\Webspace\Settings\SettingsManager">
+            <argument type="service" id="sulu_document_manager.session_manager"/>
             <argument type="service" id="sulu.phpcr.session"/>
         </service>
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -31,6 +31,11 @@
 
         <service id="sulu_document_manager.node_helper" class="Sulu\Component\DocumentManager\NodeHelper"/>
 
+        <service id="sulu_document_manager.session_manager" class="Sulu\Bundle\DocumentManagerBundle\Session\SessionManager">
+            <argument type="service" id="sulu_document_manager.default_session"/>
+            <argument type="service" id="sulu_document_manager.live_session"/>
+        </service>
+
         <service id="sulu_document_manager.metadata_factory.base" class="Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory" public="false">
             <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <argument>%sulu_document_manager.mapping%</argument>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Session/SessionManager.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Session/SessionManager.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Session;
+
+use PHPCR\SessionInterface;
+
+/**
+ * This class knows about the default and the live session, and should be used if data is written on nodes directly.
+ */
+class SessionManager implements SessionManagerInterface
+{
+    /**
+     * @var SessionInterface
+     */
+    private $defaultSession;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    public function __construct(SessionInterface $defaultSession, SessionInterface $liveSession)
+    {
+        $this->defaultSession = $defaultSession;
+        $this->liveSession = $liveSession;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setNodeProperty($nodePath, $propertyName, $value)
+    {
+        $this->setNodePropertyForSession($this->defaultSession, $nodePath, $propertyName, $value);
+        $this->setNodePropertyForSession($this->liveSession, $nodePath, $propertyName, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $this->defaultSession->save();
+        $this->liveSession->save();
+    }
+
+    /**
+     * Sets the property of the node at the given path to the given value. The change is only applied to the given
+     * session.
+     *
+     * @param SessionInterface $session
+     * @param string $nodePath
+     * @param string $propertyName
+     * @param mixed $value
+     */
+    private function setNodePropertyForSession(SessionInterface $session, $nodePath, $propertyName, $value)
+    {
+        $session->getNode($nodePath)->setProperty($propertyName, $value);
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Session/SessionManagerInterface.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Session/SessionManagerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Session;
+
+/**
+ * The session manager knows about all sessions available in the document manager.
+ *
+ * This is especially useful if some component directly writes on nodes without using documents and drafting. It will
+ * guarantee that the data will be available on both workspaces.
+ */
+interface SessionManagerInterface
+{
+    /**
+     * Sets the property of the node at the given path for all available sessions. This means that the values saved in
+     * this way will be immediately available in all workspaces.
+     *
+     * @param string $nodePath The path of the node to manipulate
+     * @param string $propertyName The name of the property to set
+     * @param mixed $value The value to set
+     */
+    public function setNodeProperty($nodePath, $propertyName, $value);
+
+    /**
+     * Flushes the data for all sessions.
+     */
+    public function flush();
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Session/SessionManagerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Session/SessionManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Session;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Bundle\DocumentManagerBundle\Session\SessionManager;
+
+class SessionManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionInterface
+     */
+    private $defaultSession;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    /**
+     * @var SessionManager
+     */
+    private $sessionManager;
+
+    public function setUp()
+    {
+        $this->defaultSession = $this->prophesize(SessionInterface::class);
+        $this->liveSession = $this->prophesize(SessionInterface::class);
+
+        $this->sessionManager = new SessionManager($this->defaultSession->reveal(), $this->liveSession->reveal());
+    }
+
+    public function testSetNodeProperty()
+    {
+        $defaultNode = $this->prophesize(NodeInterface::class);
+        $defaultNode->setProperty('settings:setting', 'data')->shouldBeCalled();
+        $this->defaultSession->getNode('/cmf/sulu_io')->willReturn($defaultNode->reveal());
+
+        $liveNode = $this->prophesize(NodeInterface::class);
+        $liveNode->setProperty('settings:setting', 'data')->shouldBeCalled();
+        $this->liveSession->getNode('/cmf/sulu_io')->willReturn($liveNode->reveal());
+
+        $this->sessionManager->setNodeProperty('/cmf/sulu_io', 'settings:setting', 'data');
+    }
+
+    public function testFlush()
+    {
+        $this->defaultSession->save()->shouldBeCalled();
+        $this->liveSession->save()->shouldBeCalled();
+        $this->sessionManager->flush();
+    }
+}

--- a/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
+++ b/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
@@ -32,8 +32,6 @@ class SessionManager implements SessionManagerInterface
     }
 
     /**
-     * @deprecated Use the doctrine_phpcr service to retreive the session
-     *
      * {@inheritdoc}
      */
     public function getSession()

--- a/src/Sulu/Component/PHPCR/SessionManager/SessionManagerInterface.php
+++ b/src/Sulu/Component/PHPCR/SessionManager/SessionManagerInterface.php
@@ -23,6 +23,8 @@ interface SessionManagerInterface
      * Returns a valid session to interact with a phpcr database.
      *
      * @return SessionInterface
+     *
+     * @deprecated Use the doctrine_phpcr service to retrieve the session
      */
     public function getSession();
 
@@ -34,6 +36,9 @@ interface SessionManagerInterface
      * @param string $segment
      *
      * @return NodeInterface
+     *
+     * @deprecated Do not use anymore, because the node is always returned from the default session, although multiple
+     *             sessions can exist
      */
     public function getRouteNode($webspaceKey, $languageCode, $segment = null);
 
@@ -54,6 +59,9 @@ interface SessionManagerInterface
      * @param string $webspaceKey
      *
      * @return NodeInterface
+     *
+     * @deprecated Do not use anymore, because the node is always returned from the default session, although multiple
+     *             sessions can exist
      */
     public function getContentNode($webspaceKey);
 
@@ -72,6 +80,9 @@ interface SessionManagerInterface
      * @param string$webspaceKey
      *
      * @return NodeInterface
+     *
+     * @deprecated Do not use anymore, because the node is always returned from the default session, although multiple
+     *             sessions can exist
      */
     public function getWebspaceNode($webspaceKey);
 
@@ -88,6 +99,9 @@ interface SessionManagerInterface
      * returns the snippet node.
      *
      * @return \PHPCR\NodeInterface
+     *
+     * @deprecated Do not use anymore, because the node is always returned from the default session, although multiple
+     *             sessions can exist
      */
     public function getSnippetNode();
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2739
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a new `SessionManager`, which will set the property of a node for the default and live workspace. This `SessionManager` will then be used for the `SettingsManager`, which writes the current default snippets on the webspace node.

#### Why?

Because currently the default snippets are only saved in the default workspace, hence have no impact on the live website.