### PR TITLE
Added parameter to disable conflict-resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents
+    * ENHANCEMENT #3332 [RouteBundle]           Added parameter to disable conflict-resolver
     * FEATURE     #3326 [RouteBundle]           Added auditable to route
     * ENHANCEMENT #3310 [All]                   Fixed test setup to correct init all bundle tests correctly
     * FEATURE     #3310 [ContentBundle]         Implemented `sulu:webspaces:copy` command

--- a/src/Sulu/Bundle/RouteBundle/Exception/RouteIsNotUniqueException.php
+++ b/src/Sulu/Bundle/RouteBundle/Exception/RouteIsNotUniqueException.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Exception;
+
+use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
+
+/**
+ * Route is not unique exception.
+ */
+class RouteIsNotUniqueException extends \DomainException
+{
+    /**
+     * @var RouteInterface
+     */
+    private $route;
+
+    /**
+     * @var RoutableInterface
+     */
+    private $entity;
+
+    /**
+     * @param RouteInterface $route
+     * @param RoutableInterface $entity
+     */
+    public function __construct(RouteInterface $route, RoutableInterface $entity)
+    {
+        $this->route = $route;
+        $this->entity = $entity;
+    }
+
+    /**
+     * Returns route.
+     *
+     * @return RouteInterface
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * Returns entity.
+     *
+     * @return RoutableInterface
+     */
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+}

--- a/src/Sulu/Bundle/RouteBundle/Manager/RouteManager.php
+++ b/src/Sulu/Bundle/RouteBundle/Manager/RouteManager.php
@@ -11,8 +11,11 @@
 
 namespace Sulu\Bundle\RouteBundle\Manager;
 
+use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
+use Sulu\Bundle\RouteBundle\Exception\RouteIsNotUniqueException;
 use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 
 /**
  * Manages routes.
@@ -30,28 +33,41 @@ class RouteManager implements RouteManagerInterface
     private $conflictResolver;
 
     /**
+     * @var RouteRepositoryInterface
+     */
+    private $routeRepository;
+
+    /**
      * @param ChainRouteGeneratorInterface $chainRouteGenerator
      * @param ConflictResolverInterface $conflictResolver
+     * @param RouteRepositoryInterface $routeRepository
      */
     public function __construct(
         ChainRouteGeneratorInterface $chainRouteGenerator,
-        ConflictResolverInterface $conflictResolver
+        ConflictResolverInterface $conflictResolver,
+        RouteRepositoryInterface $routeRepository
     ) {
         $this->chainRouteGenerator = $chainRouteGenerator;
         $this->conflictResolver = $conflictResolver;
+        $this->routeRepository = $routeRepository;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function create(RoutableInterface $entity, $path = null)
+    public function create(RoutableInterface $entity, $path = null, $resolveConflict = true)
     {
         if (null !== $entity->getRoute()) {
             throw new RouteAlreadyCreatedException($entity);
         }
 
         $route = $this->chainRouteGenerator->generate($entity, $path);
-        $route = $this->conflictResolver->resolve($route);
+        if ($resolveConflict) {
+            $route = $this->conflictResolver->resolve($route);
+        } elseif (!$this->isUnique($route)) {
+            throw new RouteIsNotUniqueException($route, $entity);
+        }
+
         $entity->setRoute($route);
 
         return $route;
@@ -60,7 +76,7 @@ class RouteManager implements RouteManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function update(RoutableInterface $entity, $path = null)
+    public function update(RoutableInterface $entity, $path = null, $resolveConflict = true)
     {
         if (null === $entity->getRoute()) {
             throw new RouteNotCreatedException($entity);
@@ -71,23 +87,24 @@ class RouteManager implements RouteManagerInterface
             return $entity->getRoute();
         }
 
-        $route = $this->conflictResolver->resolve($route);
+        if ($resolveConflict) {
+            $route = $this->conflictResolver->resolve($route);
+        } elseif (!$this->isUnique($route)) {
+            throw new RouteIsNotUniqueException($route, $entity);
+        }
 
         // path haven't changed after conflict resolving
         if ($route->getPath() === $entity->getRoute()->getPath()) {
             return $entity->getRoute();
         }
 
-        $historyRoute = $entity->getRoute()
-            ->setHistory(true)
-            ->setTarget($route);
+        $historyRoute = $entity->getRoute()->setHistory(true)->setTarget($route);
         $route->addHistory($historyRoute);
 
         foreach ($historyRoute->getHistories() as $historyRoute) {
             if ($historyRoute->getPath() === $route->getPath()) {
                 // the history route will be restored
-                $historyRoute->removeTarget()
-                    ->setHistory(false);
+                $historyRoute->removeTarget()->setHistory(false);
 
                 continue;
             }
@@ -99,5 +116,19 @@ class RouteManager implements RouteManagerInterface
         $entity->setRoute($route);
 
         return $route;
+    }
+
+    /**
+     * Returns true if route is unique.
+     *
+     * @param RouteInterface $route
+     *
+     * @return bool
+     */
+    private function isUnique(RouteInterface $route)
+    {
+        $persistedRoute = $this->routeRepository->findByPath($route->getPath(), $route->getLocale());
+
+        return !$persistedRoute || $persistedRoute->getId() === $route->getId();
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Manager/RouteManagerInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Manager/RouteManagerInterface.php
@@ -25,22 +25,22 @@ interface RouteManagerInterface
      *
      * @param RoutableInterface $entity
      * @param string|null $path
-     *
-     * @throws RouteAlreadyCreatedException
+     * @param bool $resolveConflict
      *
      * @return RouteInterface
      */
-    public function create(RoutableInterface $entity, $path = null);
+    public function create(RoutableInterface $entity, $path = null, $resolveConflict = true);
 
     /**
      * Creates a new route and handles the histories if the route has changed.
      *
      * @param RoutableInterface $entity
      * @param string|null $path
+     * @param bool $resolveConflict
      *
      * @throws RouteNotCreatedException
      *
      * @return RouteInterface|null
      */
-    public function update(RoutableInterface $entity, $path = null);
+    public function update(RoutableInterface $entity, $path = null, $resolveConflict = true);
 }

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/manager.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/manager.xml
@@ -12,6 +12,7 @@
         <service id="sulu_route.manager.route_manager" class="Sulu\Bundle\RouteBundle\Manager\RouteManager">
             <argument type="service" id="sulu_route.chain_generator"/>
             <argument type="service" id="sulu_route.manager.conflict_resolver.auto_increment"/>
+            <argument type="service" id="sulu.repository.route"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/164
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a new parameter to disable conflict-resolver for `RouteManager`.

#### Why?

The `SuluArticleBundle` generates and unify the routes at another place. The `RouteManager` should then only throw an exception.

#### Example Usage

~~~php
try{
    $routeManager->create($entity, '/test-entity', false);
} catch (RouteIsNotUniqueException $exception) {
    // Handle conflict
}
~~~

#### To Do

- [x] Tests
