### PR TITLE
allow to load document without any translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 env:
   global:
-    - JACKRABBIT_VERSION=2.12.0
+    - JACKRABBIT_VERSION=2.12.2
     - SYMFONY__PHPCR__TRANSPORT=doctrinedbal
     - TEST_FLAGS=""
     - SYMFONY__DATABASE__DRIVER=pdo_mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2764 [MediaBundle]         Fixed type filter for media content type
+    * BUGFIX      #2795 [ContentBundle]       Allow to load document without any translation
     * BUGFIX      #2791 [CustomUrlBundle]     Use the default locale of the user to load the custom url column navigation
     * BUGFIX      #2792 [ContentBundle]       Do not show empty selection for link target in ckeditor
     * FEATURE     #2703 [All]                 Improved experience when using sulu with postgres.

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1747,16 +1747,7 @@ class NodeControllerTest extends SuluTestCase
 
     public function testOrderNonExistingSource()
     {
-        $data = [
-            [
-                'title' => 'test1',
-                'url' => '/test1',
-            ],
-        ];
-
         $client = $this->createAuthenticatedClient();
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data[0]);
-        $data[0] = json_decode($client->getResponse()->getContent(), true);
 
         $client->request(
             'POST',

--- a/src/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslator.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslator.php
@@ -86,7 +86,7 @@ class RequestAnalyzerTranslator implements TranslatorInterface
             return;
         }
 
-        $this->translator->setLocale($this->requestAnalyzer->getCurrentLocalization()->getLocalization());
+        $this->translator->setLocale($this->requestAnalyzer->getCurrentLocalization()->getLocale());
         $this->initialized = true;
     }
 }

--- a/src/Sulu/Component/Content/Compat/LocalizationFinder.php
+++ b/src/Sulu/Component/Content/Compat/LocalizationFinder.php
@@ -71,7 +71,7 @@ class LocalizationFinder implements LocalizationFinderInterface
             return;
         }
 
