### PR TITLE
Fixes #3158 by adding the URI to the request attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * BUGFIX      #3158 [All]                 Fixed error where URL displayed in exception is missing
+    * BUGFIX      #3158 [WebsiteBundle]       Fixed error where URL displayed in exception is missing
     * BUGFIX      #3141 [All]                 Fixed doctrine list builder id when name is not id
 
     * ENHANCEMENT #3146 [TestBundle]          SuluTestCase: Adopted initPhpcr to work for all kernels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3158 [All]                 Fixed error where URL displayed in exception is missing
     * BUGFIX      #3141 [All]                 Fixed doctrine list builder id when name is not id
 
     * ENHANCEMENT #3146 [TestBundle]          SuluTestCase: Adopted initPhpcr to work for all kernels

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -46,7 +46,7 @@ class RequestAnalyzer implements RequestAnalyzerInterface
             return;
         }
 
-        $attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme()]);
+        $attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme(), 'requestUri' => $request->getRequestUri()]);
         foreach ($this->requestProcessors as $requestProcessor) {
             $attributes = $attributes->merge($requestProcessor->process($request, $attributes));
         }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -124,6 +124,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getHost()->willReturn('www.sulu.io');
         $request->getScheme()->willReturn('https');
+        $request->getRequestUri()->willReturn('/');
 
         $attributesBag = $this->prophesize(ParameterBag::class);
         $attributesBag->get('_sulu')->willReturn(null);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3158
| Related issues/PRs | #3158
| License | MIT

#### What's in this PR?

Adds the requestUri request attribute, which is used by the WebsiteRequestProcessor class to get the current URI.