### PR TITLE
Allow to reset the route entity target to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * ENHANCEMENT #3411 [RouteBundle]             Allow to reset the route entity target to null
     * FEATURE     #3385 [SnippetBundle]           Implement snippet areas to replace default snippets 
     * BUGFIX      #3401 [WebsiteBundle]           Fixed localizatin of sitemaps
     * BUGFIX      #3400 [PreviewBundle]           Added host to preview request

--- a/src/Sulu/Bundle/RouteBundle/Entity/BaseRoute.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/BaseRoute.php
@@ -208,7 +208,7 @@ abstract class BaseRoute implements RouteInterface, AuditableInterface
     /**
      * {@inheritdoc}
      */
-    public function setTarget(RouteInterface $target)
+    public function setTarget(RouteInterface $target = null)
     {
         $this->target = $target;
 

--- a/src/Sulu/Bundle/RouteBundle/Model/RouteInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Model/RouteInterface.php
@@ -119,7 +119,7 @@ interface RouteInterface
      *
      * @return RouteInterface
      */
-    public function setTarget(RouteInterface $target);
+    public function setTarget(RouteInterface $target = null);
 
     /**
      * Remove target.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes?
| Deprecations? | no
| License | MIT

#### What's in this PR?

Allow to reset the route entity target to null.

#### Why?

When a history url is changed from `history=1` to `history=0` also the Target need to set to null e.g. ArticleBundle. 

#### Example Usage

~~~php
$entity->setHistory(false);
$entity->setTarget(false);
~~~

#### BC Breaks/Deprecations

yes?

#### To Do

- [ ] Create a documentation PR
