### PR TITLE
fixed localization of sitemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-develop
     * FEATURE     #3385 [SnippetBundle]           Implement snippet areas to replace default snippets 
+    * BUGFIX      #3401 [WebsiteBundle]           Fixed localizatin of sitemaps
     * BUGFIX      #3400 [PreviewBundle]           Added host to preview request
     * BUGFIX      #3391 [SnippetBundle]           Snippet list: Changed field sortable; Fixed bug with copy locale functionality
     * ENHANCEMENT #3393 [AudienceTargetingBundle] Added translations for frequencies

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,14 @@ __After:__
 sulu_snippet_load_by_area('your_snippet_key')
 ```
 
+### Sitemap Localization
+
+The `build` method of the `SitemapProviderInterface` had a `$locale` parameter,
+which shouldn't be there, because the sitemaps need to be generated or all
+locales at once. If you have implemented this interface you have to adapt the
+implementation to remove the `$locale` parameter and return the URLs for all
+locales instead.
+
 ### Snippet list
 
 Some field configuration has changed, so we need to delete the saved one in the database:

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
@@ -10,6 +10,7 @@
         <service id="sulu_website.sitemap.pages_provider"
                  class="Sulu\Bundle\WebsiteBundle\Sitemap\Provider\PagesSitemapProvider">
             <argument type="service" id="sulu_content.content_repository"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
 
             <tag name="sulu.sitemap.provider" alias="pages"/>
         </service>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -4,37 +4,40 @@
     {% set registrableDomain = sulu_util_domain_info(domain).registrableDomain %}
 
     {% for entry in entries %}
-    <url>
-        <loc>{{ sulu_content_path(entry.loc, webspaceKey, locale, null, scheme) }}</loc>
-        {% if entry.lastmod %}
-        <lastmod>{{ entry.lastmod|date('Y-m-d') }}</lastmod>
-        {% endif %}
-        {% if entry.changefreq %}
-        <changefreq>{{ entry.changefreq }}</changefreq>
-        {% endif %}
-        {% if entry.priority %}
-        <priority>{{ entry.priority }}</priority>
-        {% endif %}
-
-        {% set amount = 0 %}
-        {% set defaultHref = null %}
-        {% for alternateLink in entry.alternateLinks %}
-            {% set href = sulu_content_path(alternateLink.href, webspaceKey, alternateLink.locale, null, scheme, false) %}
-            {% if href is not empty and href != alternateLink.href and sulu_util_domain_info(href).registrableDomain == registrableDomain %}
-                {% if locale != alternateLink.locale %}
-        <xhtml:link rel="alternate" hreflang="{{ alternateLink.locale|replace({'_': '-'}) }}" href="{{ href }}"/>
-                    {% set amount = amount + 1 %}
+        {% set location = sulu_content_path(entry.loc, webspaceKey, entry.locale, null, scheme) %}
+        {% if sulu_util_domain_info(location).registrableDomain == registrableDomain %}
+            <url>
+                <loc>{{ location }}</loc>
+                {% if entry.lastmod %}
+                <lastmod>{{ entry.lastmod|date('Y-m-d') }}</lastmod>
                 {% endif %}
-                {% if defaultLocale == alternateLink.locale and entry.alternateLinks|length > 1 %}
-                    {% set defaultHref = href %}
+                {% if entry.changefreq %}
+                <changefreq>{{ entry.changefreq }}</changefreq>
                 {% endif %}
-            {% endif %}
-        {% endfor %}
+                {% if entry.priority %}
+                <priority>{{ entry.priority }}</priority>
+                {% endif %}
 
-        {% if defaultHref and amount > 0 %}
-        <xhtml:link rel="alternate" hreflang="x-default" href="{{ defaultHref }}"/>
+                {% set amount = 0 %}
+                {% set defaultHref = null %}
+                {% if entry.alternateLinks|length > 1 %}
+                    {% for alternateLink in entry.alternateLinks %}
+                        {% set href = sulu_content_path(alternateLink.href, webspaceKey, alternateLink.locale, null, scheme, false) %}
+                        {% if href is not empty and href != alternateLink.href and sulu_util_domain_info(href).registrableDomain == registrableDomain %}
+                    <xhtml:link rel="alternate" hreflang="{{ alternateLink.locale|replace({'_': '-'}) }}" href="{{ href }}"/>
+                            {% set amount = amount + 1 %}
+                            {% if defaultLocale == alternateLink.locale and entry.alternateLinks|length > 1 %}
+                                {% set defaultHref = href %}
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+
+                {% if defaultHref and amount > 0 %}
+                <xhtml:link rel="alternate" hreflang="x-default" href="{{ defaultHref }}"/>
+                {% endif %}
+            </url>
         {% endif %}
-    </url>
     {% endfor %}
 </urlset>
 {% endspaceless %}

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Repository\ContentRepositoryInterface;
 use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 
 /**
  * Provides sitemap for webspaces.
@@ -30,11 +31,19 @@ class PagesSitemapProvider implements SitemapProviderInterface
     private $contentRepository;
 
     /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
      * @param ContentRepositoryInterface $contentRepository
      */
-    public function __construct(ContentRepositoryInterface $contentRepository)
-    {
+    public function __construct(
+        ContentRepositoryInterface $contentRepository,
+        WebspaceManagerInterface $webspaceManager
+    ) {
         $this->contentRepository = $contentRepository;
+        $this->webspaceManager = $webspaceManager;
     }
 
     /**
@@ -42,15 +51,23 @@ class PagesSitemapProvider implements SitemapProviderInterface
      */
     public function build($page, $portalKey, $locale)
     {
-        $pages = $this->contentRepository->findAllByPortal(
-            $locale,
-            $portalKey,
-            MappingBuilder::create()
-                ->addProperties(['changed', 'seo-hideInSitemap'])
-                ->setResolveUrl(true)
-                ->setHydrateGhost(false)
-                ->getMapping()
-        );
+        $portal = $this->webspaceManager->findPortalByKey($portalKey);
+
+        $pages = [];
+        foreach ($portal->getLocalizations() as $localization) {
+            $pages = array_merge(
+                $this->contentRepository->findAllByPortal(
+                    $localization->getLocale(),
+                    $portalKey,
+                    MappingBuilder::create()
+                        ->addProperties(['changed', 'seo-hideInSitemap'])
+                        ->setResolveUrl(true)
+                        ->setHydrateGhost(false)
+                        ->getMapping()
+                ),
+                $pages
+            );
+        }
 
         $result = [];
         foreach ($pages as $contentPage) {
@@ -66,7 +83,7 @@ class PagesSitemapProvider implements SitemapProviderInterface
                 $changed = new \DateTime($changed);
             }
 
-            $result[] = $sitemapUrl = new SitemapUrl($contentPage->getUrl(), $changed);
+            $result[] = $sitemapUrl = new SitemapUrl($contentPage->getUrl(), $contentPage->getLocale(), $changed);
             foreach ($contentPage->getUrls() as $urlLocale => $href) {
                 $sitemapUrl->addAlternateLink(new SitemapAlternateLink($href, $urlLocale));
             }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
@@ -49,7 +49,7 @@ class PagesSitemapProvider implements SitemapProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function build($page, $portalKey, $locale)
+    public function build($page, $portalKey)
     {
         $portal = $this->webspaceManager->findPortalByKey($portalKey);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
@@ -24,16 +24,12 @@ interface SitemapProviderInterface
     /**
      * Returns sitemap-entries.
      *
-     * @deprecated The $locale parameter is deprecated and will be removed in 2.0. The implementation should always
-     *     return the all available localizations.
-     *
      * @param int $page
      * @param string $portalKey
-     * @param string $locale
      *
      * @return SitemapUrl[]
      */
-    public function build($page, $portalKey, $locale);
+    public function build($page, $portalKey);
 
     /**
      * Create sitemap.

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderInterface.php
@@ -24,6 +24,9 @@ interface SitemapProviderInterface
     /**
      * Returns sitemap-entries.
      *
+     * @deprecated The $locale parameter is deprecated and will be removed in 2.0. The implementation should always
+     *     return the all available localizations.
+     *
      * @param int $page
      * @param string $portalKey
      * @param string $locale

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
@@ -80,6 +80,8 @@ class SitemapUrl
         $this->lastmod = $lastmod;
         $this->changefreq = $changefreq;
         $this->priority = $priority;
+
+        $this->addAlternateLink(new SitemapAlternateLink($loc, $locale));
     }
 
     /**
@@ -151,7 +153,7 @@ class SitemapUrl
      */
     public function addAlternateLink(SitemapAlternateLink $alternateLink)
     {
-        $this->alternateLinks[] = $alternateLink;
+        $this->alternateLinks[$alternateLink->getLocale()] = $alternateLink;
 
         return $this;
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
@@ -35,6 +35,11 @@ class SitemapUrl
     private $loc;
 
     /**
+     * @var string
+     */
+    private $locale;
+
+    /**
      * Datetime of last modification.
      *
      * @var \DateTime
@@ -68,9 +73,10 @@ class SitemapUrl
      * @param string $changefreq
      * @param float $priority
      */
-    public function __construct($loc, \DateTime $lastmod = null, $changefreq = null, $priority = null)
+    public function __construct($loc, $locale, \DateTime $lastmod = null, $changefreq = null, $priority = null)
     {
         $this->loc = $loc;
+        $this->locale = $locale;
         $this->lastmod = $lastmod;
         $this->changefreq = $changefreq;
         $this->priority = $priority;
@@ -84,6 +90,16 @@ class SitemapUrl
     public function getLoc()
     {
         return $this->loc;
+    }
+
+    /**
+     * Returns locale.
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -45,19 +45,19 @@ class SitemapControllerTest extends SuluTestCase
 
         $this->assertEquals('http://test.lo/en-us', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc')->text());
         $this->assertEquals(
-            'en',
+            'en-us',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[1]')->attr('hreflang')
         );
         $this->assertEquals(
-            'http://test.lo/en',
+            'http://test.lo/en-us',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[1]')->attr('href')
         );
         $this->assertEquals(
-            'en-us',
+            'en',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('hreflang')
         );
         $this->assertEquals(
-            'http://test.lo/en-us',
+            'http://test.lo/en',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('href')
         );
         $this->assertEquals(

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -20,43 +20,118 @@ class SitemapControllerTest extends SuluTestCase
         $this->initPhpcr();
     }
 
-    public function testIndex()
+    public function testIndexSingleLanguage()
     {
         $client = $this->createWebsiteClient();
-        $crawler = $client->request('GET', '/sitemap.xml');
+        $crawler = $client->request('GET', 'http://sulu.lo/sitemap.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
-        $this->assertEquals('http://localhost', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+        $this->assertCount(0, $crawler->filterXPath('//x:urlset/x:url/xhtml:link'));
+        $this->assertEquals('http://sulu.lo', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+    }
+
+    public function testIndexMultipleLanguage()
+    {
+        $client = $this->createWebsiteClient();
+        $crawler = $client->request('GET', 'http://test.lo/sitemap.xml');
+        $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertCount(2, $crawler->filterXPath('//x:urlset/x:url'));
+
+        $this->assertEquals('http://test.lo/en-us', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc')->text());
+        $this->assertEquals(
+            'en',
+            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[1]')->attr('hreflang')
+        );
+        $this->assertEquals(
+            'http://test.lo/en',
+            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[1]')->attr('href')
+        );
+        $this->assertEquals(
+            'en-us',
+            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('hreflang')
+        );
+        $this->assertEquals(
+            'http://test.lo/en-us',
+            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('href')
+        );
+        $this->assertEquals(
+            'x-default',
+            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[3]')->attr('hreflang')
+        );
+        $this->assertEquals(
+            'http://test.lo/en',
+            $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[3]')->attr('href')
+        );
+
+        $this->assertEquals('http://test.lo/en', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());
+        $this->assertEquals(
+            'en',
+            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[1]')->attr('hreflang')
+        );
+        $this->assertEquals(
+            'http://test.lo/en',
+            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[1]')->attr('href')
+        );
+        $this->assertEquals(
+            'en-us',
+            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[2]')->attr('hreflang')
+        );
+        $this->assertEquals(
+            'http://test.lo/en-us',
+            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[2]')->attr('href')
+        );
+        $this->assertEquals(
+            'x-default',
+            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[3]')->attr('hreflang')
+        );
+        $this->assertEquals(
+            'http://test.lo/en',
+            $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[3]')->attr('href')
+        );
+
+        $this->assertEquals('http://test.lo/en', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());
+    }
+
+    public function testIndexMultipleTlds()
+    {
+        $client = $this->createWebsiteClient();
+        $crawler = $client->request('GET', 'http://sulu.com/sitemap.xml');
+        $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+        $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
+        $this->assertNotContains('sulu.at', $crawler->text());
     }
 
     public function testProvider()
     {
         $client = $this->createWebsiteClient();
-        $client->request('GET', '/sitemaps/pages.xml');
+        $client->request('GET', 'http://sulu.lo/sitemaps/pages.xml');
         $this->assertHttpStatusCode(301, $client->getResponse());
     }
 
     public function testPaginated()
     {
         $client = $this->createWebsiteClient();
-        $crawler = $client->request('GET', '/sitemaps/pages-1.xml');
+        $crawler = $client->request('GET', 'http://sulu.lo/sitemaps/pages-1.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
-        $this->assertEquals('http://localhost', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+        $this->assertEquals('http://sulu.lo', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
     }
 
     public function testPaginatedOverMax()
     {
         $client = $this->createWebsiteClient();
-        $crawler = $client->request('GET', '/sitemaps/pages-2.xml');
+        $crawler = $client->request('GET', 'http://sulu.lo/sitemaps/pages-2.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(404, $client->getResponse());
     }
@@ -64,7 +139,7 @@ class SitemapControllerTest extends SuluTestCase
     public function testNotExistingProvider()
     {
         $client = $this->createWebsiteClient();
-        $crawler = $client->request('GET', '/sitemaps/test-2.xml');
+        $crawler = $client->request('GET', 'http://sulu.lo/sitemaps/test-2.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(404, $client->getResponse());
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
@@ -140,14 +140,14 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/en-test-1', $result[0]->getLoc());
         $alternateLinks1 = $result[0]->getAlternateLinks();
         $this->assertCount(2, $alternateLinks1);
-        $this->assertEquals('/en-test-1', $alternateLinks1[0]->getHref());
-        $this->assertEquals('/de-test-1', $alternateLinks1[1]->getHref());
+        $this->assertEquals('/en-test-1', $alternateLinks1['en']->getHref());
+        $this->assertEquals('/de-test-1', $alternateLinks1['de']->getHref());
 
         $this->assertEquals('/de-test-1', $result[1]->getLoc());
         $alternateLinks2 = $result[1]->getAlternateLinks();
         $this->assertCount(2, $alternateLinks2);
-        $this->assertEquals('/de-test-1', $alternateLinks2[0]->getHref());
-        $this->assertEquals('/en-test-1', $alternateLinks2[1]->getHref());
+        $this->assertEquals('/de-test-1', $alternateLinks2['de']->getHref());
+        $this->assertEquals('/en-test-1', $alternateLinks2['en']->getHref());
     }
 
     public function testBuildHideInSitemap()

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
@@ -83,7 +83,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($pages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
+        $result = $this->sitemapProvider->build(1, $this->portalKey);
 
         $this->assertCount(3, $result);
         for ($i = 0; $i < 3; ++$i) {
@@ -133,7 +133,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($englishPages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
+        $result = $this->sitemapProvider->build(1, $this->portalKey);
 
         $this->assertCount(2, $result);
 
@@ -173,7 +173,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($pages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
+        $result = $this->sitemapProvider->build(1, $this->portalKey);
 
         $this->assertCount(1, $result);
         $this->assertEquals($pages[0]->getUrl(), $result[0]->getLoc());
@@ -203,7 +203,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($pages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
+        $result = $this->sitemapProvider->build(1, $this->portalKey);
 
         $this->assertCount(1, $result);
         $this->assertEquals($pages[0]->getUrl(), $result[0]->getLoc());

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/PagesSitemapProviderTest.php
@@ -17,6 +17,9 @@ use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\Content\Repository\ContentRepositoryInterface;
 use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Portal;
 
 /**
  * Tests for PagesSitemapProvider.
@@ -29,14 +32,14 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
     private $contentRepository;
 
     /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
      * @var PagesSitemapProvider
      */
     private $sitemapProvider;
-
-    /**
-     * @var string
-     */
-    private $locale = 'de';
 
     /**
      * @var string
@@ -49,12 +52,20 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->contentRepository = $this->prophesize(ContentRepositoryInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
 
-        $this->sitemapProvider = new PagesSitemapProvider($this->contentRepository->reveal());
+        $this->sitemapProvider = new PagesSitemapProvider(
+            $this->contentRepository->reveal(),
+            $this->webspaceManager->reveal()
+        );
     }
 
     public function testBuild()
     {
+        $portal = new Portal();
+        $portal->addLocalization(new Localization('de'));
+        $this->webspaceManager->findPortalByKey($this->portalKey)->willReturn($portal);
+
         /** @var Content[] $pages */
         $pages = [
             $this->createContent('/test-1'),
@@ -63,7 +74,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->contentRepository->findAllByPortal(
-            $this->locale,
+            'de',
             $this->portalKey,
             MappingBuilder::create()
                 ->addProperties(['changed', 'seo-hideInSitemap'])
@@ -72,7 +83,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($pages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, $this->locale);
+        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
 
         $this->assertCount(3, $result);
         for ($i = 0; $i < 3; ++$i) {
@@ -81,8 +92,70 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testBuildMultipleLocales()
+    {
+        $portal = new Portal();
+        $portal->addLocalization(new Localization('de'));
+        $portal->addLocalization(new Localization('en'));
+        $this->webspaceManager->findPortalByKey($this->portalKey)->willReturn($portal);
+
+        $germanPages = [
+            $this->createContent('/de-test-1', false, RedirectType::NONE, [
+                'de' => '/de-test-1',
+                'en' => '/en-test-1',
+            ]),
+        ];
+
+        $englishPages = [
+            $this->createContent('/en-test-1', false, RedirectType::NONE, [
+                'en' => '/en-test-1',
+                'de' => '/de-test-1',
+            ]),
+        ];
+
+        $this->contentRepository->findAllByPortal(
+            'de',
+            $this->portalKey,
+            MappingBuilder::create()
+                ->addProperties(['changed', 'seo-hideInSitemap'])
+                ->setResolveUrl(true)
+                ->setHydrateGhost(false)
+                ->getMapping()
+        )->willReturn($germanPages);
+
+        $this->contentRepository->findAllByPortal(
+            'en',
+            $this->portalKey,
+            MappingBuilder::create()
+                ->addProperties(['changed', 'seo-hideInSitemap'])
+                ->setResolveUrl(true)
+                ->setHydrateGhost(false)
+                ->getMapping()
+        )->willReturn($englishPages);
+
+        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
+
+        $this->assertCount(2, $result);
+
+        $this->assertEquals('/en-test-1', $result[0]->getLoc());
+        $alternateLinks1 = $result[0]->getAlternateLinks();
+        $this->assertCount(2, $alternateLinks1);
+        $this->assertEquals('/en-test-1', $alternateLinks1[0]->getHref());
+        $this->assertEquals('/de-test-1', $alternateLinks1[1]->getHref());
+
+        $this->assertEquals('/de-test-1', $result[1]->getLoc());
+        $alternateLinks2 = $result[1]->getAlternateLinks();
+        $this->assertCount(2, $alternateLinks2);
+        $this->assertEquals('/de-test-1', $alternateLinks2[0]->getHref());
+        $this->assertEquals('/en-test-1', $alternateLinks2[1]->getHref());
+    }
+
     public function testBuildHideInSitemap()
     {
+        $portal = new Portal();
+        $portal->addLocalization(new Localization('de'));
+        $this->webspaceManager->findPortalByKey($this->portalKey)->willReturn($portal);
+
         /** @var Content[] $pages */
         $pages = [
             $this->createContent('/test-1'),
@@ -91,7 +164,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->contentRepository->findAllByPortal(
-            $this->locale,
+            'de',
             $this->portalKey,
             MappingBuilder::create()
                 ->addProperties(['changed', 'seo-hideInSitemap'])
@@ -100,7 +173,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($pages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, $this->locale);
+        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
 
         $this->assertCount(1, $result);
         $this->assertEquals($pages[0]->getUrl(), $result[0]->getLoc());
@@ -109,6 +182,10 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildInternalExternalLink()
     {
+        $portal = new Portal();
+        $portal->addLocalization(new Localization('de'));
+        $this->webspaceManager->findPortalByKey($this->portalKey)->willReturn($portal);
+
         /** @var Content[] $pages */
         $pages = [
             $this->createContent('/test-1'),
@@ -117,7 +194,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->contentRepository->findAllByPortal(
-            $this->locale,
+            'de',
             $this->portalKey,
             MappingBuilder::create()
                 ->addProperties(['changed', 'seo-hideInSitemap'])
@@ -126,7 +203,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
                 ->getMapping()
         )->willReturn($pages);
 
-        $result = $this->sitemapProvider->build(1, $this->portalKey, $this->locale);
+        $result = $this->sitemapProvider->build(1, $this->portalKey, 'de');
 
         $this->assertCount(1, $result);
         $this->assertEquals($pages[0]->getUrl(), $result[0]->getLoc());
@@ -146,7 +223,7 @@ class PagesSitemapProviderTest extends \PHPUnit_Framework_TestCase
     public function createContent($url, $hideInSitemap = false, $redirectTarget = RedirectType::NONE, $urls = [])
     {
         $content = new Content(
-            $this->locale,
+            'de',
             $this->portalKey,
             uniqid('test-'),
             $url,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
@@ -134,7 +134,7 @@ class XmlSitemapRendererTest extends \PHPUnit_Framework_TestCase
         $this->providerPoolInterface->hasProvider('pages')->willReturn(true);
         $this->providerPoolInterface->getProvider('pages')->willReturn($pagesProvider);
 
-        $entries = [new SitemapUrl('http://sulu.lo')];
+        $entries = [new SitemapUrl('http://sulu.lo', 'en')];
         $pagesProvider->build(1, 'sulu_io', 'en')->willReturn($entries);
         $pagesProvider->getMaxPage()->willReturn(1);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/sulu_with_localized_tld.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/webspaces/sulu_with_localized_tld.xml
@@ -4,10 +4,11 @@
           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
     <name>Sulu CMF</name>
-    <key>sulu_io</key>
+    <key>sulu_with_localized_tld</key>
 
     <localizations>
         <localization language="en"/>
+        <localization language="de"/>
     </localizations>
 
     <theme>default</theme>
@@ -39,26 +40,25 @@
     <portals>
         <portal>
             <name>Sulu CMF</name>
-            <key>sulucmf</key>
-
-            <localizations>
-                <localization language="en"/>
-            </localizations>
+            <key>sulu_with_localized_tld</key>
 
             <environments>
                 <environment type="prod">
                     <urls>
-                        <url language="en">sulu.lo</url>
+                        <url language="en">sulu.com</url>
+                        <url language="de">sulu.at</url>
                     </urls>
                 </environment>
                 <environment type="dev">
                     <urls>
-                        <url language="en">sulu.lo</url>
+                        <url language="en">sulu.com</url>
+                        <url language="de">sulu.at</url>
                     </urls>
                 </environment>
                 <environment type="test">
                     <urls>
-                        <url language="en">sulu.lo</url>
+                        <url language="en">sulu.com</url>
+                        <url language="de">sulu.at</url>
                     </urls>
                 </environment>
             </environments>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3187, fixes #3163 
| Related issues/PRs | #2916 
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/346

#### What's in this PR?

This PR adds all localizations as separate URLs to the sitemap, which was changed back in version 1.5.