### PR TITLE
added audience targeting rule for query string

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/services.xml
@@ -69,6 +69,13 @@
             <argument>%sulu_audience_targeting.headers.url%</argument>
             <tag name="sulu.audience_target_rule" alias="page"/>
         </service>
+        <service id="sulu_audience_targeting.rules.query_string"
+                 class="Sulu\Bundle\AudienceTargetingBundle\Rule\QueryStringRule">
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="translator"/>
+            <argument>%sulu_audience_targeting.headers.url%</argument>
+            <tag name="sulu.audience_target_rule" alias="query_string"/>
+        </service>
         <!--CONTENT TYPES-->
         <service id="sulu_audience_targeting.content.type.audience_targeting_groups"
                  class="Sulu\Bundle\AudienceTargetingBundle\Content\Types\AudienceTargetingGroups">

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
@@ -78,6 +78,14 @@
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>
             </trans-unit>
+            <trans-unit id="target-group-21" resname="sulu_audience_targeting.rules.query_string_parameter">
+                <source>sulu_audience_targeting.rules.query_string_parameter</source>
+                <target>Parameter</target>
+            </trans-unit>
+            <trans-unit id="target-group-22" resname="sulu_audience_targeting.rules.query_string_value">
+                <source>sulu_audience_targeting.rules.query_string_value</source>
+                <target>Wert</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
@@ -74,6 +74,10 @@
                 <source>sulu_audience_targeting.rules.page</source>
                 <target>Seite</target>
             </trans-unit>
+            <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
+                <source>sulu_audience_targeting.rules.query_string</source>
+                <target>Query String</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
@@ -78,6 +78,14 @@
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>
             </trans-unit>
+            <trans-unit id="target-group-21" resname="sulu_audience_targeting.rules.query_string_parameter">
+                <source>sulu_audience_targeting.rules.query_string_parameter</source>
+                <target>Parameter</target>
+            </trans-unit>
+            <trans-unit id="target-group-22" resname="sulu_audience_targeting.rules.query_string_value">
+                <source>sulu_audience_targeting.rules.query_string_value</source>
+                <target>Value</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
@@ -74,6 +74,10 @@
                 <source>sulu_audience_targeting.rules.page</source>
                 <target>Page</target>
             </trans-unit>
+            <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
+                <source>sulu_audience_targeting.rules.query_string</source>
+                <target>Query String</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
@@ -78,6 +78,14 @@
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>
             </trans-unit>
+            <trans-unit id="target-group-21" resname="sulu_audience_targeting.rules.query_string_parameter">
+                <source>sulu_audience_targeting.rules.query_string_parameter</source>
+                <target>le paramètre</target>
+            </trans-unit>
+            <trans-unit id="target-group-22" resname="sulu_audience_targeting.rules.query_string_value">
+                <source>sulu_audience_targeting.rules.query_string_value</source>
+                <target>la valeur</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
@@ -74,6 +74,10 @@
                 <source>sulu_audience_targeting.rules.page</source>
                 <target>Page</target>
             </trans-unit>
+            <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
+                <source>sulu_audience_targeting.rules.query_string</source>
+                <target>Query String</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
@@ -74,6 +74,10 @@
                 <source>sulu_audience_targeting.rules.page</source>
                 <target>Pagina</target>
             </trans-unit>
+            <trans-unit id="target-group-20" resname="sulu_audience_targeting.rules.query_string">
+                <source>sulu_audience_targeting.rules.query_string</source>
+                <target>Query String</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
@@ -78,6 +78,14 @@
                 <source>sulu_audience_targeting.rules.query_string</source>
                 <target>Query String</target>
             </trans-unit>
