### PR TITLE
Make seo info rewriteable by using a twig template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #---- [WebsiteBundle]       Seo info as twig template to make it rewriteable
     * BUGFIX      #2915 [MediaBundle]         Fixed height of badges in media-selection
     * ENHANCEMENT #2860 [ContentBundle]       Added url to internal links and smart-content
     * FEATURE     #2914 [CategoryBundle]      Added description and medias to category

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * FEATURE     #---- [WebsiteBundle]       Seo info as twig template to make it rewriteable
+    * FEATURE     #2919 [WebsiteBundle]       Seo info as twig template to make it rewriteable
     * BUGFIX      #2915 [MediaBundle]         Fixed height of badges in media-selection
     * ENHANCEMENT #2860 [ContentBundle]       Added url to internal links and smart-content
     * FEATURE     #2914 [CategoryBundle]      Added description and medias to category

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Extension/seo.html.twig
@@ -1,0 +1,76 @@
+{#-
+ # content array
+ # defaultLocale string
+ # seo array
+ # shadowBaseLocale string
+ # urls array
+-#}
+
+{#- set variables -#}
+{% set seo = seo|merge(app.request.get('_seo', [])) %}
+
+{#- fallback to content title when no seo title is set -#}
+{% set seoTitle = seo.title|default(content.title|default()) %}
+{% set seoDescription = seo.description %}
+{% set seoKeywords = seo.keywords %}
+
+{% set seoRobots = '' %}
+{%- if seo.noIndex|default(false) -%}
+    {% set seoRobots = seoRobots ~ 'noIndex' -%}
+{%- else -%}
+    {% set seoRobots = seoRobots ~ 'index' -%}
+{%- endif -%}
+{%- if seo.noFollow|default(false) -%}
+    {% set seoRobots = seoRobots ~ ',noFollow' -%}
+{%- else -%}
+    {% set seoRobots = seoRobots ~ ',follow' -%}
+{%- endif -%}
+
+{% set seoCanonical = seo.canonicalUrl %}
+
+{%- if not seoCanonical and shadowBaseLocale and urls[shadowBaseLocale]|default() %}
+    {% set seoCanonical = sulu_content_path(urls[shadowBaseLocale], null, locale) %}
+{%- endif -%}
+
+{#- render blocks -#}
+
+{%- block title -%}
+    {%- if seoTitle -%}
+        <title>{{ seoTitle }}</title>
+    {%- endif -%}
+{%- endblock -%}
+
+{%- block description -%}
+    {%- if seoDescription -%}
+        <meta name="description" content="{{ seoDescription }}"/>
+    {%- endif -%}
+{%- endblock -%}
+
+{%- block keywords -%}
+    {%- if seoKeywords -%}
+        <meta name="keywords" content="{{ seoKeywords }}"/>
+    {%- endif -%}
+{%- endblock -%}
+
+{%- block robots -%}
+    {%- if seoRobots -%}
+        <meta name="robots" content="{{ seoRobots }}"/>
+    {%- endif -%}
+{%- endblock -%}
+
+{%- block urls -%}
+    {#- when only one language do not show alternative -#}
+    {%- if urls|length > 1 -%}
+        {%- for locale, url in urls -%}
+            {%- if defaultLocale == locale -%}
+                <link rel="alternate" href="{{ sulu_content_path(url, null, locale) }}" hreflang="x-default"/>
+            {%- endif -%}
+            <link rel="alternate" href="{{ sulu_content_path(url, null, locale) }}" hreflang="{{ locale }}"/>
+        {%- endfor -%}
+    {%- endif -%}
+{%- endblock -%}
+
+{%- block canonical -%}
+    {#- Set canonical to itself if a bot clone the page -#}
+    <link rel="canonical" href="{{ seoCanonical|default(app.request.uri) }}"/>
+{%- endblock -%}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -61,13 +61,16 @@ class SeoTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_seo', [$this, 'renderSeoTags']),
+            new \Twig_SimpleFunction('sulu_seo', [$this, 'renderSeoTags'], ['needs_environment' => true]),
         ];
     }
 
     /**
+     * @deprecated use the twig include function to render the seo.
+     *
      * Renders all the SEO tags supported by Sulu.
      *
+     * @param \Twig_Environment $twig
      * @param array $seoExtension The values delivered by the SEO extension of Sulu
      * @param array $content The content of the current page
      * @param string[] $urls All the localized URLs for the current page
@@ -75,206 +78,35 @@ class SeoTwigExtension extends \Twig_Extension
      *
      * @return string The rendered HTML tags of the SEO extension
      */
-    public function renderSeoTags(array $seoExtension, array $content, array $urls, $shadowBaseLocale)
-    {
-        $request = $this->requestStack->getCurrentRequest();
-        $requestSeo = $request->get('_seo', []);
-        $seoExtension = array_merge($seoExtension, $requestSeo);
+    public function renderSeoTags(
+        \Twig_Environment $twig,
+        array $seoExtension,
+        array $content,
+        array $urls,
+        $shadowBaseLocale
+    ) {
+        $template = 'SuluWebsiteBundle:Extension:seo.html.twig';
 
-        $html = '';
-        // FIXME this is only necessary because we have to set a default parameter
-        $webspace = $this->requestAnalyzer->getWebspace();
-        $webspaceKey = null;
-        if ($webspace) {
-            $webspaceKey = $webspace->getKey();
-        }
-
-        $request = $this->requestStack->getCurrentRequest();
-
-        $html .= $this->renderTitle($seoExtension, $content);
-        $html .= $this->renderMetaTags($seoExtension);
-        $html .= $this->renderAlternateLinks($urls, $webspaceKey, $request->getScheme());
-        $html .= $this->renderCanonicalTag(
-            $seoExtension,
-            $urls,
-            $shadowBaseLocale,
-            $webspaceKey,
-            $request->getScheme()
+        @trigger_error(
+            'This twig extension is deprecated and should not be used anymore, include the "%s".',
+            $template
         );
-
-        return $html;
-    }
-
-    /**
-     * Renders the correct title of the current page. The correct title is either the title provided by the SEO
-     * extension, or the title of the content, if the SEO extension does not provide one.
-     *
-     * @param array $seoExtension The values delivered by the SEO extension of Sulu
-     * @param array $content The content of the current page
-     *
-     * @return string The rendered title tag
-     */
-    private function renderTitle(array $seoExtension, array $content)
-    {
-        $titleHtml = '<title>%s</title>';
-
-        if (isset($seoExtension['title']) && $seoExtension['title'] !== '') {
-            return sprintf($titleHtml, htmlentities($seoExtension['title']));
-        }
-
-        if (isset($content['title'])) {
-            return sprintf($titleHtml . PHP_EOL, htmlentities($content['title']));
-        }
-
-        return '';
-    }
-
-    /**
-     * Renders the meta tags of the SEO extension. Contains the description, keywords and the robots settings.
-     *
-     * @param array $seoExtension The values delivered by the SEO extension of Sulu
-     *
-     * @return string The rendered meta tags
-     */
-    private function renderMetaTags(array $seoExtension)
-    {
-        $html = '';
-
-        if (isset($seoExtension['description']) && $seoExtension['description'] !== '') {
-            $html .= $this->renderMetaTag('description', $seoExtension['description']);
-        }
-
-        if (isset($seoExtension['keywords']) && $seoExtension['keywords'] !== '') {
-            $html .= $this->renderMetaTag('keywords', $seoExtension['keywords']);
-        }
-
-        $robots = [];
-        if (isset($seoExtension['noIndex']) && $seoExtension['noIndex'] === true) {
-            $robots[] = 'noIndex';
-        } else {
-            $robots[] = 'index';
-        }
-
-        if (isset($seoExtension['noFollow']) && $seoExtension['noFollow'] === true) {
-            $robots[] = 'noFollow';
-        } else {
-            $robots[] = 'follow';
-        }
-
-        $html .= $this->renderMetaTag('robots', implode(',', $robots));
-
-        return $html;
-    }
-
-    /**
-     * Renders a simple meta tag.
-     *
-     * @param string $name The name of the meta tag
-     * @param string $content The content of the meta tag
-     *
-     * @return string The HTMl meta tag filled with the given values
-     */
-    private function renderMetaTag($name, $content)
-    {
-        return sprintf('<meta name="%s" content="%s"/>' . PHP_EOL, $name, htmlentities($content));
-    }
-
-    /**
-     * Renders the alternate links for this page, this means all the localizations in which this page is available. In
-     * addition the default localization is also rendered.
-     *
-     * @param string[] $urls All the localized URLs for the current page
-     * @param string $webspaceKey The key of the current webspace
-     * @param string $scheme scheme of request (http or https)
-     *
-     * @return string The rendered HTML tags
-     */
-    private function renderAlternateLinks(array $urls, $webspaceKey, $scheme)
-    {
-        $html = '';
-        $concreteTranslations = 0;
 
         $defaultLocale = null;
         $portal = $this->requestAnalyzer->getPortal();
         if ($portal) {
-            $defaultLocale = $portal->getXDefaultLocalization()->getLocalization();
+            $defaultLocale = $portal->getXDefaultLocalization()->getLocale();
         }
 
-        foreach ($urls as $locale => $url) {
-            // url = '/' means that there is no translation for this page
-            // the only exception is the homepage where the requested resource-locator is false
-            if ($url !== '/' || $this->requestAnalyzer->getResourceLocator() === false) {
-                if ($defaultLocale === $locale) {
-                    $html .= $this->renderAlternateLink($url, $webspaceKey, $locale, true, $scheme);
-                }
-
-                $html .= $this->renderAlternateLink($url, $webspaceKey, $locale, false, $scheme);
-                ++$concreteTranslations;
-            }
-        }
-
-        // if only one translation is available dismiss hreflang tags
-        if ($concreteTranslations <= 1) {
-            return '';
-        }
-
-        return $html;
-    }
-
-    /**
-     * Renders a single alternate link.
-     *
-     * @param string $url The url for the given locale of the current page
-     * @param string $webspaceKey The key of the current webspace
-     * @param string $locale The locale for which the tag should be rendered
-     * @param bool $default If true the tag will be rendered as default locale
-     * @param string $scheme scheme of request (http or https)
-     *
-     * @return string The rendered alternate link tag
-     */
-    private function renderAlternateLink($url, $webspaceKey, $locale, $default = false, $scheme = 'http')
-    {
-        return sprintf(
-            '<link rel="alternate" href="%s" hreflang="%s"/>' . PHP_EOL,
-            rtrim($this->contentPath->getContentPath($url, $webspaceKey, $locale, null, $scheme), '/'),
-            $default ? 'x-default' : str_replace('_', '-', $locale)
+        return $twig->render(
+            $template,
+            [
+                'seo' => $seoExtension,
+                'content' => $content,
+                'urls' => $urls,
+                'defaultLocale' => $defaultLocale,
+                'shadowBaseLocale' => $shadowBaseLocale,
+            ]
         );
-    }
-
-    /**
-     * Renders the canonical tag for the current page. Uses the value provided by the SEO extension. If the SEO
-     * extension does not provide a value, it checks if the current page is a shadow, and writes the correct canonical
-     * tag automatically.
-     *
-     * @param array $seoExtension The values delivered by the SEO extension of Sulu
-     * @param string[] $urls All the localized URLs for the current page
-     * @param string $shadowBaseLocale The displayed language, in case the current page is a shadow
-     * @param string $webspaceKey The key of the current webspace
-     * @param string $scheme scheme of request (http or https)
-     *
-     * @return string The rendered canonical link tag
-     */
-    private function renderCanonicalTag(array $seoExtension, array $urls, $shadowBaseLocale, $webspaceKey, $scheme)
-    {
-        $canonicalTagHtml = '<link rel="canonical" href="%s"/>' . PHP_EOL;
-
-        if (isset($seoExtension['canonicalUrl']) && $seoExtension['canonicalUrl'] !== '') {
-            return sprintf($canonicalTagHtml, $seoExtension['canonicalUrl']);
-        }
-
-        if ($shadowBaseLocale && isset($urls[$shadowBaseLocale])) {
-            return sprintf(
-                $canonicalTagHtml,
-                $this->contentPath->getContentPath(
-                    $urls[$shadowBaseLocale],
-                    $webspaceKey,
-                    $shadowBaseLocale,
-                    null,
-                    $scheme
-                )
-            );
-        }
-
-        return '';
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -66,8 +66,6 @@ class SeoTwigExtension extends \Twig_Extension
     }
 
     /**
-     * @deprecated use the twig include function to render the seo.
-     *
      * Renders all the SEO tags supported by Sulu.
      *
      * @param \Twig_Environment $twig
@@ -77,6 +75,8 @@ class SeoTwigExtension extends \Twig_Extension
      * @param string $shadowBaseLocale The displayed language, in case the current page is a shadow
      *
      * @return string The rendered HTML tags of the SEO extension
+     *
+     * @deprecated use the twig include function to render the seo.
      */
     public function renderSeoTags(
         \Twig_Environment $twig,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Fixes / issues | fixes 
| Deprecations? | no
| License | MIT

#### What's in this PR?

Move the logic and creation of the seo tags into an twig template to make it better rewriteable.

#### Why?

In some cases you want to overwrite the seo data from sulu without rewrite the whole seo data. With a simple twig include it can be partial rewriteable for users.

#### Example Usage

Simple include:

```twig
{%- include 'SuluWebsiteBundle:Extension:seo.html.twig' 
    seo: extension.seo,
    content: content,
    urls: urls,
    shadowBaseLocale: shadowBaseLocale,
    defaultLocale: request.defaultLocale|default('de')
} -%}
```

Example how to overwrite just the canonical:

```twig
{%- embed 'SuluWebsiteBundle:Extension:seo.html.twig' with {
    seo: extension.seo,
    content: content,
    urls: urls,
    shadowBaseLocale: shadowBaseLocale,
    defaultLocale: request.defaultLocale|default('de')
} -%}
    {%- block canonical -%}
                <link rel="canonical" href="{{ seoCanonical|default(app.request.schemeAndHttpHost ~ app.request.pathInfo) }}"/>
    {%- endblock -%}
{%- endembed -%}
```

#### BC Breaks/Deprecations

The `sulu_seo` twig extension was deprecated.

#### To Do

- [ ] Update documentation.
- [ ] Update sulu standard.

