### PR TITLE
various category backend enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #2910 [ContentBundle]       Updated husky and added placeholder param to date
+    * BUGFIX      #2913 [CategoryBundle]      Changed doctrine mapping from entity to mapped-superclass for category-entities
+    * ENHANCEMENT #2913 [CategoryBundle]      Added DeprecationCompilerPassTest in CategoryBundle
     * ENHANCEMENT #2912 [CategoryBundle]      Implemented category-bundle entities extensible
     * ENHANCEMENT #2912 [CategoryBundle]      Refactored CategoryBundle backend
     * ENHANCEMENT #2903 [RouteBundle]         Get class mapping configuration by class name or inheritance chain

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -314,7 +314,7 @@ class CategoryManager implements CategoryManagerInterface
     public function save($data, $userId, $locale, $patch = false)
     {
         if ($this->getProperty($data, 'id')) {
-            $categoryEntity = $this->findById($this->getProperty($data, 'id'), $locale);
+            $categoryEntity = $this->findById($this->getProperty($data, 'id'));
         } else {
             $categoryEntity = $this->categoryRepository->createNew();
         }
@@ -355,7 +355,7 @@ class CategoryManager implements CategoryManagerInterface
         }
         if (!$patch || $this->getProperty($data, 'parent')) {
             if ($this->getProperty($data, 'parent')) {
-                $parentEntity = $this->findById($this->getProperty($data, 'parent'), $locale);
+                $parentEntity = $this->findById($this->getProperty($data, 'parent'));
             } else {
                 $parentEntity = null;
             }
@@ -387,7 +387,7 @@ class CategoryManager implements CategoryManagerInterface
             throw new CategoryIdNotFoundException($id);
         }
 
