### PR TITLE
Added teaser-attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG for Sulu
     * FEATURE     #2820 [RouteBundle]         Added possibility to implement custom route-generator
     * FEATURE     #2799 [MediaBundle]         Implemented tiles view for navigating through collections
     * FEATURE     #2715 [ContentBundle]       Implemented teaser content-type
+    * ENHANCEMENT #2846 [ContentBundle]       Added teaser-attributes
     * FEATURE     #2765 [MediaBundle]         Implemented new masonry-design for media
     * ENHANCEMENT #2743 [CoreBundle]          Remove symfony deprecations and don't allow them anymore
     * BUGFIX      #2810 [ContentBundle]       Add missing translation of Content navigation tab 

--- a/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContentBundle\Teaser;
 
 use Massive\Bundle\SearchBundle\Search\QueryHit;
 use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Sulu\Bundle\ContentBundle\Search\Metadata\StructureProvider;
 use Sulu\Bundle\ContentBundle\Teaser\Configuration\TeaserConfiguration;
 use Sulu\Bundle\ContentBundle\Teaser\Provider\TeaserProviderInterface;
 
@@ -62,18 +63,23 @@ class ContentTeaserProvider implements TeaserProviderInterface
 
         /** @var QueryHit $item */
         foreach ($searchResult as $item) {
-            $title = $item->getDocument()->getField('title')->getValue();
-            $excerptTitle = $item->getDocument()->getField('excerptTitle')->getValue();
+            $document = $item->getDocument();
+
+            $title = $document->getField('title')->getValue();
+            $excerptTitle = $document->getField('excerptTitle')->getValue();
 
             $result[] = new Teaser(
                 $item->getId(),
                 'content',
                 $locale,
                 ('' !== $excerptTitle ? $excerptTitle : $title),
-                $item->getDocument()->getField('excerptDescription')->getValue(),
-                $item->getDocument()->getField('excerptMore')->getValue(),
-                $item->getDocument()->getField('__url')->getValue(),
-                $this->getMedia(json_decode($item->getDocument()->getField('excerptImages')->getValue(), true))
+                $document->getField('excerptDescription')->getValue(),
+                $document->getField('excerptMore')->getValue(),
+                $document->getField('__url')->getValue(),
+                $this->getMedia(json_decode($document->getField('excerptImages')->getValue(), true)),
+                [
+                    'structureType' => $document->getField(StructureProvider::FIELD_STRUCTURE_TYPE)->getValue(),
+                ]
             );
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Teaser/Teaser.php
+++ b/src/Sulu/Bundle/ContentBundle/Teaser/Teaser.php
@@ -57,6 +57,11 @@ class Teaser
     private $url;
 
     /**
+     * @var array
+     */
+    private $attributes;
+
+    /**
      * @param int|string $id
      * @param string $type
      * @param string $locale
@@ -65,8 +70,9 @@ class Teaser
      * @param string $moreText
      * @param string $url
      * @param int $mediaId
+     * @param array $attribute
      */
-    public function __construct($id, $type, $locale, $title, $description, $moreText, $url, $mediaId)
+    public function __construct($id, $type, $locale, $title, $description, $moreText, $url, $mediaId, $attributes = [])
     {
         $this->id = $id;
         $this->type = $type;
@@ -76,6 +82,7 @@ class Teaser
         $this->moreText = $moreText;
         $this->url = $url;
         $this->mediaId = $mediaId;
+        $this->attributes = $attributes;
     }
 
     /**
@@ -156,5 +163,15 @@ class Teaser
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * Returns attributes.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Teaser/ContentTeaserProviderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Teaser/ContentTeaserProviderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Teaser;
+
+use Massive\Bundle\SearchBundle\Search\Field;
+use Massive\Bundle\SearchBundle\Search\QueryHit;
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
+use Massive\Bundle\SearchBundle\Search\SearchQueryBuilder;
+use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Teaser\ContentTeaserProvider;
+use Sulu\Bundle\ContentBundle\Teaser\Teaser;
+use Sulu\Bundle\SearchBundle\Search\Document;
+
+class ContentTeaserProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SearchManagerInterface
+     */
+    private $searchManager;
+
+    /**
+     * @var SearchQueryBuilder
+     */
+    private $search;
+
+    /**
+     * @var ContentTeaserProvider
+     */
+    private $contentProvider;
+
+    protected function setUp()
+    {
+        $this->searchManager = $this->prophesize(SearchManagerInterface::class);
+        $this->search = $this->prophesize(SearchQueryBuilder::class);
+
+        $this->searchManager->getIndexNames()->willReturn(['page_sulu_io']);
+
+        $this->contentProvider = new ContentTeaserProvider($this->searchManager->reveal());
+    }
+
+    public function testFind()
+    {
+        $data = [
+            '123-123-123' => [
+                'title' => 'Test 1',
+                'excerptTitle' => 'Excerpt 1',
+                'excerptDescription' => 'This is a test',
+                'excerptMore' => 'Read more ...',
+                '__url' => '/test/1',
+                'excerptImages' => json_encode(['ids' => [1, 2, 3]]),
+                '_structure_type' => 'default',
+            ],
+            '456-456-456' => [
+                'title' => 'Test 2',
+                'excerptTitle' => '',
+                'excerptDescription' => '',
+                'excerptMore' => '',
+                '__url' => '/test/2',
+                'excerptImages' => json_encode([]),
+                '_structure_type' => 'overview',
+            ],
+        ];
+        $ids = array_keys($data);
+
+        $this->searchManager->createSearch(
+            Argument::that(
+                function ($searchQuery) use ($ids) {
+                    return 0 <= strpos($searchQuery, sprintf('__id:"%s"', $ids[0]))
+                        && 0 <= strpos($searchQuery, sprintf('__id:"%s"', $ids[1]));
+                }
+            )
+        )->willReturn($this->search->reveal())->shouldBeCalled();
+        $this->search->indexes(['page_sulu_io'])->willReturn($this->search->reveal())->shouldBeCalled();
+        $this->search->execute()->willReturn(
+            [$this->createQueryHit($ids[0], $data[$ids[0]]), $this->createQueryHit($ids[1], $data[$ids[1]])]
+        );
+
+        $result = $this->contentProvider->find($ids, 'de');
+
+        $this->assertCount(2, $result);
+
+        $this->assertTeaser($ids[0], $data[$ids[0]], $result[0]);
+        $this->assertTeaser($ids[1], $data[$ids[1]], $result[1]);
+    }
+
+    private function createQueryHit($id, array $data)
+    {
+        $queryHit = $this->prophesize(QueryHit::class);
+        $document = $this->prophesize(Document::class);
+        $queryHit->getDocument()->willReturn($document->reveal());
+        $queryHit->getId()->willReturn($id);
+        foreach ($data as $name => $value) {
+            $document->getField($name)->willReturn(new Field($name, $value));
+        }
+
+        return $queryHit->reveal();
+    }
+
+    private function assertTeaser($id, array $expected, Teaser $teaser)
+    {
+        $this->assertEquals($id, $teaser->getId());
+        $this->assertEquals('content', $teaser->getType());
+
+        $this->assertEquals(
+            '' !== $expected['excerptTitle'] ? $expected['excerptTitle'] : $expected['title'],
+            $teaser->getTitle()
+        );
+        $this->assertEquals($expected['excerptDescription'], $teaser->getDescription());
+        $this->assertEquals($expected['excerptMore'], $teaser->getMoreText());
+        $this->assertEquals($this->getMedia(json_decode($expected['excerptImages'], true)), $teaser->getMediaId());
+        $this->assertEquals($expected['__url'], $teaser->getUrl());
+
+        $this->assertEquals(['structureType' => $expected['_structure_type']], $teaser->getAttributes());
+    }
+
+    private function getMedia(array $data)
+    {
+        if (!array_key_exists('ids', $data)) {
+            return;
+        }
+
+        return reset($data['ids']) ?: null;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/16
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces an dynamic teaser-attributes property which can contain dynamic data related to the teaser-item.
