### PR TITLE
Used composer lock to read sulu version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * ENHANCEMENT #3154 [All]                 Upgrade symfony to ^3.0
     * ENHANCEMENT #3266 [ContentBundle]         Added locale parameter to teaser-selection-list
+    * FEATURE     #3278 [Util]                  Changed way to determine `sulu.version` to composer.lock
+    * FEATURE     #3278 [Util]                  Introduced new parameter `app.version` read from composer.json
+    * ENHANCEMENT #3154 [All]                   Upgrade symfony to ^3.0
 
 * 1.5.2 (2017-03-22)
     * HOTFIX      #3265 [ContentBundle]         Fixed internal-link selection for pages

--- a/src/Sulu/Component/Util/SuluVersionPass.php
+++ b/src/Sulu/Component/Util/SuluVersionPass.php
@@ -15,6 +15,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Finder\SplFileInfo;
 
+/**
+ * Read versions from composer.lock and composer.json.
+ */
 class SuluVersionPass implements CompilerPassInterface
 {
     /**
@@ -22,24 +25,61 @@ class SuluVersionPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $container->setParameter(
-            'sulu.version',
-            $this->getVersionFromComposerJson(realpath($container->getParameter('kernel.root_dir') . '/..'))
-        );
+        $dir = dirname(realpath($container->getParameter('kernel.root_dir')));
+
+        $container->setParameter('sulu.version', $this->getSuluVersion($dir));
+        $container->setParameter('app.version', $this->getAppVersion($dir));
     }
 
-    private function getVersionFromComposerJson($dir)
+    /**
+     * Read composer.lock file and return version of sulu.
+     *
+     * @param string $dir
+     *
+     * @return string
+     */
+    private function getSuluVersion($dir)
+    {
+        $version = '_._._';
+
+        /** @var SplFileInfo $composerFile */
+        $composerFile = new SplFileInfo($dir . '/composer.lock', '', '');
+        if (!$composerFile->isFile()) {
+            return $version;
+        }
+
+        $composer = json_decode($composerFile->getContents(), true);
+        foreach ($composer['packages'] as $package) {
+            if ($package['name'] === 'sulu/sulu') {
+                return $package['version'];
+            }
+        }
+
+        return $version;
+    }
+
+    /**
+     * Read composer.json file and return version of app.
+     *
+     * @param string $dir
+     *
+     * @return string
+     */
+    private function getAppVersion($dir)
     {
         $version = '_._._';
 
         /** @var SplFileInfo $composerFile */
         $composerFile = new SplFileInfo($dir . '/composer.json', '', '');
-        if ($composerFile->isFile()) {
-            $composerJson = json_decode($composerFile->getContents());
-
-            return $composerJson->version;
+        if (!$composerFile->isFile()) {
+            return $version;
         }
 
-        return $version;
+        $composerJson = json_decode($composerFile->getContents(), true);
+        if (!array_key_exists('version', $composerJson)) {
+            return;
+        }
+
+        return $composerJson['version'];
     }
 }

--- a/src/Sulu/Component/Util/Tests/Resources/VersionPass/composer.json
+++ b/src/Sulu/Component/Util/Tests/Resources/VersionPass/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "sulu/sulu-minimal",
+    "license": "MIT",
+    "type": "project",
+    "description": "The sulu content management framework",
+    "version": "1.2.3",
+    "autoload": {
+    },
+    "require": {
+    },
+    "require-dev": {
+    }
+}

