### PR TITLE
added onInvalid flag with ignore option to properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * FEATURE     #3300 [ContentBundle]         Added onInvalid flag with ignore option to properties
     * BUGFIX      #3298 [WebsiteBundle]         Fixed sitemap index provider without items
     * ENHANCEMENT #2944 [ContentBundle]         Added general class for sulu form highlight section
     * BUGFIX      #3292 [WebsiteBundle]         Fixed visibility of our logo in the web developer toolbar

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
@@ -11,6 +11,7 @@
         <!-- structure manager -->
         <service id="sulu_content.structure.loader.xml" class="%sulu_content.structure.loader.xml.class%"
                  public="false">
+            <argument type="service" id="sulu.content.type_manager"/>
             <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
         </service>
 

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
@@ -258,6 +258,7 @@ class XmlLegacyLoader implements LoaderInterface
 
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
         $result['multilingual'] = $this->getValueFromXPath('@multilingual', $xpath, $node, true);
+        $result['onInvalid'] = $this->getValueFromXPath('@onInvalid', $xpath, $node);
         $result['tags'] = $this->loadTags('x:tag', $tags, $xpath, $node);
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
         $result['meta'] = $this->loadMeta('x:meta/x:*', $xpath, $node);

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd
@@ -100,6 +100,13 @@
 
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:string" name="type" use="required"/>
+        <xs:attribute name="onInvalid" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="ignore"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
         <xs:attribute type="xs:string" name="mandatory" use="optional"/>
         <xs:attribute type="xs:string" name="multilingual" use="optional"/>
         <xs:attribute type="xs:nonNegativeInteger" name="minOccurs" use="optional"/>

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Content\Tests\Unit\Metadata\Factory;
 
 use Prophecy\Argument;
+use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\Loader\XmlLoader;
 use Sulu\Component\Content\Metadata\StructureMetadata;
@@ -169,11 +170,13 @@ class StructureMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetStructureWithApostrophe()
     {
+        $contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
+        $contentTypeManager->has(Argument::any())->willReturn(true);
         $cacheLifeTimeResolver = $this->prophesize(CacheLifetimeResolverInterface::class);
         $cacheLifeTimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
-        $xmlLoader = new XmlLoader($cacheLifeTimeResolver->reveal());
+        $xmlLoader = new XmlLoader($contentTypeManager->reveal(), $cacheLifeTimeResolver->reveal());
 
         $loadResult = $xmlLoader->load($this->apostropheMappingFile, 'page');
 

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLegacyLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLegacyLoaderTest.php
@@ -88,6 +88,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                             'en' => 'Placeholder-Info-EN',
                         ],
                     ],
+                    'onInvalid' => null,
                 ],
                 'url' => [
                     'name' => 'url',
@@ -107,6 +108,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'article' => [
                     'name' => 'article',
@@ -126,6 +128,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'pages' => [
                     'name' => 'pages',
@@ -145,6 +148,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'article_number' => [
                     'name' => 'article_number',
@@ -158,6 +162,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     'tags' => [],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'images' => [
                     'name' => 'images',
@@ -245,14 +250,13 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
         ];
 
         $result = $this->loadFixture('template.xml', $type);
         $this->assertEquals($template, $result);
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
     }
 
     public function testReadTitleInSection()
@@ -283,6 +287,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                             'tags' => [],
                             'params' => [],
                             'meta' => [],
+                            'onInvalid' => null,
                         ],
                     ],
                 ],
@@ -304,6 +309,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
             'tags' => [],