-        return $resultLocalization->getLocalization();
+        return $resultLocalization->getLocale();
     }
 
     /**
@@ -85,7 +85,7 @@ class LocalizationFinder implements LocalizationFinderInterface
     private function findAvailableParentLocalization(array $availableLocales, Localization $localization)
     {
         do {
-            if (in_array($localization->getLocalization(), $availableLocales)) {
+            if (in_array($localization->getLocale(), $availableLocales)) {
                 return $localization;
             }
 
@@ -111,7 +111,7 @@ class LocalizationFinder implements LocalizationFinderInterface
         if (!empty($childrenLocalizations)) {
             foreach ($childrenLocalizations as $childrenLocalization) {
                 // return the localization if a translation exists in the child localization
-                if (in_array($childrenLocalization->getLocalization(), $availableLocales)) {
+                if (in_array($childrenLocalization->getLocale(), $availableLocales)) {
                     return $childrenLocalization;
                 }
 
@@ -135,7 +135,7 @@ class LocalizationFinder implements LocalizationFinderInterface
     private function findAvailableLocalization(array $availableLocales, array $localizations)
     {
         foreach ($localizations as $localization) {
-            if (in_array($localization->getLocalization(), $availableLocales)) {
+            if (in_array($localization->getLocale(), $availableLocales)) {
                 return $localization;
             }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -128,6 +128,12 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
 
         $node = $event->getNode();
         $property = $this->getResourceSegmentProperty($document);
+
+        if (!$property) {
+            // do not set a resource segment if the document has no structure
+            return;
+        }
+
         $locale = $this->documentInspector->getOriginalLocale($document);
         $segment = $node->getPropertyValueWithDefault(
             $this->encoder->localizedSystemName(
@@ -155,7 +161,11 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
         }
 
         $property = $this->getResourceSegmentProperty($document);
-        $this->persistDocument($document, $property);
+        // check if a property for the resource segment is available, this prevents the code from failing in case there
+        // is no such property for some reason (e.g. the document doesn't have a structure)
+        if ($property) {
+            $this->persistDocument($document, $property);
+        }
     }
 
     /**
@@ -223,6 +233,11 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
     private function getResourceSegmentProperty($document)
     {
         $structure = $this->documentInspector->getStructureMetadata($document);
+
+        if (!$structure) {
+            return;
+        }
+
         $property = $structure->getPropertyByTagName('sulu.rlp');
 
         if (!$property) {

--- a/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
+++ b/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -89,13 +89,8 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
             $structureType = $this->getDefaultStructureType($type);
         }
 
-        if (!is_string($structureType)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Expected string for structureType, got: %s',
-                    is_object($structureType) ? get_class($structureType) : gettype($structureType)
-                )
-            );
+        if (!$structureType) {
+            return;
         }
 
         $cachePath = sprintf(
@@ -247,17 +242,12 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
      *
      * @param string $type
      *
-     * @return string
+     * @return string|null
      */
     private function getDefaultStructureType($type)
     {
         if (!isset($this->defaultTypes[$type])) {
-            throw new \RuntimeException(
-                sprintf(
-                    'No structure type was available and no default exists for document with alias "%s"',
-                    $type
-                )
-            );
+            return;
         }
 
         return $this->defaultTypes[$type];

--- a/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactoryInterface.php
+++ b/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactoryInterface.php
@@ -24,7 +24,7 @@ interface StructureMetadataFactoryInterface
      * @throws Exception\StructureTypeNotFoundException If the structure was not found
      * @throws Exception\DocumentTypeNotFoundException  If the document type was not mapped
      *
-     * @return StructureMetadata
+     * @return StructureMetadata|null
      */
     public function getStructureMetadata($type, $structureType);
 

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -155,8 +155,8 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->inspector->getWebspace($this->document->reveal())->willReturn(self::FIX_WEBSPACE);
         $this->inspector->getLocales($this->document->reveal())->willReturn(['de']);
         $this->webspace->getLocalization(self::FIX_LOCALE)->willReturn($this->localization1->reveal());
-        $this->localization1->getLocalization()->willReturn('en');
-        $this->localization2->getLocalization()->willReturn('de');
+        $this->localization1->getLocale()->willReturn('en');
+        $this->localization2->getLocale()->willReturn('de');
         $this->localization1->getParent()->willReturn($this->localization2->reveal());
         $this->hydrateEvent->getOption('load_ghost_content', true)->willReturn(true);
 
@@ -173,8 +173,8 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->inspector->getLocales($this->document->reveal())->willReturn(['de']);
         $this->webspace->getLocalization(self::FIX_LOCALE)->willReturn($this->localization1->reveal());
 
-        $this->localization1->getLocalization()->willReturn('en');
-        $this->localization2->getLocalization()->willReturn('de');
+        $this->localization1->getLocale()->willReturn('en');
+        $this->localization2->getLocale()->willReturn('de');
         $this->hydrateEvent->getOption('load_ghost_content', true)->willReturn(true);
 
         $this->localization1->getParent()->willReturn(null);
@@ -195,8 +195,8 @@ class FallbackLocalizationSubscriberTest extends SubscriberTestCase
         $this->inspector->getLocales($this->document->reveal())->willReturn(['de']);
         $this->webspace->getLocalization(self::FIX_LOCALE)->willReturn($this->localization1->reveal());
 
-        $this->localization1->getLocalization()->willReturn('en');
-        $this->localization2->getLocalization()->willReturn('de');
+        $this->localization1->getLocale()->willReturn('en');
+        $this->localization2->getLocale()->willReturn('de');
 
         $this->hydrateEvent->getOption('load_ghost_content', true)->willReturn(true);
 

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -147,14 +147,9 @@ class StructureMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory->getStructureMetadata('page');
     }
 
-    /**
-     * It should throw an exception if no structure type is given and no default is available.
-     *
-     * @expectedException \RuntimeException
-     */
     public function testGetStructureDefaultNoSet()
     {
-        $this->factory->getStructureMetadata('snoopet');
+        $this->assertNull($this->factory->getStructureMetadata('snoopet'));
     }
 
     /**

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -294,7 +294,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     public function findLocalization($localization)
     {
-        if ($this->getLocalization() == $localization) {
+        if ($this->getLocale() == $localization) {
             return $this;
         }
 

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -83,7 +83,7 @@ class WebspaceInitializer implements InitializerInterface
 
         $webspaceLocales = [];
         foreach ($webspace->getAllLocalizations() as $localization) {
-            $webspaceLocales[] = $localization->getLocalization();
+            $webspaceLocales[] = $localization->getLocale();
         }
 
         $homeType = $webspace->getDefaultTemplate('home');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2770
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR allows to load a document without any translation. When no translation is given at all a completely empty document is returned.

#### Why?

This PR fixes #2770, but in a different way. Instead of removing the mixin from this document it is allowed to have a document without any translation at all. This can then be loaded and doesn't throw any exceptions.

I have implemented it this way, because we might need that behavior in the future anyway. The way it was implemented currently it would not be possible to load a document when no language exists, but this situation might occur when we provide the feature to remove a specific language.