### PR TITLE
Added cache lifetime types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #2994 [HTTPCacheBundle]     Added cachelifetime types and introduced cron-expressions to calculate cachelifetime 
     * BUGFIX      #2992 [ContentBundle]       Fixed page-link-provider without request
     * BUGFIX      #2991 [MediaBundle]         Reintroduced media deep-link
     * BUGFIX      #2988 [ContentBundle]       Fixed sulu-link if selection in ckeditor is empty

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,62 @@
 # Upgrade
 
+## dev-develop
+
+### Page-Templates
+
+The cache-lifetime of page-templates was extended by the `type` attribute.
+This attribute is optional and default set to seconds which behaves like
+before and set the `max-age` to given integer.
+
+There is now a second type `expression` which allows you to define the
+lifetime with a cron-expression which enhances the developer to define
+that a page has to be invalidated at a specific time of the day (or
+whatever you need).
+
+__BEFORE:__
+```xml
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+    
+    ...
+    
+</template>
+```
+
+__NOW:__
+```xml
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+
+    <!-- releases cache each day at mitnight -->
+    <cacheLifetime type="expression">@daily</cacheLifetime>
+    
+    ...
+    
+</template>
+```
+
+Therefor we changed the type of the return value for `Sulu\Component\Content\Compat\StructureInterface::getCacheLifeTime`
+to array. This array contains the `type` and the `value` of the configured
+cache-lifetime.
+
+For resolving this array to a concrete second value we introduced the service
+`sulu_http_cache.cache_lifetime.resolver` there you can call the `resolve`
+function which returns the concrete second value.
+
 ## 1.4.0-RC1
 
 ### Refactored category management in backend

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "oro/doctrine-extensions": "^1.0",
         "goodby/csv": "^1.3",
         "doctrine/data-fixtures": "1.1.*",
