### PR TITLE
log a warning when translation is missing

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -7,6 +7,7 @@
         "classnames": "^2.2.5",
         "font-awesome": "^4.7.0",
         "history": "^4.6.3",
+        "loglevel": "^1.4.1",
         "mobx": "^3.1.16",
         "mobx-react": "^4.2.1",
         "normalize.css": "^7.0.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
@@ -1,4 +1,5 @@
 // @flow
+import * as log from 'loglevel';
 import type {TranslationMap} from './types';
 
 let translationMap: ?TranslationMap;
@@ -13,6 +14,7 @@ function clearTranslations() {
 
 function translate(key: string) {
     if (!translationMap || !(key in translationMap)) {
+        log.warn('The translation key "' + key + '" has not been translated. The key itself will be returned instead.');
         return key;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
@@ -1,5 +1,10 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
+import * as log from 'loglevel';
 import {setTranslations, clearTranslations, translate} from '../Translator';
+
+jest.mock('loglevel', () => ({
+    warn: jest.fn(),
+}));
 
 beforeEach(() => {
     clearTranslations();
@@ -12,6 +17,7 @@ test('Translator should translate translations', () => {
     expect(translate('delete')).toBe('Delete');
 });
 
-test('Translator should return key when translating non-existing keys', () => {
+test('Translator should return key when translating non-existing keys and log a warning', () => {
     expect(translate('not-existing')).toBe('not-existing');
+    expect(log.warn).toBeCalled();
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a logging library, which allows us to set different log levels and activate them differently. The first use case will be to warn about missing translations.

#### Why?

Because we care about good DX.