### PR TITLE
Added check for null target-groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
+    * BUGFIX      #3414 [MediaBundle]             Added check for null target-groups
     * ENHANCEMENT #3411 [RouteBundle]             Allow to reset the route entity target to null
     * FEATURE     #3385 [SnippetBundle]           Implement snippet areas to replace default snippets 
     * BUGFIX      #3401 [WebsiteBundle]           Fixed localizatin of sitemaps

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -1047,6 +1047,10 @@ class Media extends ApiWrapper
      */
     public function getTargetGroups()
     {
+        if (!$this->getFileVersion()->getTargetGroups()) {
+            return [];
+        }
+
         return $this->getFileVersion()->getTargetGroups()->toArray();
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add additional check for media api object `getTargetGroups`. This function returns null if the AudienceTargetBudnle` is not registered.