### PR TITLE
Added possibility to add additional attributes to "sulu:link"-tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #3350 [RouteBundle]           Fixed restore route when conflict resolver is disabled
     * BUGFIX      #3352 [RouteBundle]           Added default value to route-created field
+    * ENHANCEMENT #3344 [ContentBundle]         Added possibility to add additional attributes to "sulu:link"-tag
     * BUGFIX      #3342 [ContentBundle]         Fixed "sulu:content:types:dump" command
     * BUGFIX      #3338 [ContentBundle]         Fixed overwrite data in content-serialization
     * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents

--- a/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
@@ -54,11 +54,25 @@ class LinkTag implements TagInterface
             }
 
             $item = $contents[$provider . '-' . $attributes['href']];
+
+            $attributes['href'] = $item->getUrl();
+            $attributes['title'] = $this->getValue($attributes, 'title', $item->getTitle());
+
+            $htmlAttributes = array_map(
+                function ($value, $name) {
+                    if (in_array($name, ['provider', 'content']) || empty($value)) {
+                        return;
+                    }
+
+                    return sprintf('%s="%s"', $name, $value);
+                },
+                $attributes,
+                array_keys($attributes)
+            );
+
             $result[$tag] = sprintf(
-                '<a href="%s" title="%s"%s>%s</a>',
-                $item->getUrl(),
-                $this->getValue($attributes, 'title', $item->getTitle()),
-                (!empty($attributes['target']) ? ' target="' . $attributes['target'] . '"' : ''),
+                '<a %s>%s</a>',
+                implode(' ', array_filter($htmlAttributes)),
                 $this->getValue($attributes, 'content', $item->getTitle())
             );
         }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -106,6 +106,29 @@ class LinkTagTest extends \PHPUnit_Framework_TestCase
                 [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
                 '<a href="/de/test" title="Test-Title" target="_self">Test-Content</a>',
             ],
+            [
+                '<sulu:link href="123-123-123" provider="article" class="test">Test-Content</sulu:link>',
+                [
+                    'href' => '123-123-123',
+                    'provider' => 'article',
+                    'class' => 'test',
+                    'content' => 'Test-Content',
+                ],
+                [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
+                '<a href="/de/test" class="test" title="Page-Title">Test-Content</a>',
+            ],
+            [
+                '<sulu:link href="123-123-123" title="Test-Title" class="test" provider="article">Test-Content</sulu:link>',
+                [
+                    'href' => '123-123-123',
+                    'title' => 'Test-Title',
+                    'class' => 'test',
+                    'provider' => 'article',
+                    'content' => 'Test-Content',
+                ],
+                [new LinkItem('123-123-123', 'Page-Title', '/de/test', true)],
+                '<a href="/de/test" title="Test-Title" class="test">Test-Content</a>',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3323
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR extends the `LinkTag` to allow additional attributes.

#### Why?

In links `class` or other attributes makes sense.

#### Example Usage

~~~twig
<sulu:link provider="content" href="123-123-123" class="btn">My link</sulu:link>
~~~

