### PR TITLE
Fixed extension when purging media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #3091 [SecurityBundle]        Increased length of context field
+    * HOTFIX      #3090 [MediaBundle]           Fixed extension when purging media
     * HOTFIX      #3087 [AdminBundle]           Fixed search with umlauts in text editor
     * ENHANCEMENT #3085 [DocumentManager]       Fixed document-manager constraint
     * HOTFIX      #3065 [ContentBundle]         Fixed double '&' in column-navigation url

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,17 @@
 # Upgrade
 
+## dev-master
+
+### Format cache
+
+To generate the corrent file extension the `FormatManager::purge` interface
+has changed.
+
+```diff
+-    public function purge($idMedia, $fileName, $options)
++    public function purge($idMedia, $fileName, $mimeType, $options)
+```
+
 ## 1.4.2
 
 ### Security Context

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
@@ -35,7 +35,7 @@ interface FormatCacheInterface
      *
      * @param int $id
      * @param string $fileName
-     * @param array $options
+     * @param string $options
      *
      * @return bool
      */

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/LocalFormatCache.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyInvalidUrl;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyUrlNotFoundException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Routing\Route;
 
 class LocalFormatCache implements FormatCacheInterface
 {
@@ -46,9 +45,6 @@ class LocalFormatCache implements FormatCacheInterface
 
     public function __construct(Filesystem $filesystem, $path, $pathUrl, $segments, $formats)
     {
-        /*
-         * @var Route
-         */
         $this->filesystem = $filesystem;
         $this->path = $path;
         $this->pathUrl = $pathUrl;

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -72,7 +72,7 @@ class FormatManager implements FormatManagerInterface
     private $supportedMimeTypes;
 
     /**
-     * @param MediaRepository $mediaRepository
+     * @param MediaRepositoryInterface $mediaRepository
      * @param FormatCacheInterface $formatCache
      * @param ImageConverterInterface $converter
      * @param string $saveImage
@@ -177,9 +177,9 @@ class FormatManager implements FormatManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function purge($idMedia, $fileName, $options)
+    public function purge($idMedia, $fileName, $mimeType, $options)
     {
-        return $this->formatCache->purge($idMedia, $fileName, $options);
+        return $this->formatCache->purge($idMedia, $this->replaceExtension($fileName, $mimeType), $options);
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -78,11 +78,12 @@ interface FormatManagerInterface
      *
      * @param int $idMedia
      * @param string $fileName
-     * @param array $options
+     * @param string $mimeType
+     * @param string $options
      *
      * @return bool
      */
-    public function purge($idMedia, $fileName, $options);
+    public function purge($idMedia, $fileName, $mimeType, $options);
 
     /**
      * Clears the format cache.

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatOptions/FormatOptionsManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatOptions/FormatOptionsManager.php
@@ -248,6 +248,11 @@ class FormatOptionsManager implements FormatOptionsManagerInterface
      */
     private function purgeMedia($mediaId, FileVersion $fileVersion)
     {
-        $this->formatManager->purge($mediaId, $fileVersion->getName(), $fileVersion->getStorageOptions());
+        $this->formatManager->purge(
+            $mediaId,
+            $fileVersion->getName(),
+            $fileVersion->getMimeType(),
+            $fileVersion->getStorageOptions()
+        );
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -395,6 +395,7 @@ class MediaManager implements MediaManagerInterface
             $this->formatManager->purge(
                 $mediaEntity->getId(),
                 $currentFileVersion->getName(),
+                $currentFileVersion->getMimeType(),
                 $currentFileVersion->getStorageOptions()
             );
         } else {
@@ -414,6 +415,7 @@ class MediaManager implements MediaManagerInterface
                 $this->formatManager->purge(
                     $mediaEntity->getId(),
                     $currentFileVersion->getName(),
+                    $currentFileVersion->getMimeType(),
                     $currentFileVersion->getStorageOptions()
                 );
             }
@@ -683,6 +685,7 @@ class MediaManager implements MediaManagerInterface
                 $this->formatManager->purge(
                     $mediaEntity->getId(),
                     $fileVersion->getName(),
+                    $fileVersion->getMimeType(),
                     $fileVersion->getStorageOptions()
                 );
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/SearchIntegration/SearchIntegrationTest.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\ContentBundle\Document\HomeDocument;
 use Sulu\Bundle\MediaBundle\Api\Media as ApiMedia;
 use Sulu\Bundle\MediaBundle\Content\MediaSelectionContainer;
 use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\NodeManager;
@@ -54,7 +55,7 @@ class SearchIntegrationTest extends SuluTestCase
         $this->webspaceDocument = $this->documentManager->find('/cmf/sulu_io/contents');
 
         $mediaEntity = new Media();
-        $tagManager = $this->getMock('Sulu\Bundle\TagBundle\Tag\TagManagerInterface');
+        $tagManager = $this->prophesize(TagManagerInterface::class);
         $this->media = new ApiMedia($mediaEntity, 'de', null, $tagManager);
 
         $this->mediaSelectionContainer = $this->prophesize(MediaSelectionContainer::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -270,4 +270,18 @@ class FormatManagerTest extends \PHPUnit_Framework_TestCase
             $formats['50x50']
         );
     }
+
+    public function testPurge()
+    {
+        $this->formatCache->purge(1, 'test.jpg', null)->shouldBeCalled();
+
+        $this->formatManager->purge(1, 'test.jpg', 'image/jpeg', null);
+    }
+
+    public function testPurgeUppercaseExtension()
+    {
+        $this->formatCache->purge(1, 'test.jpg', null)->shouldBeCalled();
+
+        $this->formatManager->purge(1, 'test.JPG', 'image/jpeg', null);
+    }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatOptionsManager/FormatOptionsManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatOptionsManager/FormatOptionsManagerTest.php
@@ -138,7 +138,7 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException
+     * @expectedException \Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException
      */
     public function testGetNotExistingFormat()
     {
@@ -176,7 +176,7 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException
+     * @expectedException \Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException
      */
     public function testGetAllNotExistingFormat()
     {
@@ -206,7 +206,7 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->em->persist(Argument::type(FormatOptions::class))->shouldHaveBeenCalled();
-        $this->formatManager->purge(42, Argument::any(), Argument::any())->shouldHaveBeenCalled();
+        $this->formatManager->purge(42, Argument::any(), Argument::any(), Argument::any())->shouldHaveBeenCalled();
 
         $this->assertEquals(10, $formatOptions->getCropX());
         $this->assertEquals(11, $formatOptions->getCropY());
@@ -215,7 +215,7 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException
+     * @expectedException \Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException
      */
     public function testSaveNotExisting()
     {
@@ -233,7 +233,7 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->em->persist(Argument::type(FormatOptions::class))->shouldNotHaveBeenCalled();
-        $this->formatManager->purge(42, Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
+        $this->formatManager->purge(42, Argument::any(), Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
     }
 
     public function testDelete()
@@ -243,7 +243,7 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
         $this->formatOptionsManager->delete(42, '100x100');
 
         $this->em->remove(Argument::type(FormatOptions::class))->shouldHaveBeenCalled();
-        $this->formatManager->purge(42, Argument::any(), Argument::any())->shouldHaveBeenCalled();
+        $this->formatManager->purge(42, Argument::any(), Argument::any(), Argument::any())->shouldHaveBeenCalled();
     }
 
     public function testDeleteNotExisting()
@@ -253,6 +253,6 @@ class FormatOptionsManagerTest extends \PHPUnit_Framework_TestCase
         $this->formatOptionsManager->delete(42, '50x50');
 
         $this->em->remove(Argument::type(FormatOptions::class))->shouldNotHaveBeenCalled();
-        $this->formatManager->purge(42, Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
+        $this->formatManager->purge(42, Argument::any(), Argument::any(), Argument::any())->shouldNotHaveBeenCalled();
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -23,7 +23,6 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\Media;
-use Sulu\Bundle\MediaBundle\Entity\MediaRepository;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\MediaBundle\Media\Exception\InvalidMediaTypeException;
@@ -216,6 +215,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $file->getFileVersions()->willReturn([$fileVersion->reveal()]);
         $fileVersion->getId()->willReturn(1);
         $fileVersion->getName()->willReturn('test');
+        $fileVersion->getMimeType()->willReturn('image/png');
         $fileVersion->getStorageOptions()->willReturn(json_encode(['segment' => '01', 'fileName' => 'test.jpg']));
 
         $media = $this->prophesize(Media::class);
@@ -226,6 +226,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $this->formatManager->purge(
             1,
             'test',
+            'image/png',
             json_encode(['segment' => '01', 'fileName' => 'test.jpg'])
         )->shouldBeCalled();
 
@@ -330,7 +331,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $fileVersion->setFocusPointX(1)->shouldBeCalled();
         $fileVersion->setFocusPointY(2)->shouldBeCalled();
         $fileVersion->increaseSubVersion()->shouldBeCalled();
-        $this->formatManager->purge(1, 'test', [])->shouldBeCalled();
+        $this->formatManager->purge(1, 'test', 'image/jpeg', [])->shouldBeCalled();
 
         $this->mediaManager->save(null, ['id' => 1, 'locale' => 'en', 'focusPointX' => 1, 'focusPointY' => 2], 1);
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -30,10 +30,10 @@ class MediaSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->mediaManager = $this->getMock(MediaManagerInterface::class);
+        $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
 
         $this->mediaSelection = new MediaSelectionContentType(
-            $this->mediaManager, 'SuluMediaBundle:Template:image-selection.html.twig'
+            $this->mediaManager->reveal(), 'SuluMediaBundle:Template:image-selection.html.twig'
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
@@ -11,65 +11,67 @@
 
 namespace Sulu\Bundle\MediaBundle\Twig;
 
+use Sulu\Bundle\MediaBundle\Api\Media;
+
 class DispositionTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetMediaUrlDefaultInline()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
-        $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
-        $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
+        $mediaMock = $this->prophesize(Media::class);
+        $mediaMock->getMimeType()->willReturn('application/pdf');
+        $mediaMock->getUrl()->willReturn('http://sulu.lo/media/1');
 
         $extension = new DispositionTypeTwigExtension('inline', ['application/pdf'], []);
 
-        $result = $extension->getMediaUrl($mediaMock);
+        $result = $extension->getMediaUrl($mediaMock->reveal());
         $this->assertEquals('http://sulu.lo/media/1?inline=1', $result);
     }
 
     public function testGetMediaUrlDefaultAttachment()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
-        $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
-        $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
+        $mediaMock = $this->prophesize(Media::class);
+        $mediaMock->getMimeType()->willReturn('application/pdf');
+        $mediaMock->getUrl()->willReturn('http://sulu.lo/media/1');
 
         $extension = new DispositionTypeTwigExtension('attachment', ['application/pdf'], []);
 
-        $result = $extension->getMediaUrl($mediaMock);
+        $result = $extension->getMediaUrl($mediaMock->reveal());
         $this->assertEquals('http://sulu.lo/media/1?inline=1', $result);
     }
 
     public function testGetMediaUrlOtherMimeTypeDefaultInline()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
-        $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/html');
-        $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
+        $mediaMock = $this->prophesize(Media::class);
+        $mediaMock->getMimeType()->willReturn('application/pdf');
+        $mediaMock->getUrl()->willReturn('http://sulu.lo/media/1');
 
         $extension = new DispositionTypeTwigExtension('inline', ['application/pdf'], []);
 
-        $result = $extension->getMediaUrl($mediaMock);
+        $result = $extension->getMediaUrl($mediaMock->reveal());
         $this->assertEquals('http://sulu.lo/media/1?inline=1', $result);
     }
 
     public function testGetMediaUrlOtherMimeTypeDefaultAttachment()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
-        $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/html');
-        $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
+        $mediaMock = $this->prophesize(Media::class);
+        $mediaMock->getMimeType()->willReturn('application/html');
+        $mediaMock->getUrl()->willReturn('http://sulu.lo/media/1');
 
         $extension = new DispositionTypeTwigExtension('attachment', ['application/pdf'], []);
 
-        $result = $extension->getMediaUrl($mediaMock);
+        $result = $extension->getMediaUrl($mediaMock->reveal());
         $this->assertEquals('http://sulu.lo/media/1', $result);
     }
 
     public function testGetMediaUrlWithDispositionType()
     {
-        $mediaMock = $this->getMock('Sulu\Bundle\MediaBundle\Api\Media', [], [], '', false);
-        $mediaMock->expects($this->any())->method('getMimeType')->willReturn('application/pdf');
-        $mediaMock->expects($this->any())->method('getUrl')->willReturn('http://sulu.lo/media/1');
+        $mediaMock = $this->prophesize(Media::class);
+        $mediaMock->getMimeType()->willReturn('application/pdf');
+        $mediaMock->getUrl()->willReturn('http://sulu.lo/media/1');
 
         $extension = new DispositionTypeTwigExtension('inline', ['application/pdf'], []);
 
-        $result = $extension->getMediaUrl($mediaMock, 'attachment');
+        $result = $extension->getMediaUrl($mediaMock->reveal(), 'attachment');
         $this->assertEquals('http://sulu.lo/media/1', $result);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3086 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes an issue when the extension of the uploaded media is uppercase. This extension will be corrected by the function `replaceExtension` which was not called in the `purge` method. For more information see linked issue.