### PR TITLE
remove exception for non-Sulu user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3404 [DocumentManagerBundle] Remove exception for non-Sulu user
+
 * 1.5.4 (2017-05-31)
     * HOTFIX      #3356 [AdminBundle]           Updated husky to fix issue with ckeditor plugins
     * HOTFIX      #3314 [ContentBundle]         Fixed author migration script for removed users.

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -68,12 +68,7 @@ class SecuritySubscriber implements EventSubscriberInterface
         $user = $token->getUser();
 
         if (!$user instanceof UserInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'User must implement the Sulu UserInterface, got "%s"',
-                    is_object($user) ? get_class($user) : gettype($user)
-                )
-            );
+            return;
         }
 
         $optionsResolver->setDefault(static::USER_OPTION, $user->getId());

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -88,18 +88,17 @@ class SecuritySubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testSetDefaultUserWithNonSuluUser()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
-
         $event = $this->prophesize(ConfigureOptionsEvent::class);
 
         $optionsResolver = $this->prophesize(OptionsResolver::class);
         $event->getOptions()->willReturn($optionsResolver->reveal());
-        $optionsResolver->setDefault('user', null)->shouldBeCalled();
 
         $token = $this->prophesize(TokenInterface::class);
         $this->tokenStorage->getToken()->willReturn($token->reveal());
 
         $token->getUser()->willReturn(new \stdClass());
+
+        $optionsResolver->setDefault('user', null)->shouldBeCalled();
 
         $this->securitySubscriber->setDefaultUser($event->reveal());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3389 
| Related issues/PRs | https://github.com/sulu/sulu/pull/3042
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the exception when a User does not implement our `UserInterface`, but returns `null` instead.