### PR TITLE
Removed calls of deprecated get-localization function

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Command/MaintainResourceLocatorCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/MaintainResourceLocatorCommand.php
@@ -108,7 +108,7 @@ class MaintainResourceLocatorCommand extends Command
 
     private function upgradeLocale(Webspace $webspace, Localization $localization, OutputInterface $output)
     {
-        $output->writeln('  > Upgrade Locale: ' . $localization->getLocalization('-'));
+        $output->writeln('  > Upgrade Locale: ' . $localization->getLocale(Localization::DASH));
 
         $contentNode = $this->liveSession->getNode($this->sessionManager->getContentPath($webspace->getKey()));
 

--- a/src/Sulu/Bundle/ContentBundle/Command/ValidatePagesCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ValidatePagesCommand.php
@@ -47,9 +47,8 @@ class ValidatePagesCommand extends ContainerAwareCommand
         $select = '';
         $headers = [];
         foreach ($webspace->getAllLocalizations() as $localization) {
-            $select .= '[i18n:' . $localization->getLocalization() . '-template] as ' . $localization->getLocalization(
-                ) . ',';
-            $headers[] = $localization->getLocalization();
+            $select .= '[i18n:' . $localization->getLocale() . '-template] as ' . $localization->getLocale() . ',';
+            $headers[] = $localization->getLocale();
         }
         $select = rtrim($select, ',');
 

--- a/src/Sulu/Bundle/ContentBundle/Controller/TemplateController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/TemplateController.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ContentBundle\Controller;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Localization\Localization;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -188,8 +189,8 @@ class TemplateController extends Controller
         $i = 0;
         foreach ($webspace->getAllLocalizations() as $localization) {
             $localizations[] = [
-                'localization' => $localization->getLocalization(),
-                'name' => $localization->getLocalization('-'),
+                'localization' => $localization->getLocale(),
+                'name' => $localization->getLocale(Localization::DASH),
                 'id' => $i++,
             ];
         }
@@ -227,7 +228,7 @@ class TemplateController extends Controller
 
         $languages = [];
         foreach ($webspace->getAllLocalizations() as $localization) {
-            $languages[] = $localization->getLocalization();
+            $languages[] = $localization->getLocale();
         }
 
         return $this->render(

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507231648.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507231648.php
@@ -68,7 +68,7 @@ class Version201507231648 implements VersionInterface, ContainerAwareInterface
         $node = $sessionManager->getContentNode($webspace->getKey());
 
         foreach ($webspace->getAllLocalizations() as $localization) {
-            $locale = $localization->getLocalization();
+            $locale = $localization->getLocale();
             $propertyName = $this->getPropertyName(self::SHADOW_ON_PROPERTY, $locale);
 
             $this->upgradeNode($node, $propertyName, $locale);

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507281529.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507281529.php
@@ -52,7 +52,7 @@ class Version201507281529 implements VersionInterface, ContainerAwareInterface
         /** @var Webspace $webspace */
         foreach ($webspaces as $webspace) {
             foreach ($webspace->getAllLocalizations() as $localization) {
-                $locale = $localization->getLocalization();
+                $locale = $localization->getLocale();
 
                 $query = $queryManager->createQuery(
                     sprintf(

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201510210733.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201510210733.php
@@ -104,13 +104,13 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
             $rows = $this->session->getWorkspace()->getQueryManager()->createQuery(
                 sprintf(
                     'SELECT * FROM [nt:unstructured] WHERE [%s] = "%s"',
-                    $this->propertyEncoder->localizedSystemName('nodeType', $localization->getLocalization()),
+                    $this->propertyEncoder->localizedSystemName('nodeType', $localization->getLocale()),
                     RedirectType::EXTERNAL
                 ),
                 'JCR-SQL2'
             )->execute();
 
-            $name = $this->propertyEncoder->localizedSystemName('external', $localization->getLocalization());
+            $name = $this->propertyEncoder->localizedSystemName('external', $localization->getLocale());
             foreach ($rows->getNodes() as $node) {
                 /** @var NodeInterface $node */
                 $value = $node->getPropertyValue($name);
@@ -212,7 +212,7 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
             $rows = $this->session->getWorkspace()->getQueryManager()->createQuery(
                 sprintf(
                     'SELECT * FROM [nt:unstructured] WHERE [%s] = "%s" OR [%s] = "%s"',
-                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocalization()),
+                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocale()),
                     $structureMetadata->getName(),
                     'template',
                     $structureMetadata->getName()
@@ -221,7 +221,7 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
             )->execute();
 
             foreach ($rows->getNodes() as $node) {
-                $this->upgradeNode($node, $localization->getLocalization(), $properties, $addScheme);
+                $this->upgradeNode($node, $localization->getLocale(), $properties, $addScheme);
             }
         }
     }

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511171538.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511171538.php
@@ -172,7 +172,7 @@ class Version201511171538 implements VersionInterface, ContainerAwareInterface
             $rows = $this->session->getWorkspace()->getQueryManager()->createQuery(
                 sprintf(
                     'SELECT * FROM [nt:unstructured] WHERE [%s] = "%s" OR [%s] = "%s"',
-                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocalization()),
+                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocale()),
                     $structureMetadata->getName(),
                     'template',
                     $structureMetadata->getName()
@@ -181,7 +181,7 @@ class Version201511171538 implements VersionInterface, ContainerAwareInterface
             )->execute();
 
             foreach ($rows->getNodes() as $node) {
-                $this->upgradeNode($node, $localization->getLocalization(), $properties, $up);
+                $this->upgradeNode($node, $localization->getLocale(), $properties, $up);
             }
         }
     }

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240843.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240843.php
@@ -190,7 +190,7 @@ class Version201511240843 implements VersionInterface, ContainerAwareInterface
             $rows = $this->session->getWorkspace()->getQueryManager()->createQuery(
                 sprintf(
                     'SELECT * FROM [nt:unstructured] WHERE [%s] = "%s" OR [%s] = "%s"',
-                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocalization()),
+                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocale()),
                     $structureMetadata->getName(),
                     'template',
                     $structureMetadata->getName()
@@ -199,7 +199,7 @@ class Version201511240843 implements VersionInterface, ContainerAwareInterface
             )->execute();
 
             foreach ($rows->getNodes() as $node) {
-                $this->upgradeNode($node, $localization->getLocalization(), $properties, $up);
+                $this->upgradeNode($node, $localization->getLocale(), $properties, $up);
             }
         }
     }

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240844.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240844.php
@@ -107,13 +107,13 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
             $rows = $this->session->getWorkspace()->getQueryManager()->createQuery(
                 sprintf(
                     'SELECT * FROM [nt:unstructured] WHERE [%s] = "%s"',
-                    $this->propertyEncoder->localizedSystemName('nodeType', $localization->getLocalization()),
+                    $this->propertyEncoder->localizedSystemName('nodeType', $localization->getLocale()),
                     RedirectType::EXTERNAL
                 ),
                 'JCR-SQL2'
             )->execute();
 
