### PR TITLE
set workflowstage of copied nodes to draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * FEATURE     #2703 [All]                 Improved experience when using sulu with postgres.
     * BUGFIX      #2785 [ContentBundle]       Fixed deindexing of documents for both workspaces
     * BUGFIX      #2775 [ContentBundle]       Removed action icon for ghost pages in column-navigation (husky)
+    * BUGFIX      #2781 [ContentBundle]       Set workflowstage of copied nodes to draft
     * ENHANCEMENT #2704 [ContactBundle]       Save contact-/account-documents with save button in header
     * BUGFIX      #2648 [HttpCacheBundle]     Purge cache when removing or unpublishing page
     * FEATURE     #2780 [ContentBundle]       Added images/icons of excerpt to search index

--- a/src/Sulu/Bundle/ContentBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/Subscriber/PublishSubscriber.php
@@ -132,7 +132,7 @@ class PublishSubscriber implements EventSubscriberInterface
      */
     public function copyNodeInPublicWorkspace(CopyEvent $event)
     {
-        $this->createNodesWithUuid($event->getCopiedNode());
+        $this->copyNodeWithChildrenInPublicWorkspace($event->getCopiedNode());
     }
 
     /**
@@ -221,6 +221,15 @@ class PublishSubscriber implements EventSubscriberInterface
     public function flushPublicWorkspace()
     {
         $this->liveSession->save();
+    }
+
+    private function copyNodeWithChildrenInPublicWorkspace(NodeInterface $node)
+    {
+        $this->createNodesWithUuid($node);
+
+        foreach ($node->getNodes() as $childNode) {
+            $this->copyNodeWithChildrenInPublicWorkspace($childNode);
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1466,6 +1466,8 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals('test5', $response['title']);
         $this->assertEquals('/test2/test3/test5', $response['path']);
         $this->assertEquals('/test2/test3/testing5', $response['url']);
+        $this->assertEquals(false, $response['publishedState']);
+        $this->assertArrayNotHasKey('published', $response);
 
         // check old node
         $client->request(

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
@@ -237,6 +237,22 @@ class PublishSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->liveSession->itemExists('/cmf/sulu')->willReturn(false);
 
+        $defaultTestNode = $this->prophesize(NodeInterface::class);
+        $defaultTestNode->getPath()->willReturn('/cmf/sulu/test');
+        $defaultTestNode->getSession()->willReturn($session->reveal());
+        $defaultSuluNode->getNode('test')->willReturn($defaultTestNode);
+        $defaultTestNode->getIdentifier()->willReturn('test-uuid');
+        $defaultTestNode->getNodes()->willReturn([]);
+        $this->node->getNodes()->willReturn([$defaultTestNode->reveal()]);
+
+        $liveSuluNode->hasNode('test')->willReturn(false);
+        $liveTestNode = $this->prophesize(NodeInterface::class);
+        $liveTestNode->setMixins(['mix:referenceable'])->shouldBeCalled();
+        $liveTestNode->setProperty('jcr:uuid', 'test-uuid')->shouldBeCalled();
+        $liveSuluNode->addNode('test')->willReturn($liveTestNode->reveal());
+
+        $this->liveSession->itemExists('/cmf/sulu/test')->willReturn(false);
+
         $this->publishSubscriber->copyNodeInPublicWorkspace($event->reveal());
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2690
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR sets the workflowstage for copied nodes and its children to test.

#### Why?

Because the copied pages should not be published immediately. This already works for routes (there are no routes generated), but was not applied to the state of the nodes. This caused some wrong displaying in the column navigation and some functionality was broken (e.g. the copied page could not be deleted when it has children).