### PR TITLE
Make indexes searched by website search configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* develop
+    * FEATURE     #2811 [SearchBundle]        Make indexes searched by website search configurable
+
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release
     * BUGFIX      #2764 [MediaBundle]         Fixed type filter for media content type

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -121,7 +121,7 @@ class WebsiteSearchController implements ContainerAwareInterface
     {
         $resolver = $this->container->get('twig');
         $value = $resolver->createTemplate($value)->render([
-            'webspace' => $this->requestAnalyzer->getWebspace()
+            'webspace' => $this->requestAnalyzer->getWebspace(),
         ]);
         return $value;
     }

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -123,7 +123,7 @@ class WebsiteSearchController implements ContainerAwareInterface
         $value = $resolver->createTemplate($value)->render([
             'webspace' => $this->requestAnalyzer->getWebspace(),
         ]);
-        
+
         return $value;
     }
 

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -123,6 +123,7 @@ class WebsiteSearchController implements ContainerAwareInterface
         $value = $resolver->createTemplate($value)->render([
             'webspace' => $this->requestAnalyzer->getWebspace(),
         ]);
+        
         return $value;
     }
 

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -32,10 +32,17 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('security_context')->end()
                             ->arrayNode('contexts')
                                 ->prototype('scalar')
-                                ->defaultValue([])
+                                    ->defaultValue([])
+                                ->end()
                             ->end()
                         ->end()
                     ->end()
+                ->end()
+            ->end()
+            ->children()
+                ->arrayNode('website_indexes')
+                    ->prototype('scalar')->end()
+                    ->defaultValue(['page_{{ webspace.key }}_published'])
                 ->end()
             ->end();
 

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
@@ -57,6 +57,7 @@ class SuluSearchExtension extends Extension implements PrependExtensionInterface
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('sulu_search.indexes', $config['indexes']);
+        $container->setParameter('sulu_search.website_indexes', $config['website_indexes']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('search.xml');

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -26,6 +26,9 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.resolver.parameter"/>
             <argument type="service" id="templating"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
             <tag name="sulu.context" context="website"/>
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2811
| Related issues/PRs | #2811
| License | MIT

#### What's in this PR?

Allows the configuration of the indexes used by the `WebsiteSearchController`

#### Example Usage

~~~yaml
sulu_search:
    website_indexes:
        - 'page_{{ webspace.key }}_published'
        - 'media'
~~~