### PR TITLE
move the PageRule to ContentBundle

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -59,16 +59,6 @@
             <argument>%sulu_audience_targeting.hit.headers.referrer%</argument>
             <tag name="sulu.audience_target_rule" alias="referrer"/>
         </service>
-        <service id="sulu_audience_targeting.rules.page"
-                 class="Sulu\Bundle\AudienceTargetingBundle\Rule\PageRule">
-            <argument type="service" id="request_stack"/>
-            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
-            <argument type="service" id="translator"/>
-            <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
-            <argument>%sulu_audience_targeting.hit.headers.uuid%</argument>
-            <argument>%sulu_audience_targeting.headers.url%</argument>
-            <tag name="sulu.audience_target_rule" alias="page"/>
-        </service>
         <service id="sulu_audience_targeting.rules.query_string"
                  class="Sulu\Bundle\AudienceTargetingBundle\Rule\QueryStringRule">
             <argument type="service" id="request_stack"/>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
@@ -70,10 +70,6 @@
                 <source>smart-content.audience-targeting</source>
                 <target>Zielgruppen berücksichtigen</target>
             </trans-unit>
-            <trans-unit id="target-group-19" resname="sulu_audience_targeting.rules.page">
-                <source>sulu_audience_targeting.rules.page</source>
-                <target>Seite</target>
-            </trans-unit>
             <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
@@ -70,10 +70,6 @@
                 <source>smart-content.audience-targeting</source>
                 <target>Use target groups</target>
             </trans-unit>
-            <trans-unit id="target-group-19" resname="sulu_audience_targeting.rules.page">
-                <source>sulu_audience_targeting.rules.page</source>
-                <target>Page</target>
-            </trans-unit>
             <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
@@ -70,10 +70,6 @@
                 <source>smart-content.audience-targeting</source>
                 <target>Utiliser les groupes ciblés</target>
             </trans-unit>
-            <trans-unit id="target-group-19" resname="sulu_audience_targeting.rules.page">
-                <source>sulu_audience_targeting.rules.page</source>
-                <target>Page</target>
-            </trans-unit>
             <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
@@ -70,10 +70,6 @@
                 <source>smart-content.audience-targeting</source>
                 <target>Gebruik doelgroepen</target>
             </trans-unit>
-            <trans-unit id="target-group-19" resname="sulu_audience_targeting.rules.page">
-                <source>sulu_audience_targeting.rules.page</source>
-                <target>Pagina</target>
-            </trans-unit>
             <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -155,6 +155,10 @@ class SuluContentExtension extends Extension implements PrependExtensionInterfac
         if (array_key_exists('SuluAutomationBundle', $bundles)) {
             $loader->load('automation.xml');
         }
+
+        if (array_key_exists('SuluAudienceTargetingBundle', $bundles)) {
+            $loader->load('rule.xml');
+        }
     }
 
     private function processTemplates(ContainerBuilder $container, $config)

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/rule.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/rule.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_audience_targeting.rules.page"
+                 class="Sulu\Bundle\ContentBundle\Rule\PageRule">
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="translator"/>
+            <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
+            <argument>%sulu_audience_targeting.hit.headers.uuid%</argument>
+            <argument>%sulu_audience_targeting.headers.url%</argument>
+            <tag name="sulu.audience_target_rule" alias="page"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.de.xlf
@@ -847,6 +847,10 @@
                  <source>sulu.content.form.settings.authored</source>
                  <target>Verfasst am</target>
              </trans-unit>
+            <trans-unit id="81" resname="sulu_content.rules.page">
+                <source>sulu_content.rules.page</source>
+                <target>Seite</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.en.xlf
@@ -847,6 +847,10 @@
                  <source>sulu.content.form.settings.authored</source>
                  <target>Authored Date</target>
              </trans-unit>
+            <trans-unit id="81" resname="sulu_content.rules.page">
+                <source>sulu_content.rules.page</source>
+                <target>Page</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.fr.xlf
@@ -847,6 +847,10 @@
                  <source>sulu.content.form.settings.authored</source>
                  <target>Date</target>
              </trans-unit>
+            <trans-unit id="81" resname="sulu_content.rules.page">
+                <source>sulu_content.rules.page</source>
+                <target>Page</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/sulu/backend.nl.xlf
@@ -847,6 +847,10 @@
                  <source>sulu.content.form.settings.authored</source>
                  <target>Auteur Datum</target>
              </trans-unit>
+            <trans-unit id="81" resname="sulu_content.rules.page">
+                <source>sulu_content.rules.page</source>
+                <target>Pagina</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/ContentBundle/Rule/PageRule.php
+++ b/src/Sulu/Bundle/ContentBundle/Rule/PageRule.php
@@ -9,8 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+namespace Sulu\Bundle\ContentBundle\Rule;
 
+use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\Type\InternalLink;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -114,7 +115,7 @@ class PageRule implements RuleInterface
      */
     public function getName()
     {
-        return $this->translator->trans('sulu_audience_targeting.rules.page', [], 'backend');
+        return $this->translator->trans('sulu_content.rules.page', [], 'backend');
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Rule/PageRuleTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Rule/PageRuleTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\Rule;
 
-use Sulu\Bundle\AudienceTargetingBundle\Rule\PageRule;
+use Sulu\Bundle\ContentBundle\Rule\PageRule;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyInterface;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\Localization\Localization;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR moves the `PageRule` from the `AudienceTargetingBundle` to the `ContentBundle`, because that's the correct location. If you think further the `ArticleBundle` will also have its own rule later.