### PR TITLE
Fixed jackalope conflict in composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #3312 [SecurityBundle]        Added configuration options to send reset password message 
+    * ENHANCEMENT #3317 [All]                   Fixed jackalope conflict in composer.json
     * ENHANCEMENT #3306 [DocumentManagerBundle] Adapted document-manager service definition for new NodeNameSlugifier
     * ENHANCEMENT #3302 [ContentBundle]         Added metadata to configure remove-live
     * FEATURE     #3300 [ContentBundle]         Added onInvalid flag with ignore option to properties

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "symfony/symfony": "2.8.10",
         "symfony/phpunit-bridge": "2.8.10",
         "symfony/monolog-bundle": "2.8.10",
-        "jackalope/jackalope": ">= 1.2.8 <= 1.3.1"
+        "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1"
     },
     "replace": {
         "sulu/media-bundle": "self.version",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the conflicts constraint of `jacklope/jackalope`.