### PR TITLE
Load admin translations from Symfony endpoint

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -223,10 +223,12 @@ class AdminController
         $catalogue = $this->translator->getCatalogue($request->query->get('locale'));
         $fallbackCatalogue = $catalogue->getFallbackCatalogue();
 
-        return new JsonResponse(array_replace(
-            $fallbackCatalogue->all(static::TRANSLATION_DOMAIN),
-            $catalogue->all(static::TRANSLATION_DOMAIN))
-        );
+        $translations = $catalogue->all(static::TRANSLATION_DOMAIN);
+        if ($fallbackCatalogue) {
+            $translations = array_replace($fallbackCatalogue->all(static::TRANSLATION_DOMAIN), $translations);
+        }
+
+        return new JsonResponse($translations);
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -27,9 +27,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
 
 class AdminController
 {
+    const TRANSLATION_DOMAIN = 'admin';
+
     /**
      * @var AuthorizationCheckerInterface
      */
@@ -71,6 +74,16 @@ class AdminController
     private $engine;
 
     /**
+     * @var LocalizationManagerInterface
+     */
+    private $localizationManager;
+
+    /**
+     * @var TranslatorBagInterface
+     */
+    private $translator;
+
+    /**
      * @var string
      */
     private $environment;
@@ -105,11 +118,6 @@ class AdminController
      */
     private $fallbackLocale;
 
-    /**
-     * @var LocalizationManagerInterface
-     */
-    private $localizationManager;
-
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
         UrlGeneratorInterface $urlGenerator,
@@ -120,6 +128,7 @@ class AdminController
         ViewHandlerInterface $viewHandler,
         EngineInterface $engine,
         LocalizationManagerInterface $localizationManager,
+        TranslatorBagInterface $translator,
         $environment,
         $adminName,
         array $locales,
@@ -136,6 +145,8 @@ class AdminController
         $this->serializer = $serializer;
         $this->viewHandler = $viewHandler;
         $this->engine = $engine;
+        $this->localizationManager = $localizationManager;
+        $this->translator = $translator;
         $this->environment = $environment;
         $this->adminName = $adminName;
         $this->locales = $locales;
@@ -143,7 +154,6 @@ class AdminController
         $this->translatedLocales = $translatedLocales;
         $this->translations = $translations;
         $this->fallbackLocale = $fallbackLocale;
-        $this->localizationManager = $localizationManager;
     }
 
     /**
@@ -198,7 +208,7 @@ class AdminController
     /**
      * Returns all the configuration for the admin interface.
      */
