### PR TITLE
Return 404 http code for not existing media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2864 [MediaBundle]         Return 404 http code for not existing media
     * HOTFIX      #2804 [ListBuilder]         Fixed ids-query in doctrine-list-builder
     * HOTFIX      #2839 [WebsiteBundle]       Include port in URLs
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\MediaBundle\Controller;
 
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
-use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\FileVersionNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
@@ -22,6 +21,7 @@ use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class MediaStreamController extends Controller
@@ -79,12 +79,16 @@ class MediaStreamController extends Controller
             $version = $request->get('v', null);
             $noCount = $request->get('no-count', false);
 
+            $fileVersion = $this->getFileVersion($id, $version);
+
+            if (!$fileVersion) {
+                return new Response(null, 404);
+            }
+
             $dispositionType = ResponseHeaderBag::DISPOSITION_ATTACHMENT;
             if ($request->get('inline', false)) {
                 $dispositionType = ResponseHeaderBag::DISPOSITION_INLINE;
             }
-
-            $fileVersion = $this->getFileVersion($id, $version);
 
             if (!$noCount) {
                 $this->getMediaManager()->increaseDownloadCounter($fileVersion->getId());
@@ -153,6 +157,10 @@ class MediaStreamController extends Controller
          * @var MediaInterface
          */
         $mediaEntity = $this->container->get('sulu.repository.media')->findMediaById($id);
+
+        if (!$mediaEntity) {
+            return;
+        }
 
         $currentFileVersion = null;
         $version = $version === null ? $mediaEntity->getFiles()[0]->getVersion() : $version;

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -215,9 +215,9 @@ class FormatManager implements FormatManagerInterface
             }
             $responseMimeType = 'image/' . $imageExtension;
         } catch (MediaException $e) {
-            $responseContent = $e->getCode() . ': ' . $e->getMessage();
+            $responseContent = null;
             $status = 404;
-            $responseMimeType = 'text/plain';
+            $responseMimeType = null;
         }
 
         // Clear temp files.

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class MediaStreamControllerTest extends SuluTestCase
+{
+    public function testGetImageActionForNonExistingMedia()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/uploads/media/400x400/01/test.jpg?v=1');
+
+        $this->assertHttpStatusCode(404, $client->getResponse());
+    }
+
+    public function testDownloadActionForNonExistingMedia()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/media/999/download/test.jpg?v=1');
+
+        $this->assertHttpStatusCode(404, $client->getResponse());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2854
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR returns a 404 http code if the media is not found for a download URL.