### PR TITLE
Fix limit in SearchController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2810 [ContentBundle]       Add missing translation of Content navigation tab 
     * FEATURE     #2749 [Webspace]            Added resource-locator strategy tree_full_edit
     * BUGFIX      #2885 [ContactBundle]       Fixed toArray-Function
+    * BUGFIX      #2896 [SearchBundle]        Fixed limit in query
 
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release

--- a/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
@@ -113,6 +113,7 @@ class SearchController
         }
 
         $query->indexes($indexes);
+        $query->setLimit($limit);
 
         $time = microtime(true) - $startTime;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR adds the requested limit to the search query. Otherwise the searchquery would return 10 entries, ignoring the requests limit.

#### Why?

Otherwise you are not able to get more than 10 searchresults. If you use the 'all' index, it could be possible you only get one type of results although there are even more.