### PR TITLE
Fixed property-value offset set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3022 [ContentBundle]       Fixed property-value offset set
     * ENHANCEMENT #3190 [ContentBundle]       Extracted automation handler
     * ENHANCEMENT #3188 [AutomationBundle]    Extracted the automation-bundle
     * BUGFIX      #3183 [ContentBundle]       Fixed grid usage in conten form

--- a/src/Sulu/Component/Content/Document/Structure/PropertyValue.php
+++ b/src/Sulu/Component/Content/Document/Structure/PropertyValue.php
@@ -87,7 +87,7 @@ class PropertyValue implements \ArrayAccess
             return;
         }
 
-        $this->value[$offset] = array_merge($this->value[$offset], $value);
+        $this->value[$offset] = $value;
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Structure/PropertyValueTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Structure/PropertyValueTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Document\Structure;
+
+use Sulu\Component\Content\Document\Structure\PropertyValue;
+
+/**
+ * Tests for class PropertyValue.
+ */
+class PropertyValueTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideOffsetSetData()
+    {
+        return [
+            [[], 'foo', 'bar', ['foo' => 'bar']],
+            [['foo' => 'bar'], 'foo', 'baz', ['foo' => 'baz']],
+            [['foo' => ['bar']], 'foo', 'baz', ['foo' => 'baz']],
+            [['foo' => ['bar']], 'foo', ['baz'], ['foo' => ['baz']]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideOffsetSetData
+     */
+    public function testOffsetSet($value, $setName, $setValue, $expected)
+    {
+        $propertyValue = new PropertyValue('test', $value);
+
+        $propertyValue[$setName] = $setValue;
+
+        $this->assertEquals($propertyValue->getValue(), $expected);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3016
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes offset-set for class `PropertyValue`
