### PR TITLE
Load external map data over https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3034 [LocationBundle]      Load external map data over https
     * BUGFIX      #3031 [AdminBundle]         Fixed defaultDisplayOption in media selectio content type
 
 * 1.4.1 (2016-11-11)

--- a/src/Sulu/Bundle/LocationBundle/Resources/public/js/map/google.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/public/js/map/google.js
@@ -20,7 +20,7 @@ define([], function() {
         this.map = null;
         this.marker = null;
 
-        var gmapApiUrl = 'http://maps.google.com/maps/api/js?sensor=false';
+        var gmapApiUrl = 'https://maps.google.com/maps/api/js?sensor=false';
 
         if (providerOptions.api_key) {
             gmapApiUrl = gmapApiUrl + '&key=' + providerOptions.api_key;

--- a/src/Sulu/Bundle/LocationBundle/Resources/public/js/map/leaflet.js
+++ b/src/Sulu/Bundle/LocationBundle/Resources/public/js/map/leaflet.js
@@ -21,8 +21,8 @@ define(['require', 'leaflet'], function (require, leaflet) {
         var marker = null;
 
         // add an OpenStreetMap tile layer
-        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
 
         if (options.zoomChangeCallback) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3003 
| Related issues/PRs | #3029
| License | MIT
| Documentation PR | -

#### What's in this PR?

A fix for location content type errors when loading over https

#### Why?

Otherwise the location content types breaks

#### BC Breaks/Deprecations

OSM doesn't support https for their short url, so maybe there is someone depending on the short url somehow, but I can't imagine that.

