### PR TITLE
add polyfills for IE11

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/item.scss
@@ -16,6 +16,11 @@ $itemBorder: 1px $wildSand solid;
     font-size: 14px;
     cursor: pointer;
 
+    & > * {
+        /* IE11 will emulate 3D effect while clicking button without this */
+        position: relative;
+    }
+
     &:first-child {
         border-left: $itemBorder;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -11,8 +11,10 @@
         "mobx-react": "^4.2.1",
         "normalize.css": "^7.0.0",
         "path-to-regexp": "^1.7.0",
+        "promise-polyfill": "^6.0.2",
         "react": "^15.6.0",
-        "react-dom": "^15.6.0"
+        "react-dom": "^15.6.0",
+        "whatwg-fetch": "^2.0.3"
     },
     "devDependencies": {
         "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds polyfill packages. They also need to be configured in the `webpack.config.js` file of sulu-minimal, PR is in the making.

#### Why?

Because we want to support IE11, and these polyfills are required in order for our application to run there.