### PR TITLE
Fixes #2657 allow media upload without extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2776 [MediaBundle]         Fixed upload of media without an extension
     * BUGFIX      #2850 [ContentBundle]       Ordered response of template action alphabetically
     * BUGFIX      #2848 [ContentBundle]       Fixed preview serialization to include date and authors
     * ENHANCEMENT #2782 [MediaBundle]         Cleaned up media selection overlay styling

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -68,15 +68,15 @@ class AbstractMediaController extends RestController
      */
     protected function getTitleFromUpload($request)
     {
-        $title = null;
-
         $uploadedFile = $this->getUploadedFile($request, 'fileVersion');
 
         if ($uploadedFile) {
-            $title = implode('.', explode('.', $uploadedFile->getClientOriginalName(), -1));
-        }
+            if (strpos($uploadedFile->getClientOriginalName(), '.') === false) {
+                return $uploadedFile->getClientOriginalName();
+            }
 
-        return $title;
+            return implode('.', explode('.', $uploadedFile->getClientOriginalName(), -1));
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -144,7 +144,11 @@ class LocalStorage implements StorageInterface
 
         if ($counter > 0) {
             $fileNameParts = explode('.', $fileName, 2);
-            $newFileName = $fileNameParts[0] . '-' . $counter . '.' . $fileNameParts[1];
+            $newFileName = $fileNameParts[0] . '-' . $counter;
+
+            if (isset($fileNameParts[1])) {
+                $newFileName .=  '.' . $fileNameParts[1];
+            }
         }
 
         $filePath = $this->getPathByFolderAndFileName($folder, $newFileName);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -937,6 +937,42 @@ class MediaControllerTest extends SuluTestCase
      *
      * @group postWithoutDetails
      */
+    public function testPostWithoutExtension()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $imagePath = $this->getImagePath();
+        $this->assertTrue(file_exists($imagePath));
+        $photo = new UploadedFile($imagePath, 'photo', 'image/jpeg', 160768);
+
+        $client->request(
+            'POST',
+            '/api/media',
+            [
+                'locale' => 'en',
+                'collection' => $this->collection->getId(),
+            ],
+            [
+                'fileVersion' => $photo,
+            ]
+        );
+
+        $this->assertEquals(1, count($client->getRequest()->files->all()));
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $this->assertEquals($this->mediaDefaultTitle, $response->title);
+
+        $this->assertEquals('photo', $response->name);
+        $this->assertNotNull($response->id);
+    }
+
+    /**
+     * Test POST to create a new Media without details.
+     *
+     * @group postWithoutDetails
+     */
     public function testPostWithSmallFile()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2657
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Fix for #2657

#### Why?

To allow media upload without any extension.
