### PR TITLE
fixed generating of resource locator with missing parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3173 [ContentBundle]         Fixed generating of resource locator with missing parents
     * HOTFIX      #3170 [ContentBundle]         Fixed copy page in column navigation
     * BUGFIX      #3168 [WebsiteBundle]         Fixed hide internal/external link in sitemap
     * HOTFIX      #3170 [ContentBundle]         Fixed deleting of the smart content data source

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\ResourceLocator\Strategy;
+
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
+use Sulu\Component\Content\Types\ResourceLocator\Mapper\ResourceLocatorMapperInterface;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorGeneratorInterface;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategy;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\PHPCR\PathCleanupInterface;
+use Sulu\Component\Util\SuluNodeHelper;
+
+class ResourceLocatorStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ResourceLocatorMapperInterface
+     */
+    private $mapper;
+
+    /**
+     * @var PathCleanupInterface
+     */
+    private $cleaner;
+
+    /**
+     * @var StructureManagerInterface
+     */
+    private $structureManager;
+
+    /**
+     * @var ContentTypeManagerInterface
+     */
+    private $contentTypeManager;
+
+    /**
+     * @var SuluNodeHelper
+     */
+    private $nodeHelper;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var ResourceLocatorGeneratorInterface
+     */
+    private $resourceLocatorGenerator;
+
+    /**
+     * @var ResourceLocatorStrategy
+     */
+    private $resourceLocatorStrategy;
+
+    public function setUp()
+    {
+        $this->mapper = $this->prophesize(ResourceLocatorMapperInterface::class);
+        $this->cleaner = $this->prophesize(PathCleanupInterface::class);
+        $this->structureManager = $this->prophesize(StructureManagerInterface::class);
+        $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
+        $this->nodeHelper = $this->prophesize(SuluNodeHelper::class);
+        $this->documentInspector = $this->prophesize(DocumentInspector::class);
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->resourceLocatorGenerator = $this->prophesize(ResourceLocatorGeneratorInterface::class);
+
+        $this->resourceLocatorStrategy = $this->getMockForAbstractClass(
+            ResourceLocatorStrategy::class,
+            [
+                $this->mapper->reveal(),
+                $this->cleaner->reveal(),
+                $this->structureManager->reveal(),
+                $this->contentTypeManager->reveal(),
+                $this->nodeHelper->reveal(),
+                $this->documentInspector->reveal(),
+                $this->documentManager->reveal(),
+                $this->resourceLocatorGenerator->reveal(),
+            ]
+        );
+    }
+
+    public function testGenerate()
+    {
+        $document = $this->prophesize(ParentBehavior::class);
+
+        $this->documentManager->find('123-123-123', 'de', ['load_ghost_content' => false])
+            ->willReturn($document->reveal());
+
+        $this->documentInspector->getUuid($document->reveal())->willReturn('123-123-123');
+
+        $this->mapper->loadByContentUuid('123-123-123', 'sulu_io', 'de', null)
+            ->willThrow(ResourceLocatorNotFoundException::class);
+
+        $this->resourceLocatorGenerator->generate('test', null)->willReturn('/test');
+        $this->cleaner->cleanup('/test', 'de')->willReturn('/test');
+        $this->mapper->getUniquePath('/test', 'sulu_io', 'de', null)->willReturn('/test');
+
+        $this->assertEquals(
+            $this->resourceLocatorStrategy->generate('test', '123-123-123', 'sulu_io', 'de'),
+            '/test'
+        );
+    }
+
+    public function testGenerateWithParentDocument()
+    {
+        $document = $this->prophesize(ParentBehavior::class);
+        $parentDocument = $this->prophesize(ParentBehavior::class);
+        $document->getParent()->willReturn($parentDocument);
+
+        $this->documentManager->find('123-123-123', 'de', ['load_ghost_content' => false])
+            ->willReturn($document->reveal());
+        $this->documentManager->find('456-456-456', 'de', ['load_ghost_content' => false])
+            ->willReturn($parentDocument->reveal());
+
+        $this->documentInspector->getUuid($document->reveal())->willReturn('123-123-123');
+        $this->documentInspector->getUuid($parentDocument->reveal())->willReturn('456-456-456');
+
+        $this->mapper->loadByContentUuid('123-123-123', 'sulu_io', 'de', null)
+            ->willThrow(ResourceLocatorNotFoundException::class);
+        $this->mapper->loadByContentUuid('456-456-456', 'sulu_io', 'de', null)
+            ->willReturn('/parent');
+
+        $this->resourceLocatorGenerator->generate('test', '/parent')->willReturn('/parent/test');
+        $this->cleaner->cleanup('/parent/test', 'de')->willReturn('/parent/test');
+        $this->mapper->getUniquePath('/parent/test', 'sulu_io', 'de', null)->willReturn('/parent/test');
+
+        $this->assertEquals(
+            $this->resourceLocatorStrategy->generate('test', '123-123-123', 'sulu_io', 'de'),
+            '/parent/test'
+        );
+    }
+
+    public function testGenerateWithParent()
+    {
+        $this->resourceLocatorGenerator->generate('test', null)->willReturn('/test');
+        $this->cleaner->cleanup('/test', 'de')->willReturn('/test');
+        $this->mapper->getUniquePath('/test', 'sulu_io', 'de', null)->willReturn('/test');
+
+        $this->assertEquals(
+            $this->resourceLocatorStrategy->generate('test', null, 'sulu_io', 'de'),
+            '/test'
+        );
+    }
+}

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
@@ -144,37 +144,6 @@ class TreeFullEditStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('path/to/parent/new-page', $result);
     }
 
