### PR TITLE
Avoid seo information injection by url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2922 [WebsiteBundle]       Avoid seo information injected by url
     * HOTFIX      #2890 [Localization]        Reintroduced localization provider class
     * HOTFIX      #2876 [MediaBundle]         Changed column navigation to markable and ok button
     * HOTFIX      #2876 [ContentBundle]       Changed column navigation to markable and ok button

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
@@ -17,6 +17,7 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -91,7 +92,9 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $resourceLocator = '/test',
         $requestSeoData = []
     ) {
-        $this->request->get('_seo', [])->willReturn($requestSeoData);
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->get('_seo', [])->willReturn($requestSeoData);
+        $this->request->reveal()->attributes = $attributes->reveal();
 
         /** @var Localization $localization */
         $localization = $this->prophesize(Localization::class);
@@ -137,7 +140,9 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderSeoTagsWithoutPortal()
     {
-        $this->request->get('_seo', [])->willReturn([]);
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->get('_seo', [])->willReturn([]);
+        $this->request->reveal()->attributes = $attributes->reveal();
         $this->seoTwigExtension->renderSeoTags([], [], [], null);
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -78,7 +78,7 @@ class SeoTwigExtension extends \Twig_Extension
     public function renderSeoTags(array $seoExtension, array $content, array $urls, $shadowBaseLocale)
     {
         $request = $this->requestStack->getCurrentRequest();
-        $requestSeo = $request->get('_seo', []);
+        $requestSeo = $request->attributes->get('_seo', []);
         $seoExtension = array_merge($seoExtension, $requestSeo);
 
         $html = '';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It avoid that seo information is injected over the request get or post attributes.

#### Why?

Its evil e.g.: http://demo.sulu.io/en?_seo[title]=H4x

