### PR TITLE
Fixed internal links selection in snippets

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -297,7 +297,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $language = $this->getLanguage($request);
         $webspace = $this->getWebspace($request, false);
         $excludeGhosts = $this->getBooleanRequestParameter($request, 'exclude-ghosts', false, false);
-        $excludeShadows = $this->getBooleanRequestParameter($request, 'exclude-shadows', false, false);
         $appendWebspaceNode = $this->getBooleanRequestParameter($request, 'webspace-node', false, false);
 
         try {
@@ -307,7 +306,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
                     $webspace,
                     $language,
                     $excludeGhosts,
-                    $excludeShadows,
                     $appendWebspaceNode
                 );
             } elseif ($webspace !== null) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

Fixes the internal link selection in snippets.

#### Why?

The internal link selection inside a snippet can't be changed as the error `Call to a member function getKey() on null` in `sulu/sulu/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php` is thrown.

#### To Do

- [ ] Update `CHANGELOG.md` depending on the branch it will flow into
