### PR TITLE
Get rid of deprecated "table" console helper

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Command/ContentTypesDumpCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ContentTypesDumpCommand.php
@@ -45,6 +45,6 @@ class ContentTypesDumpCommand extends ContainerAwareCommand
         foreach ($contentTypeManager->getAll() as $alias => $service) {
             $table->addRow([$alias, $service['id']]);
         }
-        $table->render($output);
+        $table->render();
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Command/ValidatePagesCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ValidatePagesCommand.php
@@ -15,7 +15,7 @@ use Jackalope\Query\Row;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
-use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -76,8 +76,7 @@ class ValidatePagesCommand extends ContainerAwareCommand
 
         $completeHeader = array_merge(['invalid', 'path'], $headers, ['description']);
 
-        /** @var TableHelper $table */
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders($completeHeader);
         $result = 0;
         $messages = [];
@@ -113,7 +112,7 @@ class ValidatePagesCommand extends ContainerAwareCommand
 
             $table->addRow($tableRow);
         }
-        $table->render($output);
+        $table->render();
 
         $style = new OutputFormatterStyle('red', null, ['bold', 'blink']);
         $output->getFormatter()->setStyle('error', $style);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ValidatePagesCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ValidatePagesCommandTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Command;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ValidatePagesCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    public function setUp()
