### PR TITLE
Fixed detect localization in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
-* dev-develop
+* dev-master
     * ENHANCEMENT #3256 [DocumentManagerBundle] Added VersionNotFoundException to fos_rest configuration
     * HOTFIX      #3261 [Webspace]              Fixed domain match for country specific domains
     * HOTFIX      #3262 [WebsiteBundle]         Fixed seo caninical tag with shadow.
+    * HOTFIX      #3254 [RouteBundle]           Fixed detect localization in admin
 
 * 1.5.0 (2017-03-06)
     * BUGFIX      #3242 [ContentBundle]       Fixed set default author to creator contact-id

--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -110,7 +110,7 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
      * @param PortalInformation $portalInformation
      * @param Request $request
      *
-     * @return RequestAttributes|void
+     * @return array
      */
     private function matchCustomUrl($url, PortalInformation $portalInformation, Request $request)
     {
@@ -142,11 +142,11 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
             return ['customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument];
         }
 
-        $localization = $this->parse($customUrlDocument->getTargetLocale());
+        $localization = Localization::createFromString($customUrlDocument->getTargetLocale());
 
         $portalInformations = $this->webspaceManager->findPortalInformationsByWebspaceKeyAndLocale(
             $portalInformation->getWebspace()->getKey(),
-            $localization->getLocalization(),
+            $localization->getLocale(),
             $this->environment
         );
 
@@ -157,6 +157,7 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
         return [
             'portalInformation' => $portalInformation,
             'localization' => $localization,
+            'locale' => $localization->getLocale(),
             'customUrlRoute' => $routeDocument,
             'customUrl' => $customUrlDocument,
             'urlExpression' => $this->generator->generate(
@@ -164,25 +165,5 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
                 $customUrlDocument->getDomainParts()
             ),
         ];
-    }
-
-    /**
-     * Converts locale string to localization object.
-     *
-     * @param string $locale E.g. de_at or de
-     *
-     * @return Localization
-     */
-    private function parse($locale)
-    {
-        $parts = explode('_', $locale);
-
-        $localization = new Localization();
-        $localization->setLanguage($parts[0]);
-        if (count($parts) > 1) {
-            $localization->setCountry($parts[1]);
-        }
-
-        return $localization;
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -32,6 +32,7 @@ class UpdateRouteCommand extends ContainerAwareCommand
     {
         $this->setName('sulu:route:update')
             ->addArgument('entity', InputArgument::REQUIRED)
+            ->addArgument('locale', InputArgument::REQUIRED)
             ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, '', 1000)
             ->setDescription('Update the routes for all entities.')
             ->setHelp(
@@ -48,6 +49,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->getContainer()->get('translator')->setLocale($input->getArgument('locale'));
+
         $batchSize = $input->getOption('batch-size');
 
         /** @var EntityManagerInterface $entityManager */

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -25,6 +25,32 @@ class Localization implements \JsonSerializable, ArrayableInterface
     const LCID = 'de_AT';
 
     /**
+     * Create an instance of localization for given locale.
+     *
+     * @param string $locale
+     * @param string $format
+     *
+     * @return Localization
+     */
+    public static function createFromString($locale, $format = self::UNDERSCORE)
+    {
+        $delimiter = '-';
+        if (in_array($format, [self::UNDERSCORE, self::LCID])) {
+            $delimiter = '_';
+        }
+
+        $parts = explode($delimiter, $locale);
+
+        $localization = new self();
+        $localization->setLanguage(strtolower($parts[0]));
+        if (count($parts) > 1) {
+            $localization->setCountry(strtolower($parts[1]));
+        }
+
+        return $localization;
+    }
+
+    /**
      * The language of the localization.
      *
      * @var string
@@ -334,7 +360,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     public function __toString()
     {
-        return $this->getLocalization();
+        return $this->getLocale();
     }
 
     /**
@@ -343,8 +369,8 @@ class Localization implements \JsonSerializable, ArrayableInterface
     public function jsonSerialize()
     {
         return [
-            'localization' => $this->getLocalization(),
-            'name' => $this->getLocalization(),
+            'localization' => $this->getLocale(),
+            'name' => $this->getLocale(),
         ];
     }
 

--- a/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
+++ b/src/Sulu/Component/Localization/Tests/Unit/LocalizationTest.php
@@ -49,4 +49,24 @@ class LocalizationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('de-AT', $this->localization->getLocale(Localization::ISO6391));
         $this->assertEquals('de_AT', $this->localization->getLocale(Localization::LCID));
     }
+
+    public function formatProvider()
+    {
+        return [
+            [Localization::UNDERSCORE],
+            [Localization::DASH],
+            [Localization::ISO6391],
+            [Localization::LCID],
+        ];
+    }
+
+    /**
+     * @dataProvider formatProvider
+     */
+    public function testCreateFromString($format)
+    {
+        $localization = Localization::createFromString($format, $format);
+
+        $this->assertEquals('de_at', $localization->getLocale());
+    }
 }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Webspace\Analyzer\Attributes;
 
+use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -43,6 +44,10 @@ class AdminRequestProcessor implements RequestProcessorInterface
         $attributes = [];
         $attributes['webspaceKey'] = $request->get('webspace');
         $attributes['locale'] = $request->get('locale', $request->get('language'));
+
+        if ($attributes['locale']) {
+            $attributes['localization'] = Localization::createFromString($attributes['locale']);
+        }
 
         if (empty($attributes['webspaceKey'])) {
             return new RequestAttributes($attributes);

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -55,8 +55,8 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         }
 
         $attributes['localization'] = $portalInformation->getLocalization();
-        if ($portalInformation->getLocalization()) {
-            $attributes['locale'] = $portalInformation->getLocalization()->getLocale();
+        if ($attributes['localization']) {
+            $attributes['locale'] = $attributes['localization']->getLocale();
         }
 
         $attributes['segment'] = $portalInformation->getSegment();

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -34,7 +34,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         $attributes = ['requestUri' => $request->getUri()];
 
         if (null !== $localization = $portalInformation->getLocalization()) {
-            $request->setLocale($localization->getLocalization());
+            $request->setLocale($localization->getLocale());
         }
 
         $attributes['portalInformation'] = $portalInformation;
@@ -55,6 +55,10 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         }
 
         $attributes['localization'] = $portalInformation->getLocalization();
+        if ($portalInformation->getLocalization()) {
+            $attributes['locale'] = $portalInformation->getLocalization()->getLocale();
+        }
+        
         $attributes['segment'] = $portalInformation->getSegment();
 
         list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -58,7 +58,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         if ($portalInformation->getLocalization()) {
             $attributes['locale'] = $portalInformation->getLocalization()->getLocale();
         }
-        
+
         $attributes['segment'] = $portalInformation->getSegment();
 
         list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
@@ -47,12 +47,13 @@ class AdminRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $request->get('locale', $language)->willReturn($locale ?: $language);
         $request->get('language')->willReturn($language);
 
-        $localization = $this->prophesize(Localization::class);
-
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn($webspaceKey);
+
+        $localization = null;
         if ($locale || $language) {
-            $webspace->getLocalization($locale ?: $language)->willReturn($localization->reveal());
+            $localization = Localization::createFromString($locale ?: $language);
+            $webspace->getLocalization($locale ?: $language)->willReturn($localization);
         }
         $webspaceManager->findWebspaceByKey($webspaceKey)->willReturn($webspaceKey ? $webspace->reveal() : null);
 
@@ -63,10 +64,7 @@ class AdminRequestProcessorTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals($webspaceKey ? $webspace->reveal() : null, $result->getAttribute('webspace'));
-        $this->assertEquals(
-            $webspaceKey && ($locale || $language) ? $localization->reveal() : null,
-            $result->getAttribute('localization')
-        );
+        $this->assertEquals($localization, $result->getAttribute('localization'));
     }
 
     public function testValidate()

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
@@ -50,10 +50,12 @@ class AdminRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn($webspaceKey);
 
+        $expectedLocale = $locale ?: $language;
+
         $localization = null;
-        if ($locale || $language) {
-            $localization = Localization::createFromString($locale ?: $language);
-            $webspace->getLocalization($locale ?: $language)->willReturn($localization);
+        if ($expectedLocale) {
+            $localization = Localization::createFromString($expectedLocale);
+            $webspace->getLocalization($expectedLocale)->willReturn($localization);
         }
         $webspaceManager->findWebspaceByKey($webspaceKey)->willReturn($webspaceKey ? $webspace->reveal() : null);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3250
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the detection of localization in the backend if no webspace is given.

#### Why?

The route-manager uses the `RequestAnalyzerTranslator` to translate the routes. Currently if no webspace is given not locale will be set on the translator.

Additionally the command `sulu:route:update` get a new argument locale - which enables it to generate locale specific routes.

#### TODO

- [x] update route command locale