### PR TITLE
Fixed typo in the backend.en.xlf for AdminBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3098 [AdminBundle]         Fixed typo in english translation
     * BUGFIX      #3095 [ContentBundle]       Fixed sort-by for data-provider
     * ENHANCEMENT #3084 [GeneratorBundle]     Removed generator-bundle
     * ENHANCEMENT #3080 [All]                 Removed getRequest calls

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/sulu/backend.en.xlf
@@ -772,7 +772,7 @@
             </trans-unit>
             <trans-unit id="a504f522de145650142c0b4820e29a4f" resname="public.number">
                 <source>public.number</source>
-                <target>Nummer</target>
+                <target>Number</target>
             </trans-unit>
             <trans-unit id="a504f522de1456524142c0b4820e29a4f" resname="labels.successfully-saved">
                 <source>labels.successfully-saved</source>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | Yes
| New feature? | no
| Fixed tickets | fixes #3098 
| License | MIT

#### What's in this PR?

Minor fix for the typo/wrong language in the backend.en.xlf for AdminBundle

#### Why?

Line 755.
Was: "Num**m**er"
Become: "Num**b**er"

