### PR TITLE
add react styleguidist to document components

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,5 +4,7 @@ unsafe.enable_getters_and_setters=true
 module.name_mapper='.+\.s?css' -> 'empty/object'
 
 [ignore]
-.*/vendor/symfony/symfony/.*
+.*/node_modules/findup/.*
+.*/node_modules/jss/.*
 .*/node_modules/stylelint/.*
+.*/vendor/symfony/symfony/.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
     - env:
         - PHP=true
-        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction
+        - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
         - SYMFONY__DATABASE__DRIVER=pdo_pgsql
         - SYMFONY__DATABASE__USER=postgres
         - SYMFONY__DATABASE__PASSWORD=postgres

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "scripts": {
         "lint:js": "eslint .",
         "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
-        "flow": "flow"
+        "flow": "flow",
+        "styleguide": "styleguidist server"
     },
     "dependencies": {
         "sulu-admin-bundle": "file:src/Sulu/Bundle/AdminBundle/Resources/js"
@@ -15,6 +16,8 @@
         "eslint-plugin-flowtype": "^2.34.0",
         "eslint-plugin-react": "^7.0.1",
         "flow-bin": "^0.48.0",
+        "null-loader": "^0.1.1",
+        "react-styleguidist": "^5.5.7",
         "stylelint": "^7.12.0",
         "stylelint-config-standard": "^16.0.0"
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -17,7 +17,7 @@ export default class Icon extends React.PureComponent {
         );
 
         return (
-            <span className={className} />
+            <span className={className} aria-hidden={true} />
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/README.md
@@ -1,0 +1,13 @@
+This is a simple component which renders icons. It uses the [Font Awesome Icon Toolkit](http://fontawesome.io/).
+
+Pass a name to the component, and it will render the corresponding icon:
+
+```javascript
+<Icon name="floppy-o" />
+```
+
+It can also take an additional `className`, which will be added to the class of the resulting `span` tag:
+
+```javascript
+<Icon name="trash-o" className="special-icon" />
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/__snapshots__/Icon.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/__snapshots__/Icon.test.js.snap
@@ -2,12 +2,14 @@
 
 exports[`Icon should render 1`] = `
 <span
+  aria-hidden={true}
   className="fa fa-save"
 />
 `;
 
 exports[`Icon should render with class names 1`] = `
 <span
+  aria-hidden={true}
   className="test fa fa-edit"
 />
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Item.test.js.snap
@@ -7,6 +7,7 @@ exports[`Render disabled item 1`] = `
   onClick={[Function]}
 >
   <span
+    aria-hidden={true}
     className="icon fa fa-undefined"
   />
   <span
@@ -22,6 +23,7 @@ exports[`Render item 1`] = `
   onClick={[Function]}
 >
   <span
+    aria-hidden={true}
     className="icon fa fa-undefined"
   />
   <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -11,6 +11,7 @@ exports[`Render the items from the ToolbarStore 1`] = `
       onClick={[Function]}
     >
       <span
+        aria-hidden={true}
         className="icon fa fa-save"
       />
       <span
@@ -25,6 +26,7 @@ exports[`Render the items from the ToolbarStore 1`] = `
       onClick={[Function]}
     >
       <span
+        aria-hidden={true}
         className="icon fa fa-delete"
       />
       <span

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,0 +1,44 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+const glob = require('glob');
+const path = require('path');
+
+module.exports = { // eslint-disable-line
+    components: function() {
+        const folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/components/*');
+
+        return folders.map((folder) => {
+            const component = path.basename(folder);
+            return path.join(folder, component + '.js');
+        });
+    },
+    webpackConfig: {
+        module: {
+            loaders: [
+                {
+                    test: /\.js$/,
+                    exclude: /node_modules/,
+                    loader: 'babel-loader',
+                },
+                {
+                    test: /\.css/,
+                    use: [
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                modules: false,
+                            },
+                        },
+                    ],
+                },
+                {
+                    test:/\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
+                    use: [
+                        {
+                            loader: 'null-loader',
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds [react-styleguidist](https://react-styleguidist.js.org/), which allows to document our components. It also adds a small documentation for the Icon component, but without any rendered example, because the webpack configuration would be quite complicated, and it's probably not worth it.

On the side it also adds the `aria-hidden` tag on the icon itself, which was missing before.

#### Why?

Because we would like to properly document our components.