### PR TITLE
changed order of route parameters

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -36,11 +36,11 @@ class Route
      */
     private $parameters;
 
-    public function __construct(string $name, string $view, string $path, array $parameters = [])
+    public function __construct(string $name, string $path, string $view, array $parameters = [])
     {
         $this->name = $name;
-        $this->view = $view;
         $this->path = $path;
+        $this->view = $view;
         $this->parameters = $parameters;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
@@ -59,9 +59,9 @@ class AdminPoolTest extends \PHPUnit_Framework_TestCase
 
     public function testRoutes()
     {
-        $route1 = new Route('test1', 'test1', '/test1', ['value' => 'test1']);
-        $route2 = new Route('test2', 'test2', '/test2', ['value' => 'test2']);
-        $route3 = new Route('test3', 'test3', '/test3', ['value' => 'test3']);
+        $route1 = new Route('test1', '/test1', 'test1', ['value' => 'test1']);
+        $route2 = new Route('test2', '/test2', 'test2', ['value' => 'test2']);
+        $route3 = new Route('test3', '/test3', 'test3', ['value' => 'test3']);
         $this->admin1->getRoutes()->willReturn([$route1]);
         $this->admin2->getRoutes()->willReturn([$route2, $route3]);
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -152,7 +152,7 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
     public function testConfigurationAction()
     {
         $data = [
-            new Route('sulu_snippet.list', 'sulu_admin.list', '/snippets', ['type' => 'snippets']),
+            new Route('sulu_snippet.list', '/snippets', 'sulu_admin.list', ['type' => 'snippets']),
         ];
         $this->adminPool->getRoutes()->willReturn($data);
 

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -86,8 +86,8 @@ class SnippetAdmin extends Admin
     public function getRoutes(): array
     {
         return [
-            new Route('sulu_snippet.list', 'sulu_admin.list', '/snippets', ['type' => 'snippets']),
-            new Route('sulu_snippet.form', 'sulu_admin.form', '/snippets/:uuid', ['type' => 'snippets']),
+            new Route('sulu_snippet.list', '/snippets', 'sulu_admin.list', ['type' => 'snippets']),
+            new Route('sulu_snippet.form', '/snippets/:uuid', 'sulu_admin.form', ['type' => 'snippets']),
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the order of the route parameters, so that the name and pattern come first, and the react part at the end.

#### Why?

This way the elements belonging together stand next to each other.