### PR TITLE
removed promise polyfill in favour of babel-polyfill

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -12,7 +12,6 @@
         "mobx-react": "^4.2.1",
         "normalize.css": "^7.0.0",
         "path-to-regexp": "^1.7.0",
-        "promise-polyfill": "^6.0.2",
         "react": "^15.6.0",
         "react-dom": "^15.6.0",
         "whatwg-fetch": "^2.0.3"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Removes the `promise-polyfill` in exchange for the `babel-polyfill`, which will be introduce in https://github.com/sulu/sulu-minimal/pull/57.

#### Why?

Because the `babel-polyfill` includes a few more polyfills which are needed.