### PR TITLE
update flow and add children annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "eslint-plugin-import": "^2.7.0",
         "eslint-plugin-react": "^7.0.1",
         "file-loader": "^0.11.2",
-        "flow-bin": "^0.48.0",
+        "flow-bin": "^0.53.0",
         "glob": "^7.1.2",
         "null-loader": "^0.1.1",
         "postcss-hexrgba": "^1.0.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/Backdrop.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/Backdrop.js
@@ -4,14 +4,14 @@ import Portal from 'react-portal';
 import React from 'react';
 import backdropStyles from './backdrop.scss';
 
-export default class Backdrop extends React.PureComponent {
-    props: {
-        isOpen: boolean,
-        /** When set to false the backdrop renders transparent. */
-        isVisible: boolean,
-        onClick?: () => void,
-    };
+type Props = {
+    isOpen: boolean,
+    /** When set to false the backdrop renders transparent. */
+    isVisible: boolean,
+    onClick?: () => void,
+};
 
+export default class Backdrop extends React.PureComponent<Props> {
     static defaultProps = {
         isVisible: true,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -3,12 +3,12 @@ import 'font-awesome/css/font-awesome.min.css';
 import React from 'react';
 import classNames from 'classnames';
 
-export default class Icon extends React.PureComponent {
-    props: {
-        className: string,
-        name: string,
-    };
+type Props = {
+    className: string,
+    name: string,
+};
 
+export default class Icon extends React.PureComponent<Props> {
     render() {
         const className = classNames(
             this.props.className,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -9,19 +9,19 @@ import type {SelectionData} from '../RectangleSelection/types';
 import withContainerSize from '../withContainerSize';
 import imageRectangleSelectionStyles from './imageRectangleSelection.scss';
 
-@observer
-export class ImageRectangleSelection extends React.PureComponent {
-    props: {
-        /** Determines the position at which the selection box is rendered at the beginning. */
-        initialSelection?: SelectionData,
-        minWidth?: number,
-        minHeight?: number,
-        onChange?: (s: SelectionData) => void,
-        src: string,
-        containerWidth: number,
-        containerHeight: number,
-    };
+type Props = {
+    /** Determines the position at which the selection box is rendered at the beginning. */
+    initialSelection?: SelectionData,
+    minWidth?: number,
+    minHeight?: number,
+    onChange?: (s: SelectionData) => void,
+    src: string,
+    containerWidth: number,
+    containerHeight: number,
+};
 
+@observer
+export class ImageRectangleSelection extends React.PureComponent<Props> {
     image: Image;
     rounding = new RoundingNormalizer();
     @observable imageLoaded = false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
@@ -5,18 +5,18 @@ import React from 'react';
 import type {RectangleChange} from './types';
 import modifiableRectangleStyles from './modifiableRectangle.scss';
 
-@observer
-export default class ModifiableRectangle extends React.PureComponent {
-    props: {
-        left: number,
-        top: number,
-        width: number,
-        height: number,
-        backdropSize: number,
-        onChange?: (r: RectangleChange) => void,
-        onDoubleClick?: () => void,
-    };
+type Props = {
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+    backdropSize: number,
+    onChange?: (r: RectangleChange) => void,
+    onDoubleClick?: () => void,
+};
 
+@observer
+export default class ModifiableRectangle extends React.PureComponent<Props> {
     static defaultProps = {
         left: 0,
         top: 0,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import {action, observable} from 'mobx';
-import type {Children} from 'react';
+import type {Node} from 'react';
 import {observer} from 'mobx-react';
 import React from 'react';
 import withContainerSize from '../withContainerSize';
@@ -15,20 +15,18 @@ import rectangleSelectionStyles from './rectangleSelection.scss';
 type Props = {
     /** Determines the position at which the selection box is rendered at the beginning */
     initialSelection?: SelectionData,
-        minWidth?: number,
-        minHeight?: number,
-        /** Determines whether or not the data gets rounded */
-        round: boolean,
-        onChange?: (s: SelectionData) => void,
-        children?: Children,
-        containerHeight: number,
-        containerWidth: number,
+    minWidth?: number,
+    minHeight?: number,
+    /** Determines whether or not the data gets rounded */
+    round: boolean,
+    onChange?: (s: SelectionData) => void,
+    children?: Node,
+    containerHeight: number,
+    containerWidth: number,
 };
 
 @observer
-export class RectangleSelection extends React.PureComponent {
-    props: Props;
-
+export class RectangleSelection extends React.PureComponent<Props> {
     static defaultProps = {
         round: true,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/__mocks__/withContainerSize.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/__mocks__/withContainerSize.js
@@ -1,8 +1,9 @@
 // @flow
 import React from 'react';
+import type {ComponentType} from 'react';
 
-export default function withContainerSize(Component: ReactClass<*>) {
-    class withContainerSizeComponent extends React.Component {
+export default function withContainerSize(Component: ComponentType<*>) {
+    class withContainerSizeComponent extends React.Component<*> {
         component: *;
 
         componentDidMount() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
@@ -1,13 +1,13 @@
 // @flow
 import {action, observable} from 'mobx';
-import type {Element} from 'react';
+import type {ComponentType, Element, ElementRef} from 'react';
 import React from 'react';
 import {observer} from 'mobx-react';
 import styles from './withContainerSize.scss';
 
-export default function withContainerSize(Component: ReactClass<*>, containerClass: string = styles.container) {
+export default function withContainerSize(Component: ComponentType<*>, containerClass: string = styles.container) {
     @observer
-    class WithContainerSizeComponent extends React.Component {
+    class WithContainerSizeComponent extends React.Component<*> {
         component: Element<*>;
         container: HTMLElement;
         @observable containerWidth: number = 0;
@@ -24,7 +24,7 @@ export default function withContainerSize(Component: ReactClass<*>, containerCla
             window.removeEventListener('resize', this.handleWindowResize);
         }
 
-        readContainerDimensions = (container: HTMLElement) => {
+        readContainerDimensions = (container: ElementRef<'div'>) => {
             if (!container) {
                 return;
             }
@@ -35,7 +35,7 @@ export default function withContainerSize(Component: ReactClass<*>, containerCla
             }));
         };
 
-        setComponent = (c: Element<*>) => this.component = c;
+        setComponent = (component: Element<*>) => this.component = component;
         handleWindowResize = () => this.readContainerDimensions(this.container);
 
         render() {
@@ -54,7 +54,15 @@ export default function withContainerSize(Component: ReactClass<*>, containerCla
         }
     }
 
-    WithContainerSizeComponent.displayName = `withContainerSize(${Component.displayName || Component.name})`;
+    const componentName = (typeof Component.displayName === 'string'
+        ? Component.displayName
+        : (typeof Component.name === 'string'
+            ? Component.name
+            : ''
+        )
+    );
+
+    WithContainerSizeComponent.displayName = `withContainerSize(${componentName})`;
 
     return WithContainerSizeComponent;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
@@ -3,6 +3,7 @@ import {action, observable} from 'mobx';
 import type {ComponentType, Element, ElementRef} from 'react';
 import React from 'react';
 import {observer} from 'mobx-react';
+import {buildHocDisplayName} from '../../services/react';
 import styles from './withContainerSize.scss';
 
 export default function withContainerSize(Component: ComponentType<*>, containerClass: string = styles.container) {
@@ -54,15 +55,7 @@ export default function withContainerSize(Component: ComponentType<*>, container
         }
     }
 
-    const componentName = (typeof Component.displayName === 'string'
-        ? Component.displayName
-        : (typeof Component.name === 'string'
-            ? Component.name
-            : ''
-        )
-    );
-
-    WithContainerSizeComponent.displayName = `withContainerSize(${componentName})`;
+    WithContainerSizeComponent.displayName = buildHocDisplayName('withContainerSize', Component);
 
     return WithContainerSizeComponent;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -8,12 +8,12 @@ import Toolbar from '../Toolbar';
 import ViewRenderer from '../ViewRenderer';
 import applicationStyles from './application.scss';
 
-@observer
-export default class Application extends React.PureComponent {
-    props: {
-        router: Router,
-    };
+type Props = {
+    router: Router,
+};
 
+@observer
+export default class Application extends React.PureComponent<Props> {
     render() {
         return (
             <div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SplitView/SplitView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SplitView/SplitView.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 
-export default class SplitView extends React.PureComponent {
+export default class SplitView extends React.PureComponent<*> {
     render() {
         return (
             <aside />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Item.js
@@ -4,9 +4,7 @@ import Icon from '../../components/Icon';
 import type {Item as ItemType} from './types';
 import itemStyles from './item.scss';
 
-export default class Item extends React.PureComponent {
-    props: ItemType;
-
+export default class Item extends React.PureComponent<ItemType> {
     static defaultProps = {
         enabled: true,
     };
@@ -20,7 +18,7 @@ export default class Item extends React.PureComponent {
     render() {
         return (
             <button className={itemStyles.item} disabled={!this.props.enabled} onClick={this.handleClick}>
-                <Icon className={itemStyles.icon} name={this.props.icon} />
+                <Icon className={itemStyles.icon} name={this.props.icon}/>
                 <span className={itemStyles.title}>{this.props.title}</span>
             </button>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Item.js
@@ -18,7 +18,7 @@ export default class Item extends React.PureComponent<ItemType> {
     render() {
         return (
             <button className={itemStyles.item} disabled={!this.props.enabled} onClick={this.handleClick}>
-                <Icon className={itemStyles.icon} name={this.props.icon}/>
+                <Icon className={itemStyles.icon} name={this.props.icon} />
                 <span className={itemStyles.title}>{this.props.title}</span>
             </button>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -6,7 +6,7 @@ import toolbarStore from './stores/ToolbarStore';
 import toolbarStyles from './toolbar.scss';
 
 @observer
-export default class Toolbar extends React.PureComponent {
+export default class Toolbar extends React.PureComponent<*> {
     render() {
         return (
             <header className={toolbarStyles.toolbar}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -1,11 +1,12 @@
 // @flow
 import {autorun} from 'mobx';
 import React from 'react';
+import type {ComponentType} from 'react';
 import type {Item} from './types';
 import toolbarStore from './stores/ToolbarStore';
 
-export default function withToolbar(Component: ReactClass<*>, toolbar: () => Array<Item>) {
-    const WithToolbarComponent = class extends React.Component {
+export default function withToolbar(Component: ComponentType<*>, toolbar: () => Array<Item>) {
+    const WithToolbarComponent = class extends React.Component<*> {
         disposer: Function;
 
         setToolbarItems = (component: React$Element<*>) => {
@@ -25,7 +26,15 @@ export default function withToolbar(Component: ReactClass<*>, toolbar: () => Arr
         }
     };
 
-    WithToolbarComponent.displayName = `withToolbar(${Component.displayName || Component.name})`;
+    const componentName = (typeof Component.displayName === 'string'
+        ? Component.displayName
+        : (typeof Component.name === 'string'
+            ? Component.name
+            : ''
+        )
+    );
+
+    WithToolbarComponent.displayName = `withToolbar(${componentName})`;
 
     return WithToolbarComponent;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -2,6 +2,7 @@
 import {autorun} from 'mobx';
 import React from 'react';
 import type {ComponentType} from 'react';
+import {buildHocDisplayName} from '../../services/react';
 import type {Item} from './types';
 import toolbarStore from './stores/ToolbarStore';
 
@@ -26,15 +27,7 @@ export default function withToolbar(Component: ComponentType<*>, toolbar: () => 
         }
     };
 
-    const componentName = (typeof Component.displayName === 'string'
-        ? Component.displayName
-        : (typeof Component.name === 'string'
-            ? Component.name
-            : ''
-        )
-    );
-
-    WithToolbarComponent.displayName = `withToolbar(${componentName})`;
+    WithToolbarComponent.displayName = buildHocDisplayName('withToolbar', Component);
 
     return WithToolbarComponent;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -2,7 +2,12 @@
 import React from 'react';
 import viewStore from './stores/ViewStore';
 
-export default class ViewRenderer extends React.PureComponent<{name: string, parameters: Object}> {
+type Props = {
+    name: string,
+    parameters: Object,
+};
+
+export default class ViewRenderer extends React.PureComponent<Props> {
     render() {
         const view = viewStore.get(this.props.name);
         if (!view) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -2,12 +2,7 @@
 import React from 'react';
 import viewStore from './stores/ViewStore';
 
-export default class ViewRenderer extends React.PureComponent {
-    props: {
-        name: string,
-        parameters?: Object,
-    };
-
+export default class ViewRenderer extends React.PureComponent<{name: string, parameters: Object}> {
     render() {
         const view = viewStore.get(this.props.name);
         if (!view) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/stores/ViewStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/stores/ViewStore.js
@@ -1,6 +1,8 @@
 // @flow
+import type {ComponentType} from 'react';
+
 class ViewStore {
-    views: {[string]: ReactClass<*>};
+    views: {[string]: ComponentType<*>};
 
     constructor() {
         this.clear();
@@ -10,7 +12,7 @@ class ViewStore {
         this.views = {};
     }
 
-    add(name: string, view: ReactClass<*>) {
+    add(name: string, view: ComponentType<*>) {
         if (name in this.views) {
             throw new Error('The key "' + name + '" has already been used for another view');
         }
@@ -18,7 +20,7 @@ class ViewStore {
         this.views[name] = view;
     }
 
-    get(name: string): ReactClass<*> {
+    get(name: string): ComponentType<*> {
         return this.views[name];
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/react/buildHocDisplayName.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/react/buildHocDisplayName.js
@@ -1,0 +1,18 @@
+// @flow
+import type {ElementType} from 'react';
+
+function getComponentName(Component: ElementType): string {
+    if (typeof Component.displayName === 'string') {
+        return Component.displayName;
+    }
+
+    if (typeof Component.name === 'string') {
+        return Component.name;
+    }
+
+    return '';
+}
+
+export default function buildHocDisplayName(hocName: string, Component: ElementType): string {
+    return `${hocName}(${getComponentName(Component)})`;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/react/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/react/index.js
@@ -1,0 +1,4 @@
+// @flow
+import buildHocDisplayName from './buildHocDisplayName';
+
+export {buildHocDisplayName};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/react/tests/buildHocDisplayName.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/react/tests/buildHocDisplayName.test.js
@@ -1,0 +1,24 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import buildHocDisplayName from '../buildHocDisplayName';
+
+test('Build HOC display name with displayName property if it exists', () => {
+    const Component = {
+        displayName: 'componentDisplayName',
+        name: 'componentName',
+    };
+
+    expect(buildHocDisplayName('withSomeHoc', Component)).toBe('withSomeHoc(componentDisplayName)');
+});
+
+test('Build HOC display name with name property if displayName property does not exist', () => {
+    const Component = {
+        name: 'componentName',
+    };
+
+    expect(buildHocDisplayName('withSomeHoc', Component)).toBe('withSomeHoc(componentName)');
+});
+
+test('Build HOC display name with empty string if neither displayName nor name propert exists', () => {
+    const Component = {};
+    expect(buildHocDisplayName('withSomeHoc', Component)).toBe('withSomeHoc()');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -4,7 +4,7 @@ import React from 'react';
 import {translate} from '../../services/Translator';
 import {withToolbar} from '../../containers/Toolbar';
 
-class Form extends React.PureComponent {
+class Form extends React.PureComponent<*> {
     @observable dirty = false;
 
     @action

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {translate} from '../../services/Translator';
 import {withToolbar} from '../../containers/Toolbar';
 
-class List extends React.PureComponent {
+class List extends React.PureComponent<*> {
     render() {
         return (
             <h1>List</h1>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the typing of children in react using flow, which is available since [flow 0.53](https://github.com/facebook/flow/issues/1964#issuecomment-322865281).

More information about this can be found in the flow documentation:

- [React components](https://flow.org/en/docs/react/components/)
- [React children](https://flow.org/en/docs/react/children/)
- [React type reference](https://flow.org/en/docs/react/types/#toc-react-node)

#### Why?

Because typing is great 😄 

#### BC Breaks/Deprecations

The description of props in flow have changed. Instead of an own property they have to be defined as generics.

Old version:

```javascript
// @flow
import React from 'react';
import classNames from 'classnames';

export default class Icon extends React.PureComponent {
    props: {
        className: string,
        name: string,
    };

    render() {
        const className = classNames(
            this.props.className,
            'fa',
            'fa-' + this.props.name
        );

        return (
            <span className={className} aria-hidden={true} />
        );
    }
}
```

New version:

```javascript
// @flow
import React from 'react';
import classNames from 'classnames';

type Props = {
    className: string,
    name: string,
};

export default class Icon extends React.PureComponent<Props> {
    render() {
        const className = classNames(
            this.props.className,
            'fa',
            'fa-' + this.props.name
        );

        return (
            <span className={className} aria-hidden={true} />
        );
    }
}
```

#### To Do

- [x] Clarify code style
