### PR TITLE
added fake portal for preview when nothing matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-release/1.4
     * HOTFIX      #3279 [CategoryBundle]        Add missing return statement.
+    * HOTFIX      #3277 [PreviewBundle]         Added fake portal for preview when nothing matches
 
 * 1.4.11 (2017-03-22)
     * HOTFIX      #3270 [Webspace]              Removed localization usage check in webspace's xml files

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceLocalizationNotFoundException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceLocalizationNotFoundException.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
+
+/**
+ * This exception will be thrown when the given webspace does not exist.
+ */
+class WebspaceLocalizationNotFoundException extends PreviewRendererException
+{
+    /**
+     * @param object $object
+     * @param int $id
+     * @param string $webspaceKey
+     * @param string $locale
+     */
+    public function __construct($object, $id, $webspaceKey, $locale)
+    {
+        parent::__construct(
+            sprintf('Localization "%s" in webspace "%s" not found', $locale, $webspaceKey),
+            self::BASE_CODE + 7,
+            $object,
+            $id,
+            $webspaceKey,
+            $locale
+        );
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceNotFoundException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/WebspaceNotFoundException.php
@@ -12,15 +12,21 @@
 namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
 
 /**
- * This exception will be thrown when no portal exists for given locale and webspace.
+ * This exception will be thrown when the given webspace does not exist.
  */
-class PortalNotFoundException extends PreviewRendererException
+class WebspaceNotFoundException extends PreviewRendererException
 {
+    /**
+     * @param object $object
+     * @param int $id
+     * @param string $webspaceKey
+     * @param string $locale
+     */
     public function __construct($object, $id, $webspaceKey, $locale)
     {
         parent::__construct(
-            sprintf('Portal for combination of webspace "%s" and locale "%s" not found.', $webspaceKey, $locale),
-            self::BASE_CODE + 1,
+            sprintf('Webspace "%s" not found', $webspaceKey),
+            self::BASE_CODE + 6,
             $object,
             $id,
             $webspaceKey,

--- a/src/Sulu/Bundle/PreviewBundle/Resources/public/js/components/preview/main.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/public/js/components/preview/main.js
@@ -43,8 +43,8 @@ define([
                 error: errorTemplate,
                 defaultError: '<h2><%= message %></h2>',
                 9900: '<h2><%= translations.objectProviderLabel %></h2>',
-                9901: '<h2><%= translations.changeWebspaceLabel %></h2>',
-                9902: '<h2><%= translations.defaultsProviderLabel %></h2>'
+                9902: '<h2><%= translations.defaultsProviderLabel %></h2>',
+                9907: '<h2><%= translations.changeWebspaceLabel %></h2>'
             }
         };
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | #3270 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds a fake portal if no matching portal is found. 

#### Why?

This is necessary because #3270 removed the necessity of having all localization assigned to a portal. Until now there was a "dummy portal" providing the necessary information, and now this is not even necessary anymore.