### PR TITLE
Fixed "sulu:content:types:dump" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3342 [ContentBundle]         Fixed "sulu:content:types:dump" command
     * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents
     * FEATURE     #3326 [RouteBundle]           Added auditable to route
     * ENHANCEMENT #3310 [All]                   Fixed test setup to correct init all bundle tests correctly

--- a/src/Sulu/Bundle/ContentBundle/Command/ContentTypesDumpCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ContentTypesDumpCommand.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContentBundle\Command;
 
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -38,7 +39,7 @@ class ContentTypesDumpCommand extends ContainerAwareCommand
         /** @var ContentTypeManagerInterface $contentTypeManager */
         $contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders(['Alias', 'Service ID']);
 
         foreach ($contentTypeManager->getAll() as $alias => $service) {

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sulu\Bundle\ContentBundle\Command;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ContentTypesDumpCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    public function setUp()
+    {
+        $application = new Application($this->getContainer()->get('kernel'));
+
+        $command = new ContentTypesDumpCommand();
+        $command->setApplication($application);
+        $command->setContainer($this->getContainer());
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testExecute()
+    {
+        $this->tester->execute([]);
+
+        $output = $this->tester->getDisplay();
+
+        $this->assertContains('text_line', $output);
+        $this->assertContains('text_area', $output);
+        $this->assertContains('text_editor', $output);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the `sulu:content:types:dump` for symfony `3.2`.