### PR TITLE
Fixed file download url filename encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3431 [MediaBundle]             Fixed file download url filename encoding
+
 * 1.6.0 (2017-06-28)
     * ENHANCEMENT #3423 [ContentBundle]           Added config values for seo restrictions
     * ENHANCEMENT #3416 [ContentBundle]           Changed skin of history-url to large

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -888,7 +888,7 @@ class MediaManager implements MediaManagerInterface
             ],
             [
                 $id,
-                $fileName,
+                rawurlencode($fileName),
             ],
             $this->downloadPath
         ) . '?v=' . $version;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -167,7 +167,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
             [
                 'view' => 64,
             ],
-            '/',
+            '/download/{id}/media/{slug}',
             0,
             $this->targetGroupRepository->reveal()
         );
@@ -272,6 +272,14 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $media = $this->mediaManager->save($uploadedFile->reveal(), ['locale' => 'en', 'title' => 'my title'], 1);
 
         $this->assertEquals($fileName, $media->getName());
+    }
+
+    /**
+     * @dataProvider provideSpecialCharacterUrl
+     */
+    public function testSpecialCharacterUrl($id, $filename, $version, $expected)
+    {
+        $this->assertEquals($expected, $this->mediaManager->getUrl($id, $filename, $version));
     }
 
     public function testSaveWrongVersionType()
@@ -409,6 +417,15 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         return [
             ['aäüßa', 'aäüßa', 'aaeuesa', ''],
             ['aäüßa.mp4', 'aäüßa', 'aaeuesa', '.mp4'],
+        ];
+    }
+
+    public function provideSpecialCharacterUrl()
+    {
+        return [
+            [1, 'aäüßa.mp4', 2, '/download/1/media/a%C3%A4%C3%BC%C3%9Fa.mp4?v=2'],
+            [1, 'aäüßa', 2, '/download/1/media/a%C3%A4%C3%BC%C3%9Fa?v=2'],
+            [2, 'Sulu & Enterprise.doc', 2, '/download/2/media/Sulu%20%26%20Enterprise.doc?v=2'],
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3424 
| License | MIT

#### What's in this PR?

Add rawurlencode for the filename of the media url.

#### Why?

None browser e.g. native android avoid request to a none RFC valid url.

#### Example Usage

~~~php
$media->getUrl(); // should return a rawurlencoded filename
~~~


