### PR TITLE
fixed deindexing of documents for both workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * FEATURE     #2703 [All]                 Improved experience when using sulu with postgres.
+    * BUGFIX      #2785 [ContentBundle]       Fixed deindexing of documents for both workspaces
     * BUGFIX      #2775 [ContentBundle]       Removed action icon for ghost pages in column-navigation (husky)
     * ENHANCEMENT #2704 [ContactBundle]       Save contact-/account-documents with save button in header
     * BUGFIX      #2648 [HttpCacheBundle]     Purge cache when removing or unpublishing page

--- a/src/Sulu/Bundle/ContentBundle/Search/EventSubscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventSubscriber/StructureSubscriber.php
@@ -128,7 +128,18 @@ class StructureSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->searchManager->deindex($document);
+        if (!$document instanceof WorkflowStageBehavior) {
+            $this->searchManager->deindex($document);
+        } else {
+            $workflowStage = $document->getWorkflowStage();
+
+            foreach (WorkflowStage::$stages as $stage) {
+                $document->setWorkflowStage($stage);
+                $this->searchManager->deindex($document);
+            }
+
+            $document->setWorkflowStage($workflowStage);
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
@@ -138,6 +138,27 @@ class StructureSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->subscriber->deindexRemovedDocument($removeEvent->reveal());
     }
 
+    public function testDeindexRemovedDocumentWithWorkflowStageBehavior()
+    {
+        $removeEvent = $this->prophesize(RemoveEvent::class);
+
+        $document = $this->prophesize(StructureBehavior::class)
+            ->willImplement(WorkflowStageBehavior::class);
+        $removeEvent->getDocument()->willReturn($document);
+
+        $document->getWorkflowStage()->willReturn(WorkflowStage::TEST);
+
+        $document->setWorkflowStage(WorkflowStage::TEST)->shouldBeCalled();
+        $this->searchManager->deindex($document)->shouldBeCalled();
+
+        $document->setWorkflowStage(WorkflowStage::PUBLISHED)->shouldBeCalled();
+        $this->searchManager->deindex($document)->shouldBeCalled();
+
+        $document->setWorkflowStage(WorkflowStage::TEST)->shouldBeCalled();
+
+        $this->subscriber->deindexRemovedDocument($removeEvent->reveal());
+    }
+
     public function testDeindexUnpublishedDocument()
     {
         $unpublishEvent = $this->prophesize(UnpublishEvent::class);

--- a/src/Sulu/Component/Content/Document/WorkflowStage.php
+++ b/src/Sulu/Component/Content/Document/WorkflowStage.php
@@ -19,6 +19,13 @@ namespace Sulu\Component\Content\Document;
 final class WorkflowStage
 {
     /**
+     * An array containing all the available workflow stages.
+     *
+     * @var array
+     */
+    public static $stages = [self::TEST, self::PUBLISHED];
+
+    /**
      * Document is published.
      */
     const PUBLISHED = 2;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2779
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR sets the workflowstage to both possible values before deindexing them. This is necessary because the document is only removed from one of both indexes otherwise.