### PR TITLE
renamed audience targeting cookies

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
@@ -52,10 +52,10 @@ class CachingTest extends SuluTestCase
         $this->assertCount(2, $response->headers->getCookies());
         /** @var Cookie $visitorTargetGroupCookie */
         $visitorTargetGroupCookie = $response->headers->getCookies()[0];
-        $this->assertEquals('sulu-visitor-target-group', $visitorTargetGroupCookie->getName());
+        $this->assertEquals('_svtg', $visitorTargetGroupCookie->getName());
         $this->assertEquals($targetGroup->getId(), $visitorTargetGroupCookie->getValue());
         $visitorSessionCookie = $response->headers->getCookies()[1];
-        $this->assertEquals('sulu-visitor-session', $visitorSessionCookie->getName());
+        $this->assertEquals('_svs', $visitorSessionCookie->getName());
 
         return [$client, $cookieJar];
     }
@@ -89,10 +89,10 @@ class CachingTest extends SuluTestCase
         $this->assertCount(2, $response->headers->getCookies());
         /** @var Cookie $cookie */
         $visitorTargetGroupCookie = $response->headers->getCookies()[0];
-        $this->assertEquals('sulu-visitor-target-group', $visitorTargetGroupCookie->getName());
+        $this->assertEquals('_svtg', $visitorTargetGroupCookie->getName());
         $this->assertEquals(0, $visitorTargetGroupCookie->getValue());
         $visitorSessionCookie = $response->headers->getCookies()[1];
-        $this->assertEquals('sulu-visitor-session', $visitorSessionCookie->getName());
+        $this->assertEquals('_svs', $visitorSessionCookie->getName());
 
         return [$client, $cookieJar];
     }
@@ -106,7 +106,7 @@ class CachingTest extends SuluTestCase
         /** @var CookieJar $cookieJar */
         list($client, $cookieJar) = $arguments;
 
-        $cookieJar->expire('sulu-visitor-session');
+        $cookieJar->expire('_svs');
 
         $client->request('GET', '/');
         $response = $client->getResponse();
@@ -115,9 +115,9 @@ class CachingTest extends SuluTestCase
 
         /** @var Cookie $visitorTargetGroupCookie */
         $visitorTargetGroupCookie = $response->headers->getCookies()[0];
-        $this->assertEquals('sulu-visitor-target-group', $visitorTargetGroupCookie->getName());
+        $this->assertEquals('_svtg', $visitorTargetGroupCookie->getName());
         $visitorSessionCookie = $response->headers->getCookies()[1];
-        $this->assertEquals('sulu-visitor-session', $visitorSessionCookie->getName());
+        $this->assertEquals('_svs', $visitorSessionCookie->getName());
 
         return [$client, $cookieJar];
     }
@@ -131,7 +131,7 @@ class CachingTest extends SuluTestCase
         /** @var CookieJar $cookieJar */
         list($client, $cookieJar) = $arguments;
 
-        $cookieJar->expire('sulu-visitor-session');
+        $cookieJar->expire('_svs');
 
         $targetGroup1 = $this->createTargetGroup(
             5,
@@ -154,10 +154,10 @@ class CachingTest extends SuluTestCase
 
         /** @var Cookie $visitorTargetGroupCookie */
         $visitorTargetGroupCookie = $response->headers->getCookies()[0];
-        $this->assertEquals('sulu-visitor-target-group', $visitorTargetGroupCookie->getName());
+        $this->assertEquals('_svtg', $visitorTargetGroupCookie->getName());
         $this->assertEquals($targetGroup2->getId(), $visitorTargetGroupCookie->getValue());
         $visitorSessionCookie = $response->headers->getCookies()[1];
-        $this->assertEquals('sulu-visitor-session', $visitorSessionCookie->getName());
+        $this->assertEquals('_svs', $visitorSessionCookie->getName());
     }
 
     /**

--- a/src/Sulu/Component/HttpCache/HttpCache.php
+++ b/src/Sulu/Component/HttpCache/HttpCache.php
@@ -29,11 +29,11 @@ class HttpCache extends AbstractHttpCache
 
     const TARGET_GROUP_HEADER = 'X-Sulu-Target-Group';
 
-    const TARGET_GROUP_COOKIE = 'sulu-visitor-target-group';
+    const TARGET_GROUP_COOKIE = '_svtg';
 
     const TARGET_GROUP_COOKIE_LIFETIME = 2147483647;
 
-    const VISITOR_SESSION_COOKIE = 'sulu-visitor-session';
+    const VISITOR_SESSION_COOKIE = '_svs';
 
     const USER_CONTEXT_URL_HEADER = 'X-Forwarded-URL';
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/329

#### What's in this PR?

Renamed cookies from audience targeting to shorter names.