### PR TITLE
Added metadata to configure remove-live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #3306 [DocumentManagerBundle] Adapted document-manager service definition for new NodeNameSlugifier
+    * ENHANCEMENT #3302 [ContentBundle]         Added metadata to configure remove-live
     * FEATURE     #3300 [ContentBundle]         Added onInvalid flag with ignore option to properties
     * BUGFIX      #3298 [WebsiteBundle]         Fixed sitemap index provider without items
     * ENHANCEMENT #3299 [RouteBundle]           Added route-generator pool to combine different route-generators

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
@@ -130,6 +130,7 @@
             <argument type="service" id="sulu_document_manager.live_session"/>
             <argument type="service" id="sulu_document_manager.node_helper"/>
             <argument type="service" id="sulu_document_manager.property_encoder"/>
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
             <tag name="sulu_document_manager.event_subscriber"/>
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | requires https://github.com/sulu/sulu-document-manager/pull/109 and related to https://github.com/sulu/SuluArticleBundle/pull/139 build ontop https://github.com/sulu/sulu/pull/3299
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds a check which uses a new metadata property to avoid removing the live node for special documents.

#### To Do

- [x] Tests
