### PR TITLE
fixed uncatchable exception when use sulu_media_resolve twig extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2969 [MediaBundle]         Fixed uncatchable exception when use sulu_media_resolve twig extension 
     * BUGFIX      #3012 [MediaBundle]         Update format url when subversion changes
     * BUGFIX      #3014 [PreviewBundle]       Use the correct PHPCR session for the preview
 
@@ -33,7 +34,7 @@ CHANGELOG for Sulu
     * FEATURE     #2967 [ContentBundle]       Refactored link-tag to allow extending over provider
     * FEATURE     #2966 [MediaBundle]         Added warning when unsaved crop will be lost
     * ENHANCEMENT #2948 [AdminBundle]         Replace colors and images by overwritable variables
-    
+
 * 1.4.0-RC1 (2016-10-06)
     * ENHANCEMENT #2964 [RouteBundle]         Content type route: Added possibility to pass parameter 'inputType' to component
     * BUGFIX      #2962 [WebsiteBundle]       Removed nested-sitemapindex

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/MediaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/MediaTwigExtensionTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\MediaBundle\Tests\Unit\Twig;
 use Prophecy\Argument;
 use Sulu\Bundle\MediaBundle\Api\Media as MediaApi;
 use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\MediaBundle\Twig\MediaTwigExtension;
 
@@ -155,5 +156,24 @@ class MediaTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result[0]->getId());
         $this->assertEquals(3, $result[1]->getId());
         $this->assertEquals(2, $result[2]->getId());
+    }
+
+    public function testResolveNullMedia()
+    {
+        $mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $extension = new MediaTwigExtension($mediaManager->reveal());
+
+        $this->assertNull($extension->resolveMediaFunction(null, 'en'));
+    }
+
+    public function testResolveNotExistMedia()
+    {
+        $mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $extension = new MediaTwigExtension($mediaManager->reveal());
+        $mediaManager->getById(404, 'en')->will(function($args) {
+            throw new MediaNotFoundException($args[0]);
+        });
+
+        $this->assertNull($extension->resolveMediaFunction(404, 'en'));
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MediaBundle\Twig;
 
 use Sulu\Bundle\MediaBundle\Api\Media as MediaApi;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 
 /**
@@ -50,15 +51,23 @@ class MediaTwigExtension extends \Twig_Extension
      * @param int|MediaInterface $media id to resolve
      * @param string $locale
      *
-     * @return MediaApi
+     * @return MediaApi|null
      */
     public function resolveMediaFunction($media, $locale)
     {
+        if (!$media) {
+            return;
+        }
+
         if (is_object($media)) {
             return $this->resolveMediaObject($media, $locale);
         }
 
-        return $this->mediaManager->getById($media, $locale);
+        try {
+            return $this->mediaManager->getById($media, $locale);
+        } catch (MediaNotFoundException $e) {
+            return;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2881 |
| License | MIT |
#### What's in this PR?

Fixed #2881 call of sulu_media_resolve with not exist media.
#### Why?

You are not able to catch exceptions in twig.
#### Example Usage

{% set media = sulu_media_resolve(null, 'de') %}
