### PR TITLE
add audience targeting caching headers only if necessary

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupEvaluationController.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupEvaluationController.php
@@ -94,7 +94,7 @@ class TargetGroupEvaluationController
      */
     public function targetGroupHitAction()
     {
-        $currentTargetGroup = $this->targetGroupRepository->find($this->targetGroupStore->getTargetGroupId());
+        $currentTargetGroup = $this->targetGroupRepository->find($this->targetGroupStore->getTargetGroupId(true));
 
         $targetGroup = $this->targetGroupEvaluator->evaluate(TargetGroupRuleInterface::FREQUENCY_HIT, $currentTargetGroup);
         $response = new Response();

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -146,7 +146,6 @@ class TargetGroupSubscriber implements EventSubscriberInterface
             ],
             KernelEvents::RESPONSE => [
                 ['addVaryHeader'],
-                ['setMaxAgeHeader'],
                 ['addSetCookieHeader'],
                 ['addTargetGroupHitScript'],
             ],
@@ -205,20 +204,6 @@ class TargetGroupSubscriber implements EventSubscriberInterface
 
         if ($this->targetGroupStore->hasInfluencedContent() && $request->getRequestUri() !== $this->targetGroupUrl) {
             $response->setVary($this->targetGroupHeader, false);
-        }
-    }
-
-    /**
-     * Sets the max age header to zero if the response was influenced by a target group. That is necessary, because the
-     * target group can change within a very short amount of time, and the browser cache would be wrong then.
-     *
-     * @param FilterResponseEvent $event
-     */
-    public function setMaxAgeHeader(FilterResponseEvent $event)
-    {
-        if ($this->targetGroupStore->hasInfluencedContent()) {
-            $event->getResponse()->setMaxAge(0);
-            $event->getResponse()->setSharedMaxAge(0);
         }
     }
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupStore.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupStore.php
@@ -19,43 +19,60 @@ class TargetGroupStore implements TargetGroupStoreInterface
     /**
      * @var string
      */
-    private $targetGroup;
+    private $targetGroupId;
 
     /**
      * @var bool
      */
