### PR TITLE
Fix system collection generation for anon. user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2925 [WebsiteBundle]       Fixed seo when no data is available
     * FEATURE     #2920 [WebsiteBundle]       Seo info as twig template to make it rewriteable
     * ENHANCEMENT #2915 [WebsiteBundle]       Refactored xml sitemap
+    * BUGFIX      #2923 [MediaBundle]         Fixes system collection creation for anon. authenticated users
     * BUGFIX      #2915 [MediaBundle]         Fixed height of badges in media-selection
     * ENHANCEMENT #2860 [ContentBundle]       Added url to internal links and smart-content
     * FEATURE     #2914 [CategoryBundle]      Added description and medias to category

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -709,7 +709,11 @@ class CollectionManager implements CollectionManagerInterface
     protected function getCurrentUser()
     {
         if ($this->tokenStorage && ($token = $this->tokenStorage->getToken())) {
-            return $this->tokenStorage ? $token->getUser() : null;
+            $user = $token->getUser();
+
+            if ($user instanceof UserInterface) {
+                return $user;
+            }
         }
 
         return;

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Component\Cache\CacheInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -134,6 +135,10 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
     private function getUserId()
     {
         if (!$this->tokenProvider || ($token = $this->tokenProvider->getToken()) === null) {
+            return;
+        }
+
+        if (!$token->getUser() instanceof UserInterface) {
             return;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix system collection generation for anon. user.

#### Why?

When a system collection is used on the website and the user is authenticated as `anon.` it will not possible the system collection can not be created.