### PR TITLE
Added images/icons of excerpt to search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * ENHANCEMENT #2704 [ContactBundle]       Save contact-/account-documents with save button in header
     * BUGFIX      #2648 [HttpCacheBundle]     Purge cache when removing or unpublishing page
+    * FEATURE     #2780 [ContentBundle]       Added images/icons of excerpt to search index
     * BUGFIX      #2685 [ContentBundle]       Fixed resource locator adaption for pages with ghost-ancestors
     * BUGFIX      #2758 [ContentBundle]       Fixed wrong disabeling of button in block type
     * FEATURE     #2761 [All]                 Added Dutch translation

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "friendsofsymfony/rest-bundle": "~1.4",
         "guzzle/guzzle": "3.*",
         "imagine/imagine": "~0.6.1",
-        "massive/search-bundle": "0.15.*",
+        "massive/search-bundle": "dev-develop",
         "sulu/document-manager": "0.8.*",
         "sensio/framework-extra-bundle": "3.0.*",
         "stof/doctrine-extensions-bundle": "1.1.*",

--- a/src/Sulu/Bundle/ContentBundle/Content/templates/excerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Content/templates/excerpt.xml
@@ -26,6 +26,8 @@
                 <title lang="de">Text für weiterführenden Link</title>
                 <title lang="en">Text for more link</title>
             </meta>
+
+            <tag name="sulu.search.field"/>
         </property>
 
         <property name="description" type="text_editor">
@@ -60,6 +62,8 @@
                 <title lang="de">Icon</title>
                 <title lang="en">Icon</title>
             </meta>
+
+            <tag name="sulu.search.field" type="json"/>
         </property>
 
         <property name="images" type="media_selection">
@@ -67,6 +71,8 @@
                 <title lang="de">Bilder</title>
                 <title lang="en">Images</title>
             </meta>
+
+            <tag name="sulu.search.field" type="json"/>
         </property>
     </properties>
 </template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixed #2337 
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/98 (already merged)
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add exception images and icons to massive-search index.