### PR TITLE
Removed phpcr-odm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG for Sulu
     * FEATURE     #3037 [AutomationBundle]    Added automation-bundle
     * BUGFIX      #3052 [ContentBundle]       Fixed loading tree (with uuid) without webspace
     * ENHANCEMENT #3067 [ContentBundle]       Removed symfony-acl-voter
+    * ENHANCEMENT #3068 [CoreBundle]          Removed phpcr-odm
     * ENHANCEMENT #2856 [ContactBundle]       Removed not needed css
     * BUGFIX      #3034 [LocationBundle]      Load external map data over https
     * BUGFIX      #3031 [AdminBundle]         Fixed defaultDisplayOption in media selectio content type

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "cboden/ratchet": "0.3.*",
         "doctrine/orm": "2.5.*",
         "doctrine/phpcr-bundle": "~1.2.4",
-        "doctrine/phpcr-odm": "~1.3.0",
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/doctrine-cache-bundle": "~1.0",
         "friendsofsymfony/http-cache": "1.3.*",

--- a/src/Sulu/Bundle/ContentBundle/Command/ContentLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ContentLocaleCopyCommand.php
@@ -93,7 +93,7 @@ EOT
         $overwrite = $input->getOption('overwrite');
         $dryRun = $input->getOption('dry-run');
 
-        $this->session = $this->getContainer()->get('doctrine_phpcr')->getManager()->getPhpcrSession();
+        $this->session = $this->getContainer()->get('doctrine_phpcr.session');
         $this->queryManager = $this->session->getWorkspace()->getQueryManager();
         $this->languageNamespace = $this->getContainer()->getParameter('sulu.content.language.namespace');
         $this->contentMapper = $this->getContainer()->get('sulu.content.mapper');

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -58,7 +58,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                 'doctrine_phpcr',
                 [
                     'session' => $phpcrConfig,
-                    'odm' => [],
                 ]
             );
         }
@@ -144,10 +143,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         if ($container->hasExtension('jms_serializer')) {
             $container->prependExtensionConfig('jms_serializer', ['metadata' => ['debug' => '%kernel.debug%']]);
-        }
-
-        if ($container->hasExtension('cmf_core')) {
-            $container->prependExtensionConfig('cmf_core', ['publish_workflow' => ['enabled' => false]]);
         }
 
         if ($container->hasExtension('fos_rest')) {

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -62,7 +62,6 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
 
         if ($container->hasExtension('doctrine_phpcr')) {
             $doctrinePhpcrConfig = [
-                'odm' => [],
                 'session' => [
                     'sessions' => $config['sessions'],
                 ],

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Group.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Group.php
@@ -11,6 +11,9 @@
 
 namespace Sulu\Bundle\SecurityBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use JMS\Serializer\Annotation\Exclude;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
@@ -23,16 +26,22 @@ class Group extends ApiEntity implements AuditableInterface
 {
     /**
      * @var int
+     *
+     * @Exclude
      */
     private $lft;
 
     /**
      * @var int
+     *
+     * @Exclude
      */
     private $rgt;
 
     /**
      * @var int
+     *
+     * @Exclude
      */
     private $depth;
 
@@ -57,12 +66,12 @@ class Group extends ApiEntity implements AuditableInterface
     private $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection
+     * @var Collection
      */
     private $children;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection
+     * @var Collection
      */
     private $userGroups;
 
@@ -72,28 +81,29 @@ class Group extends ApiEntity implements AuditableInterface
     private $parent;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection
+     * @var Collection
      */
     private $roles;
 
     /**
      * @var UserInterface
+     *
+     * @Exclude
      */
     private $changer;
 
     /**
      * @var UserInterface
+     *
+     * @Exclude
      */
     private $creator;
 
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
-        $this->children = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->userGroups = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->roles = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->children = new ArrayCollection();
+        $this->userGroups = new ArrayCollection();
+        $this->roles = new ArrayCollection();
     }
 
     /**
@@ -249,7 +259,7 @@ class Group extends ApiEntity implements AuditableInterface
     /**
      * Get children.
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getChildren()
     {
@@ -283,7 +293,7 @@ class Group extends ApiEntity implements AuditableInterface
     /**
      * Get userGroups.
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getUserGroups()
     {
@@ -341,7 +351,7 @@ class Group extends ApiEntity implements AuditableInterface
     /**
      * Get roles.
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection
      */
     public function getRoles()
     {

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -28,12 +28,15 @@ class Role extends BaseRole
 
     /**
      * @var Collection
+     *
      * @Exclude
      */
     private $userRoles;
 
     /**
      * @var Collection
+     *
+     * @Exclude
      */
     private $groups;
 

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -74,7 +74,6 @@ class SuluTestKernel extends SuluKernel
 
         if ($this->getContext() === self::CONTEXT_WEBSITE) {
             // smyfony-cmf
-            $bundles[] = new \Symfony\Cmf\Bundle\CoreBundle\CmfCoreBundle();
             $bundles[] = new \Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle();
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\WebsiteBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use JMS\Serializer\Annotation\Exclude;
 
 /**
  * Analytics.
@@ -36,6 +37,8 @@ class Analytics
 
     /**
      * @var string
+     *
+     * @Exclude
      */
     private $content;
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
@@ -50,5 +50,14 @@ class AnalyticsSerializeEventSubscriber implements EventSubscriberInterface
             $value->domains = true;
             $event->getVisitor()->visitProperty($metadata, $value, $event->getContext());
         }
+
+        // the content will be appended dynamically because the metadata changes from string to array
+        // depended on the type of analytics.
+        // see issue: https://github.com/sulu/sulu/issues/3088
+        $content = $analytics->getContent();
+        if (!is_string($content)) {
+            $content = $event->getContext()->accept($content);
+        }
+        $event->getVisitor()->addData('content', $content);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-document-manager/pull/103 https://github.com/sulu/sulu-minimal/pull/33 https://github.com/sulu/sulu-standard/pull/772
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the direct dependency to phpcr/odm (it is inherited by another phpcr repo) and also remove the config which initializes it.

This is done because the odm isnt used currently.