### PR TITLE
return system collection media only with granted permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2861 [ContentBundle]       Removed bug with displaced multifield remove icon
+    * BUGFIX      #2929 [MediaBundle]         Return system collection media only with granted permissions
     * FEATURE     #2999 [MediaBundle]         Added correct mime type to image after editing with aviary 
     * FEATURE     #2994 [HTTPCacheBundle]     Added cachelifetime types and introduced cron-expressions to calculate cachelifetime 
     * FEATURE     #3000 [MediaBundle]         Added paste media transformation

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -25,6 +25,7 @@ use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
+use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 use Sulu\Component\Rest\ListBuilder\ListRepresentation;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerInterface;
@@ -218,6 +219,29 @@ class MediaController extends AbstractMediaController implements
         // set the types
         if (count($types)) {
             $listBuilder->in($fieldDescriptors['type'], $types);
+        }
+
+        if (!$this->getSecurityChecker()->hasPermission('sulu.media.system_collections', PermissionTypes::VIEW)) {
+            $systemCollection = $this->getCollectionRepository()
+                ->findCollectionByKey(SystemCollectionManagerInterface::COLLECTION_KEY);
+
+            $lftExpression = $listBuilder->createWhereExpression(
+                $fieldDescriptors['lft'],
+                $systemCollection->getLft(),
+                ListBuilderInterface::WHERE_COMPARATOR_LESS
+            );
+            $rgtExpression = $listBuilder->createWhereExpression(
+                $fieldDescriptors['rgt'],
+                $systemCollection->getRgt(),
+                ListBuilderInterface::WHERE_COMPARATOR_GREATER
+            );
+
+            $listBuilder->addExpression(
+                $listBuilder->createOrExpression([
+                    $lftExpression,
+                    $rgtExpression,
+                ])
+            );
         }
 
         // field which will be needed afterwards to generate route

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/list-builder/Media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/list-builder/Media.xml
@@ -33,6 +33,12 @@
             <orm:field-name>SuluMediaBundle:FileVersion.defaultMeta</orm:field-name>
         </orm:join>
     </orm:joins>
+    <orm:joins name="collection">
+        <orm:join>
+            <orm:entity-name>SuluMediaBundle:Collection</orm:entity-name>
+            <orm:field-name>%sulu.model.media.class%.collection</orm:field-name>
+        </orm:join>
+    </orm:joins>
 
     <properties>
         <property name="id" list:translation="public.id" display="no" list:type="integer">
@@ -143,6 +149,20 @@
             <orm:entity-name>SuluMediaBundle:FileVersionMeta</orm:entity-name>
 
             <orm:joins ref="fileVersionMeta"/>
+        </property>
+
+        <property name="lft" display="never">
+            <orm:field-name>lft</orm:field-name>
+            <orm:entity-name>SuluMediaBundle:Collection</orm:entity-name>
+
+            <orm:joins ref="collection"/>
+        </property>
+
+        <property name="rgt" display="never">
+            <orm:field-name>rgt</orm:field-name>
+            <orm:entity-name>SuluMediaBundle:Collection</orm:entity-name>
+
+            <orm:joins ref="collection"/>
         </property>
     </properties>
 </class>

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
@@ -155,7 +155,7 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
      */
     private function buildSystemCollections($locale, $userId)
     {
-        $root = $this->getOrCreateRoot('system_collections', 'System', $locale, $userId);
+        $root = $this->getOrCreateRoot(SystemCollectionManagerInterface::COLLECTION_KEY, 'System', $locale, $userId);
         $collections = ['root' => $root->getId()];
         $collections = array_merge($collections, $this->iterateOverCollections($this->config, $userId, $root->getId()));
 

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManagerInterface.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManagerInterface.php
@@ -18,6 +18,8 @@ interface SystemCollectionManagerInterface
 {
     const COLLECTION_TYPE = 'collection.system';
 
+    const COLLECTION_KEY = 'system_collections';
+
     /**
      * Builds cache for system collections.
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2841 |
| Related issues/PRs | none |
| License | MIT |
| Documentation PR | none |
#### What's in this PR?

This PR includes a join to the collections for the query done in the screen with all media. This is necessary to check if the media is in a system collection, which is required to check if it should be returned based on the user's permission.
#### To Do
- [ ] Tests
