### PR TITLE
Fixed set default author to creator contact-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * BUGFIX      #3242 [ContentBundle]       Fixed set default author to creator contact-id
+
 * 1.5.0-RC3(2017-02-28)
     * BUGFIX      #3234 [HttpCacheBundle]     Added console terminate to flush-subscriber
     * BUGFIX      #3206 [SnippetBundle]       Corrected translations in copy locale and open ghost overlay

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -36,6 +36,7 @@
         <service id="sulu_document_manager.suscriber.behavior.author"
                  class="Sulu\Component\Content\Document\Subscriber\AuthorSubscriber">
             <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu.repository.user" />
 
             <tag name="sulu_document_manager.event_subscriber" />
         </service>

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/AuthorSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/AuthorSubscriberTest.php
@@ -13,12 +13,15 @@ namespace Sulu\Component\Content\Tests\Unit\Document\Subscriber;
 
 use PHPCR\NodeInterface;
 use Prophecy\Argument;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Content\Document\Behavior\AuthorBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
 use Sulu\Component\Content\Document\Subscriber\AuthorSubscriber;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\Security\Authentication\UserRepositoryInterface;
 
 /**
  * Tests for author-subscriber.
@@ -31,6 +34,11 @@ class AuthorSubscriberTest extends \PHPUnit_Framework_TestCase
     private $propertyEncoder;
 
     /**
+     * @var UserRepositoryInterface
+     */
+    protected $userRepository;
+
+    /**
      * @var AuthorSubscriber
      */
     private $authorSubscriber;
@@ -41,7 +49,11 @@ class AuthorSubscriberTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
-        $this->authorSubscriber = new AuthorSubscriber($this->propertyEncoder->reveal());
+        $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
+        $this->authorSubscriber = new AuthorSubscriber(
+            $this->propertyEncoder->reveal(),
+            $this->userRepository->reveal()
+        );
     }
 
     public function testSetAuthorOnDocument()
@@ -107,10 +119,10 @@ class AuthorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHOR_PROPERTY_NAME, 'de')
             ->willReturn('sulu:author');
 
-        $document->getAuthor()->willReturn([1, 2, 3]);
+        $document->getAuthor()->willReturn(1);
         $document->getAuthored()->willReturn(new \DateTime('2017-01-01'));
 
-        $node->setProperty('sulu:author', [1, 2, 3])->shouldBeCalled();
+        $node->setProperty('sulu:author', 1)->shouldBeCalled();
         $node->setProperty('sulu:authored', new \DateTime('2017-01-01'))->shouldBeCalled();
 
         $this->authorSubscriber->setAuthorOnNode($event->reveal());
@@ -131,10 +143,10 @@ class AuthorSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHOR_PROPERTY_NAME, 'de')
             ->willReturn('i18n:author');
 
-        $document->getAuthor()->willReturn([1, 2, 3]);
+        $document->getAuthor()->willReturn(1);
         $document->getAuthored()->willReturn(new \DateTime('2017-01-01'));
 
-        $node->setProperty('i18n:author', [1, 2, 3])->shouldBeCalled();
+        $node->setProperty('i18n:author', 1)->shouldBeCalled();
         $node->setProperty('i18n:authored', new \DateTime('2017-01-01'))->shouldBeCalled();
 
         $this->authorSubscriber->setAuthorOnNode($event->reveal());
@@ -150,16 +162,22 @@ class AuthorSubscriberTest extends \PHPUnit_Framework_TestCase
         $event->getNode()->willReturn($node->reveal());
         $event->getLocale()->willReturn('de');
 
-        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHORED_PROPERTY_NAME, 'de')->willReturn(
-                'i18n:authored'
-            );
-        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHOR_PROPERTY_NAME, 'de')->willReturn(
-                'i18n:author'
-            );
+        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHORED_PROPERTY_NAME, 'de')
+            ->willReturn('i18n:authored');
+        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHOR_PROPERTY_NAME, 'de')
+            ->willReturn('i18n:author');
 
-        $document->getCreator()->willReturn([1, 2, 3]);
+        $contact = $this->prophesize(Contact::class);
+        $contact->getId()->willReturn(5);
+
+        $user = $this->prophesize(User::class);
+        $user->getContact()->willReturn($contact->reveal());
+
+        $this->userRepository->findUserById(1)->willReturn($user->reveal());
+
+        $document->getCreator()->willReturn(1);
         $document->getAuthor()->willReturn(null);
-        $document->setAuthor([1, 2, 3])->shouldBeCalled()->will(
+        $document->setAuthor(5)->shouldBeCalled()->will(
             function ($arguments) use ($document) {
                 $document->getAuthor()->willReturn($arguments[0]);
             }
@@ -172,7 +190,76 @@ class AuthorSubscriberTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $node->setProperty('i18n:author', [1, 2, 3])->shouldBeCalled();
+        $node->setProperty('i18n:author', 5)->shouldBeCalled();
+        $node->setProperty('i18n:authored', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->authorSubscriber->setAuthorOnNode($event->reveal());
+    }
+
+    public function testSetAuthorOnNodeDefaultValueNoCreator()
+    {
+        $event = $this->prophesize(AbstractMappingEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $document = $this->prophesize(AuthorBehavior::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHORED_PROPERTY_NAME, 'de')
+            ->willReturn('i18n:authored');
+        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHOR_PROPERTY_NAME, 'de')
+            ->willReturn('i18n:author');
+
+        $this->userRepository->findUserById(Argument::any())->shouldNotBeCalled();
+
+        $document->getCreator()->willReturn(null);
+        $document->getAuthor()->willReturn(null);
+        $document->setAuthor(Argument::any())->shouldNotBeCalled();
+
+        $document->getAuthored()->willReturn(null);
+        $document->setAuthored(Argument::type(\DateTime::class))->shouldBeCalled()->will(
+            function ($arguments) use ($document) {
+                $document->getAuthored()->willReturn($arguments[0]);
+            }
+        );
+
+        $node->setProperty('i18n:author', null)->shouldBeCalled();
+        $node->setProperty('i18n:authored', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->authorSubscriber->setAuthorOnNode($event->reveal());
+    }
+
+    public function testSetAuthorOnNodeDefaultValueNoContact()
+    {
+        $event = $this->prophesize(AbstractMappingEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $document = $this->prophesize(AuthorBehavior::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHORED_PROPERTY_NAME, 'de')
+            ->willReturn('i18n:authored');
+        $this->propertyEncoder->encode('system', AuthorSubscriber::AUTHOR_PROPERTY_NAME, 'de')
+            ->willReturn('i18n:author');
+
+        $user = $this->prophesize(User::class);
+        $this->userRepository->findUserById(1)->willReturn($user->reveal());
+
+        $document->getCreator()->willReturn(1);
+        $document->getAuthor()->willReturn(null);
+        $document->setAuthor(Argument::any())->shouldNotBeCalled();
+
+        $document->getAuthored()->willReturn(null);
+        $document->setAuthored(Argument::type(\DateTime::class))->shouldBeCalled()->will(
+            function ($arguments) use ($document) {
+                $document->getAuthored()->willReturn($arguments[0]);
+            }
+        );
+
+        $node->setProperty('i18n:author', null)->shouldBeCalled();
         $node->setProperty('i18n:authored', Argument::type(\DateTime::class))->shouldBeCalled();
 
         $this->authorSubscriber->setAuthorOnNode($event->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the problem that new pages get the creator-id as author. But the author should be the contact id of the author.