### PR TITLE
Fixed webspace country specific domain match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.4.10
+    * HOTFIX      #3261 [Webspace]              Fixed domain match for country specific domains
     * HOTFIX      #3262 [WebsiteBundle]         Fixed seo caninical tag with shadow.
 
 * 1.4.9 (2017-03-06)

--- a/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/UrlTest.php
@@ -19,7 +19,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['de', 'at', 'de', 'at', true],
-            ['de', '', 'de', null, true],
+            ['de', '', 'de', '', true],
             ['de', null, 'de', null, true],
             [null, null, 'en', 'gb', true],
             ['en', null, 'de', null, false],

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -190,6 +190,7 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
         $environment = $this->prophesize(Environment::class);
         $url = new Url('sulu.lo', 'prod');
         $url->setLanguage('de');
+        $url->setCountry('');
         $environment->getUrls()->willReturn([$url]);
         $this->portal->getEnvironment('prod')->willReturn($environment->reveal());
         $this->webspace->addPortal($this->portal->reveal());
@@ -212,6 +213,27 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod'));
         $this->assertTrue($this->webspace->hasDomain('sulu.lo', 'prod', 'de_at'));
         $this->assertFalse($this->webspace->hasDomain('sulu.lo', 'prod', 'de'));
+    }
+
+    public function testHasDomainWithLocationAndCountry()
+    {
+        $environment = $this->prophesize(Environment::class);
+        $url = new Url('sulu.de', 'prod');
+        $url->setLanguage('de');
+        $url->setCountry('');
+        $urlAt = new Url('sulu.at', 'prod');
+        $urlAt->setLanguage('de');
+        $urlAt->setCountry('at');
+        $environment->getUrls()->willReturn([$url, $urlAt]);
+        $this->portal->getEnvironment('prod')->willReturn($environment->reveal());
+        $this->webspace->addPortal($this->portal->reveal());
+
+        $this->assertTrue($this->webspace->hasDomain('sulu.de', 'prod'));
+        $this->assertTrue($this->webspace->hasDomain('sulu.at', 'prod'));
+        $this->assertFalse($this->webspace->hasDomain('sulu.at', 'prod', 'de'));
+        $this->assertFalse($this->webspace->hasDomain('sulu.de', 'prod', 'de_at'));
+        $this->assertTrue($this->webspace->hasDomain('sulu.de', 'prod', 'de'));
+        $this->assertTrue($this->webspace->hasDomain('sulu.at', 'prod', 'de_at'));
     }
 
     public function testAddTemplate()

--- a/src/Sulu/Component/Webspace/Url.php
+++ b/src/Sulu/Component/Webspace/Url.php
@@ -245,8 +245,8 @@ class Url implements ArrayableInterface
      */
     public function isValidLocale($language, $country)
     {
-        return (empty($this->getLanguage()) || $this->getLanguage() === $language)
-            && (empty($this->getCountry()) || $this->getCountry() === $country);
+        return ($this->getLanguage() === $language && $this->getCountry() === $country)
+            || (empty($this->getLanguage()) && empty($this->getCountry()));
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -431,7 +431,7 @@ class Webspace implements ArrayableInterface
     {
         $localizationParts = explode('_', $locale);
         $language = $localizationParts[0];
-        $country = isset($localizationParts[1]) ? $localizationParts[1] : null;
+        $country = isset($localizationParts[1]) ? $localizationParts[1] : '';
 
         foreach ($this->getPortals() as $portal) {
             foreach ($portal->getEnvironment($environment)->getUrls() as $url) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

In the following domain configuration:

```xml
<url language="de">sulu.de</url>
<url language="de" country="it">sulu.it</url>
```

The first domain will also match for `de-it` because the country check will be ignored when the url has no country attribute.

#### Why?

The sulu.it will not be used to generate the `sulu_content_path` meta tags like alternate urls.

#### Example Usage

```twig
{{ sulu_content_path('/', null, 'de_it') }}
```

