### PR TITLE
Fixed url generation of type portal routes

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -50,7 +50,7 @@ class RequestListener
                 $context->setParameter('prefix', $portalInformation->getPrefix());
             }
             if (!$context->hasParameter('host')) {
-                $context->setParameter('host', $portalInformation->getHost());
+                $context->setParameter('host', explode(':', $portalInformation->getHost())[0]);
             }
         }
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -50,7 +50,7 @@ class RequestListener
                 $context->setParameter('prefix', $portalInformation->getPrefix());
             }
             if (!$context->hasParameter('host')) {
-                $context->setParameter('host', explode(':', $portalInformation->getHost())[0]);
+                $context->setParameter('host', $portalInformation->getHost());
             }
         }
     }

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -297,7 +297,7 @@ class PortalInformation implements ArrayableInterface
      */
     public function getPrefix()
     {
-        return substr($this->url, $this->getHostLength());
+        return substr($this->url, $this->getHostLength(true));
     }
 
     /**
@@ -375,11 +375,17 @@ class PortalInformation implements ArrayableInterface
     /**
      * Calculate the length of the host part of the URL.
      *
+     * @param bool $withPort
+     *
      * @return int
      */
-    private function getHostLength()
+    private function getHostLength($withPort = false)
     {
-        $hostLength = strpos($this->url, '/');
+        $hostLength = false;
+        if (!$withPort) {
+            $hostLength = strpos($this->url, ':');
+        }
+        $hostLength = ($hostLength === false) ? strpos($this->url, '/') : $hostLength;
         $hostLength = ($hostLength === false) ? strlen($this->url) : $hostLength;
 
         return $hostLength;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Fixed Issues | fixes #3211

#### What's in this PR?

Fix the `path` and `url` with port when e.g use `server:run` command.

#### Why?

Symfony itself have no port in there route definition and will add the request port by itself so only the host without port should add as default for the context.

Current output:
![bildschirmfoto 2017-02-15 um 16 26 21](https://cloud.githubusercontent.com/assets/1698337/22981065/97fcc254-f39b-11e6-8377-747697267510.png)

Fixed output:

![bildschirmfoto 2017-02-15 um 16 26 32](https://cloud.githubusercontent.com/assets/1698337/22981053/922e8d3a-f39b-11e6-9e85-00377a6a1bc4.png)

#### Example Usage

```twig
{{ dump(path('sulu_search.website_search')) }}
{{ dump(url('sulu_search.website_search')) }}
```

#### BC Breaks/Deprecations

getHost will return host without port.

#### To Do

- [ ] Changelog
- [ ] PR for 1.4 ???
