### PR TITLE
fixed maintain command for resource locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #2870 [ContentBundle]       Fixed NodeOrderBuilder for publishing
+    * HOTFIX      #2869 [ContentBundle]       Fixed maintain command for resource locator
     * HOTFIX      #2864 [MediaBundle]         Return 404 http code for not existing media
     * HOTFIX      #2865 [ContentBundle]       Fixed button text for unpublish dialog
     * HOTFIX      #2863 [MediaBundle]         Removed default limit from collection controller and children join from collection-repository

--- a/src/Sulu/Bundle/ContentBundle/Command/MaintainResourceLocatorCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/MaintainResourceLocatorCommand.php
@@ -11,46 +11,91 @@
 
 namespace Sulu\Bundle\ContentBundle\Command;
 
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
 use Sulu\Component\Content\Compat\Structure;
-use Sulu\Component\Content\Compat\Structure\StructureBridge;
-use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
-use Sulu\Component\Content\Mapper\ContentMapperInterface;
-use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
-use Sulu\Component\Content\Types\ResourceLocator;
-use Sulu\Component\Content\Types\Rlp\Strategy\RlpStrategyInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Upgrades Resourcelocators to 0.9.0.
- *
- * @deprecated
+ * Writes the current resource locator on the cached property of the node in the live workspace.
+ * The default workspace should not be touched, because these might represent changes already entered by a user.
  */
