### PR TITLE
Fixed restore route when conflict resolver is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3350 [RouteBundle]           Fixed restore route when conflict resolver is disabled
     * BUGFIX      #3342 [ContentBundle]         Fixed "sulu:content:types:dump" command
     * ENHANCEMENT #3329 [ContentBundle]         Added possibility to set the published date for documents
     * ENHANCEMENT #3332 [RouteBundle]           Added parameter to disable conflict-resolver

--- a/src/Sulu/Bundle/RouteBundle/Entity/BaseRoute.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/BaseRoute.php
@@ -13,6 +13,9 @@ namespace Sulu\Bundle\RouteBundle\Entity;
 
 use Hateoas\Configuration\Annotation\Relation;
 use Hateoas\Configuration\Annotation\Route as HateoasRoute;
+use JMS\Serializer\Annotation\ExclusionPolicy;
+use JMS\Serializer\Annotation\Expose;
+use JMS\Serializer\Annotation\VirtualProperty;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Persistence\Model\AuditableTrait;
@@ -27,6 +30,8 @@ use Sulu\Component\Persistence\Model\AuditableTrait;
  *         parameters = { "id" = "expr(object.getId())" }
  *     )
  * )
+ *
+ * @ExclusionPolicy("all")
  */
 abstract class BaseRoute implements RouteInterface, AuditableInterface
 {
@@ -34,16 +39,22 @@ abstract class BaseRoute implements RouteInterface, AuditableInterface
 
     /**
      * @var int
+     *
+     * @Expose
      */
     private $id;
 
     /**
      * @var string
+     *
+     * @Expose
      */
     private $path;
 
     /**
      * @var string
+     *
+     * @Expose
      */
     private $locale;
 
@@ -59,6 +70,8 @@ abstract class BaseRoute implements RouteInterface, AuditableInterface
 
     /**
      * @var bool
+     *
+     * @Expose
      */
     private $history = false;
 
@@ -228,5 +241,15 @@ abstract class BaseRoute implements RouteInterface, AuditableInterface
         $this->histories[] = $history;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @VirtualProperty
+     */
+    public function getCreated()
+    {
+        return $this->created;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR reintroduces restore for disabled conflict-resolver.

This happens when you try to restore a route in SuluArticleBundle. There the conflict-resolver is disabled and you change the route to an old one - you will see an error instead of restoring the route.