### PR TITLE
index correct language of shadow document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3451 [ContentBundle]           Index correct language of shadow document
+
 * 1.6.1 (2017-07-10)
     * HOTFIX      #3437 [AdminBundle]             Added save url to storage for update-url event
     * HOTFIX      #3433 [ContentBundle]           Fixed url generation for domain root page

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/search.xml
@@ -38,7 +38,6 @@
 
         <service id="sulu_content.search.event_subscriber.structure" class="%sulu_content.search.event_subscriber.structure.class%">
             <argument type="service" id="massive_search.search_manager" />
-            <argument type="service" id="sulu_document_manager.metadata_factory" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -120,7 +120,7 @@ class StructureProvider implements ProviderInterface
 
         $indexMeta = $this->factory->createIndexMetadata();
         $indexMeta->setIdField($this->factory->createMetadataField('uuid'));
-        $indexMeta->setLocaleField($this->factory->createMetadataField('locale'));
+        $indexMeta->setLocaleField($this->factory->createMetadataField('originalLocale'));
 
         $indexName = 'page';
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes parts of #3427 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the error explained in #3427, but only the reindexing part.

The problem that still persists is that if a page is configured to be a shadow page, it will be indexed in the wrong language. It's like that because the `DocumentManager` only sets the `shadowLocale` property on the document, and leaves all other properties as they are, which means that at [this line](https://github.com/sulu/sulu/blob/2676cbd/src/Sulu/Bundle/ContentBundle/Search/EventSubscriber/StructureSubscriber.php#L115) the non-shadow properties are placed. This probably also has to be like that, because otherwise the `MappingSubscriber` will probably overwrite the existing properties on the node.

I sadly don't see any fast solution for this, since just calling the `DocumentManager::find` method in the above linked code doesn't work, and would probably even cause more issues in the future.