### PR TITLE
Add missing return statement in CategoryRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.4
+    * HOTFIX      #3279 [CategoryBundle]        Add missing return statement.
+
 * 1.4.11 (2017-03-22)
     * HOTFIX      #3270 [Webspace]              Removed localization usage check in webspace's xml files
     * HOTFIX      #3263 [SearchBundle]          Escape search terms

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
@@ -207,7 +207,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
     {
         @trigger_error(__method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findCategoriesByIds() instead.', E_USER_DEPRECATED);
 
-        $this->findCategoriesByIds($ids);
+        return $this->findCategoriesByIds($ids);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| BC breaks? | no
| License | MIT

#### What's in this PR?

Currently the deprecated 'findCategoryByIds' function is missing
a return statement and is not usable.
This commit adds the missing statement.