-    public function configurationAction(): Response
+    public function configV2Action(): Response
     {
         $view = View::create([
             'routes' => $this->adminPool->getRoutes(),
@@ -206,6 +216,17 @@ class AdminController
         $view->setFormat('json');
 
         return $this->viewHandler->handle($view);
+    }
+
+    public function translationsAction(Request $request): Response
+    {
+        $catalogue = $this->translator->getCatalogue($request->query->get('locale'));
+        $fallbackCatalogue = $catalogue->getFallbackCatalogue();
+
+        return new JsonResponse(array_replace(
+            $fallbackCatalogue->all(static::TRANSLATION_DOMAIN),
+            $catalogue->all(static::TRANSLATION_DOMAIN))
+        );
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -3,10 +3,15 @@ sulu_admin_v2:
     defaults:
         _controller: sulu_admin.admin_controller:indexV2Action
 
-sulu_admin_v2.configuration:
-    path: /configuration
+sulu_admin_v2.config:
+    path: /v2/config
     defaults:
-        _controller: sulu_admin.admin_controller:configurationAction
+        _controller: sulu_admin.admin_controller:configV2Action
+
+sulu_admin_v2.translation:
+    path: /v2/translations
+    defaults:
+        _controller: sulu_admin.admin_controller:translationsAction
 
 sulu_admin:
     path:  /

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -21,6 +21,7 @@
             <argument type="service" id="fos_rest.view_handler"/>
             <argument type="service" id="templating"/>
             <argument type="service" id="sulu.core.localization_manager"/>
+            <argument type="service" id="translator.default"/>
             <argument>%kernel.environment%</argument>
             <argument>%sulu_admin.name%</argument>
             <argument>%sulu_core.locales%</argument>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -5,6 +5,7 @@ import {useStrict} from 'mobx';
 import createHistory from 'history/createHashHistory';
 import Application from './containers/Application';
 import {viewStore} from './containers/ViewRenderer';
+import Requester from './services/Requester';
 import Router, {routeStore} from './services/Router';
 import Form from './views/Form';
 import List from './views/List';
@@ -19,7 +20,7 @@ function startApplication() {
     render(<Application router={router} />, document.getElementById('application'));
 }
 
-fetch('/admin/v2/config', {credentials: 'same-origin'})
+Requester.get('/admin/v2/config')
     .then((response) => response.json())
     .then((json) => routeStore.addCollection(json.routes))
     .then(startApplication);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -7,6 +7,7 @@ import Application from './containers/Application';
 import {viewStore} from './containers/ViewRenderer';
 import Requester from './services/Requester';
 import Router, {routeStore} from './services/Router';
+import translator from './services/Translator';
 import Form from './views/Form';
 import List from './views/List';
 
@@ -20,7 +21,12 @@ function startApplication() {
     render(<Application router={router} />, document.getElementById('application'));
 }
 
-Requester.get('/admin/v2/config')
+const translationPromise = Requester.get('/admin/v2/translations?locale=en')
     .then((response) => response.json())
-    .then((json) => routeStore.addCollection(json.routes))
-    .then(startApplication);
+    .then((json) => translator.set(json));
+
+const configPromise = Requester.get('/admin/v2/config')
+    .then((response) => response.json())
+    .then((json) => routeStore.addCollection(json.routes));
+
+Promise.all([translationPromise, configPromise]).then(startApplication);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -7,7 +7,7 @@ import Application from './containers/Application';
 import {viewStore} from './containers/ViewRenderer';
 import Requester from './services/Requester';
 import Router, {routeStore} from './services/Router';
-import translator from './services/Translator';
+import {setTranslations} from './services/Translator';
 import Form from './views/Form';
 import List from './views/List';
 
@@ -23,7 +23,7 @@ function startApplication() {
 
 const translationPromise = Requester.get('/admin/v2/translations?locale=en')
     .then((response) => response.json())
-    .then((json) => translator.set(json));
+    .then((json) => setTranslations(json));
 
 const configPromise = Requester.get('/admin/v2/config')
     .then((response) => response.json())

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -22,11 +22,9 @@ function startApplication() {
 }
 
 const translationPromise = Requester.get('/admin/v2/translations?locale=en')
-    .then((response) => response.json())
-    .then((json) => setTranslations(json));
+    .then((response) => setTranslations(response));
 
 const configPromise = Requester.get('/admin/v2/config')
-    .then((response) => response.json())
-    .then((json) => routeStore.addCollection(json.routes));
+    .then((response) => routeStore.addCollection(response.routes));
 
 Promise.all([translationPromise, configPromise]).then(startApplication);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -19,7 +19,7 @@ function startApplication() {
     render(<Application router={router} />, document.getElementById('application'));
 }
 
-fetch('/admin/configuration', {credentials: 'same-origin'})
+fetch('/admin/v2/config', {credentials: 'same-origin'})
     .then((response) => response.json())
     .then((json) => routeStore.addCollection(json.routes))
     .then(startApplication);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -2,7 +2,7 @@
 const defaultOptions = {credentials: 'same-origin'};
 
 export default class Requester {
-    static get(url: string) {
+    static get(url: string): Promise<Response> {
         return fetch(url, defaultOptions);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -1,0 +1,8 @@
+// @flow
+const defaultOptions = {credentials: 'same-origin'};
+
+export default class Requester {
+    static get(url: string) {
+        return fetch(url, defaultOptions);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -2,7 +2,8 @@
 const defaultOptions = {credentials: 'same-origin'};
 
 export default class Requester {
-    static get(url: string): Promise<Response> {
-        return fetch(url, defaultOptions);
+    static get(url: string): Promise<Object> {
+        return fetch(url, defaultOptions)
+            .then((response) => response.json());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Requester from './Requester';
+
+export default Requester;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -3,16 +3,27 @@
 import Requester from '../Requester';
 
 test('Add credentials to fetch request', () => {
+    const promise = new Promise(() => 'test');
+
     global.fetch = jest.fn();
+    global.fetch.mockReturnValue(promise);
 
     Requester.get('/some-url');
 
     expect(global.fetch).toBeCalledWith('/some-url', {credentials: 'same-origin'});
 });
 
-test('Return value from fetch call', () => {
-    global.fetch = jest.fn();
-    global.fetch.mockReturnValue('test');
+test('Return json from fetch call', () => {
+    const request = {
+        json: jest.fn(),
+    };
+    request.json.mockReturnValue('test');
+    const promise = new Promise((resolve) => resolve(request));
 
-    expect(Requester.get('/some-url')).toBe('test');
+    global.fetch = jest.fn();
+    global.fetch.mockReturnValue(promise);
+
+    return Requester.get('/some-url').then(data => {
+        expect(data).toBe('test');
+    });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -1,0 +1,18 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+/* global global */
+import Requester from '../Requester';
+
+test('Add credentials to fetch request', () => {
+    global.fetch = jest.fn();
+
+    Requester.get('/some-url');
+
+    expect(global.fetch).toBeCalledWith('/some-url', {credentials: 'same-origin'});
+});
+
+test('Return value from fetch call', () => {
+    global.fetch = jest.fn();
+    global.fetch.mockReturnValue('test');
+
+    expect(Requester.get('/some-url')).toBe('test');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
@@ -1,0 +1,24 @@
+// @flow
+import type {TranslationMap} from './types';
+
+class Translator {
+    translations: ?TranslationMap;
+
+    set(translations: TranslationMap) {
+        this.translations = translations;
+    }
+
+    clear() {
+        this.translations = null;
+    }
+
+    translate(key: string) {
+        if (!this.translations || !(key in this.translations)) {
+            throw new Error('Translation for key "' + key + '" not found');
+        }
+
+        return this.translations[key];
+    }
+}
+
+export default new Translator();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
@@ -13,7 +13,7 @@ function clearTranslations() {
 
 function translate(key: string) {
     if (!translationMap || !(key in translationMap)) {
-        throw new Error('Translation for key "' + key + '" not found');
+        return key;
     }
 
     return translationMap[key];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
@@ -1,24 +1,22 @@
 // @flow
 import type {TranslationMap} from './types';
 
-class Translator {
-    translations: ?TranslationMap;
+let translationMap: ?TranslationMap;
 
-    set(translations: TranslationMap) {
-        this.translations = translations;
-    }
-
-    clear() {
-        this.translations = null;
-    }
-
-    translate(key: string) {
-        if (!this.translations || !(key in this.translations)) {
-            throw new Error('Translation for key "' + key + '" not found');
-        }
-
-        return this.translations[key];
-    }
+function setTranslations(translations: TranslationMap) {
+    translationMap = translations;
 }
 
-export default new Translator();
+function clearTranslations() {
+    translationMap = null;
+}
+
+function translate(key: string) {
+    if (!translationMap || !(key in translationMap)) {
+        throw new Error('Translation for key "' + key + '" not found');
+    }
+
+    return translationMap[key];
+}
+
+export {setTranslations, clearTranslations, translate};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Translator from './Translator';
+
+export default Translator;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/index.js
@@ -1,4 +1,4 @@
 // @flow
-import Translator from './Translator';
+import {setTranslations, clearTranslations, translate} from './Translator';
 
-export default Translator;
+export {setTranslations, clearTranslations, translate};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
@@ -1,0 +1,32 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import translator from '../Translator';
+
+beforeEach(() => {
+    translator.clear();
+});
+
+test('Translator should set translations', () => {
+    const translations = {'save': 'Save'};
+
+    translator.set(translations);
+
+    expect(translator.translations).toBe(translations);
+});
+
+test('Translator should clear translations', () => {
+    translator.set({'save': 'Save'});
+    translator.clear();
+
+    expect(translator.translations).toBe(null);
+});
+
+test('Translator should translate translations', () => {
+    translator.set({'save': 'Save', 'delete': 'Delete'});
+
+    expect(translator.translate('save')).toBe('Save');
+    expect(translator.translate('delete')).toBe('Delete');
+});
+
+test('Translator should throw error when translating non-existing keys', () => {
+    expect(() => translator.translate('not-existing')).toThrow(/not-existing/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
@@ -12,6 +12,6 @@ test('Translator should translate translations', () => {
     expect(translate('delete')).toBe('Delete');
 });
 
-test('Translator should throw error when translating non-existing keys', () => {
-    expect(() => translate('not-existing')).toThrow(/not-existing/);
+test('Translator should return key when translating non-existing keys', () => {
+    expect(translate('not-existing')).toBe('not-existing');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
@@ -1,32 +1,17 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import translator from '../Translator';
+import {setTranslations, clearTranslations, translate} from '../Translator';
 
 beforeEach(() => {
-    translator.clear();
-});
-
-test('Translator should set translations', () => {
-    const translations = {'save': 'Save'};
-
-    translator.set(translations);
-
-    expect(translator.translations).toBe(translations);
-});
-
-test('Translator should clear translations', () => {
-    translator.set({'save': 'Save'});
-    translator.clear();
-
-    expect(translator.translations).toBe(null);
+    clearTranslations();
 });
 
 test('Translator should translate translations', () => {
-    translator.set({'save': 'Save', 'delete': 'Delete'});
+    setTranslations({'save': 'Save', 'delete': 'Delete'});
 
-    expect(translator.translate('save')).toBe('Save');
-    expect(translator.translate('delete')).toBe('Delete');
+    expect(translate('save')).toBe('Save');
+    expect(translate('delete')).toBe('Delete');
 });
 
 test('Translator should throw error when translating non-existing keys', () => {
-    expect(() => translator.translate('not-existing')).toThrow(/not-existing/);
+    expect(() => translate('not-existing')).toThrow(/not-existing/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/types.js
@@ -1,0 +1,4 @@
+// @flow
+export type TranslationMap = {
+    [string]: string,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import {withToolbar} from '../../containers/Toolbar';
+import translator from '../../services/Translator';
 
 class Form extends React.PureComponent {
     @observable dirty = false;
@@ -21,7 +22,7 @@ class Form extends React.PureComponent {
 export default withToolbar(Form, function() {
     return [
         {
-            title: 'Save',
+            title: translator.translate('sulu_admin.save'),
             icon: 'floppy-o',
             enabled: this.dirty,
             onClick: () => {
@@ -29,7 +30,7 @@ export default withToolbar(Form, function() {
             },
         },
         {
-            title: 'Delete',
+            title: translator.translate('sulu_admin.delete'),
             icon: 'trash-o',
             onClick: () => {
                 this.setDirty(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {action, observable} from 'mobx';
 import {withToolbar} from '../../containers/Toolbar';
-import translator from '../../services/Translator';
+import {translate} from '../../services/Translator';
 
 class Form extends React.PureComponent {
     @observable dirty = false;
@@ -22,7 +22,7 @@ class Form extends React.PureComponent {
 export default withToolbar(Form, function() {
     return [
         {
-            title: translator.translate('sulu_admin.save'),
+            title: translate('sulu_admin.save'),
             icon: 'floppy-o',
             enabled: this.dirty,
             onClick: () => {
@@ -30,7 +30,7 @@ export default withToolbar(Form, function() {
             },
         },
         {
-            title: translator.translate('sulu_admin.delete'),
+            title: translate('sulu_admin.delete'),
             icon: 'trash-o',
             onClick: () => {
                 this.setDirty(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {withToolbar} from '../../containers/Toolbar';
+import translator from '../../services/Translator';
 
 class List extends React.PureComponent {
     render() {
@@ -13,11 +14,11 @@ class List extends React.PureComponent {
 export default withToolbar(List, function() {
     return [
         {
-            title: 'Add',
+            title: translator.translate('sulu_admin.add'),
             icon: 'plus-circle',
         },
         {
-            title: 'Delete',
+            title: translator.translate('sulu_admin.delete'),
             icon: 'trash-o',
         },
     ];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import {withToolbar} from '../../containers/Toolbar';
-import translator from '../../services/Translator';
+import {translate} from '../../services/Translator';
 
 class List extends React.PureComponent {
     render() {
@@ -14,11 +14,11 @@ class List extends React.PureComponent {
 export default withToolbar(List, function() {
     return [
         {
-            title: translator.translate('sulu_admin.add'),
+            title: translate('sulu_admin.add'),
             icon: 'plus-circle',
         },
         {
-            title: translator.translate('sulu_admin.delete'),
+            title: translate('sulu_admin.delete'),
             icon: 'trash-o',
         },
     ];

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -1,4 +1,5 @@
 {
-    "sulu_admin.save": "Speichern",
-    "sulu_admin.delete": "Löschen"
+    "sulu_admin.add": "Hinzufügen",
+    "sulu_admin.delete": "Löschen",
+    "sulu_admin.save": "Speichern"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -1,0 +1,4 @@
+{
+    "sulu_admin.save": "Speichern",
+    "sulu_admin.delete": "Löschen"
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -1,0 +1,4 @@
+{
+    "sulu_admin.save": "Save",
+    "sulu_admin.delete": "Delete"
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -1,4 +1,5 @@
 {
-    "sulu_admin.save": "Save",
-    "sulu_admin.delete": "Delete"
+    "sulu_admin.add": "Add",
+    "sulu_admin.delete": "Delete",
+    "sulu_admin.save": "Save"
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -204,6 +204,19 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($resultTranslations, json_decode($response->getContent(), true));
     }
 
+    public function testTranslationActionWithoutFallback()
+    {
+        $request = new Request(['locale' => 'en']);
+
+        $catalogue = $this->prophesize(MessageCatalogueInterface::class);
+        $catalogue->all('admin')->willReturn(['save' => 'Save']);
+        $catalogue->getFallbackCatalogue()->willReturn(null);
+        $this->translator->getCatalogue('en')->willReturn($catalogue->reveal());
+
+        $response = $this->adminController->translationsAction($request);
+        $this->assertEquals(['save' => 'Save'], json_decode($response->getContent(), true));
+    }
+
     public function testContextsAction()
     {
         $request = $this->prophesize(Request::class);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -27,6 +27,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
 
 class AdminControllerTest extends \PHPUnit_Framework_TestCase
 {
@@ -74,6 +76,11 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
      * @var LocalizationManagerInterface
      */
     private $localizationManager;
+
+    /**
+     * @var TranslatorBagInterface
+     */
+    private $translator;
 
     /**
      * @var string
@@ -128,6 +135,7 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
         $this->viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $this->engine = $this->prophesize(EngineInterface::class);
         $this->localizationManager = $this->prophesize(LocalizationManagerInterface::class);
+        $this->translator = $this->prophesize(TranslatorBagInterface::class);
 
         $this->adminController = new AdminController(
             $this->authorizationChecker->reveal(),
@@ -139,6 +147,7 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
             $this->viewHandler->reveal(),
             $this->engine->reveal(),
             $this->localizationManager->reveal(),
+            $this->translator->reveal(),
             $this->environment,
             $this->adminName,
             $this->locales,
@@ -160,7 +169,39 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
             return $view->getFormat() === 'json' && $view->getData() === ['routes' => $data];
         }))->shouldBeCalled()->willReturn(new Response());
 
-        $this->adminController->configurationAction();
+        $this->adminController->configV2Action();
+    }
+
+    public function provideTranslationsAction()
+    {
+        return [
+            ['en', ['save' => 'Save'], [], ['save' => 'Save']],
+            ['de', ['save' => 'Speichern'], [], ['save' => 'Speichern']],
+            [
+                'de',
+                ['save' => 'Speichern'],
+                ['save' => 'Save', 'delete' => 'Delete'],
+                ['save' => 'Speichern', 'delete' => 'Delete'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTranslationsAction
+     */
+    public function testTranslationsAction($locale, $translations, $fallbackTranslations, $resultTranslations)
+    {
+        $request = new Request(['locale' => $locale]);
+
+        $catalogue = $this->prophesize(MessageCatalogueInterface::class);
+        $catalogue->all('admin')->willReturn($translations);
+        $fallbackCatalogue = $this->prophesize(MessageCatalogueInterface::class);
+        $fallbackCatalogue->all('admin')->willReturn($fallbackTranslations);
+        $catalogue->getFallbackCatalogue()->willReturn($fallbackCatalogue);
+        $this->translator->getCatalogue($locale)->willReturn($catalogue->reveal());
+
+        $response = $this->adminController->translationsAction($request);
+        $this->assertEquals($resultTranslations, json_decode($response->getContent(), true));
     }
 
     public function testContextsAction()

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -393,7 +393,7 @@ class ResettingControllerTest extends SuluTestCase
         ]);
 
         return [
-            'subject' => $this->getContainer()->getParameter('sulu_security.reset_password.mail.subject'),
+            'subject' => 'Reset your Sulu password',
             'body' => trim($body),
             'sender' => $sender ? $sender : 'no-reply@' . $client->getRequest()->getHost(),
         ];

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -1,4 +1,6 @@
 framework:
+    translator:
+        fallbacks: ["en"]
     secret: secret
     router: { resource: "%kernel.root_dir%/config/routing.yml" }
     templating: { engines: ['twig'] }

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
@@ -19,7 +19,7 @@ class DataCacheTest extends \PHPUnit_Framework_TestCase
 {
     public function provideIsFreshData()
     {
-        $tmpFile = tempnam('/tmp', 'sulu-test');
+        $tmpFile = tempnam(sys_get_temp_dir(), 'sulu-test');
 
         return [
             [$tmpFile, false, false],

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
@@ -46,7 +46,7 @@ class DataCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testWrite()
     {
-        $file = tempnam('/tmp', 'sulu-test');
+        $file = tempnam(sys_get_temp_dir(), 'sulu-test');
         $cache = new DataCache($file);
 
         $cache->write(['test' => 'test']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a Symfony endpoint `/v2/translations` which takes a locale and returns all translations in that locale from the `admin` domain.

The react admin will do a request to this domain, and set the result to the translator (also implemented in this PR), which can be used to translate the UI afterwards.

#### Why?

Because loading translations from the server via a endpoint allows an external developer to easily override/add translations without touching and javascript or creating a new webpack build.

#### Example Usage

~~~javscript
translator.set({'save': 'Save'});
translator.translate('save');
~~~