### PR TITLE
fixed sulu_content_path for language-specific domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #3130 [ContentBundle]         Fixed moving of blocks without maxOccurs
+    * HOTFIX      #3131 [WebsiteBundle]         Fixed sulu_content_path for language-specific domains
 
 * 1.4.3 (2016-12-21)
     * HOTFIX      #3108 [ContentBundle]         Fixed support for multiple properties with minOccurs of 1

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
@@ -57,13 +57,13 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->suluWebspace = $this->prophesize(Webspace::class);
         $this->suluWebspace->getKey()->willReturn('sulu_io');
-        $this->suluWebspace->hasDomain('www.sulu.io', $this->environment)->willReturn(true);
-        $this->suluWebspace->hasDomain('www.test.io', $this->environment)->willReturn(false);
+        $this->suluWebspace->hasDomain('www.sulu.io', $this->environment, 'de')->willReturn(true);
+        $this->suluWebspace->hasDomain('www.test.io', $this->environment, 'de')->willReturn(false);
 
         $this->testWebspace = $this->prophesize(Webspace::class);
         $this->testWebspace->getKey()->willReturn('test_io');
-        $this->testWebspace->hasDomain('www.test.io', $this->environment)->willReturn(true);
-        $this->testWebspace->hasDomain('www.sulu.io', $this->environment)->willReturn(false);
+        $this->testWebspace->hasDomain('www.test.io', $this->environment, 'de')->willReturn(true);
+        $this->testWebspace->hasDomain('www.sulu.io', $this->environment, 'de')->willReturn(false);
 
         $this->requestAnalyzer->getAttribute('scheme')->willReturn('http');
         $this->requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
@@ -92,6 +92,21 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
         )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
 
         $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
+    }
+
+    public function testGetContentPathWithLocaleForDifferentDomain()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('en.sulu.io');
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'sulu_io',
+            null,
+            'http'
+        )->willReturn('de.sulu.io/test');
+        $this->suluWebspace->hasDomain('en.sulu.io', 'prod', 'de')->willReturn(false);
+        $this->assertEquals('de.sulu.io/test', $this->extension->getContentPath('/test', null, 'de'));
     }
 
     public function testGetContentPathWithWebspaceKey()
@@ -132,7 +147,7 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPathWithWebspaceKeyHostNotWebspace()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.xy.io');
-        $this->testWebspace->hasDomain('www.xy.io', $this->environment)->willReturn(false);
+        $this->testWebspace->hasDomain('www.xy.io', $this->environment, 'de')->willReturn(false);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -72,7 +72,9 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
 
         $url = null;
         $host = $this->requestAnalyzer->getAttribute('host');
-        if (!$domain && $this->webspaceManager->findWebspaceByKey($webspaceKey)->hasDomain($host, $this->environment)) {
+        if (!$domain
+            && $this->webspaceManager->findWebspaceByKey($webspaceKey)->hasDomain($host, $this->environment, $locale)
+        ) {
             $domain = $host;
         }
 
@@ -84,6 +86,7 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
             $domain,
             $scheme
         );
