### PR TITLE
Fixed index pages with redirect-behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #3282 [ContentBundle]         Fixed teaser-selection locale
+    * HOTFIX      #3281 [ContentBundle]         Fixed index pages with redirect-behavior
 
 * 1.5.2 (2017-03-22)
     * HOTFIX      #3265 [ContentBundle]         Fixed internal-link selection for pages

--- a/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\ContentBundle\Search\EventListener;
 
 use Massive\Bundle\SearchBundle\Search\Event\HitEvent;
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
 /**
@@ -37,11 +38,17 @@ class HitListener
      */
     public function onHit(HitEvent $event)
     {
-        if (false === $event->getMetadata()->reflection->isSubclassOf('Sulu\Bundle\ContentBundle\Document\BasePageDocument')) {
+        if (false === $event->getMetadata()->reflection->isSubclassOf(BasePageDocument::class)) {
             return;
         }
 
         $document = $event->getHit()->getDocument();
+        if ($document->getUrl()[0] !== '/') {
+            // is absolute URL
+
+            return;
+        }
+
         $url = sprintf(
             '%s/%s',
             rtrim($this->requestAnalyzer->getResourceLocatorPrefix(), '/'),

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventListener/HitListenerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Search/EventListener/HitListenerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Search\EventListener;
+
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Event\HitEvent;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\QueryHit;
+use Prophecy\Argument;
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
+use Sulu\Bundle\ContentBundle\Search\EventListener\HitListener;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+class HitListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var HitListener
+     */
+    private $listener;
+
+    /**
+     * @var Document
+     */
+    private $document;
+
+    /**
+     * @var HitEvent
+     */
+    private $event;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $reflection = $this->prophesize(\ReflectionClass::class);
+        $reflection->isSubclassOf(BasePageDocument::class)->willReturn(true);
+
+        $metadata = $this->prophesize(ClassMetadata::class);
+        $metadata->reveal()->reflection = $reflection->reveal();
+
+        $this->document = $this->prophesize(Document::class);
+
+        $hit = $this->prophesize(QueryHit::class);
+        $hit->getDocument()->willReturn($this->document->reveal());
+
+        $this->event = $this->prophesize(HitEvent::class);
+        $this->event->getMetadata()->willReturn($metadata->reveal());
+        $this->event->getHit()->willReturn($hit->reveal());
+
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->listener = new HitListener($this->requestAnalyzer->reveal());
+    }
+
+    public function testOnHit()
+    {
+        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/en');
+
+        $this->document->getUrl()->willReturn('/test');
+        $this->document->setUrl('/en/test')->shouldBeCalled();
+
+        $this->listener->onHit($this->event->reveal());
+    }
+
+    public function testOnHitAbsolute()
+    {
+        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/en');
+
+        $this->document->getUrl()->willReturn('http://www.google.at');
+        $this->document->setUrl(Argument::any())->shouldNotBeCalled();
+
+        $this->listener->onHit($this->event->reveal());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/SuluArticleBundle/issues/113
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Pages with internal or external link type indexes their "not existing" resource-segment as url.
This PR add an expression to determine correct URL:
* internal: resource-segment of target
* external: external URL

#### Why?

The teaser-provider uses this field to extract URL from lucene document.

#### To Do

- [x] Code format
