### PR TITLE
use disabled attribute instead of separate class

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Item.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import classNames from 'classnames';
 import type {Item as ItemType} from './types';
 import Icon from '../../components/Icon';
 import itemStyles from './item.scss';
@@ -19,13 +18,8 @@ export default class Item extends React.PureComponent {
     };
 
     render() {
-        const liClassNames = classNames({
-            [`${itemStyles['item']}`]: true,
-            [`${itemStyles['item-disabled']}`]: !this.props.enabled,
-        });
-
         return (
-            <button className={liClassNames} onClick={this.handleClick}>
+            <button className={itemStyles.item} disabled={!this.props.enabled} onClick={this.handleClick}>
                 <Icon className={itemStyles.icon} name={this.props.icon} />
                 <span className={itemStyles.title}>{this.props.title}</span>
             </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/item.scss
@@ -23,11 +23,11 @@ $itemBorder: 1px $wildSand solid;
     &:last-child {
         border-right: $itemBorder;
     }
-}
 
-.item-disabled {
-    color: $itemTextColorDisabled;
-    cursor: default;
+    &:disabled {
+        color: $itemTextColorDisabled;
+        cursor: default;
+    }
 }
 
 .icon {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Item.test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`Render disabled item 1`] = `
 <button
-  className="item item-disabled"
+  className="item"
+  disabled={true}
   onClick={[Function]}
 >
   <span
@@ -17,6 +18,7 @@ exports[`Render disabled item 1`] = `
 exports[`Render item 1`] = `
 <button
   className="item"
+  disabled={false}
   onClick={[Function]}
 >
   <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -6,7 +6,8 @@ exports[`Render the items from the ToolbarStore 1`] = `
 >
   <nav>
     <button
-      className="item item-disabled"
+      className="item"
+      disabled={true}
       onClick={[Function]}
     >
       <span
@@ -20,6 +21,7 @@ exports[`Render the items from the ToolbarStore 1`] = `
     </button>
     <button
       className="item"
+      disabled={false}
       onClick={[Function]}
     >
       <span


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR replaces the `item-disabled` class with the usage of the `disabled` attribute.

#### Why?

Because this makes the application more accessible.