### PR TITLE
Fixed sitemap index provider without items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3298 [WebsiteBundle]         Fixed sitemap index provider without items
     * ENHANCEMENT #2944 [ContentBundle]         Added general class for sulu form highlight section
     * BUGFIX      #3292 [WebsiteBundle]         Fixed visibility of our logo in the web developer toolbar
     * ENHANCEMENT #3291 [TagBundle]             Added all parameters to tag manager

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap-index.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap-index.xml.twig
@@ -2,7 +2,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% import _self as self %}
-    {% for sitemap in sitemaps %}
+    {% for sitemap in sitemaps if sitemap.maxPage %}
     {% for page in range(1, sitemap.maxPage) %}
     <sitemap>
         {{ self.loc(sitemap.alias, page, scheme|default(), domain|default()) }}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Will fix sitemap index generation when maxPage of a sitemap provider is 0.

#### Why?

It would render `1..0` which would create a sitemap e.g. `sitemaps/articles-0.xml` and `sitemaps/articles-1.xml`. 
