### PR TITLE
Fixed smart-content out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-develop
     * BUGFIX      #3391 [SnippetBundle]           Snippet list: Changed field sortable; Fixed bug with copy locale functionality
     * ENHANCEMENT #3393 [AudienceTargetingBundle] Added translations for frequencies
+    * BUGFIX      #3392 [ContentBundle]           Fixed smart-content out of range
     * FEATURE     #3387 [AudienceTargetingBundle] Added rule for detecting device type
     * BUGFIX      #3385 [SecurityBundle]          Fixed UserLocaleListener
     * BUGFIX      #3384 [Webspace]                Fixed usage of Sulu with non-default HTTP port

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\ContentBundle\Form\Type\HomeDocumentType;
 use Sulu\Bundle\ContentBundle\Form\Type\PageDocumentType;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
-use Sulu\Component\SmartContent\Exception\PageOutOfBoundsException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -88,7 +87,6 @@ class SuluContentExtension extends Extension implements PrependExtensionInterfac
                     'exception' => [
                         'codes' => [
                             ResourceLocatorAlreadyExistsException::class => 409,
-                            PageOutOfBoundsException::class => 404,
                         ],
                     ],
                 ]

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -17,6 +17,8 @@ use Sulu\Bundle\ContentBundle\Document\RouteDocument;
 use Sulu\Bundle\ContentBundle\Form\Type\HomeDocumentType;
 use Sulu\Bundle\ContentBundle\Form\Type\PageDocumentType;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
