### PR TITLE
Feature/single select default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3475 [ContentBundle]           Added possibility to set default value for single-select
     * HOTFIX      #3470 [DocumentManagerBundle]   Fixed document-manager load-fixtures command
-    * HOTFIX      #3465 [ContentBundle]           Fixed interpretion of code in block preview
+    * HOTFIX      #3465 [ContentBundle]           Fixed interpretation of code in block preview
     * ENHANCEMENT #3464 [ContentBundle]           Added additional-slides configuration for teaser-provider
     
 * 1.6.2 (2017-07-31)

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/single_select.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/single_select.html.twig
@@ -8,7 +8,11 @@
                    value="{{ value.name }}"
                    data-property='{{ property|json_encode }}'
                    data-mapper-property="{{ property.name }}"
-                   class="preview-update trigger-save-button form-element"/>
+                   class="preview-update trigger-save-button form-element"
+                    {% if value.name == params.default_value.value|default() %}
+                        checked
+                    {% endif %}
+            />
             <span class="icon"></span>
         </div>
         {{ value.getTitle(userLocale) }}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs/pull/349

#### What's in this PR?

You can add a default value for single-selects in the xml

#### Why?

Single-selects are not validated if they are required.

#### Example Usage

~~~xml
<property name="position" type="single_select" mandatory="true">
    <meta>
        <title lang="en">Position</title>
    </meta>
    <params>
        <param name="default_value" value="start"/>
        <param name="values" type="collection">
            <param name="start">
                <meta>
                    <title lang="en">App start</title>
                </meta>
            </param>
            <param name="result">
                <meta>
                    <title lang="en">Result screen</title>
                </meta>
            </param>
        </param>
    </params>
</property>
~~~

#### To Do

- [ ] Create a documentation PR
