### PR TITLE
fixed cache clearing on publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #3158 [WebsiteBundle]       Fixed error where URL displayed in exception is missing
+    * BUGFIX      #3149 [ContentBundle]       Fixed cache clearing on publishing
     * BUGFIX      #3141 [All]                 Fixed doctrine list builder id when name is not id
 
     * ENHANCEMENT #3146 [TestBundle]          SuluTestCase: Adopted initPhpcr to work for all kernels

--- a/src/Sulu/Component/HttpCache/ProxyClient/Symfony.php
+++ b/src/Sulu/Component/HttpCache/ProxyClient/Symfony.php
@@ -156,7 +156,8 @@ class Symfony implements ProxyClientInterface, PurgeInterface
             );
         }
 
-        Promise\settle($promises);
+        $combinedPromise = Promise\settle($promises);
+        $combinedPromise->wait();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR waits for the promises sent by the cache purging requests. Otherwise the php process will be killed too early leaving the cache intact.