-    public function testGenerateUnpublishedParent()
-    {
-        $title = 'new-page';
-        $parentUuid = 'uuid-uuid-uuid-uuid';
-        $webspaceKey = 'sulu_io';
-        $languageCode = 'de';
-
-        $grandParent = $this->prophesize(PageDocument::class);
-        $grandParent->getPublished()->willReturn(true);
-        $grandParentUuid = 'grand-parent-uuid-uuid';
-
-        $parent = $this->prophesize(PageDocument::class);
-        $parent->getPublished()->willReturn(false);
-        $parent->getParent()->willReturn($grandParent->reveal());
-
-        $this->documentManager->find($parentUuid, $languageCode, ['load_ghost_content' => false])->willReturn($parent);
-        $this->documentInspector->getUuid($grandParent)->willReturn($grandParentUuid);
-        $this->mapper->loadByContentUuid($grandParentUuid, $webspaceKey, $languageCode, null)->willReturn(
-            'path/to/grandparent'
-        );
-        $this->cleaner->cleanup('path/to/grandparent/new-page', $languageCode)->willReturn(
-            'path/to/grandparent/new-page'
-        );
-        $this->mapper->getUniquePath('path/to/grandparent/new-page', $webspaceKey, $languageCode, null)->willReturn(
-            'path/to/grandparent/new-page-1'
-        );
-
-        $result = $this->treeStrategy->generate($title, $parentUuid, $webspaceKey, $languageCode);
-        $this->assertEquals('path/to/grandparent/new-page-1', $result);
-    }
-
     public function testGenerateWithoutParentUuid()
     {
         $title = 'new-page';
@@ -184,7 +153,7 @@ class TreeFullEditStrategyTest extends \PHPUnit_Framework_TestCase
         $parent = $this->prophesize(PageDocument::class);
         $parent->getPublished()->willReturn(true);
 
-        $this->cleaner->cleanup('//new-page', $languageCode)->willReturn('/new-page');
+        $this->cleaner->cleanup('/new-page', $languageCode)->willReturn('/new-page');
         $this->mapper->getUniquePath('/new-page', $webspaceKey, $languageCode, null)->willReturn(
             'path/to/parent/new-page'
         );

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
@@ -146,37 +146,6 @@ class TreeLeafEditStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('path/to/parent/new-page', $result);
     }
 
-    public function testGenerateUnpublishedParent()
-    {
-        $title = 'new-page';
-        $parentUuid = 'uuid-uuid-uuid-uuid';
-        $webspaceKey = 'sulu_io';
-        $languageCode = 'de';
-
-        $grandParent = $this->prophesize(PageDocument::class);
-        $grandParent->getPublished()->willReturn(true);
-        $grandParentUuid = 'grand-parent-uuid-uuid';
-
-        $parent = $this->prophesize(PageDocument::class);
-        $parent->getPublished()->willReturn(false);
-        $parent->getParent()->willReturn($grandParent->reveal());
-
-        $this->documentManager->find($parentUuid, $languageCode, ['load_ghost_content' => false])->willReturn($parent);
-        $this->documentInspector->getUuid($grandParent)->willReturn($grandParentUuid);
-        $this->mapper->loadByContentUuid($grandParentUuid, $webspaceKey, $languageCode, null)->willReturn(
-            'path/to/grandparent'
-        );
-        $this->cleaner->cleanup('path/to/grandparent/new-page', $languageCode)->willReturn(
-            'path/to/grandparent/new-page'
-        );
-        $this->mapper->getUniquePath('path/to/grandparent/new-page', $webspaceKey, $languageCode, null)->willReturn(
-            'path/to/grandparent/new-page-1'
-        );
-
-        $result = $this->treeStrategy->generate($title, $parentUuid, $webspaceKey, $languageCode);
-        $this->assertEquals('path/to/grandparent/new-page-1', $result);
-    }
-
     public function testGenerateWithoutParentUuid()
     {
         $title = 'new-page';
@@ -186,7 +155,7 @@ class TreeLeafEditStrategyTest extends \PHPUnit_Framework_TestCase
         $parent = $this->prophesize(PageDocument::class);
         $parent->getPublished()->willReturn(true);
 
-        $this->cleaner->cleanup('//new-page', $languageCode)->willReturn('/new-page');
+        $this->cleaner->cleanup('/new-page', $languageCode)->willReturn('/new-page');
         $this->mapper->getUniquePath('/new-page', $webspaceKey, $languageCode, null)->willReturn(
             'path/to/parent/new-page'
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the logic to get the resolvable parent. Instead of simply checking if the node is published the real data from the route tree is loaded.

#### Why?

The current logic is not sufficient, because internal links do not have a node in the route tree. This breaks the generating of routes in the page form and while copying pages, where the page is copied under a page, which has content but no route in a language.