### PR TITLE
Remove temp position property on contact

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,10 @@ Renamed following Methods:
 
 * Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface::count => Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface::countCollections
 
+### Contact temporarily position removed
+
+The `setCurrentPosition` function was removed from the contact entity as this position was only used temporarily and was not persisted to the database. Use the `setPosition` to set the contact main account position function instead.
+
 ### Dependency updates
 
 Follow upgrade path of following libraries:

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -60,14 +60,6 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
     protected $title;
 
     /**
-     * @Accessor(getter="getPosition")
-     * @Groups({"fullContact"})
-     *
-     * @var string
-     */
-    protected $position;
-
-    /**
      * @var \DateTime
      */
     protected $birthday;
@@ -362,23 +354,15 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
         $mainAccountContact = $this->getMainAccountContact();
         if ($mainAccountContact) {
             $mainAccountContact->setPosition($position);
-            $this->position = $position;
         }
 
         return $this;
     }
 
     /**
-     * Sets position variable.
+     * @VirtualProperty
+     * @Groups({"fullContact"})
      *
-     * @param $position
-     */
-    public function setCurrentPosition($position)
-    {
-        $this->position = $position;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getPosition()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3221 
| License | MIT

#### What's in this PR?

It removes the temporily position property of the contact.

#### Why?

It was shown as null when the contact has a position #3221 as it is also not saved to the database it doesnt make sense here.

#### BC Breaks/Deprecations

Removes the `setCurrentPosition` from contact entity.

