### PR TITLE
allow same image format key if formats are identical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3210 [MediaBundle]         Allow same image format key if formats are identical
     * BUGFIX      #3200 [SecurityBundle]      Fixed broken UserManager when used without Security
     * BUGFIX      #3183 [ContentBundle]       Fixed Windows xinclude error
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/AbstractImageFormatCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/AbstractImageFormatCompilerPass.php
@@ -85,9 +85,9 @@ abstract class AbstractImageFormatCompilerPass implements CompilerPassInterface
 
         $fileFormats = $loader->load($file);
         foreach ($fileFormats as $format) {
-            if (array_key_exists($format['key'], $formats)) {
+            if (array_key_exists($format['key'], $formats) && $formats[$format['key']] !== $format) {
                 throw new InvalidArgumentException(
-                    sprintf('Media format with key "%x" already exists!', $format['key'])
+                    sprintf('Media format with key "%s" already exists!', $format['key'])
                 );
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR is an addition to https://github.com/sulu/sulu/pull/3040. It allows multiple themes to have the same image format key, if the format behind the key is exactly the same.

#### Why?

If two different themes have the exact same format it doesn't make sense to have two different keys, because also too many files are dumped.
