### PR TITLE
make redirects for all routes to circumvent double slash problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * BUGFIX      #2997 [AdminBundle]         Disabled double click on ghost page in internal links
     * BUGFIX      #2834 [SecurityBundle]      Fixed bug with set all/none button in settings/ user role
     * ENHANCEMENT #3004 [ContentBundle]       Fixed last selected page after search
+    * BUGFIX      #3019 [WesbiteBundle]       Fixed redirect for double slash
     * BUGFIX      #2969 [MediaBundle]         Fixed uncatchable exception when use sulu_media_resolve twig extension 
     * BUGFIX      #3018 [WebsiteBundle]       Fixed port handling for webspaces
     * BUGFIX      #3012 [MediaBundle]         Update format url when subversion changes

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -129,7 +129,7 @@ class ContentRouteProvider implements RouteProviderInterface
             // redirect webspace correctly with locale
             $collection->add(
                 'redirect_' . uniqid(),
-                $this->getRedirectWebSpaceRoute($request)
+                $this->getRedirectWebSpaceRoute()
             );
         } elseif (
             $request->getRequestFormat() === 'html' &&
@@ -177,7 +177,10 @@ class ContentRouteProvider implements RouteProviderInterface
                     // redirect page to page without slash at the end
                     $collection->add(
                         'redirect_' . uniqid(),
-                        $this->getRedirectWebSpaceRoute($request)
+                        $this->getRedirectRoute(
+                            $request,
+                            $this->requestAnalyzer->getResourceLocatorPrefix() . rtrim($resourceLocator, '/')
+                        )
                     );
                 } elseif ($document->getRedirectType() === RedirectType::INTERNAL) {
                     // redirect internal link
@@ -292,11 +295,9 @@ class ContentRouteProvider implements RouteProviderInterface
     }
 
     /**
-     * @param Request $request
-     *
      * @return Route
      */
-    protected function getRedirectWebSpaceRoute(Request $request)
+    protected function getRedirectWebSpaceRoute()
     {
         $localization = $this->defaultLocaleProvider->getDefaultLocale();
 
@@ -306,11 +307,16 @@ class ContentRouteProvider implements RouteProviderInterface
         $redirect = $this->urlReplacer->replaceLocalization($redirect, $localization->getLocale(Localization::DASH));
 
         // redirect by information from webspace config
+        // has to be done for all routes, because double slashes introduce problems otherwise
         return new Route(
-            $request->getPathInfo(), [
+            '/{wildcard}',
+            [
                 '_controller' => 'SuluWebsiteBundle:Redirect:redirectWebspace',
                 'url' => $this->requestAnalyzer->getPortalUrl(),
                 'redirect' => $redirect,
+            ],
+            [
+                'wildcard' => '.*',
             ]
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2562, fixes #3020 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the redirect to match all routes. This is necessary because of [Symfony trims routes](https://github.com/sulu/sulu/issues/2562#issuecomment-259144408).

#### BC Breaks/Deprecations

The route returned when a redirect is happening changed to a more general format. Hopefully other applications haven't been relying on that exact return value.

