### PR TITLE
Escape search terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* unreleased
+    * HOTFIX      #3261 [WebsiteBundle]         Escape search terms
+
 * 1.4.10 (2017-03-15)
     * HOTFIX      #3261 [Webspace]              Fixed domain match for country specific domains
     * HOTFIX      #3262 [WebsiteBundle]         Fixed seo caninical tag with shadow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * unreleased
-    * HOTFIX      #3261 [WebsiteBundle]         Escape search terms
+    * HOTFIX      #3263 [WebsiteBundle]         Escape search terms
 
 * 1.4.10 (2017-03-15)
     * HOTFIX      #3261 [Webspace]              Fixed domain match for country specific domains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * unreleased
-    * HOTFIX      #3263 [WebsiteBundle]         Escape search terms
+    * HOTFIX      #3263 [SearchBundle]          Escape search terms
 
 * 1.4.10 (2017-03-15)
     * HOTFIX      #3261 [Webspace]              Fixed domain match for country specific domains

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -86,8 +86,8 @@ class WebsiteSearchController
             foreach ($queryValues as $queryValue) {
                 if (strlen($queryValue) > 2) {
                     $queryString .= '+("' . self::escapeDoubleQuotes($queryValue) . '" OR ' .
-                        preg_replace('/([^\pL\s\d])/u', '?', $queryValue) . '* OR ' .
-                        preg_replace('/([^\pL\s\d])/u', '', $queryValue) . '~) ';
+                        '"' . preg_replace('/([^\pL\s\d])/u', '?', $queryValue) . '*" OR ' .
+                        '"' . preg_replace('/([^\pL\s\d])/u', '', $queryValue) . '~") ';
                 } else {
                     $queryString .= '+("' . self::escapeDoubleQuotes($queryValue) . '") ';
                 }

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -79,7 +79,9 @@ class WebsiteSearchControllerTest extends \PHPUnit_Framework_TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
         $searchQueryBuilder = $this->prophesize(SearchQueryBuilder::class);
-        $this->searchManager->createSearch('+("Test" OR Test* OR Test~) ')->willReturn($searchQueryBuilder->reveal());
+        $this->searchManager->createSearch('+("Test" OR "Test*" OR "Test~") ')->willReturn(
+            $searchQueryBuilder->reveal()
+        );
         $searchQueryBuilder->locale('en')->willReturn($searchQueryBuilder->reveal());
         $searchQueryBuilder->index('page_sulu_published')->willReturn($searchQueryBuilder->reveal());
         $searchQueryBuilder->execute()->willReturn([]);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Search terms are escaped.

#### Why?

Words containing special characters have led to empty search result.

