### PR TITLE
Fixed author migration script for removed users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* 1.5.4 (dev-master)
+    * HOTFIX      #3314 [ContentBundle]         Fixed author migration script for removed users.
+
 * 1.5.3 (2017-04-06)
     * HOTFIX      #3279 [CategoryBundle]        Add missing return statement.
     * HOTFIX      #3277 [PreviewBundle]         Added fake portal for preview when nothing matches

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -47,6 +47,8 @@ start values for `author` and `authored`.
 app/console phpcr:migrations:migrate
 ```
 
+If the migration failed with `getContact() on a none object` upgrade to at least 1.5.4 and run the migration command again.
+
 ### Twig 2
 
 If you upgrade twig to version 2 please read follow

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201702021447.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201702021447.php
@@ -91,10 +91,13 @@ class Version201702021447 implements VersionInterface, ContainerAwareInterface
                 $creatorPropertyName = sprintf('i18n:%s-creator', $localization->getLocale());
                 if ($node->hasProperty($creatorPropertyName)) {
                     $user = $this->userRepository->findUserById($node->getPropertyValue($creatorPropertyName));
-                    $node->setProperty(
-                        sprintf('i18n:%s-author', $localization->getLocale()),
-                        $user->getContact()->getId()
-                    );
+
+                    if ($user) {
+                        $node->setProperty(
+                            sprintf('i18n:%s-author', $localization->getLocale()),
+                            $user->getContact()->getId()
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It is not possible to upgrade to sulu 1.5 when you have a removed user referenced as creator in the nodes. `Call getContact on a none object` when running `phpcr:migrations:migrate` for the author migration.

#### Why?

To avoid errors in migration script when author not longer exists.

#### Example Usage

~~~bash
# create page on 1.4
# remove user
# upgrade to 1.5
app/console phpcr:migrations:migrate
~~~

