### PR TITLE
fixed preview serialization to include dates and authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2848 [ContentBundle]       Fixed preview serialization to include date and authors
     * ENHANCEMENT #2782 [MediaBundle]         Cleaned up media selection overlay styling
     * BUGFIX      #2774 [SecurityBundle]      Added translations to settings user role for hovering single permission
     * BUGFIX      #2798 [ContactBundle]       Contact cards are now ordered correctly and by fullName by default

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/serializer/Document.BasePageDocument.xml
@@ -20,11 +20,11 @@
 
         <property name="nodeName" type="string"/>
         <property name="title" type="string" groups="defaultPage,smallPage"/>
-        <property name="creator" type="integer" groups="defaultPage"/>
-        <property name="changer" type="integer" groups="defaultPage"/>
-        <property name="created" type="DateTime" groups="defaultPage"/>
-        <property name="published" type="DateTime" groups="defaultPage,smallPage"/>
-        <property name="changed" type="DateTime" groups="defaultPage"/>
+        <property name="creator" type="integer" groups="defaultPage,preview"/>
+        <property name="changer" type="integer" groups="defaultPage,preview"/>
+        <property name="created" type="DateTime" groups="defaultPage,preview"/>
+        <property name="published" type="DateTime" groups="defaultPage,smallPage,preview"/>
+        <property name="changed" type="DateTime" groups="defaultPage,preview"/>
         <property name="resourceSegment" exclude="true"/>
         <property name="navigationContexts" type="array" serialized-name="navContexts" groups="defaultPage,smallPage"/>
         <property name="redirectType" type="integer" serialized-name="nodeType" groups="defaultPage,smallPage"/>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Compat/StructureBridgeSerializationTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Compat/StructureBridgeSerializationTest.php
@@ -82,6 +82,10 @@ class StructureBridgeSerializationTest extends SuluTestCase
 
         $this->assertInstanceOf(StructureBridge::class, $result);
         $this->assertEquals('internallinks', $result->getKey());
+        $this->assertEquals(1, $result->getChanger());
+        $this->assertEquals(1, $result->getCreator());
+        $this->assertInstanceOf(\DateTime::class, $result->getChanged());
+        $this->assertInstanceOf(\DateTime::class, $result->getCreated());
 
         $property = $result->getProperty('internalLinks');
         $this->assertInstanceOf(Property::class, $property);
@@ -108,7 +112,7 @@ class StructureBridgeSerializationTest extends SuluTestCase
             true
         );
 
-        $this->documentManager->persist($page, 'fr');
+        $this->documentManager->persist($page, 'fr', ['user' => 1]);
         $this->documentManager->flush();
 
         return $page;

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -613,8 +613,8 @@ class CustomUrlControllerTest extends SuluTestCase
         $this->assertArrayHasKey('creator', $responseData);
         $this->assertArrayHasKey('changer', $responseData);
 
-        $this->assertGreaterThanOrEqual($dateTime, new \DateTime($responseData['created']));
-        $this->assertGreaterThanOrEqual($dateTime, new \DateTime($responseData['changed']));
+        $this->assertGreaterThanOrEqual(new \DateTime($responseData['created']), $dateTime);
+        $this->assertGreaterThanOrEqual(new \DateTime($responseData['changed']), $dateTime);
         $this->assertEquals(Urlizer::urlize($data['title']), $responseData['nodeName']);
         if (array_key_exists('targetDocument', $data)) {
             $this->assertEquals('Homepage', $responseData['targetTitle']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2837 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The PR includes the `changed`, `changer`, `created`, `creator` and `published` fields to the preview serialization, so that the fields are correctly passed to the preview.