### PR TITLE
Fixed bug for save if route already exists empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #3032 [ContentBundle]       Fixed publishing for shadow page targeting drafts
+    * BUGFIX      #3035 [DocumentManagerBundle] Fixed bug for save if route already exists empty
 
 * 1.4.1 (2016-11-11)
     * BUGFIX      #3024 [ContentBundle]       Use session from document manager instead of doctrine

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "guzzle/guzzle": "3.*",
         "imagine/imagine": "~0.6.1",
         "massive/search-bundle": "0.16.*",
-        "sulu/document-manager": "0.8.*",
+        "sulu/document-manager": "dev-master",
         "sensio/framework-extra-bundle": "3.0.*",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "symfony-cmf/routing-bundle": "1.2.*",

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -180,6 +180,24 @@ class PhpcrMapperTest extends SuluTestCase
         $this->assertTrue($node->hasProperty('sulu:content'));
     }
 
+    public function testSaveEmptyRouteNode()
+    {
+        $childDocument = $this->createDocument($this->homeDocument, 'Test-Child', '/test/child');
+        $this->documentManager->persist($childDocument, 'de');
+        $this->documentManager->publish($childDocument, 'de');
+
+        $document = $this->createDocument($this->homeDocument, 'Test-Child', '/test');
+        $this->documentManager->persist($document, 'de');
+
+        $this->phpcrMapper->save($document);
+        $this->sessionManager->getSession()->save();
+
+        $node = $this->session->getNode('/cmf/sulu_io/routes/de/test');
+        $this->assertEquals($node->getPropertyValue('sulu:content'), $this->documentInspector->getNode($document));
+        $this->assertTrue($node->hasProperty('sulu:history'));
+        $this->assertTrue($node->hasProperty('sulu:content'));
+    }
+
     public function testReadFailure()
     {
         $content = $this->session->getNode('/cmf/sulu_io/contents')->addNode('content');

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -99,6 +99,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
                 [
                     'path' => $routeDocumentPath,
                     'auto_create' => true,
+                    'override' => true,
                 ]
             );
             $this->documentManager->publish($routeDocument, $locale);
@@ -117,9 +118,9 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
             function ($resourceLocator, \PHPCR\NodeInterface $node) {
                 if (false === $node->getPropertyValue('sulu:history') && false !== $resourceLocator) {
                     return $resourceLocator;
-                } else {
-                    return false;
                 }
+
+                return false;
             },
             $webspaceKey,
             $languageCode,
@@ -128,9 +129,9 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
 
         if ($result !== null) {
             return $result;
-        } else {
-            throw new ResourceLocatorNotFoundException();
         }
+
+        throw new ResourceLocatorNotFoundException();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-document-manager/pull/96
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug if a route already exists as empty node.

#### Why?

This happens with resource-locator `tree_full_edit` strategy, where its possible to create a tree for routes and afterwards create a "parent" of this tree. This crashes currently "fataly" so that the page cannot be saved (published) anymore.

#### To Do

- [ ] Tests

