### PR TITLE
Removed get-type from content-type-interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3360 [ContentBundle]         Removed get-type from content-type-interface 
     * BUGFIX      #3350 [RouteBundle]           Fixed restore route when conflict resolver is disabled
     * BUGFIX      #3352 [RouteBundle]           Added default value to route-created field
     * ENHANCEMENT #3344 [ContentBundle]         Added possibility to add additional attributes to "sulu:link"-tag

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,14 @@
 
 ## dev-develop
 
+### ContentTypeInterface
+
+Following methods and constants was removed from `ContentTypeInterface`.
+
+* `PRE_SAVE`
+* `POST_SAVE`
+* `getType()`
+
 ### Route-Table changed
 
 The route-table was extended with auditable information. Run following command to

--- a/src/Sulu/Bundle/CategoryBundle/Content/Types/CategoryList.php
+++ b/src/Sulu/Bundle/CategoryBundle/Content/Types/CategoryList.php
@@ -16,7 +16,6 @@ use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
-use Sulu\Component\Content\ContentTypeInterface;
 
 /**
  * Content Type for the CategoryList, uses the CategoryManager-Service and the Datagrid from Husky.
@@ -41,17 +40,6 @@ class CategoryList extends ComplexContentType implements ContentTypeExportInterf
     {
         $this->categoryManager = $categoryManager;
         $this->template = $template;
-    }
-
-    /**
-     * returns type of ContentType
-     * PRE_SAVE or POST_SAVE.
-     *
-     * @return int
-     */
-    public function getType()
-    {
-        return ContentTypeInterface::PRE_SAVE;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
@@ -23,7 +23,6 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
-use Sulu\Component\Content\ContentTypeInterface;
 
 /**
  * ContentType for Contact.
@@ -74,14 +73,6 @@ class ContactSelectionContentType extends ComplexContentType implements ContentT
         $this->serializer = $serializer;
         $this->converter = $converter;
         $this->comparator = $comparator;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return ContentTypeInterface::PRE_SAVE;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionContentTypeTest.php
@@ -25,7 +25,6 @@ use Sulu\Bundle\ContactBundle\Util\IndexComparator;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\ContentTypeInterface;
 
 class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
 {
@@ -100,20 +99,6 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->property->getStructure()->willReturn($this->structure->reveal());
 
         $this->serializer = $this->prophesize(Serializer::class);
-    }
-
-    public function testGetType()
-    {
-        $type = new ContactSelectionContentType(
-            $this->template,
-            $this->contactManager->reveal(),
-            $this->accountManager->reveal(),
-            $this->serializer->reveal(),
-            new CustomerIdConverter(),
-            new IndexComparator()
-        );
-
-        $this->assertEquals(ContentTypeInterface::PRE_SAVE, $type->getType());
     }
 
     public function testGetTemplate()

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/InternalLinks.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/InternalLinks.php
@@ -69,14 +69,6 @@ class InternalLinks extends ComplexContentType implements ContentTypeExportInter
     /**
      * {@inheritdoc}
      */
-    public function getType()
-    {
-        return self::PRE_SAVE;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function read(
         NodeInterface $node,
         PropertyInterface $property,

--- a/src/Sulu/Bundle/LocationBundle/Content/Types/LocationContentType.php
+++ b/src/Sulu/Bundle/LocationBundle/Content/Types/LocationContentType.php
@@ -85,14 +85,6 @@ class LocationContentType extends ComplexContentType implements ContentTypeExpor
     /**
      * {@inheritdoc}
      */
-    public function getType()
-    {
-        return self::PRE_SAVE;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function read(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
     {
         $data = json_decode($node->getPropertyValueWithDefault($property->getName(), '{}'), true);

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -81,14 +81,6 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
     /**
      * {@inheritdoc}
      */
-    public function getType()
-    {
-        return self::PRE_SAVE;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function read(
         NodeInterface $node,
         PropertyInterface $property,

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -22,7 +22,6 @@ use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
-use Sulu\Component\Content\ContentTypeInterface;
 
 /**
  * ContentType for Snippets.
@@ -59,14 +58,6 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
         $this->defaultSnippetManager = $defaultSnippetManager;
         $this->defaultEnabled = $defaultEnabled;
         $this->template = $template;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return ContentTypeInterface::PRE_SAVE;
     }
 
     /**

--- a/src/Sulu/Bundle/TagBundle/Content/Types/TagList.php
+++ b/src/Sulu/Bundle/TagBundle/Content/Types/TagList.php
@@ -16,7 +16,6 @@ use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
-use Sulu\Component\Content\ContentTypeInterface;
 
 /**
  * Content Type for the TagList, uses the TagManager-Service and the AutoCompleteList from Husky.
@@ -41,17 +40,6 @@ class TagList extends ComplexContentType implements ContentTypeExportInterface
     {
         $this->tagManager = $tagManager;
         $this->template = $template;
-    }
-
-    /**
-     * returns type of ContentType
-     * PRE_SAVE or POST_SAVE.
-     *
-     * @return int
-     */
-    public function getType()
-    {
-        return ContentTypeInterface::PRE_SAVE;
     }
 
     /**

--- a/src/Sulu/Component/Content/ContentTypeInterface.php
+++ b/src/Sulu/Component/Content/ContentTypeInterface.php
@@ -20,24 +20,6 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 interface ContentTypeInterface
 {
     /**
-     * @deprecated All the ContentTypes should be of this type, so declaring it explicitly is not necessary
-     */
-    const PRE_SAVE = 1;
-
-    /**
-     * @deprecated This type is not supported anymore, because it is not even used by the ResourceLocator anymore
-     */
-    const POST_SAVE = 2;
-
-    /**
-     * returns type of ContentType
-     * PRE_SAVE or POST_SAVE.
-     *
-     * @return int
-     */
-    public function getType();
-
-    /**
      * Reads the value for given property from the content repository then sets the value of the Sulu property.
      *
      * @param NodeInterface     $node

--- a/src/Sulu/Component/Content/SimpleContentType.php
+++ b/src/Sulu/Component/Content/SimpleContentType.php
@@ -104,14 +104,6 @@ abstract class SimpleContentType implements ContentTypeInterface, ContentTypeExp
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return ContentTypeInterface::PRE_SAVE;
-    }
-
-    /**
      * magic getter for twig templates.
      *
      * @param $property string name of property

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -55,14 +55,6 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
     /**
      * {@inheritdoc}
      */
-    public function getType()
-    {
-        return ContentTypeInterface::PRE_SAVE;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function read(
         NodeInterface $node,
         PropertyInterface $property,

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -208,14 +208,6 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
     /**
      * {@inheritdoc}
      */
-    public function getType()
-    {
-        return self::PRE_SAVE;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getContentData(PropertyInterface $property)
     {
         // check memoize


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes (removed deprecated methods)
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the deprecated method `getType` and the two deprecated constants `PRE_SAVE` and `POST_SAVE` from `ContentTypeInterface`.