### PR TITLE
fixed session and visitor evaluation for page rule

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
@@ -39,7 +39,13 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('header')->defaultValue(HttpCache::TARGET_GROUP_HEADER)->end()
+                ->arrayNode('headers')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('target_group')->defaultValue(HttpCache::TARGET_GROUP_HEADER)->end()
+                        ->scalarNode('url')->defaultValue(HttpCache::USER_CONTEXT_URL_HEADER)->end()
+                    ->end()
+                ->end()
                 ->scalarNode('url')->defaultValue(HttpCache::TARGET_GROUP_URL)->end()
                 ->arrayNode('cookies')
                     ->addDefaultsIfNotSet()
@@ -55,7 +61,6 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('headers')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('url')->defaultValue('X-Forwarded-URL')->end()
                                 ->scalarNode('referrer')->defaultValue('X-Forwarded-Referrer')->end()
                                 ->scalarNode('uuid')->defaultValue('X-Forwarded-UUID')->end()
                             ->end()

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/SuluAudienceTargetingExtension.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/SuluAudienceTargetingExtension.php
@@ -40,13 +40,11 @@ class SuluAudienceTargetingExtension extends Extension
             TargetGroupRuleInterface::FREQUENCY_VISITOR_NAME => TargetGroupRuleInterface::FREQUENCY_VISITOR,
         ]);
 
-        $container->setParameter('sulu_audience_targeting.header', $config['header']);
+        $container->setParameter('sulu_audience_targeting.headers.target_group', $config['headers']['target_group']);
+        $container->setParameter('sulu_audience_targeting.headers.url', $config['headers']['url']);
+
         $container->setParameter('sulu_audience_targeting.url', $config['url']);
         $container->setParameter('sulu_audience_targeting.hit.url', $config['hit']['url']);
