### PR TITLE
remove the automation tab from ghost page forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG for Sulu
     * ENHANCMENT  #3182 [SecurityBundle]      Added unique constraint for permission context and role
     * ENHANCEMENT #3179 [All]                 Added exception throw when field descriptor reference is not found
     * BUGFIX      #3040 [MediaBundle]         Throw exception when multiple formats have the same key
+    * BUGFIX      #3180 [AutomationBundle]    Remove the automation tab from ghost page forms
     * FEATURE     #3164 [AdminBundle]         Extracted csv-export into extension
     * BUGFIX      #3158 [WebsiteBundle]       Fixed error where URL displayed in exception is missing
     * BUGFIX      #3149 [ContentBundle]       Fixed cache clearing on publishing

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/automation.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/automation.xml
@@ -12,6 +12,14 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.repository.task"/>
             <argument type="string">%sulu_content.page_document.class%</argument>
+            <argument>45</argument>
+            <argument type="collection">
+                <argument type="collection">
+                    <argument key="property">url</argument>
+                    <argument key="operator" type="constant">\Sulu\Bundle\AdminBundle\Navigation\DisplayCondition::OPERATOR_NOT_EQUAL</argument>
+                    <argument key="value"></argument>
+                </argument>
+            </argument>
 
             <tag name="sulu_admin.content_navigation" alias="content"/>
             <tag name="sulu.context" context="admin"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | https://github.com/sulu/SuluAutomationBundle/pull/4
| License | MIT
| Documentation PR | ---

#### What's in this PR?

There was a condition missing in the content navigation for the automation.

#### Why?

The automation tab also occured when creating a new language of an already existing page.