### PR TITLE
Include port in URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #2804 [ListBuilder]         Fixed ids-query in doctrine-list-builder
+    * HOTFIX      #2839 [WebsiteBundle]       Include port in URLs
 
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade
 
+## dev-master
+
+If Sulu is used in combination with a port, the port has to be included in the
+URLs of the webspace configuration. So if you want to use Sulu on port 8080 the
+configuration has to look like this:
+
+```xml
+<url>sulu.lo:8080/{localization}</url>
+```
+
+The port can still be emitted if the standard HTTP or HTTPS port is used.
+
 ## 1.3.0-RC3
 
 ### Resource-locator generation

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
@@ -112,14 +112,11 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPathWithWebspaceKeyNotFoundForDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
-        $this->webspaceManager->findUrlByResourceLocator(
-            '/test',
-            $this->environment,
-            'de',
-            'test_io',
-            'www.test.io',
-            'http'
-        )->willReturn(null)->shouldBeCalledTimes(1);
+
+        // empty webspace object will not contain domain as tested in isFromDomain call
+        $webspace = new Webspace();
+        $this->webspaceManager->findWebspaceByKey('test_io')->willReturn($webspace);
+
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -72,27 +72,18 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
 
         $url = null;
         $host = $this->requestAnalyzer->getAttribute('host');
-        if ($domain || $this->webspaceManager->findWebspaceByKey($webspaceKey)->hasDomain($host, $this->environment)) {
-            $url = $this->webspaceManager->findUrlByResourceLocator(
-                $route,
-                $this->environment,
-                $locale,
-                $webspaceKey,
-                $domain ?: $this->requestAnalyzer->getAttribute('host'),
-                $scheme
-            );
+        if (!$domain && $this->webspaceManager->findWebspaceByKey($webspaceKey)->hasDomain($host, $this->environment)) {
+            $domain = $host;
         }
 
-        if (!$url && !$domain) {
-            $url = $this->webspaceManager->findUrlByResourceLocator(
-                $route,
-                $this->environment,
-                $locale,
-                $webspaceKey,
-                null,
-                $scheme
-            );
-        }
+        $url = $this->webspaceManager->findUrlByResourceLocator(
+            $route,
+            $this->environment,
+            $locale,
+            $webspaceKey,
+            $domain,
+            $scheme
+        );
 
         return $url ?: $route;
     }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -111,7 +111,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         }
 
         $resourceLocator = substr(
-            $request->getHost() . $path,
+            $request->getHttpHost() . $path,
             strlen($portalInformation->getUrl())
         );
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -60,12 +60,12 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
      */
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
-        $url = $request->getHost() . $request->getPathInfo();
-        $urlInfo = parse_url($request->getScheme() . '://' . $url);
+        $host = $request->getHttpHost();
+        $url = $host . $request->getPathInfo();
         foreach ($this->webspaceManager->getPortalInformations($this->environment) as $portalInformation) {
-            $portalUrl = $this->replacer->replaceHost($portalInformation->getUrl(), $urlInfo['host']);
+            $portalUrl = $this->replacer->replaceHost($portalInformation->getUrl(), $host);
             $portalInformation->setUrl($portalUrl);
-            $portalRedirect = $this->replacer->replaceHost($portalInformation->getRedirect(), $urlInfo['host']);
+            $portalRedirect = $this->replacer->replaceHost($portalInformation->getRedirect(), $host);
             $portalInformation->setRedirect($portalRedirect);
         }
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -23,7 +23,6 @@ use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
 class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
@@ -105,12 +104,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2, $portalInformation3]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
-        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
-        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('/test'));
-        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/test']);
 
         $this->replacer->replaceHost(null, 'sulu.lo')->willReturn(null);
         $this->replacer->replaceHost('{host}', 'sulu.lo')->willReturn('sulu.lo');
@@ -170,12 +164,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
-        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
-        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('/test'));
-        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/test']);
 
         $this->replacer->replaceHost(null, 'sulu.lo')->willReturn(null);
         $this->replacer->replaceHost('{host}', 'sulu.lo')->willReturn('sulu.lo');
@@ -233,12 +222,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2]);
 
-        $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');
-        $request->request = new ParameterBag(['post' => 1]);
-        $request->query = new ParameterBag(['get' => 1]);
-        $request->expects($this->any())->method('getHost')->will($this->returnValue('sulu.lo'));
-        $request->expects($this->any())->method('getPathInfo')->will($this->returnValue('/de'));
-        $request->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/de']);
 
         $this->replacer->replaceHost(null, 'sulu.lo')->willReturn('sulu.lo');
         $this->replacer->replaceHost('sulu.lo', 'sulu.lo')->willReturn('sulu.lo');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2423, fixes #2824
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the correct port to links on the website.

#### BC Breaks/Deprecations

The port has now also to be added in the webspace configuration. However, nothing has to be changed if standard ports are used.