### PR TITLE
Fixed ids-query in doctrine-list-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #2804 [ListBuilder]         Fixed ids-query in doctrine-list-builder
+
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release
     * BUGFIX      #2764 [MediaBundle]         Fixed type filter for media content type

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
@@ -45,6 +45,11 @@ class SuluSearchExtension extends Extension implements PrependExtensionInterface
             'services' => [
                 'factory' => 'sulu_search.search.factory',
             ],
+            'persistence' => [
+                'doctrine_orm' => [
+                    'enabled' => true,
+                ],
+            ],
         ]);
     }
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -70,6 +70,7 @@ class SearchControllerTest extends SuluTestCase
                     ],
                     'totals' => [
                         'product' => 0,
+                        'contact' => 0,
                     ],
                     'total' => 0,
                 ],
@@ -111,6 +112,7 @@ class SearchControllerTest extends SuluTestCase
                     ],
                     'totals' => [
                         'product' => 1,
+                        'contact' => 0,
                     ],
                     'total' => 1,
                 ],
@@ -152,6 +154,7 @@ class SearchControllerTest extends SuluTestCase
                     ],
                     'totals' => [
                         'product' => 2,
+                        'contact' => 0,
                     ],
                     'total' => 2,
                 ],

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -325,7 +325,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         $addJoins = $this->getNecessaryJoins($entityNames);
 
         // create querybuilder and add select
-        $queryBuilder = $this->createQueryBuilder($addJoins, false)->select($select);
+        $queryBuilder = $this->createQueryBuilder($addJoins)->select($select);
 
         if ($this->user && $this->permission && array_key_exists($this->permission, $this->permissions)) {
             $this->addAccessControl(
@@ -415,11 +415,10 @@ class DoctrineListBuilder extends AbstractListBuilder
      * Creates Querybuilder.
      *
      * @param array|null $joins Define which joins should be made
-     * @param bool|true $groupBy Defines if the GROUP BY clause should be added
      *
      * @return \Doctrine\ORM\QueryBuilder
      */
-    protected function createQueryBuilder($joins = null, $groupBy = true)
+    protected function createQueryBuilder($joins = null)
     {
         $this->queryBuilder = $this->em->createQueryBuilder()
             ->from($this->entityName, $this->entityName);
@@ -433,10 +432,7 @@ class DoctrineListBuilder extends AbstractListBuilder
             }
         }
 
-        // group by
-        if (true === $groupBy) {
-            $this->assignGroupBy($this->queryBuilder);
-        }
+        $this->assignGroupBy($this->queryBuilder);
 
         if ($this->search !== null) {
             $searchParts = [];

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -721,7 +721,7 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
         $nameFieldDescriptor = new DoctrineFieldDescriptor('name', 'name_alias', self::$entityName);
 
         $this->queryBuilder->addSelect('SuluCoreBundle:Example.name AS name_alias')->shouldBeCalled();
-        $this->queryBuilder->groupBy(self::$entityName . '.name')->shouldBeCalled();
+        $this->queryBuilder->groupBy(self::$entityName . '.name')->shouldBeCalledTimes(2);
 
         $this->doctrineListBuilder->setSelectFields(
             [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the query-builder when the ids-query depends on group-by.

Additionally the prepend for activating orm-indexing in massive-search was missing.

#### To Do

- [x] Tests

