### PR TITLE
Load react routes from server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 **/node_modules/
+**/vendor/
 
 # TODO Remove these rules once the old code is removed
 Gruntfile.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 
 language: php
 
+php: 7.1
+
 cache:
   directories:
     - $HOME/.composer/cache
@@ -18,14 +20,12 @@ env:
 
 matrix:
   include:
-    - php: 5.5
-      env:
+    - env:
         - PHP=true
-        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
-    - php: 7.0
-      env:
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction"
+    - env:
         - PHP=true
-        - COMPOSER_FLAGS="--prefer-dist --no-interaction
+        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction
         - SYMFONY__DATABASE__DRIVER=pdo_pgsql
         - SYMFONY__DATABASE__USER=postgres
         - SYMFONY__DATABASE__PASSWORD=postgres

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 build: false
 
 init:
-  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;c:\cygwin\bin;%PATH%
+  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php71;c:\cygwin\bin;%PATH%
 
   # uncomment to allow remote desktop connection
   #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
@@ -28,11 +28,12 @@ cache:
 
 install:
   # install SSL and php
+  - ps: Set-Service wuauserv -StartupType Manual
   - cinst -y OpenSSL.Light
-  - cinst -y php --version 7.0.9 --allow-empty-checksums
+  - cinst -y php
 
   # configure PHP and enable extensions.
-  - cd c:\tools\php
+  - cd c:\tools\php71
   - copy php.ini-production php.ini /Y
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
@@ -46,13 +47,11 @@ install:
   - echo extension=php_fileinfo.dll >> php.ini
   - echo memory_limit=1G >> php.ini
   - appveyor DownloadFile https://phar.phpunit.de/phpunit.phar
-  - ps: echo ("@php c:\tools\php\phpunit.phar %*") | Out-File phpunit.bat -encoding ascii
+  - ps: echo ("@php c:\tools\php71\phpunit.phar %*") | Out-File phpunit.bat -encoding ascii
 
   # install and start jackrabbit
   - cd %APPVEYOR_BUILD_FOLDER%
-  - ls
   - if not exist jackrabbit-standalone-%JACKRABBIT_VERSION%.jar appveyor DownloadFile http://archive.apache.org/dist/jackrabbit/%JACKRABBIT_VERSION%/jackrabbit-standalone-%JACKRABBIT_VERSION%.jar
-  - ls
   - ps: Start-Process ("jackrabbit-standalone-" + $env:JACKRABBIT_VERSION + ".jar")
 
   # install composer and phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.1",
         "cboden/ratchet": "0.3.*",
         "doctrine/orm": "^2.5.3",
         "doctrine/annotations": "^1.2",

--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -25,6 +25,11 @@ abstract class Admin
      */
     protected $navigation;
 
+    public function getRoutes()
+    {
+        return [];
+    }
+
     /**
      * Sets the navigation containing the position of the admin in the navigation.
      *
@@ -47,6 +52,8 @@ abstract class Admin
 
     /**
      * Returns the bundle name for the javascript main file.
+     *
+     * @deprecated Will not be used and removed in 2.0
      *
      * @return string
      */

--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Admin;
 
+use Sulu\Bundle\AdminBundle\Admin\Routing\Route;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 
 /**
@@ -25,7 +26,12 @@ abstract class Admin
      */
     protected $navigation;
 
-    public function getRoutes()
+    /**
+     * Returns all the routes for the frontend admin interface.
+     *
+     * @return Route[]
+     */
+    public function getRoutes(): array
     {
         return [];
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -46,7 +46,20 @@ class AdminPool
     }
 
     /**
-     * Returns the navigation combined from all admin-objects.
+     * Returns all the routes for the frontend application from all Admin objects.
+     */
+    public function getRoutes()
+    {
+        $routes = [];
+        $this->iterateAdmins(function(Admin $admin) use (&$routes) {
+            $routes = array_merge($routes, $admin->getRoutes());
+        });
+
+        return $routes;
+    }
+
+    /**
+     * Returns the navigation combined from all Admin objects.
      *
      * @return Navigation
      */
