### PR TITLE
fixed UserLocaleListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3385 [SecurityBundle]        Fixed UserLocaleListener
     * BUGFIX      #3384 [Webspace]              Fixed usage of Sulu with non-default HTTP port
     * ENHANCEMENT #3343 [MediaBundle]           Use media disposition type config to serve media files
 

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\SecurityBundle\EventListener;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Sets the locale of the current User to the request. Required for the translator to work properly.
@@ -25,9 +26,15 @@ class UserLocaleListener
      */
     private $tokenStorage;
 
-    public function __construct(TokenStorageInterface $tokenStorage)
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
     {
         $this->tokenStorage = $tokenStorage;
+        $this->translator = $translator;
     }
 
     /**
@@ -47,6 +54,8 @@ class UserLocaleListener
             return;
         }
 
-        $event->getRequest()->setLocale($user->getLocale());
+        $locale = $user->getLocale();
+        $event->getRequest()->setLocale($locale);
+        $this->translator->setLocale($locale);
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -173,6 +173,14 @@
             <tag name="twig.extension"/>
         </service>
 
+        <service id="sulu_security.user_locale_listener"
+                 class="Sulu\Bundle\SecurityBundle\EventListener\UserLocaleListener">
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="translator"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="copyUserLocaleToRequest"/>
+            <tag name="sulu.context" context="admin"/>
+        </service>
+
         <service id="sulu_security.js_config" class="Sulu\Bundle\SecurityBundle\Security\SecurityConfig">
             <argument type="string">sulu_security.contexts</argument>
             <argument type="service" id="sulu_security.access_control_manager"/>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
@@ -18,14 +18,10 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var UserInterface
-     */
-    private $user;
-
     /**
      * @var TokenInterface
      */
@@ -35,6 +31,11 @@ class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
      * @var TokenStorageInterface
      */
     private $tokenStorage;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
     /**
      * @var Request
@@ -62,13 +63,16 @@ class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
         $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
         $this->tokenStorage->getToken()->willReturn($this->token->reveal());
 
-        $this->userLocaleListener = new UserLocaleListener($this->tokenStorage->reveal());
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+
+        $this->userLocaleListener = new UserLocaleListener($this->tokenStorage->reveal(), $this->translator->reveal());
     }
 
     public function testCopyUserLocaleToRequestWithoutUser()
     {
         $this->request->setLocale(Argument::any())->shouldNotBeCalled();
         $this->userLocaleListener->copyUserLocaleToRequest($this->event->reveal());
+        $this->translator->setLocale(Argument::any())->shouldNotBeCalled();
     }
 
     public function testCopyUserLocaleToRequest()
@@ -78,6 +82,7 @@ class UserLocaleListenerTest extends \PHPUnit_Framework_TestCase
         $this->token->getUser()->willReturn($user);
 
         $this->request->setLocale('de')->shouldBeCalled();
+        $this->translator->setLocale('de')->shouldBeCalled();
         $this->userLocaleListener->copyUserLocaleToRequest($this->event->reveal());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #---
| Related issues/PRs | #---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the `UserLocaleListener`. It has to set the locale on both the `Request` and the `Translator`, because it cannot have a higher priority than the 

#### Why?

This bug was the reason that the conditions in the audience targeting were not translated.