### PR TITLE
Update imagine dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3363 [MediaBundle]           Fixed compatibility with newest imagick version
     * ENHANCEMENT #3360 [ContentBundle]         Removed get-type from content-type-interface 
     * BUGFIX      #3350 [RouteBundle]           Fixed restore route when conflict resolver is disabled
     * BUGFIX      #3352 [RouteBundle]           Added default value to route-created field

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "jms/serializer-bundle": "^1.2",
         "friendsofsymfony/rest-bundle": "^1.6",
         "guzzlehttp/guzzle": "^6.2",
-        "imagine/imagine": "~0.6.1",
+        "imagine/imagine": "~0.6.1 || ~0.7.0",
         "massive/search-bundle": "0.16.*",
         "sensio/framework-extra-bundle": "^3.0",
         "sulu/document-manager": "dev-develop",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

### What's in this PR?

Allow imagine 0.7 version to be installed.

### Why?

The old 0.6 is incompatible with the newset Imagick version.

### BC Breaks/Deprecations

No BC Break 0.6 is still allowed.

[Changes 0.6-0.7](https://github.com/avalanche123/Imagine/compare/v0.6.3...v0.7.0)

### Related issues to 0.6

 - https://github.com/avalanche123/Imagine/pull/547
 - https://github.com/avalanche123/Imagine/issues/539