-class MaintainResourceLocatorCommand extends ContainerAwareCommand
+class MaintainResourceLocatorCommand extends Command
 {
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var SessionManagerInterface
+     */
+    private $sessionManager;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var StructureMetadataFactory
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    public function __construct(
+        WebspaceManagerInterface $webspaceManager,
+        SessionManagerInterface $sessionManager,
+        SessionInterface $liveSession,
+        MetadataFactoryInterface $metadataFactory,
+        StructureMetadataFactory $structureMetadataFactory,
+        PropertyEncoder $propertyEncoder
+    ) {
+        $this->webspaceManager = $webspaceManager;
+        $this->sessionManager = $sessionManager;
+        $this->liveSession = $liveSession;
+        $this->metadataFactory = $metadataFactory;
+        $this->structureMetadataFactory = $structureMetadataFactory;
+        $this->propertyEncoder = $propertyEncoder;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
         $this->setName('sulu:content:resource-locator:maintain')
-            ->setDescription('Resets the cached url value on every node');
+            ->setDescription('Resets the cached url value on every node in the live workspace');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var WebspaceManagerInterface $webspaceManager */
-        $webspaceManager = $this->getContainer()->get('sulu_core.webspace.webspace_manager');
-
         /** @var Webspace $webspace */
-        foreach ($webspaceManager->getWebspaceCollection() as $webspace) {
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             $this->upgradeWebspace($webspace, $output);
         }
+
+        $this->liveSession->save();
     }
 
     private function upgradeWebspace(Webspace $webspace, OutputInterface $output)
@@ -65,93 +110,84 @@ class MaintainResourceLocatorCommand extends ContainerAwareCommand
     {
         $output->writeln('  > Upgrade Locale: ' . $localization->getLocalization('-'));
 
-        /** @var ContentMapperInterface $contentMapper */
-        $contentMapper = $this->getContainer()->get('sulu.content.mapper');
-        $startPage = $contentMapper->loadStartPage($webspace->getKey(), $localization->getLocalization());
+        $contentNode = $this->liveSession->getNode($this->sessionManager->getContentPath($webspace->getKey()));
 
-        $this->upgradeNode($startPage, $webspace, $localization, $output);
-        $this->upgradeByParent($startPage, $webspace, $localization, $contentMapper, $output);
+        $this->upgradeNode($contentNode, $webspace, $localization, $output);
+        $this->upgradeByParent($contentNode, $webspace, $localization, $output);
     }
 
     private function upgradeByParent(
-        StructureBridge $parent,
+        NodeInterface $parentNode,
         Webspace $webspace,
         Localization $localization,
-        ContentMapperInterface $contentMapper,
         OutputInterface $output
     ) {
-        $pages = $contentMapper->loadByParent(
-            $parent->getUuid(),
-            $webspace->getKey(),
-            $localization->getLocalization(),
-            1
-        );
-
-        foreach ($pages as $page) {
-            $this->upgradeNode($page, $webspace, $localization, $output, substr_count($page->getPath(), '/'));
-            $this->upgradeByParent($page, $webspace, $localization, $contentMapper, $output);
+        foreach ($parentNode->getNodes() as $childNode) {
+            $this->upgradeNode($childNode, $webspace, $localization, $output, substr_count($childNode->getPath(), '/'));
+            $this->upgradeByParent($childNode, $webspace, $localization, $output);
         }
     }
 
     private function upgradeNode(
-        StructureBridge $page,
+        NodeInterface $node,
         Webspace $webspace,
         Localization $localization,
         OutputInterface $output,
         $depth = 0
     ) {
-        /** @var SessionManagerInterface $sessionManager */
-        $sessionManager = $this->getContainer()->get('sulu.phpcr.session');
-        $session = $sessionManager->getSession();
-        $node = $session->getNodeByIdentifier($page->getUuid());
+        $locale = $localization->getLocale();
 
-        /** @var RlpStrategyInterface $strategy */
-        $strategy = $this->getContainer()->get('sulu.content.rlp.strategy.tree');
-
-        /** @var ResourceLocator $resourceLocator */
-        $resourceLocator = $this->getContainer()->get('sulu.content.type.resource_locator');
-
-        if (!$page->hasTag('sulu.rlp')) {
+        $localizedTemplatePropertyName = $this->propertyEncoder->localizedSystemName('template', $locale);
+        if (!$node->hasProperty($localizedTemplatePropertyName)) {
             return;
         }
 
-        $property = $page->getPropertyByTagName('sulu.rlp');
-        if (
-            $property->getContentTypeName() !== 'resource_locator' &&
-            $page->getNodeType() !== Structure::NODE_TYPE_CONTENT
-        ) {
-            return;
-        }
-
-        $transProperty = new TranslatedProperty(
-            $property,
-            $localization->getLocalization(),
-            $this->getContainer()->getParameter('sulu.content.language.namespace')
+        $structureMetadata = $this->structureMetadataFactory->getStructureMetadata(
+            $this->metadataFactory->getMetadataForPhpcrNode($node)->getAlias(),
+            $node->getPropertyValue($localizedTemplatePropertyName)
         );
 
-        try {
-            // load value
-            $rl = $strategy->loadByContent($node, $webspace->getKey(), $localization->getLocalization());
+        $property = $structureMetadata->getPropertyByTagName('sulu.rlp');
+        if (!$property) {
+            return;
+        }
 
-            // save value
-            $property->setValue($rl);
-            $resourceLocator->write(
-                $node,
-                $transProperty,
-                1,
-                $webspace->getKey(),
-                $localization->getLocalization(),
-                null
-            );
-            $session->save();
+        $nodeType = $node->getPropertyValue($this->propertyEncoder->localizedSystemName('nodeType', $locale));
+        if ($property->getContentTypeName() !== 'resource_locator' && $nodeType !== Structure::NODE_TYPE_CONTENT) {
+            return;
+        }
 
-            $prefix = '   ';
-            for ($i = 0; $i < $depth; ++$i) {
-                $prefix .= '-';
+        $baseRoutePath = $this->sessionManager->getRoutePath($webspace->getKey(), $localization->getLocale());
+        foreach ($node->getReferences('sulu:content') as $routeProperty) {
+            if (strpos($routeProperty->getPath(), $baseRoutePath) !== 0) {
+                continue;
             }
 
-            $output->writeln($prefix . '> "' . $page->getPropertyValue('title') . '": ' . $rl);
-        } catch (ResourceLocatorNotFoundException $ex) {
+            $routeNode = $routeProperty->getParent();
+            if ($routeNode->getPropertyValue('sulu:history') === true) {
+                continue;
+            }
+
+            $resourceLocator = substr($routeNode->getPath(), strlen($baseRoutePath));
+
+            if ($resourceLocator) {
+                // only set if resource locator is not empty
+                // if the resource locator is empty it is the homepage, whose url should not be changed
+                $node->setProperty(
+                    $this->propertyEncoder->localizedContentName($property->getName(), $locale),
+                    $resourceLocator
+                );
+
+                $prefix = '   ';
+                for ($i = 0; $i < $depth; ++$i) {
+                    $prefix .= '-';
+                }
+
+                $title = $node->getPropertyValue($this->propertyEncoder->localizedContentName('title', $locale));
+                $output->writeln($prefix . '> "' . $title . '": ' . $resourceLocator);
+            }
+
+            break;
         }
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -144,6 +144,7 @@ class SuluContentExtension extends Extension implements PrependExtensionInterfac
         $loader->load('compat.xml');
         $loader->load('document.xml');
         $loader->load('serializer.xml');
+        $loader->load('command.xml');
     }
 
     private function processTemplates(ContainerBuilder $container, $config)

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/command.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_content.command.maintain_resource_locator"
+                 class="Sulu\Bundle\ContentBundle\Command\MaintainResourceLocatorCommand">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="service" id="sulu.phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.live_session"/>
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
+            <argument type="service" id="sulu_content.structure.factory"/>
+            <argument type="service" id="sulu_document_manager.property_encoder"/>
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>
+

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Command/MaintainResourceLocatorCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Command/MaintainResourceLocatorCommandTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Command;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Bundle\ContentBundle\Command\MaintainResourceLocatorCommand;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\PropertyEncoder;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Document\RedirectType;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
+use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MaintainResourceLocatorCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var SessionManagerInterface
+     */
+    private $sessionManager;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var StructureMetadataFactory
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var MaintainResourceLocatorCommand
+     */
+    private $maintainResourceLocatorCommand;
+
+    /**
+     * @var InputInterface
+     */
+    private $input;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function setUp()
+    {
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->sessionManager = $this->prophesize(SessionManagerInterface::class);
+        $this->liveSession = $this->prophesize(SessionInterface::class);
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->structureMetadataFactory = $this->prophesize(StructureMetadataFactory::class);
+        $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
+
+        $this->maintainResourceLocatorCommand = new MaintainResourceLocatorCommand(
+            $this->webspaceManager->reveal(),
+            $this->sessionManager->reveal(),
+            $this->liveSession->reveal(),
+            $this->metadataFactory->reveal(),
+            $this->structureMetadataFactory->reveal(),
+            $this->propertyEncoder->reveal()
+        );
+
+        $this->input = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+    }
+
+    public function testExecute()
+    {
+        $webspace1 = new Webspace();
+        $webspace1->setKey('sulu_io');
+        $webspace1->addLocalization(new Localization('de'));
+
+        $this->webspaceManager->getWebspaceCollection()->willReturn([$webspace1]);
+
+        $this->sessionManager->getContentPath('sulu_io')->willReturn('/cmf/sulu_io/contents');
+        $this->sessionManager->getRoutePath('sulu_io', 'de')->willReturn('/cmf/sulu_io/routes/de');
+        $this->propertyEncoder->localizedSystemName('template', 'de')->willReturn('i18n:de-template');
+        $this->propertyEncoder->localizedSystemName('nodeType', 'de')->willReturn('i18n:de-nodeType');
+        $this->propertyEncoder->localizedContentName('url', 'de')->willReturn('i18n:de-url');
+        $this->propertyEncoder->localizedContentName('title', 'de')->willReturn('i18n:de-title');
+
+        $liveContentNode = $this->prophesize(NodeInterface::class);
+        $this->liveSession->getNode('/cmf/sulu_io/contents')->willReturn($liveContentNode);
+        $this->liveSession->save()->shouldBeCalled();
+
+        $metadata = new Metadata();
+        $metadata->setAlias('page');
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getContentTypeName()->willReturn('resource_locator');
+        $property->getName()->willReturn('url');
+        $structureMetadata = $this->prophesize(StructureMetadata::class);
+        $structureMetadata->getPropertyByTagName('sulu.rlp')->willReturn($property->reveal());
+
+        $this->metadataFactory->getMetadataForPhpcrNode($liveContentNode->reveal())->willReturn($metadata);
+        $liveContentNode->getPropertyValue('i18n:de-template')->willReturn('default');
+        $liveContentNode->hasProperty('i18n:de-template')->willReturn(false);
+        $liveContentNode->getPropertyValue('i18n:de-nodeType')->shouldNotBeCalled();
+        $liveContentNode->getReferences('sulu:content')->shouldNotBeCalled();
+        $this->structureMetadataFactory->getStructureMetadata('page', 'default')
+            ->willReturn($structureMetadata->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $this->metadataFactory->getMetadataForPhpcrNode($node->reveal())->willReturn($metadata);
+        $node->getPropertyValue('i18n:de-template')->willReturn('default');
+        $node->hasProperty('i18n:de-template')->willReturn(true);
+        $node->getPropertyValue('i18n:de-nodeType')->willReturn(RedirectType::NONE);
+        $node->getPath()->willReturn('/cmf/sulu_io/contents/test');
+        $node->getPropertyValue('i18n:de-title')->willReturn('test');
+
+        $historyRouteProperty = $this->prophesize(NodeInterface::class);
+        $historyRouteProperty->getPath()->willReturn('/cmf/sulu_io/routes/de/test/sulu:content');
+        $historyRouteNode = $this->prophesize(NodeInterface::class);
+        $historyRouteNode->getPropertyValue('sulu:history')->willReturn(true);
+        $historyRouteProperty->getParent()->willReturn($historyRouteNode->reveal());
+
+        $routeProperty = $this->prophesize(NodeInterface::class);
+        $routeProperty->getPath()->willReturn('/cmf/sulu_io/routes/de/testng/sulu:content');
+        $routeNode = $this->prophesize(NodeInterface::class);
+        $routeNode->getPropertyValue('sulu:history')->willReturn(false);
+        $routeNode->getPath()->willReturn('/cmf/sulu_io/routes/de/testing');
+        $routeProperty->getParent()->willReturn($routeNode->reveal());
+        $node->getReferences('sulu:content')->willReturn([$historyRouteProperty->reveal(), $routeProperty->reveal()]);
+
+        $node->getNodes()->willReturn([]);
+        $this->structureMetadataFactory->getStructureMetadata('page', 'default')
+            ->willReturn($structureMetadata->reveal());
+        $liveContentNode->getNodes()->willReturn([$node->reveal()]);
+
+        $node->setProperty('i18n:de-url', '/testing')->shouldBeCalled();
+
+        $executeMethod = new \ReflectionMethod($this->maintainResourceLocatorCommand, 'execute');
+        $executeMethod->setAccessible(true);
+
+        $executeMethod->invoke($this->maintainResourceLocatorCommand, $this->input->reveal(), $this->output->reveal());
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -113,7 +113,7 @@ class DocumentInspector extends BaseDocumentInspector
     {
         return $this->structureFactory->getStructureMetadata(
             $this->getMetadata($document)->getAlias(),
-            $structureType = $document->getStructureType()
+            $document->getStructureType()
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2818
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the command for maintaining the resource locator. It only fixes them in the live workspace, because on the draft workspace it might contain data that has been edited by the content manager.