### PR TITLE
Fixed namespace collision in media entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #2995 [MediaBundle]         Fixed namespace collision in media entity
     * HOTFIX      #2955 [ContentBundle]       Fixed changing block types when maxOccurs are reached
     * HOTFIX      #2959 [All]                 Fixed compatibility for twig 1.26
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Entity;
 
-use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityInterface;
@@ -185,7 +185,7 @@ interface CollectionInterface extends AuditableInterface, SecuredEntityInterface
     public function getType();
 
     /**
-     * @param Collection $children
+     * @param DoctrineCollection $children
      */
-    public function setChildren(Collection $children);
+    public function setChildren(DoctrineCollection $children);
 }

--- a/src/Sulu/Bundle/MediaBundle/Entity/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/Media.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Collection as DoctrineCollection;
 use JMS\Serializer\Annotation\Exclude;
 use Sulu\Component\Security\Authentication\UserInterface;
 
@@ -37,7 +37,7 @@ class Media implements MediaInterface
     protected $changed;
 
     /**
-     * @var Collection
+     * @var DoctrineCollection
      */
     protected $files;
 

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -94,6 +94,10 @@ class MetadataSubscriber implements EventSubscriber
      */
     private function setAssociationMappings(ClassMetadataInfo $metadata, Configuration $configuration)
     {
+        if (!class_exists($metadata->getName())) {
+            return;
+        }
+
         foreach (class_parents($metadata->getName()) as $parent) {
             $parentMetadata = new ClassMetadata(
                 $parent,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2990 
| License | MIT

#### What's in this PR?

Backport #2513 to 1.3.

#### Why?

Fix namespace conflict.

