### PR TITLE
Fixed page-link-provider without request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #2992 [ContentBundle]       Fixed page-link-provider without request
     * BUGFIX      #2991 [MediaBundle]         Reintroduced media deep-link
     * BUGFIX      #2988 [ContentBundle]       Fixed sulu-link if selection in ckeditor is empty
     * BUGFIX      #2985 [ContentBundle]       Fixed link-provider overlay-spacing

--- a/src/Sulu/Bundle/ContentBundle/Markup/Link/PageLinkProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Markup/Link/PageLinkProvider.php
@@ -79,7 +79,10 @@ class PageLinkProvider implements LinkProviderInterface
     public function preload(array $hrefs, $locale, $published = true)
     {
         $request = $this->requestStack->getCurrentRequest();
-        $scheme = $request->getScheme();
+        $scheme = 'http';
+        if ($request) {
+            $scheme = $request->getScheme();
+        }
 
         $contents = $this->contentRepository->findByUuids(
             array_unique(array_values($hrefs)),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

The PageLinkProvider throws an error if there is no request (like reindexing).