### PR TITLE
Fixed url generation for domain root url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3433 [ContentBundle]           Fixed url generation for domain root page
     * HOTFIX      #3432 [SnippetBundle]           Fixed not working smart content in snippet bundle
     * HOTFIX      #3431 [MediaBundle]             Fixed file download url filename encoding
     * HOTFIX      #3430 [WebsiteBundle]           Fixed 404 page for none localized urls

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -31,7 +31,7 @@ class SitemapControllerTest extends SuluTestCase
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
         $this->assertCount(0, $crawler->filterXPath('//x:urlset/x:url/xhtml:link'));
-        $this->assertEquals('http://sulu.lo', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+        $this->assertEquals('http://sulu.lo/', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
     }
 
     public function testIndexMultipleLanguage()
@@ -125,7 +125,7 @@ class SitemapControllerTest extends SuluTestCase
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
-        $this->assertEquals('http://sulu.lo', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+        $this->assertEquals('http://sulu.lo/', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
     }
 
     public function testPaginatedOverMax()

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -156,7 +156,7 @@ class WebspaceManager implements WebspaceManagerInterface
         foreach ($portals as $portalInformation) {
             $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
-            $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
+            $url = $this->createResourceLocatorUrl($scheme, $portalInformation->getUrl(), $resourceLocator);
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
                 $urls[] = $url;
             }
@@ -191,7 +191,7 @@ class WebspaceManager implements WebspaceManagerInterface
                 || $portalInformation->getLocalization()->getLocalization() === $languageCode
             );
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
-            $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
+            $url = $this->createResourceLocatorUrl($scheme, $portalInformation->getUrl(), $resourceLocator);
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
                 if ($portalInformation->isMain()) {
                     array_unshift($urls, $url);
@@ -386,5 +386,24 @@ class WebspaceManager implements WebspaceManagerInterface
     protected function matchUrl($url, $portalUrl)
     {
         return WildcardUrlUtil::match($url, $portalUrl);
+    }
+
+    /**
+     * Return a valid resource locator url.
+     *
+     * @param string $scheme
+     * @param string $portalUrl
+     * @param string $resourceLocator
+     *
+     * @return string
+     */
+    private function createResourceLocatorUrl($scheme, $portalUrl, $resourceLocator)
+    {
+        if (strpos($portalUrl, '/') !== false) {
+            // trim slash when resourceLocator is not domain root
+            $resourceLocator = rtrim($resourceLocator, '/');
+        }
+
+        return rtrim(sprintf('%s://%s', $scheme, $portalUrl), '/') . $resourceLocator;
     }
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -665,6 +665,30 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals(['https://sulu.lo/test'], $result);
     }
 
+    public function testFindUrlsByResourceLocatorRoot()
+    {
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/', 'dev', 'en_us', 'massiveart');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('http://massiveart.lo/en-us/w', $result);
+        $this->assertContains('http://massiveart.lo/en-us/s', $result);
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/', 'dev', 'de_at', 'sulu_io');
+        $this->assertEquals(['http://sulu.lo/'], $result);
+    }
+
+    public function testFindUrlsByResourceLocatorRootWithScheme()
+    {
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/', 'dev', 'en_us', 'massiveart', null, 'https');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('https://massiveart.lo/en-us/w', $result);
+        $this->assertContains('https://massiveart.lo/en-us/s', $result);
+
+        $result = $this->webspaceManager->findUrlsByResourceLocator('/', 'dev', 'de_at', 'sulu_io', null, 'https');
+        $this->assertEquals(['https://sulu.lo/'], $result);
+    }
+
     public function testFindUrlByResourceLocator()
     {
         $result = $this->webspaceManager->findUrlByResourceLocator('/test', 'dev', 'de_at', 'sulu_io');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add a slash to the  homepage of a webspace when it is not a folder e.g. `https://example.org` will be `https://example.org/`.

#### Why?

A browser always request `https://example.org/` and tools like onpage will throw an error that the current page `https://example.org/` is not listed in the sitemap or are false in the content. So all root urls of a domain should keep the `/`. 

#### Example Usage

```twig
{{ sulu_content_path('/') }} {# should output `https://example.org/` instead of `https://example.org`
```

#### To Do

- [x] Add Testcases
