### PR TITLE
use new reindex command in IndexBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+<<<<<<< e6bdf47eb60571109973b78ca1d126e211fea931
     * HOTFIX      #2873 [ContentBundle]       Include live session in CleanupHistoryCommand
+=======
+    * HOTFIX      #2874 [SearchBundle]        Use new reindex command in IndexBuilder
+>>>>>>> use new reindex command in IndexBuilder
     * HOTFIX      #2870 [ContentBundle]       Fixed NodeOrderBuilder for publishing
     * HOTFIX      #2869 [ContentBundle]       Fixed maintain command for resource locator
     * HOTFIX      #2864 [MediaBundle]         Return 404 http code for not existing media

--- a/src/Sulu/Bundle/SearchBundle/Build/IndexBuilder.php
+++ b/src/Sulu/Bundle/SearchBundle/Build/IndexBuilder.php
@@ -43,6 +43,6 @@ class IndexBuilder extends SuluBuilder
      */
     public function build()
     {
-        $this->execCommand('Create search indexes', 'sulu:search:reindex-content');
+        $this->execCommand('Create search indexes', 'massive:search:reindex');
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2818 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR uses the `massive:search:reindex` command in the `IndexBuilder`.

#### Why?

Because the previously used command doesn't exist anymore.