### PR TITLE
fix call to doctrine including type hints

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/TemplateControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/TemplateControllerTest.php
@@ -73,7 +73,7 @@ class TemplateControllerTest extends SuluTestCase
     public function testGetActionSorting()
     {
         $client = $this->createAuthenticatedClient();
-        $client->request('GET', '/content/template');
+        $client->request('GET', '/content/template?webspace=sulu_io');
 
         $this->assertHttpStatusCode(200, $client->getResponse());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The `webspace` parameter had to be added to a test, because based on it there will be a call to a doctrine library.

#### Why?

The doctrine library has been updated, and this update includes some static type hints, which make our tests currently fail.