### PR TITLE
fixed background of media overlay for preview icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3010 [MediaBundle]         Fixed background of media overlay for preview icons
     * BUGFIX      #2899 [ContentBundle]       Disabled self referencing on internal links
     * FEATURE     #2898 [CustomUrlBundle]     Added action button for ghost pages in custom url target selection
     * BUGFIX      #3009 [ContentBundle]       Fixed skin of teaser-select overlay

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/css/main.css
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/css/main.css
@@ -766,14 +766,28 @@ a.media-edit-link,
   width: 100%;
   height: 100%;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 89, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 68, ../scss/modules/media-edit-overlay.scss */
+.media-edit-preview-image[class^=fa-] {
+  background: none;
+  border: none;
+  margin-top: 30px;
+}
+/* line 74, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 .media-edit-preview-image.icon {
   color: #999;
   font-size: 150px;
   text-align: center;
   vertical-align: middle;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 96, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 81, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 .media-edit-preview-image .file-version-change,
 .media-edit-preview-image img {
   position: absolute;
@@ -787,30 +801,50 @@ a.media-edit-link,
   max-height: 100%;
   max-width: 100%;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 107, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 92, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 .media-edit-preview-image #file-version-change {
   width: 100%;
   height: 100%;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 111, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 96, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 .media-edit-preview-image #file-version-change .dropzone-container {
   width: 150px;
   height: 150px;
 }
 
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 119, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 104, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-preview .media-edit-preview-image-container {
   background-color: #ddd;
   position: relative;
   text-align: center;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 125, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 110, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-preview .media-edit-preview-image-container:before {
   content: '';
   display: block;
   padding-top: 100%;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 132, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 117, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-preview #preview-image-change {
   position: absolute;
   top: 0;
@@ -820,18 +854,30 @@ a.media-edit-link,
   width: 100%;
   height: 100%;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 142, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 127, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-preview #preview-image-change .dropzone-container {
   width: 150px;
   height: 150px;
 }
 
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 149, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 134, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 .overlay-footer .btn.media-reset-preview-action.hide {
   display: none;
 }
 
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 154, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 139, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-info .info-label-container {
   overflow: visible;
   position: absolute;
@@ -840,17 +886,29 @@ a.media-edit-link,
   left: 0;
   right: 0;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 163, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 148, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-info textarea.description {
   height: 80px;
   min-height: 80px;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 168, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 153, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-info .media-info-preview {
   position: relative;
   text-align: center;
 }
+<<<<<<< c67fe81b84d9f04be9acc9f09d65dd364d0711c8
 /* line 172, ../scss/modules/media-edit-overlay.scss */
+=======
+/* line 157, ../scss/modules/media-edit-overlay.scss */
+>>>>>>> fixed background of media overlay for preview icons
 #media-info .media-info-preview:before {
   content: '';
   display: block;

--- a/src/Sulu/Bundle/MediaBundle/Resources/public/scss/modules/media-edit-overlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/scss/modules/media-edit-overlay.scss
@@ -86,6 +86,12 @@ a.media-edit-link,
     width: 100%;
     height: 100%;
 
+    &[class^=fa-] {
+        background: none;
+        border: none;
+        margin-top: 30px;
+    }
+
     &.icon {
         color: $grayLight;
         font-size: 150px;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Previously the preview in the media overlay for non-images looked something like this:
![image](https://cloud.githubusercontent.com/assets/405874/19935422/50beb6be-a11a-11e6-96be-22d914a9f71b.png)

This PR fixes the design, it removes the background with the squares and the border and fixes the positioning.