-        $container->setParameter(
-            'sulu_audience_targeting.hit.headers.url',
-            $config['hit']['headers']['url']
-        );
         $container->setParameter(
             'sulu_audience_targeting.hit.headers.referrer',
             $config['hit']['headers']['referrer']

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Request;
+
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestProcessorInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Reads the host and path from the passed original request. Will override the values from the UrlRequestProcessor. Used
+ * for the recognizing of page in the sub requests for the caching.
+ */
+class ForwardedUrlRequestProcessor implements RequestProcessorInterface
+{
+    /**
+     * @var string
+     */
+    private $urlHeader;
+
+    /**
+     * @param string $urlHeader
+     */
+    public function __construct($urlHeader)
+    {
+        $this->urlHeader = $urlHeader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Request $request, RequestAttributes $requestAttributes)
+    {
+        if (!$request->headers->has($this->urlHeader)) {
+            return new RequestAttributes();
+        }
+
+        $originalRequest = Request::create($request->headers->get($this->urlHeader));
+        $host = $originalRequest->getHttpHost();
+
+        return new RequestAttributes(['host' => $host, 'path' => $originalRequest->getPathInfo()]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(RequestAttributes $attributes)
+    {
+        return true;
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -28,6 +28,13 @@
             <tag name="jms_serializer.event_subscriber" />
             <tag name="sulu.context" context="admin"/>
         </service>
+        <!--REQUEST-->
+        <service id="sulu_audience_targeting.request_processor.forwarded_url"
+                 class="Sulu\Bundle\AudienceTargetingBundle\Request\ForwardedUrlRequestProcessor">
+            <argument>%sulu_audience_targeting.headers.url%</argument>
+            <tag name="sulu.request_attributes" priority="96"/>
+            <tag name="sulu.context" context="website"/>
+        </service>
         <!--RULES-->
         <service id="sulu_audience_targeting.target_group_evaluator"
                  class="Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupEvaluator">
@@ -55,8 +62,11 @@
         <service id="sulu_audience_targeting.rules.page"
                  class="Sulu\Bundle\AudienceTargetingBundle\Rule\PageRule">
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="translator"/>
+            <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument>%sulu_audience_targeting.hit.headers.uuid%</argument>
+            <argument>%sulu_audience_targeting.headers.url%</argument>
             <tag name="sulu.audience_target_rule" alias="page"/>
         </service>
         <!--CONTENT TYPES-->
@@ -78,7 +88,7 @@
             <argument type="service" id="sulu_audience_targeting.target_group_evaluator"/>
             <argument type="service" id="sulu.repository.target_group"/>
             <argument type="service" id="sulu_audience_targeting.target_group_store"/>
-            <argument>%sulu_audience_targeting.header%</argument>
+            <argument>%sulu_audience_targeting.headers.target_group%</argument>
         </service>
         <service id="sulu_audience_targeting.target_group_subscriber"
                  class="Sulu\Bundle\AudienceTargetingBundle\EventListener\TargetGroupSubscriber">
@@ -89,10 +99,10 @@
             <argument type="service" id="sulu.repository.target_group"/>
             <argument>%sulu_audience_targeting.url%</argument>
             <argument>%sulu_audience_targeting.hit.url%</argument>
-            <argument>%sulu_audience_targeting.hit.headers.url%</argument>
+            <argument>%sulu_audience_targeting.headers.url%</argument>
             <argument>%sulu_audience_targeting.hit.headers.referrer%</argument>
             <argument>%sulu_audience_targeting.hit.headers.uuid%</argument>
-            <argument>%sulu_audience_targeting.header%</argument>
+            <argument>%sulu_audience_targeting.headers.target_group%</argument>
             <argument>%sulu_audience_targeting.cookies.target_group%</argument>
             <argument>%sulu_audience_targeting.cookies.session%</argument>
             <tag name="kernel.event_subscriber"/>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+
+use Sulu\Bundle\AudienceTargetingBundle\Request\ForwardedUrlRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Symfony\Component\HttpFoundation\Request;
+
+class ForwardedUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideProcess
+     */
+    public function testProcess($urlHeader, $url, $host, $path)
+    {
+        $forwardedUrlRequestProcessor = new ForwardedUrlRequestProcessor($urlHeader);
+        $request = new Request();
+        $request->headers->set($urlHeader, $url);
+        $requestAttributes = $forwardedUrlRequestProcessor->process($request, new RequestAttributes());
+
+        $this->assertEquals($host, $requestAttributes->getAttribute('host'));
+        $this->assertEquals($path, $requestAttributes->getAttribute('path'));
+    }
+
+    public function provideProcess()
+    {
+        return [
+            ['X-Forwarded-Url', 'http://127.0.0.1:8000/en/test', '127.0.0.1:8000', '/en/test'],
+            ['X-Url', 'http://sulu.lo/en/test', 'sulu.lo', '/en/test'],
+            ['X-Forwarded-Url', 'http://sulu.lo/de/test', 'sulu.lo', '/de/test'],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -8,7 +8,6 @@
             <argument type="service" id="request_stack"/>
             <argument type="collection"/>
         </service>
-
         <service id="sulu_core.request_processor.parameter"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\ParameterRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -17,7 +16,11 @@
             <tag name="sulu.context" context="website"/>
             <tag name="sulu.request_attributes" priority="128"/>
         </service>
-
+        <service id="sulu_core.request_processor.url"
+                 class="Sulu\Component\Webspace\Analyzer\Attributes\UrlRequestProcessor">
+            <tag name="sulu.context" context="website"/>
+            <tag name="sulu.request_attributes" priority="64"/>
+        </service>
         <service id="sulu_core.request_processor.admin"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\AdminRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -26,7 +29,6 @@
             <tag name="sulu.context" context="admin"/>
             <tag name="sulu.request_attributes" priority="0"/>
         </service>
-
         <service id="sulu_core.request_processor.website"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
@@ -37,7 +39,6 @@
             <tag name="sulu.context" context="website"/>
             <tag name="sulu.request_attributes" priority="0"/>
         </service>
-
         <service id="sulu_core.request_processor.portal_information"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\PortalInformationRequestProcessor">
             <tag name="sulu.context" context="website"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -146,7 +146,7 @@ class ContentRouteProvider implements RouteProviderInterface
         } else {
             // just show the page
             $portal = $this->requestAnalyzer->getPortal();
-            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
             $resourceLocatorStrategy = $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey($portal->getWebspace()->getKey());
 
             try {

--- a/src/Sulu/Component/HttpCache/HttpCache.php
+++ b/src/Sulu/Component/HttpCache/HttpCache.php
@@ -35,6 +35,8 @@ class HttpCache extends AbstractHttpCache
 
     const VISITOR_SESSION_COOKIE = 'sulu-visitor-session';
 
+    const USER_CONTEXT_URL_HEADER = 'X-Forwarded-URL';
+
     /**
      * @var bool
      */
@@ -157,6 +159,8 @@ class HttpCache extends AbstractHttpCache
         if ($currentTargetGroup) {
             $targetGroupRequest->headers->set(static::TARGET_GROUP_HEADER, $currentTargetGroup);
         }
+
+        $targetGroupRequest->headers->set(static::USER_CONTEXT_URL_HEADER, $request->getUri());
 
         // use the parent class to avoid target group based caching
         $targetGroupResponse = parent::handle($targetGroupRequest);

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -63,7 +63,8 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
 
         list($resourceLocator, $format) = $this->getResourceLocatorFromRequest(
             $portalInformation,
-            $request
+            $request,
+            $requestAttributes->getAttribute('path')
         );
 
         $attributes['urlExpression'] = $portalInformation->getUrlExpression();
@@ -92,13 +93,12 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
      *
      * @param PortalInformation $portalInformation
      * @param Request $request
+     * @param string $path
      *
      * @return array
      */
-    private function getResourceLocatorFromRequest(PortalInformation $portalInformation, Request $request)
+    private function getResourceLocatorFromRequest(PortalInformation $portalInformation, Request $request, $path)
     {
-        $path = $request->getPathInfo();
-
         // extract file and extension info
         $pathParts = explode('/', $path);
         $fileInfo = explode('.', array_pop($pathParts));

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/UrlRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/UrlRequestProcessor.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Analyzer\Attributes;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Reads the host and path from the request and writes them into the request attributes.
+ */
+class UrlRequestProcessor implements RequestProcessorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Request $request, RequestAttributes $requestAttributes)
+    {
+        $host = $request->getHttpHost();
+
+        return new RequestAttributes(['host' => $host, 'path' => $request->getPathInfo()]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(RequestAttributes $attributes)
+    {
+        return true;
+    }
+}

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -60,8 +60,8 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
      */
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
-        $host = $request->getHttpHost();
-        $url = $host . $request->getPathInfo();
+        $host = $requestAttributes->getAttribute('host');
+        $url = $host . $requestAttributes->getAttribute('path');
         foreach ($this->webspaceManager->getPortalInformations($this->environment) as $portalInformation) {
             $portalUrl = $this->replacer->replaceHost($portalInformation->getUrl(), $host);
             $portalInformation->setUrl($portalUrl);

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -46,7 +46,7 @@ class RequestAnalyzer implements RequestAnalyzerInterface
             return;
         }
 
-        $attributes = new RequestAttributes(['host' => $request->getHost(), 'scheme' => $request->getScheme(), 'requestUri' => $request->getRequestUri()]);
+        $attributes = new RequestAttributes(['scheme' => $request->getScheme(), 'requestUri' => $request->getRequestUri()]);
         foreach ($this->requestProcessors as $requestProcessor) {
             $attributes = $attributes->merge($requestProcessor->process($request, $attributes));
         }

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -16,6 +16,7 @@ use Prophecy\Argument;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\Attributes\PortalInformationRequestProcessor;
+use Sulu\Component\Webspace\Analyzer\Attributes\UrlRequestProcessor;
 use Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -65,6 +66,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
         $this->requestAnalyzer = new RequestAnalyzer(
             $this->requestStack->reveal(),
             [
+                new UrlRequestProcessor(),
                 new WebsiteRequestProcessor(
                     $this->webspaceManager->reveal(), $this->contentMapper->reveal(), $this->replacer->reveal(), 'prod'
                 ),

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -66,12 +66,12 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [],
-            ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => $config['path_info']]
+            ['HTTP_HOST' => 'sulu.lo']
         );
 
         $attributes = $this->portalInformationRequestProcessor->process(
             $request,
-            new RequestAttributes(['portalInformation' => $portalInformation])
+            new RequestAttributes(['portalInformation' => $portalInformation, 'path' => $config['path_info']])
         );
 
         $this->assertEquals($localization->getLocale(), $request->getLocale());
@@ -121,12 +121,12 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [],
-            ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => $config['path_info']]
+            ['HTTP_HOST' => 'sulu.lo']
         );
 
         $attributes = $this->portalInformationRequestProcessor->process(
             $request,
-            new RequestAttributes(['portalInformation' => $portalInformation])
+            new RequestAttributes(['portalInformation' => $portalInformation, 'path' => $config['path_info']])
         );
 
         $this->assertEquals($localization->getLocale(), $request->getLocale());
@@ -164,12 +164,12 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [],
-            ['HTTP_HOST' => 'sulu.lo:8000', 'REQUEST_URI' => '/test/path/to']
+            ['HTTP_HOST' => 'sulu.lo:8000']
         );
 
         $attributes = $this->portalInformationRequestProcessor->process(
             $request,
-            new RequestAttributes(['portalInformation' => $portalInformation])
+            new RequestAttributes(['portalInformation' => $portalInformation, 'path' => '/test/path/to'])
         );
 
         $this->assertEquals('/path/to', $attributes->getAttribute('resourceLocator'));

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\Attributes\UrlRequestProcessor;
+use Symfony\Component\HttpFoundation\Request;
+
+class UrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UrlRequestProcessor
+     */
+    private $urlRequestProcessor;
+
+    public function setUp()
+    {
+        $this->urlRequestProcessor = new UrlRequestProcessor();
+    }
+
+    /**
+     * @dataProvider provideProcess
+     */
+    public function testProcess($url, $host, $path)
+    {
+        $request = Request::create($url);
+        $requestAttributes = $this->urlRequestProcessor->process($request, new RequestAttributes());
+
+        $this->assertEquals($host, $requestAttributes->getAttribute('host'));
+        $this->assertEquals($path, $requestAttributes->getAttribute('path'));
+    }
+
+    public function provideProcess()
+    {
+        return [
+            ['http://127.0.0.1:8000/en/test', '127.0.0.1:8000', '/en/test'],
+            ['http://sulu.lo/en/test', 'sulu.lo', '/en/test'],
+            ['http://sulu.lo/de/test', 'sulu.lo', '/de/test'],
+        ];
+    }
+}

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -104,14 +104,14 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2, $portalInformation3]);
 
-        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/test']);
+        $request = new Request();
 
         $this->replacer->replaceHost(null, 'sulu.lo')->willReturn(null);
         $this->replacer->replaceHost('{host}', 'sulu.lo')->willReturn('sulu.lo');
         $this->replacer->replaceHost('{host}/de', 'sulu.lo')->willReturn('sulu.lo/de');
         $this->replacer->replaceHost('sulu.io/de', 'sulu.lo')->willReturn('sulu.io/de');
 
-        $attributes = $this->provider->process($request, new RequestAttributes());
+        $attributes = $this->provider->process($request, new RequestAttributes(['host' => 'sulu.lo', 'path' => '/test']));
 
         $this->assertEquals('sulu.lo', $attributes->getAttribute('portalInformation')->getUrl());
         $this->assertEquals('sulu.lo', $portalInformation1->getUrl());
@@ -164,13 +164,13 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2]);
 
-        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/test']);
+        $request = new Request();
 
         $this->replacer->replaceHost(null, 'sulu.lo')->willReturn(null);
         $this->replacer->replaceHost('{host}', 'sulu.lo')->willReturn('sulu.lo');
         $this->replacer->replaceHost('sulu.lo', 'sulu.lo')->willReturn('sulu.lo');
 
-        $attributes = $this->provider->process($request, new RequestAttributes());
+        $attributes = $this->provider->process($request, new RequestAttributes(['host' => 'sulu.lo', 'path' => '/test']));
 
         $this->assertEquals($portalInformation2, $attributes->getAttribute('portalInformation'));
         $this->assertEquals('sulu.lo', $portalInformation1->getUrl());
@@ -222,13 +222,13 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->webspaceManager->getPortalInformations('prod')
             ->willReturn([$portalInformation1, $portalInformation2]);
 
-        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/de']);
+        $request = new Request();
 
         $this->replacer->replaceHost(null, 'sulu.lo')->willReturn('sulu.lo');
         $this->replacer->replaceHost('sulu.lo', 'sulu.lo')->willReturn('sulu.lo');
         $this->replacer->replaceHost('sulu.lo/de', 'sulu.lo')->willReturn('sulu.lo/de');
 
-        $attributes = $this->provider->process($request, new RequestAttributes());
+        $attributes = $this->provider->process($request, new RequestAttributes(['host' => 'sulu.lo', 'path' => 'de']));
 
         $this->assertEquals($portalInformation1, $attributes->getAttribute('portalInformation'));
     }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/RequestAnalyzerTest.php
@@ -143,7 +143,6 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
 
         $requestAnalyzer->analyze($request->reveal());
 
-        $this->assertEquals('www.sulu.io', $requestAnalyzer->getAttribute('host'));
         $this->assertEquals('https', $requestAnalyzer->getAttribute('scheme'));
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the session and visitor evaluation of the page rule, which previously only worked in the dev environment. The problem was that the structure attribute was not written at the time it was read. So I have to pass the original URL and do a lookup for it.