-        "layershifter/tld-extract": "^1.1"
+        "layershifter/tld-extract": "^1.1",
+        "mtdowling/cron-expression": "^1.1"
     },
     "require-dev": {
         "phpcr/phpcr-shell": "~1.0.0@alpha",

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
@@ -9,7 +9,10 @@
 
     <services>
         <!-- structure manager -->
-        <service id="sulu_content.structure.loader.xml" class="%sulu_content.structure.loader.xml.class%" public="false"/>
+        <service id="sulu_content.structure.loader.xml" class="%sulu_content.structure.loader.xml.class%"
+                 public="false">
+            <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
+        </service>
 
         <service id="sulu_content.structure.factory" class="%sulu_content.structure.factory.class%">
             <argument type="service" id="sulu_content.structure.loader.xml" />

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -38,6 +38,7 @@ class SuluHttpCacheExtension extends Extension
         $loader->load('event-subscribers.xml');
         $loader->load('proxy-client.xml');
         $loader->load('structure-cache-handlers.xml');
+        $loader->load('services.xml');
 
         $this->configureProxyClient($config['proxy_client'], $container);
         $this->configureStructureCacheHandlers($config['handlers'], $container);

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/services.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_http_cache.cache_lifetime.resolver" class="Sulu\Component\HttpCache\CacheLifetimeResolver"/>
+    </services>
+</container>

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/structure-cache-handlers.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/structure-cache-handlers.xml
@@ -24,6 +24,7 @@
         </service>
 
         <service id="sulu_http_cache.handler.public" class="Sulu\Component\HttpCache\Handler\PublicHandler">
+            <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
             <argument>%sulu_http_cache.handler.public.max_age%</argument>
             <argument>%sulu_http_cache.handler.public.shared_max_age%</argument>
             <argument>%sulu_http_cache.handler.public.use_page_ttl%</argument>
@@ -31,6 +32,7 @@
         </service>
 
         <service id="sulu_http_cache.handler.debug" class="Sulu\Component\HttpCache\Handler\DebugHandler">
+            <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
             <argument>%sulu_http_cache.handler.aggregate.handlers%</argument>
             <argument>%sulu_http_cache.proxy_client.name%</argument>
             <tag name="sulu_http_cache.handler" alias="debug" />

--- a/src/Sulu/Component/Content/Compat/PageInterface.php
+++ b/src/Sulu/Component/Content/Compat/PageInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Content\Compat;
 
-use Sulu\Component\Content\Compat\StructureExtension\StructureExtensionInterface;
-
 /**
  * Structure for template.
  */
@@ -35,7 +33,7 @@ interface PageInterface extends StructureInterface
     /**
      * cacheLifeTime of template definition.
      *
-     * @return int
+     * @return array
      */
     public function getCacheLifeTime();
 
@@ -62,7 +60,7 @@ interface PageInterface extends StructureInterface
     public function setNavContexts($navContexts);
 
     /**
-     * @return StructureExtensionInterface[]
+     * @return array
      */
     public function getExt();
 

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -142,43 +142,52 @@ class XmlLoader extends XmlLegacyLoader
 
     private function normalizePropertyData($data)
     {
-        $data = array_replace_recursive([
-            'type' => null,
-            'multilingual' => true,
-            'mandatory' => true,
-            'colSpan' => null,
-            'cssClass' => null,
-            'minOccurs' => null,
-            'maxOccurs' => null,
-        ], $this->normalizeItem($data));
+        $data = array_replace_recursive(
+            [
+                'type' => null,
+                'multilingual' => true,
+                'mandatory' => true,
+                'colSpan' => null,
+                'cssClass' => null,
+                'minOccurs' => null,
+                'maxOccurs' => null,
+            ],
+            $this->normalizeItem($data)
+        );
 
         return $data;
     }
 
     private function normalizeStructureData($data)
     {
-        $data = array_replace_recursive([
-            'key' => null,
-            'view' => null,
-            'controller' => null,
-            'internal' => false,
-            'cacheLifetime' => null,
-        ], $this->normalizeItem($data));
+        $data = array_replace_recursive(
+            [
+                'key' => null,
+                'view' => null,
+                'controller' => null,
+                'internal' => false,
+                'cacheLifetime' => null,
+            ],
+            $this->normalizeItem($data)
+        );
 
         return $data;
     }
 
     private function normalizeItem($data)
     {
-        $data = array_merge_recursive([
-            'meta' => [
-                'title' => [],
-                'info_text' => [],
-                'placeholder' => [],
+        $data = array_merge_recursive(
+            [
+                'meta' => [
+                    'title' => [],
+                    'info_text' => [],
+                    'placeholder' => [],
+                ],
+                'params' => [],
+                'tags' => [],
             ],
-            'params' => [],
-            'tags' => [],
-        ], $data);
+            $data
+        );
 
         return $data;
     }

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd
@@ -28,7 +28,7 @@
             <xs:element type="xs:string" name="view" minOccurs="1" maxOccurs="1"/>
             <xs:element type="xs:string" name="controller" minOccurs="1" maxOccurs="1"/>
             <xs:element type="xs:string" name="internal" minOccurs="0" maxOccurs="1"/>
-            <xs:element type="xs:integer" name="cacheLifetime" minOccurs="1" maxOccurs="1"/>
+            <xs:element type="cacheLifetimeType" name="cacheLifetime" minOccurs="1" maxOccurs="1"/>
             <xs:element type="rootPropertiesType" name="properties" minOccurs="1" maxOccurs="1"/>
 
             <xs:element name="meta">
@@ -55,7 +55,7 @@
     <xs:complexType name="langType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:attribute name="lang" use="required" type="xs:string" />
+                <xs:attribute name="lang" use="required" type="xs:string"/>
                 <xs:attributeGroup ref="defaultAttributes"/>
             </xs:extension>
         </xs:simpleContent>
@@ -149,10 +149,34 @@
             <xs:extension base="xs:string">
                 <xs:attribute type="xs:string" name="name" use="required"/>
                 <xs:attribute type="xs:int" name="priority" use="optional"/>
-                <xs:anyAttribute namespace="##any" processContents="lax" />
+                <xs:anyAttribute namespace="##any" processContents="lax"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
+
+    <xs:complexType name="cacheLifetimeType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="type" default="seconds">
+                    <xs:simpleType>
+                        <xs:union memberTypes="cacheLifetimeTypeEnum cacheLifetimeTypeAnyString"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="cacheLifetimeTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="seconds"/>
+            <xs:enumeration value="expression"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="cacheLifetimeTypeAnyString">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9a-zA-Z]*"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="paramsType">
         <xs:sequence>

--- a/src/Sulu/Component/Content/Metadata/StructureMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/StructureMetadata.php
@@ -28,7 +28,7 @@ class StructureMetadata extends ItemMetadata
     public $resource;
 
     /**
-     * @var string
+     * @var array
      */
     public $cacheLifetime;
 
@@ -68,11 +68,15 @@ class StructureMetadata extends ItemMetadata
     public function getProperty($name)
     {
         if (!isset($this->properties[$name])) {
-            throw new \InvalidArgumentException(sprintf(
-                'Unknown model property "%s", in structure "%s". Known model properties: "%s". Loaded from "%s"',
-                $name, $this->getName(), implode('", "', array_keys($this->properties)),
-                $this->resource
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown model property "%s", in structure "%s". Known model properties: "%s". Loaded from "%s"',
+                    $name,
+                    $this->getName(),
+                    implode('", "', array_keys($this->properties)),
+                    $this->resource
+                )
+            );
         }
 
         return $this->properties[$name];
@@ -139,10 +143,14 @@ class StructureMetadata extends ItemMetadata
         $properties = $this->getPropertiesByTagName($tagName);
 
         if (!$properties) {
-            throw new \InvalidArgumentException(sprintf(
-                'No property with tag "%s" exists. In structure "%s" loaded from "%s"',
-                $tagName, $this->name, $this->resource
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'No property with tag "%s" exists. In structure "%s" loaded from "%s"',
+                    $tagName,
+                    $this->name,
+                    $this->resource
+                )
+            );
         }
 
         return reset($properties);

--- a/src/Sulu/Component/Content/Tests/Functional/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
@@ -14,9 +14,10 @@ namespace Sulu\Component\Content\Tests\Functional\Document\Subscriber;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\ContentBundle\Document\HomeDocument;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 
-class ShadowCopyPropertiesSubscriberTest extends \Sulu\Bundle\TestBundle\Testing\SuluTestCase
+class ShadowCopyPropertiesSubscriberTest extends SuluTestCase
 {
     /**
      * @var DocumentManagerInterface

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLegacyLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLegacyLoaderTest.php
@@ -12,7 +12,9 @@
 namespace Sulu\Component\Content\Tests\Unit\Metadata\Loader;
 
 use InvalidArgumentException;
+use Prophecy\Argument;
 use Sulu\Component\Content\Metadata\Loader\XmlLegacyLoader;
+use Sulu\Component\HttpCache\CacheLifetimeResolverInterface;
 
 class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,7 +32,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'tags' => [
                 [
                     'name' => 'some.random.structure.tag',
@@ -260,7 +262,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'properties' => [
                 'title_section' => [
                     'name' => 'title_section',
@@ -330,7 +332,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'properties' => [],
             'tags' => [],
             'meta' => [],
@@ -358,7 +360,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template_block',
             'view' => 'ClientWebsiteBundle:Website:complex.html.twig',
             'controller' => 'SuluWebsiteBundle:Default:index',
-            'cacheLifetime' => 4800,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 4800],
             'properties' => [
                 'title' => [
                     'name' => 'title',
@@ -641,7 +643,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template_block_types',
             'view' => 'ClientWebsiteBundle:Website:complex.html.twig',
             'controller' => 'SuluWebsiteBundle:Default:index',
-            'cacheLifetime' => 4800,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 4800],
             'properties' => [
                 'title' => [
                     'name' => 'title',
@@ -853,7 +855,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template_sections',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'properties' => [
                 'title' => [
                     'name' => 'title',
@@ -1058,7 +1060,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template_nesting_params',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'properties' => [
                 'title' => [
                     'name' => 'title',
@@ -1124,7 +1126,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template_meta_params',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'properties' => [
                 'title' => [
                     'name' => 'title',
@@ -1194,7 +1196,9 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'The tag with the name "sulu.rlp" is required, but was not found in the template "template"'
         );
 
-        $templateReader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $templateReader = new XmlLegacyLoader($resolver->reveal());
         $result = $templateReader->load(
             implode(
                 DIRECTORY_SEPARATOR,
@@ -1206,7 +1210,9 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testWithoutRlpTagTypePageInternal()
     {
-        $templateReader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $templateReader = new XmlLegacyLoader($resolver->reveal());
         $result = $templateReader->load(
             implode(
                 DIRECTORY_SEPARATOR,
@@ -1226,7 +1232,9 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'The tag with the name "sulu.rlp" is required, but was not found in the template "template"'
         );
 
-        $templateReader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $templateReader = new XmlLegacyLoader($resolver->reveal());
         $result = $templateReader->load(
             implode(
                 DIRECTORY_SEPARATOR,
@@ -1238,7 +1246,9 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testWithoutRlpTagTypeHomeInternal()
     {
-        $templateReader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $templateReader = new XmlLegacyLoader($resolver->reveal());
         $result = $templateReader->load(
             implode(
                 DIRECTORY_SEPARATOR,
@@ -1253,7 +1263,9 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testWithoutRlpTagTypeSnippet()
     {
-        $templateReader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $templateReader = new XmlLegacyLoader($resolver->reveal());
         $result = $templateReader->load(
             implode(
                 DIRECTORY_SEPARATOR,
@@ -1269,12 +1281,17 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
     public function testCacheLifeTimeZero()
     {
         $result = $this->loadFixture('template_lifetime_0.xml');
-        $this->assertSame(0, $result['cacheLifetime']);
+        $this->assertEquals(
+            ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 0],
+            $result['cacheLifetime']
+        );
     }
 
     public function testWithoutRlpTagTypeSnippetInternal()
     {
-        $templateReader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $templateReader = new XmlLegacyLoader($resolver->reveal());
         $result = $templateReader->load(
             implode(
                 DIRECTORY_SEPARATOR,
@@ -1297,7 +1314,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             'key' => 'template',
             'view' => 'page.html.twig',
             'controller' => 'SuluContentBundle:Default:index',
-            'cacheLifetime' => 2400,
+            'cacheLifetime' => ['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 2400],
             'tags' => [],
             'meta' => [
                 'title' => [
@@ -1347,6 +1364,41 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($x));
     }
 
+    public function testLoadCacheLifetimeExpression()
+    {
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_EXPRESSION, '@daily')->willReturn(true);
+        $xmlLegacyLoader = new XmlLegacyLoader($resolver->reveal());
+        $result = $xmlLegacyLoader->load(
+            implode(
+                DIRECTORY_SEPARATOR,
+                [$this->getResourceDirectory(), 'DataFixtures', 'Page', 'template_expression.xml']
+            ),
+            'page'
+        );
+
+        $this->assertEquals(
+            ['type' => CacheLifetimeResolverInterface::TYPE_EXPRESSION, 'value' => '@daily'],
+            $result['cacheLifetime']
+        );
+    }
+
+    public function testLoadCacheLifetimeInvalidExpression()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_EXPRESSION, 'test')->willReturn(false);
+        $xmlLegacyLoader = new XmlLegacyLoader($resolver->reveal());
+        $result = $xmlLegacyLoader->load(
+            implode(
+                DIRECTORY_SEPARATOR,
+                [$this->getResourceDirectory(), 'DataFixtures', 'Page', 'template_invalid_expression.xml']
+            ),
+            'page'
+        );
+    }
+
     private function arrayRecursiveDiff($aArray1, $aArray2)
     {
         $aReturn = [];
@@ -1373,7 +1425,9 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
     private function loadFixture($name, $type = 'page')
     {
-        $xmlLegacyLoader = new XmlLegacyLoader();
+        $resolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $resolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())->willReturn(true);
+        $xmlLegacyLoader = new XmlLegacyLoader($resolver->reveal());
         $result = $xmlLegacyLoader->load(
             implode(DIRECTORY_SEPARATOR, [$this->getResourceDirectory(), 'DataFixtures', 'Page', $name]),
             $type

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Component\Content\Tests\Unit\Metadata\Loader;
 
+use Prophecy\Argument;
 use Sulu\Component\Content\Metadata\Loader\XmlLoader;
+use Sulu\Component\HttpCache\CacheLifetimeResolverInterface;
 
 class XmlLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,18 +22,30 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
      */
     private $loader;
 
+    /**
+     * @var CacheLifetimeResolverInterface
+     */
+    private $cacheLifetimeResolver;
+
     public function setUp()
     {
-        $this->loader = new XmlLoader();
+        $this->cacheLifetimeResolver = $this->prophesize(CacheLifetimeResolverInterface::class);
+        $this->loader = new XmlLoader($this->cacheLifetimeResolver->reveal());
     }
 
     public function testLoadTemplate()
     {
+        $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
+            ->willReturn(true);
+
         $result = $this->load('template.xml');
     }
 
     public function testLoadBlockMetaTitles()
     {
+        $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
+            ->willReturn(true);
+
         $result = $this->load('template_block_types.xml');
 
         $blockTypes = $result->getProperty('block1')->getComponents();
@@ -46,6 +60,9 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadBlockTypeWithoutMeta()
     {
+        $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
+            ->willReturn(true);
+
         $result = $this->load('template_block_type_without_meta.xml');
 
         $this->assertCount(1, $result->getProperty('block1')->getComponents());
@@ -53,6 +70,9 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
 
     private function load($name)
     {
+        $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
+            ->willReturn(true);
+
         $result = $this->loader->load(
             $this->getResourceDirectory() . '/DataFixtures/Page/' . $name
         );

--- a/src/Sulu/Component/HttpCache/CacheLifetimeResolver.php
+++ b/src/Sulu/Component/HttpCache/CacheLifetimeResolver.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\HttpCache;
+
+use Cron\CronExpression;
+
+/**
+ * The cache lifetime resolver resolves the given cache lifetime metadata based on the type
+ * and returns an absolute cache lifetime in seconds.
+ */
+class CacheLifetimeResolver implements CacheLifetimeResolverInterface
+{
+    /**
+     * Cache lifetime types.
+     *
+     * @var array
+     */
+    protected static $types = [self::TYPE_SECONDS, self::TYPE_EXPRESSION];
+
+    /**
+     * Cached cache lifetimes.
+     *
+     * @var array
+     */
+    protected $cacheLifetimes = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($type, $value)
+    {
+        $cacheLifetimeKey = sprintf('%s:%s', $type, $value);
+
+        if (!array_key_exists($cacheLifetimeKey, $this->cacheLifetimes)) {
+            switch ($type) {
+                case self::TYPE_EXPRESSION:
+                    $this->cacheLifetimes[$cacheLifetimeKey] = $this->getCacheLifetimeForExpression($value);
+                    break;
+                case self::TYPE_SECONDS:
+                    $this->cacheLifetimes[$cacheLifetimeKey] = (int) $value;
+                    break;
+                default:
+                    $this->cacheLifetimes[$cacheLifetimeKey] = 0;
+            }
+        }
+
+        return $this->cacheLifetimes[$cacheLifetimeKey];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($type, $value)
+    {
+        if (!in_array($type, self::$types)) {
+            return false;
+        }
+
+        if (self::TYPE_EXPRESSION === $type) {
+            return CronExpression::isValidExpression($value);
+        }
+
+        return is_numeric($value);
+    }
+
+    /**
+     * @param string $expression Cron expression
+     *
+     * @return int Cache lifetime in seconds
+     */
+    protected function getCacheLifetimeForExpression($expression)
+    {
+        if (!CronExpression::isValidExpression($expression)) {
+            return 0;
+        }
+
+        $now = new \DateTime();
+        $cronExpression = CronExpression::factory($expression);
+        $endTime = $cronExpression->getNextRunDate($now);
+
+        return $endTime->getTimestamp() - $now->getTimestamp();
+    }
+}

--- a/src/Sulu/Component/HttpCache/CacheLifetimeResolverInterface.php
+++ b/src/Sulu/Component/HttpCache/CacheLifetimeResolverInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\HttpCache;
+
+/**
+ * A cache lifetime resolver should resolve the given cache lifetime metadata based on the type
+ * and should return an absolute cache lifetime in seconds.
+ */
+interface CacheLifetimeResolverInterface
+{
+    /**
+     * Cache lifetime in seconds.
+     */
+    const TYPE_SECONDS = 'seconds';
+
+    /**
+     * Cache lifetime as cron expression.
+     */
+    const TYPE_EXPRESSION = 'expression';
+
+    /**
+     * Get cache lifetime in seconds.
+     *
+     * @param string $type
+     * @param mixed $value
+     *
+     * @return int Cache lifetime in seconds
+     */
+    public function resolve($type, $value);
+
+    /**
+     * Returns true if combination of type and value is supported.
+     *
+     * @param string $type
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function supports($type, $value);
+}

--- a/src/Sulu/Component/HttpCache/Tests/Unit/CacheLifetimeResolverTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/CacheLifetimeResolverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\HttpCache\Tests\Unit;
+
+use Cron\CronExpression;
+use Sulu\Component\HttpCache\CacheLifetimeResolver;
+use Sulu\Component\HttpCache\CacheLifetimeResolverInterface;
+
+class CacheLifetimeResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSupportWrongType()
+    {
+        $cacheLifetimeResolver = new CacheLifetimeResolver();
+
+        $this->assertFalse($cacheLifetimeResolver->supports('test', '10'));
+    }
+
+    public function testSupportSeconds()
+    {
+        $cacheLifetimeResolver = new CacheLifetimeResolver();
+
+        $this->assertTrue($cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, '10'));
+        $this->assertTrue($cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, 10));
+        $this->assertTrue($cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, 0));
+        $this->assertFalse($cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, 'asdf'));
+    }
+
+    public function testSupportExpression()
+    {
+        $cacheLifetimeResolver = new CacheLifetimeResolver();
+
+        $this->assertTrue($cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_EXPRESSION, '@daily'));
+        $this->assertTrue(
+            $cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_EXPRESSION, '0 0 1 1 *')
+        );
+        $this->assertFalse($cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_EXPRESSION, 'asdf'));
+    }
+
+    public function testResolveSeconds()
+    {
+        $cacheLifetimeResolver = new CacheLifetimeResolver();
+
+        $this->assertEquals(10, $cacheLifetimeResolver->resolve(CacheLifetimeResolverInterface::TYPE_SECONDS, '10'));
+        $this->assertEquals(10, $cacheLifetimeResolver->resolve(CacheLifetimeResolverInterface::TYPE_SECONDS, 10));
+        $this->assertEquals(0, $cacheLifetimeResolver->resolve(CacheLifetimeResolverInterface::TYPE_SECONDS, 0));
+    }
+
+    public function testResolveExpression()
+    {
+        $cacheLifetimeResolver = new CacheLifetimeResolver();
+
+        $now = new \DateTime();
+        $this->assertLessThanOrEqual(
+            CronExpression::factory('@daily')->getNextRunDate()->getTimestamp() - $now->getTimestamp(),
+            $cacheLifetimeResolver->resolve(CacheLifetimeResolverInterface::TYPE_EXPRESSION, '@daily')
+        );
+        $this->assertLessThanOrEqual(
+            CronExpression::factory('0 0 1 1 *')->getNextRunDate()->getTimestamp() - $now->getTimestamp(),
+            $cacheLifetimeResolver->resolve(CacheLifetimeResolverInterface::TYPE_EXPRESSION, '0 0 1 1 *')
+        );
+    }
+}

--- a/tests/Resources/DataFixtures/Page/template_expression.xml
+++ b/tests/Resources/DataFixtures/Page/template_expression.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template_expression</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime type="expression">@daily</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Titel</title>
+                <title lang="en">Title</title>
+
+                <info_text lang="de">Titel-Info-DE</info_text>
+                <info_text lang="en">Title-Info-EN</info_text>
+
+                <placeholder lang="de">Platzhalter-Info-DE</placeholder>
+                <placeholder lang="en">Placeholder-Info-EN</placeholder>
+            </meta>
+
+            <indexField />
+
+            <tag name="sulu.node.title" priority="10"/>
+
+            <tag name="some.random.tag" one="1" two="2" three="three" />
+        </property>
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" priority="1"/>
+        </property>
+    </properties>
+</template>

--- a/tests/Resources/DataFixtures/Page/template_invalid_expression.xml
+++ b/tests/Resources/DataFixtures/Page/template_invalid_expression.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template_expression</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime type="expression">test</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Titel</title>
+                <title lang="en">Title</title>
+
+                <info_text lang="de">Titel-Info-DE</info_text>
+                <info_text lang="en">Title-Info-EN</info_text>
+
+                <placeholder lang="de">Platzhalter-Info-DE</placeholder>
+                <placeholder lang="en">Placeholder-Info-EN</placeholder>
+            </meta>
+
+            <indexField />
+
+            <tag name="sulu.node.title" priority="10"/>
+
+            <tag name="some.random.tag" one="1" two="2" three="three" />
+        </property>
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" priority="1"/>
+        </property>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/283

#### What's in this PR?

Added cache lifetime types.

#### Why?

Currently we support only absolute values in seconds. Now we added the support different types. For now seconds and cron expressions are implemented.