### PR TITLE
fixed length of underline in media selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2959 [MediaBundle]         Fixed length of underline in media selection overlay
     * BUGFIX      #2957 [MediaBundle]         Show missing image in media selection
     * FEATURE     #2951 [MediaBundle]         Added adobe creative sdk to edit uploaded images
     * FEATURE     #2947 [MediaBundle]         Redesign of media selection overlay

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/css/main.css
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/css/main.css
@@ -570,11 +570,15 @@
   padding: 20px;
   overflow: auto;
 }
-/* line 131, ../scss/modules/media-selection.scss */
+/* line 130, ../scss/modules/media-selection.scss */
+.media-selection-overlay .list-container .collection-view .sulu-title {
+  width: auto;
+}
+/* line 135, ../scss/modules/media-selection.scss */
 .media-selection-overlay .toolbar-container {
   background: #52B6CA;
 }
-/* line 135, ../scss/modules/media-selection.scss */
+/* line 139, ../scss/modules/media-selection.scss */
 .media-selection-overlay .back {
   display: inline-block;
   vertical-align: top;
@@ -586,7 +590,7 @@
   margin-right: -5px;
   color: #fff;
 }
-/* line 147, ../scss/modules/media-selection.scss */
+/* line 151, ../scss/modules/media-selection.scss */
 .media-selection-overlay .toolbar {
   display: inline-block;
   vertical-align: top;

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/scss/modules/media-selection.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/scss/modules/media-selection.scss
@@ -126,6 +126,10 @@
         width: 100%;
         padding: 20px;
         overflow: auto;
+
+        .collection-view .sulu-title {
+            width: auto;
+        }
     }
 
     .toolbar-container {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the length of the underline for the title in the media selection overlay.

#### Why?

The problem was that the `sulu-title` class is part of a css definition with media queries, and the overlay is located within this element, so these rules apply. I had to add another rule which is more specific then the existing one, that's why the nesting level is a bit deep.

Actually the real problem is that the `sulu-title` class has a width on its own. But fixing that would probably be too much work right now.