@@ -313,8 +319,6 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
         $result = $this->loadFixture('template_title_in_section.xml');
 
         $this->assertEquals($template, $result);
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
     }
 
     /**
@@ -379,6 +383,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'url' => [
                     'name' => 'url',
@@ -398,6 +403,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'article' => [
                     'name' => 'article',
@@ -411,6 +417,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     'tags' => [],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'block1' => [
                     'name' => 'block1',
@@ -452,6 +459,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                                 'article1.1' => [
                                     'name' => 'article1.1',
@@ -465,6 +473,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                                 'block1.1' => [
                                     'name' => 'block1.1',
@@ -518,6 +527,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                                                     ],
                                                                     'params' => [],
                                                                     'meta' => [],
+                                                                    'onInvalid' => null,
                                                                 ],
                                                                 'article2.1.2' => [
                                                                     'name' => 'article2.1.2',
@@ -531,6 +541,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                                                     'tags' => [],
                                                                     'params' => [],
                                                                     'meta' => [],
+                                                                    'onInvalid' => null,
                                                                 ],
                                                                 'block1.1.3' => [
                                                                     'name' => 'block1.1.3',
@@ -561,6 +572,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                                                                     'tags' => [],
                                                                                     'params' => [],
                                                                                     'meta' => [],
+                                                                                    'onInvalid' => null,
                                                                                 ],
                                                                             ],
                                                                         ],
@@ -599,6 +611,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                                                     'tags' => [],
                                                                     'params' => [],
                                                                     'meta' => [],
+                                                                    'onInvalid' => null,
                                                                 ],
                                                             ],
                                                         ],
@@ -624,6 +637,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     'tags' => [],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
             'tags' => [],
@@ -632,8 +646,6 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->loadFixture('template_block.xml');
         $this->assertEquals($template, $result);
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
     }
 
     public function testBlockMultipleTypes()
@@ -662,6 +674,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'url' => [
                     'name' => 'url',
@@ -681,6 +694,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'block1' => [
                     'name' => 'block1',
@@ -748,11 +762,12 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                                 'article' => [
                                     'name' => 'article',
                                     'type' => 'text_area',
-                                    'minOccurs' => 2,
+                                    'minOccurs' => '2',
                                     'maxOccurs' => null,
                                     'colspan' => null,
                                     'cssClass' => null,
@@ -761,6 +776,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                             ],
                         ],
@@ -793,11 +809,12 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                                 'name' => [
                                     'name' => 'name',
                                     'type' => 'text_line',
-                                    'minOccurs' => 2,
+                                    'minOccurs' => '2',
                                     'maxOccurs' => null,
                                     'colspan' => null,
                                     'cssClass' => null,
@@ -806,11 +823,12 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                                 'article' => [
                                     'name' => 'article',
                                     'type' => 'text_editor',
-                                    'minOccurs' => 2,
+                                    'minOccurs' => '2',
                                     'maxOccurs' => null,
                                     'colspan' => null,
                                     'cssClass' => null,
@@ -819,6 +837,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                     'tags' => [],
                                     'params' => [],
                                     'meta' => [],
+                                    'onInvalid' => null,
                                 ],
                             ],
                         ],
@@ -836,6 +855,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     'tags' => [],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
             'tags' => [],
@@ -844,8 +864,6 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->loadFixture('template_block_types.xml');
         $this->assertEquals($template, $result);
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
     }
 
     public function testSections()
@@ -887,6 +905,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                             'en' => 'Placeholder-Info-EN',
                         ],
                     ],
+                    'onInvalid' => null,
                 ],
                 'test' => [
                     'name' => 'test',
@@ -923,6 +942,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                             ],
                             'params' => [],
                             'meta' => [],
+                            'onInvalid' => null,
                         ],
                         'article' => [
                             'name' => 'article',
@@ -942,6 +962,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                             ],
                             'params' => [],
                             'meta' => [],
+                            'onInvalid' => null,
                         ],
                         'block' => [
                             'name' => 'block',
@@ -981,6 +1002,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                                             'tags' => [],
                                             'params' => [],
                                             'meta' => [],
+                                            'onInvalid' => null,
                                         ],
                                     ],
                                 ],
@@ -1006,13 +1028,14 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'images' => [
                     'name' => 'images',
                     'type' => 'image_selection',
-                    'minOccurs' => 0,
-                    'maxOccurs' => 2,
-                    'colspan' => 6,
+                    'minOccurs' => '0',
+                    'maxOccurs' => '2',
+                    'colspan' => '6',
                     'cssClass' => null,
                     'mandatory' => false,
                     'multilingual' => true,
@@ -1032,6 +1055,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
             'tags' => [],
@@ -1039,8 +1063,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
         ];
 
         $result = $this->loadFixture('template_sections.xml');
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
+        $this->assertEquals($template, $result);
     }
 
     public function testReservedName()
@@ -1086,6 +1109,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'url' => [
                     'name' => 'url',
@@ -1105,6 +1129,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
             'tags' => [],
@@ -1113,8 +1138,6 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->loadFixture('template_nesting_params.xml');
 
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
         $this->assertEquals($template, $result);
     }
 
@@ -1147,6 +1170,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                         ],
                     ],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'url' => [
                     'name' => 'url',
@@ -1166,6 +1190,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
             'tags' => [],
@@ -1329,6 +1354,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     'tags' => [],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
                 'url' => [
                     'name' => 'url',
@@ -1348,14 +1374,13 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
                     ],
                     'params' => [],
                     'meta' => [],
+                    'onInvalid' => null,
                 ],
             ],
         ];
 
         $result = $this->loadFixture('template_with_xinclude.xml');
         $this->assertEquals($template, $result);
-        $x = $this->arrayRecursiveDiff($result, $template);
-        $this->assertEquals(0, count($x));
     }
 
     public function testLoadCacheLifetimeExpression()
@@ -1391,30 +1416,6 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             ),
             'page'
         );
-    }
-
-    private function arrayRecursiveDiff($aArray1, $aArray2)
-    {
-        $aReturn = [];
-
-        foreach ($aArray1 as $mKey => $mValue) {
-            if (array_key_exists($mKey, $aArray2)) {
-                if (is_array($mValue)) {
-                    $aRecursiveDiff = $this->arrayRecursiveDiff($mValue, $aArray2[$mKey]);
-                    if (count($aRecursiveDiff)) {
-                        $aReturn[$mKey] = $aRecursiveDiff;
-                    }
-                } else {
-                    if ($mValue != $aArray2[$mKey]) {
-                        $aReturn[$mKey] = $mValue;
-                    }
-                }
-            } else {
-                $aReturn[$mKey] = $mValue;
-            }
-        }
-
-        return $aReturn;
     }
 
     private function loadFixture($name, $type = 'page')

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Content\Tests\Unit\Metadata\Loader;
 
 use Prophecy\Argument;
+use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Metadata\Loader\XmlLoader;
 use Sulu\Component\HttpCache\CacheLifetimeResolverInterface;
 
@@ -23,18 +24,30 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
     private $loader;
 
     /**
+     * @var ContentTypeManagerInterface
+     */
+    private $contentTypeManager;
+
+    /**
      * @var CacheLifetimeResolverInterface
      */
     private $cacheLifetimeResolver;
 
     public function setUp()
     {
+        $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
         $this->cacheLifetimeResolver = $this->prophesize(CacheLifetimeResolverInterface::class);
-        $this->loader = new XmlLoader($this->cacheLifetimeResolver->reveal());
+        $this->loader = new XmlLoader($this->contentTypeManager->reveal(), $this->cacheLifetimeResolver->reveal());
     }
 
     public function testLoadTemplate()
     {
+        $this->contentTypeManager->has('text_line')->willReturn(true);
+        $this->contentTypeManager->has('resource_locator')->willReturn(true);
+        $this->contentTypeManager->has('text_area')->willReturn(true);
+        $this->contentTypeManager->has('smart_content_selection')->willReturn(true);
+        $this->contentTypeManager->has('image_selection')->willReturn(true);
+
         $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
@@ -43,6 +56,11 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadBlockMetaTitles()
     {
+        $this->contentTypeManager->has('text_line')->willReturn(true);
+        $this->contentTypeManager->has('text_editor')->willReturn(true);
+        $this->contentTypeManager->has('resource_locator')->willReturn(true);
+        $this->contentTypeManager->has('text_area')->willReturn(true);
+
         $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
@@ -60,12 +78,41 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadBlockTypeWithoutMeta()
     {
+        $this->contentTypeManager->has('text_line')->willReturn(true);
+        $this->contentTypeManager->has('resource_locator')->willReturn(true);
+        $this->contentTypeManager->has('text_area')->willReturn(true);
+
         $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
         $result = $this->load('template_block_type_without_meta.xml');
 
         $this->assertCount(1, $result->getProperty('block1')->getComponents());
+    }
+
+    public function testLoadInvalidIgnore()
+    {
+        $this->contentTypeManager->has('text_line')->willReturn(true);
+        $this->contentTypeManager->has('resource_locator')->willReturn(true);
+        $this->contentTypeManager->has('test')->willReturn(false);
+        $result = $this->load('template_with_invalid_ignore.xml');
+
+        $properties = $result->getProperties();
+
+        $this->assertCount(2, $properties);
+        $this->assertEquals('title', $properties['title']->getName());
+        $this->assertEquals('url', $properties['url']->getName());
+    }
+
+    public function testLoadInvalidWithoutIgnore()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->contentTypeManager->has('text_line')->willReturn(true);
+        $this->contentTypeManager->has('resource_locator')->willReturn(true);
+        $this->contentTypeManager->has('test')->willReturn(false);
+        $this->contentTypeManager->getAll()->willReturn(['text_line' => [], 'resource_locator' => []]);
+        $result = $this->load('template_without_invalid_ignore.xml');
     }
 
     private function load($name)

--- a/tests/Resources/DataFixtures/Page/template_with_invalid_ignore.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_invalid_ignore.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <meta>
+        <title lang="de">Das ist das Template 1</title>
+        <title lang="en">That´s the template 1</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true"/>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" priority="1"/>
+        </property>
+
+        <property name="test" type="test" onInvalid="ignore"/>
+    </properties>
+</template>

--- a/tests/Resources/DataFixtures/Page/template_without_invalid_ignore.xml
+++ b/tests/Resources/DataFixtures/Page/template_without_invalid_ignore.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <meta>
+        <title lang="de">Das ist das Template 1</title>
+        <title lang="en">That´s the template 1</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true"/>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" priority="1"/>
+        </property>
+
+        <property name="test" type="test"/>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | #3204
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR allows to add an `onInvalid` attribute to the properties in the XML templates. If the attribute is set to `ignore` the property will not be added, in case a non-existing type is configured.

#### Why?

Because we want to add an audience target group content type to the `excerpt.xml` template, and it is not said that it is existing in all installation (most installations will probably turn of audience targeting).

This is the only easy way we found to add it to the `excerpt` template and keep it working when the audience target group content type is not available in the current installation.

This is because the entire save process is also built on top of this URL, so simply adding it somehow on our own in the form would be a huge hack.

#### Example Usage

~~~xml
<property name="test" type="test" onInvalid="ignore"/>
~~~