### PR TITLE
Make indexes searched by website search configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG for Sulu
     * FEATURE     #2765 [MediaBundle]         Implemented new masonry-design for media
     * ENHANCEMENT #2743 [CoreBundle]          Remove symfony deprecations and don't allow them anymore
     * BUGFIX      #2810 [ContentBundle]       Add missing translation of Content navigation tab 
+    * FEATURE     #2811 [SearchBundle]        Make indexes searched by website search configurable
 
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -16,15 +16,18 @@ use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This controller handles the search for the website.
  */
-class WebsiteSearchController
+class WebsiteSearchController implements ContainerAwareInterface
 {
     use RequestParametersTrait;
+    use ContainerAwareTrait;
 
     /**
      * @var SearchManagerInterface
@@ -94,10 +97,15 @@ class WebsiteSearchController
             }
         }
 
+
+
         $hits = $this->searchManager
             ->createSearch($queryString)
             ->locale($locale)
-            ->index('page_' . $webspace->getKey() . '_published')
+            ->indexes(array_map(
+                [$this, 'resolveIndexPlaceholders'],
+                $this->container->getParameter('sulu_search.website_indexes') ?: []
+            ))
             ->execute();
 
         return $this->engine->renderResponse(
@@ -107,6 +115,18 @@ class WebsiteSearchController
                 $this->requestAnalyzer
             )
         );
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return mixed
+     */
+    private function resolveIndexPlaceholders($value)
+    {
+        $webspace = $this->requestAnalyzer->getWebspace();
+
+        return str_replace(['{ webspace_key }'], [$webspace->getKey()], $value);
     }
 
     /**

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -32,10 +32,17 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('security_context')->end()
                             ->arrayNode('contexts')
                                 ->prototype('scalar')
-                                ->defaultValue([])
+                                    ->defaultValue([])
+                                ->end()
                             ->end()
                         ->end()
                     ->end()
+                ->end()
+            ->end()
+            ->children()
+                ->arrayNode('website_indexes')
+                    ->prototype('scalar')->end()
+                    ->defaultValue(['page_{ webspace_key }_published'])
                 ->end()
             ->end();
 

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
@@ -57,6 +57,7 @@ class SuluSearchExtension extends Extension implements PrependExtensionInterface
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('sulu_search.indexes', $config['indexes']);
+        $container->setParameter('sulu_search.website_indexes', $config['website_indexes']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('search.xml');

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -26,6 +26,9 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.resolver.parameter"/>
             <argument type="service" id="templating"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
             <tag name="sulu.context" context="website"/>
         </service>
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -19,6 +19,7 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -43,6 +44,10 @@ class WebsiteSearchControllerTest extends \PHPUnit_Framework_TestCase
      * @var EngineInterface
      */
     private $engine;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
 
     /**
      * @var WebsiteSearchController
@@ -55,6 +60,7 @@ class WebsiteSearchControllerTest extends \PHPUnit_Framework_TestCase
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
         $this->engine = $this->prophesize(EngineInterface::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
 
         $this->websiteSearchController = new WebsiteSearchController(
             $this->searchManager->reveal(),
@@ -62,6 +68,7 @@ class WebsiteSearchControllerTest extends \PHPUnit_Framework_TestCase
             $this->parameterResolver->reveal(),
             $this->engine->reveal()
         );
+        $this->websiteSearchController->setContainer($this->container->reveal());
     }
 
     public function testQueryAction()
@@ -78,10 +85,19 @@ class WebsiteSearchControllerTest extends \PHPUnit_Framework_TestCase
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
+        $this->container->getParameter('sulu_search.website_indexes')->willReturn(['page_{ webspace_key }_published']);
+
+        /** @var \Twig_Environment $twigEnvironment */
+        $twigEnvironment = $this->prophesize(\Twig_Environment::class);
+        $this->container->get('twig')->willReturn($twigEnvironment->reveal());
+        $twigTemplate = $this->prophesize(\Twig_Template::class);
+        $twigEnvironment->createTemplate('page_{ webspace_key }_published')->willReturn($twigTemplate);
+        $twigTemplate->render(['webspace' => $webspace])->willReturn('page_sulu_published');
+
         $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);
         $this->searchManager->createSearch('+("Test" OR Test* OR Test~) ')->willReturn($searchQueryBuilder->reveal());
         $searchQueryBuilder->locale('en')->willReturn($searchQueryBuilder->reveal());
-        $searchQueryBuilder->index('page_sulu_published')->willReturn($searchQueryBuilder->reveal());
+        $searchQueryBuilder->indexes(['page_sulu_published'])->willReturn($searchQueryBuilder->reveal());
         $searchQueryBuilder->execute()->willReturn([]);
 
         $this->parameterResolver->resolve(

--- a/src/Sulu/Bundle/SearchBundle/Tests/app/config/config.yml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/app/config/config.yml
@@ -6,3 +6,6 @@ sulu_content:
         mapping:
             Sulu\Bundle\ContentBundle\Document\PageDocument:
                 index: page
+sulu_search:
+    website_indexes:
+        - 'page_{ webspace_key }_published'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2811
| Related issues/PRs | #2811
| License | MIT

#### What's in this PR?

Allows the configuration of the indexes used by the `WebsiteSearchController`

#### Example Usage

~~~yaml
sulu_search:
    website_indexes:
        - 'page_{{ webspace.key }}_published'
        - 'media'
~~~



Sorry for deleting #2812 
@danrot 