### PR TITLE
SecuritySubscriber throws exception when User is not an instance of UserInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG for Sulu
     * BUGFIX      #3385 [SecurityBundle]          Fixed UserLocaleListener
     * BUGFIX      #3384 [Webspace]                Fixed usage of Sulu with non-default HTTP port
     * ENHANCEMENT #3343 [MediaBundle]             Use media disposition type config to serve media files
-    * ENHANCEMENT #3390 [RouteBundle]             Avoid BC break in content-type "route" form 
+    * ENHANCEMENT #3390 [RouteBundle]             Avoid BC break in content-type "route" form
 
 * 1.6.0-RC1 (2017-06-01)
     * BUGFIX      #3381 [WebsiteBundle]         Fixed partial redirect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3397 [DocumentManagerBundle]   Removed exception when user is not instance of Sulu UserInterface
     * BUGFIX      #3391 [SnippetBundle]           Snippet list: Changed field sortable; Fixed bug with copy locale functionality
     * ENHANCEMENT #3393 [AudienceTargetingBundle] Added translations for frequencies
     * FEATURE     #3387 [AudienceTargetingBundle] Added rule for detecting device type
     * BUGFIX      #3385 [SecurityBundle]          Fixed UserLocaleListener
     * BUGFIX      #3384 [Webspace]                Fixed usage of Sulu with non-default HTTP port
     * ENHANCEMENT #3343 [MediaBundle]             Use media disposition type config to serve media files
-    * ENHANCEMENT #3390 [RouteBundle]             Avoid BC break in content-type "route" form
+    * ENHANCEMENT #3390 [RouteBundle]             Avoid BC break in content-type "route" form 
 
 * 1.6.0-RC1 (2017-06-01)
     * BUGFIX      #3381 [WebsiteBundle]         Fixed partial redirect

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -68,12 +68,7 @@ class SecuritySubscriber implements EventSubscriberInterface
         $user = $token->getUser();
 
         if (!$user instanceof UserInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'User must implement the Sulu UserInterface, got "%s"',
-                    is_object($user) ? get_class($user) : gettype($user)
-                )
-            );
+            return null;
         }
 
         $optionsResolver->setDefault(static::USER_OPTION, $user->getId());

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -68,7 +68,7 @@ class SecuritySubscriber implements EventSubscriberInterface
         $user = $token->getUser();
 
         if (!$user instanceof UserInterface) {
-            return null;
+            return;
         }
 
         $optionsResolver->setDefault(static::USER_OPTION, $user->getId());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3389
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Addresses this issue [#3389](https://github.com/sulu/sulu/issues/3389)

SecuritySubscriber currently throws an error when the user is not an instance of Sulu\Component\Security\Authentication\UserInterface. As far as I can tell, this prevents one from using a custom user provider on a secured route (where the site has tokenStorage).

This change solved our specific problem: using Symfony LDAP component to authenticate various custom routes.