### PR TITLE
Fixed compatibility for twig 1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2959 [MediaBundle]         Fixed length of underline in media selection overlay
+    * BUGFIX      #2959 [All]                 Fixed compatibility for twig 1.26
     * BUGFIX      #2957 [MediaBundle]         Show missing image in media selection
     * FEATURE     #2951 [MediaBundle]         Added adobe creative sdk to edit uploaded images
     * FEATURE     #2947 [MediaBundle]         Redesign of media selection overlay

--- a/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
@@ -24,7 +24,7 @@ class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwi
     /**
      * @var SnippetTwigExtensionInterface
      */
-    private $extension;
+    protected $extension;
 
     /**
      * @var MemoizeInterface
@@ -37,7 +37,9 @@ class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwi
     private $lifeTime;
 
     /**
-     * Constructor.
+     * @param SnippetTwigExtensionInterface $extension
+     * @param MemoizeInterface $memoizeCache
+     * @param int $lifeTime
      */
     public function __construct(SnippetTwigExtensionInterface $extension, MemoizeInterface $memoizeCache, $lifeTime)
     {
@@ -52,14 +54,6 @@ class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwi
     public function getName()
     {
         return $this->extension->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions()
-    {
-        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
@@ -12,12 +12,15 @@
 namespace Sulu\Bundle\SnippetBundle\Twig;
 
 use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 
 /**
  * Provides memoized Twig functions to handle snippets.
  */
 class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensionInterface
 {
+    use MemoizeTwigExtensionTrait;
+
     /**
      * @var SnippetTwigExtensionInterface
      */
@@ -56,7 +59,7 @@ class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwi
      */
     public function getFunctions()
     {
-        return $this->extension->getFunctions();
+        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
@@ -17,24 +17,9 @@ use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 /**
  * Provides memoized Twig functions to handle snippets.
  */
-class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensionInterface
+class MemoizedSnippetTwigExtension extends \Twig_Extension
 {
     use MemoizeTwigExtensionTrait;
-
-    /**
-     * @var SnippetTwigExtensionInterface
-     */
-    protected $extension;
-
-    /**
-     * @var MemoizeInterface
-     */
-    private $memoizeCache;
-
-    /**
-     * @var int
-     */
-    private $lifeTime;
 
     /**
      * @param SnippetTwigExtensionInterface $extension
@@ -54,13 +39,5 @@ class MemoizedSnippetTwigExtension extends \Twig_Extension implements SnippetTwi
     public function getName()
     {
         return $this->extension->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function loadSnippet($uuid, $locale = null)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'loadSnippet'], $this->lifeTime);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
@@ -12,12 +12,15 @@
 namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
 use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 
 /**
  * Provides memoized Interface to load content.
  */
 class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwigExtensionInterface
 {
+    use MemoizeTwigExtensionTrait;
+
     /**
      * @var ContentTwigExtensionInterface
      */
@@ -72,6 +75,6 @@ class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwi
      */
     public function getFunctions()
     {
-        return $this->extension->getFunctions();
+        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
@@ -17,24 +17,9 @@ use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 /**
  * Provides memoized Interface to load content.
  */
-class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwigExtensionInterface
+class MemoizedContentTwigExtension extends \Twig_Extension
 {
     use MemoizeTwigExtensionTrait;
-
-    /**
-     * @var ContentTwigExtensionInterface
-     */
-    protected $extension;
-
-    /**
-     * @var MemoizeInterface
-     */
-    private $memoizeCache;
-
-    /**
-     * @var int
-     */
-    private $lifeTime;
 
     /**
      * @param ContentTwigExtensionInterface $extension
@@ -46,22 +31,6 @@ class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwi
         $this->extension = $extension;
         $this->memoizeCache = $memoizeCache;
         $this->lifeTime = $lifeTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function loadParent($uuid)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'loadParent'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function load($uuid)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'load'], $this->lifeTime);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
@@ -24,7 +24,7 @@ class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwi
     /**
      * @var ContentTwigExtensionInterface
      */
-    private $extension;
+    protected $extension;
 
     /**
      * @var MemoizeInterface
@@ -37,7 +37,9 @@ class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwi
     private $lifeTime;
 
     /**
-     * Constructor.
+     * @param ContentTwigExtensionInterface $extension
+     * @param MemoizeInterface $memoizeCache
+     * @param $lifeTime
      */
     public function __construct(ContentTwigExtensionInterface $extension, MemoizeInterface $memoizeCache, $lifeTime)
     {
@@ -68,13 +70,5 @@ class MemoizedContentTwigExtension extends \Twig_Extension implements ContentTwi
     public function getName()
     {
         return $this->extension->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions()
-    {
-        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -17,81 +17,20 @@ use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 /**
  * Provides memoized navigation functions.
  */
-class MemoizedNavigationTwigExtension extends \Twig_Extension implements NavigationTwigExtensionInterface
+class MemoizedNavigationTwigExtension extends \Twig_Extension
 {
     use MemoizeTwigExtensionTrait;
 
     /**
-     * @var NavigationTwigExtensionInterface
-     */
-    protected $extension;
-
-    /**
-     * @var MemoizeInterface
-     */
-    private $memoizeCache;
-
-    /**
-     * @var int
-     */
-    private $lifeTime;
-
-    /**
-     * Constructor.
+     * @param NavigationTwigExtensionInterface $extension
+     * @param MemoizeInterface $memoizeCache
+     * @param $lifeTime
      */
     public function __construct(NavigationTwigExtensionInterface $extension, MemoizeInterface $memoizeCache, $lifeTime)
     {
         $this->extension = $extension;
         $this->memoizeCache = $memoizeCache;
         $this->lifeTime = $lifeTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function flatRootNavigationFunction($context = null, $depth = 1, $loadExcerpt = false)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'flatRootNavigationFunction'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function treeRootNavigationFunction($context = null, $depth = 1, $loadExcerpt = false)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'treeRootNavigationFunction'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function treeNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'treeNavigationFunction'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function flatNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'flatNavigationFunction'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function breadcrumbFunction($uuid)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'breadcrumbFunction'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function navigationIsActiveFunction($requestUrl, $itemUrl)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'navigationIsActiveFunction'], $this->lifeTime);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -24,7 +24,7 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
     /**
      * @var NavigationTwigExtensionInterface
      */
-    private $extension;
+    protected $extension;
 
     /**
      * @var MemoizeInterface
@@ -100,13 +100,5 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
     public function getName()
     {
         return $this->extension->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions()
-    {
-        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -12,12 +12,15 @@
 namespace Sulu\Bundle\WebsiteBundle\Twig\Navigation;
 
 use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 
 /**
  * Provides memoized navigation functions.
  */
 class MemoizedNavigationTwigExtension extends \Twig_Extension implements NavigationTwigExtensionInterface
 {
+    use MemoizeTwigExtensionTrait;
+
     /**
      * @var NavigationTwigExtensionInterface
      */
@@ -104,6 +107,6 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension implements Navigat
      */
     public function getFunctions()
     {
-        return $this->extension->getFunctions();
+        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
@@ -17,24 +17,9 @@ use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 /**
  * Provides memoized twig functions for sitemap.
  */
-class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensionInterface
+class MemoizedSitemapTwigExtension extends \Twig_Extension
 {
     use MemoizeTwigExtensionTrait;
-
-    /**
-     * @var SitemapTwigExtensionInterface
-     */
-    protected $extension;
-
-    /**
-     * @var MemoizeInterface
-     */
-    private $memoizeCache;
-
-    /**
-     * @var int
-     */
-    private $lifeTime;
 
     /**
      * @param SitemapTwigExtensionInterface $extension
@@ -54,21 +39,5 @@ class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwi
     public function getName()
     {
         return $this->extension->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function sitemapUrlFunction($url, $locale = null, $webspaceKey = null)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'sitemapUrlFunction'], $this->lifeTime);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function sitemapFunction($locale = null, $webspaceKey = null)
-    {
-        return $this->memoizeCache->memoize([$this->extension, 'sitemapFunction'], $this->lifeTime);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
@@ -12,12 +12,15 @@
 namespace Sulu\Bundle\WebsiteBundle\Twig\Sitemap;
 
 use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 
 /**
  * Provides memoized twig functions for sitemap.
  */
 class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensionInterface
 {
+    use MemoizeTwigExtensionTrait;
+
     /**
      * @var SitemapTwigExtensionInterface
      */
@@ -56,7 +59,7 @@ class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwi
      */
     public function getFunctions()
     {
-        return $this->extension->getFunctions();
+        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
@@ -24,7 +24,7 @@ class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwi
     /**
      * @var SitemapTwigExtensionInterface
      */
-    private $extension;
+    protected $extension;
 
     /**
      * @var MemoizeInterface
@@ -37,7 +37,9 @@ class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwi
     private $lifeTime;
 
     /**
-     * Constructor.
+     * @param SitemapTwigExtensionInterface $extension
+     * @param MemoizeInterface $memoizeCache
+     * @param $lifeTime
      */
     public function __construct(SitemapTwigExtensionInterface $extension, MemoizeInterface $memoizeCache, $lifeTime)
     {
@@ -52,14 +54,6 @@ class MemoizedSitemapTwigExtension extends \Twig_Extension implements SitemapTwi
     public function getName()
     {
         return $this->extension->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions()
-    {
-        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
     }
 
     /**

--- a/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
+++ b/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
@@ -17,9 +17,19 @@ namespace Sulu\Component\Cache;
 trait MemoizeTwigExtensionTrait
 {
     /**
-     * @var \Twig_Extension
+     * @var \Twig_ExtensionInterface
      */
     protected $extension;
+
+    /**
+     * @var MemoizeInterface
+     */
+    protected $memoizeCache;
+
+    /**
+     * @var int
+     */
+    protected $lifeTime;
 
     /**
      * {@see \Twig_Extension::getFunctions}.
@@ -29,11 +39,13 @@ trait MemoizeTwigExtensionTrait
         $result = [];
         foreach ($this->extension->getFunctions() as $function) {
             $callable = $function->getCallable();
-            if (is_array($callable)) {
-                $callable[0] = $this;
-            }
 
-            $result[] = new \Twig_SimpleFunction($function->getName(), $callable);
+            $result[] = new \Twig_SimpleFunction(
+                $function->getName(),
+                function () use ($callable) {
+                    return $this->memoizeCache->memoize($callable, $this->lifeTime);
+                }
+            );
         }
 
         return $result;

--- a/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
+++ b/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
@@ -17,6 +17,19 @@ namespace Sulu\Component\Cache;
 trait MemoizeTwigExtensionTrait
 {
     /**
+     * @var \Twig_Extension
+     */
+    protected $extension;
+
+    /**
+     * {@see \Twig_Extension::getFunctions}.
+     */
+    public function getFunctions()
+    {
+        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
+    }
+
+    /**
      * Convert simple twig functions to use a new context.
      *
      * @param \Twig_SimpleFunction[] $functions

--- a/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
+++ b/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Cache;
+
+/**
+ * Provides functionality to convert twig functions.
+ */
+trait MemoizeTwigExtensionTrait
+{
+    /**
+     * Convert simple twig functions to use a new context.
+     *
+     * @param \Twig_SimpleFunction[] $functions
+     * @param mixed $context
+     *
+     * @return \Twig_SimpleFunction[]
+     */
+    protected function convertTwigFunctions(array $functions, $context)
+    {
+        $result = [];
+        foreach ($functions as $function) {
+            $callable = $function->getCallable();
+            if (is_array($callable)) {
+                $callable[0] = $context;
+            }
+
+            $result[] = new \Twig_SimpleFunction($function->getName(), $callable);
+        }
+
+        return $result;
+    }
+}

--- a/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
+++ b/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
@@ -26,24 +26,11 @@ trait MemoizeTwigExtensionTrait
      */
     public function getFunctions()
     {
-        return $this->convertTwigFunctions($this->extension->getFunctions(), $this);
-    }
-
-    /**
-     * Convert simple twig functions to use a new context.
-     *
-     * @param \Twig_SimpleFunction[] $functions
-     * @param mixed $context
-     *
-     * @return \Twig_SimpleFunction[]
-     */
-    protected function convertTwigFunctions(array $functions, $context)
-    {
         $result = [];
-        foreach ($functions as $function) {
+        foreach ($this->extension->getFunctions() as $function) {
             $callable = $function->getCallable();
             if (is_array($callable)) {
-                $callable[0] = $context;
+                $callable[0] = $this;
             }
 
             $result[] = new \Twig_SimpleFunction($function->getName(), $callable);

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -25,12 +25,20 @@ class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
      */
     protected $reflectionMethod;
 
+    /**
+     * @var \ReflectionProperty
+     */
+    protected $reflectionProperty;
+
     protected function setUp()
     {
         $this->trait = $this->getMockForTrait(MemoizeTwigExtensionTrait::class);
 
         $this->reflectionMethod = new \ReflectionMethod(get_class($this->trait), 'convertTwigFunctions');
         $this->reflectionMethod->setAccessible(true);
+
+        $this->reflectionProperty = new \ReflectionProperty(get_class($this->trait), 'extension');
+        $this->reflectionProperty->setAccessible(true);
     }
 
     public function testConvert()
@@ -49,6 +57,31 @@ class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('sulu_content_load', $result[0]->getName());
         $this->assertEquals([$this, 'load'], $result[0]->getCallable());
+
+        $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
+        $this->assertEquals($before[1]->getCallable(), $result[1]->getCallable());
+    }
+
+    public function testGetFunctions()
+    {
+        $before = [
+            new \Twig_SimpleFunction('sulu_content_load', [new \stdClass(), 'load']),
+            new \Twig_SimpleFunction(
+                'sulu_content_load_parent',
+                function () {
+                }
+            ),
+        ];
+
+        $extension = $this->prophesize(\Twig_Extension::class);
+        $extension->getFunctions()->willReturn($before);
+
+        $this->reflectionProperty->setValue($this->trait, $extension->reveal());
+
+        $result = $this->trait->getFunctions();
+
+        $this->assertEquals('sulu_content_load', $result[0]->getName());
+        $this->assertEquals([$this->trait, 'load'], $result[0]->getCallable());
 
         $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
         $this->assertEquals($before[1]->getCallable(), $result[1]->getCallable());

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Cache\Tests\Unit\Cache;
+
+use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
+
+class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MemoizeTwigExtensionTrait
+     */
+    protected $trait;
+
+    /**
+     * @var \ReflectionMethod
+     */
+    protected $reflectionMethod;
+
+    protected function setUp()
+    {
+        $this->trait = $this->getMockForTrait(MemoizeTwigExtensionTrait::class);
+
+        $this->reflectionMethod = new \ReflectionMethod(get_class($this->trait), 'convertTwigFunctions');
+        $this->reflectionMethod->setAccessible(true);
+    }
+
+    public function testConvert()
+    {
+        $before = [
+            new \Twig_SimpleFunction('sulu_content_load', [new \stdClass(), 'load']),
+            new \Twig_SimpleFunction(
+                'sulu_content_load_parent',
+                function () {
+                }
+            ),
+        ];
+
+        /** @var \Twig_SimpleFunction[] $result */
+        $result = $this->reflectionMethod->invokeArgs($this->trait, [$before, $this]);
+
+        $this->assertEquals('sulu_content_load', $result[0]->getName());
+        $this->assertEquals([$this, 'load'], $result[0]->getCallable());
+
+        $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
+        $this->assertEquals($before[1]->getCallable(), $result[1]->getCallable());
+    }
+}

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Component\Cache\Tests\Unit\Cache;
 
+use Prophecy\Argument;
+use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
 
 class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
@@ -21,40 +23,89 @@ class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
     protected $trait;
 
     /**
+     * @var \Twig_ExtensionInterface
+     */
+    protected $extension;
+
+    /**
      * @var \ReflectionProperty
      */
-    protected $reflectionProperty;
+    protected $extensionProperty;
+
+    /**
+     * @var MemoizeInterface
+     */
+    protected $memoizeCache;
+
+    /**
+     * @var \ReflectionProperty
+     */
+    protected $memoizeCacheProperty;
+
+    /**
+     * @var int
+     */
+    protected $lifeTime;
+
+    /**
+     * @var \ReflectionProperty
+     */
+    protected $lifeTimeProperty;
 
     protected function setUp()
     {
+        $this->memoizeCache = $this->prophesize(MemoizeInterface::class);
+        $this->extension = $this->prophesize(\Twig_ExtensionInterface::class);
+
         $this->trait = $this->getMockForTrait(MemoizeTwigExtensionTrait::class);
 
-        $this->reflectionProperty = new \ReflectionProperty(get_class($this->trait), 'extension');
-        $this->reflectionProperty->setAccessible(true);
+        $this->extensionProperty = new \ReflectionProperty(get_class($this->trait), 'extension');
+        $this->extensionProperty->setAccessible(true);
+        $this->extensionProperty->setValue($this->trait, $this->extension->reveal());
+
+        $this->memoizeCacheProperty = new \ReflectionProperty(get_class($this->trait), 'memoizeCache');
+        $this->memoizeCacheProperty->setAccessible(true);
+        $this->memoizeCacheProperty->setValue($this->trait, $this->memoizeCache->reveal());
+
+        $this->lifeTimeProperty = new \ReflectionProperty(get_class($this->trait), 'lifeTime');
+        $this->lifeTimeProperty->setAccessible(true);
+        $this->lifeTimeProperty->setValue($this->trait, $this->lifeTime);
     }
 
     public function testGetFunctions()
     {
         $before = [
-            new \Twig_SimpleFunction('sulu_content_load', [new \stdClass(), 'load']),
+            new \Twig_SimpleFunction(
+                'sulu_content_load',
+                function () {
+                    return 1;
+                }
+            ),
             new \Twig_SimpleFunction(
                 'sulu_content_load_parent',
                 function () {
+                    return 2;
                 }
             ),
         ];
 
-        $extension = $this->prophesize(\Twig_Extension::class);
-        $extension->getFunctions()->willReturn($before);
+        $this->extension->getFunctions()->willReturn($before);
+        $this->memoizeCache->memoize(Argument::type('callable'), $this->lifeTime)->will(
+            function ($arguments) {
+                return call_user_func($arguments[0]);
+            }
+        )->shouldBeCalledTimes(2);
 
-        $this->reflectionProperty->setValue($this->trait, $extension->reveal());
-
+        /** @var \Twig_SimpleFunction[] $result */
         $result = $this->trait->getFunctions();
 
+        $this->assertInstanceOf(\Twig_SimpleFunction::class, $result[0]);
         $this->assertEquals('sulu_content_load', $result[0]->getName());
-        $this->assertEquals([$this->trait, 'load'], $result[0]->getCallable());
 
+        $this->assertInstanceOf(\Twig_SimpleFunction::class, $result[1]);
         $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
-        $this->assertEquals($before[1]->getCallable(), $result[1]->getCallable());
+
+        $this->assertEquals(1, call_user_func($result[0]->getCallable()));
+        $this->assertEquals(2, call_user_func($result[1]->getCallable()));
     }
 }

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -21,11 +21,6 @@ class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
     protected $trait;
 
     /**
-     * @var \ReflectionMethod
-     */
-    protected $reflectionMethod;
-
-    /**
      * @var \ReflectionProperty
      */
     protected $reflectionProperty;
@@ -34,32 +29,8 @@ class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
     {
         $this->trait = $this->getMockForTrait(MemoizeTwigExtensionTrait::class);
 
-        $this->reflectionMethod = new \ReflectionMethod(get_class($this->trait), 'convertTwigFunctions');
-        $this->reflectionMethod->setAccessible(true);
-
         $this->reflectionProperty = new \ReflectionProperty(get_class($this->trait), 'extension');
         $this->reflectionProperty->setAccessible(true);
-    }
-
-    public function testConvert()
-    {
-        $before = [
-            new \Twig_SimpleFunction('sulu_content_load', [new \stdClass(), 'load']),
-            new \Twig_SimpleFunction(
-                'sulu_content_load_parent',
-                function () {
-                }
-            ),
-        ];
-
-        /** @var \Twig_SimpleFunction[] $result */
-        $result = $this->reflectionMethod->invokeArgs($this->trait, [$before, $this]);
-
-        $this->assertEquals('sulu_content_load', $result[0]->getName());
-        $this->assertEquals([$this, 'load'], $result[0]->getCallable());
-
-        $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
-        $this->assertEquals($before[1]->getCallable(), $result[1]->getCallable());
     }
 
     public function testGetFunctions()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR ensures compatibility with twig/twig 1.26.

#### Why?

Twig changes the way they write the cache. Before 1.26: they get the extension by "name". With 1.26: The class-name is used for array-index. We wrap the extension at some places there the wrong class name will be used.