--- a/src/Sulu/Component/Util/Tests/Resources/VersionPass/composer.lock
+++ b/src/Sulu/Component/Util/Tests/Resources/VersionPass/composer.lock
@@ -1,0 +1,124 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5cf1d56888f674c15bc54bdbcc421e3a",
+    "packages": [
+        {
+            "name": "sulu/sulu",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sulu/sulu.git",
+                "reference": "82a7a2de143329d227e5e09ed4cc5250b1617dab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sulu/sulu/zipball/82a7a2de143329d227e5e09ed4cc5250b1617dab",
+                "reference": "82a7a2de143329d227e5e09ed4cc5250b1617dab",
+                "shasum": ""
+            },
+            "require": {
+                "cboden/ratchet": "0.3.*",
+                "doctrine/annotations": "^1.2",
+                "doctrine/data-fixtures": "1.1.*",
+                "doctrine/doctrine-bundle": "~1.0",
+                "doctrine/doctrine-cache-bundle": "~1.1",
+                "doctrine/orm": "^2.5.3",
+                "doctrine/phpcr-bundle": "^1.3.5",
+                "friendsofsymfony/http-cache": "~1.4",
+                "friendsofsymfony/rest-bundle": "^1.6",
+                "gedmo/doctrine-extensions": "~2.4",
+                "goodby/csv": "^1.3",
+                "guzzlehttp/guzzle": "^6.2",
+                "imagine/imagine": "~0.6.1",
+                "jms/serializer-bundle": "^1.1",
+                "layershifter/tld-extract": "^1.1",
+                "massive/search-bundle": "0.16.*",
+                "mtdowling/cron-expression": "^1.1",
+                "oro/doctrine-extensions": "^1.0",
+                "pagerfanta/pagerfanta": "^1.0.4",
+                "php": "^5.5 || ^7.0",
+                "pulse00/ffmpeg-bundle": "^0.6",
+                "ramsey/uuid": "^3.1",
+                "sensio/framework-extra-bundle": "^3.0",
+                "stof/doctrine-extensions-bundle": "^1.2.2",
+                "sulu/document-manager": "~0.9.1",
+                "symfony-cmf/routing-bundle": "^1.2 || ^2.0",
+                "symfony/swiftmailer-bundle": "~2.3",
+                "symfony/symfony": "^2.8.7 || ^3.0",
+                "twig/twig": "^1.11 || ^2.0",
+                "willdurand/hateoas-bundle": "^1.1"
+            },
+            "replace": {
+                "sulu/admin-bundle": "self.version",
+                "sulu/category-bundle": "self.version",
+                "sulu/contact-bundle": "self.version",
+                "sulu/content-bundle": "self.version",
+                "sulu/generator-bundle": "self.version",
+                "sulu/location-bundle": "self.version",
+                "sulu/media-bundle": "self.version",
+                "sulu/search-bundle": "self.version",
+                "sulu/security-bundle": "self.version",
+                "sulu/snippet-bundle": "self.version",
+                "sulu/tag-bundle": "self.version",
+                "sulu/test-bundle": "self.version",
+                "sulu/translate-bundle": "self.version",
+                "sulu/website-bundle": "self.version"
+            },
+            "require-dev": {
+                "doctrine/doctrine-fixtures-bundle": "~2.3",
+                "jackalope/jackalope-doctrine-dbal": "^1.2.5",
+                "massive/build-bundle": "~0.3.0",
+                "matthiasnoback/symfony-config-test": "^1.1",
+                "matthiasnoback/symfony-dependency-injection-test": "^0.7.3",
+                "phpcr/phpcr-shell": "~1.0",
+                "phpdocumentor/reflection-docblock": "~3.1",
+                "phpspec/prophecy": "^1.4",
+                "phpunit/phpunit": "^4.8.31",
+                "sensio/framework-extra-bundle": "~3.0",
+                "symfony/monolog-bundle": "^2.8.7 || ^3.0",
+                "symfony/phpunit-bridge": "^2.8.7 || ^3.0",
+                "twig/twig": "~1.11",
+                "zendframework/zend-stdlib": "~2.3",
+                "zendframework/zendsearch": "@dev"
+            },
+            "suggest": {
+                "doctrine/doctrine-bundle": "~1.6",
+                "massive/build-bundle": "^0.3",
+                "sensio/framework-extra-bundle": "~3.0",
+                "symfony/monolog-bundle": "~2.8 || ~3.0",
+                "zendframework/zend-stdlib": "Needed (as in require dev) in addition to zendsearch",
+                "zendframework/zendsearch": "To use the PHP based Zend Search library (based on Lucene)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sulu\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Sulu/Component/*/Tests/",
+                    "src/Sulu/Bundle/*/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sulu Community",
+                    "homepage": "https://github.com/sulu-io/sulu/contributors"
+                }
+            ],
+            "description": "Sulu core distribution",
+            "keywords": [
+                "core",
+                "sulu"
+            ],
+            "time": "2017-03-16 10:06:54"
+        }
+    ]
+}

--- a/src/Sulu/Component/Util/Tests/Unit/SuluVersionPassTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluVersionPassTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Util\Tests\Unit;
+
+use Sulu\Component\Util\SuluVersionPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SuluVersionPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $versionPass = new SuluVersionPass();
+        $container = $this->prophesize(ContainerBuilder::class);
+        $container->getParameter('kernel.root_dir')->willReturn(dirname(__DIR__) . '/Resources/VersionPass/app');
+
+        $container->setParameter('sulu.version', '1.5.2')->shouldBeCalled();
+        $container->setParameter('app.version', '1.2.3')->shouldBeCalled();
+
+        $versionPass->process($container->reveal());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3064 
| Related issues/PRs | https://github.com/sulu/sulu-minimal/pull/41 https://github.com/sulu/sulu-standard/pull/808
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the way to determine sulu version and use composer.lock instead of json.