### PR TITLE
Extracted tag-extractor from html-markup-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3094 [MarkupBundle]        Extracted tag-extractor from html-markup-parser
     * BUGFIX      #3111 [LocationBundle]      Fixed coordinates update for google map provider
     * BUGFIX      #3098 [AdminBundle]         Fixed typo in english translation
     * ENHANCEMENT #3097 [All]                 Updated dependencies

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -22,6 +22,7 @@ class TagCompilerPass implements CompilerPassInterface
 {
     const SERVICE_ID = 'sulu_markup.tag.registry';
     const TAG_NAME = 'sulu_markup.tag';
+    const NAMESPACE_ATTRIBUTE = 'namespace';
     const TAG_ATTRIBUTE = 'tag';
     const TYPE_ATTRIBUTE = 'type';
 
@@ -38,13 +39,15 @@ class TagCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
             foreach ($tags as $attributes) {
                 $type = $attributes[self::TYPE_ATTRIBUTE];
-                $alias = $attributes[self::TAG_ATTRIBUTE];
+                $namespace = array_key_exists(self::NAMESPACE_ATTRIBUTE, $attributes)
+                    ? $attributes[self::NAMESPACE_ATTRIBUTE] : 'sulu';
+                $tag = $attributes[self::TAG_ATTRIBUTE];
 
                 if (!array_key_exists($type, $references)) {
                     $references[$type] = [];
                 }
 
-                $references[$type][$alias] = new Reference($id);
+                $references[$type][$namespace][$tag] = new Reference($id);
             }
         }
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/DelegatingTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/DelegatingTagExtractor.php
@@ -49,7 +49,7 @@ class DelegatingTagExtractor implements TagExtractorInterface
     {
         $result = [];
         foreach ($this->pool as $tagExtractor) {
-            $result = array_merge_recursive($result, $tagExtractor->extract($html));
+            $result = array_merge($result, $tagExtractor->extract($html));
         }
 
         return $result;

--- a/src/Sulu/Bundle/MarkupBundle/Markup/DelegatingTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/DelegatingTagExtractor.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup;
+
+/**
+ * Uses multiple tag-extractor to extract all special tags from given html.
+ */
+class DelegatingTagExtractor implements TagExtractorInterface
+{
+    /**
+     * @var TagExtractorInterface[]
+     */
+    private $pool;
+
+    /**
+     * @param TagExtractorInterface[] $pool
+     */
+    public function __construct(array $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count($html)
+    {
+        $result = 0;
+        foreach ($this->pool as $tagExtractor) {
+            $result += $tagExtractor->count($html);
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extract($html)
+    {
+        $result = [];
+        foreach ($this->pool as $tagExtractor) {
+            $result = array_merge_recursive($result, $tagExtractor->extract($html));
+        }
+
+        return $result;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
@@ -48,11 +48,13 @@ class HtmlMarkupParser implements MarkupParserInterface
         }
 
         $sortedTags = $this->tagExtractor->extract($content);
-        foreach ($sortedTags as $name => $tags) {
-            $tags = $this->tagRegistry->getTag($name, 'html')->parseAll($tags, $locale);
+        foreach ($sortedTags as $namespace => $tagNames) {
+            foreach ($tagNames as $name => $tags) {
+                $tags = $this->tagRegistry->getTag($name, 'html', $namespace)->parseAll($tags, $locale);
 
-            foreach ($tags as $tag => $newTag) {
-                $content = str_replace($tag, $newTag, $content);
+                foreach ($tags as $tag => $newTag) {
+                    $content = str_replace($tag, $newTag, $content);
+                }
             }
         }
 
@@ -64,17 +66,19 @@ class HtmlMarkupParser implements MarkupParserInterface
      */
     public function validate($content, $locale)
     {
-        $sortedTags = $this->tagExtractor->extract($content);
-        if (0 === count($sortedTags)) {
+        if (0 === $this->tagExtractor->count($content)) {
             return [];
         }
 
         $result = [];
-        foreach ($sortedTags as $name => $tags) {
-            $result = array_merge(
-                $result,
-                $this->tagRegistry->getTag($name, 'html')->validateAll($tags, $locale)
-            );
+        $sortedTags = $this->tagExtractor->extract($content);
+        foreach ($sortedTags as $namespace => $tagNames) {
+            foreach ($tagNames as $name => $tags) {
+                $result = array_merge(
+                    $result,
+                    $this->tagRegistry->getTag($name, 'html', $namespace)->validateAll($tags, $locale)
+                );
+            }
         }
 
         return $result;

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
@@ -24,11 +24,6 @@ class HtmlMarkupParser implements MarkupParserInterface
     private $tagRegistry;
 
     /**
-     * @var string
-     */
-    private $namespace;
-
-    /**
      * @var TagExtractorInterface
      */
     private $tagExtractor;
@@ -36,16 +31,11 @@ class HtmlMarkupParser implements MarkupParserInterface
     /**
      * @param TagRegistryInterface $tagRegistry
      * @param TagExtractorInterface $tagExtractor
-     * @param string $namespace
      */
-    public function __construct(
-        TagRegistryInterface $tagRegistry,
-        TagExtractorInterface $tagExtractor,
-        $namespace = 'sulu'
-    ) {
+    public function __construct(TagRegistryInterface $tagRegistry, TagExtractorInterface $tagExtractor)
+    {
         $this->tagRegistry = $tagRegistry;
         $this->tagExtractor = $tagExtractor;
-        $this->namespace = $namespace;
     }
 
     /**
@@ -53,11 +43,11 @@ class HtmlMarkupParser implements MarkupParserInterface
      */
     public function parse($content, $locale)
     {
-        if (0 === $this->tagExtractor->count($content, $this->namespace)) {
+        if (0 === $this->tagExtractor->count($content)) {
             return $content;
         }
 
-        $sortedTags = $this->tagExtractor->extract($content, $this->namespace);
+        $sortedTags = $this->tagExtractor->extract($content);
         foreach ($sortedTags as $name => $tags) {
             $tags = $this->tagRegistry->getTag($name, 'html')->parseAll($tags, $locale);
 
@@ -74,7 +64,7 @@ class HtmlMarkupParser implements MarkupParserInterface
      */
     public function validate($content, $locale)
     {
-        $sortedTags = $this->tagExtractor->extract($content, $this->namespace);
+        $sortedTags = $this->tagExtractor->extract($content);
         if (0 === count($sortedTags)) {
             return [];
         }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlMarkupParser.php
@@ -47,15 +47,12 @@ class HtmlMarkupParser implements MarkupParserInterface
             return $content;
         }
 
-        $sortedTags = $this->tagExtractor->extract($content);
-        foreach ($sortedTags as $namespace => $tagNames) {
-            foreach ($tagNames as $name => $tags) {
-                $tags = $this->tagRegistry->getTag($name, 'html', $namespace)->parseAll($tags, $locale);
+        $tagMatchGroups = $this->tagExtractor->extract($content);
+        foreach ($tagMatchGroups as $tagMatchGroup) {
+            $tags = $this->tagRegistry->getTag($tagMatchGroup->getTagName(), 'html', $tagMatchGroup->getNamespace())
+                ->parseAll($tagMatchGroup->getTags(), $locale);
 
-                foreach ($tags as $tag => $newTag) {
-                    $content = str_replace($tag, $newTag, $content);
-                }
-            }
+            $content = str_replace(array_keys($tags), array_values($tags), $content);
         }
 
         return $this->parse($content, $locale);
@@ -71,14 +68,12 @@ class HtmlMarkupParser implements MarkupParserInterface
         }
 
         $result = [];
-        $sortedTags = $this->tagExtractor->extract($content);
-        foreach ($sortedTags as $namespace => $tagNames) {
-            foreach ($tagNames as $name => $tags) {
-                $result = array_merge(
-                    $result,
-                    $this->tagRegistry->getTag($name, 'html', $namespace)->validateAll($tags, $locale)
-                );
-            }
+        $tagMatchGroups = $this->tagExtractor->extract($content);
+        foreach ($tagMatchGroups as $tagMatchGroup) {
+            $tags = $this->tagRegistry->getTag($tagMatchGroup->getTagName(), 'html', $tagMatchGroup->getNamespace())
+                ->validateAll($tagMatchGroup->getTags(), $locale);
+
+            $result = array_merge($result, $tags);
         }
 
         return $result;

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -63,7 +63,7 @@ class HtmlTagExtractor implements TagExtractorInterface
             $sortedTags[$name][$tag] = array_filter(array_merge($attributes, ['content' => $content]));
         }
 
-        return $sortedTags;
+        return [$this->namespace => $sortedTags];
     }
 
     /**

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -21,19 +21,32 @@ class HtmlTagExtractor implements TagExtractorInterface
     const TAG_REGEX = '/(?<tag><%1$s:(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s:\2>).)*)<\/%1$s:\2>))/';
 
     /**
-     * {@inheritdoc}
+     * @var string
      */
-    public function count($html, $namespace)
+    private $namespace;
+
+    /**
+     * @param string $namespace
+     */
+    public function __construct($namespace)
     {
-        return preg_match_all(sprintf(self::COUNT_REGEX, $namespace), $html, $matches);
+        $this->namespace = $namespace;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function extract($html, $namespace)
+    public function count($html)
     {
-        if (!preg_match_all(sprintf(self::TAG_REGEX, $namespace), $html, $matches)) {
+        return preg_match_all(sprintf(self::COUNT_REGEX, $this->namespace), $html, $matches);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extract($html)
+    {
+        if (!preg_match_all(sprintf(self::TAG_REGEX, $this->namespace), $html, $matches)) {
             return [];
         }
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup;
+
+/**
+ * Extracts tags from html content.
+ */
+class HtmlTagExtractor implements TagExtractorInterface
+{
+    const COUNT_REGEX = '/<%1$s:[a-z]+/';
+    const ATTRIBUTE_REGEX = '/(?<name>\b[\w-]+\b)\s*=\s*"(?<value>[^"]*)"/';
+    const TAG_REGEX = '/(?<tag><%1$s:(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s:\2>).)*)<\/%1$s:\2>))/';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count($html, $namespace)
+    {
+        return preg_match_all(sprintf(self::COUNT_REGEX, $namespace), $html, $matches);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extract($html, $namespace)
+    {
+        if (!preg_match_all(sprintf(self::TAG_REGEX, $namespace), $html, $matches)) {
+            return [];
+        }
+
+        $sortedTags = [];
+        for ($i = 0, $length = count($matches['name']); $i < $length; ++$i) {
+            $tag = $matches['tag'][$i];
+            $name = $matches['name'][$i];
+            $content = $matches['content'][$i];
+            if (!array_key_exists($name, $sortedTags)) {
+                $sortedTags[$name] = [];
+            }
+
+            $attributes = $this->getAttributes($matches['attributes'][$i]);
+            $sortedTags[$name][$tag] = array_filter(array_merge($attributes, ['content' => $content]));
+        }
+
+        return $sortedTags;
+    }
+
+    /**
+     * Returns attributes of given html-tag.
+     *
+     * @param string $tag
+     *
+     * @return array
+     */
+    private function getAttributes($tag)
+    {
+        if (!preg_match_all(self::ATTRIBUTE_REGEX, $tag, $matches)) {
+            return [];
+        }
+
+        $attributes = [];
+        for ($i = 0, $length = count($matches['name']); $i < $length; ++$i) {
+            $value = $matches['value'][$i];
+
+            if ($value === 'true' || $value === 'false') {
+                $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            }
+
+            $attributes[$matches['name'][$i]] = $value;
+        }
+
+        return $attributes;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -50,20 +50,21 @@ class HtmlTagExtractor implements TagExtractorInterface
             return [];
         }
 
+        /** @var TagMatchGroup[] $sortedTags */
         $sortedTags = [];
         for ($i = 0, $length = count($matches['name']); $i < $length; ++$i) {
             $tag = $matches['tag'][$i];
             $name = $matches['name'][$i];
             $content = $matches['content'][$i];
             if (!array_key_exists($name, $sortedTags)) {
-                $sortedTags[$name] = [];
+                $sortedTags[$name] = new TagMatchGroup($this->namespace, $name);
             }
 
             $attributes = $this->getAttributes($matches['attributes'][$i]);
-            $sortedTags[$name][$tag] = array_filter(array_merge($attributes, ['content' => $content]));
+            $sortedTags[$name]->addTag($tag, array_filter(array_merge($attributes, ['content' => $content])));
         }
 
-        return [$this->namespace => $sortedTags];
+        return array_values($sortedTags);
     }
 
     /**

--- a/src/Sulu/Bundle/MarkupBundle/Markup/TagExtractorInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/TagExtractorInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup;
+
+/**
+ * Interface for tag-extractors.
+ */
+interface TagExtractorInterface
+{
+    /**
+     * @param string $html
+     * @param string $namespace
+     *
+     * @return int
+     */
+    public function count($html, $namespace);
+
+    /**
+     * Returns found tags and their attributes.
+     *
+     * @param string $html
+     * @param string $namespace
+     *
+     * @return array
+     */
+    public function extract($html, $namespace);
+}

--- a/src/Sulu/Bundle/MarkupBundle/Markup/TagExtractorInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/TagExtractorInterface.php
@@ -17,20 +17,20 @@ namespace Sulu\Bundle\MarkupBundle\Markup;
 interface TagExtractorInterface
 {
     /**
+     * Count tags occurrences.
+     *
      * @param string $html
-     * @param string $namespace
      *
      * @return int
      */
-    public function count($html, $namespace);
+    public function count($html);
 
     /**
      * Returns found tags and their attributes.
      *
      * @param string $html
-     * @param string $namespace
      *
      * @return array
      */
-    public function extract($html, $namespace);
+    public function extract($html);
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/TagExtractorInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/TagExtractorInterface.php
@@ -30,7 +30,7 @@ interface TagExtractorInterface
      *
      * @param string $html
      *
-     * @return array
+     * @return TagMatchGroup[]
      */
     public function extract($html);
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/TagMatchGroup.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/TagMatchGroup.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup;
+
+/**
+ * Represents a group of tag-matches with the same namespace and name.
+ */
+class TagMatchGroup
+{
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * @var string
+     */
+    private $tagName;
+
+    /**
+     * @var array
+     */
+    private $tags;
+
+    /**
+     * @param string $namespace
+     * @param string $tagName
+     * @param array $tags
+     */
+    public function __construct($namespace, $tagName, array $tags = [])
+    {
+        $this->namespace = $namespace;
+        $this->tagName = $tagName;
+        $this->tags = $tags;
+    }
+
+    /**
+     * Returns namespace.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Returns tagName.
+     *
+     * @return string
+     */
+    public function getTagName()
+    {
+        return $this->tagName;
+    }
+
+    /**
+     * Returns tags.
+     *
+     * @return array
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * Add a new tag to group.
+     *
+     * @param string $tag
+     * @param array $tagAttributes
+     *
+     * @return $this
+     */
+    public function addTag($tag, array $tagAttributes)
+    {
+        $this->tags[$tag] = $tagAttributes;
+
+        return $this;
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -7,11 +7,20 @@
             <argument type="collection"/>
         </service>
 
-        <service id="sulu_markup.parser.html_extractor" class="Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor"/>
+        <service id="sulu_markup.parser.html_extractor" class="Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor">
+            <argument type="string">sulu</argument>
+
+            <tag name="sulu_markup.parser.html_extractor"/>
+        </service>
+
+        <service id="sulu_markup.parser.delegating_html_extractor"
+                 class="Sulu\Bundle\MarkupBundle\Markup\DelegatingTagExtractor">
+            <argument type="collection"/>
+        </service>
 
         <service id="sulu_markup.parser" class="Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser">
             <argument type="service" id="sulu_markup.tag.registry"/>
-            <argument type="service" id="sulu_markup.parser.html_extractor"/>
+            <argument type="service" id="sulu_markup.parser.delegating_html_extractor"/>
 
             <tag name="sulu_markup.parser" type="html"/>
         </service>

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -7,8 +7,11 @@
             <argument type="collection"/>
         </service>
 
+        <service id="sulu_markup.parser.html_extractor" class="Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor"/>
+
         <service id="sulu_markup.parser" class="Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser">
             <argument type="service" id="sulu_markup.tag.registry"/>
+            <argument type="service" id="sulu_markup.parser.html_extractor"/>
 
             <tag name="sulu_markup.parser" type="html"/>
         </service>

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MarkupBundle;
 
 use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\ParserCompilerPass;
 use Sulu\Bundle\MarkupBundle\DependencyInjection\CompilerPass\TagCompilerPass;
+use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,5 +28,11 @@ class SuluMarkupBundle extends Bundle
 
         $container->addCompilerPass(new ParserCompilerPass());
         $container->addCompilerPass(new TagCompilerPass());
+        $container->addCompilerPass(
+            new TaggedServiceCollectorCompilerPass(
+                'sulu_markup.parser.delegating_html_extractor',
+                'sulu_markup.parser.html_extractor'
+            )
+        );
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagNotFoundException.php
@@ -19,6 +19,11 @@ class TagNotFoundException extends \Exception
     /**
      * @var string
      */
+    private $namespace;
+
+    /**
+     * @var string
+     */
     private $tagName;
 
     /**
@@ -27,13 +32,15 @@ class TagNotFoundException extends \Exception
     private $type;
 
     /**
+     * @param string $namespace
      * @param string $tagName
      * @param int $type
      */
-    public function __construct($tagName, $type)
+    public function __construct($namespace, $tagName, $type)
     {
-        parent::__construct(sprintf('Tag "%s" for type "%s" not found', $tagName, $type));
+        parent::__construct(sprintf('Tag "%s:%s" for type "%s" not found', $namespace, $tagName, $type));
 
+        $this->namespace = $namespace;
         $this->tagName = $tagName;
         $this->type = $type;
     }

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
@@ -38,7 +38,7 @@ class TagRegistry implements TagRegistryInterface
             || !array_key_exists($namespace, $this->tags[$type])
             || !array_key_exists($name, $this->tags[$type][$namespace])
         ) {
-            throw new TagNotFoundException($name, $type);
+            throw new TagNotFoundException($namespace, $name, $type);
         }
 
         return $this->tags[$type][$namespace][$name];

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
@@ -32,12 +32,15 @@ class TagRegistry implements TagRegistryInterface
     /**
      * {@inheritdoc}
      */
-    public function getTag($name, $type)
+    public function getTag($name, $type, $namespace = 'sulu')
     {
-        if (!array_key_exists($type, $this->tags) || !array_key_exists($name, $this->tags[$type])) {
+        if (!array_key_exists($type, $this->tags)
+            || !array_key_exists($namespace, $this->tags[$type])
+            || !array_key_exists($name, $this->tags[$type][$namespace])
+        ) {
             throw new TagNotFoundException($name, $type);
         }
 
-        return $this->tags[$type][$name];
+        return $this->tags[$type][$namespace][$name];
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistryInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistryInterface.php
@@ -21,10 +21,11 @@ interface TagRegistryInterface
      *
      * @param string $name
      * @param string $type
+     * @param string $namespace
      *
      * @return TagInterface
      *
      * @throws TagNotFoundException
      */
-    public function getTag($name, $type);
+    public function getTag($name, $type, $namespace = 'sulu');
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/DelegatingTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/DelegatingTagExtractorTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup;
 
 use Sulu\Bundle\MarkupBundle\Markup\DelegatingTagExtractor;
 use Sulu\Bundle\MarkupBundle\Markup\TagExtractorInterface;
+use Sulu\Bundle\MarkupBundle\Markup\TagMatchGroup;
 
 class DelegatingTagExtractorTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,14 +53,18 @@ class DelegatingTagExtractorTest extends \PHPUnit_Framework_TestCase
 
         $extractors[0]->extract($this->html)->willReturn(
             [
-                'link' => ['<sulu:link/>' => ['content' => '']],
-                'media' => ['<sulu:media id="1"/>' => ['content' => '', 'id' => 1]],
+                new TagMatchGroup('sulu', 'link', ['<sulu:link/>' => ['content' => '']]),
+                new TagMatchGroup('sulu', 'media', ['<sulu:media id="1"/>' => ['content' => '', 'id' => 1]]),
             ]
         )->shouldBeCalledTimes(1);
         $extractors[1]->extract($this->html)->willReturn(
             [
-                'link' => ['<test:link href="123-123-123/>' => ['content' => '', 'href' => '123-123-123']],
-                'test' => ['<test:test/>' => ['content' => '']],
+                new TagMatchGroup(
+                    'test',
+                    'link',
+                    ['<test:link href="123-123-123/>' => ['content' => '', 'href' => '123-123-123']]
+                ),
+                new TagMatchGroup('test', 'test', ['<test:test/>' => ['content' => '']]),
             ]
         )->shouldBeCalledTimes(1);
 
@@ -74,12 +79,14 @@ class DelegatingTagExtractorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             [
-                'link' => [
-                    '<sulu:link/>' => ['content' => ''],
-                    '<test:link href="123-123-123/>' => ['content' => '', 'href' => '123-123-123'],
-                ],
-                'media' => ['<sulu:media id="1"/>' => ['content' => '', 'id' => 1]],
-                'test' => ['<test:test/>' => ['content' => '']],
+                new TagMatchGroup('sulu', 'link', ['<sulu:link/>' => ['content' => '']]),
+                new TagMatchGroup('sulu', 'media', ['<sulu:media id="1"/>' => ['content' => '', 'id' => 1]]),
+                new TagMatchGroup(
+                    'test',
+                    'link',
+                    ['<test:link href="123-123-123/>' => ['content' => '', 'href' => '123-123-123']]
+                ),
+                new TagMatchGroup('test', 'test', ['<test:test/>' => ['content' => '']]),
             ],
             $extractor->extract($this->html)
         );

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/DelegatingTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/DelegatingTagExtractorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup;
+
+use Sulu\Bundle\MarkupBundle\Markup\DelegatingTagExtractor;
+use Sulu\Bundle\MarkupBundle\Markup\TagExtractorInterface;
+
+class DelegatingTagExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    private $html = '<html><body><h1>Test</h1></body></html>';
+
+    public function testCount()
+    {
+        $extractors = [
+            $this->prophesize(TagExtractorInterface::class),
+            $this->prophesize(TagExtractorInterface::class),
+        ];
+
+        $extractors[0]->count($this->html)->willReturn(11)->shouldBeCalledTimes(1);
+        $extractors[1]->count($this->html)->willReturn(1)->shouldBeCalledTimes(1);
+
+        $extractor = new DelegatingTagExtractor(
+            array_map(
+                function ($extrator) {
+                    return $extrator->reveal();
+                },
+                $extractors
+            )
+        );
+
+        $this->assertEquals(12, $extractor->count($this->html));
+    }
+
+    public function testExtract()
+    {
+        $extractors = [
+            $this->prophesize(TagExtractorInterface::class),
+            $this->prophesize(TagExtractorInterface::class),
+        ];
+
+        $extractors[0]->extract($this->html)->willReturn(
+            [
+                'link' => ['<sulu:link/>' => ['content' => '']],
+                'media' => ['<sulu:media id="1"/>' => ['content' => '', 'id' => 1]],
+            ]
+        )->shouldBeCalledTimes(1);
+        $extractors[1]->extract($this->html)->willReturn(
+            [
+                'link' => ['<test:link href="123-123-123/>' => ['content' => '', 'href' => '123-123-123']],
+                'test' => ['<test:test/>' => ['content' => '']],
+            ]
+        )->shouldBeCalledTimes(1);
+
+        $extractor = new DelegatingTagExtractor(
+            array_map(
+                function ($extrator) {
+                    return $extrator->reveal();
+                },
+                $extractors
+            )
+        );
+
+        $this->assertEquals(
+            [
+                'link' => [
+                    '<sulu:link/>' => ['content' => ''],
+                    '<test:link href="123-123-123/>' => ['content' => '', 'href' => '123-123-123'],
+                ],
+                'media' => ['<sulu:media id="1"/>' => ['content' => '', 'id' => 1]],
+                'test' => ['<test:test/>' => ['content' => '']],
+            ],
+            $extractor->extract($this->html)
+        );
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup;
 
 use Prophecy\Argument;
 use Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser;
+use Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor;
 use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
 use Sulu\Bundle\MarkupBundle\Tag\TagNotFoundException;
 use Sulu\Bundle\MarkupBundle\Tag\TagRegistryInterface;
@@ -56,7 +57,7 @@ class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
         $this->tagRegistry->getTag('media', 'html')->willReturn($this->mediaTag->reveal());
         $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test', 'html'));
 
-        $this->parser = new HtmlMarkupParser($this->tagRegistry->reveal());
+        $this->parser = new HtmlMarkupParser($this->tagRegistry->reveal(), new HtmlTagExtractor());
     }
 
     public function testParse()
@@ -191,6 +192,37 @@ EOT;
         $response = $this->parser->parse($content, 'de');
 
         $this->assertContains('<a href="/test" title="test">link content</a>', $response);
+    }
+
+    public function testParseNested()
+    {
+        $this->linkTag->parseAll(
+            [
+                '<sulu:link href="123-123-123" title="test"><sulu:media id="1"/></sulu:link>' => [
+                    'href' => '123-123-123',
+                    'title' => 'test',
+                    'content' => '<sulu:media id="1"/>',
+                ],
+            ],
+            'de'
+        )->willReturn(
+            ['<sulu:link href="123-123-123" title="test"><sulu:media id="1"/></sulu:link>' => '<a href="/test" title="test"><sulu:media id="1"/></a>']
+        );
+
+        $this->mediaTag->parseAll(['<sulu:media id="1"/>' => ['id' => 1]], 'de')
+            ->willReturn(['<sulu:media id="1"/>' => '<img src="test.jpg"/>']);
+
+        $content = <<<'EOT'
+<html>
+    <body>
+        <sulu:link href="123-123-123" title="test"><sulu:media id="1"/></sulu:link>
+    </body>
+</html>
+EOT;
+
+        $response = $this->parser->parse($content, 'de');
+
+        $this->assertContains('<a href="/test" title="test"><img src="test.jpg"/></a>', $response);
     }
 
     public function testValidate()

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup;
 
 use Prophecy\Argument;
+use Sulu\Bundle\MarkupBundle\Markup\DelegatingTagExtractor;
 use Sulu\Bundle\MarkupBundle\Markup\HtmlMarkupParser;
 use Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor;
 use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
@@ -57,7 +58,10 @@ class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
         $this->tagRegistry->getTag('media', 'html')->willReturn($this->mediaTag->reveal());
         $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test', 'html'));
 
-        $this->parser = new HtmlMarkupParser($this->tagRegistry->reveal(), new HtmlTagExtractor());
+        $this->parser = new HtmlMarkupParser(
+            $this->tagRegistry->reveal(),
+            new DelegatingTagExtractor([new HtmlTagExtractor('sulu')])
+        );
     }
 
     public function testParse()

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -56,7 +56,7 @@ class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
         $this->tagRegistry = $this->prophesize(TagRegistryInterface::class);
         $this->tagRegistry->getTag('link', 'html', 'sulu')->willReturn($this->linkTag->reveal());
         $this->tagRegistry->getTag('media', 'html', 'sulu')->willReturn($this->mediaTag->reveal());
-        $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test', 'html'));
+        $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('sulu', 'test', 'html'));
 
         $this->parser = new HtmlMarkupParser(
             $this->tagRegistry->reveal(),

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -54,8 +54,8 @@ class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
         $this->linkTag = $this->prophesize(TagInterface::class);
         $this->mediaTag = $this->prophesize(TagInterface::class);
         $this->tagRegistry = $this->prophesize(TagRegistryInterface::class);
-        $this->tagRegistry->getTag('link', 'html')->willReturn($this->linkTag->reveal());
-        $this->tagRegistry->getTag('media', 'html')->willReturn($this->mediaTag->reveal());
+        $this->tagRegistry->getTag('link', 'html', 'sulu')->willReturn($this->linkTag->reveal());
+        $this->tagRegistry->getTag('media', 'html', 'sulu')->willReturn($this->mediaTag->reveal());
         $this->tagRegistry->getTag(Argument::any())->willThrow(new TagNotFoundException('test', 'html'));
 
         $this->parser = new HtmlMarkupParser(

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
@@ -47,7 +47,8 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
         $result = $extractor->extract($html);
 
         $this->assertCount(1, $result);
-        $this->assertEquals($result['sulu'][$tagName][$tag], $attributes);
+        $this->assertEquals($result[0]->getTagName(), $tagName);
+        $this->assertEquals($result[0]->getTags()[$tag], $attributes);
     }
 
     public function provideMultipleTags()
@@ -81,10 +82,9 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
         $extractor = new HtmlTagExtractor('sulu');
         $result = $extractor->extract($html);
 
-        $this->assertCount(count($counts), $result['sulu']);
-
-        foreach ($counts as $key => $value) {
-            $this->assertCount($value, $result['sulu'][$key]);
+        $this->assertCount(count($counts), $result);
+        foreach ($result as $tagMatchGroup) {
+            $this->assertCount($counts[$tagMatchGroup->getTagName()], $tagMatchGroup->getTags());
         }
     }
 

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
@@ -47,7 +47,7 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
         $result = $extractor->extract($html);
 
         $this->assertCount(1, $result);
-        $this->assertEquals($result[$tagName][$tag], $attributes);
+        $this->assertEquals($result['sulu'][$tagName][$tag], $attributes);
     }
 
     public function provideMultipleTags()
@@ -81,10 +81,10 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
         $extractor = new HtmlTagExtractor('sulu');
         $result = $extractor->extract($html);
 
-        $this->assertCount(count($counts), $result);
+        $this->assertCount(count($counts), $result['sulu']);
 
         foreach ($counts as $key => $value) {
-            $this->assertCount($value, $result[$key]);
+            $this->assertCount($value, $result['sulu'][$key]);
         }
     }
 

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup;
+
+use Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor;
+
+/**
+ * Tests for HtmlTagExtractor.
+ */
+class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideTags()
+    {
+        return [
+            ['<sulu:tag/>', 'tag', []],
+            ['<sulu:tag />', 'tag', []],
+            ['<sulu:tag></sulu:tag>', 'tag', []],
+            ['<sulu:tag href="1"/>', 'tag', ['href' => '1']],
+            ['<sulu:tag>Test</sulu:tag>', 'tag', ['content' => 'Test']],
+            ['<sulu:tag>http://www.google.com</sulu:tag>', 'tag', ['content' => 'http://www.google.com']],
+            ['<sulu:tag><a href="http://google.com">http://google.com</a></sulu:tag>', 'tag', ['content' => '<a href="http://google.com">http://google.com</a>']],
+            ['<sulu:tag href="http://google.com">http://google.com</sulu:tag>', 'tag', ['href' => 'http://google.com', 'content' => 'http://google.com']],
+            ['<sulu:tag id="1">http://google.com</sulu:tag>', 'tag', ['id' => '1', 'content' => 'http://google.com']],
+            ['<sulu:tag id="a slash (/) in here is allowed">http://google.com</sulu:tag>', 'tag', ['id' => 'a slash (/) in here is allowed', 'content' => 'http://google.com']],
+            ['<sulu:tag id="2">everything also <tags/> are allowed</sulu:tag>', 'tag', ['id' => '2', 'content' => 'everything also <tags/> are allowed']],
+            ['<sulu:link target="1-1-1-1-1"><sulu:media id="123" /></sulu:link>', 'link', ['target' => '1-1-1-1-1', 'content' => '<sulu:media id="123" />']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTags
+     */
+    public function testExtract($tag, $tagName, array $attributes)
+    {
+        $html = '<html><body>' . $tag . '</body></html>';
+
+        $extractor = new HtmlTagExtractor();
+        $result = $extractor->extract($html, 'sulu');
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($result[$tagName][$tag], $attributes);
+    }
+
+    public function provideMultipleTags()
+    {
+        $tags = [
+            '<sulu:tag/>',
+            '<sulu:tag />',
+            '<sulu:tag></sulu:tag>',
+            '<sulu:tag href="1"/>',
+            '<sulu:tag>Test</sulu:tag>',
+            '<sulu:tag>http://www.google.com</sulu:tag>',
+            '<sulu:tag><a href="http://google.com">http://google.com</a></sulu:tag>',
+            '<sulu:tag href="http://google.com">http://google.com</sulu:tag>',
+            '<sulu:tag id="1">http://google.com</sulu:tag>',
+            '<sulu:tag id="a slash (/) in here isnt allowed">http://google.com</sulu:tag>',
+            '<sulu:tag id="2">everything but <tags/> are allowed</sulu:tag>',
+            // media cannot be detected with current regex. will be solved with recursion.
+            '<sulu:link target="1-1-1-1-1"><sulu:media id="123" /></sulu:link>',
+        ];
+
+        return [
+            ['<html><body>' . implode($tags) . '</body></html>', ['tag' => 11, 'link' => 1], 13],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMultipleTags
+     */
+    public function testExtractAll($html, array $counts)
+    {
+        $extractor = new HtmlTagExtractor();
+        $result = $extractor->extract($html, 'sulu');
+
+        $this->assertCount(count($counts), $result);
+
+        foreach ($counts as $key => $value) {
+            $this->assertCount($value, $result[$key]);
+        }
+    }
+
+    /**
+     * @dataProvider provideMultipleTags
+     */
+    public function testCount($html, array $counts, $count)
+    {
+        $extractor = new HtmlTagExtractor();
+
+        $result = $extractor->count($html, 'sulu');
+        $this->assertEquals($count, $result);
+    }
+}

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlTagExtractorTest.php
@@ -43,8 +43,8 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
     {
         $html = '<html><body>' . $tag . '</body></html>';
 
-        $extractor = new HtmlTagExtractor();
-        $result = $extractor->extract($html, 'sulu');
+        $extractor = new HtmlTagExtractor('sulu');
+        $result = $extractor->extract($html);
 
         $this->assertCount(1, $result);
         $this->assertEquals($result[$tagName][$tag], $attributes);
@@ -78,8 +78,8 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExtractAll($html, array $counts)
     {
-        $extractor = new HtmlTagExtractor();
-        $result = $extractor->extract($html, 'sulu');
+        $extractor = new HtmlTagExtractor('sulu');
+        $result = $extractor->extract($html);
 
         $this->assertCount(count($counts), $result);
 
@@ -93,9 +93,9 @@ class HtmlTagExtractorTest extends \PHPUnit_Framework_TestCase
      */
     public function testCount($html, array $counts, $count)
     {
-        $extractor = new HtmlTagExtractor();
+        $extractor = new HtmlTagExtractor('sulu');
 
-        $result = $extractor->count($html, 'sulu');
+        $result = $extractor->count($html);
         $this->assertEquals($count, $result);
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Tag/TagRegistryTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Tag/TagRegistryTest.php
@@ -20,7 +20,7 @@ class TagRegistryTest extends \PHPUnit_Framework_TestCase
     public function testGetTag()
     {
         $tag = $this->prophesize(TagInterface::class)->reveal();
-        $registry = new TagRegistry(['html' => ['test' => $tag]]);
+        $registry = new TagRegistry(['html' => ['sulu' => ['test' => $tag]]]);
 
         $this->assertEquals($tag, $registry->getTag('test', 'html'));
     }
@@ -37,7 +37,8 @@ class TagRegistryTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(TagNotFoundException::class);
 
-        $registry = new TagRegistry(['test' => $this->prophesize(TagInterface::class)->reveal()]);
+        $tag = $this->prophesize(TagInterface::class)->reveal();
+        $registry = new TagRegistry(['html' => ['sulu' => ['test' => $tag]]]);
         $registry->getTag('test-2', 'xml');
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2786 
| Related issues/PRs | https://github.com/sulu/sulu/issues/3105
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/297

#### What's in this PR?

This PR introduces a new service which will be used to extract tags from html-markup. 

#### TODO

- [x] tag inside tag
- [x] documentation