### PR TITLE
fix doctrine errors for mysql older than 5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3484 [TestBundle]              Fix doctrine errors for mysql older than 5.7
     * HOTFIX      #3475 [ContentBundle]           Added possibility to set default value for single-select
     * HOTFIX      #3470 [DocumentManagerBundle]   Fixed document-manager load-fixtures command
     * HOTFIX      #3465 [ContentBundle]           Fixed interpretation of code in block preview

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml.dist
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml.dist
@@ -6,7 +6,7 @@ parameters:
     database.name:     sulu_test
     database.port:     ~
     database.password: ~
-    database.version:  5.7
+    database.version:  5.6
 
     phpcr.transport:   doctrinedbal
     phpcr.backend_url: http://localhost:8080/server/


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR sets the database version in the tests to 5.6, to avoid using the `JSON` datatype which is not available before mysql 5.7.

#### Why?

Because we want to support older mysql versions as well.