### PR TITLE
Added redirect parameter of custom-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * BUGFIX      #3350 [RouteBundle]           Fixed restore route when conflict resolver is disabled
     * BUGFIX      #3352 [RouteBundle]           Added default value to route-created field
     * ENHANCEMENT #3344 [ContentBundle]         Added possibility to add additional attributes to "sulu:link"-tag
+    * ENHANCEMENT #3345 [CustomUrlBundle]       Added redirect parameter of custom-url
     * BUGFIX      #3342 [ContentBundle]         Fixed "sulu:content:types:dump" command
     * BUGFIX      #3338 [ContentBundle]         Fixed overwrite data in content-serialization
     * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
@@ -52,6 +52,10 @@ class RedirectEnhancer extends AbstractEnhancer
             $defaults['_webspace']->getKey()
         );
 
+        if ($request->getQueryString()) {
+            $url .= '?' . $request->getQueryString();
+        }
+
         return [
             '_controller' => 'SuluWebsiteBundle:Redirect:redirect',
             'url' => $url,

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
@@ -60,4 +60,47 @@ class RedirectEnhancerTest extends \PHPUnit_Framework_TestCase
             $defaults
         );
     }
+
+    public function testEnhanceWithQueryString()
+    {
+        $request = $this->prophesize(Request::class);
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu_io');
+
+        $customUrl = $this->prophesize(CustomUrlDocument::class);
+        $customUrl->isRedirect()->willReturn(true);
+        $customUrl->getTargetLocale()->willReturn('de');
+
+        $target = $this->prophesize(PageDocument::class);
+        $target->getResourceSegment()->willReturn('/test');
+        $customUrl->getTargetDocument()->willReturn($target);
+
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $webspaceManager->findUrlByResourceLocator(
+            '/test',
+            'prod',
+            'de',
+            'sulu_io'
+        )->willReturn('sulu.io/test');
+
+        $request->getQueryString()->willReturn('param=1');
+
+        $enhancer = new RedirectEnhancer($webspaceManager->reveal());
+
+        $defaults = $enhancer->enhance(
+            ['_custom_url' => $customUrl->reveal(), '_webspace' => $webspace->reveal(), '_environment' => 'prod'],
+            $request->reveal()
+        );
+
+        $this->assertEquals(
+            [
+                '_custom_url' => $customUrl->reveal(),
+                '_webspace' => $webspace->reveal(),
+                '_environment' => 'prod',
+                '_controller' => 'SuluWebsiteBundle:Redirect:redirect',
+                'url' => 'sulu.io/test?param=1',
+            ],
+            $defaults
+        );
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2308
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR appends the `$request->getQueryString()` to the redirected URL.