### PR TITLE
fixed usage of Sulu with non-default HTTP port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * BUGFIX      #3384 [Webspace]              Fixed usage of Sulu with non-default HTTP port
+    * ENHANCEMENT #3343 [MediaBundle]           Use media disposition type config to serve media files
+
 * 1.6.0-RC1 (2017-06-01)
     * BUGFIX      #3381 [WebsiteBundle]         Fixed partial redirect
     * BUGFIX      #3379 [All]                   Upgraded to Symfony 3.3
@@ -16,7 +20,6 @@ CHANGELOG for Sulu
     * BUGFIX      #3350 [RouteBundle]           Fixed restore route when conflict resolver is disabled
     * BUGFIX      #3352 [RouteBundle]           Added default value to route-created field
     * ENHANCEMENT #3344 [ContentBundle]         Added possibility to add additional attributes to "sulu:link"-tag
-    * ENHANCEMENT #3343 [MediaBundle]           Use media disposition type config to serve media files
     * ENHANCEMENT #3345 [CustomUrlBundle]       Added redirect parameter of custom-url
     * BUGFIX      #3342 [ContentBundle]         Fixed "sulu:content:types:dump" command
     * BUGFIX      #3338 [ContentBundle]         Fixed overwrite data in content-serialization

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Request/ForwardedUrlRequestProcessor.php
@@ -44,9 +44,10 @@ class ForwardedUrlRequestProcessor implements RequestProcessorInterface
         }
 
         $originalRequest = Request::create($request->headers->get($this->urlHeader));
-        $host = $originalRequest->getHttpHost();
+        $host = $originalRequest->getHost();
+        $port = $originalRequest->getPort();
 
-        return new RequestAttributes(['host' => $host, 'path' => $originalRequest->getPathInfo()]);
+        return new RequestAttributes(['host' => $host, 'port' => $port, 'path' => $originalRequest->getPathInfo()]);
     }
 
     /**

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
@@ -20,7 +20,7 @@ class ForwardedUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideProcess
      */
-    public function testProcess($urlHeader, $url, $host, $path)
+    public function testProcess($urlHeader, $url, $host, $port, $path)
     {
         $forwardedUrlRequestProcessor = new ForwardedUrlRequestProcessor($urlHeader);
         $request = new Request();
@@ -28,15 +28,16 @@ class ForwardedUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $requestAttributes = $forwardedUrlRequestProcessor->process($request, new RequestAttributes());
 
         $this->assertEquals($host, $requestAttributes->getAttribute('host'));
+        $this->assertEquals($port, $requestAttributes->getAttribute('port'));
         $this->assertEquals($path, $requestAttributes->getAttribute('path'));
     }
 
     public function provideProcess()
     {
         return [
-            ['X-Forwarded-Url', 'http://127.0.0.1:8000/en/test', '127.0.0.1:8000', '/en/test'],
-            ['X-Url', 'http://sulu.lo/en/test', 'sulu.lo', '/en/test'],
-            ['X-Forwarded-Url', 'http://sulu.lo/de/test', 'sulu.lo', '/de/test'],
+            ['X-Forwarded-Url', 'http://127.0.0.1:8000/en/test', '127.0.0.1', 8000, '/en/test'],
+            ['X-Url', 'http://sulu.lo/en/test', 'sulu.lo', 80, '/en/test'],
+            ['X-Forwarded-Url', 'http://sulu.lo/de/test', 'sulu.lo', 80, '/de/test'],
         ];
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentPathTwigExtensionTest.php
@@ -82,6 +82,7 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPath()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -94,9 +95,60 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
     }
 
