### PR TITLE
fixed analytics for preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3295 [WebsiteBundle]         Removed analytics code from preview
     * HOTFIX      #3289 [ContentBundle]         Fixed smart-content to use it without webspace
     * HOTFIX      #3282 [ContentBundle]         Fixed teaser-selection locale
     * HOTFIX      #3281 [ContentBundle]         Fixed index pages with redirect-behavior

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -41,16 +41,30 @@ class AppendAnalyticsListener
      */
     private $environment;
 
+    /**
+     * @var bool
+     */
+    private $preview;
+
+    /**
+     * @param EngineInterface $engine
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     * @param AnalyticsRepository $analyticsRepository
+     * @param $environment
+     * @param bool $preview
+     */
     public function __construct(
         EngineInterface $engine,
         RequestAnalyzerInterface $requestAnalyzer,
         AnalyticsRepository $analyticsRepository,
-        $environment
+        $environment,
+        $preview = false
     ) {
         $this->engine = $engine;
         $this->requestAnalyzer = $requestAnalyzer;
         $this->analyticsRepository = $analyticsRepository;
         $this->environment = $environment;
+        $this->preview = $preview;
     }
 
     /**
@@ -60,7 +74,8 @@ class AppendAnalyticsListener
      */
     public function onResponse(FilterResponseEvent $event)
     {
-        if (0 !== strpos($event->getResponse()->headers->get('Content-Type'), 'text/html')
+        if ($this->preview
+            || 0 !== strpos($event->getResponse()->headers->get('Content-Type'), 'text/html')
             || $this->requestAnalyzer->getPortalInformation() === null
         ) {
             return;

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
@@ -37,6 +37,7 @@
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.analytics.repository"/>
             <argument>%kernel.environment%</argument>
+            <argument type="expression">container.hasParameter('sulu.preview') ? parameter('sulu.preview') : ''</argument>
 
             <tag name="sulu.context" context="website"/>
             <tag name="kernel.event_listener" event="kernel.response" method="onResponse" priority="-5"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -137,4 +137,26 @@ class AppendAnalyticsListenerTest extends \PHPUnit_Framework_TestCase
         )->shouldBeCalled();
         $listener->onResponse($event->reveal());
     }
+
+    public function testAppendPreview()
+    {
+        $engine = $this->prophesize(EngineInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
+
+        $analyticsRepository->findByUrl('1.sulu.lo/2', 'sulu_io', 'prod')->willReturn(['test' => 1]);
+        $listener = new AppendAnalyticsListener(
+            $engine->reveal(),
+            $requestAnalyzer->reveal(),
+            $analyticsRepository->reveal(),
+            'prod',
+            true
+        );
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $event->getRequest()->shouldNotBeCalled();
+        $event->getResponse()->shouldNotBeCalled();
+
+        $listener->onResponse($event->reveal());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu-standard#806
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR disable analytics listener for preview.

#### Why?

The analytics should not be there in the preview.