### PR TITLE
added translations for frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * BUGFIX      #3391 [SnippetBundle]           Snippet list: Changed field sortable; Fixed bug with copy locale functionality
+    * ENHANCEMENT #3393 [AudienceTargetingBundle] Added translations for frequencies
     * FEATURE     #3387 [AudienceTargetingBundle] Added rule for detecting device type
     * BUGFIX      #3385 [SecurityBundle]          Fixed UserLocaleListener
     * BUGFIX      #3384 [Webspace]                Fixed usage of Sulu with non-default HTTP port

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Controller/TemplateController.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Controller/TemplateController.php
@@ -47,7 +47,7 @@ class TemplateController extends Controller
         foreach (array_flip($this->getParameter('sulu_audience_targeting.frequencies')) as $name => $value) {
             $frequencies[] = [
                 'id' => $value,
-                'name' => $name,
+                'name' => $this->get('translator')->trans('sulu_audience_targeting.frequencies.' . $name, [], 'backend'),
             ];
         }
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.de.xlf
@@ -36,7 +36,7 @@
             </trans-unit>
             <trans-unit id="target-group-10">
                 <source>sulu_audience_targeting.frequency</source>
-                <target>Häufigkeit</target>
+                <target>Zuweisung bei</target>
             </trans-unit>
             <trans-unit id="target-group-11">
                 <source>sulu_audience_targeting.conditions</source>
@@ -105,6 +105,18 @@
             <trans-unit id="target-group-28" resname="sulu_audience_targeting.device_types.desktop">
                 <source>sulu_audience_targeting.device_types.desktop</source>
                 <target>Desktop</target>
+            </trans-unit>
+            <trans-unit id="target-group-29" resname="sulu_audience_targeting.frequencies.hit">
+                <source>sulu_audience_targeting.frequencies.hit</source>
+                <target>jedem Seitenaufruf</target>
+            </trans-unit>
+            <trans-unit id="target-group-30" resname="sulu_audience_targeting.frequencies.session">
+                <source>sulu_audience_targeting.frequencies.session</source>
+                <target>jeder Sitzung</target>
+            </trans-unit>
+            <trans-unit id="target-group-31" resname="sulu_audience_targeting.frequencies.visitor">
+                <source>sulu_audience_targeting.frequencies.visitor</source>
+                <target>erstem Besuch</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.en.xlf
@@ -36,7 +36,7 @@
             </trans-unit>
             <trans-unit id="target-group-10">
                 <source>sulu_audience_targeting.frequency</source>
-                <target>Frequency</target>
+                <target>Assigned at</target>
             </trans-unit>
             <trans-unit id="target-group-11">
                 <source>sulu_audience_targeting.conditions</source>
@@ -105,6 +105,18 @@
             <trans-unit id="target-group-28" resname="sulu_audience_targeting.device_types.desktop">
                 <source>sulu_audience_targeting.device_types.desktop</source>
                 <target>Desktop</target>
+            </trans-unit>
+            <trans-unit id="target-group-29" resname="sulu_audience_targeting.frequencies.hit">
+                <source>sulu_audience_targeting.frequencies.hit</source>
+                <target>each page visit</target>
+            </trans-unit>
+            <trans-unit id="target-group-30" resname="sulu_audience_targeting.frequencies.session">
+                <source>sulu_audience_targeting.frequencies.session</source>
+                <target>each session</target>
+            </trans-unit>
+            <trans-unit id="target-group-31" resname="sulu_audience_targeting.frequencies.visitor">
+                <source>sulu_audience_targeting.frequencies.visitor</source>
+                <target>first visit</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.fr.xlf
@@ -36,7 +36,7 @@
             </trans-unit>
             <trans-unit id="target-group-10">
                 <source>sulu_audience_targeting.frequency</source>
-                <target>Fréquence</target>
+                <target>Assigné à</target>
             </trans-unit>
             <trans-unit id="target-group-11">
                 <source>sulu_audience_targeting.conditions</source>
@@ -105,6 +105,18 @@
             <trans-unit id="target-group-28" resname="sulu_audience_targeting.device_types.desktop">
                 <source>sulu_audience_targeting.device_types.desktop</source>
                 <target>Ordinateur</target>
+            </trans-unit>
+            <trans-unit id="target-group-29" resname="sulu_audience_targeting.frequencies.hit">
+                <source>sulu_audience_targeting.frequencies.hit</source>
+                <target>chaque page visitée</target>
+            </trans-unit>
+            <trans-unit id="target-group-30" resname="sulu_audience_targeting.frequencies.session">
+                <source>sulu_audience_targeting.frequencies.session</source>
+                <target>chaque session</target>
+            </trans-unit>
+            <trans-unit id="target-group-31" resname="sulu_audience_targeting.frequencies.visitor">
+                <source>sulu_audience_targeting.frequencies.visitor</source>
+                <target>la première visite</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/sulu/backend.nl.xlf
@@ -36,7 +36,7 @@
             </trans-unit>
             <trans-unit id="target-group-10">
                 <source>sulu_audience_targeting.frequency</source>
-                <target>Frequentie</target>
+                <target>Toegewezen bij</target>
             </trans-unit>
             <trans-unit id="target-group-11">
                 <source>sulu_audience_targeting.conditions</source>
@@ -105,6 +105,18 @@
             <trans-unit id="target-group-28" resname="sulu_audience_targeting.device_types.desktop">
                 <source>sulu_audience_targeting.device_types.desktop</source>
                 <target>PC</target>
+            </trans-unit>
+            <trans-unit id="target-group-29" resname="sulu_audience_targeting.frequencies.hit">
+                <source>sulu_audience_targeting.frequencies.hit</source>
+                <target>ieder paginabezoek</target>
+            </trans-unit>
+            <trans-unit id="target-group-30" resname="sulu_audience_targeting.frequencies.session">
+                <source>sulu_audience_targeting.frequencies.session</source>
+                <target>iedere sessie</target>
+            </trans-unit>
+            <trans-unit id="target-group-31" resname="sulu_audience_targeting.frequencies.visitor">
+                <source>sulu_audience_targeting.frequencies.visitor</source>
+                <target>eerste bezoek</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a clearer translation for the frequency in the ruleset overlay of the audience targeting.

#### Why?

Because the previous texts were not self-explaining.