### PR TITLE
Added console terminate to flush-subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3234 [HttpCacheBundle]     Added console terminate to flush-subscriber
     * BUGFIX      #3206 [SnippetBundle]       Corrected translations in copy locale and open ghost overlay
     * ENHANCEMENT #3206 [ContentBundle]       Made translations for copy locale and open ghost overlay changeable
     * BUGFIX      #3228 [ContentBundle]       Added authored translation for smart-content

--- a/src/Sulu/Component/HttpCache/EventSubscriber/FlushSubscriber.php
+++ b/src/Sulu/Component/HttpCache/EventSubscriber/FlushSubscriber.php
@@ -12,8 +12,8 @@
 namespace Sulu\Component\HttpCache\EventSubscriber;
 
 use Sulu\Component\HttpCache\HandlerFlushInterface;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -41,15 +41,14 @@ class FlushSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::TERMINATE => 'onTerminate',
+            ConsoleEvents::TERMINATE => 'onTerminate',
         ];
     }
 
     /**
      * Flush the cache on kernel terminate.
-     *
-     * @param PostResponseEvent $event
      */
-    public function onTerminate(PostResponseEvent $event)
+    public function onTerminate()
     {
         $this->handler->flush();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes cache clear when done in commands (automation).