### PR TITLE
Videos can now be uploaded without ffmpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2929 [MediaBundle]         Return system collection media only with granted permissions
     * FEATURE     #3002 [MediaBundle]         Added config for choosing formats which can be cropped in media selection
     * FEATURE     #2999 [MediaBundle]         Added correct mime type to image after editing with aviary 
+    * BUGFIX      #2998 [MediaBundle]         Videos can now be uploaded without ffmpeg
     * FEATURE     #2994 [HTTPCacheBundle]     Added cachelifetime types and introduced cron-expressions to calculate cachelifetime 
     * FEATURE     #3000 [MediaBundle]         Added paste media transformation
     * BUGFIX      #2992 [ContentBundle]       Fixed page-link-provider without request

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MediaBundle\Media\Manager;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManager;
+use FFMpeg\Exception\ExecutableNotFoundException;
 use FFMpeg\FFProbe;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Api\Media;
@@ -295,9 +296,13 @@ class MediaManager implements MediaManagerInterface
         $mimeType = $uploadedFile->getMimeType();
         $properties = [];
 
-        // if the file is a video we add the duration
-        if (fnmatch('video/*', $mimeType)) {
-            $properties['duration'] = $this->ffprobe->format($uploadedFile->getPathname())->get('duration');
+        try {
+            // if the file is a video we add the duration
+            if (fnmatch('video/*', $mimeType)) {
+                $properties['duration'] = $this->ffprobe->format($uploadedFile->getPathname())->get('duration');
+            }
+        } catch (ExecutableNotFoundException $e) {
+            // Exception is thrown if ffmpeg is not installed -> duration is not set
         }
 
         return $properties;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2422 |
| Related issues/PRs | #issuenum |
| License | MIT |
| Documentation PR | sulu/sulu-docs#prnum |
#### What's in this PR?

Fixes bug which disabled video upload without ffmpeg.
