### PR TITLE
Updating image editor URL for secure sites

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/public/js/services/image-editor.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/public/js/services/image-editor.js
@@ -12,9 +12,16 @@ define(['config', 'jquery'], function(Config, $) {
     'use strict';
 
     var featherEditor;
+    var featherUrl;
 
     if (!!Config.get('sulu-media').adobeCreativeKey) {
-        require(['//feather.aviary.com/imaging/v3/editor.js'], function() {
+        if (location.protocol === 'https:') {
+            featherUrl = 'https://dme0ih8comzn4.cloudfront.net/imaging/v3/editor.js';
+        } else {
+            featherUrl = '//feather.aviary.com/imaging/v3/editor.js';
+        }
+            
+        require([featherUrl], function() {
             featherEditor = new Aviary.Feather({
                 apiKey: Config.get('sulu-media').adobeCreativeKey,
                 theme: 'minimum',


### PR DESCRIPTION
Closes https://github.com/sulu/sulu-standard/issues/784

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | https://github.com/sulu/sulu-standard/issues/784
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Adobe requires a different URL for their JavaScript SDK on secure environments

#### Why?

The image editor works on our local and QA environments but when it went onto our live environment it stopped working
