### PR TITLE
Bumped twig version to ^1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.3
+    * HOTFIX      #3128 [All]                 Bumped twig version to ^1.11
+
 * 1.3.5 (2016-11-24)
     * HOTFIX      #3033 [SnippetBundle]       Handle references to deleted snippets in snippet selection
     * HOTFIX      #3032 [ContentBundle]       Fixed publishing for shadow page targeting drafts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ cache:
 install:
   # install SSL and php
   - cinst -y OpenSSL.Light
-  - cinst -y php
+  - cinst -y php --version 7.0.9 --allow-empty-checksums
 
   # configure PHP and enable extensions.
   - cd c:\tools\php

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "pulse00/ffmpeg-bundle": "^0.6",
         "oro/doctrine-extensions": "^1.0",
         "goodby/csv": "^1.3",
-        "doctrine/data-fixtures": "1.1.*"
+        "doctrine/data-fixtures": "1.1.*",
+        "twig/twig": "^1.11"
     },
     "require-dev": {
         "phpcr/phpcr-shell": "~1.0.0@alpha",
@@ -50,7 +51,6 @@
         "symfony/phpunit-bridge": "~2.8",
         "sensio/framework-extra-bundle": "~3.0",
         "symfony/monolog-bundle": "2.4.*",
-        "twig/twig": "~1.11",
         "zendframework/zend-stdlib": "~2.3",
         "zendframework/zendsearch": "@dev",
         "doctrine/doctrine-fixtures-bundle": "2.2.*",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR bumps version of twig to `^1.11`