+    {
+        $application = new Application($this->getContainer()->get('kernel'));
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+
+        $command = new ValidatePagesCommand();
+        $command->setApplication($application);
+        $command->setContainer($this->getContainer());
+        $this->tester = new CommandTester($command);
+
+        $this->setupPages();
+    }
+
+    public function testExecute()
+    {
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+        $this->assertCount(4, $homeDocument->getChildren());
+
+        $this->tester->execute([
+            'webspaceKey' => 'sulu_io',
+        ]);
+
+        // should complain on smartcontent, setupPages() sets up 2 smartcontent nodes
+        $output = $this->tester->getDisplay();
+        $this->assertContains('2 Errors found', $output);
+    }
+
+    /**
+     * Creates pages.
+     */
+    protected function setupPages()
+    {
+        $this->initPhpcr();
+
+        $testIoHomeDocument = $this->documentManager->find('/cmf/test_io/contents', 'de');
+
+        $page1 = $this->documentManager->create('page');
+        $page1->setStructureType('default');
+        $page1->setTitle('Node1');
+        $page1->setResourceSegment('/node1');
+        $this->documentManager->persist(
+            $page1,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page1_1 = $this->documentManager->create('page');
+        $page1_1->setStructureType('default');
+        $page1_1->setTitle('Node1-1');
+        $page1_1->getStructure()->bind(['article' => 'This is a perfect description.']);
+        $page1_1->setResourceSegment('/node1-1');
+        $this->documentManager->persist(
+            $page1_1,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents/node1',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page1_1_1 = $this->documentManager->create('page');
+        $page1_1_1->setStructureType('default');
+        $page1_1_1->setTitle('Node1-1-1');
+        $page1_1_1->getStructure()->bind(['article' => 'This is a perfect description.']);
+        $page1_1_1->setResourceSegment('/node1-1-1');
+        $this->documentManager->persist(
+            $page1_1_1,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents/node1/node1-1',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page2 = $this->documentManager->create('page');
+        $page2->setStructureType('smartcontent');
+        $page2->setTitle('Node2');
+        $page2->getStructure()->bind(
+            [
+                'title' => 'Node2',
+                'smart_content' => [
+                    'dataSource' => $page1->getUuid(),
+                ],
+            ]
+        );
+        $page2->setResourceSegment('/node2');
+        $this->documentManager->persist(
+            $page2,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page2_1 = $this->documentManager->create('page');
+        $page2_1->setStructureType('internallinks');
+        $page2_1->setTitle('Node2-1');
+        $page2_1->getStructure()->bind(
+            [
+                'title' => 'Node2-1',
+                'internalLinks' => [
+                    $page1->getUuid(),
+                    $page2->getUuid(),
+                    $testIoHomeDocument->getUuid(),
+                ],
+            ]
+        );
+        $page2_1->setResourceSegment('/node2-1');
+        $this->documentManager->persist(
+            $page2_1,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents/node2',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page2_1_1 = $this->documentManager->create('page');
+        $page2_1_1->setStructureType('default');
+        $page2_1_1->setTitle('Node2-1-1');
+        $page2_1_1->getStructure()->bind(['article' => 'This is a perfect description.']);
+        $page2_1_1->setResourceSegment('/node2-1-1');
+        $this->documentManager->persist(
+            $page2_1_1,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents/node2/node2-1',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page3 = $this->documentManager->create('page');
+        $page3->setStructureType('smartcontent');
+        $page3->setTitle('Node3');
+        $page3->getStructure()->bind(
+            [
+                'title' => 'Node3',
+                'smart_content' => [
+                    'dataSource' => $testIoHomeDocument->getUuid(),
+                ],
+            ]
+        );
+        $page3->setResourceSegment('/node3');
+        $this->documentManager->persist(
+            $page3,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents',
+            ]
+        );
+        $this->documentManager->flush();
+
+        $page4 = $this->documentManager->create('page');
+        $page4->setStructureType('block');
+        $page4->setTitle('Node4');
+        $page4->getStructure()->bind(
+            [
+                'title' => 'Node4',
+                'article' => [
+                    [
+                        'text' => '<p><sulu:link href="' . $page1->getUuid() . '" provider="page" target="_self" title="Link-Title">Link-Title</sulu:link></p>',
+                        'title' => 'Node4 block',
+                        'type' => 'textEditor',
+                    ],
+                ],
+            ]
+        );
+        $page4->setResourceSegment('/node4');
+        $this->documentManager->persist(
+            $page4,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents',
+            ]
+        );
+        $this->documentManager->flush();
+    }
+}

--- a/src/Sulu/Bundle/WebsocketBundle/Command/DumpWebsocketAppsCommand.php
+++ b/src/Sulu/Bundle/WebsocketBundle/Command/DumpWebsocketAppsCommand.php
@@ -42,8 +42,7 @@ class DumpWebsocketAppsCommand extends ContainerAwareCommand
     {
         $manager = $this->getContainer()->get(self::MANAGER_ID);
 
-        /** @var Table $table */
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table->setHeaders(['App-Name', 'Route', 'Allowed-Origins', 'Host-Name']);
 
         foreach ($manager->getApps() as $app) {
@@ -57,6 +56,6 @@ class DumpWebsocketAppsCommand extends ContainerAwareCommand
             );
         }
 
-        $table->render($output);
+        $table->render();
     }
 }

--- a/src/Sulu/Bundle/WebsocketBundle/Tests/Functional/Command/DumpWebsocketAppsCommandTest.php
+++ b/src/Sulu/Bundle/WebsocketBundle/Tests/Functional/Command/DumpWebsocketAppsCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsocketBundle\Command;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DumpWebsocketAppsCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    public function setUp()
+    {
+        $application = new Application($this->getContainer()->get('kernel'));
+        $command = new DumpWebsocketAppsCommand();
+        $command->setApplication($application);
+        $command->setContainer($this->getContainer());
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testExecute()
+    {
+        $this->tester->execute([]);
+
+        $output = $this->tester->getDisplay();
+
+        $this->assertContains('admin', $output);
+        $this->assertContains('localhost', $output);
+    }
+}

--- a/src/Sulu/Bundle/WebsocketBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/WebsocketBundle/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit bootstrap="../TestBundle/Resources/app/bootstrap.php" colors="true">
 
     <testsuites>
-        <testsuite name="SuluWebsite Test Suite">
+        <testsuite name="SuluWebsocketBundle Test Suite">
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
@@ -20,6 +20,7 @@
     <php>
         <server name="KERNEL_DIR" value="Tests/app"/>
         <var name="APP_DB" value="mysql"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3365
| Related issues/PRs | #2106
| License | MIT
| Documentation PR | -

#### What's in this PR?

Get rid of deprecated console helpers still used by some cli commands

#### Why?

This could be a show-stopper for Symfony 3.x support