+    public function testGetContentPathWithPort()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(8000);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'http'
+        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io:8000/de/test', $this->extension->getContentPath('/test'));
+    }
+
+    public function testGetContentPathWithHttpsPort()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('scheme')->willReturn('https');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(444);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'https'
+        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io:444/de/test', $this->extension->getContentPath('/test'));
+    }
+
+    public function testGetContentPathWithDefaultHttpsPort()
+    {
+        $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('scheme')->willReturn('https');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(443);
+        $this->webspaceManager->findUrlByResourceLocator(
+            '/test',
+            $this->environment,
+            'de',
+            'sulu_io',
+            'www.sulu.io',
+            'https'
+        )->willReturn('www.sulu.io/de/test')->shouldBeCalledTimes(1);
+
+        $this->assertEquals('www.sulu.io/de/test', $this->extension->getContentPath('/test'));
+    }
+
     public function testGetContentPathWithLocaleForDifferentDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('en.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -112,6 +164,7 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPathWithWebspaceKey()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,
@@ -127,6 +180,7 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPathWithWebspaceKeyNotFoundForDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.test.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
 
         // empty webspace object will not contain domain as tested in isFromDomain call
         $webspace = new Webspace();
@@ -147,6 +201,7 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPathWithWebspaceKeyHostNotWebspace()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.xy.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->testWebspace->hasDomain('www.xy.io', $this->environment, 'de')->willReturn(false);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
@@ -163,6 +218,7 @@ class ContentPathTwigExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetContentPathWithWebspaceKeyAndDomain()
     {
         $this->requestAnalyzer->getAttribute('host')->willReturn('www.sulu.io');
+        $this->requestAnalyzer->getAttribute('port')->willReturn(80);
         $this->webspaceManager->findUrlByResourceLocator(
             '/test',
             $this->environment,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -87,6 +87,13 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
             $scheme
         );
 
+        $port = $this->requestAnalyzer->getAttribute('port');
+        if ($url && strpos($url, $host) !== false) {
+            if (!('http' == $scheme && $port == 80) && !('https' == $scheme && $port == 443)) {
+                $url = str_replace($host, $host . ':' . $port, $url);
+            }
+        }
+
         if (!$withoutDomain && !$url) {
             $url = $this->webspaceManager->findUrlByResourceLocator(
                 $route,

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -71,7 +71,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         $attributes['resourceLocator'] = $resourceLocator;
         $attributes['format'] = $format;
 
-        $attributes['resourceLocatorPrefix'] = substr($portalInformation->getUrl(), strlen($request->getHttpHost()));
+        $attributes['resourceLocatorPrefix'] = substr($portalInformation->getUrl(), strlen($request->getHost()));
 
         if (null !== $format) {
             $request->setRequestFormat($format);
@@ -110,7 +110,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         }
 
         $resourceLocator = substr(
-            $request->getHttpHost() . $path,
+            $request->getHost() . $path,
             strlen($portalInformation->getUrl())
         );
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/UrlRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/UrlRequestProcessor.php
@@ -23,9 +23,10 @@ class UrlRequestProcessor implements RequestProcessorInterface
      */
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
-        $host = $request->getHttpHost();
+        $host = $request->getHost();
+        $port = $request->getPort();
 
-        return new RequestAttributes(['host' => $host, 'path' => $request->getPathInfo()]);
+        return new RequestAttributes(['host' => $host, 'port' => $port, 'path' => $request->getPathInfo()]);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -148,34 +148,6 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
     }
 
-    public function testProcessWithPort()
-    {
-        $portalInformation = new PortalInformation(
-            RequestAnalyzerInterface::MATCH_TYPE_FULL,
-            null,
-            null,
-            null,
-            'sulu.lo:8000/test'
-        );
-
-        $request = new Request(
-            [],
-            [],
-            [],
-            [],
-            [],
-            ['HTTP_HOST' => 'sulu.lo:8000']
-        );
-
-        $attributes = $this->portalInformationRequestProcessor->process(
-            $request,
-            new RequestAttributes(['portalInformation' => $portalInformation, 'path' => '/test/path/to'])
-        );
-
-        $this->assertEquals('/path/to', $attributes->getAttribute('resourceLocator'));
-        $this->assertEquals('/test', $attributes->getAttribute('resourceLocatorPrefix'));
-    }
-
     public function testValidate()
     {
         $this->assertTrue($this->portalInformationRequestProcessor->validate(new RequestAttributes()));

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
@@ -30,21 +30,22 @@ class UrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideProcess
      */
-    public function testProcess($url, $host, $path)
+    public function testProcess($url, $host, $port, $path)
     {
         $request = Request::create($url);
         $requestAttributes = $this->urlRequestProcessor->process($request, new RequestAttributes());
 
         $this->assertEquals($host, $requestAttributes->getAttribute('host'));
+        $this->assertEquals($port, $requestAttributes->getAttribute('port'));
         $this->assertEquals($path, $requestAttributes->getAttribute('path'));
     }
 
     public function provideProcess()
     {
         return [
-            ['http://127.0.0.1:8000/en/test', '127.0.0.1:8000', '/en/test'],
-            ['http://sulu.lo/en/test', 'sulu.lo', '/en/test'],
-            ['http://sulu.lo/de/test', 'sulu.lo', '/de/test'],
+            ['http://127.0.0.1:8000/en/test', '127.0.0.1', 8000, '/en/test'],
+            ['http://sulu.lo/en/test', 'sulu.lo', 80, '/en/test'],
+            ['http://sulu.lo/de/test', 'sulu.lo', 80, '/de/test'],
         ];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | replaces https://github.com/sulu/sulu/pull/3211
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR replaces `Request::getHttpHost` calls with `Request::getHost`.

#### Why?

The difference between these calls is, that `getHttpHost` also includes the port if it is a non-default port. The problem with that is, that our application should actually not care about the port at all, as it is also the case with Symfony. (also see comment in https://github.com/sulu/sulu/pull/3211#issuecomment-280271005)

The thing is that we can't solve all of that at once. So for now I fixed this call everywhere, but our `sulu_content_path` twig method still have to add the port to the resulting URL. But at least we have to care about the port at a single location now.