### PR TITLE
Activate cache handlers only in prod-environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * HOTFIX      #2989 [ContentBundle]       Fixed internal-link-uuid in query-builder
     * HOTFIX      #2989 [MediaBundle]         Added file-version name database-index
+    * HOTFIX      #3015 [HTTPCacheBundle]     Activate cache handlers only in prod-environment
 
 * 1.3.2 (2016-11-03)
     * HOTFIX      #2995 [MediaBundle]         Fixed namespace collision in media entity

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -14,17 +14,32 @@ namespace Sulu\Bundle\HttpCacheBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class SuluHttpCacheExtension extends Extension
+/**
+ * Container extension for sulu-http-cache bundle.
+ */
+class SuluHttpCacheExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container)
     {
-        return new Configuration();
+        if (in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
+            $container->prependExtensionConfig(
+                'sulu_http_cache',
+                [
+                    'handlers' => [
+                        'public' => ['enabled' => false],
+                        'url' => ['enabled' => false],
+                        'tags' => ['enabled' => false],
+                    ],
+                ]
+            );
+        }
     }
 
     /**
@@ -48,7 +63,7 @@ class SuluHttpCacheExtension extends Extension
     /**
      * Configure the proxy client services.
      *
-     * @param array            $config
+     * @param array $config
      * @param ContainerBuilder $container
      */
     private function configureProxyClient($config, ContainerBuilder $container)
@@ -63,11 +78,13 @@ class SuluHttpCacheExtension extends Extension
             }
 
             if (null !== $proxyClientName) {
-                throw new InvalidConfigurationException(sprintf(
-                    'Cannot enable more than one proxy, trying to enable "%s" when "%s" is already enabled',
-                    $name,
-                    $proxyClientName
-                ));
+                throw new InvalidConfigurationException(
+                    sprintf(
+                        'Cannot enable more than one proxy, trying to enable "%s" when "%s" is already enabled',
+                        $name,
+                        $proxyClientName
+                    )
+                );
             }
 
             $proxyClientName = $name;
@@ -84,7 +101,7 @@ class SuluHttpCacheExtension extends Extension
     /**
      * Configure the varnish services.
      *
-     * @param array            $config
+     * @param array $config
      * @param ContainerBuilder $container
      */
     private function configureProxyClientVarnish($config, ContainerBuilder $container)
@@ -100,7 +117,7 @@ class SuluHttpCacheExtension extends Extension
     /**
      * Configure the structure cache handler services.
      *
-     * @param array            $config
+     * @param array $config
      * @param ContainerBuilder $container
      */
     private function configureStructureCacheHandlers($config, ContainerBuilder $container)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-standard/pull/760
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR insures that the http-cache flush will only be called after in prod-environment.
