### PR TITLE
Avoid BC break in content-type "route" form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG for Sulu
     * BUGFIX      #3385 [SecurityBundle]          Fixed UserLocaleListener
     * BUGFIX      #3384 [Webspace]                Fixed usage of Sulu with non-default HTTP port
     * ENHANCEMENT #3343 [MediaBundle]             Use media disposition type config to serve media files
+    * ENHANCEMENT #3390 [RouteBundle]             Avoid BC break in content-type "route" form
 
 * 1.6.0-RC1 (2017-06-01)
     * BUGFIX      #3381 [WebsiteBundle]         Fixed partial redirect

--- a/src/Sulu/Bundle/RouteBundle/Resources/views/Template/content-types/route.html.twig
+++ b/src/Sulu/Bundle/RouteBundle/Resources/views/Template/content-types/route.html.twig
@@ -5,7 +5,7 @@
      data-form="true"
      data-type="resourceLocator"
      data-aura-component="resource-locator@sulucontent"
-     data-aura-history-api="/admin/api/routes?history=true&entityClass=<%= entityClass %>&entityId=<%= entityId %>&locale={{ languageCode }}"
+     data-aura-history-api="<% if(typeof entityClass !== 'undefined') { %>/admin/api/routes?history=true&entityClass=<%= entityClass %>&entityId=<%= entityId %>&locale={{ languageCode }}<% } %>"
      data-aura-history-result-key="routes"
      data-aura-path-key="path"
      data-type-instance-name="{{ id|raw }}"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | avoid one
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR avoid a BC break in the content form for  `route` content-type.

#### Why?

The form will be used in SuluArticleBundle and breaks current versions with the current RC1.
