### PR TITLE
fix cases in navigation translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3022 [ContentBundle]       Fix cases in navigation translations
     * BUGFIX      #2997 [AdminBundle]         Disabled double click on ghost page in internal links
     * BUGFIX      #2834 [SecurityBundle]      Fixed bug with set all/none button in settings/ user role
     * ENHANCEMENT #3004 [ContentBundle]       Fixed last selected page after search

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -328,11 +328,11 @@
             </trans-unit>
             <trans-unit id="f1234df37123123ed4a7343623dfdf011" resname="sulu.content.form.settings.all-nav-contexts">
                 <source>sulu.content.form.settings.all-nav-contexts</source>
-                <target>Allen Navigationen</target>
+                <target>allen Navigationen</target>
             </trans-unit>
             <trans-unit id="aaaaaaa37123123ed4a7343623dfdf012" resname="sulu.content.form.settings.no-nav-contexts">
                 <source>sulu.content.form.settings.no-nav-contexts</source>
-                <target>Keiner Navigation</target>
+                <target>keiner Navigation</target>
             </trans-unit>
             <trans-unit id="aaaaaaa371239fbed4a73a4123dfdf008" resname="sulu.content.form.settings.shadow_page">
                 <source>sulu.content.form.settings.shadow_page</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -328,11 +328,11 @@
             </trans-unit>
             <trans-unit id="f1234df37123123ed4a7343623dfdf011" resname="sulu.content.form.settings.all-nav-contexts">
                 <source>sulu.content.form.settings.all-nav-contexts</source>
-                <target>All navigations</target>
+                <target>all navigations</target>
             </trans-unit>
             <trans-unit id="f1234df37123123ed4a7343623dfdf012" resname="sulu.content.form.settings.no-nav-contexts">
                 <source>sulu.content.form.settings.no-nav-contexts</source>
-                <target>No navigation</target>
+                <target>no navigation</target>
             </trans-unit>
             <trans-unit id="aaaaaaf371239fbed4a73a4123dfdf008" resname="sulu.content.form.settings.shadow_page">
                 <source>sulu.content.form.settings.shadow_page</source>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.nl.xlf
@@ -328,11 +328,11 @@
             </trans-unit>
             <trans-unit id="f1234df37123123ed4a7343623dfdf011" resname="sulu.content.form.settings.all-nav-contexts">
                 <source>sulu.content.form.settings.all-nav-contexts</source>
-                <target>Alle navigatie</target>
+                <target>alle navigatie</target>
             </trans-unit>
             <trans-unit id="f1234df37123123ed4a7343623dfdf012" resname="sulu.content.form.settings.no-nav-contexts">
                 <source>sulu.content.form.settings.no-nav-contexts</source>
-                <target>Geen navigatie</target>
+                <target>geen navigatie</target>
             </trans-unit>
             <trans-unit id="aaaaaaf371239fbed4a73a4123dfdf008" resname="sulu.content.form.settings.shadow_page">
                 <source>sulu.content.form.settings.shadow_page</source>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu-standard/issues/753
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The cases of the translations were fixed, because they read in combination with the label as a sentence:

![image](https://cloud.githubusercontent.com/assets/405874/20172428/5625b96a-a735-11e6-8ecb-d0d4bfd78323.png)
