### PR TITLE
Fix toArray function in Contact Entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #2743 [CoreBundle]          Remove symfony deprecations and don't allow them anymore
     * BUGFIX      #2810 [ContentBundle]       Add missing translation of Content navigation tab 
     * FEATURE     #2749 [Webspace]            Added resource-locator strategy tree_full_edit
+    * BUGFIX      #2885 [ContactBundle]       Fixed toArray-Function
 
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -1017,7 +1017,7 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
     public function toArray()
     {
         return [
-            'id' => $this->getLastName(),
+            'id' => $this->getId(),
             'firstName' => $this->getFirstName(),
             'middleName' => $this->getMiddleName(),
             'lastName' => $this->getLastName(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | only if somebody used it wrong before
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR fixes the return result of the toArray Function inside the Contact Entity. Now it returns the contacts id, not its lastname.

#### Why?

Without this PR the toArray function returns the contacts lastname as id. 

