### PR TITLE
Make removeComposerLockFromGitIgnore compatible with Windows

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
@@ -29,7 +29,7 @@ class ScriptHandler
         }
 
         $gitignore = file_get_contents(static::GIT_IGNORE_FILE);
-        $gitignore = str_replace('composer.lock' . PHP_EOL, '', $gitignore);
+        $gitignore = str_replace("composer.lock\n", '', $gitignore);
         file_put_contents(static::GIT_IGNORE_FILE, $gitignore);
     }
 }


### PR DESCRIPTION
The constant PHP_EOL evaluates to "\r\n" (CR LF) on Windows while the .gitignore file is versioned with LF end-of-lines. So in essence, this fixes the script to work on Windows, otherwise it would leave the .gitignore untouched since the "search" part cannot be found.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Small change to fix the post-create-project-cmd on Windows.

#### Why?

PHP_EOL on Windows is different than the EOL used in .gitignore, thus the script fails currently.

#### Example Usage

~~~shell
composer run-script post-create-project-cmd
~~~
