### PR TITLE
Fixed missing referenced UUIDs for contentTypes nested in a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG for Sulu
     * ENHANCEMENT #2856 [ContactBundle]       Removed not needed css
     * BUGFIX      #3034 [LocationBundle]      Load external map data over https
     * BUGFIX      #3031 [AdminBundle]         Fixed defaultDisplayOption in media selectio content type
+    * BUGFIX      #3075 [ContentComponent]    Fixed missing referenced UUIDs for contentTypes nested in a block
 
 * 1.4.2 (2016-11-24)
     * HOTFIX      #3032 [ContentBundle]         Fixed publishing for shadow page targeting drafts

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -411,4 +411,27 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
         $property->setValue($value);
         $this->doWrite($node, $property, $userId, $webspaceKey, $languageCode, $segmentKey, true);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReferencedUuids(PropertyInterface $property)
+    {
+        $data = $this->prepareData(
+            $property,
+            function (ContentTypeInterface $contentType, $property) {
+                return $contentType->getReferencedUuids($property);
+            },
+            false
+        );
+
+        $referencedUuids = [];
+        array_walk_recursive($data, function ($val) use (&$referencedUuids) {
+            if (!in_array($val, $referencedUuids)) {
+                $referencedUuids[] = $val;
+            }
+        });
+
+        return $referencedUuids;
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds the aggregated referenced UUIDs from all content types nested in a block to the block element itself.

#### Why?

This allows the nesting of complex datatypes (eg. Internal Links, Smart Content) in a block element and having the Sulu HttpCacheBundle Tag handler setting the correct ban keys for every element displayed on the site.

#### Example Usage

Setup:
* Create a simple template with a block containing a smart content element.
* Configure Sulu HTTP HttpCacheBundle to use the Tag handler

Usage:
* Create a page using the simple template
* Configure smart content so it has a result set
* Request the published page and check for the X-Cache-Tags-Header in the HTTP request

Without this bugfix, the X-Cache-Tags-Header contains only the ID of the current page. With this bugfix, the X-Cache-Tags-Header contains all IDs of the result set in addition to the current page's one.
