### PR TITLE
Fixed sort-by for data-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3095 [ContentBundle]       Fixed sort-by for data-provider
     * ENHANCEMENT #3084 [GeneratorBundle]     Removed generator-bundle
     * ENHANCEMENT #3080 [All]                 Removed getRequest calls
     * ENHANCENEMT #3070 [All]                 Removed guzzle3 dependency

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
@@ -98,6 +98,29 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $result->getReferencedUuids());
     }
 
+    public function testNullSortBy()
+    {
+        $contacts = [
+            $this->createContact(1, 'Max', 'Mustermann')->reveal(),
+            $this->createContact(2, 'Erika', 'Mustermann')->reveal(),
+            $this->createContact(3, 'Leon', 'Mustermann')->reveal(),
+        ];
+
+        $dataItems = [];
+        foreach ($contacts as $contact) {
+            $dataItems[] = $this->createDataItem($contact);
+        }
+
+        $serializer = $this->prophesize(SerializerInterface::class);
+        $provider = new ContactDataProvider(
+            $this->getRepository(['sortBy' => null], 1, null, null, $contacts),
+            $serializer->reveal()
+        );
+
+        $result = $provider->resolveDataItems(['sortBy' => null], [], ['webspace' => 'sulu_io', 'locale' => 'en']);
+        $this->assertEquals($dataItems, $result->getItems());
+    }
+
     public function resourceItemsDataProvider()
     {
         $contacts = [

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -30,7 +30,7 @@ trait DataProviderRepositoryTrait
             ->orderBy($alias . '.id', 'ASC');
         $this->appendJoins($queryBuilder, $alias, $locale);
 
-        if (array_key_exists('sortBy', $filters)) {
+        if (array_key_exists('sortBy', $filters) && is_array($filters['sortBy'])) {
             $sortMethod = array_key_exists('sortMethod', $filters) ? $filters['sortMethod'] : 'asc';
             $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, $alias, $locale);
         }
@@ -65,13 +65,12 @@ trait DataProviderRepositoryTrait
         $tagRelation = $this->appendTagsRelation($queryBuilder, 'c');
         $categoryRelation = $this->appendCategoriesRelation($queryBuilder, 'c');
 
-        if (array_key_exists('sortBy', $filters)) {
+        if (array_key_exists('sortBy', $filters) && is_array($filters['sortBy'])) {
             $sortMethod = array_key_exists('sortMethod', $filters) ? $filters['sortMethod'] : 'asc';
             $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, 'c', $locale);
         }
 
         $parameter = array_merge($parameter, $this->append($queryBuilder, 'c', $locale, $options));
-
         if (isset($filters['dataSource'])) {
             $includeSubFolders = $this->getBoolean($filters['includeSubFolders'] ?: false);
             $parameter = array_merge(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug when the sort-by of smart-content is null. 

https://github.com/sulu/sulu/pull/3078#pullrequestreview-13283850