### PR TITLE
added unique constraint for permission context and role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCMENT  #3182 [SecurityBundle]      Added unique constraint for permission context and role
     * ENHANCEMENT #3179 [All]                 Added exception throw when field descriptor reference is not found
     * FEATURE     #3164 [AdminBundle]         Extracted csv-export into extension
     * BUGFIX      #3158 [WebsiteBundle]       Fixed error where URL displayed in exception is missing

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Permission.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Permission.orm.xml
@@ -3,6 +3,10 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Sulu\Bundle\SecurityBundle\Entity\Permission" table="se_permissions">
+        <unique-constraints>
+            <unique-constraint columns="context,module,idRoles"/>
+        </unique-constraints>
+
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added unique constraint for permission context and role

#### Why?

To avoid duplicated add permissions to a role.

#### Example Usage

~~~sql
INSERT INTO `se_permissions` (`context`, `module`, `permissions`, `idRoles`) VALUES ('app.test', NULL, 80, 1);
INSERT INTO `se_permissions` (`context`, `module`, `permissions`, `idRoles`) VALUES ('app.test', NULL, 80, 1);
~~~
