### PR TITLE
Fixed hide internal/external link in sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * BUGFIX      #3168 [WebsiteBundle]         Fixed hide internal/external link in sitemap
     * BUGFIX      #3167 [SnippetBundle]         Fixed error when snippet template has a category field.
     * HOTFIX      #3162 [MediaBundle]           Fixed type filtering in media-selection
     * HOTFIX      #3150 [HTTPCacheBundle]       Fixed invalidate cache for https

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\WebsiteBundle\Sitemap\Sitemap;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapAlternateLink;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
+use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Repository\ContentRepositoryInterface;
 use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
 
@@ -53,7 +54,10 @@ class PagesSitemapProvider implements SitemapProviderInterface
 
         $result = [];
         foreach ($pages as $contentPage) {
-            if (!$contentPage->getUrl() || true === $contentPage['seo-hideInSitemap']) {
+            if (!$contentPage->getUrl()
+                || true === $contentPage['seo-hideInSitemap']
+                || $contentPage->getNodeType() !== RedirectType::NONE
+            ) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Sitemap;
+
+use Sulu\Bundle\WebsiteBundle\Sitemap\Provider\PagesSitemapProvider;
+use Sulu\Component\Content\Document\RedirectType;
+use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\Content\Repository\Content;
+use Sulu\Component\Content\Repository\ContentRepositoryInterface;
+use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
+
+/**
+ * Tests for PagesSitemapProvider.
+ */
+class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContentRepositoryInterface
+     */
+    private $contentRepository;
+
+    /**
+     * @var PagesSitemapProvider
+     */
+    private $sitemapProvider;
+
+    /**
+     * @var string
+     */
+    private $locale = 'de';
+
+    /**
+     * @var string
+     */
+    private $portalKey = 'sulu_io';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->contentRepository = $this->prophesize(ContentRepositoryInterface::class);
+
+        $this->sitemapProvider = new PagesSitemapProvider($this->contentRepository->reveal());
+    }
+
+    public function testBuild()
+    {
+        /** @var Content[] $pages */
+        $pages = [
+            $this->createContent('/test-1'),
+            $this->createContent('/test-2'),
+            $this->createContent('/test-3'),
+        ];
+
+        $this->contentRepository->findAllByPortal(
+            $this->locale,
+            $this->portalKey,
+            MappingBuilder::create()
+                ->addProperties(['changed', 'seo-hideInSitemap'])
+                ->setResolveUrl(true)
+                ->setHydrateGhost(false)
+                ->getMapping()
+        )->willReturn($pages);
+
+        $result = $this->sitemapProvider->build(1, $this->portalKey, $this->locale);
+
+        $this->assertCount(3, $result);
+        for ($i = 0; $i < 3; ++$i) {
+            $this->assertEquals($pages[$i]->getUrl(), $result[$i]->getLoc());
+            $this->assertEquals($pages[$i]->getData()['changed'], $result[$i]->getLastMod());
+        }
+    }
+
+    public function testBuildHideInSitemap()
+    {
+        /** @var Content[] $pages */
+        $pages = [
+            $this->createContent('/test-1'),
+            $this->createContent('/test-2', true),
+            $this->createContent('/test-3', true),
+        ];
+
+        $this->contentRepository->findAllByPortal(
+            $this->locale,
+            $this->portalKey,
+            MappingBuilder::create()
+                ->addProperties(['changed', 'seo-hideInSitemap'])
+                ->setResolveUrl(true)
+                ->setHydrateGhost(false)
+                ->getMapping()
+        )->willReturn($pages);
+
+        $result = $this->sitemapProvider->build(1, $this->portalKey, $this->locale);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($pages[0]->getUrl(), $result[0]->getLoc());
+        $this->assertEquals($pages[0]->getData()['changed'], $result[0]->getLastMod());
+    }
+
+    public function testBuildInternalExternalLink()
+    {
+        /** @var Content[] $pages */
+        $pages = [
+            $this->createContent('/test-1'),
+            $this->createContent('/test-2', false, RedirectType::INTERNAL),
+            $this->createContent('/test-3', false, RedirectType::EXTERNAL),
+        ];
+
+        $this->contentRepository->findAllByPortal(
+            $this->locale,
+            $this->portalKey,
+            MappingBuilder::create()
+                ->addProperties(['changed', 'seo-hideInSitemap'])
+                ->setResolveUrl(true)
+                ->setHydrateGhost(false)
+                ->getMapping()
+        )->willReturn($pages);
+
+        $result = $this->sitemapProvider->build(1, $this->portalKey, $this->locale);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($pages[0]->getUrl(), $result[0]->getLoc());
+        $this->assertEquals($pages[0]->getData()['changed'], $result[0]->getLastMod());
+    }
+
+    /**
+     * Create a new content-page.
+     *
+     * @param string $url
+     * @param bool $hideInSitemap
+     * @param int $redirectTarget
+     * @param array $urls
+     *
+     * @return Content
+     */
+    public function createContent($url, $hideInSitemap = false, $redirectTarget = RedirectType::NONE, $urls = [])
+    {
+        $content = new Content(
+            $this->locale,
+            $this->portalKey,
+            uniqid('test-'),
+            $url,
+            WorkflowStage::PUBLISHED,
+            $redirectTarget,
+            false,
+            ['seo-hideInSitemap' => $hideInSitemap, 'changed' => new \DateTime()],
+            []
+        );
+        $content->setUrl($url);
+        $content->setUrls($urls);
+
+        return $content;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes internal/external links from sitemap.

#### Why?

From SEO perspective external links are not part of the website and internal links are present from the linked page.