-        /** @var CategoryTranslation $translation */
+        /** @var CategoryTranslationInterface $translation */
         foreach ($entity->getTranslations() as $translation) {
             foreach ($translation->getKeywords() as $keyword) {
                 $this->keywordManager->delete($keyword, $entity);

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManagerInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManagerInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\CategoryBundle\Category;
 
-use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Exception\CategoryIdNotFoundException;
 use Sulu\Bundle\CategoryBundle\Exception\CategoryKeyNotFoundException;
 use Sulu\Bundle\CategoryBundle\Exception\CategoryKeyNotUniqueException;
@@ -29,7 +29,7 @@ interface CategoryManagerInterface
      *
      * @param int $id
      *
-     * @return Category
+     * @return CategoryInterface
      *
      * @throws CategoryIdNotFoundException if the given id is not assigned to an existing category
      */
@@ -40,7 +40,7 @@ interface CategoryManagerInterface
      *
      * @param string $key
      *
-     * @return Category
+     * @return CategoryInterface
      *
      * @throws CategoryKeyNotFoundException if the given key is not assigned to an existing category
      */
@@ -52,7 +52,7 @@ interface CategoryManagerInterface
      *
      * @param array $ids
      *
-     * @return Category[]
+     * @return CategoryInterface[]
      */
     public function findByIds(array $ids);
 
@@ -65,7 +65,7 @@ interface CategoryManagerInterface
      * @param string|null $sortBy    column name to sort the categories by
      * @param string|null $sortOrder sort order
      *
-     * @return Category[]
+     * @return CategoryInterface[]
      *
      * @deprecated Use ::findChildrenByParentId instead
      */
@@ -90,7 +90,7 @@ interface CategoryManagerInterface
      * @param string|null $sortBy    column name to sort by
      * @param string|null $sortOrder sort order
      *
-     * @return Category[]
+     * @return CategoryInterface[]
      *
      * @deprecated Use ::findChildrenByParentKey instead
      */
@@ -118,7 +118,7 @@ interface CategoryManagerInterface
      * @param $locale
      * @param bool $patch
      *
-     * @return Category
+     * @return CategoryInterface
      *
      * @throws CategoryIdNotFoundException if data.id is set, but the id is not assigned to a existing category
      * @throws CategoryKeyNotUniqueException
@@ -142,7 +142,7 @@ interface CategoryManagerInterface
      * @param \Sulu\Bundle\CategoryBundle\Entity\CategoryInterface $category
      * @param string   $locale
      *
-     * @return Category
+     * @return CategoryInterface
      */
     public function getApiObject($category, $locale);
 
@@ -152,7 +152,7 @@ interface CategoryManagerInterface
      * @param \Sulu\Bundle\CategoryBundle\Entity\CategoryInterface[] $categories
      * @param string     $locale
      *
-     * @return Category
+     * @return CategoryInterface
      */
     public function getApiObjects($categories, $locale);
 

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
-    <entity name="Sulu\Bundle\CategoryBundle\Entity\Category" table="ca_categories">
+    <mapped-superclass name="Sulu\Bundle\CategoryBundle\Entity\Category" table="ca_categories">
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
@@ -41,5 +41,5 @@
         <one-to-many field="children" target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryInterface" mapped-by="parent"/>
 
         <gedmo:tree type="nested"/>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryMeta.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryMeta.orm.xml
@@ -3,7 +3,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Sulu\Bundle\CategoryBundle\Entity\CategoryMeta" table="ca_category_meta">
+    <mapped-superclass name="Sulu\Bundle\CategoryBundle\Entity\CategoryMeta" table="ca_category_meta">
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
@@ -20,5 +20,5 @@
                 <join-column name="idCategories" on-delete="CASCADE" referenced-column-name="id" nullable="false"/>
             </join-columns>
         </many-to-one>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
@@ -3,7 +3,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation" table="ca_category_translations">
+    <mapped-superclass name="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation" table="ca_category_translations">
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
@@ -21,5 +21,5 @@
         </many-to-one>
         <many-to-many field="keywords" mapped-by="categoryTranslations"
                       target-entity="Sulu\Bundle\CategoryBundle\Entity\KeywordInterface"/>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
@@ -3,7 +3,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Sulu\Bundle\CategoryBundle\Entity\Keyword" table="ca_keywords">
+    <mapped-superclass name="Sulu\Bundle\CategoryBundle\Entity\Keyword" table="ca_keywords">
         <indexes>
             <index columns="keyword"/>
         </indexes>
@@ -30,5 +30,5 @@
                 </inverse-join-columns>
             </join-table>
         </many-to-many>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Content/Types/CategoryListTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Content/Types/CategoryListTest.php
@@ -21,8 +21,8 @@ class CategoryListTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetContentData()
     {
-        $entity1 = $this->prophesize(\Sulu\Bundle\CategoryBundle\Entity\Category::class);
-        $entity2 = $this->prophesize(\Sulu\Bundle\CategoryBundle\Entity\Category::class);
+        $entity1 = $this->prophesize(\Sulu\Bundle\CategoryBundle\Entity\CategoryInterface::class);
+        $entity2 = $this->prophesize(\Sulu\Bundle\CategoryBundle\Entity\CategoryInterface::class);
 
         $category1 = $this->prophesize(Category::class);
         $category1->toArray()->willReturn('someArrayData');

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/DependencyInjection/DeprecationCompilerPassTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/DependencyInjection/DeprecationCompilerPassTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sulu\Bundle\CategoryBundle\DependencyInjection\DeprecationCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Test the deprecation transformation compiler pass.
+ */
+class DeprecationCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DeprecationCompilerPass());
+    }
+
+    public function testDeprecatedEntityParameters()
+    {
+        $this->setParameter('sulu.model.category.class', 'path-to-category-entity');
+        $this->setParameter('sulu.model.keyword.class', 'path-to-keyword-entity');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('sulu_category.entity.category', 'path-to-category-entity');
+        $this->assertContainerBuilderHasParameter('sulu_category.entity.keyword', 'path-to-keyword-entity');
+    }
+
+    public function testDeprecatedRepositoryServices()
+    {
+        $categoryRepositoryDefinition = new Definition();
+        $this->setDefinition('sulu.repository.category', $categoryRepositoryDefinition);
+        $keywordRepositoryDefinition = new Definition();
+        $this->setDefinition('sulu.repository.keyword', $keywordRepositoryDefinition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasAlias('sulu_category.category_repository', 'sulu.repository.category');
+        $this->assertContainerBuilderHasAlias('sulu_category.keyword_repository', 'sulu.repository.keyword');
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR implements three category backend enhancements:

1. added DeprecationCompilerPassTest
The DeprecationCompilerPassTest checks if the DeprecationCompilerPass is working as expected.

2. adjusted return-/variable-types to interfaces
The type of multiple category related classes is changed from the entity to the respective entity-interface to ensure extensibility.

3. changed doctrine mapping from entity to mapped-superclass
The doctrine mapping of the category-entities is changed from entity to mapped-superclass to enable extending these entities.