### PR TITLE
Remove minlength from account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2764 [MediaBundle]         Fixed type filter for media content type
     * BUGFIX      #2795 [ContentBundle]       Allow to load document without any translation
+    * ENHANCEMENT #2796 [ContactBundle]       Remove minlength of 3 from organisation name
     * BUGFIX      #2791 [CustomUrlBundle]     Use the default locale of the user to load the custom url column navigation
     * BUGFIX      #2792 [ContentBundle]       Do not show empty selection for link target in ckeditor
     * FEATURE     #2703 [All]                 Improved experience when using sulu with postgres.

--- a/src/Sulu/Bundle/ContactBundle/Resources/views/Template/account.form.html.twig
+++ b/src/Sulu/Bundle/ContactBundle/Resources/views/Template/account.form.html.twig
@@ -17,7 +17,6 @@
                 <div>
                     <input class="form-element input-bold" type="text" id="name"
                            data-validation-required="true"
-                           data-validation-min-length="3"
                            data-mapper-property="name"/>
                 </div>
             </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove the minlength of 3 from organisation name.

#### Why?

The content manager should be allowed to enter whatever he want to enter as organisation name.
