### PR TITLE
Added filters to resthelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #3176 [All]                 Added filters to resthelper
     * BUGFIX      #3158 [WebsiteBundle]       Fixed error where URL displayed in exception is missing
     * BUGFIX      #3149 [ContentBundle]       Fixed cache clearing on publishing
     * BUGFIX      #3141 [All]                 Fixed doctrine list builder id when name is not id

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -22,6 +22,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class ListRestHelper implements ListRestHelperInterface
 {
+    const PARAMETER_FIELDS = 'fields';
+    const PARAMETER_PAGE = 'page';
+    const PARAMETER_SEARCH = 'search';
+    const PARAMETER_SEARCH_FIELDS = 'searchFields';
+    const PARAMETER_SORT_BY = 'sortBy';
+    const PARAMETER_SORT_ORDER = 'sortOrder';
+
     /**
      * The current request object.
      *
@@ -57,7 +64,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSortColumn()
     {
-        return $this->getRequest()->get('sortBy', null);
+        return $this->getRequest()->get(self::PARAMETER_SORT_BY, null);
     }
 
     /**
@@ -67,7 +74,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSortOrder()
     {
-        return $this->getRequest()->get('sortOrder', 'asc');
+        return $this->getRequest()->get(self::PARAMETER_SORT_ORDER, 'asc');
     }
 
     /**
@@ -93,7 +100,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getOffset()
     {
-        $page = $this->getRequest()->get('page', 1);
+        $page = $this->getRequest()->get(self::PARAMETER_PAGE, 1);
         $limit = $this->getLimit();
 
         return ($limit != null) ? $limit * ($page - 1) : null;
@@ -106,7 +113,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getPage()
     {
-        return $this->getRequest()->get('page', 1);
+        return $this->getRequest()->get(self::PARAMETER_PAGE, 1);
     }
 
     /**
@@ -117,7 +124,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getFields()
     {
-        $fields = $this->getRequest()->get('fields');
+        $fields = $this->getRequest()->get(self::PARAMETER_FIELDS);
 
         return ($fields != null) ? explode(',', $fields) : null;
     }
@@ -129,7 +136,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSearchPattern()
     {
-        return $this->getRequest()->get('search');
+        return $this->getRequest()->get(self::PARAMETER_SEARCH);
     }
 
     /**
@@ -139,8 +146,46 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSearchFields()
     {
-        $searchFields = $this->getRequest()->get('searchFields');
+        $searchFields = $this->getRequest()->get(self::PARAMETER_SEARCH_FIELDS);
 
         return ($searchFields != null) ? explode(',', $searchFields) : [];
+    }
+
+    /**
+     * Returns an array of available filters.
+     *
+     * @return string[]
+     */
+    public function getFilters()
+    {
+        $filters = [];
+
+        $parameters = $this->getRequest()->query->all();
+
+        foreach ($parameters as $name => $value) {
+            // ignore empty values and none filter parameters
+            if ($value && !in_array($name, $this->getNoneFilterParameters())) {
+                $filters[$name] = $value;
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Returns an array of none available filter parameters.
+     *
+     * @return array
+     */
+    protected function getNoneFilterParameters()
+    {
+        return [
+            self::PARAMETER_FIELDS,
+            self::PARAMETER_PAGE,
+            self::PARAMETER_SEARCH,
+            self::PARAMETER_SEARCH_FIELDS,
+            self::PARAMETER_SORT_BY,
+            self::PARAMETER_SORT_ORDER,
+        ];
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
@@ -73,4 +73,11 @@ interface ListRestHelperInterface
      * @return array|null
      */
     public function getSearchFields();
+
+    /**
+     * Returns an array of available filters.
+     *
+     * @return string[]
+     */
+    public function getFilters();
 }

--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -38,9 +38,13 @@ class RestHelper implements RestHelperInterface
      */
     public function initializeListBuilder(ListBuilderInterface $listBuilder, array $fieldDescriptors)
     {
+        // add pagination
         $listBuilder->limit($this->listRestHelper->getLimit())->setCurrentPage($this->listRestHelper->getPage());
+
+        // add field descriptors
         $listBuilder->setFieldDescriptors($fieldDescriptors);
 
+        // add select fields
         $fields = $this->listRestHelper->getFields();
         if ($fields != null) {
             foreach ($fields as $field) {
@@ -54,6 +58,7 @@ class RestHelper implements RestHelperInterface
             $listBuilder->setSelectFields($fieldDescriptors);
         }
 
+        // add search
         $searchFields = $this->listRestHelper->getSearchFields();
         if ($searchFields != null) {
             foreach ($searchFields as $searchField) {
@@ -63,9 +68,22 @@ class RestHelper implements RestHelperInterface
             $listBuilder->search($this->listRestHelper->getSearchPattern());
         }
 
+        // add sort
         $sortBy = $this->listRestHelper->getSortColumn();
         if ($sortBy != null) {
             $listBuilder->sort($fieldDescriptors[$sortBy], $this->listRestHelper->getSortOrder());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFilters(ListBuilderInterface $listBuilder, array $fieldDescriptors)
+    {
+        foreach ($this->listRestHelper->getFilters() as $filterKey => $filterValue) {
+            if (isset($fieldDescriptors[$filterKey])) {
+                $listBuilder->where($fieldDescriptors[$filterKey], $filterValue);
+            }
         }
     }
 }

--- a/src/Sulu/Component/Rest/RestHelperInterface.php
+++ b/src/Sulu/Component/Rest/RestHelperInterface.php
@@ -46,4 +46,12 @@ interface RestHelperInterface
         callable $update = null,
         callable $delete = null
     );
+
+    /**
+     * Add filters to list builder with values from the request.
+     *
+     * @param ListBuilderInterface $listBuilder
+     * @param array $fieldDescriptors
+     */
+    public function addFilters(ListBuilderInterface $listBuilder, array $fieldDescriptors);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add filters to resthelper.

#### Why?

I used mostly this filter implementation in my controllers and copy it currently from project to project. 

#### Example Usage

```php
$restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
$restHelper->addFilters($listBuilder, $filterableFieldDescriptors);
```

#### BC Breaks/Deprecations

New function in RestHelperInterface

#### To Do

- [ ] Create a documentation
- [ ] Create Tests
- [ ] Limit Parameter missing as constant or parameter
