### PR TITLE
fixed support for multiple properties with minOccurs of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3108 [ContentBundle]         Fixed support for multiple properties with minOccurs of 1
     * HOTFIX      #3099 [ContentBundle]         Display draft internal link in test mode
     * HOTFIX      #3091 [SecurityBundle]        Increased length of context field
     * HOTFIX      #3090 [MediaBundle]           Fixed extension when purging media

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,17 @@
 
 ## dev-master
 
+### Multiple properties in template
+
+There was a bug in the template definition for the `minOccurs` field. It was
+not working if the `minOccurs` field had a value of `1`. So if you have a field
+like the following and you don't want it to be a multiple field you have to
+remove the `minOccurs` property:
+
+```xml
+    <property name="test1" type="text_line" minOccurs="2"></property>
+```
+
 ### Format cache
 
 To generate the correct file extension the `FormatManager::purge` interface

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/block.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/block.js
@@ -205,7 +205,10 @@ define([
         };
 
     return function($el, options, form) {
-        var defaults = {},
+        var defaults = {
+                min: 0,
+                max: null
+            },
 
             subType = {
                 initializeSub: function() {

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
@@ -16,8 +16,8 @@
              data-form="true"
              data-type="block"
              data-type-config='[{% for type in property.types %}{"data": "{{ type.name }}", "title": "{{ type.getTitle(userLocale) }}", "tpl": "{{ type.name }}-{{ id|raw }}-tpl"}{{ loop.last==false?',':'' }}{% endfor %}]'
-             data-type-min="{{ property.minOccurs }}"
-             data-type-max="{{ property.maxOccurs }}"
+             {% if property.minOccurs is not null %}data-type-min="{{ property.minOccurs }}"{% endif %}
+             {% if property.maxoccurs is not null %}data-type-max="{{ property.maxOccurs }}"{% endif %}
              data-type-default="{{ property.defaultTypeName }}"
              data-mapper-property="{{ property.name }}"
              data-mapper-full-class="full"

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/add_button.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/add_button.html.twig
@@ -2,5 +2,7 @@
     <div id="mapper-add-{{ property.name }}" class="addButton" data-mapper-add="{{ property.name }}">
         <span class="control-label">Add {{ property.name }}</span>
     </div>
-    <span class="desc">(<span id="current-counter-{{ property.name }}">{{ property.minOccurs }}</span> out of <span>{{ property.maxOccurs }}</span>)</span>
+    {% if property.maxOccurs is not null %}
+    <span class="desc">(<span id="current-counter-{{ property.name }}">{{ property.minOccurs|default(1) }}</span> out of <span>{{ property.maxOccurs }}</span>)</span>
+    {% endif %}
 </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/multiple.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/multiple.html.twig
@@ -3,8 +3,8 @@
         <div class="sortable grid-row multiple-property"
              id="{{ id|raw }}"
              data-type="collection"
-             data-type-min="{{ property.minOccurs }}"
-             data-type-max="{{ property.maxOccurs }}"
+             {% if property.minOccurs is not null %}data-type-min="{{ property.minOccurs }}"{% endif %}
+             {% if property.maxOccurs is not null %}data-type-max="{{ property.maxOccurs }}"{% endif %}
              data-mapper-property='[{"data": "{{ property.name }}", "tpl": "{{ id|raw }}-tpl"}]'
              data-mapper-full-class="full"
              data-mapper-empty-class="empty">

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Twig;
+
+use Sulu\Bundle\ContentBundle\Twig\ContentTwigExtension;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\ContentTypeManagerInterface;
+
+class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContentTypeManagerInterface
+     */
+    private $contentTypeManager;
+
+    /**
+     * @var ContentTwigExtension
+     */
+    private $contentTwigExtension;
+
+    public function setUp()
+    {
+        $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
+        $this->contentTwigExtension = new ContentTwigExtension($this->contentTypeManager->reveal());
+    }
+
+    public function provideNeedsAddButton()
+    {
+        return [
+            [0, 1, true],
+            [10, 10, false],
+            [10, 20, true],
+            [10, null, true],
+        ];
+    }
+
+    /**
+     * @dataProvider provideNeedsAddButton
+     */
+    public function testNeedsAddButton($minOccurs, $maxOccurs, $result)
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getMinOccurs()->willReturn($minOccurs);
+        $property->getMaxOccurs()->willReturn($maxOccurs);
+
+        $this->assertEquals($result, $this->contentTwigExtension->needsAddButtonFunction($property->reveal()));
+    }
+
+    public function provideTestIsMultiple()
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestIsMultiple
+     */
+    public function testIsMultiple($value)
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getIsMultiple()->willReturn($value);
+
+        $this->assertEquals($value, $this->contentTwigExtension->isMultipleTest($property->reveal()));
+    }
+}

--- a/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Twig/ContentTwigExtension.php
@@ -126,7 +126,14 @@ class ContentTwigExtension extends \Twig_Extension
      */
     public function needsAddButtonFunction(PropertyInterface $property)
     {
-        return $property->getMaxOccurs() > $property->getMinOccurs();
+        $minOccurs = $property->getMinOccurs();
+        $maxOccurs = $property->getMaxOccurs();
+
+        if (is_null($maxOccurs) && $minOccurs >= 1) {
+            return true;
+        }
+
+        return $maxOccurs > $minOccurs;
     }
 
     /**
@@ -138,7 +145,7 @@ class ContentTwigExtension extends \Twig_Extension
      */
     public function isMultipleTest($property)
     {
-        return $property->getMinOccurs() > 1;
+        return $property->getIsMultiple();
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -294,6 +294,16 @@ class BlockProperty extends Property implements BlockPropertyInterface
         return true;
     }
 
+    public function getIsMultiple()
+    {
+        if (is_null($this->getMinOccurs()) || is_null($this->getMaxOccurs())) {
+            // in contrast to properties blocks are multiple by default
+            return true;
+        }
+
+        return parent::getIsMultiple();
+    }
+
     public function __clone()
     {
         $clone = new self(

--- a/src/Sulu/Component/Content/Compat/Property.php
+++ b/src/Sulu/Component/Content/Compat/Property.php
@@ -366,7 +366,26 @@ class Property implements PropertyInterface, \JsonSerializable
      */
     public function getIsMultiple()
     {
-        return $this->minOccurs > 1 || $this->maxOccurs > 1;
+        $minOccurs = $this->getMinOccurs();
+        $maxOccurs = $this->getMaxOccurs();
+
+        if (is_null($minOccurs) && is_null($maxOccurs)) {
+            // if no occurs attributes are set it defaults to false
+            return false;
+        }
+
+        if (0 === $minOccurs && 1 === $maxOccurs) {
+            // this one allows to have an optional field
+            return true;
+        }
+
+        if (1 === $minOccurs && 1 === $maxOccurs) {
+            // if the occurences have a high and low limit of 1 it should be displayed as single
+            return false;
+        }
+
+        // if minOccurs is set a value of 1 is enough, because maxOccurs would be considered "unbound" when null
+        return $minOccurs >= 1 || $maxOccurs > 1;
     }
 
     /**

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -134,8 +134,8 @@ class XmlLoader extends XmlLegacyLoader
         $property->colSpan = $data['colspan'];
         $property->cssClass = $data['cssClass'];
         $property->tags = $data['tags'];
-        $property->minOccurs = $data['minOccurs'] !== null ? intval($data['minOccurs']) : 1;
-        $property->maxOccurs = $data['maxOccurs'] ? intval($data['maxOccurs']) : 999;
+        $property->minOccurs = $data['minOccurs'] !== null ? intval($data['minOccurs']) : null;
+        $property->maxOccurs = $data['maxOccurs'] ? intval($data['maxOccurs']) : null;
         $property->parameters = $data['params'];
         $this->mapMeta($property, $data['meta']);
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockPropertyTest.php
@@ -40,4 +40,27 @@ class BlockPropertyTest extends \PHPUnit_Framework_TestCase
 
         $blockProperty->setValue($data);
     }
+
+    public function provideIsMultiple()
+    {
+        return [
+            [null, null, true],
+            [null, 5, true],
+            [null, 1, true],
+            [3, null, true],
+            [3, 5, true],
+            [3, 3, true],
+            [1, 1, false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIsMultiple
+     */
+    public function testGetIsMultiple()
+    {
+        $blockProperty = new BlockProperty('block', [], 'test', false, false, null, null);
+
+        $this->assertEquals(true, $blockProperty->getIsMultiple());
+    }
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/PropertyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/PropertyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Compat;
+
+use Sulu\Component\Content\Compat\Property;
+
+class PropertyTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideIsMultipleTest()
+    {
+        return [
+            [0, 1, true],
+            [0, 10, true],
+            [1, 2, true],
+            [2, null, true],
+            [1, null, true],
+            [null, 3, true],
+            [1, 1, false],
+            [null, null, false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIsMultipleTest
+     */
+    public function testIsMultipleTest($minOccurs, $maxOccurs, $result)
+    {
+        $property = new Property('test', [], 'text_line', false, true, $maxOccurs, $minOccurs);
+
+        $this->assertEquals($result, $property->getIsMultiple());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3046 
| Related issues/PRs | replaces #2653 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the behavior of the `minOccurs` property on the template xml with a value of 1.

#### BC Breaks/Deprecations

The behavior of the `minOccurs` and `maxOccurs` fields have slightly changed. However, if somebody has set them, they were not acting correctly, so I would not really say it is a BC break.