+            <trans-unit id="target-group-21" resname="sulu_audience_targeting.rules.query_string_parameter">
+                <source>sulu_audience_targeting.rules.query_string_parameter</source>
+                <target>Parameter</target>
+            </trans-unit>
+            <trans-unit id="target-group-22" resname="sulu_audience_targeting.rules.query_string_value">
+                <source>sulu_audience_targeting.rules.query_string_value</source>
+                <target>Waarde</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/QueryStringRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/QueryStringRule.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule;
+
+use Sulu\Bundle\AudienceTargetingBundle\Rule\Type\KeyValue;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class QueryStringRule implements RuleInterface
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var string
+     */
+    private $urlHeader;
+
+    public function __construct(RequestStack $requestStack, TranslatorInterface $translator, $urlHeader)
+    {
+        $this->requestStack = $requestStack;
+        $this->translator = $translator;
+        $this->urlHeader = $urlHeader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evaluate(array $options)
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if ($url = $request->headers->get($this->urlHeader)) {
+            // the URL from the header has precedence over the real URL
+            // the header is set in the target group hit request
+            $request = Request::create($url);
+        }
+
+        $value = $request->get($options['parameter']);
+        if (!$value) {
+            return false;
+        }
+
+        return $value == $options['value'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->translator->trans('sulu_audience_targeting.rules.query_string', [], 'backend');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return new KeyValue('parameter', 'value');
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/QueryStringRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/QueryStringRule.php
@@ -73,6 +73,11 @@ class QueryStringRule implements RuleInterface
      */
     public function getType()
     {
-        return new KeyValue('parameter', 'value');
+        return new KeyValue(
+            'parameter',
+            'value',
+            $this->translator->trans('sulu_audience_targeting.rules.query_string_parameter', [], 'backend'),
+            $this->translator->trans('sulu_audience_targeting.rules.query_string_value', [], 'backend')
+        );
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/Type/KeyValue.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/Type/KeyValue.php
@@ -23,10 +23,22 @@ class KeyValue implements RuleTypeInterface
      */
     private $valueName;
 
-    public function __construct($keyName, $valueName)
+    /**
+     * @var string
+     */
+    private $keyPlaceholder;
+
+    /**
+     * @var string
+     */
+    private $valuePlaceholder;
+
+    public function __construct($keyName, $valueName, $keyPlaceholder, $valuePlaceHolder)
     {
         $this->keyName = $keyName;
         $this->valueName = $valueName;
+        $this->keyPlaceholder = $keyPlaceholder;
+        $this->valuePlaceholder = $valuePlaceHolder;
     }
 
     /**
@@ -38,13 +50,15 @@ class KeyValue implements RuleTypeInterface
                 <input class="form-element"
                        type="text"
                        data-rule-type="text"
-                       data-condition-name="' . $this->keyName . '" />
+                       data-condition-name="' . $this->keyName . '"
+                       placeholder="' . $this->keyPlaceholder . '"/>
             </div>
             <div class="grid-col-6">
                 <input class="form-element"
                        type="text"
                        data-rule-type="text"
-                       data-condition-name="' . $this->valueName . '" />
+                       data-condition-name="' . $this->valueName . '"
+                       placeholder="' . $this->valuePlaceholder . '"/>
             </div>';
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Rule/Type/KeyValue.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Rule/Type/KeyValue.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Rule\Type;
+
+class KeyValue implements RuleTypeInterface
+{
+    /**
+     * @var string
+     */
+    private $keyName;
+
+    /**
+     * @var string
+     */
+    private $valueName;
+
+    public function __construct($keyName, $valueName)
+    {
+        $this->keyName = $keyName;
+        $this->valueName = $valueName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplate()
+    {
+        return '<div class="grid-col-6">
+                <input class="form-element"
+                       type="text"
+                       data-rule-type="text"
+                       data-condition-name="' . $this->keyName . '" />
+            </div>
+            <div class="grid-col-6">
+                <input class="form-element"
+                       type="text"
+                       data-rule-type="text"
+                       data-condition-name="' . $this->valueName . '" />
+            </div>';
+    }
+}

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/QueryStringRuleTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Rule;
+
+use Sulu\Bundle\AudienceTargetingBundle\Rule\QueryStringRule;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class QueryStringRuleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function setUp()
+    {
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+    }
+
+    /**
+     * @dataProvider provideEvaluate
+     */
+    public function testEvaluate($url, $urlHeader, $urlHeaderValue, $options, $result)
+    {
+        $queryStringRule = new QueryStringRule($this->requestStack->reveal(), $this->translator->reveal(), $urlHeader);
+
+        $request = Request::create($url);
+        $request->headers->set($urlHeader, $urlHeaderValue);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+        $this->assertEquals($result, $queryStringRule->evaluate($options));
+    }
+
+    public function provideEvaluate()
+    {
+        return [
+            [
+                'http://sulu.lo?test=asdf',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test', 'value' => 'asdf'],
+                true,
+            ],
+            [
+                'http://sulu.lo?test1=asdf&test2=jkl',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test1', 'value' => 'asdf'],
+                true,
+            ],
+            [
+                'http://sulu.lo?test1=asdf&test2=jkl',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test2', 'value' => 'jkl'],
+                true,
+            ],
+            [
+                'http://sulu.lo?test=jkl',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test', 'value' => 'asdf'],
+                false,
+            ],
+            [
+                'http://sulu.lo?test=asdf',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test1', 'value' => 'asdf'],
+                false,
+            ],
+            [
+                'http://sulu.lo?test1=asdf&test2=jkl',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test2', 'value' => 'j'],
+                false,
+            ],
+            [
+                'http://sulu.lo?test1=asdf&test2=jkl',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test3', 'value' => 'asdf'],
+                false,
+            ],
+            [
+                'http://sulu.lo',
+                'X-Forwarded-URL',
+                null,
+                ['parameter' => 'test1', 'value' => 'asdf'],
+                false,
+            ],
+            [
+                'http://sulu.lo/_target_group_hit',
+                'X-Forwarded-URL',
+                'http://sulu.lo?test=asdf',
+                ['parameter' => 'test', 'value' => 'asdf'],
+                true,
+            ],
+            [
+                'http://sulu.lo/_target_group_hit',
+                'X-Forwarded-URL',
+                'http://sulu.lo?test1=asdf',
+                ['parameter' => 'test', 'value' => 'asdf'],
+                false,
+            ],
+            [
+                'http://sulu.lo/_target_group_hit?test=asdf',
+                'X-Forwarded-URL',
+                'http://sulu.lo?test1=asdf',
+                ['parameter' => 'test', 'value' => 'asdf'],
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes parts of #3203 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds a rule which allows to define certain values of the query string.

#### Why?

E.g. the target group could check this way if the user landed here because of a campaign.