### PR TITLE
fixed wrong parsing of webspace from path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * HOTFIX      #3032 [ContentBundle]       Fixed publishing for shadow page targeting drafts
+    * HOTFIX      #3032 [ContentBundle]         Fixed publishing for shadow page targeting drafts
     * BUGFIX      #3035 [DocumentManagerBundle] Fixed bug for save if route already exists empty
+    * HOTFIX      #3039 [ContentBundle]         Fixed wrong parsing of webspace from path
 
 * 1.4.1 (2016-11-11)
     * BUGFIX      #3024 [ContentBundle]       Use session from document manager instead of doctrine

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrade
 
+## dev-master
+
+### Webspace keys
+
+Webspace keys are only allowed to have lower case letters, numbers and `-` or
+`_`. Other characters might cause problems and are therefore already restricted
+in the XSD file. If you have other characters you have to rename your webspace.
+
+In case you have to you also must rename the `/cmf/<webspace>` e.g. using the
+PHPCR shell and reconfigure your role permissions. You should also clear the
+search index with the `massive:search:purge` command and reindex with the
+`massive:search:reindex` command.
+
 ## 1.4.0
 
 ### Ports in webspace config

--- a/src/Sulu/Component/Util/SuluNodeHelper.php
+++ b/src/Sulu/Component/Util/SuluNodeHelper.php
@@ -164,7 +164,7 @@ class SuluNodeHelper
      */
     public function extractWebspaceFromPath($path)
     {
-        $match = preg_match('/^\/' . $this->getPath('base') . '\/(\w*)\/.*$/', $path, $matches);
+        $match = preg_match('/^\/' . $this->getPath('base') . '\/([^\/]*)\/.*$/', $path, $matches);
 
         if ($match) {
             return $matches[1];

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -11,11 +11,62 @@
 
 namespace Sulu\Component\Content\Tests\Unit\Mapper\Translation;
 
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPCR\SessionInterface;
 use Sulu\Component\Util\SuluNodeHelper;
 
 class SuluNodeHelperTest extends \PHPUnit_Framework_TestCase
 {
-    protected $properties;
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property1;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property2;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property3;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property4;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property5;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property6;
+
+    /**
+     * @var PropertyInterface
+     */
+    private $property7;
+
+    /**
+     * @var SuluNodeHelper
+     */
+    private $helper;
 
     public function setUp()
     {
@@ -98,6 +149,7 @@ class SuluNodeHelperTest extends \PHPUnit_Framework_TestCase
             ['/cmf/webspace_five/foo/bar/dar/ding', 'webspace_five'],
             ['', null],
             ['asdasd', null],
+            ['/cmf/sulu-io/content/articles', 'sulu-io'],
         ];
     }
 

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
@@ -5,7 +5,13 @@
     <xs:complexType name="webspaceType">
         <xs:sequence>
             <xs:element type="xs:string" name="name"/>
-            <xs:element type="xs:string" name="key"/>
+            <xs:element name="key">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[a-z0-9_-]+"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
             <xs:element type="security" name="security" minOccurs="0" maxOccurs="1"/>
             <xs:element type="localizationsType" name="localizations"/>
             <xs:element type="segmentsType" name="segments" maxOccurs="1" minOccurs="0"/>

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -6,7 +6,13 @@
     <xs:complexType name="webspaceType">
         <xs:sequence>
             <xs:element type="xs:string" name="name"/>
-            <xs:element type="xs:string" name="key"/>
+            <xs:element name="key">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[a-z0-9_-]+"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
             <xs:element type="security" name="security" minOccurs="0" maxOccurs="1"/>
             <xs:element type="localizationsType" name="localizations"/>
             <xs:element type="segmentsType" name="segments" maxOccurs="1" minOccurs="0"/>

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Webspace\Tests\Unit\Loader;
 
 use Prophecy\Argument;
+use Sulu\Component\Webspace\Exception\InvalidWebspaceException;
 use Sulu\Component\Webspace\Loader\XmlFileLoader10;
 use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
 use Symfony\Component\Config\FileLocatorInterface;
@@ -124,5 +125,14 @@ class XmlFileLoader10Test extends WebspaceTestCase
 
         $this->assertEquals(['page' => 'default', 'homepage' => 'overview', 'home' => 'overview'], $webspace->getDefaultTemplates());
         $this->assertEquals(['error-404' => 'test.html.twig', 'error' => 'test.html.twig'], $webspace->getTemplates());
+    }
+
+    public function testLoadWithInvalidWebspaceKey()
+    {
+        $this->setExpectedException(InvalidWebspaceException::class);
+
+        $this->loader->load(
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/invalid/sulu.io_deprecated_invalid_webspace_key.xml'
+        );
     }
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -436,6 +436,15 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertNull($devUrl->getSegment());
     }
 
