### PR TITLE
Added exception throw when field descriptor reference is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3179 [All]                 Added exception throw when field descriptor reference is not found
     * FEATURE     #3164 [AdminBundle]         Extracted csv-export into extension
     * BUGFIX      #3158 [WebsiteBundle]       Fixed error where URL displayed in exception is missing
     * BUGFIX      #3149 [ContentBundle]       Fixed cache clearing on publishing

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/list-builder/Account.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/list-builder/Account.xml
@@ -134,7 +134,7 @@
                 <orm:field-name>firstName</orm:field-name>
                 <orm:entity-name>%sulu.model.contact.class%</orm:entity-name>
 
-                <orm:joins ref="accountContact"/>
+                <orm:joins ref="mainContact"/>
             </orm:field>
 
             <orm:field>

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
@@ -234,6 +234,8 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
      * @param \DOMElement $fieldNode
      *
      * @return FieldMetadata
+     *
+     * @throws \Exception
      */
     protected function getField(\DOMXPath $xpath, \DOMElement $fieldNode)
     {
@@ -241,7 +243,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
             $nodeList = $xpath->query(sprintf('/x:class/x:properties/x:*[@name="%s"]', $reference));
 
             if ($nodeList->length === 0) {
-                return;
+                throw new \Exception(sprintf('Rest metadata doctrine field reference "%s" was not found.', $reference));
             }
 
             return $this->getField($xpath, $nodeList->item(0));
@@ -269,6 +271,8 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
      * @param \DOMXPath $xpath
      * @param \DOMElement $joinsNode
      * @param FieldMetadata $field
+     *
+     * @throws \Exception
      */
     protected function getJoinsMetadata(\DOMXPath $xpath, \DOMElement $joinsNode, FieldMetadata $field)
     {
@@ -276,7 +280,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
             $nodeList = $xpath->query(sprintf('/x:class/orm:joins[@name="%s"]', $reference));
 
             if ($nodeList->length === 0) {
-                return;
+                throw new \Exception(sprintf('Rest metadata doctrine joins reference "%s" was not found.', $reference));
             }
 
             $this->getJoinsMetadata($xpath, $nodeList->item(0), $field);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Currently when load meta data for the field descriptor and add a none exist reference as joins the driver will not fail.

#### Why?

It should throw an exception to avoid problems which only appears when the user hide view specific columns only

#### Example Usage

~~~xml
<class xmlns="http://schemas.sulu.io/class/general"
       xmlns:orm="http://schemas.sulu.io/class/doctrine"
       xmlns:list="http://schemas.sulu.io/class/list">
    <orm:joins name="creator">
        <orm:join>
            <orm:entity-name>%sulu.model.user.class%</orm:entity-name>
            <orm:field-name>%sulu.model.comment.class%.creator</orm:field-name>
        </orm:join>
    </orm:joins>

    <properties>
        <property name="creatorId" filter-type="integer" list:translation="public.creator" list:type="integer">
            <orm:field-name>id</orm:field-name>
            <orm:entity-name>%sulu.model.user.class%</orm:entity-name>

            <orm:joins ref="creator"/>
        </property>

        <property name="creatorUsername" filter-type="integer" list:translation="public.username" list:type="integer">
            <orm:field-name>username</orm:field-name>
            <orm:entity-name>%sulu.model.user.class%</orm:entity-name>

            <orm:joins ref="creatorFalseWrittenAndNotExist"/>
        </property>
    </properties>
</class>
~~~

To example will work when creatorId,creatorUsername is set as fields but not when only creatorUsername is set as fields.