### PR TITLE
Bugfix in rectangle selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -2,7 +2,7 @@
 import {action, computed, observable} from 'mobx';
 import React from 'react';
 import RectangleSelection from '../RectangleSelection';
-import RoundingNormalizer from '../RectangleSelection/dataNormalizers/RoundingNormalizer';
+import RoundingNormalizer from '../RectangleSelection/normalizers/RoundingNormalizer';
 import type {SelectionData} from '../RectangleSelection/types';
 import imageRectangleSelectionStyles from './imageRectangleSelection.scss';
 import log from 'loglevel';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/PositionNormalizer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/PositionNormalizer.js
@@ -1,7 +1,7 @@
 // @flow
-import type {DataNormalizer, SelectionData} from '../types';
+import type {Normalizer, SelectionData} from '../types';
 
-export default class PositionNormalizer implements DataNormalizer {
+export default class PositionNormalizer implements Normalizer {
     containerWidth: number;
     containerHeight: number;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RatioNormalizer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RatioNormalizer.js
@@ -1,7 +1,7 @@
 // @flow
-import type {DataNormalizer, SelectionData} from '../types';
+import type {Normalizer, SelectionData} from '../types';
 
-export default class RatioNormalizer implements DataNormalizer {
+export default class RatioNormalizer implements Normalizer {
     width: number;
     height: number;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RoundingNormalizer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RoundingNormalizer.js
@@ -1,7 +1,7 @@
 // @flow
-import type {DataNormalizer, SelectionData} from '../types';
+import type {Normalizer, SelectionData} from '../types';
 
-export default class RoundingNormalizer implements DataNormalizer {
+export default class RoundingNormalizer implements Normalizer {
     normalize(data: SelectionData): SelectionData {
         return {
             width: Math.round(data.width),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/SizeNormalizer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/SizeNormalizer.js
@@ -1,7 +1,7 @@
 // @flow
-import type {DataNormalizer, SelectionData} from '../types';
+import type {Normalizer, SelectionData} from '../types';
 
-export default class SizeNormalizer implements DataNormalizer {
+export default class SizeNormalizer implements Normalizer {
     containerWidth: number;
     containerHeight: number;
     minWidth: number;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/PositionNormalizer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/PositionNormalizer.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import PositionNormalizer from '../../dataNormalizers/PositionNormalizer';
+import PositionNormalizer from '../../normalizers/PositionNormalizer';
 
 test('The PositionNormalizer should correctly constrain the selection downwards', () => {
     const position = new PositionNormalizer(200, 300);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RatioNormalizer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RatioNormalizer.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import RatioNormalizer from '../../dataNormalizers/RatioNormalizer';
+import RatioNormalizer from '../../normalizers/RatioNormalizer';
 
 test('The RatioNormalizer should only make the values smaller, never bigger', () => {
     const ratio = new RatioNormalizer(1, 2);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RoundingNormalizer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RoundingNormalizer.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import RoundingNormalizer from '../../dataNormalizers/RoundingNormalizer';
+import RoundingNormalizer from '../../normalizers/RoundingNormalizer';
 
 test('The RoundingNormalizer should round correctly', () => {
     let size = new RoundingNormalizer();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/SizeNormalizer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/SizeNormalizer.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import SizeNormalizer from '../../dataNormalizers/SizeNormalizer';
+import SizeNormalizer from '../../normalizers/SizeNormalizer';
 
 test('The SizeNormalizer should correctly constrain the selection downwards', () => {
     let size = new SizeNormalizer(1000, 500);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/types.js
@@ -1,5 +1,5 @@
 // @flow
-export interface DataNormalizer {
+export interface Normalizer {
     normalize(data: SelectionData): SelectionData,
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

- The data normalizers in the rectangle selection component got renamed to just `normalizers`.
- The normalizers in the rectangle selection are not constructed through a getter anymore, but with an via a designated method.

#### Why?
The getter was called way to often (when moving the rectangle). As most calls were unnecessary, the creation of the normalizers was moved to a method which gets called only when really necessary. 