### PR TITLE
use the correct PHPCR session for the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #3012 [MediaBundle]         Update format url when subversion changes
+    * BUGFIX      #3014 [PreviewBundle]       Use the correct PHPCR session for the preview
 
 * 1.4.0-RC2 (2016-11-03)
     * BUGFIX      #3010 [MediaBundle]         Fixed background of media overlay for preview icons

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
@@ -32,8 +32,8 @@
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu.content.resource_locator.strategy_pool" />
-            <argument type="service" id="doctrine_phpcr.session"/>
-            <argument type="service" id="doctrine_phpcr.live_session"/>
+            <argument type="service" id="sulu_document_manager.default_session"/>
+            <argument type="service" id="sulu_document_manager.live_session"/>
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
@@ -41,8 +41,8 @@
                  class="Sulu\Component\Content\Document\Subscriber\WorkflowStageSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
-            <argument type="service" id="doctrine_phpcr.session"/>
-            <argument type="service" id="doctrine_phpcr.live_session"/>
+            <argument type="service" id="sulu_document_manager.default_session"/>
+            <argument type="service" id="sulu_document_manager.live_session"/>
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -71,15 +71,15 @@
 
         <service id="sulu_document_manager.subscriber.behavior.filing"
                  class="Sulu\Component\Content\Document\Subscriber\StructureTypeFilingSubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session" />
-            <argument type="service" id="doctrine_phpcr.live_session" />
+            <argument type="service" id="sulu_document_manager.default_session" />
+            <argument type="service" id="sulu_document_manager.live_session" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
         <service id="sulu_document_manager.subscriber.behavior.alias"
                  class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber">
-            <argument type="service" id="doctrine_phpcr.default_session" />
-            <argument type="service" id="doctrine_phpcr.live_session" />
+            <argument type="service" id="sulu_document_manager.default_session" />
+            <argument type="service" id="sulu_document_manager.live_session" />
             <argument type="service" id="sulu_document_manager.metadata_factory.base" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -78,4 +78,12 @@ class PreviewKernel extends \WebsiteKernel
 
         return $cacheDirectory;
     }
+
+    public function getKernelParameters()
+    {
+        return array_merge(
+            parent::getKernelParameters(),
+            ['sulu.preview' => true]
+        );
+    }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -3,3 +3,6 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
+
+sulu_document_manager:
+    default_session: default

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -3,6 +3,3 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
-
-sulu_document_manager:
-    default_session: default

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -76,9 +76,7 @@ abstract class SuluKernel extends Kernel
     {
         return array_merge(
             parent::getKernelParameters(),
-            [
-                'sulu.context' => $this->getContext(),
-            ]
+            ['sulu.context' => $this->getContext()]
         );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/2973
| Related issues/PRs | https://github.com/sulu/sulu-minimal/pull/29 https://github.com/sulu/sulu-standard/pull/758
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR makes the PHPCR session use the correct session, so that it also finds pages which have never been published yet.

#### Why?

Because the preview breaks otherwise.