### PR TITLE
Added cache configuration for preview & websocket

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -12,3 +12,4 @@ disabled:
     - phpdoc_to_comment
     - blankline_after_open_tag
     - function_declaration
+    - single_line_class_definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #3069 [PreviewBundle]       Added cache configuration for preview & websocket context
     * FEATURE     #3066 [AutomationBundle]    Added notification-badge to automation-tab
     * ENHANCEMENT #3059 [ContentBundle]       Fixed deprecation in WebspaceCollection rendering
     * ENHANCEMENT #3058 [All]                 Fixed some config files for symfony3

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
         "doctrine/orm": "2.5.*",
         "doctrine/phpcr-bundle": "~1.2.4",
         "doctrine/phpcr-odm": "~1.3.0",
+        "doctrine/doctrine-bundle": "~1.0",
+        "doctrine/doctrine-cache-bundle": "~1.0",
         "friendsofsymfony/http-cache": "1.3.*",
         "friendsofsymfony/rest-bundle": "~1.4",
         "guzzle/guzzle": "3.*",
@@ -44,7 +46,6 @@
     },
     "require-dev": {
         "phpcr/phpcr-shell": "~1.0.0@alpha",
-        "doctrine/doctrine-bundle": "1.4.*",
         "jackalope/jackalope-jackrabbit": "~1.2.0",
         "jackalope/jackalope-doctrine-dbal": "~1.2.0",
         "guzzle/plugin-mock": "3.9.*",

--- a/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
@@ -45,9 +45,79 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(500)
                     ->info('Used for the delayed send of changes')
                 ->end()
+                ->arrayNode('cache')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('type')->defaultValue('file_system')->end()
+                        ->scalarNode('namespace')->defaultNull()->end()
+                        ->append($this->addBasicProviderNode('apc'))
+                        ->append($this->addBasicProviderNode('apcu'))
+                        ->append($this->addBasicProviderNode('array'))
+                        ->append($this->addFileSystemNode())
+                        ->append($this->addRedisNode())
+                    ->end()
+                ->end()
             ->end()
         ->end();
 
         return $treeBuilder;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function addBasicProviderNode($name)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($name);
+
+        return $node;
+    }
+
+    /**
+     * Build file_system node configuration definition.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function addFileSystemNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('file_system');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('directory')->defaultValue('%sulu.cache_dir%/preview')->end()
+                ->scalarNode('extension')->defaultNull()->end()
+                ->integerNode('umask')->defaultValue(0002)->end()
+            ->end();
+
+        return $node;
+    }
+
+    /**
+     * Build redis node configuration definition.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function addRedisNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('redis');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('connection_id')->defaultNull()->end()
+                ->scalarNode('host')->defaultValue('127.0.0.1')->end()
+                ->scalarNode('port')->defaultValue('6379')->end()
+                ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('timeout')->defaultNull()->end()
+                ->scalarNode('database')->defaultNull()->end()
+            ->end();
+
+        return $node;
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PreviewBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -66,7 +67,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param string $name
      *
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     * @return NodeDefinition
      */
     private function addBasicProviderNode($name)
     {
@@ -79,7 +80,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Build file_system node configuration definition.
      *
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     * @return NodeDefinition
      */
     private function addFileSystemNode()
     {
@@ -100,7 +101,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Build redis node configuration definition.
      *
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     * @return NodeDefinition
      */
     private function addRedisNode()
     {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -14,6 +14,7 @@
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>
         </service>
+
         <service id="sulu_preview.js_config" class="Sulu\Bundle\AdminBundle\Admin\JsConfig">
             <argument type="string">sulu_preview</argument>
             <argument type="collection">
@@ -25,11 +26,9 @@
         </service>
 
         <!-- preview -->
-        <service id="sulu_preview.preview.data_cache" class="Doctrine\Common\Cache\FilesystemCache">
-            <argument type="string">%sulu.cache_dir%/preview/data</argument>
-        </service>
         <service id="sulu_preview.preview.kernel_factory"
                  class="Sulu\Bundle\PreviewBundle\Preview\Renderer\WebsiteKernelFactory"/>
+
         <service id="sulu_preview.preview.renderer" class="Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewRenderer">
             <argument type="service" id="sulu_route.routing.defaults_provider"/>
             <argument type="service" id="request_stack"/>
@@ -41,9 +40,10 @@
             </argument>
             <argument type="string">%kernel.environment%</argument>
         </service>
+
         <service id="sulu_preview.preview" class="Sulu\Bundle\PreviewBundle\Preview\Preview">
             <argument type="collection"/>
-            <argument type="service" id="sulu_preview.preview.data_cache"/>
+            <argument type="service" id="sulu_preview.preview.cache"/>
             <argument type="service" id="sulu_preview.preview.renderer"/>
         </service>
 

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -28,6 +28,7 @@ class SuluTestKernel extends SuluKernel
         $bundles = [
             // Dependencies
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
             new \Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle(),
             new \JMS\SerializerBundle\JMSSerializerBundle(),
             new \Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -27,6 +27,7 @@ class SuluTestKernel extends SuluKernel
     {
         $bundles = [
             // Dependencies
+            new \Sulu\Bundle\CoreBundle\SuluCoreBundle(),
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new \Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
             new \Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle(),
@@ -46,7 +47,6 @@ class SuluTestKernel extends SuluKernel
 
             // Sulu
             new \Sulu\Bundle\SearchBundle\SuluSearchBundle(),
-            new \Sulu\Bundle\CoreBundle\SuluCoreBundle(),
             new \Sulu\Bundle\PersistenceBundle\SuluPersistenceBundle(),
             new \Sulu\Bundle\AdminBundle\SuluAdminBundle(),
             new \Sulu\Bundle\ContentBundle\SuluContentBundle(),

--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Configuration.php
@@ -38,8 +38,78 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('http_host')->defaultValue('localhost')->end()
                     ->end()
                 ->end()
+                ->arrayNode('cache')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('type')->defaultValue('file_system')->end()
+                        ->scalarNode('namespace')->defaultNull()->end()
+                        ->append($this->addBasicProviderNode('apc'))
+                        ->append($this->addBasicProviderNode('apcu'))
+                        ->append($this->addBasicProviderNode('array'))
+                        ->append($this->addFileSystemNode())
+                        ->append($this->addRedisNode())
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function addBasicProviderNode($name)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($name);
+
+        return $node;
+    }
+
+    /**
+     * Build file_system node configuration definition.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function addFileSystemNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('file_system');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('directory')->defaultValue('%sulu.cache_dir%/websocket')->end()
+                ->scalarNode('extension')->defaultNull()->end()
+                ->integerNode('umask')->defaultValue(0002)->end()
+            ->end();
+
+        return $node;
+    }
+
+    /**
+     * Build redis node configuration definition.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function addRedisNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('redis');
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('connection_id')->defaultNull()->end()
+                ->scalarNode('host')->defaultValue('127.0.0.1')->end()
+                ->scalarNode('port')->defaultValue('6379')->end()
+                ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('timeout')->defaultNull()->end()
+                ->scalarNode('database')->defaultNull()->end()
+            ->end();
+
+        return $node;
     }
 }

--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsocketBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -58,7 +59,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param string $name
      *
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     * @return NodeDefinition
      */
     private function addBasicProviderNode($name)
     {
@@ -71,7 +72,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Build file_system node configuration definition.
      *
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     * @return NodeDefinition
      */
     private function addFileSystemNode()
     {
@@ -92,7 +93,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Build redis node configuration definition.
      *
-     * @return \Symfony\Component\Config\Definition\Builder\NodeDefinition
+     * @return NodeDefinition
      */
     private function addRedisNode()
     {

--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/SuluWebsocketExtension.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/SuluWebsocketExtension.php
@@ -13,13 +13,14 @@ namespace Sulu\Bundle\WebsocketBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * {@inheritdoc}
  */
-class SuluWebsocketExtension extends Extension
+class SuluWebsocketExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -36,5 +37,27 @@ class SuluWebsocketExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if ($container->hasExtension('doctrine_cache')) {
+            $configs = $container->getExtensionConfig($this->getAlias());
+            $config = $this->processConfiguration(new Configuration(), $configs);
+
+            $container->prependExtensionConfig('doctrine_cache',
+                [
+                    'aliases' => [
+                        'sulu_websocket.websocket.cache' => 'sulu_websocket',
+                    ],
+                    'providers' => [
+                        'sulu_websocket' => $config['cache'],
+                    ],
+                ]
+            );
+        }
     }
 }

--- a/src/Sulu/Bundle/WebsocketBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsocketBundle/Resources/config/services.xml
@@ -43,18 +43,18 @@
         </service>
 
         <service id="sulu_websocket.admin.message_builder" class="Sulu\Component\Websocket\MessageDispatcher\MessageBuilder"/>
-        <service id="sulu_websocket.admin.message_dispatcher.app.cache" class="%sulu_websocket.admin.message_dispatcher.app.cache.class%" public="false">
-            <argument type="string">%sulu.cache_dir%/preview/context</argument>
-        </service>
+
         <service id="sulu_websocket.admin.message_dispatcher" class="%sulu_websocket.admin.message_dispatcher.class%" public="false">
             <argument type="service" id="sulu_websocket.admin.message_builder"/>
+
             <tag name="sulu.context" context="admin"/>
             <tag name="sulu.websocket.message.dispatcher" alias="admin"/>
         </service>
+
         <service id="sulu_websocket.admin.message_dispatcher.app" class="%sulu_websocket.admin.message_dispatcher.app.class%">
             <argument type="string">admin</argument>
             <argument type="service" id="sulu_websocket.admin.message_dispatcher"/>
-            <argument type="service" id="sulu_websocket.admin.message_dispatcher.app.cache"/>
+            <argument type="service" id="sulu_websocket.websocket.cache"/>
 
             <tag name="sulu.context" context="admin"/>
             <tag name="sulu.websocket.app" route="/admin" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Cache configuration for preview & web socket.

#### Why?

If you have multiple web servers you need a central cache for the preview and web socket connection.

#### Example Usage

~~~yml
sulu_preview:
    cache:
        type: redis

sulu_websocket:
    cache:
        type: redis
~~~