### PR TITLE
Implemented radio and radio-group component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
@@ -1,0 +1,22 @@
+Radio buttons keep no internal state and have to be managed from the outside, like shown in the
+following example:
+```
+initialState = {value: '1'};
+<div>
+    <Radio checked={state.value === '1'} onChange={() => setState({value: '1'})} />
+    <Radio checked={state.value === '2'} onChange={() => setState({value: '2'})} />
+    <Radio checked={state.value === '3'} onChange={() => setState({value: '3'})} />
+</div>
+```
+
+```
+const RadioGroup = require('./RadioGroup').default;
+
+initialState = {value: '1'};
+
+<RadioGroup value={state.value} onChange={(value) => setState({value})}>
+    <Radio value="1" />
+    <Radio value="2" />
+    <Radio value="3" />
+</RadioGroup>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
@@ -4,9 +4,9 @@ following example:
 ```
 initialState = {value: '1'};
 <div>
-    <Radio checked={state.value === '1'} onChange={() => setState({value: '1'})} />
-    <Radio checked={state.value === '2'} onChange={() => setState({value: '2'})} />
-    <Radio checked={state.value === '3'} onChange={() => setState({value: '3'})} />
+    <Radio checked={state.value === '1'} onChange={() => setState({value: '1'})}>Radio 1</Radio>
+    <Radio checked={state.value === '2'} onChange={() => setState({value: '2'})}>Radio 2</Radio>
+    <Radio checked={state.value === '3'} onChange={() => setState({value: '3'})}>Radio 3</Radio>
 </div>
 ```
 
@@ -18,8 +18,8 @@ const RadioGroup = require('./RadioGroup').default;
 initialState = {value: '1'};
 
 <RadioGroup value={state.value} onChange={(value) => setState({value})}>
-    <Radio value="1" />
-    <Radio value="2" />
-    <Radio value="3" />
+    <Radio value="1">Radio 1</Radio>
+    <Radio value="2">Radio 2</Radio>
+    <Radio value="3">Radio 3</Radio>
 </RadioGroup>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
@@ -1,5 +1,6 @@
 Radio buttons keep no internal state and have to be managed from the outside, like shown in the
 following example:
+
 ```
 initialState = {value: '1'};
 <div>
@@ -9,6 +10,8 @@ initialState = {value: '1'};
 </div>
 ```
 
+In most cases the state management of the radio buttons will be the same.
+For that matter the `RadioGroup` component makes the use of the radio buttons more convenient.
 ```
 const RadioGroup = require('./RadioGroup').default;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -1,12 +1,13 @@
 // @flow
 import React from 'react';