+    public function testLoadWithInvalidWebspaceKey()
+    {
+        $this->setExpectedException(InvalidWebspaceException::class);
+
+        $this->loader->load(
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/invalid/sulu.io_invalid_webspace_key.xml'
+        );
+    }
+
     public function testTemplateWithNonUniqueType()
     {
         $this->setExpectedException(InvalidWebspaceException::class);

--- a/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_deprecated_invalid_webspace_key.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_deprecated_invalid_webspace_key.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.0.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu io</key>
+
+    <localizations>
+        <localization language="en" country="us" shadow="auto"/>
+        <localization language="de" country="at" default="true"/>
+    </localizations>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulu_io</key>
+
+            <localizations>
+                <localization language="de" country="at" default="true"/>
+            </localizations>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="de" country="at">test.at</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_invalid_webspace_key.xml
+++ b/tests/Resources/DataFixtures/Webspace/invalid/sulu.io_invalid_webspace_key.xml
@@ -4,11 +4,7 @@
            xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
     <name>Sulu CMF</name>
-    <key>sulu_io_no_xdefault_locale</key>
-
-    <security>
-        <system>sulu_io</system>
-    </security>
+    <key>sulu io</key>
 
     <localizations>
         <localization language="en" country="us" shadow="auto"/>
@@ -22,47 +18,19 @@
         <default-template type="homepage">overview</default-template>
     </default-templates>
 
-    <navigation>
-        <contexts>
-            <context key="main">
-                <meta>
-                    <title lang="de">Hauptnavigation</title>
-                    <title lang="en">Mainnavigation</title>
-                </meta>
-            </context>
-            <context key="footer">
-                <meta>
-                    <title lang="de">Unten</title>
-                    <title lang="en">Footer</title>
-                </meta>
-            </context>
-        </contexts>
-    </navigation>
-
-    <resource-locator>
-        <strategy>short</strategy>
-    </resource-locator>
-
     <portals>
         <portal>
             <name>Sulu CMF AT</name>
-            <key>no_xdefault_locale</key>
+            <key>sulu_io</key>
 
             <localizations>
                 <localization language="de" country="at" default="true"/>
-                <localization language="en" country="us"/>
             </localizations>
 
             <environments>
                 <environment type="prod">
                     <urls>
                         <url language="de" country="at">test.at</url>
-                        <url redirect="sulu.at">www.test.at</url>
-                    </urls>
-                </environment>
-                <environment type="dev">
-                    <urls>
-                        <url language="de" country="at">test.lo</url>
                     </urls>
                 </environment>
             </environments>

--- a/tests/Resources/DataFixtures/Webspace/xdefault/sulu.io_xdefault_locale.xml
+++ b/tests/Resources/DataFixtures/Webspace/xdefault/sulu.io_xdefault_locale.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
     <name>Sulu CMF</name>
-    <key>sulu.io_xdefault_locale</key>
+    <key>sulu_io_xdefault_locale</key>
 
     <security>
         <system>sulu_io</system>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3008, fixes sulu-standard#536
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the Regex for returning the webspace from a path. Previously it only recognized the regex group `\w*` as webspace, which e.g. didn't include `-`.

