### PR TITLE
Attempt to show original-sized files

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/schema/formats/formats-1.1.xsd
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/schema/formats/formats-1.1.xsd
@@ -18,7 +18,7 @@
                     <xs:field xpath="@lang"/>
                 </xs:unique>
             </xs:element>
-            <xs:element name="scale" type="scaleType"/>
+            <xs:element name="scale" type="scaleType" minOccurs="0"/>
             <xs:element name="transformations" type="transformationsType" minOccurs="0"/>
             <xs:element type="optionsType" name="options" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>


### PR DESCRIPTION
For example we can show file with original size. ImageMagic to long scale file with needed format (even format file == format in xml file).
ImagineImageConverter.php expect scale == null and everywhere check this param (isset(format['scale']).

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | Yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Added the ability not to specify a parameter <scale> in formats image-formats.xml and custom image-formats.xml files.

#### Why?

This will not scale the image or animate image. For example create 'original' format in image-formats.xml, with original width and height. Sometimes GIFs scale to long to needed format. It is faster generate original GIF (by designer) in needed format and upload to Sulu. Without scaling it is fast method to include GIF to page.

#### Example Usage Before

~~~xml
<format key="original">
   <meta>
       <title lang="en">ImageName</title>
       <title lang="de">ImageName</title>
   </meta>
   <scale x="1020"/>
</format>
~~~

#### Example Usage After

~~~xml
<format key="original">
   <meta>
       <title lang="en">ImageName</title>
       <title lang="de">ImageName</title>
   </meta>
</format>
~~~