### PR TITLE
use session from document manager instead doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * BUGFIX      #3024 [ContentBundle]       Use session from document manager instead of doctrine
+
 * 1.4.0 (2016-11-10)
     * BUGFIX      #3022 [ContentBundle]       Fix cases in navigation translations
     * BUGFIX      #2997 [AdminBundle]         Disabled double click on ghost page in internal links

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -51,8 +51,8 @@ class NodeControllerTest extends SuluTestCase
     public function setUp()
     {
         $this->em = $this->getEntityManager();
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
-        $this->liveSession = $this->getContainer()->get('doctrine_phpcr.live_session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
+        $this->liveSession = $this->getContainer()->get('sulu_document_manager.live_session');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
 
         $this->initOrm();

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/DocumentManagerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/DocumentManagerTest.php
@@ -44,8 +44,8 @@ class DocumentManagerTest extends SuluTestCase
         $this->initPhpcr();
 
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->defaultSession = $this->getContainer()->get('doctrine_phpcr.session');
-        $this->liveSession = $this->getContainer()->get('doctrine_phpcr.live_session');
+        $this->defaultSession = $this->getContainer()->get('sulu_document_manager.default_session');
+        $this->liveSession = $this->getContainer()->get('sulu_document_manager.live_session');
 
         $this->homeDocument = $this->documentManager->find('/cmf/sulu_io/contents', 'en');
     }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -172,7 +172,7 @@
 
         <!-- sulu node helper -->
         <service id="sulu.util.node_helper" class="%sulu.util.node_helper.class%">
-            <argument type="service" id="doctrine_phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.default_session"/>
             <argument>%sulu.content.language.namespace%</argument>
             <argument type="collection">
                 <argument key="base">%sulu.content.node_names.base%</argument>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
@@ -9,7 +9,7 @@
 
     <services>
         <service id="sulu.phpcr.session" class="%sulu.phpcr.session.class%">
-            <argument type="service" id="doctrine_phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.default_session"/>
             <argument type="collection">
                 <argument key="base">%sulu.content.node_names.base%</argument>
                 <argument key="content">%sulu.content.node_names.content%</argument>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -151,7 +151,7 @@
         </service>
 
         <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
-            <argument type="service" id="doctrine_phpcr.session" />
+            <argument type="service" id="sulu_document_manager.default_session" />
             <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>

--- a/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/SuluTestCase.php
@@ -54,8 +54,8 @@ abstract class SuluTestCase extends KernelTestCase
         parent::setUp();
 
         $this->importer = new PHPCRImporter(
-            $this->getContainer()->get('doctrine_phpcr.session'),
-            $this->getContainer()->get('doctrine_phpcr.live_session')
+            $this->getContainer()->get('sulu_document_manager.default_session'),
+            $this->getContainer()->get('sulu_document_manager.live_session')
         );
     }
 
@@ -150,8 +150,8 @@ abstract class SuluTestCase extends KernelTestCase
     protected function initPhpcr()
     {
         /** @var SessionInterface $session */
-        $session = $this->getContainer()->get('doctrine_phpcr.session');
-        $liveSession = $this->getContainer()->get('doctrine_phpcr.live_session');
+        $session = $this->getContainer()->get('sulu_document_manager.default_session');
+        $liveSession = $this->getContainer()->get('sulu_document_manager.live_session');
 
         if ($session->nodeExists('/cmf')) {
             NodeHelper::purgeWorkspace($session);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -96,7 +96,7 @@ class SitemapGeneratorTest extends SuluTestCase
     {
         $this->initPhpcr();
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->webspaceManager = $this->getContainer()->get('sulu_core.webspace.webspace_manager');
         $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');

--- a/src/Sulu/Component/Content/Tests/Functional/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Document/Subscriber/ShadowCopyPropertiesSubscriberTest.php
@@ -38,7 +38,7 @@ class ShadowCopyPropertiesSubscriberTest extends SuluTestCase
     {
         $this->initPhpcr();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
 
         $this->homeDocument = $this->documentManager->find('/cmf/sulu_io/contents', 'en');
 

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -89,7 +89,7 @@ class ContentMapperTest extends SuluTestCase
         $this->extensions = [new TestExtension('test1'), new TestExtension('test2', 'test2')];
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->extensionManager = $this->getContainer()->get('sulu_content.extension.manager');
         $this->contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -84,7 +84,7 @@ class ContentRepositoryTest extends SuluTestCase
 
     public function setUp()
     {
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->propertyEncoder = $this->getContainer()->get('sulu_document_manager.property_encoder');

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -75,7 +75,7 @@ class PhpcrMapperTest extends SuluTestCase
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
@@ -46,7 +46,7 @@ class TreeFullEditStrategyTest extends SuluTestCase
         $this->resourceLocatorStrategy = $this->getContainer()->get('sulu.content.resource_locator.strategy.tree_full_edit');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
 
 
         $this->initPhpcr();

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
@@ -46,7 +46,7 @@ class TreeLeafEditStrategyTest extends SuluTestCase
         $this->resourceLocatorStrategy = $this->getContainer()->get('sulu.content.resource_locator.strategy.tree_leaf_edit');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
-        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
+        $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
 
 
         $this->initPhpcr();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR uses the PHPCR session from the document manager. 

#### Why?

Because then other bundles don't have to know about PHPCR at all, but can simply rely on the values from the `DocumentManager`.