### PR TITLE
Add missing translation of Content navigation tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* develop
+    * BUGFIX      #2810 [ContentBundle]       Add missing translation of Content navigation tab 
+
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release
     * BUGFIX      #2764 [MediaBundle]         Fixed type filter for media content type

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.de.xlf
@@ -698,6 +698,10 @@
                 <source>content-navigation.contents.excerpt</source>
                 <target>Auszug &amp; Kategorien</target>
             </trans-unit>
+            <trans-unit id="948826fa2261f741d03a40c20af27c1b" resname="content-navigation.contents.permissions">
+                <source>content-navigation.contents.permissions</source>
+                <target>Berechtigungen</target>
+            </trans-unit>
             <trans-unit id="c964588d92c25e70ec2d7f9be4e28ebc" resname="select.edit-entries">
                 <source>select.edit-entries</source>
                 <target>Bearbeiten</target>

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.en.xlf
@@ -702,6 +702,10 @@
                 <source>content-navigation.contents.excerpt</source>
                 <target>Excerpt &amp; Categories</target>
             </trans-unit>
+            <trans-unit id="948826fa2261f741d03a40c20af27c1b" resname="content-navigation.contents.permissions">
+                <source>content-navigation.contents.permissions</source>
+                <target>Permissions</target>
+            </trans-unit>
             <trans-unit id="c964588d92c25e70ec2d7f9be4e28ebc" resname="select.edit-entries">
                 <source>select.edit-entries</source>
                 <target>Edit</target>

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.fr.xlf
@@ -704,6 +704,10 @@
                 <source>content-navigation.contents.excerpt</source>
                 <target>Extrait &amp; Categories</target>
             </trans-unit>
+            <trans-unit id="948826fa2261f741d03a40c20af27c1b" resname="content-navigation.contents.permissions">
+                <source>content-navigation.contents.permissions</source>
+                <target>Permissions</target>
+            </trans-unit>
             <trans-unit id="c964588d92c25e70ec2d7f9be4e28ebc" resname="select.edit-entries">
                 <source>select.edit-entries</source>
                 <target>Editer</target>

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.nl.xlf
@@ -702,6 +702,10 @@
                 <source>content-navigation.contents.excerpt</source>
                 <target>Samenvatting en categorieën</target>
             </trans-unit>
+            <trans-unit id="948826fa2261f741d03a40c20af27c1b" resname="content-navigation.contents.permissions">
+                <source>content-navigation.contents.permissions</source>
+                <target>Rechten</target>
+            </trans-unit>
             <trans-unit id="c964588d92c25e70ec2d7f9be4e28ebc" resname="select.edit-entries">
                 <source>select.edit-entries</source>
                 <target>Bewerk</target>

--- a/src/Sulu/Bundle/ContentBundle/Admin/ContentContentNavigationProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Admin/ContentContentNavigationProvider.php
@@ -101,7 +101,7 @@ class ContentContentNavigationProvider implements ContentNavigationProviderInter
         $securityContext = 'sulu.webspaces.' . $options['webspace'];
 
         if ($this->enabledSecurity && $this->securityChecker->hasPermission($securityContext, PermissionTypes::SECURITY)) {
-            $permissions = new ContentNavigationItem('Permissions');
+            $permissions = new ContentNavigationItem('content-navigation.contents.permissions');
             $permissions->setId('tab-permissions');
             $permissions->setAction('permissions');
             $permissions->setPosition(50);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2805
| Related issues/PRs | n/a
| License | MIT
| Documentation PR | n/a

#### What's in this PR?

Added a tab translation that is missing
