### PR TITLE
Use enzyme wrappers in snapshots

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
@@ -1,12 +1,12 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import {render} from 'enzyme';
 import Icon from '../Icon';
 
 test('Icon should render', () => {
-    expect(ReactTestRenderer.create(<Icon name="save" />)).toMatchSnapshot();
+    expect(render(<Icon name="save" />)).toMatchSnapshot();
 });
 
 test('Icon should render with class names', () => {
-    expect(ReactTestRenderer.create(<Icon className="test" name="edit" />)).toMatchSnapshot();
+    expect(render(<Icon className="test" name="edit" />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/__snapshots__/Icon.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/__snapshots__/Icon.test.js.snap
@@ -2,14 +2,14 @@
 
 exports[`Icon should render 1`] = `
 <span
-  aria-hidden={true}
-  className="fa fa-save"
+  aria-hidden="true"
+  class="fa fa-save"
 />
 `;
 
 exports[`Icon should render with class names 1`] = `
 <span
-  aria-hidden={true}
-  className="test fa fa-edit"
+  aria-hidden="true"
+  class="test fa fa-edit"
 />
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/Application.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/Application.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import {render} from 'enzyme';
 import Application from '../Application';
 
 jest.mock('../../ViewRenderer', () => function Test() {
@@ -9,7 +9,7 @@ jest.mock('../../ViewRenderer', () => function Test() {
 
 test('Application should not fail if current route does not exist', () => {
     const router = jest.fn();
-    const view = ReactTestRenderer.create(<Application router={router} />);
+    const view = render(<Application router={router} />);
 
     expect(view).toMatchSnapshot();
 });
@@ -21,7 +21,7 @@ test('Application should render based on current route', () => {
         },
     };
 
-    const view = ReactTestRenderer.create(<Application router={router} />);
+    const view = render(<Application router={router} />);
 
     expect(view).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Application should not fail if current route does not exist 1`] = `
 <div>
   <header
-    className="toolbar"
+    class="toolbar"
   >
     <nav />
   </header>
@@ -15,7 +15,7 @@ exports[`Application should not fail if current route does not exist 1`] = `
 exports[`Application should render based on current route 1`] = `
 <div>
   <header
-    className="toolbar"
+    class="toolbar"
   >
     <nav />
   </header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Item.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Item.test.js
@@ -1,15 +1,14 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
-import {shallow} from 'enzyme';
+import {render, shallow} from 'enzyme';
 import Item from '../Item';
 
 test('Render item', () => {
-    expect(ReactTestRenderer.create(<Item />)).toMatchSnapshot();
+    expect(render(<Item />)).toMatchSnapshot();
 });
 
 test('Render disabled item', () => {
-    expect(ReactTestRenderer.create(<Item enabled={false} />)).toMatchSnapshot();
+    expect(render(<Item enabled={false} />)).toMatchSnapshot();
 });
 
 test('Click on item fires onClick callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import {render} from 'enzyme';
 import Toolbar from '../Toolbar';
 import toolbarStore from '../stores/ToolbarStore';
 
@@ -18,6 +18,6 @@ test('Render the items from the ToolbarStore', () => {
             icon: 'delete',
         },
     ];
-    const view = ReactTestRenderer.create(<Toolbar />);
+    const view = render(<Toolbar />);
     expect(view).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Item.test.js.snap
@@ -2,32 +2,29 @@
 
 exports[`Render disabled item 1`] = `
 <button
-  className="item"
-  disabled={true}
-  onClick={[Function]}
+  class="item"
+  disabled=""
 >
   <span
-    aria-hidden={true}
-    className="icon fa fa-undefined"
+    aria-hidden="true"
+    class="icon fa fa-undefined"
   />
   <span
-    className="title"
+    class="title"
   />
 </button>
 `;
 
 exports[`Render item 1`] = `
 <button
-  className="item"
-  disabled={false}
-  onClick={[Function]}
+  class="item"
 >
   <span
-    aria-hidden={true}
-    className="icon fa fa-undefined"
+    aria-hidden="true"
+    class="icon fa fa-undefined"
   />
   <span
-    className="title"
+    class="title"
   />
 </button>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -2,35 +2,32 @@
 
 exports[`Render the items from the ToolbarStore 1`] = `
 <header
-  className="toolbar"
+  class="toolbar"
 >
   <nav>
     <button
-      className="item"
-      disabled={true}
-      onClick={[Function]}
+      class="item"
+      disabled=""
     >
       <span
-        aria-hidden={true}
-        className="icon fa fa-save"
+        aria-hidden="true"
+        class="icon fa fa-save"
       />
       <span
-        className="title"
+        class="title"
       >
         Save
       </span>
     </button>
     <button
-      className="item"
-      disabled={false}
-      onClick={[Function]}
+      class="item"
     >
       <span
-        aria-hidden={true}
-        className="icon fa fa-delete"
+        aria-hidden="true"
+        class="icon fa fa-delete"
       />
       <span
-        className="title"
+        class="title"
       >
         Delete
       </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/withToolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/withToolbar.test.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Bind toolbar method to component instance 1`] = `
-<h1>
-  Test
-</h1>
-`;
-
 exports[`Pass props to rendered component 1`] = `
 <h1>
   Test

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import {mount, render} from 'enzyme';
 import toolbarStore from '../stores/ToolbarStore';
 import withToolbar from '../withToolbar';
 
@@ -14,7 +14,7 @@ test('Pass props to rendered component', () => {
     const Component = (props) => (<h1>{props.title}</h1>);
     const ComponentWithToolbar = withToolbar(Component, () => []);
 
-    expect(ReactTestRenderer.create(<ComponentWithToolbar title="Test" />)).toMatchSnapshot();
+    expect(render(<ComponentWithToolbar title="Test" />)).toMatchSnapshot();
 });
 
 test('Bind toolbar method to component instance', () => {
@@ -36,8 +36,7 @@ test('Bind toolbar method to component instance', () => {
         }];
     });
 
-    expect(ReactTestRenderer.create(<ComponentWithToolbar />)).toMatchSnapshot();
-
+    mount(<ComponentWithToolbar />);
     expect(toolbarStore.setItems).toBeCalledWith([{
         title: 'Save',
         icon: 'save',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import {render} from 'enzyme';
 import ViewRenderer from '../ViewRenderer';
 import viewStore from '../stores/ViewStore';
 
@@ -10,19 +10,19 @@ jest.mock('../stores/ViewStore', () => ({
 
 test('Render view returned from ViewRegistry', () => {
     viewStore.get.mockReturnValue(() => (<h1>Test</h1>));
-    const view = ReactTestRenderer.create(<ViewRenderer name="test" />);
+    const view = render(<ViewRenderer name="test" />);
     expect(view).toMatchSnapshot();
     expect(viewStore.get).toBeCalledWith('test');
 });
 
 test('Render view returned from ViewRegistry with passed props', () => {
     viewStore.get.mockReturnValue((props) => (<h1>{props.value}</h1>));
-    const view = ReactTestRenderer.create(<ViewRenderer name="test" parameters={{value: 'Test from props'}} />);
+    const view = render(<ViewRenderer name="test" parameters={{value: 'Test from props'}} />);
     expect(view).toMatchSnapshot();
     expect(viewStore.get).toBeCalledWith('test');
 });
 
 test('Render view should throw if view does not exist', () => {
     viewStore.get.mockReturnValue(undefined);
-    expect(() => ReactTestRenderer.create(<ViewRenderer name="not_existing" />)).toThrow(/not_existing/);
+    expect(() => render(<ViewRenderer name="not_existing" />)).toThrow(/not_existing/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -24,6 +24,7 @@
         "babel-preset-es2015": "^6.24.1",
         "babel-preset-react": "^6.24.1",
         "enzyme": "^2.9.1",
+        "enzyme-to-json": "^1.5.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^20.0.4",
         "react-test-renderer": "^15.6.1"
@@ -31,6 +32,9 @@
     "jest": {
         "moduleNameMapper": {
             "\\.(scss|css)$": "identity-obj-proxy"
-        }
+        },
+        "snapshotSerializers": [
+            "enzyme-to-json/serializer"
+        ]
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Explain the contents of the PR.

#### Why?

Enzyme wrappers ware very convenient when writing tests. However, they cannot be used together with the jest snapshot functionality. This PR introduces a dependency which allows this.

#### Example Usage

~~~javascript
const view = mount(<MyComponent />);
expect(view).toMatchSnapshot();
~~~