-import type {ElementRef} from 'react';
+import type {ElementRef, Node} from 'react';
 import radioStyles from './radio.scss';
 
 type Props = {
     checked: boolean,
     value: string,
     onChange?: (value: string) => void,
+    children: Node,
 };
 
 export default class Radio extends React.PureComponent<Props> {
@@ -29,15 +30,26 @@ export default class Radio extends React.PureComponent<Props> {
 
     render() {
         return (
-            <span onClick={this.handleClick} className={radioStyles.radio}>
-                <input
-                    ref={this.setInput}
-                    type="radio"
-                    checked={this.props.checked}
-                    onClick={this.handleInputClick}
-                    onChange={this.handleChange} />
-                <span />
-            </span>
+            <label className={radioStyles.radio}>
+                <span onClick={this.handleClick}>
+                    <input
+                        ref={this.setInput}
+                        type="radio"
+                        checked={this.props.checked}
+                        onClick={this.handleInputClick}
+                        onChange={this.handleChange} />
+                    <span />
+                </span>
+                {this.renderChildren()}
+            </label>
         );
+    }
+
+    renderChildren() {
+        if (this.props.children) {
+            return <span>{this.props.children}</span>;
+        }
+
+        return null;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -1,0 +1,42 @@
+// @flow
+import * as React from 'react';
+import radioStyles from './radio.scss';
+
+type Props = {
+    checked: boolean,
+    value: string,
+    onChange?: (value: string) => void,
+};
+
+export default class Radio extends React.PureComponent<Props> {
+    static defaultProps = {
+        value: 'on',
+        checked: false,
+    };
+
+    input: React.ElementRef<'input'>;
+
+    handleChange = () => {
+        if (this.props.onChange) {
+            this.props.onChange(this.props.value);
+        }
+    };
+
+    handleButtonClick = () => this.input.click();
+    handleInputClick = (event: Event) => event.stopPropagation();
+    setInput = (input: React.ElementRef<'input'>) => this.input = input;
+
+    render() {
+        return (
+            <span onClick={this.handleButtonClick} className={radioStyles.radio}>
+                <input
+                    ref={this.setInput}
+                    type="radio"
+                    checked={this.props.checked}
+                    onClick={this.handleInputClick}
+                    onChange={this.handleChange} />
+                <span />
+            </span>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -1,5 +1,6 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
+import type {ElementRef} from 'react';
 import radioStyles from './radio.scss';
 
 type Props = {
@@ -14,7 +15,7 @@ export default class Radio extends React.PureComponent<Props> {
         checked: false,
     };
 
-    input: React.ElementRef<'input'>;
+    input: ElementRef<'input'>;
 
     handleChange = () => {
         if (this.props.onChange) {
@@ -22,13 +23,13 @@ export default class Radio extends React.PureComponent<Props> {
         }
     };
 
-    handleButtonClick = () => this.input.click();
+    handleClick = () => this.input.click();
     handleInputClick = (event: Event) => event.stopPropagation();
-    setInput = (input: React.ElementRef<'input'>) => this.input = input;
+    setInput = (input: ElementRef<'input'>) => this.input = input;
 
     render() {
         return (
-            <span onClick={this.handleButtonClick} className={radioStyles.radio}>
+            <span onClick={this.handleClick} className={radioStyles.radio}>
                 <input
                     ref={this.setInput}
                     type="radio"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react';
+import Radio from './Radio';
+
+type Props = {
+    value: string,
+    onChange?: () => void,
+    className?: string,
+    children?: React.ChildrenArray<*>,
+};
+
+export default class RadioGroup extends React.PureComponent<Props> {
+    addPropsToRadioChildren(children: React.ChildrenArray<*>) {
+        return React.Children.map(children, (child) => {
+            if (child.type === Radio) {
+                return React.cloneElement(child, {
+                    checked: this.props.value && child.props.value === this.props.value,
+                    onChange: this.props.onChange,
+                });
+            }
+            return React.cloneElement(child, {
+                children: child.props.children ? this.addPropsToRadioChildren(child.props.children) : null,
+            });
+        });
+    }
+
+    render() {
+        return (
+            <div className={this.props.className}>
+                {this.addPropsToRadioChildren(this.props.children)}
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
@@ -1,16 +1,17 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
+import type {ChildrenArray} from 'react';
 import Radio from './Radio';
 
 type Props = {
     value: string,
     onChange?: () => void,
     className?: string,
-    children?: React.ChildrenArray<*>,
+    children?: ChildrenArray<*>,
 };
 
 export default class RadioGroup extends React.PureComponent<Props> {
-    addPropsToRadioChildren(children: React.ChildrenArray<*>) {
+    addPropsToRadioChildren(children: ChildrenArray<*>) {
         return React.Children.map(children, (child) => {
             if (child.type === Radio) {
                 return React.cloneElement(child, {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
@@ -1,34 +1,25 @@
 // @flow
 import React from 'react';
-import type {ChildrenArray} from 'react';
+import type {ChildrenArray, Element} from 'react';
 import Radio from './Radio';
 
 type Props = {
     value: string,
     onChange?: () => void,
     className?: string,
-    children?: ChildrenArray<*>,
+    children: ?ChildrenArray<Element<typeof Radio>>,
 };
 
 export default class RadioGroup extends React.PureComponent<Props> {
-    addPropsToRadioChildren(children: ChildrenArray<*>) {
-        return React.Children.map(children, (child) => {
-            if (child.type === Radio) {
-                return React.cloneElement(child, {
-                    checked: this.props.value && child.props.value === this.props.value,
-                    onChange: this.props.onChange,
-                });
-            }
-            return React.cloneElement(child, {
-                children: child.props.children ? this.addPropsToRadioChildren(child.props.children) : null,
-            });
-        });
-    }
-
     render() {
         return (
             <div className={this.props.className}>
-                {this.addPropsToRadioChildren(this.props.children)}
+                {React.Children.map(this.props.children, (child: any) => {
+                    return React.cloneElement(child, {
+                        checked: this.props.value && child.props.value === this.props.value,
+                        onChange: this.props.onChange,
+                    });
+                })}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Radio from './Radio';
+
+export default Radio;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/radio.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/radio.scss
@@ -2,6 +2,8 @@
 
 $radius: 8px;
 $color: $blueZodiac;
+$borderWidth: 3px;
+$borderColor: $white;
 
 .radio {
     display: inline-block;
@@ -22,11 +24,11 @@ $color: $blueZodiac;
         position: absolute;
         top: 0;
         left: 0;
-        width: calc(2 * $radius);
-        height: calc(2 * $radius);
+        width: 100%;
+        height: 100%;
         border-radius: $radius;
         background: $wildSand;
-        border: 3px solid $white;
+        border: $borderWidth solid $borderColor;
     }
 
     input:checked + span {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/radio.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/radio.scss
@@ -1,0 +1,35 @@
+@import '../../containers/Application/colors.scss';
+
+$radius: 8px;
+$color: $blueZodiac;
+
+.radio {
+    display: inline-block;
+    width: calc(2 * $radius);
+    height: calc(2 * $radius);
+    position: relative;
+
+    input {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        cursor: pointer;
+        z-index: 1;
+    }
+
+    input + span {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: calc(2 * $radius);
+        height: calc(2 * $radius);
+        border-radius: $radius;
+        background: $wildSand;
+        border: 3px solid $white;
+    }
+
+    input:checked + span {
+        background: $color;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/radio.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/radio.scss
@@ -4,12 +4,27 @@ $radius: 8px;
 $color: $blueZodiac;
 $borderWidth: 3px;
 $borderColor: $white;
+$marginBottom: 10px;
+$fontSize: 12px;
 
 .radio {
-    display: inline-block;
-    width: calc(2 * $radius);
-    height: calc(2 * $radius);
-    position: relative;
+    display: flex;
+    margin-bottom: $marginBottom;
+    align-items: center;
+    cursor: pointer;
+
+    & > span:nth-child(1) {
+        display: block;
+        width: calc(2 * $radius);
+        height: calc(2 * $radius);
+        position: relative;
+    }
+
+    & > span:nth-child(2) {
+        display: block;
+        margin-left: 10px;
+        font-size: $fontSize;
+    }
 
     input {
         position: relative;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/Radio.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/Radio.test.js
@@ -4,18 +4,23 @@ import React from 'react';
 import Radio from '../Radio';
 
 test('The component should render in unchecked state', () => {
-    const radio = render(<Radio checked={false} />);
+    const radio = render(<Radio checked={false}>My radio</Radio>);
     expect(radio).toMatchSnapshot();
 });
 
 test('The component should render in checked state', () => {
+    const radio = render(<Radio checked={true}>My radio</Radio>);
+    expect(radio).toMatchSnapshot();
+});
+
+test('The component should render without children', () => {
     const radio = render(<Radio checked={true} />);
     expect(radio).toMatchSnapshot();
 });
 
 test('A click on the button should trigger the change callback', () => {
     const onChangeSpy = jest.fn();
-    const radio = shallow(<Radio value="my-radio" checked={false} onChange={onChangeSpy} />);
+    const radio = shallow(<Radio value="my-radio" checked={false} onChange={onChangeSpy}>My radio</Radio>);
     radio.find('input').simulate('change');
     expect(onChangeSpy).toHaveBeenCalledWith('my-radio');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/Radio.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/Radio.test.js
@@ -1,0 +1,21 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import {shallow, render} from 'enzyme';
+import React from 'react';
+import Radio from '../Radio';
+
+test('The component should render in unchecked state', () => {
+    const radio = render(<Radio checked={false} />);
+    expect(radio).toMatchSnapshot();
+});
+
+test('The component should render in checked state', () => {
+    const radio = render(<Radio checked={true} />);
+    expect(radio).toMatchSnapshot();
+});
+
+test('A click on the button should trigger the change callback', () => {
+    const onChangeSpy = jest.fn();
+    const radio = shallow(<Radio value="my-radio" checked={false} onChange={onChangeSpy} />);
+    radio.find('input').simulate('change');
+    expect(onChangeSpy).toHaveBeenCalledWith('my-radio');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
@@ -1,0 +1,61 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import {mount, render} from 'enzyme';
+import React from 'react';
+import RadioGroup from '../RadioGroup';
+import Radio from '../Radio';
+
+jest.mock('../Radio');
+
+test('The component should render', () => {
+    const group = render(
+        <RadioGroup className="my-group" value="1">
+            <Radio value="1" />
+            <Radio value="2" />
+            <Radio value="3" />
+        </RadioGroup>
+    );
+    expect(group).toMatchSnapshot();
+});
+
+test('The component should check the correct radio', () => {
+    const group = mount(
+        <RadioGroup value="1">
+            <Radio value="1" />
+            <Radio value="2" />
+            <Radio value="3" />
+        </RadioGroup>
+    );
+    const radios = group.find(Radio);
+    expect(radios.get(0).props.checked).toBe(true);
+    expect(radios.get(1).props.checked).toBe(false);
+    expect(radios.get(2).props.checked).toBe(false);
+});
+
+test('The component should check the correct radio of nested radios', () => {
+    const group = mount(
+        <RadioGroup value="2">
+            <div><Radio value="1" /></div>
+            <div><div><Radio value="2" /></div></div>
+            <Radio value="3" />
+        </RadioGroup>
+    );
+    const radios = group.find(Radio);
+    expect(radios.get(0).props.checked).toBe(false);
+    expect(radios.get(1).props.checked).toBe(true);
+    expect(radios.get(2).props.checked).toBe(false);
+});
+
+test('The component should pass the change callback to the radios', () => {
+    const onChange = () => 'my-on-change';
+    const group = mount(
+        <RadioGroup onChange={onChange}>
+            <Radio value="1" />
+            <Radio value="2" />
+            <Radio value="3" />
+        </RadioGroup>
+    );
+    const radios = group.find(Radio);
+    expect(radios.get(0).props.onChange()).toBe('my-on-change');
+    expect(radios.get(1).props.onChange()).toBe('my-on-change');
+    expect(radios.get(2).props.onChange()).toBe('my-on-change');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
@@ -38,20 +38,6 @@ test('The component should check the correct radio', () => {
     expect(radios.get(2).props.checked).toBe(false);
 });
 
-test('The component should check the correct radio of nested radios', () => {
-    const group = mount(
-        <RadioGroup value="2">
-            <div><Radio value="1" /></div>
-            <div><div><Radio value="2" /></div></div>
-            <Radio value="3" />
-        </RadioGroup>
-    );
-    const radios = group.find(Radio);
-    expect(radios.get(0).props.checked).toBe(false);
-    expect(radios.get(1).props.checked).toBe(true);
-    expect(radios.get(2).props.checked).toBe(false);
-});
-
 test('The component should pass the change callback to the radios', () => {
     const onChange = () => 'my-on-change';
     const group = mount(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
@@ -4,13 +4,8 @@ import React from 'react';
 import RadioGroup from '../RadioGroup';
 import Radio from '../Radio';
 
-jest.mock('../Radio', () => {
-    const {PureComponent} = require.requireActual('react');
-    return class Radio extends PureComponent {
-        render () {
-            return <p>My radio mock</p>;
-        }
-    };
+jest.mock('../Radio', () => function Radio() {
+    return <p>My radio mock</p>;
 });
 
 test('The component should render', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/RadioGroup.test.js
@@ -4,7 +4,14 @@ import React from 'react';
 import RadioGroup from '../RadioGroup';
 import Radio from '../Radio';
 
-jest.mock('../Radio');
+jest.mock('../Radio', () => {
+    const {PureComponent} = require.requireActual('react');
+    return class Radio extends PureComponent {
+        render () {
+            return <p>My radio mock</p>;
+        }
+    };
+});
 
 test('The component should render', () => {
     const group = render(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/Radio.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/Radio.test.js.snap
@@ -1,24 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The component should render in checked state 1`] = `
-<span
+<label
   class="radio"
 >
-  <input
-    checked=""
-    type="radio"
-  />
-  <span />
-</span>
+  <span>
+    <input
+      checked=""
+      type="radio"
+    />
+    <span />
+  </span>
+  <span>
+    My radio
+  </span>
+</label>
 `;
 
 exports[`The component should render in unchecked state 1`] = `
-<span
+<label
   class="radio"
 >
-  <input
-    type="radio"
-  />
-  <span />
-</span>
+  <span>
+    <input
+      type="radio"
+    />
+    <span />
+  </span>
+  <span>
+    My radio
+  </span>
+</label>
+`;
+
+exports[`The component should render without children 1`] = `
+<label
+  class="radio"
+>
+  <span>
+    <input
+      checked=""
+      type="radio"
+    />
+    <span />
+  </span>
+</label>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/Radio.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/Radio.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The component should render in checked state 1`] = `
+<span
+  class="radio"
+>
+  <input
+    checked=""
+    tabindex="-1"
+    type="radio"
+  />
+  <span />
+</span>
+`;
+
+exports[`The component should render in unchecked state 1`] = `
+<span
+  class="radio"
+>
+  <input
+    tabindex="-1"
+    type="radio"
+  />
+  <span />
+</span>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/Radio.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/Radio.test.js.snap
@@ -6,7 +6,6 @@ exports[`The component should render in checked state 1`] = `
 >
   <input
     checked=""
-    tabindex="-1"
     type="radio"
   />
   <span />
@@ -18,7 +17,6 @@ exports[`The component should render in unchecked state 1`] = `
   class="radio"
 >
   <input
-    tabindex="-1"
     type="radio"
   />
   <span />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/RadioGroup.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/RadioGroup.test.js.snap
@@ -3,5 +3,15 @@
 exports[`The component should render 1`] = `
 <div
   class="my-group"
-/>
+>
+  <p>
+    My radio mock
+  </p>
+  <p>
+    My radio mock
+  </p>
+  <p>
+    My radio mock
+  </p>
+</div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/RadioGroup.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/__snapshots__/RadioGroup.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The component should render 1`] = `
+<div
+  class="my-group"
+/>
+`;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

A custom radio button component as well as a radio group component.

#### Why?

The radio component is needed in various use cases. The group component makes the state management of the radio components easier, as it wraps multiple of them and makes sure that only a single one of them is checked.

#### Example Usage

~~~javascript
initialState = {value: '1'};
<div>
    <Radio checked={state.value === '1'} onChange={() => setState({value: '1'})} />
    <Radio checked={state.value === '2'} onChange={() => setState({value: '2'})} />
    <Radio checked={state.value === '3'} onChange={() => setState({value: '3'})} />
</div>
~~~

```javascript
initialState = {value: '1'};
<RadioGroup value={state.value} onChange={(value) => setState({value})}>
    <Radio value="1" />
    <Radio value="2" />
    <Radio value="3" />
</RadioGroup>
```