### PR TITLE
[SecurityBundle] Load user with contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2849 [SecurityBundle]      Load contact when loading the user with permissions
     * ENHANCEMENT #2500 [MediaBundle]         Refactored handling of post data for media
     * ENHANCEMENT #2497 [MediaBundle]         Implemented MediaInterface for inheritance
     * BUGFIX      #2504 [WebsiteBundle]       Fixed http-cache clear if var dir exists

--- a/src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/UserRepository.php
@@ -287,9 +287,11 @@ class UserRepository extends EntityRepository implements UserRepositoryInterface
     private function getUserWithPermissionsQuery()
     {
         return $this->createQueryBuilder('user')
+            ->addSelect('contact')
             ->addSelect('userRoles')
             ->addSelect('role')
             ->addSelect('permissions')
+            ->leftJoin('user.contact', 'contact')
             ->leftJoin('user.userRoles', 'userRoles')
             ->leftJoin('userRoles.role', 'role')
             ->leftJoin('role.permissions', 'permissions');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
#### What's in this PR?

Loads the contact to the user in the UserRepository `getUserWithPermissionsQuery`.
#### Why?

Solves the problem that the user has no association to his contact.
