### PR TITLE
Fixed navigation on removed template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #2513 [PersistanceBundle]   Fix doctrine generator commands
     * BUGFIX      #2776 [MediaBundle]         Fixed upload of media without an extension
+    * BUGFIX      #2867 [ContentBundle]       Fixed navigation on removed template
     * BUGFIX      #2850 [ContentBundle]       Ordered response of template action alphabetically
     * BUGFIX      #2848 [ContentBundle]       Fixed preview serialization to include date and authors
     * ENHANCEMENT #2782 [MediaBundle]         Cleaned up media selection overlay styling

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -41,6 +41,7 @@ use Sulu\Component\Content\Exception\TranslatedNodeNotFoundException;
 use Sulu\Component\Content\Extension\ExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Mapper\Event\ContentNodeEvent;
+use Sulu\Component\Content\Metadata\Factory\Exception\StructureTypeNotFoundException;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\Content\Types\ResourceLocatorInterface;
 use Sulu\Component\DocumentManager\DocumentManager;
@@ -652,7 +653,13 @@ class ContentMapper implements ContentMapperInterface
 
         // check and determine shadow-nodes
         $node = $row->getNode('page');
-        $document = $this->documentManager->find($node->getIdentifier(), $locale);
+
+        try {
+            $document = $this->documentManager->find($node->getIdentifier(), $locale);
+        } catch (StructureTypeNotFoundException $e) {
+            return false;
+        }
+
         $originalDocument = $document;
 
         if (!$node->hasProperty($templateName) && !$node->hasProperty($nodeTypeName)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Fixes? | fixes part of #2101 
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixed crash of website on page without a template.

#### Why?

When a template is removed and still a page in the navigation has this template the website will crash.