-    private $changed = false;
+    private $changedTargetGroup = false;
+
+    /**
+     * @var bool
+     */
+    private $influencedContent = false;
 
     /**
      * {@inheritdoc}
      */
     public function setTargetGroupId($targetGroupId)
     {
-        $this->targetGroup = $targetGroupId;
+        $this->targetGroupId = $targetGroupId;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getTargetGroupId()
+    public function getTargetGroupId($internal = false)
     {
-        return $this->targetGroup;
+        if (!$internal) {
+            $this->influencedContent = true;
+        }
+
+        return $this->targetGroupId;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function updateTargetGroupId($targetGroupid)
+    public function updateTargetGroupId($targetGroupId)
     {
-        $this->changed = $this->getTargetGroupId() != $targetGroupid;
-        $this->setTargetGroupId($targetGroupid);
+        $this->changedTargetGroup = $this->targetGroupId != $targetGroupId;
+        $this->setTargetGroupId($targetGroupId);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function hasChanged()
+    public function hasChangedTargetGroup()
     {
-        return $this->changed;
+        return $this->changedTargetGroup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasInfluencedContent()
+    {
+        return $this->influencedContent;
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupStoreInterface.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupStoreInterface.php
@@ -25,23 +25,32 @@ interface TargetGroupStoreInterface
     /**
      * Returns the id of the current TargetGroup from the current request.
      *
+     * @param bool $internal True for internal calls, which means the result has no influence on the page output
+     *
      * @return string
      */
-    public function getTargetGroupId();
+    public function getTargetGroupId($internal = false);
 
     /**
      * Sets the given target group as the new one, and marking this value as changed.
      *
-     * @param $targetGroupid
+     * @param $targetGroupId
      *
      * @return string
      */
-    public function updateTargetGroupId($targetGroupid);
+    public function updateTargetGroupId($targetGroupId);
 
     /**
      * Returns whether the value hold by this store has changed or not.
      *
      * @return bool
      */
-    public function hasChanged();
+    public function hasChangedTargetGroup();
+
+    /**
+     * Returns whether the content from this request has been influenced by the target group or not.
+     *
+     * @return bool
+     */
+    public function hasInfluencedContent();
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Controller/TargetGroupEvaluationControllerTest.php
@@ -105,7 +105,7 @@ class TargetGroupEvaluationControllerTest extends \PHPUnit_Framework_TestCase
             TargetGroupRuleInterface::FREQUENCY_HIT,
             $oldTargetGroup
         )->willReturn($newTargetGroup);
-        $this->targetGroupStore->getTargetGroupId()->willReturn($oldTargetGroup->getId());
+        $this->targetGroupStore->getTargetGroupId(true)->willReturn($oldTargetGroup->getId());
         $targetGroupEvaluationController = new TargetGroupEvaluationController(
             $this->targetGroupEvaluator->reveal(),
             $this->targetGroupRepository->reveal(),

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -299,49 +299,6 @@ class TargetGroupSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideSetMaxAgeHeader
-     */
-    public function testSetMaxAgeHeader($hasInfluenced, $maxAge, $result)
-    {
-        $targetGroupSubscriber = new TargetGroupSubscriber(
-            $this->twig->reveal(),
-            false,
-            $this->targetGroupStore->reveal(),
-            $this->targetGroupEvaluator->reveal(),
-            $this->targetGroupRepository->reveal(),
-            '/_target_group',
-            '/_target_group_hit',
-            'X-Forwarded-Url',
-            'X-Forwarded-Referer',
-            'X-Forwarded-UUID',
-            'X-Sulu-Target-Group',
-            'sulu-visitor-target-group',
-            'visitor-session'
-        );
-
-        $event = $this->prophesize(FilterResponseEvent::class);
-        $response = new Response();
-        $response->setMaxAge($maxAge);
-        $response->setSharedMaxAge($maxAge);
-        $event->getResponse()->willReturn($response);
-
-        $this->targetGroupStore->hasInfluencedContent()->willReturn($hasInfluenced);
-
-        $targetGroupSubscriber->setMaxAgeHeader($event->reveal());
-
-        $this->assertEquals($result, $response->getMaxAge());
-        $this->assertEquals($result, $response->headers->getCacheControlDirective('s-maxage'));
-    }
-
-    public function provideSetMaxAgeHeader()
-    {
-        return [
-            [true, 100, 0],
-            [false, 100, 100],
-        ];
-    }
-
-    /**
      * @dataProvider provideAddSetCookieHeader
      */
     public function testAddSetCookieHeader($targetGroupCookie, $visitorSession, $hasChanged, $cookieValue)

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/UserContext/TargetGroupStoreTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/UserContext/TargetGroupStoreTest.php
@@ -29,17 +29,25 @@ class TargetGroupStoreTest extends \PHPUnit_Framework_TestCase
     {
         $this->targetGroupStore->setTargetGroupId('2');
         $this->assertEquals('2', $this->targetGroupStore->getTargetGroupId());
+        $this->assertEquals(true, $this->targetGroupStore->hasInfluencedContent());
+    }
+
+    public function testGetTargetGroupIdInternal()
+    {
+        $this->targetGroupStore->setTargetGroupId('2');
+        $this->assertEquals('2', $this->targetGroupStore->getTargetGroupId(true));
+        $this->assertEquals(false, $this->targetGroupStore->hasInfluencedContent());
     }
 
     public function testUpdateTargetGroupId()
     {
         $this->targetGroupStore->setTargetGroupId('2');
         $this->assertEquals('2', $this->targetGroupStore->getTargetGroupId());
-        $this->assertFalse($this->targetGroupStore->hasChanged());
+        $this->assertFalse($this->targetGroupStore->hasChangedTargetGroup());
 
         $this->targetGroupStore->updateTargetGroupId('3');
         $this->assertEquals('3', $this->targetGroupStore->getTargetGroupId());
-        $this->assertTrue($this->targetGroupStore->hasChanged());
+        $this->assertTrue($this->targetGroupStore->hasChangedTargetGroup());
     }
 
     public function testChangeTargetGroupIdToSame()
@@ -47,7 +55,7 @@ class TargetGroupStoreTest extends \PHPUnit_Framework_TestCase
         $this->targetGroupStore->setTargetGroupId('2');
         $this->targetGroupStore->updateTargetGroupId('2');
         $this->assertEquals('2', $this->targetGroupStore->getTargetGroupId());
-        $this->assertFalse($this->targetGroupStore->hasChanged());
+        $this->assertFalse($this->targetGroupStore->hasChangedTargetGroup());
     }
 
     public function testChangeTargetGroupIdToSameDifferentType()
@@ -55,6 +63,6 @@ class TargetGroupStoreTest extends \PHPUnit_Framework_TestCase
         $this->targetGroupStore->setTargetGroupId('2');
         $this->targetGroupStore->updateTargetGroupId(2);
         $this->assertEquals('2', $this->targetGroupStore->getTargetGroupId());
-        $this->assertFalse($this->targetGroupStore->hasChanged());
+        $this->assertFalse($this->targetGroupStore->hasChangedTargetGroup());
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/app/AppKernel.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/app/AppKernel.php
@@ -11,6 +11,8 @@
 
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class AppKernel extends SuluTestKernel
 {
@@ -23,5 +25,13 @@ class AppKernel extends SuluTestKernel
         } else {
             $loader->load(__DIR__ . '/config/config_website.yml');
         }
+    }
+
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        // emulate that the target group had an influence on the result
+        $this->getContainer()->get('sulu_audience_targeting.target_group_store')->getTargetGroupId();
+
+        return parent::handle($request, $type, $catch);
     }
 }

--- a/src/Sulu/Component/HttpCache/HttpCache.php
+++ b/src/Sulu/Component/HttpCache/HttpCache.php
@@ -101,7 +101,7 @@ class HttpCache extends AbstractHttpCache
      */
     protected function isFreshEnough(Request $request, Response $entry)
     {
-        if (!$entry->isFresh() && !$this->isFreshCacheEntry($entry)) {
+        if (!$this->isFreshCacheEntry($entry)) {
             return $this->lock($request, $entry);
         }
 

--- a/src/Sulu/Component/HttpCache/HttpCache.php
+++ b/src/Sulu/Component/HttpCache/HttpCache.php
@@ -74,6 +74,11 @@ class HttpCache extends AbstractHttpCache
             $this->setTargetGroupCookie($response, $request);
         }
 
+        if ($this->hasAudienceTargeting && in_array(static::TARGET_GROUP_HEADER, $response->getVary())) {
+            $response->setMaxAge(0);
+            $response->setSharedMaxAge(0);
+        }
+
         return $response;
     }
 
@@ -101,7 +106,7 @@ class HttpCache extends AbstractHttpCache
      */
     protected function isFreshEnough(Request $request, Response $entry)
     {
-        if (!$this->isFreshCacheEntry($entry)) {
+        if (!$entry->isFresh() && !$this->isFreshCacheEntry($entry)) {
             return $this->lock($request, $entry);
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/327

#### What's in this PR?

This PR checks if the Target Group influenced the rendered body of the response using the `TargetGroupStore`, and only set the `Vary` and `s-maxage` header if the response was influenced by the target group.

#### Why?

This should result in more cache hits, since pages which are not influenced by target groups do also not vary based on this header in the cache.

#### Example Usage

Simply call `$targetGroupStore->getTargetGroupId()` where ever you are in need of the target group. The service will remember that and Sulu sets the correct headers for you.

#### To Do

- [ ] Create a documentation PR
