### PR TITLE
Fixed port handling for webspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #2969 [MediaBundle]         Fixed uncatchable exception when use sulu_media_resolve twig extension 
+    * BUGFIX      #3018 [WebsiteBundle]       Fixed port handling for webspaces
     * BUGFIX      #3012 [MediaBundle]         Update format url when subversion changes
     * BUGFIX      #3014 [PreviewBundle]       Use the correct PHPCR session for the preview
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrade
 
+## dev-develop
+
+### Ports in webspace config
+
+From now on the the port has to be a part of the URL in the webspace
+configuration. So if you are running your website on a different port than the
+default port of the protocol you are using, you have to change the webspace
+config. The port must still be omitted when the `{host}` placeholder is used.
+
 ## 1.4.0-RC2
 
 ### Admin User Settings

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -66,12 +66,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         $attributes['resourceLocator'] = $resourceLocator;
         $attributes['format'] = $format;
 
-        $host = $request->getHost();
-        if ($portalInformation->getType() !== RequestAnalyzerInterface::MATCH_TYPE_WILDCARD) {
-            $urlInfo = parse_url($request->getScheme() . '://' . $portalInformation->getUrl());
-            $host = $urlInfo['host'];
-        }
-        $attributes['resourceLocatorPrefix'] = substr($portalInformation->getUrl(), strlen($host));
+        $attributes['resourceLocatorPrefix'] = substr($portalInformation->getUrl(), strlen($request->getHttpHost()));
 
         if (null !== $format) {
             $request->setRequestFormat($format);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -25,11 +25,11 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @var PortalInformationRequestProcessor
      */
-    private $provider;
+    private $portalInformationRequestProcessor;
 
     public function setUp()
     {
-        $this->provider = new PortalInformationRequestProcessor();
+        $this->portalInformationRequestProcessor = new PortalInformationRequestProcessor();
     }
 
     /**
@@ -69,7 +69,7 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => $config['path_info']]
         );
 
-        $attributes = $this->provider->process(
+        $attributes = $this->portalInformationRequestProcessor->process(
             $request,
             new RequestAttributes(['portalInformation' => $portalInformation])
         );
@@ -124,7 +124,7 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => $config['path_info']]
         );
 
-        $attributes = $this->provider->process(
+        $attributes = $this->portalInformationRequestProcessor->process(
             $request,
             new RequestAttributes(['portalInformation' => $portalInformation])
         );
@@ -148,9 +148,37 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
     }
 
+    public function testProcessWithPort()
+    {
+        $portalInformation = new PortalInformation(
+            RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            null,
+            null,
+            null,
+            'sulu.lo:8000/test'
+        );
+
+        $request = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_HOST' => 'sulu.lo:8000', 'REQUEST_URI' => '/test/path/to']
+        );
+
+        $attributes = $this->portalInformationRequestProcessor->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertEquals('/path/to', $attributes->getAttribute('resourceLocator'));
+        $this->assertEquals('/test', $attributes->getAttribute('resourceLocatorPrefix'));
+    }
+
     public function testValidate()
     {
-        $this->assertTrue($this->provider->validate(new RequestAttributes()));
+        $this->assertTrue($this->portalInformationRequestProcessor->validate(new RequestAttributes()));
     }
 
     public function provideProcess()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/288

#### What's in this PR?

This PR adds the usage of the missing port when manipulating a URL.

#### Why?

When Sulu was run on a port different from the default port, the homepage was not working.

#### BC Breaks/Deprecations

The port must be included in the webspace configuration file if it is not the default port.

#### To Do

- [x] Update documentation

