### PR TITLE
Fixed overwrite data in content-serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #3342 [ContentBundle]         Fixed "sulu:content:types:dump" command
+    * BUGFIX      #3338 [ContentBundle]         Fixed overwrite data in content-serialization
     * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents
     * ENHANCEMENT #3332 [RouteBundle]           Added parameter to disable conflict-resolver
     * FEATURE     #3326 [RouteBundle]           Added auditable to route

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/doctrine-cache-bundle": "~1.1",
         "friendsofsymfony/http-cache": "~1.4",
-        "jms/serializer-bundle": "^1.1",
+        "jms/serializer-bundle": "^1.2",
         "friendsofsymfony/rest-bundle": "^1.6",
         "guzzlehttp/guzzle": "^6.2",
         "imagine/imagine": "~0.6.1",

--- a/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
+++ b/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
@@ -76,22 +76,22 @@ class SerializerEventListener implements EventSubscriberInterface
         }
 
         foreach ($content->getData() as $key => $value) {
-            $visitor->addData($key, $value);
+            $visitor->setData($key, $value);
         }
 
-        $visitor->addData('publishedState', (WorkflowStage::PUBLISHED === $content->getWorkflowStage()));
+        $visitor->setData('publishedState', (WorkflowStage::PUBLISHED === $content->getWorkflowStage()));
 
         if (RedirectType::EXTERNAL === $content->getNodeType()) {
-            $visitor->addData('linked', 'external');
+            $visitor->setData('linked', 'external');
         } elseif (RedirectType::INTERNAL === $content->getNodeType()) {
-            $visitor->addData('linked', 'internal');
+            $visitor->setData('linked', 'internal');
         }
 
         if (null !== $content->getLocalizationType()) {
-            $visitor->addData('type', $content->getLocalizationType()->toArray());
+            $visitor->setData('type', $content->getLocalizationType()->toArray());
         }
 
-        $visitor->addData(
+        $visitor->setData(
             '_permissions',
             $this->accessControlManager->getUserPermissionByArray(
                 $content->getLocale(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a problem when calling a URL with a field which is automatically populated. (call `/admin/api/nodes?language=<locale>&webspace=<webspace>&fields=title,order,published,url` for an example

#### Why?

The serializer throws an exception when using `addData` and the property already exists. Version `1.4` introduces a method `setData` which overwrites the property without exception.