### PR TITLE
Added possibility to overwrite published date of document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents
     * FEATURE     #3326 [RouteBundle]           Added auditable to route
     * ENHANCEMENT #3310 [All]                   Fixed test setup to correct init all bundle tests correctly
     * FEATURE     #3310 [ContentBundle]         Implemented `sulu:webspaces:copy` command

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -189,7 +189,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->setWorkflowStageOnNode($event->getNode(), $event->getLocale(), WorkflowStage::TEST, false);
+        $this->setWorkflowStageOnNode($event->getNode(), $event->getLocale(), WorkflowStage::TEST, null);
     }
 
     /**
@@ -253,7 +253,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
 
         $publishDate = $document->getPublished();
 
-        if (!$document->getPublished() && $workflowStage === WorkflowStage::PUBLISHED) {
+        if (!$publishDate && $workflowStage === WorkflowStage::PUBLISHED) {
             $publishDate = new \DateTime();
             $accessor->set(self::PUBLISHED_FIELD, $publishDate);
         }
@@ -275,7 +275,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
      * @param int $workflowStage
      * @param \DateTime $publishDate
      */
-    private function setWorkflowStageOnNode(NodeInterface $node, $locale, $workflowStage, $publishDate)
+    private function setWorkflowStageOnNode(NodeInterface $node, $locale, $workflowStage, \DateTime $publishDate = null)
     {
         $node->setProperty(
             $this->propertyEncoder->localizedSystemName(self::WORKFLOW_STAGE_FIELD, $locale),

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -163,6 +163,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
             $this->propertyEncoder->localizedSystemName(self::WORKFLOW_STAGE_FIELD, $locale),
             WorkflowStage::TEST
         );
+
         $node->setProperty($this->propertyEncoder->localizedSystemName(self::PUBLISHED_FIELD, $locale), null);
     }
 
@@ -250,17 +251,19 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
         $path = $this->documentInspector->getPath($document);
         $document->setWorkflowStage($workflowStage);
 
-        $updatePublished = !$document->getPublished() && $workflowStage === WorkflowStage::PUBLISHED;
-        if ($updatePublished) {
-            $accessor->set(self::PUBLISHED_FIELD, new \DateTime());
+        $publishDate = $document->getPublished();
+
+        if (!$document->getPublished() && $workflowStage === WorkflowStage::PUBLISHED) {
+            $publishDate = new \DateTime();
+            $accessor->set(self::PUBLISHED_FIELD, $publishDate);
         }
 
         $defaultNode = $this->defaultSession->getNode($path);
-        $this->setWorkflowStageOnNode($defaultNode, $locale, $workflowStage, $updatePublished);
+        $this->setWorkflowStageOnNode($defaultNode, $locale, $workflowStage, $publishDate);
 
         if ($live) {
             $liveNode = $this->liveSession->getNode($path);
-            $this->setWorkflowStageOnNode($liveNode, $locale, $workflowStage, $updatePublished);
+            $this->setWorkflowStageOnNode($liveNode, $locale, $workflowStage, $publishDate);
         }
     }
 
@@ -270,19 +273,19 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
      * @param NodeInterface $node
      * @param string $locale
      * @param int $workflowStage
-     * @param bool $updatePublished
+     * @param \DateTime $publishDate
      */
-    private function setWorkflowStageOnNode(NodeInterface $node, $locale, $workflowStage, $updatePublished)
+    private function setWorkflowStageOnNode(NodeInterface $node, $locale, $workflowStage, $publishDate)
     {
         $node->setProperty(
             $this->propertyEncoder->localizedSystemName(self::WORKFLOW_STAGE_FIELD, $locale),
             $workflowStage
         );
 
-        if ($updatePublished) {
+        if ($publishDate) {
             $node->setProperty(
                 $this->propertyEncoder->localizedSystemName(self::PUBLISHED_FIELD, $locale),
-                new \DateTime()
+                $publishDate
             );
         }
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WorkflowStageSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/WorkflowStageSubscriberTest.php
@@ -145,11 +145,12 @@ class WorkflowStageSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $event = $this->getPersistEventMock();
 
-        $this->document->getPublished()->willReturn(new \DateTime());
+        $published = new \DateTime();
+        $this->document->getPublished()->willReturn($published);
 
         $this->document->setWorkflowStage(WorkflowStage::TEST)->shouldBeCalled();
         $this->defaultNode->setProperty('i18n:de-state', WorkflowStage::TEST)->shouldBeCalled();
-        $this->defaultNode->setProperty('i18n:de-published', Argument::any())->shouldNotBeCalled();
+        $this->defaultNode->setProperty('i18n:de-published', $published)->shouldBeCalled();
         $this->liveNode->setProperty('i18n:de-state', Argument::any())->shouldNotBeCalled();
         $this->liveNode->setProperty('i18n:de-published', Argument::any())->shouldNotBeCalled();
 
@@ -183,13 +184,14 @@ class WorkflowStageSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $event = $this->getPublishEventMock();
 
-        $this->document->getPublished()->willReturn(new \DateTime());
+        $published = new \DateTime();
+        $this->document->getPublished()->willReturn($published);
 
         $this->document->setWorkflowStage(WorkflowStage::PUBLISHED)->shouldBeCalled();
         $this->defaultNode->setProperty('i18n:de-state', WorkflowStage::PUBLISHED)->shouldBeCalled();
-        $this->defaultNode->setProperty('i18n:de-published', Argument::any())->shouldNotBeCalled();
+        $this->defaultNode->setProperty('i18n:de-published', $published)->shouldBeCalled();
         $this->liveNode->setProperty('i18n:de-state', WorkflowStage::PUBLISHED)->shouldBeCalled();
-        $this->liveNode->setProperty('i18n:de-published', Argument::any())->shouldNotBeCalled();
+        $this->liveNode->setProperty('i18n:de-published', $published)->shouldBeCalled();
 
         $this->documentAccessor->set('published', Argument::any())->shouldNotBeCalled();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set the document published date when property is not set.

#### Why?

It allow to set the published date by reflection for import scripts.

