### PR TITLE
Updated minimum "phpspec/prophecy" version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3147 [All]                 Updated minimum "phpspec/prophecy" version
     * ENHANCEMENT #3126 [All]                 Fixed deprecations to be compatible to twig2
     * ENHANCEMENT #3094 [MarkupBundle]        Extracted tag-extractor from html-markup-parser
     * BUGFIX      #3111 [LocationBundle]      Fixed coordinates update for google map provider

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "matthiasnoback/symfony-config-test": "^1.1",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.3",
         "phpunit/phpunit": "^4.8.31",
+        "phpspec/prophecy": "^1.4",
         "symfony/phpunit-bridge": "~2.8.7, !=2.8.10",
         "sensio/framework-extra-bundle": "~3.0",
         "symfony/monolog-bundle": "~2.8 || ~3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the tests for `TaskManager` because they currently fail in develop (e.g. https://travis-ci.org/sulu/sulu/jobs/192337103)

#### Why?

PHPUnit `4.8.31` relies on `"phpspec/prophecy": "^1.3.1"` which does not supports `willReturnArgument` with an `index !== 0`.

see:
* https://github.com/phpspec/prophecy/blob/v1.4.0/src/Prophecy/Prophecy/MethodProphecy.php#L149
* https://github.com/phpspec/prophecy/blob/v1.3.1/src/Prophecy/Prophecy/MethodProphecy.php#L147

i have changed the implementation to an own one to avoid the direct dependency on prophecy in sulu.