### PR TITLE
display draft internal link in test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3099 [ContentBundle]         Display draft internal link in test mode
     * HOTFIX      #3091 [SecurityBundle]        Increased length of context field
     * HOTFIX      #3090 [MediaBundle]           Fixed extension when purging media
     * HOTFIX      #3087 [AdminBundle]           Fixed search with umlauts in text editor

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -46,6 +46,7 @@ class ContentRepository implements ContentRepositoryInterface
         'creator',
         'changed',
         'changer',
+        'published',
         'shadowOn',
         'shadowBase',
     ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3063 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the `published` field to the non-fallback fields for resolving internal links with the `ContentRepository`.