### PR TITLE
Fixed apostrophe bug in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3001 [ContentBundle]       Fixed apostrophe bug in template
     * BUGFIX      #2861 [ContentBundle]       Removed bug with displaced multifield remove icon
     * FEATURE     #2999 [MediaBundle]         Added correct mime type to image after editing with aviary 
     * FEATURE     #2994 [HTTPCacheBundle]     Added cachelifetime types and introduced cron-expressions to calculate cachelifetime 

--- a/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
+++ b/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -127,14 +127,12 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
             $resources = [new FileResource($filePath)];
 
             $cache->write(
-                sprintf('<?php $metadata = \'%s\';', serialize($metadata)),
+                serialize($metadata),
                 $resources
             );
         }
 
-        require $cachePath;
-
-        $structure = unserialize($metadata);
+        $structure = unserialize(file_get_contents($cachePath));
 
         $this->cache[$cacheKey] = $structure;
 

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/data/apostrophe/apostrophe.xml
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/data/apostrophe/apostrophe.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+    <key>apostrophe</key>
+    <view>AppBundle:templates:apostrophe</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Sitemap</title>
+        <title lang="de">Sitemap</title>
+    </meta>
+
+    <properties>
+        <section name="highlight">
+            <properties>
+                <property name="title" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Title's</title>
+                        <title lang="de">Titel's</title>
+                    </meta>
+
+                    <params>
+                        <param name="headline" value="true"/>
+                    </params>
+
+                    <tag name="sulu.rlp.part"/>
+                </property>
+
+                <property name="url" type="resource_locator" mandatory="true">
+                    <meta>
+                        <title lang="en">Resource Locator</title>
+                        <title lang="de">Adresse</title>
+                    </meta>
+
+                    <tag name="sulu.rlp"/>
+                </property>
+            </properties>
+        </section>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #2932 |
| Related issues/PRs | #issuenum |
| License | MIT |
| Documentation PR | sulu/sulu-docs#prnum |
#### What's in this PR?

Apostrophes can now be used in template titles.
