### PR TITLE
Fixed error when downloading media without extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3444 [MediaBundle]             Fixed error when download of media without extension
     * HOTFIX      #3441 [PreviewBundle]           Fixed bug in preview when running on https
     * HOTFIX      #3451 [ContentBundle]           Index correct language of shadow document
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -117,8 +117,6 @@ class MediaStreamController extends Controller
         $locale,
         $dispositionType = ResponseHeaderBag::DISPOSITION_ATTACHMENT
     ) {
-        $cleaner = $this->get('sulu.content.path_cleaner');
-
         $fileName = $fileVersion->getName();
         $fileSize = $fileVersion->getSize();
         $storageOptions = $fileVersion->getStorageOptions();
@@ -129,13 +127,11 @@ class MediaStreamController extends Controller
 
         $response = new BinaryFileResponse($path);
 
-        $pathInfo = pathinfo($fileName);
-
         // Prepare headers
         $disposition = $response->headers->makeDisposition(
             $dispositionType,
             $fileName,
-            $cleaner->cleanup($pathInfo['filename'], $locale) . '.' . $pathInfo['extension']
+            $this->cleanUpFileName($fileName, $locale)
         );
 
         // Set headers
@@ -184,6 +180,25 @@ class MediaStreamController extends Controller
         }
 
         return $currentFileVersion;
+    }
+
+    /**
+     * Cleaned up filename.
+     *
+     * @param string $fileName
+     * @param string $locale
+     *
+     * @return string
+     */
+    private function cleanUpFileName($fileName, $locale)
+    {
+        $pathInfo = pathinfo($fileName);
+        $cleanedFileName = $this->get('sulu.content.path_cleaner')->cleanup($pathInfo['filename'], $locale);
+        if (isset($pathInfo['extension'])) {
+            $cleanedFileName .= '.' . $pathInfo['extension'];
+        }
+
+        return $cleanedFileName;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -11,10 +11,43 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes;
+use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadMediaTypes;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class MediaStreamControllerTest extends SuluTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $collectionTypes = new LoadCollectionTypes();
+        $collectionTypes->load($this->getEntityManager());
+        $mediaTypes = new LoadMediaTypes();
+        $mediaTypes->load($this->getEntityManager());
+    }
+
+    public function testDownloadAction()
+    {
+        $filePath = tempnam(sys_get_temp_dir(), 'test.jpg');
+        $media = $this->createMedia($filePath, 'file-without-extension');
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', $media->getUrl());
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    public function testDownloadWithoutExtensionAction()
+    {
+        $filePath = tempnam(sys_get_temp_dir(), 'file-without-extension');
+        $media = $this->createMedia($filePath, 'File without Extension');
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', $media->getUrl());
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+    }
+
     public function testGetImageActionForNonExistingMedia()
     {
         $client = $this->createAuthenticatedClient();
@@ -31,5 +64,47 @@ class MediaStreamControllerTest extends SuluTestCase
         $client->request('GET', '/media/999/download/test.jpg?v=1');
 
         $this->assertHttpStatusCode(404, $client->getResponse());
+    }
+
+    private function createUploadedFile($path)
+    {
+        return new UploadedFile($path, basename($path), mime_content_type($path), filesize($path));
+    }
+
+    private function createCollection($title = 'Test')
+    {
+        $collection = $this->getCollectionManager()->save(
+            [
+                'title' => $title,
+                'locale' => 'en',
+                'type' => ['id' => 1],
+            ],
+            null
+        );
+
+        return $collection->getId();
+    }
+
+    private function createMedia($path, $title)
+    {
+        return $this->getMediaManager()->save(
+            $this->createUploadedFile($path),
+            [
+                'title' => $title,
+                'collection' => $this->createCollection(),
+                'locale' => 'en',
+            ],
+            null
+        );
+    }
+
+    private function getMediaManager()
+    {
+        return $this->getContainer()->get('sulu_media.media_manager');
+    }
+
+    private function getCollectionManager()
+    {
+        return $this->getContainer()->get('sulu_media.collection_manager');
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Only add extension as name when extension exist in pathinfo.

#### Why?

Else PHP Logs a notice error when accessing an error key which does not exist.

#### TODO

 - [x] Testcase