### PR TITLE
fixed broken UserManager when used without Security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * BUGFIX      #3183 [ContentComponent]    Fixed Windows xinclude error
+    * BUGFIX      #3200 [SecurityBundle]      Fixed broken UserManager when used without Security
+    * BUGFIX      #3183 [ContentBundle]       Fixed Windows xinclude error
 
 * 1.5.0-RC1 (2017-02-13)
     * BUGFIX      #3022 [ContentBundle]       Fixed property-value offset set

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/UserManagerCompilerPass.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/UserManagerCompilerPass.php
@@ -23,32 +23,20 @@ class UserManagerCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->hasDefinition('security.token_storage')) {
-            $container->setDefinition(
-                'sulu_security.user_manager',
-                new Definition(
-                    'Sulu\Bundle\SecurityBundle\UserManager\UserManager',
-                    [
-                        new Reference('doctrine.orm.entity_manager'),
-                        new Reference('security.encoder_factory'),
-                        new Reference('sulu.repository.role'),
-                        new Reference('sulu_security.group_repository'),
-                        new Reference('sulu_contact.contact_manager'),
-                        new Reference('sulu_security.salt_generator'),
-                        new Reference('sulu.repository.user'),
-                    ]
-                )
-            );
-        } else {
-            $container->setDefinition(
-                'sulu_security.user_manager',
-                new Definition(
-                    'Sulu\Bundle\SecurityBundle\UserManager\UserManager',
-                    [
-                        new Reference('doctrine.orm.entity_manager'),
-                    ]
-                )
-            );
-        }
+        $container->setDefinition(
+            'sulu_security.user_manager',
+            new Definition(
+                'Sulu\Bundle\SecurityBundle\UserManager\UserManager',
+                [
+                    new Reference('doctrine.orm.entity_manager'),
+                    $container->hasDefinition('security.token_storage') ? new Reference('security.encoder_factory') : null,
+                    new Reference('sulu.repository.role'),
+                    new Reference('sulu_security.group_repository'),
+                    new Reference('sulu_contact.contact_manager'),
+                    new Reference('sulu_security.salt_generator'),
+                    new Reference('sulu.repository.user'),
+                ]
+            )
+        );
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/DependencyInjection/Compiler/UserManagerCompilerPassTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/DependencyInjection/Compiler/UserManagerCompilerPassTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Sulu\Bundle\SecurityBundle\DependencyInjection\Compiler\UserManagerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class UserManagerCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $containerBuilder;
+    /**
+     * @var UserManagerCompilerPass
+     */
+    private $userManagerCompilerPass;
+
+    public function setUp()
+    {
+        $this->containerBuilder = $this->prophesize(ContainerBuilder::class);
+        $this->userManagerCompilerPass = new UserManagerCompilerPass();
+    }
+
+    public function testProcessWithSecurity()
+    {
+        $this->containerBuilder->hasDefinition('security.token_storage')->willReturn(true);
+        $this->containerBuilder->setDefinition(
+            'sulu_security.user_manager',
+            new Definition(
+                'Sulu\Bundle\SecurityBundle\UserManager\UserManager',
+                [
+                    new Reference('doctrine.orm.entity_manager'),
+                    new Reference('security.encoder_factory'),
+                    new Reference('sulu.repository.role'),
+                    new Reference('sulu_security.group_repository'),
+                    new Reference('sulu_contact.contact_manager'),
+                    new Reference('sulu_security.salt_generator'),
+                    new Reference('sulu.repository.user'),
+                ]
+            )
+        )->shouldBeCalled();
+        $this->userManagerCompilerPass->process($this->containerBuilder->reveal());
+    }
+
+    public function testProcessWithoutSecurity()
+    {
+        $this->containerBuilder->hasDefinition('security.token_storage')->willReturn(false);
+        $this->containerBuilder->setDefinition(
+            'sulu_security.user_manager',
+            new Definition(
+                'Sulu\Bundle\SecurityBundle\UserManager\UserManager',
+                [
+                    new Reference('doctrine.orm.entity_manager'),
+                    null,
+                    new Reference('sulu.repository.role'),
+                    new Reference('sulu_security.group_repository'),
+                    new Reference('sulu_contact.contact_manager'),
+                    new Reference('sulu_security.salt_generator'),
+                    new Reference('sulu.repository.user'),
+                ]
+            )
+        )->shouldBeCalled();
+        $this->userManagerCompilerPass->process($this->containerBuilder->reveal());
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -586,6 +586,12 @@ class UserManager implements UserManagerInterface
      */
     private function encodePassword(UserInterface $user, $password, $salt)
     {
+        if (!$this->encoderFactory) {
+            throw new \InvalidArgumentException(
+                'For encoding a password the "EncoderFactory" must be passed to the "UserManager".'
+            );
+        }
+
         $encoder = $this->encoderFactory->getEncoder($user);
 
         return $encoder->encodePassword($password, $salt);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3196 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds all the parameters to the `UserManager` except for the one really being absent when used without Security. Then all the queries should work.