### PR TITLE
Fix spacing between rows and section in content template generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * BUGFIX      #3351 [ContentBundle]         Fix spacing between rows and section in content template generation
     * ENHANCEMENT #3764 [Component]             Allow dynamic order of elements in webspace xml
     * HOTFIX      #3752 [ContentBundle]         Overwrite 'doctrine:phpcr:workspace:import' set default to throw
     * ENHANCEMENT #3775 [Component]             Use is iterable instead of custom is_array twig function in webspace dumper

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
@@ -1,5 +1,8 @@
-<div class="grid-col-{{ property.colspan != "" ? property.colspan : '12' }} floating m-top-20">
-    <h2 class="light">{{ property.getTitle(userLocale) }}</h2>
+<div class="grid-col-{{ property.colspan != "" ? property.colspan : '12' }} floating">
+    {% set blockTitle = property.getTitle(userLocale) %}
+    {% if blockTitle %}
+        <h2 class="light">{{ blockTitle }}</h2>
+    {% endif %}
 
     <div class="grid">
         <div id="text-block-header-{{ id|raw }}" class="text-blocks-header">
@@ -11,7 +14,7 @@
             </div>
             <div class="clear"></div>
         </div>
-        <div class="grid-row small"
+        <div class="grid-row m-bottom-0"
              id="{{ id|raw }}"
              data-form="true"
              data-type="block"
@@ -64,7 +67,7 @@
             {% endfor %}
         </div>
 
-        <div class="text-block-footer" id="{{ id|raw }}-add" style="width: 200px">
+        <div class="text-block-footer m-bottom-0" id="{{ id|raw }}-add" style="width: 200px">
 
         </div>
     </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/properties.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/properties.html.twig
@@ -1,6 +1,7 @@
 <div class="grid-row">
 {# initialize columns #}
 {% set columns = 0 %}
+{% set lastProperty = null %}
 {% for property in properties %}
 
     {# set propertyColspan with default if colspan is not set #}
@@ -12,7 +13,12 @@
         {% set columns = columns + propertyColspan %}
     {% else %}
         </div>
-        <div class="grid-row">
+        
+        {% set gridRowClass = '' %}
+        {% if property.contentTypeName == 'section' and lastProperty.contentTypeName|default != 'section' %}
+            {% set gridRowClass = ' m-top-40' %}
+        {% endif %}
+        <div class="grid-row{{ gridRowClass }}">
         {# set current amount of colspans #}
         {% set columns = propertyColspan %}
     {% endif %}
@@ -71,5 +77,7 @@
             } only %}
         {% endif %}
     {% endif %}
+
+    {% set lastProperty = property %}
 {% endfor %}
 </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/section.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/section.html.twig
@@ -3,14 +3,14 @@
         <h2 class="divider m-bottom-20"
             title="{{ property.getInfoText(userLocale) }}">{{ property.getTitle(userLocale) }}</h2>
 
-        <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+        {% if property.getInfoText(userLocale) %}
+            <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+        {% endif %}
     {% endif %}
 
     <div class="grid">
-        <div class="grid-row">
-            {% include 'SuluContentBundle:Template:macros/properties.html.twig' with {
-                'properties': property.childProperties
-            } %}
-        </div>
+        {% include 'SuluContentBundle:Template:macros/properties.html.twig' with {
+            'properties': property.childProperties
+        } %}
     </div>
 </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/single.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/single.html.twig
@@ -6,5 +6,7 @@
 
     {% include type.template %}
 
-    <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+    {% if property.getInfoText(userLocale) %}
+        <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+    {% endif %}
 </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug? | no
| New Feature? | no
| Sulu Version | 1.6.10

### Actual Behavior

![2017-05-12-15-20-vital lo- 1](https://cloud.githubusercontent.com/assets/1698337/26000189/4ba37378-3728-11e7-9a1a-fe4c84d18f1f.png)
![2017-05-12-15-20-vital lo](https://cloud.githubusercontent.com/assets/1698337/26000194/50109440-3728-11e7-8f99-8c45b9e995fc.png)

### Expected Behavior

This is the status with this PR:

![2017-05-12-15-19-vital lo 1](https://cloud.githubusercontent.com/assets/1698337/26000208/5a562046-3728-11e7-958e-ab60c9d04d60.png)
![2017-05-12-15-19-vital lo](https://cloud.githubusercontent.com/assets/1698337/26000209/5c4883f8-3728-11e7-90f4-0f5ee0318707.png)

### Example Usage 

1. Create properties before the first section (space before this section is not the same as for others)
2. Create a block inside a section (space seems to big)

