### PR TITLE
Fixed allDomains option for analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3297 [WebsiteBundle]         Fixed allDomains option for Analytics
     * HOTFIX      #3295 [WebsiteBundle]         Removed analytics code from preview
     * HOTFIX      #3289 [ContentBundle]         Fixed smart-content to use it without webspace
     * HOTFIX      #3282 [ContentBundle]         Fixed teaser-selection locale

--- a/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
@@ -54,6 +54,8 @@ class Analytics
 
     /**
      * @var Collection
+     *
+     * @Exclude
      */
     private $domains;
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\WebsiteBundle\EventSubscriber;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\Metadata\PropertyMetadata;
 use Sulu\Bundle\WebsiteBundle\Entity\Analytics;
 
 /**
@@ -44,12 +43,14 @@ class AnalyticsSerializeEventSubscriber implements EventSubscriberInterface
             return;
         }
 
+        // domains can be an array or a boolean, this difference is necessary for the datagrid to recognize if it is
+        // valid for all domains or only a single one
+        $domains = $analytics->getDomains();
         if ($analytics->isAllDomains()) {
-            $metadata = new PropertyMetadata($event->getType()['name'], 'domains');
-            $value = new \stdClass();
-            $value->domains = true;
-            $event->getVisitor()->visitProperty($metadata, $value, $event->getContext());
+            $domains = true;
         }
+
+        $event->getVisitor()->addData('domains', $event->getContext()->accept($domains));
 
         // the content will be appended dynamically because the metadata changes from string to array
         // depended on the type of analytics.

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/AnalyticsControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/AnalyticsControllerTest.php
@@ -47,6 +47,23 @@ class AnalyticsControllerTest extends SuluTestCase
         $this->assertEmpty($response['_embedded']['analytics']);
     }
 
+    public function testListWithAllDomains()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/webspaces/blog_sulu_io/analytics');
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $items = $response['_embedded']['analytics'];
+        $this->assertCount(1, $items);
+        $this->assertEquals('test piwik', $items[0]['title']);
+        $this->assertEquals('piwik', $items[0]['type']);
+        $this->assertEquals('123', $items[0]['content']);
+        $this->assertEquals(true, $items[0]['domains']);
+    }
+
     public function testList()
     {
         $client = $this->createAuthenticatedClient();
@@ -256,6 +273,16 @@ class AnalyticsControllerTest extends SuluTestCase
                     ['url' => 'www.test.io', 'environment' => 'dev'],
                     ['url' => '{country}.test.io', 'environment' => 'prod'],
                 ],
+            ]
+        );
+        $this->entities[] = $this->analyticsManager->create(
+            'blog_sulu_io',
+            [
+                'title' => 'test piwik',
+                'type' => 'piwik',
+                'content' => '123',
+                'allDomains' => true,
+                'domains' => [],
             ]
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the `allDomains` options for the Analytics webspace settings.

#### Why?

Because it was throwing an error before.