### PR TITLE
Improved bug with grid elements not floating correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2900 [ContentBundle]       Improved bug with grid elements not floating correctly
     * ENHANCEMENT #2927 [ContactBundle]       Enables the extensibility of matchings for contact-selection
     * BUGFIX      #2925 [WebsiteBundle]       Fixed seo when no data is available
     * FEATURE     #2920 [WebsiteBundle]       Seo info as twig template to make it rewriteable

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
@@ -50,8 +50,24 @@
                                     <div class="type-select"></div>
                                 </div>
                             </div>
+                            {# initialize columns #}
+                            {% set columns = 0 %}
                             <div class="block block-{{ property.name }}">
+                                <div class="grid-row small">
                                 {% for child in type.childProperties %}
+                                    {# set childColspan with default if colspan is not set #}
+                                    {% set childColspan = child.colspan != "" ? child.colspan : 12 %}
+
+                                    {# create new row if there are more then 12 colspans in a row #}
+                                    {% if columns + childColspan <= 12 %}
+                                        {# set current amount of colspans #}
+                                        {% set columns = columns + childColspan %}
+                                    {% else %}
+                                        </div>
+                                        <div class="grid-row small">
+                                        {# set current amount of colspans #}
+                                        {% set columns = childColspan %}
+                                    {% endif %}
 
                                     {# get Type for property #}
                                     {% set type = sulu_get_type(child.contentTypeName) %}
@@ -64,7 +80,7 @@
                                         {% include 'SuluContentBundle:Template:macros/single.html.twig' with {'property': child, 'params': params, 'type': type, 'id': id ~ '-' ~ child.name ~ '<~=index~>', 'webspaceKey': webspaceKey, 'languageCode': languageCode, 'userLocale': userLocale} only %}
                                     {% endif %}
                                 {% endfor %}
-                                <div class="clear"></div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content.html.twig
@@ -26,7 +26,24 @@
     {% endif %}
 
     <div class="fixed-width">
+        <div class="grid-row">
+        {# initialize columns #}
+        {% set columns = 0 %}
         {% for property in template.properties if property != firstSection %}
+
+            {# set propertyColspan with default if colspan is not set #}
+            {% set propertyColspan = property.colspan != "" ? property.colspan : 12 %}
+
+            {# create new row if there are more then 12 colspans in a row #}
+            {% if columns + propertyColspan <= 12 %}
+                {# set current amount of colspans #}
+                {% set columns = columns + propertyColspan %}
+            {% else %}
+                </div>
+                <div class="grid-row">
+                {# set current amount of colspans #}
+                {% set columns = propertyColspan %}
+            {% endif %}
 
             {# get params for property #}
             {% set params = sulu_get_params(property) %}
@@ -82,6 +99,7 @@
                 {% endif %}
             {% endif %}
         {% endfor %}
+        </div>
     </div>
 </form>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/issues/646
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Improves problem with elements not floating correctly.

#### Example Usage

Please do not use grid like this:

```
<div class="grid">
    <div class="grid-row">
        <div class="grid-col-9 floating form-group" />
        <div class="grid-col-3 floating form-group" />
        <div class="grid-col-9 floating form-group" />
        <div class="grid-col-3 floating form-group" />
    </div>
</div>
```

Use it like this:

```
<div class="grid">
    <div class="grid-row">
        <div class="grid-col-9 floating form-group" />
        <div class="grid-col-3 floating form-group" />
    </div>
    <div class="grid-row">
        <div class="grid-col-9 floating form-group" />
        <div class="grid-col-3 floating form-group" />
    </div>
</div>
```