### PR TITLE
Fixed invalidate cache for https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3150 [HTTPCacheBundle]       Fixed invalidate cache for https
+
 * 1.4.5 (2016-01-16)
-    * BUGFIX      #3043 [ContentBudle]        Fixed bind null values on managed-structure
+    * BUGFIX      #3043 [ContentBudle]          Fixed bind null values on managed-structure
 
 * 1.4.4 (2016-01-12)
     * HOTFIX      #3140 [MediaBundle]           Use https variant of adobe creative image editor

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/event-subscribers.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/event-subscribers.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="sulu_document_manager.document_inspector"/>
             <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="service" id="request_stack"/>
             <argument>%kernel.environment%</argument>
 
             <tag name="sulu_document_manager.event_subscriber"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu-standard#791
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The scheme of the purge url will not be handled.

The `webspaceManager->findUrlsByResourceLocator` function has a parameter `scheme` a default value `http` this function has to be called twice one call with `http` and one call with `https`.