+
         if (!$withoutDomain && !$url) {
             $url = $this->webspaceManager->findUrlByResourceLocator(
                 $route,

--- a/src/Sulu/Component/Webspace/Tests/Unit/PortalTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/PortalTest.php
@@ -11,7 +11,11 @@
 
 namespace Sulu\Component\Webspace\Tests\Unit;
 
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Environment;
+use Sulu\Component\Webspace\Exception\EnvironmentNotFoundException;
 use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Url;
 
 class PortalTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,13 +24,28 @@ class PortalTest extends \PHPUnit_Framework_TestCase
      */
     private $portal;
 
+    /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
+     * @var Localization
+     */
+    private $localization;
+
+    /**
+     * @var Url
+     */
+    private $url;
+
     public function setUp()
     {
         parent::setUp();
         $this->portal = new Portal();
-        $this->environment = $this->prophesize('Sulu\Component\Webspace\Environment');
-        $this->localization = $this->prophesize('Sulu\Component\Localization\Localization');
-        $this->url = $this->prophesize('Sulu\Component\Webspace\Url');
+        $this->environment = $this->prophesize(Environment::class);
+        $this->localization = $this->prophesize(Localization::class);
+        $this->url = $this->prophesize(Url::class);
     }
 
     public function testGetEnvironment()
@@ -39,14 +58,14 @@ class PortalTest extends \PHPUnit_Framework_TestCase
 
     public function testGetNotExistringEnvironment()
     {
-        $this->setExpectedException('Sulu\Component\Webspace\Exception\EnvironmentNotFoundException');
+        $this->setExpectedException(EnvironmentNotFoundException::class);
 
         $this->portal->getEnvironment('dev');
     }
 
     public function testGetEnvironmentFromEmptyPortal()
     {
-        $this->setExpectedException('Sulu\Component\Webspace\Exception\EnvironmentNotFoundException');
+        $this->setExpectedException(EnvironmentNotFoundException::class);
         $this->portal->getEnvironment('dev');
     }
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
@@ -15,20 +15,35 @@ use Sulu\Component\Webspace\Url;
 
 class UrlTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Url
-     */
-    private $url;
-
-    public function setUp()
+    public function provideIsValidLocale()
     {
-        parent::setUp();
+        return [
+            ['de', 'at', 'de', 'at', true],
+            ['de', '', 'de', null, true],
+            ['de', null, 'de', null, true],
+            [null, null, 'en', 'gb', true],
+            ['en', null, 'de', null, false],
+            ['en', 'us', 'en', 'gb', false],
+            ['de', 'at', 'de', null, false],
+        ];
+    }
 
-        $this->url = new Url();
+    /**
+     * @dataProvider provideIsValidLocale
+     */
+    public function testIsValidLocale($urlLanguage, $urlCountry, $testLanguage, $testCountry, $result)
+    {
+        $url = new Url();
+        $url->setLanguage($urlLanguage);
+        $url->setCountry($urlCountry);
+
+        $this->assertEquals($result, $url->isValidLocale($testLanguage, $testCountry));
     }
 
     public function testToArray()
     {
+        $url = new Url();
+
         $expected = [
             'language' => 'ello',
             'country' => 'as',
@@ -40,14 +55,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             'environment' => null,
         ];
 
-        $this->url->setUrl($expected['url']);
-        $this->url->setLanguage($expected['language']);
-        $this->url->setCountry($expected['country']);
-        $this->url->setSegment($expected['segment']);
-        $this->url->setRedirect($expected['redirect']);
-        $this->url->setMain($expected['main']);
-        $this->url->setAnalyticsKey($expected['analyticsKey']);
+        $url->setUrl($expected['url']);
+        $url->setLanguage($expected['language']);
+        $url->setCountry($expected['country']);
+        $url->setSegment($expected['segment']);
+        $url->setRedirect($expected['redirect']);
+        $url->setMain($expected['main']);
+        $url->setAnalyticsKey($expected['analyticsKey']);
 
-        $this->assertEquals($expected, $this->url->toArray());
+        $this->assertEquals($expected, $url->toArray());
     }
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -57,10 +57,10 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
 
         $this->webspace = new Webspace();
 
-        $this->portal = $this->prophesize('Sulu\Component\Webspace\Portal');
-        $this->localization = $this->prophesize('Sulu\Component\Localization\Localization');
-        $this->security = $this->prophesize('Sulu\Component\Webspace\Security');
-        $this->segment = $this->prophesize('Sulu\Component\Webspace\Segment');
+        $this->portal = $this->prophesize(Portal::class);
+        $this->localization = $this->prophesize(Localization::class);
+        $this->security = $this->prophesize(Security::class);
+        $this->segment = $this->prophesize(Segment::class);
     }
 
     public function testToArray()
@@ -183,6 +183,35 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod'));
         $this->assertTrue($this->webspace->hasDomain('1.sulu.lo', 'prod'));
+    }
+
+    public function testHasDomainWithLocalization()
+    {
+        $environment = $this->prophesize(Environment::class);
+        $url = new Url('sulu.lo', 'prod');
+        $url->setLanguage('de');
+        $environment->getUrls()->willReturn([$url]);
+        $this->portal->getEnvironment('prod')->willReturn($environment->reveal());
+        $this->webspace->addPortal($this->portal->reveal());
+
+        $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod'));
+        $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod', 'de'));
+        $this->assertFalse($this->webspace->hasDomain('sulu.lo', 'prod', 'en'));
+    }
+
+    public function testHasDomainWithLocalizationWithCountry()
+    {
+        $environment = $this->prophesize(Environment::class);
+        $url = new Url('sulu.lo', 'prod');
+        $url->setLanguage('de');
+        $url->setCountry('at');
+        $environment->getUrls()->willReturn([$url]);
+        $this->portal->getEnvironment('prod')->willReturn($environment->reveal());
+        $this->webspace->addPortal($this->portal->reveal());
+
+        $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod'));
+        $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod', 'de_at'));
+        $this->assertFalse($this->webspace->hasDomain('sulu.lo', 'prod', 'de'));
     }
 
     public function testAddTemplate()

--- a/src/Sulu/Component/Webspace/Url.php
+++ b/src/Sulu/Component/Webspace/Url.php
@@ -236,6 +236,20 @@ class Url implements ArrayableInterface
     }
 
     /**
+     * Checks if this URL handles the locale for the given language and country.
+     *
+     * @param string $language
+     * @param string $country
+     *
+     * @return bool
+     */
+    public function isValidLocale($language, $country)
+    {
+        return (empty($this->getLanguage()) || $this->getLanguage() === $language)
+            && (empty($this->getCountry()) || $this->getCountry() === $country);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function toArray($depth = null)

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -421,17 +421,24 @@ class Webspace implements ArrayableInterface
      *
      * @param string $domain
      * @param string $environment
+     * @param string $locale
      *
      * @return bool
      *
      * @throws Exception\EnvironmentNotFoundException
      */
-    public function hasDomain($domain, $environment)
+    public function hasDomain($domain, $environment, $locale = null)
     {
+        $localizationParts = explode('_', $locale);
+        $language = $localizationParts[0];
+        $country = isset($localizationParts[1]) ? $localizationParts[1] : null;
+
         foreach ($this->getPortals() as $portal) {
             foreach ($portal->getEnvironment($environment)->getUrls() as $url) {
                 $host = parse_url('//' . $url->getUrl())['host'];
-                if ($host === $domain || $host === '{host}') {
+                if (($locale === null || $url->isValidLocale($language, $country))
+                    && ($host === $domain || $host === '{host}')
+                ) {
                     return true;
                 }
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu-standard#787
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds an additional check to the `hasDomain` method of the webspace, which allows to check if a domain is existing in a certain locale. It works as before if no locale is passed.

#### Why?

This is required because we need to check if the given domain also exists in the given locale of the `sulu_content_path` twig method.