### PR TITLE
set log level based on build environment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,9 @@
         "es6": true,
         "jest": true
     },
+    "globals": {
+        "process": true
+    },
     "extends": [
         "eslint:recommended",
         "plugin:react/recommended",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {render} from 'react-dom';
 import {useStrict} from 'mobx';
+import log from 'loglevel';
 import createHistory from 'history/createHashHistory';
 import Application from './containers/Application';
 import {viewStore} from './containers/ViewRenderer';
@@ -12,6 +13,9 @@ import Form from './views/Form';
 import List from './views/List';
 
 useStrict(true);
+
+window.log = log;
+log.setDefaultLevel(process.env.NODE_ENV === 'production' ? log.levels.ERROR : log.levels.TRACE);
 
 viewStore.add('sulu_admin.list', List);
 viewStore.add('sulu_admin.form', Form);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
@@ -1,5 +1,5 @@
 // @flow
-import * as log from 'loglevel';
+import log from 'loglevel';
 import type {TranslationMap} from './types';
 
 let translationMap: ?TranslationMap;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/tests/Translator.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import * as log from 'loglevel';
+import log from 'loglevel';
 import {setTranslations, clearTranslations, translate} from '../Translator';
 
 jest.mock('loglevel', () => ({


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will change the default log level based on the build environment. On the production build only errors will be logged, and on a development build all logs will be shown.

In addition to that it exposes the `log` variable to `window`. This allows to change the log level using the console of the developer tools using a statement like `log.setLevel(0)` (this would change from the current setting to show all logs).

#### Why?

Because we want different logs in different environments. And the log level can be changed on the fly, which allows for easier debugging in certain situations.