-            $name = $this->propertyEncoder->localizedSystemName('external', $localization->getLocalization());
+            $name = $this->propertyEncoder->localizedSystemName('external', $localization->getLocale());
             foreach ($rows->getNodes() as $node) {
                 /** @var NodeInterface $node */
                 $value = $node->getPropertyValue($name);
@@ -224,7 +224,7 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
             $rows = $this->session->getWorkspace()->getQueryManager()->createQuery(
                 sprintf(
                     'SELECT * FROM [nt:unstructured] WHERE [%s] = "%s" OR [%s] = "%s"',
-                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocalization()),
+                    $this->propertyEncoder->localizedSystemName('template', $localization->getLocale()),
                     $structureMetadata->getName(),
                     'template',
                     $structureMetadata->getName()
@@ -233,7 +233,7 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
             )->execute();
 
             foreach ($rows->getNodes() as $node) {
-                $this->upgradeNode($node, $localization->getLocalization(), $properties, $addScheme);
+                $this->upgradeNode($node, $localization->getLocale(), $properties, $addScheme);
             }
         }
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -314,7 +314,7 @@ class DocumentInspector extends BaseDocumentInspector
         $resourceLocatorProperty = $structure->getPropertyByTagName('sulu.rlp');
 
         foreach ($webspace->getAllLocalizations() as $localization) {
-            $resolvedLocale = $localization->getLocalization();
+            $resolvedLocale = $localization->getLocale();
             $locale = $resolvedLocale;
 
             $shadowEnabledName = $this->encoder->localizedSystemName(

--- a/src/Sulu/Bundle/SnippetBundle/Controller/LanguageController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/LanguageController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Controller;
 
 use FOS\RestBundle\Routing\ClassResourceInterface;
+use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -39,11 +40,11 @@ class LanguageController extends Controller implements ClassResourceInterface
         foreach ($webspaceManager->getWebspaceCollection() as $webspace) {
             $i = 0;
             foreach ($webspace->getAllLocalizations() as $localization) {
-                if (!in_array($localization->getLocalization(), $locales)) {
-                    $locales[] = $localization->getLocalization();
+                if (!in_array($localization->getLocale(), $locales)) {
+                    $locales[] = $localization->getLocale();
                     $localizations[] = [
-                        'localization' => $localization->getLocalization(),
-                        'name' => $localization->getLocalization('-'),
+                        'localization' => $localization->getLocale(),
+                        'name' => $localization->getLocale(Localization::DASH),
                         'id' => $i++,
                     ];
                 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
@@ -75,7 +75,7 @@ class SnippetTwigExtensionTest extends SuluTestCase
                     [
                         'webspaceKey' => $webspace->getKey(),
                         'webspace' => $webspace,
-                        'locale' => $localization->getLocalization(),
+                        'locale' => $localization->getLocale(),
                         'localization' => $localization,
                     ]
                 ),

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
@@ -65,7 +65,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
     public function loadSnippet($uuid, $locale = null)
     {
         if ($locale === null) {
-            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
         }
 
         try {

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
@@ -72,7 +72,7 @@ class ParameterResolver implements ParameterResolverInterface
 
         foreach ($allLocalizations as $localization) {
             /* @var Localization $localization */
-            $locale = $localization->getLocalization();
+            $locale = $localization->getLocale();
 
             if (array_key_exists($locale, $pageUrls)) {
                 $urls[$locale] = $pageUrls[$locale];

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -52,7 +52,7 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
     {
         // determine default locale (if one exists)
         $defaultLocalization = $requestAnalyzer->getPortal()->getDefaultLocalization();
-        $defaultLocale = $defaultLocalization ? $defaultLocalization->getLocalization() : null;
+        $defaultLocale = $defaultLocalization ? $defaultLocalization->getLocale() : null;
 
         $currentLocale = null;
         $currentLocalization = $requestAnalyzer->getCurrentLocalization();

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGenerator.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGenerator.php
@@ -89,10 +89,10 @@ class SitemapGenerator implements SitemapGeneratorInterface
 
         $defaultLocalization = $webspace->getDefaultLocalization();
         if ($defaultLocalization) {
-            $webspaceSitemap->setDefaultLocalization($defaultLocalization->getLocalization());
+            $webspaceSitemap->setDefaultLocalization($defaultLocalization->getLocale());
         }
         foreach ($webspace->getAllLocalizations() as $localization) {
-            $webspaceSitemap->addLocalization($localization->getLocalization());
+            $webspaceSitemap->addLocalization($localization->getLocale());
         }
 
         return $webspaceSitemap;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
@@ -97,7 +97,7 @@ class SeoTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
         /** @var Localization $localization */
         $localization = $this->prophesize(Localization::class);
-        $localization->getLocalization()->willReturn($xDefaultLocale ?: $defaultLocale);
+        $localization->getLocale()->willReturn($xDefaultLocale ?: $defaultLocale);
 
         /** @var Portal $portal */
         $portal = $this->prophesize(Portal::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -76,7 +76,7 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
         $contentStructure = $this->contentMapper->load(
             $uuid,
             $this->requestAnalyzer->getWebspace()->getKey(),
-            $this->requestAnalyzer->getCurrentLocalization()->getLocalization()
+            $this->requestAnalyzer->getCurrentLocalization()->getLocale()
         );
 
         return $this->structureResolver->resolve($contentStructure);

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -76,7 +76,7 @@ class MetaTwigExtension extends \Twig_Extension
 
         $defaultLocale = null;
         if ($currentPortal !== null && ($defaultLocale = $currentPortal->getXDefaultLocalization()) !== null) {
-            $defaultLocale = $defaultLocale->getLocalization();
+            $defaultLocale = $defaultLocale->getLocale();
         }
 
         $result = [];

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -66,7 +66,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     public function flatRootNavigationFunction($context = null, $depth = 1, $loadExcerpt = false)
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
 
         return $this->navigationMapper->getRootNavigation($webspaceKey, $locale, $depth, true, $context, $loadExcerpt);
     }
@@ -77,7 +77,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     public function treeRootNavigationFunction($context = null, $depth = 1, $loadExcerpt = false)
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
 
         return $this->navigationMapper->getRootNavigation($webspaceKey, $locale, $depth, false, $context, $loadExcerpt);
     }
@@ -88,7 +88,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     public function flatNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null)
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
 
         if ($level !== null) {
             $breadcrumb = $this->contentMapper->loadBreadcrumb(
@@ -114,7 +114,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     public function treeNavigationFunction($uuid, $context = null, $depth = 1, $loadExcerpt = false, $level = null)
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
 
         if ($level !== null) {
             $breadcrumb = $this->contentMapper->loadBreadcrumb(
@@ -140,7 +140,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     public function breadcrumbFunction($uuid)
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
 
         return $this->navigationMapper->getBreadcrumb(
             $uuid,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
@@ -73,7 +73,7 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
         }
 
         if ($locale === null) {
-            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
         }
 
         return $this->webspaceManager->findUrlByResourceLocator(
@@ -94,7 +94,7 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
         }
 
         if ($locale === null) {
-            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
+            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
         }
 
         return $this->sitemapGenerator->generate($webspaceKey, $locale)->getSitemap();

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -452,7 +452,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         return array_map(
             function (Localization $localization) {
-                return $localization->getLocalization();
+                return $localization->getLocale();
             },
             $webspace->getAllLocalizations()
         );
@@ -471,7 +471,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         return array_map(
             function (Localization $localization) {
-                return $localization->getLocalization();
+                return $localization->getLocale();
             },
             $portal->getLocalizations()
         );
@@ -486,7 +486,7 @@ class ContentRepository implements ContentRepositoryInterface
     {
         return array_map(
             function (Localization $localization) {
-                return $localization->getLocalization();
+                return $localization->getLocale();
             },
             $this->webspaceManager->getAllLocalizations()
         );

--- a/src/Sulu/Component/CustomUrl/Document/Subscriber/CustomUrlSubscriber.php
+++ b/src/Sulu/Component/CustomUrl/Document/Subscriber/CustomUrlSubscriber.php
@@ -158,7 +158,7 @@ class CustomUrlSubscriber implements EventSubscriberInterface
         $path = sprintf('%s/%s', $routesPath, $domain);
         $routeDocument = $this->findOrCreateRoute($path, $persistedLocale, $document, $domain);
         $routeDocument->setTargetDocument($document);
-        $routeDocument->setLocale($locale->getLocalization());
+        $routeDocument->setLocale($locale->getLocale());
         $routeDocument->setHistory(false);
 
         $this->documentManager->persist(

--- a/src/Sulu/Component/CustomUrl/Generator/Generator.php
+++ b/src/Sulu/Component/CustomUrl/Generator/Generator.php
@@ -89,7 +89,7 @@ class Generator implements GeneratorInterface
 
         $domain = $this->urlReplacer->replaceLanguage($domain, $locale->getLanguage());
         $domain = $this->urlReplacer->replaceCountry($domain, $locale->getCountry());
-        $domain = $this->urlReplacer->replaceLocalization($domain, $locale->getLocalization());
+        $domain = $this->urlReplacer->replaceLocalization($domain, $locale->getLocale());
 
         return $this->urlReplacer->cleanup($domain);
     }

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -178,7 +178,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
 
         foreach ($portal->getLocalizations() as $localization) {
             if ($webspaceDefaultLocalization
-                && $webspaceDefaultLocalization->getLocalization() == $localization->getLocalization()
+                && $webspaceDefaultLocalization->getLocale() == $localization->getLocale()
             ) {
                 $localization->setDefault(true);
                 $portal->setDefaultLocalization($localization);

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -154,7 +154,7 @@ class WebspaceManager implements WebspaceManagerInterface
             [RequestAnalyzerInterface::MATCH_TYPE_FULL]
         );
         foreach ($portals as $portalInformation) {
-            $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;
+            $sameLocalization = $portalInformation->getLocalization()->getLocale() === $languageCode;
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
             $url = $this->createResourceLocatorUrl($scheme, $portalInformation->getUrl(), $resourceLocator);
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
@@ -188,7 +188,7 @@ class WebspaceManager implements WebspaceManagerInterface
         foreach ($portals as $portalInformation) {
             $sameLocalization = (
                 $portalInformation->getLocalization() === null
-                || $portalInformation->getLocalization()->getLocalization() === $languageCode
+                || $portalInformation->getLocalization()->getLocale() === $languageCode
             );
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
             $url = $this->createResourceLocatorUrl($scheme, $portalInformation->getUrl(), $resourceLocator);

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -142,7 +142,7 @@ class Portal
     public function getLocalization($locale)
     {
         foreach ($this->getLocalizations() as $localization) {
-            if ($locale === $localization->getLocalization()) {
+            if ($locale === $localization->getLocale()) {
                 return $localization;
             }
         }

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -145,7 +145,7 @@ class PortalInformation implements ArrayableInterface
             return;
         }
 
-        return $this->localization->getLocalization();
+        return $this->localization->getLocale();
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
@@ -72,7 +72,7 @@ class XmlFileLoader10Test extends WebspaceTestCase
         $this->assertEquals(null, $webspace->getLocalizations()[1]->getShadow());
         $this->assertEquals(true, $webspace->getLocalizations()[1]->isDefault());
 
-        $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocale());
 
         $this->assertEquals('sulu', $webspace->getTheme());
         $this->assertEquals(
@@ -87,7 +87,7 @@ class XmlFileLoader10Test extends WebspaceTestCase
         $this->assertEquals('at', $webspace->getPortals()[0]->getLocalizations()[1]->getCountry());
         $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[1]->isDefault());
 
-        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
 
         $this->assertEquals(3, count($webspace->getPortals()[0]->getEnvironments()));
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -71,7 +71,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals(null, $webspace->getLocalizations()[1]->getShadow());
         $this->assertEquals(true, $webspace->getLocalizations()[1]->isDefault());
 
-        $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocale());
 
         $this->assertEquals('sulu', $webspace->getTheme());
         $this->assertEquals(
@@ -87,7 +87,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals('at', $webspace->getPortals()[0]->getLocalizations()[1]->getCountry());
         $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[1]->isDefault());
 
-        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
 
         $this->assertEquals(3, count($webspace->getPortals()[0]->getEnvironments()));
 
@@ -153,7 +153,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals(null, $webspace->getLocalizations()[2]->getShadow());
         $this->assertEquals(false, $webspace->getLocalizations()[2]->isDefault());
 
-        $this->assertEquals('fr_ca', $webspace->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('fr_ca', $webspace->getDefaultLocalization()->getLocale());
 
         $this->assertEquals('w', $webspace->getSegments()[0]->getKey());
         $this->assertEquals('winter', $webspace->getSegments()[0]->getName());
@@ -190,7 +190,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals('Footer', $webspace->getNavigation()->getContexts()[1]->getTitle('en'));
         $this->assertEquals('Footer', $webspace->getNavigation()->getContexts()[1]->getTitle('fr'));
 
-        $this->assertEquals('de', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
 
         $this->assertEquals('Massive Art US', $webspace->getPortals()[0]->getName());
 
@@ -223,7 +223,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals('ca', $webspace->getPortals()[1]->getLocalizations()[1]->getCountry());
         $this->assertEquals(false, $webspace->getPortals()[1]->getLocalizations()[1]->isDefault());
 
-        $this->assertEquals('en_ca', $webspace->getPortals()[1]->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('en_ca', $webspace->getPortals()[1]->getDefaultLocalization()->getLocale());
 
         $this->assertEquals(2, count($webspace->getPortals()[1]->getEnvironments()));
 
@@ -291,7 +291,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals(null, $webspace->getLocalizations()[1]->getShadow());
         $this->assertEquals(true, $webspace->getLocalizations()[1]->isDefault());
 
-        $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocale());
 
         $this->assertEquals('sulu', $webspace->getTheme());
 
@@ -311,7 +311,7 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals(null, $webspace->getPortals()[0]->getLocalizations()[2]->getShadow());
         $this->assertEquals(true, $webspace->getPortals()[0]->getLocalizations()[2]->isDefault());
 
-        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
 
         $this->assertCount(2, $webspace->getPortals()[0]->getEnvironments());
 
@@ -473,8 +473,8 @@ class XmlFileLoader11Test extends WebspaceTestCase
             $this->getResourceDirectory() . '/DataFixtures/Webspace/xdefault/sulu.io_xdefault_locale.xml'
         );
 
-        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
-        $this->assertEquals('en_us', $webspace->getPortals()[0]->getXDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
+        $this->assertEquals('en_us', $webspace->getPortals()[0]->getXDefaultLocalization()->getLocale());
     }
 
     public function testXDefaulLocaleNotExists()
@@ -483,8 +483,8 @@ class XmlFileLoader11Test extends WebspaceTestCase
             $this->getResourceDirectory() . '/DataFixtures/Webspace/xdefault/sulu.io_no_xdefault_locale.xml'
         );
 
-        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocalization());
-        $this->assertEquals('de_at', $webspace->getPortals()[0]->getXDefaultLocalization()->getLocalization());
+        $this->assertEquals('de_at', $webspace->getPortals()[0]->getDefaultLocalization()->getLocale());
+        $this->assertEquals('de_at', $webspace->getPortals()[0]->getXDefaultLocalization()->getLocale());
     }
 
     public function testInvalidCustomUrl()

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -190,11 +190,11 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
 
         $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $portalInformations['sulu.de']->getType());
         $this->assertEquals('sulu.de', $portalInformations['sulu.de']->getUrl());
-        $this->assertEquals('de', $portalInformations['sulu.de']->getLocalization()->getLocalization());
+        $this->assertEquals('de', $portalInformations['sulu.de']->getLocalization()->getLocale());
 
         $this->assertEquals(RequestAnalyzerInterface::MATCH_TYPE_FULL, $portalInformations['sulu.us']->getType());
         $this->assertEquals('sulu.us', $portalInformations['sulu.us']->getUrl());
-        $this->assertEquals('en', $portalInformations['sulu.us']->getLocalization()->getLocalization());
+        $this->assertEquals('en', $portalInformations['sulu.us']->getLocalization()->getLocale());
     }
 
     public function testBuildWithMainUrl()

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -265,7 +265,7 @@ class WebspaceManagerTest extends WebspaceTestCase
     public function testFindPortalInformationByUrl()
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.at/test/test/test', 'prod');
-        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocalization());
+        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
         $this->assertNull($portalInformation->getSegment());
 
         /** @var Webspace $webspace */
@@ -311,7 +311,7 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
 
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.lo', 'dev');
-        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocalization());
+        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
         $this->assertNull($portalInformation->getSegment());
 
         /* @var Portal $portal */
@@ -407,7 +407,7 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.lo', $environmentDev->getUrls()[0]->getUrl());
 
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('sulu.lo', 'dev');
-        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocalization());
+        $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
         $this->assertNull($portalInformation->getSegment());
 
         /* @var Portal $portal */
@@ -516,7 +516,7 @@ class WebspaceManagerTest extends WebspaceTestCase
     public function testFindPortalInformationByUrlWithSegment()
     {
         $portalInformation = $this->webspaceManager->findPortalInformationByUrl('en.massiveart.us/w/about-us', 'prod');
-        $this->assertEquals('en_us', $portalInformation->getLocalization()->getLocalization());
+        $this->assertEquals('en_us', $portalInformation->getLocalization()->getLocale());
         $this->assertEquals('winter', $portalInformation->getSegment()->getName());
 
         /** @var Portal $portal */

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -148,16 +148,16 @@ class WebspaceTest extends \PHPUnit_Framework_TestCase
         $this->webspace->addLocalization($localeEn);
 
         $result = $this->webspace->getLocalization('de');
-        $this->assertEquals('de', $result->getLocalization());
+        $this->assertEquals('de', $result->getLocale());
 
         $result = $this->webspace->getLocalization('de_at');
-        $this->assertEquals('de_at', $result->getLocalization());
+        $this->assertEquals('de_at', $result->getLocale());
 
         $result = $this->webspace->getLocalization('de_ch');
-        $this->assertEquals('de_ch', $result->getLocalization());
+        $this->assertEquals('de_ch', $result->getLocale());
 
         $result = $this->webspace->getLocalization('en');
-        $this->assertEquals('en', $result->getLocalization());
+        $this->assertEquals('en', $result->getLocale());
 
         $result = $this->webspace->getLocalization('en_us');
         $this->assertEquals(null, $result);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the calls of the deprecated `Localization::getLocalization` function.

#### Why?

The Symfony-Toolbar from 3.3 dumps data into the cache. The amount of data raises when more deprecations are raised (see https://github.com/symfony/symfony/issues/23233). This changes will remove lots of unnecessary deprecations which will be called inside our codebase.
