### PR TITLE
Fixed 404 page for none localized urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #3431 [MediaBundle]             Fixed file download url filename encoding
+    * HOTFIX      #3430 [WebsiteBundle]           Fixed 404 page for none localized urls
 
 * 1.6.0 (2017-06-28)
     * ENHANCEMENT #3423 [ContentBundle]           Added config values for seo restrictions

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -33,10 +33,6 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
 
         $attributes = ['requestUri' => $request->getUri()];
 
-        if (null !== $localization = $portalInformation->getLocalization()) {
-            $request->setLocale($localization->getLocale());
-        }
-
         $attributes['portalInformation'] = $portalInformation;
 
         $attributes['getParameter'] = $request->query->all();
@@ -55,8 +51,14 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         }
 
         $attributes['localization'] = $portalInformation->getLocalization();
+
+        if (!$attributes['localization'] && $portalInformation->getPortal()) {
+            $attributes['localization'] = $portalInformation->getPortal()->getDefaultLocalization();
+        }
+
         if ($attributes['localization']) {
             $attributes['locale'] = $attributes['localization']->getLocale();
+            $request->setLocale($attributes['locale']);
         }
 
         $attributes['segment'] = $portalInformation->getSegment();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -91,6 +91,65 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider provideProcess
+     */
+    public function testProcessWithoutLocaliziation($config, $expected = [])
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu');
+
+        $defaultLocalization = new Localization();
+        $defaultLocalization->setCountry('ch');
+        $defaultLocalization->setLanguage('it');
+
+        $portal = new Portal();
+        $portal->setKey('sulu');
+        $portal->setDefaultLocalization($defaultLocalization);
+
+        $portalInformation = new PortalInformation(
+            $config['match_type'],
+            $webspace,
+            $portal,
+            null,
+            $config['portal_url'],
+            null,
+            $config['redirect'],
+            null,
+            false,
+            $config['url_expression']
+        );
+
+        $request = new Request(
+            ['get' => 1],
+            ['post' => 1],
+            [],
+            [],
+            [],
+            ['HTTP_HOST' => 'sulu.lo']
+        );
+
+        $attributes = $this->portalInformationRequestProcessor->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation, 'path' => $config['path_info']])
+        );
+
+        $this->assertEquals('it_ch', $request->getLocale());
+
+        $this->assertEquals('it_ch', $attributes->getAttribute('localization'));
+        $this->assertEquals('sulu', $attributes->getAttribute('webspace')->getKey());
+        $this->assertEquals('sulu', $attributes->getAttribute('portal')->getKey());
+        $this->assertNull($attributes->getAttribute('segment'));
+
+        $this->assertEquals($expected['portal_url'], $attributes->getAttribute('portalUrl'));
+        $this->assertEquals($expected['redirect'], $attributes->getAttribute('redirect'));
+        $this->assertEquals($expected['resource_locator'], $attributes->getAttribute('resourceLocator'));
+        $this->assertEquals($expected['resource_locator_prefix'], $attributes->getAttribute('resourceLocatorPrefix'));
+        $this->assertEquals($expected['url_expression'], $attributes->getAttribute('urlExpression'));
+        $this->assertEquals(['post' => 1], $attributes->getAttribute('postParameter'));
+        $this->assertEquals(['get' => 1], $attributes->getAttribute('getParameter'));
+    }
+
+    /**
      * @dataProvider provideProcessWithFormat
      */
     public function testProcessWithFormat($config, $expected = [])


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set the current localization to default localization when not exist.

#### Why?

Fixed rendering of 404 page when e.g. webspace config is: `<url>sulu.io/{localization}</url>` and the request page is `sulu.io/test`.

#### Example Usage

```php
$requestAnalyzer->getCurrentLocalization();
$request->getLocale();
```

#### BC Breaks/Deprecations

There always exist a current localization.
