### PR TITLE
Reintroducing localization provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2890 [Localization]        Reintroduced localization provider class
     * HOTFIX      #2876 [MediaBundle]         Changed column navigation to markable and ok button
     * HOTFIX      #2876 [ContentBundle]       Changed column navigation to markable and ok button
     * HOTFIX      #2883 [WebsiteBundle]       Fixed translator locale for localizations with country

--- a/src/Sulu/Component/Localization/Provider/LocalizationProvider.php
+++ b/src/Sulu/Component/Localization/Provider/LocalizationProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Localization\Provider;
+
+use Sulu\Component\Localization\Localization;
+
+/**
+ * Basic localization provider.
+ */
+class LocalizationProvider implements LocalizationProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $locales;
+
+    /**
+     * @param array $locales
+     */
+    public function __construct(array $locales)
+    {
+        $this->locales = $locales;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllLocalizations()
+    {
+        $result = [];
+        foreach ($this->locales as $locale) {
+            $result[] = $this->parse($locale);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Converts locale string to localization object.
+     *
+     * @param string $locale E.g. de_at or de
+     *
+     * @return Localization
+     */
+    private function parse($locale)
+    {
+        $parts = explode('_', $locale);
+
+        $localization = new Localization();
+        $localization->setLanguage($parts[0]);
+        if (count($parts) > 1) {
+            $localization->setCountry($parts[1]);
+        }
+
+        return $localization;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | kind of
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | nope
| Related issues/PRs | no
| License | MIT
| Documentation PR | sulu/sulu-docs#271

#### What's in this PR?

This PR reintroduces the localization provider class which got removed in Sulu version 1.3 (http://github.com/sulu/sulu/pull/2618)

#### Why?

Before it was possible to add system locales by just create a tagged service. With the removal of the localization provider every bundle would have to create it's own localization provider class.

Now it's possible to add locales by simple defining a service as follows:

Example:

```{xml}
    <service id="sulu_product.localization_provider" class="Sulu\Component\Localization\Provider\LocalizationProvider">
        <argument>%sulu_core.locales%</argument>

        <tag name="sulu.localization_provider"/>
    </service>
```

#### To Do

- [x] Create a documentation page