@@ -54,26 +67,42 @@ class AdminPool
     {
         /** @var Navigation $navigation */
         $navigation = null;
-        foreach ($this->pool as $admin) {
-            /* @var Admin $admin */
-            if ($navigation == null) {
+        $this->iterateAdmins(function(Admin $admin) use (&$navigation) {
+            if ($navigation === null) {
                 $navigation = $admin->getNavigation();
-            } else {
-                $navigation = $navigation->merge($admin->getNavigation());
+
+                return;
             }
-        }
+            $navigation = $navigation->merge($admin->getNavigation());
+        });
 
         return $navigation;
     }
 
+    /**
+     * Returns the combined security contexts from all Admin objects.
+     *
+     * @return array
+     */
     public function getSecurityContexts()
     {
         $contexts = [];
-        foreach ($this->pool as $admin) {
-            /* @var Admin $admin */
+        $this->iterateAdmins(function(Admin $admin) use (&$contexts) {
             $contexts = array_merge_recursive($contexts, $admin->getSecurityContexts());
-        }
+        });
 
         return $contexts;
+    }
+
+    /**
+     * Helper function to iterate over all available Admin objects.
+     *
+     * @param callable $callback
+     */
+    private function iterateAdmins($callback)
+    {
+        foreach ($this->pool as $admin) {
+            $callback($admin);
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -48,7 +48,7 @@ class AdminPool
     /**
      * Returns all the routes for the frontend application from all Admin objects.
      */
-    public function getRoutes()
+    public function getRoutes(): array
     {
         $routes = [];
         $this->iterateAdmins(function(Admin $admin) use (&$routes) {
@@ -96,10 +96,8 @@ class AdminPool
 
     /**
      * Helper function to iterate over all available Admin objects.
-     *
-     * @param callable $callback
      */
-    private function iterateAdmins($callback)
+    private function iterateAdmins(callable $callback): void
     {
         foreach ($this->pool as $admin) {
             $callback($admin);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Routing;
+
+class Route
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $view;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array
+     */
+    private $parameters;
+
+    public function __construct($name, $view, $path, $parameters = [])
+    {
+        $this->name = $name;
+        $this->view = $view;
+        $this->path = $path;
+        $this->parameters = $parameters;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -11,6 +11,9 @@
 
 namespace Sulu\Bundle\AdminBundle\Admin\Routing;
 
+/**
+ * Represents a route for adminstration frontend.
+ */
 class Route
 {
     /**

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -33,7 +33,7 @@ class Route
      */
     private $parameters;
 
-    public function __construct($name, $view, $path, $parameters = [])
+    public function __construct(string $name, string $view, string $path, array $parameters = [])
     {
         $this->name = $name;
         $this->view = $view;

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -196,11 +196,9 @@ class AdminController
     }
 
     /**
-     * Returns all the metadata for the admin interface.
-     *
-     * @return Response
+     * Returns all the configuration for the admin interface.
      */
-    public function metadataAction()
+    public function configurationAction(): Response
     {
         $view = View::create([
             'routes' => $this->adminPool->getRoutes(),

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\AdminBundle\Controller;
 
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandlerInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
@@ -21,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -56,6 +59,11 @@ class AdminController
      * @var SerializerInterface
      */
     private $serializer;
+
+    /**
+     * @var ViewHandlerInterface
+     */
+    private $viewHandler;
 
     /**
      * @var EngineInterface
@@ -109,6 +117,7 @@ class AdminController
         AdminPool $adminPool,
         JsConfigPool $jsConfigPool,
         SerializerInterface $serializer,
+        ViewHandlerInterface $viewHandler,
         EngineInterface $engine,
         LocalizationManagerInterface $localizationManager,
         $environment,
@@ -125,6 +134,7 @@ class AdminController
         $this->adminPool = $adminPool;
         $this->jsConfigPool = $jsConfigPool;
         $this->serializer = $serializer;
+        $this->viewHandler = $viewHandler;
         $this->engine = $engine;
         $this->environment = $environment;
         $this->adminName = $adminName;
@@ -183,6 +193,21 @@ class AdminController
     public function indexV2Action()
     {
         return $this->engine->renderResponse('SuluAdminBundle:Admin:main.html.twig');
+    }
+
+    /**
+     * Returns all the metadata for the admin interface.
+     *
+     * @return Response
+     */
+    public function metadataAction()
+    {
+        $view = View::create([
+            'routes' => $this->adminPool->getRoutes(),
+        ]);
+        $view->setFormat('json');
+
+        return $this->viewHandler->handle($view);
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -3,6 +3,11 @@ sulu_admin_v2:
     defaults:
         _controller: sulu_admin.admin_controller:indexV2Action
 
+sulu_admin_v2.metadata:
+    path: /metadata
+    defaults:
+        _controller: sulu_admin.admin_controller:metadataAction
+
 sulu_admin:
     path:  /
     defaults:

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -3,10 +3,10 @@ sulu_admin_v2:
     defaults:
         _controller: sulu_admin.admin_controller:indexV2Action
 
-sulu_admin_v2.metadata:
-    path: /metadata
+sulu_admin_v2.configuration:
+    path: /configuration
     defaults:
-        _controller: sulu_admin.admin_controller:metadataAction
+        _controller: sulu_admin.admin_controller:configurationAction
 
 sulu_admin:
     path:  /

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="sulu_admin.admin_pool"/>
             <argument type="service" id="sulu_admin.js_config_pool"/>
             <argument type="service" id="jms_serializer"/>
+            <argument type="service" id="fos_rest.view_handler"/>
             <argument type="service" id="templating"/>
             <argument type="service" id="sulu.core.localization_manager"/>
             <argument>%kernel.environment%</argument>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -9,18 +9,14 @@ import Router, {routeStore} from './services/Router';
 
 useStrict(true);
 
-viewStore.add('hello_world', () => (<h1>Hello World!</h1>));
+viewStore.add('sulu_admin.list', () => (<h1>Hello World!</h1>));
 
-routeStore.add({
-    name: 'hello_world',
-    view: 'hello_world',
-    path: '/',
-});
+function startApplication() {
+    const router = new Router(createHistory());
+    render(<Application router={router} />, document.getElementById('application'));
+}
 
-const router = new Router(createHistory());
-router.navigate('hello_world');
-
-render(
-    <Application router={router} />,
-    document.getElementById('application')
-);
+fetch('/admin/metadata', {credentials: 'same-origin'})
+    .then((response) => response.json())
+    .then((json) => routeStore.addCollection(json.routes))
+    .then(startApplication);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -16,7 +16,7 @@ function startApplication() {
     render(<Application router={router} />, document.getElementById('application'));
 }
 
-fetch('/admin/metadata', {credentials: 'same-origin'})
+fetch('/admin/configuration', {credentials: 'same-origin'})
     .then((response) => response.json())
     .then((json) => routeStore.addCollection(json.routes))
     .then(startApplication);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/stores/RouteStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/stores/RouteStore.js
@@ -14,7 +14,7 @@ class RouteStore {
 
     add(route: Route) {
         if (route.name in this.routes) {
-            throw new Error('The name "' + name + '" has already been used for another route');
+            throw new Error('The name "' + route.name + '" has already been used for another route');
         }
         this.routes[route.name] = route;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/stores/RouteStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/stores/RouteStore.js
@@ -13,7 +13,14 @@ class RouteStore {
     }
 
     add(route: Route) {
+        if (route.name in this.routes) {
+            throw new Error('The name "' + name + '" has already been used for another route');
+        }
         this.routes[route.name] = route;
+    }
+
+    addCollection(routes: Array<Route>) {
+        routes.forEach((route) => this.add(route));
     }
 
     get(name: string): Route {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/stores/RouteStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/stores/RouteStore.test.js
@@ -75,12 +75,12 @@ test('Add a route collection to the RouteStore', () => {
 
 test('Add route with existing key should throw', () => {
     const route = {
-        name: 'route',
+        name: 'test_route',
         view: 'view',
         pattern: '/route',
     };
 
     routeStore.add(route);
 
-    expect(() => routeStore.add(route)).toThrow('route');
+    expect(() => routeStore.add(route)).toThrow('test_route');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/stores/RouteStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/stores/RouteStore.test.js
@@ -47,3 +47,40 @@ test('Get routes from RouteStore', () => {
         route2: route2,
     });
 });
+
+test('Add a route collection to the RouteStore', () => {
+    const route1 = {
+        name: 'route1',
+        view: 'view1',
+        pattern: '/route/1',
+        parameters: {
+            test: 'value',
+        },
+    };
+
+    const route2 = {
+        name: 'route2',
+        view: 'view2',
+        pattern: '/route/2',
+        parameters: {
+            test2: 'value2',
+        },
+    };
+
+    routeStore.addCollection([route1, route2]);
+
+    expect(routeStore.get('route1')).toBe(route1);
+    expect(routeStore.get('route2')).toBe(route2);
+});
+
+test('Add route with existing key should throw', () => {
+    const route = {
+        name: 'route',
+        view: 'view',
+        pattern: '/route',
+    };
+
+    routeStore.add(route);
+
+    expect(() => routeStore.add(route)).toThrow('route');
+});

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -23,6 +23,7 @@ use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -148,7 +149,7 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testMetadataAction()
+    public function testConfigurationAction()
     {
         $data = [
             new Route('sulu_snippet.list', 'sulu_admin.list', '/snippets', ['type' => 'snippets']),
@@ -157,9 +158,9 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
 
         $this->viewHandler->handle(Argument::that(function(View $view) use ($data) {
             return $view->getFormat() === 'json' && $view->getData() === ['routes' => $data];
-        }))->shouldBeCalled();
+        }))->shouldBeCalled()->willReturn(new Response());
 
-        $this->adminController->metadataAction();
+        $this->adminController->configurationAction();
     }
 
     public function testContextsAction()

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Admin;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\Routing\Route;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 use Sulu\Bundle\AdminBundle\Navigation\NavigationItem;
 use Sulu\Bundle\ContentBundle\Admin\ContentAdmin;
@@ -77,6 +78,16 @@ class SnippetAdmin extends Admin
         }
 
         $this->setNavigation(new Navigation($rootNavigationItem));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoutes()
+    {
+        return [
+            new Route('sulu_snippet.list', 'sulu_admin.list', '/snippets', ['type' => 'snippets']),
+        ];
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -83,7 +83,7 @@ class SnippetAdmin extends Admin
     /**
      * {@inheritdoc}
      */
-    public function getRoutes()
+    public function getRoutes(): array
     {
         return [
             new Route('sulu_snippet.list', 'sulu_admin.list', '/snippets', ['type' => 'snippets']),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR loads the routes for the react application from the server.

`add metadata action` is the first commit from this PR, the rest comes from #3405 