### PR TITLE
Use non-deprecated getLocale method in WebspaceManager

### DIFF
--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -154,7 +154,7 @@ class WebspaceManager implements WebspaceManagerInterface
             [RequestAnalyzerInterface::MATCH_TYPE_FULL]
         );
         foreach ($portals as $portalInformation) {
-            $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;
+            $sameLocalization = $portalInformation->getLocalization()->getLocale() === $languageCode;
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
             $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
@@ -188,7 +188,7 @@ class WebspaceManager implements WebspaceManagerInterface
         foreach ($portals as $portalInformation) {
             $sameLocalization = (
                 $portalInformation->getLocalization() === null
-                || $portalInformation->getLocalization()->getLocalization() === $languageCode
+                || $portalInformation->getLocalization()->getLocale() === $languageCode
             );
             $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
             $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Removes some deprecated functions that appear to be a cause of Chrome `ERR_EMPTY_RESPONSE` pages

#### Why?

I managed to track line `191` down as a source of Chrome `ERR_EMPTY_RESPONSE` errors. Changing it to the newer method stops the error in my case. I'm not sure what in my data is causing it currently but it also happens when you have no pages except the home page and several locales in the same language (GB, US, AU) for example.

First tracked it to the `getContentPath` method in `ContentPathTwigExtension.php` and followed the trail into `WebspaceManager.php`. My xDebug isn't working currently but this fixes whatever conditions led to the error.

This sort of locale switch causes the start of the problem:
```
<ul class="locale-switch">
    {% for locale, url in urls %}
        <li{% if request.locale == locale %} class="active"{% endif %}>
            <a href="{{ sulu_content_path((url?:'/'), request.webspaceKey, locale) }}">{{ locale }}</a>
        </li>
    {% endfor %}
</ul>
```

