### PR TITLE
Hide system collection's media if permission is not granted (#2841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG for Sulu
     * FEATURE     #2765 [MediaBundle]         Implemented new masonry-design for media
     * ENHANCEMENT #2743 [CoreBundle]          Remove symfony deprecations and don't allow them anymore
     * BUGFIX      #2810 [ContentBundle]       Add missing translation of Content navigation tab 
+    * BUGFIX      #2841 [MediaBundle]         Hide system collection's media if permission is not granted
 
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -199,6 +199,12 @@ class MediaController extends AbstractMediaController implements
             }
             $listBuilder->addSelectField($fieldDescriptors['collection']);
             $listBuilder->where($fieldDescriptors['collection'], $collectionId);
+        } elseif (!$this->getSecurityChecker()->hasPermission('sulu.media.system_collections', PermissionTypes::VIEW)) {
+            $nonSystemCollections = $this->getCollectionRepository()->findCollectionSet(
+                100,
+                ['systemCollections' => false]
+            );
+            $listBuilder->in($fieldDescriptors['collection'], $nonSystemCollections);
         }
 
         // If no limit is set in request and limit is set by ids


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2841 |
| Related issues/PRs | #2841 |
| License | MIT |
#### What's in this PR?

Only select media in non system collections if the access to them is not granted.
