### PR TITLE
Improved speed of route-update-command for lots of entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2831 [RouteBundle]         Improved speed of route-update-command for lots of entities
     * FEATURE     #2826 [AdminBundle]         Made the reset to the "show all" only happen, when the datagrid was in the "show selected" state before (husky)
     * FEATURE     #2803 [MediaBundle]         Add breadcrumb to collection's edit
     * ENHANCEMENT #2814 [MediaBundle]         Removed overlay from dropzone and implemented own overlay-style for dropzone (husky)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR improves the speed of `sulu:route:update` for lots of entities. It introduces a batch-size option which will be used to determine how ofter the flush should be called.

#### Why?

For lots of entities the command was fucking slow (: