### PR TITLE
added rule evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * ENHANCEMENT #3154 [All]                 Upgrade symfony to ^3.0
+    * ENHANCEMENT #3280 [AudienceTargetBundle]  Added rule evaluation
+    * ENHANCEMENT #3154 [All]                   Upgrade symfony to ^3.0
     * ENHANCEMENT #3266 [ContentBundle]         Added locale parameter to teaser-selection-list
 
 * 1.5.2 (2017-03-22)

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/AddRulesPass.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/AddRulesPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddRulesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $ruleCollection = $container->getDefinition('sulu_audience_targeting.rules_collection');
+        $taggedServices = $container->findTaggedServiceIds('sulu.audience_target_rule');
+
+        $ruleReferences = [];
+        foreach ($taggedServices as $id => $attributes) {
+            if (!isset($attributes[0]['alias'])) {
+                throw new \InvalidArgumentException(
+                    sprintf('No "alias" specified for audience targeting rule with service ID: "%s"', $id)
+                );
+            }
+
+            $ruleReferences[$attributes[0]['alias']] = new Reference($id);
+        }
+
+        $ruleCollection->replaceArgument(0, $ruleReferences);
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupConditionInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupConditionInterface.php
@@ -34,7 +34,7 @@ interface TargetGroupConditionInterface
     public function setType($type);
 
     /**
-     * @return string
+     * @return array
      */
     public function getCondition();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupInterface.php
@@ -103,7 +103,7 @@ interface TargetGroupInterface
     public function removeWebspace(TargetGroupWebspaceInterface $webspace);
 
     /**
-     * @return Collection
+     * @return TargetGroupRuleInterface[]
      */
     public function getRules();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRepository.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRepository.php
@@ -30,7 +30,7 @@ class TargetGroupRepository extends EntityRepository implements TargetGroupRepos
             ->join('targetGroupRules.conditions', 'targetGroupConditions')
             ->leftJoin('targetGroup.webspaces', 'targetGroupWebspaces')
             ->where('targetGroup.active = true')
-            ->andWhere('(targetGroupWebspaces.webspaceKey = :webspace OR targetGroup.allWebspaces = true)')
+            ->andWhere('(targetGroup.allWebspaces = true OR targetGroupWebspaces.webspaceKey = :webspace)')
             ->orderBy('targetGroup.priority', 'desc')
             ->getQuery();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRepository.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRepository.php
@@ -18,4 +18,22 @@ use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
  */
 class TargetGroupRepository extends EntityRepository implements TargetGroupRepositoryInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function findAllActiveForWebspaceOrderedByPriority($webspace)
+    {
+        $query = $this->createQueryBuilder('targetGroup')
+            ->addSelect('targetGroupRules')
+            ->addSelect('targetGroupConditions')
+            ->join('targetGroup.rules', 'targetGroupRules')
+            ->join('targetGroupRules.conditions', 'targetGroupConditions')
+            ->leftJoin('targetGroup.webspaces', 'targetGroupWebspaces')
+            ->where('targetGroup.active = true')
+            ->andWhere('(targetGroupWebspaces.webspaceKey = :webspace OR targetGroup.allWebspaces = true)')
+            ->orderBy('targetGroup.priority', 'desc')
+            ->getQuery();
+
+        return $query->setParameter('webspace', $webspace)->getResult();
+    }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRepositoryInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRepositoryInterface.php
@@ -18,4 +18,12 @@ use Sulu\Component\Persistence\Repository\RepositoryInterface;
  */
 interface TargetGroupRepositoryInterface extends RepositoryInterface
 {
+    /**
+     * Returns all active TargetGroups from the given webspace ordered by their priority.
+     *
+     * @param string $webspace
+     *
+     * @return TargetGroupInterface[]
+     */
+    public function findAllActiveForWebspaceOrderedByPriority($webspace);
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRuleInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRuleInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\AudienceTargetingBundle\Entity;
 
-use Doctrine\Common\Collections\Collection;
-
 /**
  * Interface for target group rule entity.
  */
@@ -60,7 +58,7 @@ interface TargetGroupRuleInterface
     public function setTargetGroup(TargetGroupInterface $targetGroup);
 
     /**
-     * @return Collection
+     * @return TargetGroupConditionInterface[]
      */
     public function getConditions();
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/doctrine/TargetGroupCondition.orm.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/doctrine/TargetGroupCondition.orm.xml
@@ -10,8 +10,8 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="type" column="type" type="string" length="255" nullable="false"/>
-        <field name="condition" column="condition" type="text" nullable="false"/>
+        <field name="type" column="`type`" type="string" length="255" nullable="false"/>
+        <field name="condition" column="`condition`" type="json_array" nullable="false"/>
 
         <many-to-one field="rule"
                      inversed-by="conditions"

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -24,5 +24,21 @@
             <tag name="jms_serializer.event_subscriber" />
             <tag name="sulu.context" context="admin"/>
         </service>
+        <!--RULES-->
+        <service id="sulu_audience_targeting.target_group_evaluator"
+                 class="Sulu\Bundle\AudienceTargetingBundle\Rule\TargetGroupEvaluator">
+            <argument type="service" id="sulu_audience_targeting.rules_collection"/>
+            <argument type="service" id="sulu.repository.target_group"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+        </service>
+        <service id="sulu_audience_targeting.rules_collection"
+                 class="Sulu\Bundle\AudienceTargetingBundle\Rule\RuleCollection">
+            <argument type="collection"></argument>
+        </service>
+        <service id="sulu_audience_targeting.rules.locale"
+                 class="Sulu\Bundle\AudienceTargetingBundle\Rule\LocaleRule">
+            <argument type="service" id="request_stack"/>
+            <tag name="sulu.audience_target_rule" alias="locale"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/LocaleRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/LocaleRule.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * This rule determines if the request has been sent in the desired language.
+ */
+class LocaleRule implements RuleInterface
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evaluate(array $options)
+    {
+        if (!isset($options['locale'])) {
+            return false;
+        }
+
+        $languages = $this->requestStack->getCurrentRequest()->getLanguages();
+        if (!$languages) {
+            return false;
+        }
+
+        return substr($languages[0], 0, 2) === $options['locale'];
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollection.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollection.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+class RuleCollection implements RuleCollectionInterface
+{
+    /**
+     * @var RuleInterface[]
+     */
+    private $rules;
+
+    /**
+     * @param array $rules
+     */
+    public function __construct(array $rules)
+    {
+        $this->rules = $rules;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRule($name)
+    {
+        if (!isset($this->rules[$name])) {
+            throw new RuleNotFoundException($name);
+        }
+
+        return $this->rules[$name];
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollectionInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleCollectionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+interface RuleCollectionInterface
+{
+    /**
+     * Returns the rule with the given name.
+     *
+     * @param string $name
+     *
+     * @return RuleInterface
+     *
+     * @throws RuleNotFoundException
+     */
+    public function getRule($name);
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+/**
+ * Interface for rules, which should help to find a matching target group.
+ */
+interface RuleInterface
+{
+    /**
+     * Returns a string representation of the evaluation of the rule for the current context.
+     *
+     * @param array $options The options to evaluate against
+     *
+     * @return bool
+     */
+    public function evaluate(array $options);
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleNotFoundException.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/RuleNotFoundException.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+/**
+ * This exception is thrown when a rule is tried to access, which does not exist.
+ */
+class RuleNotFoundException extends \RuntimeException
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+
+        parent::__construct(sprintf('The rule with the name "%s" could not be found.', $this->name));
+    }
+
+    /**
+     * Returns the name of the rule, which cannot be found.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/TargetGroupEvaluator.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/TargetGroupEvaluator.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRepositoryInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+/**
+ * This class finds the correct target group (which are defined in the database) for the given circumstances. It
+ * therefore uses a set of implemented rules, which also take data from the database.
+ */
+class TargetGroupEvaluator implements TargetGroupEvaluatorInterface
+{
+    /**
+     * @var TargetGroupRepositoryInterface
+     */
+    private $targetGroupRepository;
+
+    /**
+     * @var RuleCollectionInterface
+     */
+    private $ruleCollection;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function __construct(
+        RuleCollectionInterface $ruleCollection,
+        TargetGroupRepositoryInterface $targetGroupRepository,
+        RequestAnalyzerInterface $requestAnalyzer
+    ) {
+        $this->ruleCollection = $ruleCollection;
+        $this->targetGroupRepository = $targetGroupRepository;
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evaluate()
+    {
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
+        foreach ($this->targetGroupRepository->findAllActiveForWebspaceOrderedByPriority($webspaceKey) as $targetGroup) {
+            if ($this->evaluateTargetGroup($targetGroup)) {
+                return $targetGroup;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Evaluates if one of the rules of the given TargetGroup match. If one of these rules are matching the entire
+     * target group is matching.
+     *
+     * @param TargetGroupInterface $targetGroup
+     *
+     * @return bool
+     */
+    private function evaluateTargetGroup(TargetGroupInterface $targetGroup)
+    {
+        foreach ($targetGroup->getRules() as $targetGroupRule) {
+            if ($this->evaluateTargetGroupRule($targetGroupRule)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Evaluates if the given rule is matching. Only returns true if all of the conditions are matching.
+     *
+     * @param TargetGroupRuleInterface $targetGroupRule
+     *
+     * @return bool
+     */
+    private function evaluateTargetGroupRule(TargetGroupRuleInterface $targetGroupRule)
+    {
+        foreach ($targetGroupRule->getConditions() as $targetGroupCondition) {
+            $rule = $this->ruleCollection->getRule($targetGroupCondition->getType());
+
+            if (!$rule->evaluate($targetGroupCondition->getCondition())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/TargetGroupEvaluatorInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/TargetGroupEvaluatorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
+
+/**
+ * Finds the correct target group based on the given rules.
+ */
+interface TargetGroupEvaluatorInterface
+{
+    /**
+     * Returns the target group which matches the current circumstances.
+     *
+     * @return TargetGroupInterface
+     */
+    public function evaluate();
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AudienceTargetingBundle;
 
+use Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupConditionInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleInterface;
@@ -38,5 +39,7 @@ class SuluAudienceTargetingBundle extends Bundle
             ],
             $container
         );
+
+        $container->addCompilerPass(new AddRulesPass());
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Entity/TargetGroupRepositoryTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Entity/TargetGroupRepositoryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Functional\Entity;
+
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroup;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupCondition;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRepository;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRule;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupWebspace;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class TargetGroupRepositoryTest extends SuluTestCase
+{
+    /**
+     * @var TargetGroupRepository
+     */
+    private $targetGroupRepository;
+
+    public function setUp()
+    {
+        $this->targetGroupRepository = $this->getEntityManager()->getRepository(TargetGroup::class);
+        $this->purgeDatabase();
+    }
+
+    public function testFindAllActiveForWebspaceOrderedByPriority()
+    {
+        $targetGroup1 = $this->createTargetGroup('Target Group 1', false, true, 5);
+        $targetGroupRule1 = $this->createTargetGroupRule('Target Group Rule 1', $targetGroup1);
+        $targetGroupCondition1 = $this->createTargetGroupCondition($targetGroupRule1);
+
+        $targetGroup2 = $this->createTargetGroup('Target Group 2', true, true, 3);
+        $targetGroupRule2 = $this->createTargetGroupRule('Target Group Rule 2', $targetGroup2);
+        $targetGroupCondition2 = $this->createTargetGroupCondition($targetGroupRule2);
+
+        $targetGroup3 = $this->createTargetGroup('Target Group 3', true, false, 5);
+        $targetGroupRule3 = $this->createTargetGroupRule('Target Group Rule 3', $targetGroup3);
+        $targetGroupCondition3 = $this->createTargetGroupCondition($targetGroupRule3);
+        $targetGroupWebspace3 = $this->createTargetgroupWebspace('sulu_io', $targetGroup3);
+
+        $targetGroup4 = $this->createTargetGroup('Target Group 4', true, false, 4);
+        $targetGroupRule4 = $this->createTargetGroupRule('Target Group Rule 4', $targetGroup4);
+        $targetGroupCondition4 = $this->createTargetGroupCondition($targetGroupRule4);
+        $targetGroupWebspace4 = $this->createTargetgroupWebspace('test', $targetGroup4);
+
+        $this->getEntityManager()->flush();
+
+        $targetGroups = $this->targetGroupRepository->findAllActiveForWebspaceOrderedByPriority('sulu_io');
+
+        $this->assertCount(2, $targetGroups);
+        $this->assertEquals('Target Group 3', $targetGroups[0]->getTitle());
+        $this->assertEquals('Target Group 2', $targetGroups[1]->getTitle());
+    }
+
+    /**
+     * @return TargetGroup
+     */
+    private function createTargetGroup($name, $active, $allWebspaces, $priority)
+    {
+        $targetGroup = new TargetGroup();
+        $targetGroup->setActive($active);
+        $targetGroup->setAllWebspaces($allWebspaces);
+        $targetGroup->setPriority($priority);
+        $targetGroup->setTitle($name);
+
+        $this->getEntityManager()->persist($targetGroup);
+
+        return $targetGroup;
+    }
+
+    /**
+     * @param $targetGroup
+     *
+     * @return TargetGroupRule
+     */
+    private function createTargetGroupRule($name, TargetGroup $targetGroup)
+    {
+        $targetGroupRule = new TargetGroupRule();
+        $targetGroupRule->setTargetGroup($targetGroup);
+        $targetGroupRule->setTitle($name);
+        $targetGroupRule->setFrequency(1);
+
+        $this->getEntityManager()->persist($targetGroupRule);
+
+        return $targetGroupRule;
+    }
+
+    private function createTargetGroupCondition(TargetGroupRule $targetGroupRule)
+    {
+        $targetGroupCondition = new TargetGroupCondition();
+        $targetGroupCondition->setRule($targetGroupRule);
+        $targetGroupCondition->setType('test');
+        $targetGroupCondition->setCondition([]);
+
+        $this->getEntityManager()->persist($targetGroupCondition);
+
+        return $targetGroupCondition;
+    }
+
+    private function createTargetgroupWebspace($webspaceKey, $targetGroup3)
+    {
+        $targetGroupWebspace = new TargetGroupWebspace();
+        $targetGroupWebspace->setTargetGroup($targetGroup3);
+        $targetGroupWebspace->setWebspaceKey($webspaceKey);
+
+        $this->getEntityManager()->persist($targetGroupWebspace);
+
+        return $targetGroupWebspace;
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/LocaleRuleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
+
+use Sulu\Bundle\AudienceTargetingBundle\Rule\LocaleRule;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class LocaleRuleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var LocaleRule
+     */
+    private $localeRule;
+
+    public function setUp()
+    {
+        $this->request = $this->prophesize(Request::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
+
+        $this->localeRule = new LocaleRule($this->requestStack->reveal());
+    }
+
+    /**
+     * @dataProvider provideEvaluationData
+     */
+    public function testEvaluate($languages, $options, $result)
+    {
+        $this->request->getLanguages()->willReturn($languages);
+        $this->assertEquals($result, $this->localeRule->evaluate($options));
+    }
+
+    public function provideEvaluationData()
+    {
+        return [
+            [['de'], ['locale' => 'de'], true],
+            [['de'], ['locale' => 'en'], false],
+            [['de', 'en'], ['locale' => 'de'], true],
+            [['de_DE', 'en'], ['locale' => 'de'], true],
+            [['en_US', 'en'], ['locale' => 'de'], false],
+            [[], ['locale' => 'de'], false],
+            [['en_US', 'en'], [], false],
+            [[], [], false],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/RuleCollectionTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/RuleCollectionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
+
+use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleCollection;
+use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleNotFoundException;
+
+class RuleCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetName()
+    {
+        $rule1 = $this->prophesize(RuleInterface::class);
+        $rule2 = $this->prophesize(RuleInterface::class);
+
+        $ruleCollection = new RuleCollection(['rule1' => $rule1->reveal(), 'rule2' => $rule2->reveal()]);
+
+        $this->assertSame($rule1->reveal(), $ruleCollection->getRule('rule1'));
+        $this->assertSame($rule2->reveal(), $ruleCollection->getRule('rule2'));
+    }
+
+    public function testGetNotExistingName()
+    {
+        $this->setExpectedException(RuleNotFoundException::class, 'The rule with the name "rule" could not be found.');
+        $ruleCollection = new RuleCollection([]);
+
+        $ruleCollection->getRule('rule');
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
+
+use Prophecy\Argument;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroup;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupCondition;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRepositoryInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRule;
+use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleCollectionInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleInterface;
+use Sulu\Bundle\AudienceTargetingBundle\Rule\TargetGroupEvaluator;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class TargetGroupEvaluatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RuleCollectionInterface
+     */
+    private $ruleCollection;
+
+    /**
+     * @var TargetGroupRepositoryInterface
+     */
+    private $targetGroupRepository;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var TargetGroupEvaluator
+     */
+    private $targetGroupEvaluator;
+
+    public function setUp()
+    {
+        $this->ruleCollection = $this->prophesize(RuleCollectionInterface::class);
+        $this->targetGroupRepository = $this->prophesize(TargetGroupRepositoryInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->targetGroupEvaluator = new TargetGroupEvaluator(
+            $this->ruleCollection->reveal(),
+            $this->targetGroupRepository->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    /**
+     * @dataProvider provideEvaluationData
+     */
+    public function testEvaluate($targetGroups, $ruleWhitelists, $webspaceKey, $evaluatedTargetGroup)
+    {
+        $webspace = new Webspace();
+        $webspace->setKey($webspaceKey);
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $rules = [];
+        foreach ($ruleWhitelists as $ruleName => $ruleWhitelist) {
+            $rules[$ruleName] = $this->prophesize(RuleInterface::class);
+            $rules[$ruleName]->evaluate(Argument::any())->will(function($arguments) use ($ruleWhitelist) {
+                return in_array($arguments[0], $ruleWhitelist);
+            });
+        }
+        $this->ruleCollection->getRule(Argument::any())->will(function($arguments) use ($rules) {
+            return $rules[$arguments[0]];
+        });
+
+        $this->targetGroupRepository->findAllActiveForWebspaceOrderedByPriority($webspaceKey)->willReturn($targetGroups);
+
+        $this->assertEquals($evaluatedTargetGroup, $this->targetGroupEvaluator->evaluate());
+    }
+
+    public function provideEvaluationData()
+    {
+        $targetGroup1 = new TargetGroup();
+
+        $targetGroup2 = new TargetGroup();
+        $targetGroupRule2 = new TargetGroupRule();
+        $targetGroupCondition2 = new TargetGroupCondition();
+        $targetGroupCondition2->setType('rule1');
+        $targetGroupCondition2->setCondition(['targetGroup2']);
+        $targetGroupRule2->addCondition($targetGroupCondition2);
+        $targetGroup2->addRule($targetGroupRule2);
+
+        $targetGroup3 = new TargetGroup();
+        $targetGroupRule3 = new TargetGroupRule();
+        $targetGroupCondition3 = new TargetGroupCondition();
+        $targetGroupCondition3->setType('rule1');
+        $targetGroupCondition3->setCondition(['targetGroup3']);
+        $targetGroupRule3->addCondition($targetGroupCondition3);
+        $targetGroup3->addRule($targetGroupRule3);
+
+        $targetGroup4 = new TargetGroup();
+        $targetGroupRule4 = new TargetGroupRule();
+        $targetGroupCondition4_1 = new TargetGroupCondition();
+        $targetGroupCondition4_1->setType('rule1');
+        $targetGroupCondition4_1->setCondition(['targetGroup4']);
+        $targetGroupRule4->addCondition($targetGroupCondition4_1);
+        $targetGroupCondition4_2 = new TargetGroupCondition();
+        $targetGroupCondition4_2->setType('rule2');
+        $targetGroupCondition4_2->setCondition(['targetGroup4']);
+        $targetGroupRule4->addCondition($targetGroupCondition4_2);
+        $targetGroup4->addRule($targetGroupRule4);
+
+        $targetGroup5 = new TargetGroup();
+        $targetGroupRule5_1 = new TargetGroupRule();
+        $targetGroupCondition5_1 = new TargetGroupCondition();
+        $targetGroupCondition5_1->setType('rule1');
+        $targetGroupCondition5_1->setCondition(['targetGroup5']);
+        $targetGroupRule5_1->addCondition($targetGroupCondition5_1);
+        $targetGroup5->addRule($targetGroupRule5_1);
+        $targetGroupRule5_2 = new TargetGroupRule();
+        $targetGroupCondition5_2 = new TargetGroupCondition();
+        $targetGroupCondition5_2->setType('rule2');
+        $targetGroupCondition5_2->setCondition(['targetGroup5']);
+        $targetGroupRule5_2->addCondition($targetGroupCondition5_2);
+        $targetGroup5->addRule($targetGroupRule5_2);
+
+        return [
+            [[], [], 'sulu_io', null],
+            [[$targetGroup1], [], 'sulu_io', null],
+            [[$targetGroup2], ['rule1' => [['targetGroup2']]], 'sulu_io', $targetGroup2],
+            [[$targetGroup2], ['rule1' => [['targetGroup2']]], 'test', $targetGroup2],
+            [[$targetGroup2], ['rule1' => []], 'sulu_io', null],
+            [[$targetGroup2, $targetGroup3], ['rule1' => [['targetGroup2'], ['targetGroup3']]], 'sulu_io', $targetGroup2],
+            [[$targetGroup3, $targetGroup2], ['rule1' => [['targetGroup2'], ['targetGroup3']]], 'sulu_io', $targetGroup3],
+            [[$targetGroup2, $targetGroup3], ['rule1' => [['targetGroup3']]], 'sulu_io', $targetGroup3],
+            [[$targetGroup2, $targetGroup3], ['rule1' => []], 'sulu_io', null],
+            [[$targetGroup4], ['rule1' => [[]], 'rule2' => [['targetGroup4']]], 'sulu_io', null],
+            [[$targetGroup4], ['rule1' => [['targetGroup4']], 'rule2' => [['targetGroup4']]], 'sulu_io', $targetGroup4],
+            [[$targetGroup5], ['rule1' => [['targetGroup5']], 'rule2' => [['targetGroup5']]], 'sulu_io', $targetGroup5],
+            [[$targetGroup5], ['rule1' => [], 'rule2' => [['targetGroup5']]], 'sulu_io', $targetGroup5],
+            [[$targetGroup5], ['rule1' => [], 'rule2' => []], 'sulu_io', null],
+        ];
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes parts of #3203
| Related issues/PRs | none
| License | MIT
| Documentation PR | TODO

#### What's in this PR?

This PR adds the recognizing of the target group for the current request. This is done by implementing different `RuleInterface`s, which evaluate the given circumstances against options which are passed to the method.

The `TargetGroupEvaluator` iterates over all `TargetGroup`s and evaluates all required implementations of the `RuleInterface` with the data provided by the `TargetGroup`.