### PR TITLE
Added route-provider cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #2904 [RouteBundle]         Added route-provider cache
     * BUGFIX      #2893 [ContentBundle]       Fixed stop overlay-component for teaser-selection
     * BUGFIX      #2878 [ContentBundle]       Added instanceof check for shadow-behavior functions
     * FEATURE     #2875 [RouteBundle]         Added route-content-type


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces an array-cache in the route-provider which enhances the generation of route objects.

#### Why?

This Provider will be called mutliple times when using Symfony router.

#### To Do

- [ ] Tests

