### PR TITLE
Adapted document-manager service definition for new NodeNameSlugifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3306 [DocumentManagerBundle] Adapted document-manager service definition for new NodeNameSlugifier
     * FEATURE     #3300 [ContentBundle]         Added onInvalid flag with ignore option to properties
     * BUGFIX      #3298 [WebsiteBundle]         Fixed sitemap index provider without items
     * ENHANCEMENT #3299 [RouteBundle]           Added route-generator pool to combine different route-generators

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "imagine/imagine": "~0.6.1",
         "massive/search-bundle": "0.16.*",
         "sensio/framework-extra-bundle": "^3.0",
-        "sulu/document-manager": "~0.9.1",
+        "sulu/document-manager": "dev-develop",
         "stof/doctrine-extensions-bundle": "^1.2.2",
         "gedmo/doctrine-extensions": "~2.4",
         "symfony-cmf/routing-bundle": "^1.2 || ^2.0",

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -15,7 +15,7 @@
         <service id="sulu_document_manager.subscriber.behavior.auto_name"
                  class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber">
             <argument type="service" id="sulu_document_manager.document_registry" />
-            <argument type="service" id="sulu_document_manager.slugifier" />
+            <argument type="service" id="sulu_document_manager.node_name_slugifier" />
             <argument type="service" id="sulu_document_manager.name_resolver" />
             <argument type="service" id="sulu_document_manager.node_manager" />
             <tag name="sulu_document_manager.event_subscriber" />

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -49,6 +49,11 @@
             <argument>Ferrandini\Urlizer::urlize</argument>
         </service>
 
+        <service id="sulu_document_manager.node_name_slugifier"
+                 class="Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier" public="false">
+            <argument type="service" id="sulu_document_manager.slugifier"/>
+        </service>
+
         <service id="sulu_document_manager.namespace_registry" class="Sulu\Component\DocumentManager\NamespaceRegistry" public="false">
             <argument>%sulu_document_manager.namespace_mapping%</argument>
         </service>


### PR DESCRIPTION
This PR adapts the service definition of the document manager.

See main PR https://github.com/sulu/sulu-document-manager/pull/110