### PR TITLE
Added paste media transformator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * FEATURE     #2994 [HTTPCacheBundle]     Added cachelifetime types and introduced cron-expressions to calculate cachelifetime 
+    * FEATURE     #3000 [MediaBundle]         Added paste media transformation
     * BUGFIX      #2992 [ContentBundle]       Fixed page-link-provider without request
     * BUGFIX      #2991 [MediaBundle]         Reintroduced media deep-link
     * BUGFIX      #2988 [ContentBundle]       Fixed sulu-link if selection in ckeditor is empty

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
@@ -20,17 +20,20 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ImageTransformationCompilerPass implements CompilerPassInterface
 {
+    const POOL_SERVICE_ID = 'sulu_media.image.transformation_pool';
+    const TAG = 'sulu_media.image.transformation';
+
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('sulu_media.image.transformation_manager')) {
+        if (!$container->hasDefinition(self::POOL_SERVICE_ID)) {
             return;
         }
 
-        $definition = $container->getDefinition('sulu_media.image.transformation_manager');
-        $taggedServices = $container->findTaggedServiceIds('sulu_media.image.transformation');
+        $definition = $container->getDefinition(self::POOL_SERVICE_ID);
+        $taggedServices = $container->findTaggedServiceIds(self::TAG);
 
         foreach ($taggedServices as $id => $tags) {
             foreach ($tags as $attributes) {

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/PasteTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/PasteTransformation.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
+
+use Imagine\Gd\Imagine as GdImagine;
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
+use Imagine\Imagick\Imagine as ImagickImagine;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * Class PasteTransformation.
+ */
+class PasteTransformation implements TransformationInterface
+{
+    /**
+     * @var FileLocator
+     */
+    private $fileLocator;
+
+    /**
+     * MaskTransformation constructor.
+     *
+     * @param FileLocator $fileLocator
+     */
+    public function __construct(
+        FileLocator $fileLocator
+    ) {
+        $this->fileLocator = $fileLocator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ImageInterface $image, $parameters)
+    {
+        $maskPath = isset($parameters['image']) ? $this->fileLocator->locate($parameters['image']) : null;
+
+        if (!$maskPath) {
+            return $image;
+        }
+
+        $originalWidth = $image->getSize()->getWidth();
+        $originalHeight = $image->getSize()->getHeight();
+        $top = isset($parameters['top']) ? $parameters['top'] : 0;
+        $left = isset($parameters['left']) ? $parameters['left'] : 0;
+
+        $width = isset($parameters['width']) ? $parameters['width'] : $originalWidth;
+        $height = isset($parameters['height']) ? $parameters['height'] : $originalHeight;
+
+        // imagine will error when mask is bigger then the given image
+        // this could happen in forceRatio true mode so we need also scale the mask
+        if ($width > $originalWidth) {
+            $width = $originalWidth;
+            $height = (int) ($height / $width * $originalWidth);
+        }
+
+        if ($height > $originalHeight) {
+            $height = $originalHeight;
+            $width = (int) ($width / $height * $originalHeight);
+        }
+
+        // create mask
+        $mask = $this->createMask(
+            $maskPath,
+            $width,
+            $height
+        );
+
+        // add mask to image
+        $image->paste($mask, new Point($top, $left));
+
+        return $image;
+    }
+
+    /**
+     * Create mask.
+     *
+     * @param $maskPath
+     * @param $width
+     * @param $height
+     *
+     * @return ImageInterface
+     */
+    protected function createMask($maskPath, $width, $height)
+    {
+        try {
+            // todo get this from a service
+            $imagine = new ImagickImagine();
+        } catch (\RuntimeException $ex) {
+            $imagine = new GdImagine();
+        }
+
+        $mask = $imagine->open($maskPath);
+        $mask->resize(
+            new Box(
+                $width ?: 1,
+                $height ?: 1
+            )
+        );
+
+        return $mask;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -84,6 +84,12 @@
             <tag name="sulu_media.image.transformation" alias="crop" />
         </service>
 
+        <service id="sulu_media.image.transformation.paste" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\PasteTransformation">
+            <argument type="service" id="file_locator"/>
+
+            <tag name="sulu_media.image.transformation" alias="paste" />
+        </service>
+
         <service id="sulu_media.media_manager" class="%sulu_media.media_manager.class%">
             <argument type="service" id="sulu.repository.media" />
             <argument type="service" id="sulu_media.collection_repository" />

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/ImageTransformationCompilerPassTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/ImageTransformationCompilerPassTest.php
@@ -36,16 +36,16 @@ class ImageTransformationCompilerPassTest extends AbstractCompilerPassTestCase
     public function if_compiler_pass_collects_services_by_adding_method_calls_these_will_exist()
     {
         $transformationManager = new Definition();
-        $this->setDefinition('sulu_media.image.transformation_manager', $transformationManager);
+        $this->setDefinition(ImageTransformationCompilerPass::POOL_SERVICE_ID, $transformationManager);
 
         $transformation = new Definition();
-        $transformation->addTag('sulu_media.image.transformation', ['alias' => 'resize']);
+        $transformation->addTag(ImageTransformationCompilerPass::TAG, ['alias' => 'resize']);
         $this->setDefinition('sulu_media.image.transformation.resize', $transformation);
 
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sulu_media.image.transformation_manager',
+            ImageTransformationCompilerPass::POOL_SERVICE_ID,
             'add',
             [
                 new Reference('sulu_media.image.transformation.resize'),

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
+
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Prophecy\Argument;
+use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\PasteTransformation;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * Class PasteTransformationTest
+ * Test the paste transformation service.
+ */
+class PasteTransformationTest extends SuluTestCase
+{
+    /**
+     * @var PasteTransformation
+     */
+    protected $pasteTransformation;
+
+    /**
+     * @var FileLocator
+     */
+    protected $fileLocator;
+
+    public function setUp()
+    {
+        $this->fileLocator = $this->prophesize(FileLocator::class);
+        $this->fileLocator->locate('test.jpg')->willReturn(
+            __DIR__ . '/../../../../app/Resources/images/photo.jpeg'
+        );
+
+        $this->pasteTransformation = new pasteTransformation(
+            $this->fileLocator->reveal()
+        );
+
+        parent::setUp();
+    }
+
+    public function testPaste()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $image->getSize()->willReturn(new Box(700, 500));
+        $image->paste(Argument::any(), Argument::any())->shouldBeCalled();
+
+        $returnImage = $this->pasteTransformation->execute(
+            $image->reveal(),
+            [
+                'image' => 'test.jpg',
+            ]
+        );
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+
+    public function testNoPaste()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $image->getSize()->willReturn(new Box(700, 500));
+        $image->paste(Argument::any(), Argument::any())->shouldNotBeCalled();
+
+        $returnImage = $this->pasteTransformation->execute(
+            $image->reveal(),
+            []
+        );
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
#### What's in this PR?

Fix the media transformator pool compiler pass. Added a paste transformator to overlay an image.
#### Why?

With the paste function a image can be added above another image.
#### Example Usage

``` xml
<format>
    <name>400x400-mask</name>
    <commands>
        <command>
            <action>scale</action>
            <parameters>
                <parameter name="x">400</parameter>
                <parameter name="y">400</parameter>
            </parameters>
        </command>
        <command>
            <action>paste</action>
            <parameters>
                <parameter name="image">@AppBundle/Resources/public/border.png</parameter>
            </parameters>
        </command>
    </commands>
</format>
```
