### PR TITLE
Changed content-type write handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * HOTFIX      #2989 [ContentBundle]       Fixed internal-link-uuid in query-builder
     * HOTFIX      #2989 [MediaBundle]         Added file-version name database-index
     * HOTFIX      #3015 [HTTPCacheBundle]     Activate cache handlers only in prod-environment
+    * HOTFIX      #3017 [ContentBundle]       Changed content-type write handling
 
 * 1.3.2 (2016-11-03)
     * HOTFIX      #2995 [MediaBundle]         Fixed namespace collision in media entity

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/SuluNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/SuluNode.php
@@ -1,0 +1,477 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Subscriber\PHPCR;
+
+use PHPCR\ItemInterface;
+use PHPCR\ItemVisitorInterface;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyType;
+
+/**
+ * Wraps PHPCR-Node and adds some extra logic to detect property type-changes.
+ */
+class SuluNode implements \IteratorAggregate, NodeInterface
+{
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @param NodeInterface $node
+     */
+    public function __construct(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->node->getPath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->node->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAncestor($depth)
+    {
+        return $this->node->getAncestor($depth);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return $this->node->getParent();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDepth()
+    {
+        return $this->node->getDepth();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSession()
+    {
+        return $this->node->getSession();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNode()
+    {
+        return $this->node->isNode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNew()
+    {
+        return $this->node->isNew();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isModified()
+    {
+        return $this->node->isModified();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSame(ItemInterface $otherItem)
+    {
+        return $this->node->isSame($otherItem);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function accept(ItemVisitorInterface $visitor)
+    {
+        return $this->node->accept($visitor);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function revert()
+    {
+        return $this->node->revert();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove()
+    {
+        return $this->node->remove();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addNode($relPath, $primaryNodeTypeName = null)
+    {
+        return $this->node->addNode($relPath, $primaryNodeTypeName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addNodeAutoNamed($nameHint = null, $primaryNodeTypeName = null)
+    {
+        return $this->node->addNodeAutoNamed($nameHint, $primaryNodeTypeName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function orderBefore($srcChildRelPath, $destChildRelPath)
+    {
+        return $this->node->orderBefore($srcChildRelPath, $destChildRelPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rename($newName)
+    {
+        return $this->node->rename($newName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProperty($name, $value, $type = PropertyType::UNDEFINED)
+    {
+        $oldValue = $this->getPropertyValueWithDefault($name, null);
+        if ($oldValue !== null && gettype($value) !== gettype($oldValue)) {
+            $this->node->getProperty($name)->remove();
+        }
+
+        return $this->node->setProperty($name, $value, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNode($relPath)
+    {
+        return $this->node->getNode($relPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodes($nameFilter = null, $typeFilter = null)
+    {
+        return $this->node->getNodes($nameFilter, $typeFilter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeNames($nameFilter = null, $typeFilter = null)
+    {
+        return $this->node->getNodeNames($nameFilter, $typeFilter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperty($relPath)
+    {
+        return $this->node->getProperty($relPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPropertyValue($name, $type = PropertyType::UNDEFINED)
+    {
+        return $this->node->getPropertyValue($name, $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPropertyValueWithDefault($relPath, $defaultValue)
+    {
+        return $this->node->getPropertyValueWithDefault($relPath, $defaultValue);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties($nameFilter = null)
+    {
+        return $this->node->getProperties($nameFilter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPropertiesValues($nameFilter = null, $dereference = true)
+    {
+        return $this->node->getPropertiesValues($nameFilter, $dereference);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrimaryItem()
+    {
+        return $this->node->getPrimaryItem();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return $this->node->getIdentifier();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndex()
+    {
+        return $this->node->getIndex();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReferences($name = null)
+    {
+        return $this->node->getReferences($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWeakReferences($name = null)
+    {
+        return $this->node->getWeakReferences($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasNode($relPath)
+    {
+        return $this->node->hasNode($relPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasProperty($relPath)
+    {
+        return $this->node->hasProperty($relPath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasNodes()
+    {
+        return $this->node->hasNodes();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasProperties()
+    {
+        return $this->node->hasProperties();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrimaryNodeType()
+    {
+        return $this->node->getPrimaryNodeType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMixinNodeTypes()
+    {
+        return $this->node->getMixinNodeTypes();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNodeType($nodeTypeName)
+    {
+        return $this->node->isNodeType($nodeTypeName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPrimaryType($nodeTypeName)
+    {
+        return $this->node->setPrimaryType($nodeTypeName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addMixin($mixinName)
+    {
+        return $this->node->addMixin($mixinName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeMixin($mixinName)
+    {
+        return $this->node->removeMixin($mixinName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMixins(array $mixinNames)
+    {
+        return $this->node->setMixins($mixinNames);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canAddMixin($mixinName)
+    {
+        return $this->node->canAddMixin($mixinName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return $this->node->getDefinition();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($srcWorkspace)
+    {
+        return $this->node->update($srcWorkspace);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCorrespondingNodePath($workspaceName)
+    {
+        return $this->node->getCorrespondingNodePath($workspaceName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSharedSet()
+    {
+        return $this->node->getSharedSet();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeSharedSet()
+    {
+        return $this->node->removeSharedSet();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeShare()
+    {
+        return $this->node->removeShare();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCheckedOut()
+    {
+        return $this->node->isCheckedOut();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isLocked()
+    {
+        return $this->node->isLocked();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function followLifecycleTransition($transition)
+    {
+        return $this->node->followLifecycleTransition($transition);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedLifecycleTransitions()
+    {
+        return $this->node->getAllowedLifecycleTransitions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        if (!$this->node instanceof \IteratorAggregate) {
+            return;
+        }
+
+        return $this->node->getIterator();
+    }
+}

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -21,6 +21,7 @@ use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\Structure\ManagedStructure;
 use Sulu\Component\Content\Document\Structure\Structure;
 use Sulu\Component\Content\Document\Structure\StructureInterface;
+use Sulu\Component\Content\Document\Subscriber\PHPCR\SuluNode;
 use Sulu\Component\Content\Exception\MandatoryPropertyException;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
@@ -346,16 +347,8 @@ class StructureSubscriber implements EventSubscriberInterface
             $legacyProperty = $this->legacyPropertyFactory->createTranslatedProperty($structureProperty, $locale);
             $legacyProperty->setValue($value);
 
-            $contentType->remove(
-                $node,
-                $legacyProperty,
-                $webspaceName,
-                $locale,
-                null
-            );
-
             $contentType->write(
-                $node,
+                new SuluNode($node),
                 $legacyProperty,
                 null,
                 $webspaceName,

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/PHPCR/SuluNodeTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber\PHPCR;
+
+use PHPCR\ItemVisitorInterface;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPCR\PropertyType;
+use PHPCR\SessionInterface;
+use Sulu\Component\Content\Document\Subscriber\PHPCR\SuluNode;
+
+/**
+ * Tests for calss SuluNode.
+ */
+class SuluNodeTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideDelegateData()
+    {
+        return [
+            ['getPath', '/test'],
+            ['getName', 'test'],
+            ['getAncestor', [$this->prophesize(NodeInterface::class)->reveal()], [1]],
+            ['getParent', $this->prophesize(NodeInterface::class)->reveal()],
+            ['getDepth', 1],
+            ['getSession', $this->prophesize(SessionInterface::class)->reveal()],
+            ['isNode', true],
+            ['isNew', true],
+            ['isModified', true],
+            ['isSame', false, [$this->prophesize(NodeInterface::class)->reveal()]],
+            ['accept', true, [$this->prophesize(ItemVisitorInterface::class)->reveal()]],
+            ['revert', true],
+            ['remove', null],
+            ['addNode', $this->prophesize(NodeInterface::class)->reveal(), ['test-1', 'sulu:content']],
+            ['addNodeAutoNamed', $this->prophesize(NodeInterface::class)->reveal(), ['test-1', 'sulu:content']],
+            ['orderBefore', $this->prophesize(NodeInterface::class)->reveal(), ['test-1', 'test-2']],
+            ['rename', null, ['test-1']],
+            ['getNode', $this->prophesize(NodeInterface::class)->reveal(), ['test-1']],
+            ['getNodes', [$this->prophesize(NodeInterface::class)->reveal()], ['test-*', 'sulu:*']],
+            ['getNodeNames', ['test-1'], ['test-*', 'sulu:*']],
+            ['getProperty', $this->prophesize(PropertyInterface::class)->reveal(), ['test-1']],
+            ['getPropertyValue', 'test-1', ['test-1', PropertyType::TYPENAME_DATE]],
+            ['getPropertyValueWithDefault', 'test-1', ['test-1', null]],
+            ['getProperties', [$this->prophesize(PropertyInterface::class)->reveal()], ['test-*']],
+            ['getPropertiesValues', ['test-1'], ['test-*', false]],
+            ['getPrimaryItem', 'sulu:content'],
+            ['getIdentifier', '123-123-123'],
+            ['getIndex', 1],
+            ['getReferences', [$this->prophesize(NodeInterface::class)->reveal()], ['sulu:content']],
+            ['getWeakReferences', [$this->prophesize(NodeInterface::class)->reveal()], ['sulu:content']],
+            ['hasNode', true, ['test-1']],
+            ['hasProperty', true, ['test-1']],
+            ['hasNodes', true],
+            ['hasProperties', true],
+            ['getPrimaryNodeType', 'sulu:content'],
+            ['getMixinNodeTypes', ['sulu:content']],
+            ['isNodeType', true, ['sulu:content']],
+            ['setPrimaryType', null, ['sulu:content']],
+            ['addMixin', null, ['sulu:content']],
+            ['removeMixin', null, ['sulu:content']],
+            ['setMixins', null, [['sulu:content']]],
+            ['update', null, ['default']],
+            ['getCorrespondingNodePath', '/test-1', ['default']],
+            ['getSharedSet', [$this->prophesize(NodeInterface::class)->reveal()]],
+            ['removeSharedSet', null],
+            ['removeShare', null],
+            ['isCheckedOut', true],
+            ['isLocked', true],
+            ['followLifecycleTransition', true, ['test-1']],
+            ['getAllowedLifecycleTransitions', ['test-1']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDelegateData
+     */
+    public function testDelegate($functionName, $returnValue, $arguments = [])
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        call_user_func_array([$node, $functionName], $arguments)->willReturn($returnValue);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($returnValue, call_user_func_array([$suluNode, $functionName], $arguments));
+    }
+
+    public function testGetIterator()
+    {
+        $node = $this->prophesize(NodeInterface::class)->willImplement(\IteratorAggregate::class);
+        $node->getIterator()->willReturn($this->prophesize(\Iterator::class)->reveal());
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertInstanceOf(\Iterator::class, $suluNode->getIterator());
+    }
+
+    public function testSetProperty()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $node = $this->prophesize(NodeInterface::class)->willImplement(\IteratorAggregate::class);
+
+        $node->setProperty('test-1', 'test', PropertyType::STRING)->willReturn($property->reveal());
+        $node->getPropertyValueWithDefault('test-1', null)->willReturn(null);
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($property->reveal(), $suluNode->setProperty('test-1', 'test', PropertyType::STRING));
+    }
+
+    public function testSetPropertySameType()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $node = $this->prophesize(NodeInterface::class)->willImplement(\IteratorAggregate::class);
+
+        $node->setProperty('test-1', 'test', PropertyType::STRING)->willReturn($property->reveal());
+        $node->getPropertyValueWithDefault('test-1', null)->willReturn('same-type');
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($property->reveal(), $suluNode->setProperty('test-1', 'test', PropertyType::STRING));
+    }
+
+    public function testSetPropertyDifferentType()
+    {
+        $oldProperty = $this->prophesize(PropertyInterface::class);
+        $property = $this->prophesize(PropertyInterface::class);
+        $node = $this->prophesize(NodeInterface::class)->willImplement(\IteratorAggregate::class);
+
+        $node->setProperty('test-1', 'test', PropertyType::STRING)->willReturn($property->reveal());
+        $node->getPropertyValueWithDefault('test-1', null)->willReturn(['different-type']);
+        $node->getProperty('test-1')->willReturn($oldProperty->reveal());
+        $oldProperty->remove()->shouldBeCalled();
+
+        $suluNode = new SuluNode($node->reveal());
+
+        $this->assertEquals($property->reveal(), $suluNode->setProperty('test-1', 'test', PropertyType::STRING));
+    }
+}

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/StructureSubscriberTest.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Structure\ManagedStructure;
 use Sulu\Component\Content\Document\Structure\PropertyValue;
 use Sulu\Component\Content\Document\Structure\Structure;
+use Sulu\Component\Content\Document\Subscriber\PHPCR\SuluNode;
 use Sulu\Component\Content\Document\Subscriber\StructureSubscriber;
 use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
@@ -418,10 +419,10 @@ class StructureSubscriberTest extends SubscriberTestCase
             'webspace',
             'fr',
             null
-        )->shouldBeCalled();
+        )->shouldNotBeCalled();
 
         $this->contentType->write(
-            $this->node->reveal(),
+            new SuluNode($this->node->reveal()),
             $this->legacyProperty->reveal(),
             null,
             'webspace',

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Document\Subscriber\PHPCR\SuluNode;
 use Sulu\Component\Content\Exception\UnexpectedPropertyType;
 
 /**
@@ -243,16 +244,8 @@ class BlockContentType extends ComplexContentType
         $contentType = $this->contentTypeManager->get($property->getContentTypeName());
         $blockPropertyWrapper = new BlockPropertyWrapper($property, $blockProperty, $index);
 
-        // TODO find a better why for change Types (same hack is used in ContentMapper:save )
-        $contentType->remove(
-            $node,
-            $blockPropertyWrapper,
-            $webspaceKey,
-            $languageCode,
-            $segmentKey
-        );
         $contentType->write(
-            $node,
+            new SuluNode($node),
             $blockPropertyWrapper,
             $userId,
             $webspaceKey,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (in some cases)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | non
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the write handling of content-types and removes the `remove`-call and remove old properties only if type has changed.

#### TODO

- [x] Tests