### PR TITLE
fixed wrong cache key generation for MemoizeTwigExtensionTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * ENHANCEMENT #3188 [AutomationBundle]    Extracted the automation-bundle
     * BUGFIX      #3183 [ContentBundle]       Fixed grid usage in conten form
+    * BUGFIX      #3186 [Cache]               Fixed wrong cache key generation for MemoizeTwigExtensionTrait
     * ENHANCMENT  #3182 [SecurityBundle]      Added unique constraint for permission context and role
     * ENHANCEMENT #3179 [All]                 Added exception throw when field descriptor reference is not found
     * BUGFIX      #3040 [MediaBundle]         Throw exception when multiple formats have the same key

--- a/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
@@ -78,7 +78,9 @@ class CategoryTwigExtension extends \Twig_Extension
      */
     public function getCategoriesFunction($locale, $parentKey = null)
     {
-        return $this->memoizeCache->memoize(
+        return $this->memoizeCache->memoizeById(
+            'sulu_categories',
+            func_get_args(),
             function ($locale, $parentKey = null) {
                 $entities = $this->categoryManager->findChildrenByParentKey($parentKey);
                 $categories = $this->categoryManager->getApiObjects($entities, $locale);

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -69,7 +69,9 @@ class TagTwigExtension extends \Twig_Extension
      */
     public function getTagsFunction()
     {
-        return $this->memoizeCache->memoize(
+        return $this->memoizeCache->memoizeById(
+            'sulu_tags',
+            func_get_args(),
             function () {
                 $tags = $this->tagManager->findAll();
 

--- a/src/Sulu/Component/Cache/MemoizeInterface.php
+++ b/src/Sulu/Component/Cache/MemoizeInterface.php
@@ -26,6 +26,8 @@ interface MemoizeInterface
      * @throws \InvalidArgumentException
      *
      * @return mixed
+     *
+     * @deprecated Will be removed with 2.0. Use MemoizeInterface::memoizeById instead.
      */
     public function memoize($compute, $lifeTime = null);
 

--- a/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
+++ b/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
@@ -39,11 +39,12 @@ trait MemoizeTwigExtensionTrait
         $result = [];
         foreach ($this->extension->getFunctions() as $function) {
             $callable = $function->getCallable();
+            $name = $function->getName();
 
             $result[] = new \Twig_SimpleFunction(
-                $function->getName(),
-                function () use ($callable) {
-                    return $this->memoizeCache->memoize($callable, $this->lifeTime);
+                $name,
+                function () use ($callable, $name) {
+                    return $this->memoizeCache->memoizeById($name, func_get_args(), $callable, $this->lifeTime);
                 }
             );
         }

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -90,11 +90,18 @@ class MemoizeTwigExtensionTraitTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->extension->getFunctions()->willReturn($before);
-        $this->memoizeCache->memoize(Argument::type('callable'), $this->lifeTime)->will(
-            function ($arguments) {
-                return call_user_func($arguments[0]);
-            }
-        )->shouldBeCalledTimes(2);
+        $this->memoizeCache->memoizeById('sulu_content_load', [], Argument::type('callable'), $this->lifeTime)
+            ->will(
+                function ($arguments) {
+                    return call_user_func($arguments[2]);
+                }
+            );
+        $this->memoizeCache->memoizeById('sulu_content_load_parent', [], Argument::type('callable'), $this->lifeTime)
+            ->will(
+                function ($arguments) {
+                    return call_user_func($arguments[2]);
+                }
+            );
 
         /** @var \Twig_SimpleFunction[] $result */
         $result = $this->trait->getFunctions();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu-standard#799
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the `getFunctions` implementation of the `MemoizeTwigExtensionTrait` to use the actual parameters and the `memoizeById` method instead of relying on the `debug_backtrace` magic happening in the `Memoize` class.

I still left the `memoize` method of the `Memoize` class there, because the twig extensions for categories and tags still use it, but they could be refactored to use the same way as the twig extension for content. Then we could get rid of the ugly `debug_backtrace` call.

The question is if we should already deprecate the `memoize` call, so that it is safe to remove it in 2.0.

#### Why?

The issue sulu/sulu-standard#799 happened because the trait we use in the `ContentTwigExtension` changes the backtrace to a closure, and the key is not matching anymore then.

#### To Do

- [x] Deprecate stuff (first decide on what exactly)
