### PR TITLE
Fixed order of contact cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2798 [ContactBundle]       Contact cards are now ordered correctly and by fullName by default
     * ENHANCEMENT #2835 [CoreBundle]          Used the delegating file loader from symfony instead of own implementation for loading webspace xml files
     * ENHANCEMENT #2831 [RouteBundle]         Improved speed of route-update-command for lots of entities
     * FEATURE     #2826 [AdminBundle]         Made the reset to the "show all" only happen, when the datagrid was in the "show selected" state before (husky)

--- a/src/Sulu/Bundle/ContactBundle/Resources/public/js/components/card-decorator/card-view.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/public/js/components/card-decorator/card-view.js
@@ -223,6 +223,9 @@ define(function() {
              * @param items {Array} array with items to render
              */
             renderRecords: function(items, appendAtBottom) {
+                if (typeof appendAtBottom === 'undefined') {
+                    appendAtBottom = true;
+                }
                 this.updateEmptyIndicatorVisibility();
                 this.sandbox.util.foreach(items, function(record) {
                     var item = processContentFilters.call(this, record);

--- a/src/Sulu/Bundle/ContactBundle/Resources/public/js/components/contacts/list/main.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/public/js/components/contacts/list/main.js
@@ -153,7 +153,7 @@ define([
         getDatagridConfig: function() {
             return {
                 el: this.sandbox.dom.find('#people-list', this.$el),
-                url: '/admin/api/contacts?flat=true',
+                url: '/admin/api/contacts?flat=true&sortBy=fullName&sortOrder=asc',
                 searchInstanceName: 'contacts',
                 searchFields: ['fullName', 'mainEmail'],
                 resultKey: 'contacts',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2732 
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Contact cards now load in the correct order and are sorted by fullName by default.
