### PR TITLE
Added effect transformation for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG for Sulu
 ==================
 * dev-master
+    * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media
     * HOTFIX      #3750 [PreviewBundle]           Fixed refresh preview
 
 * 1.6.14 (2018-02-06)

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/schema/formats/formats-1.0.xsd
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/schema/formats/formats-1.0.xsd
@@ -27,7 +27,7 @@
     <xs:complexType name="commandType">
         <xs:sequence>
             <xs:element type="xs:string" name="action"/>
-            <xs:element type="parametersType" name="parameters"/>
+            <xs:element type="parametersType" name="parameters" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/BlurTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/BlurTransformation.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
+
+use Imagine\Image\ImageInterface;
+
+/**
+ * Adds the blur effect to an image.
+ */
+class BlurTransformation implements TransformationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ImageInterface $image, $parameters)
+    {
+        if (!isset($parameters['sigma'])) {
+            throw new \RuntimeException('The parameter "sigma" is required for "blur" transformation.');
+        }
+
+        if (!is_numeric($parameters['sigma'])) {
+            throw new \RuntimeException('The parameter "sigma" need to be a numeric value for "blur" transformation.');
+        }
+
+        $image->effects()->blur((float) $parameters['sigma']);
+
+        return $image;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/GammaTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/GammaTransformation.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
+
+use Imagine\Image\ImageInterface;
+
+/**
+ * Adds the gamma effect to an image.
+ */
+class GammaTransformation implements TransformationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ImageInterface $image, $parameters)
+    {
+        if (!isset($parameters['correction'])) {
+            throw new \RuntimeException('The parameter "correction" is required for "gamma" transformation.');
+        }
+
+        if (!is_numeric($parameters['correction'])) {
+            throw new \RuntimeException(
+                'The parameter "correction" need to be a numeric value for "gamma" transformation.'
+            );
+        }
+
+        $image->effects()->gamma((float) $parameters['correction']);
+
+        return $image;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/GrayscaleTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/GrayscaleTransformation.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
+
+use Imagine\Image\ImageInterface;
+
+/**
+ * Add the grayscale effect to an image.
+ */
+class GrayscaleTransformation implements TransformationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ImageInterface $image, $parameters)
+    {
+        $image->effects()->grayscale();
+
+        return $image;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/NegativeTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/NegativeTransformation.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
+
+use Imagine\Image\ImageInterface;
+
+/**
+ * Adds the negative effect to an image.
+ */
+class NegativeTransformation implements TransformationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ImageInterface $image, $parameters)
+    {
+        $image->effects()->negative();
+
+        return $image;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/PasteTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/PasteTransformation.php
@@ -47,7 +47,7 @@ class PasteTransformation implements TransformationInterface
         $maskPath = isset($parameters['image']) ? $this->fileLocator->locate($parameters['image']) : null;
 
         if (!$maskPath) {
-            return $image;
+            throw new \RuntimeException('The parameter "image" is required for "paste" transformation.');
         }
 
         $originalWidth = $image->getSize()->getWidth();

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/SharpenTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/SharpenTransformation.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
+
+use Imagine\Image\ImageInterface;
+
+/**
+ * Add the sharpen effect to an image.
+ */
+class SharpenTransformation implements TransformationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ImageInterface $image, $parameters)
+    {
+        $image->effects()->sharpen();
+
+        return $image;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -108,6 +108,26 @@
             <tag name="sulu_media.image.transformation" alias="paste" />
         </service>
 
+        <service id="sulu_media.image.transformation.blur" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\BlurTransformation">
+            <tag name="sulu_media.image.transformation" alias="blur" />
+        </service>
+
+        <service id="sulu_media.image.transformation.gamma" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\GammaTransformation">
+            <tag name="sulu_media.image.transformation" alias="gamma" />
+        </service>
+
+        <service id="sulu_media.image.transformation.grayscale" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\GrayscaleTransformation">
+            <tag name="sulu_media.image.transformation" alias="grayscale" />
+        </service>
+
+        <service id="sulu_media.image.transformation.negative" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\NegativeTransformation">
+            <tag name="sulu_media.image.transformation" alias="negative" />
+        </service>
+
+        <service id="sulu_media.image.transformation.sharpen" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\SharpenTransformation">
+            <tag name="sulu_media.image.transformation" alias="sharpen" />
+        </service>
+
         <service id="sulu_media.media_manager" class="%sulu_media.media_manager.class%">
             <argument type="service" id="sulu.repository.media" />
             <argument type="service" id="sulu_media.collection_repository" />

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/BlurTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/BlurTransformationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
+
+use Imagine\Effects\EffectsInterface;
+use Imagine\Image\ImageInterface;
+use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\BlurTransformation;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+/**
+ * Test the blur transformation.
+ */
+class BlurTransformationTest extends SuluTestCase
+{
+    /**
+     * @var BlurTransformation
+     */
+    protected $transformation;
+
+    public function setUp()
+    {
+        $this->transformation = new BlurTransformation();
+
+        parent::setUp();
+    }
+
+    public function testBlur()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $effects = $this->prophesize(EffectsInterface::class);
+        $effects->blur(0.75)->shouldBeCalled();
+        $image->effects()->willReturn($effects);
+
+        $returnImage = $this->transformation->execute(
+            $image->reveal(),
+            [
+                'sigma' => '0.75',
+            ]
+        );
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/GammaTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/GammaTransformationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
+
+use Imagine\Effects\EffectsInterface;
+use Imagine\Image\ImageInterface;
+use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\GammaTransformation;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+/**
+ * Test the gamma transformation.
+ */
+class GammaTransformationTest extends SuluTestCase
+{
+    /**
+     * @var GammaTransformation
+     */
+    protected $transformation;
+
+    public function setUp()
+    {
+        $this->transformation = new GammaTransformation();
+
+        parent::setUp();
+    }
+
+    public function testGamma()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $effects = $this->prophesize(EffectsInterface::class);
+        $effects->gamma(0.75)->shouldBeCalled();
+        $image->effects()->willReturn($effects);
+
+        $returnImage = $this->transformation->execute(
+            $image->reveal(),
+            [
+                'correction' => '0.75',
+            ]
+        );
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/GrayscaleTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/GrayscaleTransformationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
+
+use Imagine\Effects\EffectsInterface;
+use Imagine\Image\ImageInterface;
+use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\GrayscaleTransformation;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+/**
+ * Test the grayscale transformation.
+ */
+class GrayscaleTransformationTest extends SuluTestCase
+{
+    /**
+     * @var GrayscaleTransformation
+     */
+    protected $transformation;
+
+    public function setUp()
+    {
+        $this->transformation = new GrayscaleTransformation();
+
+        parent::setUp();
+    }
+
+    public function testGrayscale()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $effects = $this->prophesize(EffectsInterface::class);
+        $effects->grayscale()->shouldBeCalled();
+        $image->effects()->willReturn($effects);
+
+        $returnImage = $this->transformation->execute($image->reveal(), []);
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/NegativeTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/NegativeTransformationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
+
+use Imagine\Effects\EffectsInterface;
+use Imagine\Image\ImageInterface;
+use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\NegativeTransformation;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+/**
+ * Test the negative transformation.
+ */
+class NegativeTransformationTest extends SuluTestCase
+{
+    /**
+     * @var NegativeTransformation
+     */
+    protected $transformation;
+
+    public function setUp()
+    {
+        $this->transformation = new NegativeTransformation();
+
+        parent::setUp();
+    }
+
+    public function testNegative()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $effects = $this->prophesize(EffectsInterface::class);
+        $effects->negative()->shouldBeCalled();
+        $image->effects()->willReturn($effects);
+
+        $returnImage = $this->transformation->execute($image->reveal(), []);
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
@@ -67,14 +67,12 @@ class PasteTransformationTest extends SuluTestCase
     public function testNoPaste()
     {
         $image = $this->prophesize(ImageInterface::class);
-        $image->getSize()->willReturn(new Box(700, 500));
-        $image->paste(Argument::any(), Argument::any())->shouldNotBeCalled();
+
+        $this->setExpectedException(\RuntimeException::class);
 
         $returnImage = $this->pasteTransformation->execute(
             $image->reveal(),
             []
         );
-
-        $this->assertInstanceOf(ImageInterface::class, $returnImage);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/SharpenTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/SharpenTransformationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
+
+use Imagine\Effects\EffectsInterface;
+use Imagine\Image\ImageInterface;
+use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\SharpenTransformation;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+/**
+ * Test the sharpen transformation.
+ */
+class SharpenTransformationTest extends SuluTestCase
+{
+    /**
+     * @var SharpenTransformation
+     */
+    protected $transformation;
+
+    public function setUp()
+    {
+        $this->transformation = new SharpenTransformation();
+
+        parent::setUp();
+    }
+
+    public function testSharpen()
+    {
+        $image = $this->prophesize(ImageInterface::class);
+        $effects = $this->prophesize(EffectsInterface::class);
+        $effects->sharpen()->shouldBeCalled();
+        $image->effects()->willReturn($effects);
+
+        $returnImage = $this->transformation->execute($image->reveal(), []);
+
+        $this->assertInstanceOf(ImageInterface::class, $returnImage);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add the imagine effects as sulu image transformers.

#### Example Usage

Old format:

```xml
    <format>
        <name>400x400-effect</name>
        <commands>
            <command>
                <action>scale</action>
                <parameters>
                    <parameter name="x">400</parameter>
                    <parameter name="y">400</parameter>
                </parameters>
            </command>
            <command>
                <action>blur</action>
                <parameters>
                    <parameter name="sigma">6</parameter>
                </parameters>
            </command>
        </commands>
    </format>
```

New format:

```xml
    <format key="400x400-effect">
        <meta>
            <title lang="en">400x400</title>
        </meta>
        <scale x="400" y="400"/>
         
        <transformations>
            <transformation>
                <effect>blur</effect>
                <parameters>
                    <parameter name="sigma">6</parameter>
                </parameters>
            </transformation>
        </transformations>
    </format>
```

# TODO

 - [x] blur own transformer
 - [x] gamma effect transformer
 - [x] grayscale own transformer
 - [x] negative own transformer
 - [x] sharpen own transformer