+use Sulu\Component\SmartContent\Exception\PageOutOfBoundsException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -85,7 +87,8 @@ class SuluContentExtension extends Extension implements PrependExtensionInterfac
                 [
                     'exception' => [
                         'codes' => [
-                            'Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException' => 409,
+                            ResourceLocatorAlreadyExistsException::class => 409,
+                            PageOutOfBoundsException::class => 404,
                         ],
                     ],
                 ]

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -382,13 +382,18 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
      */
     private function getCurrentPage($pageParameter)
     {
-        if ($this->requestStack->getCurrentRequest() !== null) {
-            $page = $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
-        } else {
-            $page = 1;
+        if ($this->requestStack->getCurrentRequest() === null) {
+            return 1;
         }
 
-        return intval($page);
+        $page = $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
+        if ($page < 1) {
+            return 1;
+        } elseif ($page > PHP_INT_MAX) {
+            return PHP_INT_MAX;
+        }
+
+        return $page;
     }
 
     /**

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -298,6 +298,10 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
                 $page,
                 $pageSize
             );
+
+            if ($page > 1 && 0 === count($data->getItems())) {
+                throw new PageOutOfBoundsException($page);
+            }
         } else {
             $data = $provider->resolveResourceItems(
                 $filters,

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
+use Sulu\Component\SmartContent\Exception\PageOutOfBoundsException;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 use Sulu\Component\Util\ArrayableInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -379,6 +380,8 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
      * @param string $pageParameter
      *
      * @return int
+     *
+     * @throws PageOutOfBoundsException
      */
     private function getCurrentPage($pageParameter)
     {
@@ -387,10 +390,8 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         }
 
         $page = $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
-        if ($page < 1) {
-            return 1;
-        } elseif ($page > PHP_INT_MAX) {
-            return PHP_INT_MAX;
+        if ($page < 1 || $page > PHP_INT_MAX) {
+            throw new PageOutOfBoundsException($page);
         }
 
         return $page;

--- a/src/Sulu/Component/SmartContent/Exception/PageOutOfBoundsException.php
+++ b/src/Sulu/Component/SmartContent/Exception/PageOutOfBoundsException.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\SmartContent\Exception;
+
+/**
+ * The requested page was out of bounds.
+ */
+class PageOutOfBoundsException extends SmartContentException
+{
+    /**
+     * @var int
+     */
+    private $page;
+
+    /**
+     * @param int $page
+     */
+    public function __construct($page)
+    {
+        parent::__construct(sprintf('Page "%s" out of bounds exception.', $page));
+
+        $this->page = $page;
+    }
+
+    /**
+     * Returns page.
+     *
+     * @return int
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+}

--- a/src/Sulu/Component/SmartContent/Exception/PageOutOfBoundsException.php
+++ b/src/Sulu/Component/SmartContent/Exception/PageOutOfBoundsException.php
@@ -11,10 +11,12 @@
 
 namespace Sulu\Component\SmartContent\Exception;
 
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
 /**
  * The requested page was out of bounds.
  */
-class PageOutOfBoundsException extends SmartContentException
+class PageOutOfBoundsException extends NotFoundHttpException
 {
     /**
      * @var int

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\SmartContent\Tests\Unit;
 
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\SmartContent\Configuration\ProviderConfiguration;
@@ -21,6 +22,7 @@ use Sulu\Component\SmartContent\DataProviderInterface;
 use Sulu\Component\SmartContent\DataProviderPool;
 use Sulu\Component\SmartContent\DataProviderPoolInterface;
 use Sulu\Component\SmartContent\DataProviderResult;
+use Sulu\Component\SmartContent\Exception\PageOutOfBoundsException;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -462,10 +464,9 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             [3, 3, 8, '123-123-123', [7, 8], false],
             // fourth page page-size 3 (empty result)
             [4, 3, 8, '123-123-123', [], false],
-            [-1, 3, 8, '123-123-123', [1, 2, 3], true],
-            [-1, 3, 8, '123-123-123', [1, 2, 3], true],
-            [0, 3, 8, '123-123-123', [1, 2, 3], true],
-            ['99999999999999999999', 3, 8, '123-123-123', [1, 2, 3], true],
+            [-1, 3, 8, '123-123-123', [1, 2, 3], true, PageOutOfBoundsException::class],
+            [0, 3, 8, '123-123-123', [1, 2, 3], true, PageOutOfBoundsException::class],
+            ['99999999999999999999', 3, 8, '123-123-123', [1, 2, 3], true, PageOutOfBoundsException::class],
         ];
     }
 
@@ -478,10 +479,15 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $limitResult,
         $uuid,
         $expectedData,
-        $hasNextPage
+        $hasNextPage,
+        $exception = null
     ) {
+        if ($exception) {
+            $this->setExpectedException($exception);
+        }
+
         $property = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\PropertyInterface',
+            PropertyInterface::class,
             [],
             '',
             true,
@@ -547,7 +553,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ],
             ['webspaceKey' => null, 'locale' => null],
             $limitResult,
-            $page < 1 ? 1 : ($page > PHP_INT_MAX ? PHP_INT_MAX : $page),
+            $page,
             $pageSize
         )->willReturn(new DataProviderResult($expectedData, $hasNextPage, $expectedData));
 
@@ -573,8 +579,13 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $limitResult,
         $uuid,
         $expectedData,
-        $hasNextPage
+        $hasNextPage,
+        $exception = null
     ) {
+        if ($exception) {
+            $this->setExpectedException($exception);
+        }
+
         $property = $this->getMockForAbstractClass(
             'Sulu\Component\Content\Compat\PropertyInterface',
             [],

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\SmartContent\Tests\Unit;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Component\SmartContent\ContentType as SmartContent;
 use Sulu\Component\SmartContent\DataProviderInterface;
@@ -461,6 +462,10 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             [3, 3, 8, '123-123-123', [7, 8], false],
             // fourth page page-size 3 (empty result)
             [4, 3, 8, '123-123-123', [], false],
+            [-1, 3, 8, '123-123-123', [1, 2, 3], true],
+            [-1, 3, 8, '123-123-123', [1, 2, 3], true],
+            [0, 3, 8, '123-123-123', [1, 2, 3], true],
+            ['99999999999999999999', 3, 8, '123-123-123', [1, 2, 3], true],
         ];
     }
 
@@ -484,9 +489,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             true,
             ['getValue', 'getParams']
         );
-        $structure = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\StructureInterface'
-        );
+        $structure = $this->getMockForAbstractClass(StructureInterface::class);
 
         $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'))
@@ -544,7 +547,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ],
             ['webspaceKey' => null, 'locale' => null],
             $limitResult,
-            $page,
+            $page < 1 ? 1 : ($page > PHP_INT_MAX ? PHP_INT_MAX : $page),
             $pageSize
         )->willReturn(new DataProviderResult($expectedData, $hasNextPage, $expectedData));
 
@@ -643,7 +646,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ],
             ['webspaceKey' => null, 'locale' => null],
             $limitResult,
-            $page,
+            $page < 1 ? 1 : ($page > PHP_INT_MAX ? PHP_INT_MAX : $page),
             $pageSize
         )->willReturn(new DataProviderResult($expectedData, $hasNextPage, $expectedData));
 

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -463,7 +463,8 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             // third page page-size 3 (only two pages because of the limit-result)
             [3, 3, 8, '123-123-123', [7, 8], false],
             // fourth page page-size 3 (empty result)
-            [4, 3, 8, '123-123-123', [], false],
+            [4, 3, 8, '123-123-123', [], false, PageOutOfBoundsException::class],
+            [1, 3, 8, '123-123-123', [], false],
             [-1, 3, 8, '123-123-123', [1, 2, 3], true, PageOutOfBoundsException::class],
             [0, 3, 8, '123-123-123', [1, 2, 3], true, PageOutOfBoundsException::class],
             ['99999999999999999999', 3, 8, '123-123-123', [1, 2, 3], true, PageOutOfBoundsException::class],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3388
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug when passing invalid values for current page over request to smart-content.

#### Why?

If you pass `$page < 1 || $page > PHP_INT_MAX` to smart-content doctrine throws exception later on.
