### PR TITLE
Implemented cropped text component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/CroppedText.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/CroppedText.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import croppedTextStyle from './croppedText.scss';
+
+type Props = {
+    children: string,
+};
+
+export default class CroppedText extends React.PureComponent<Props> {
+    render() {
+        const index = Math.ceil(this.props.children.length / 2);
+        const frontText = this.props.children.substr(0, index);
+        const backText = this.props.children.substr(index);
+
+        return (
+            <div
+                title={this.props.children}
+                aria-label={this.props.children}
+                className={croppedTextStyle.croppedText}>
+                <div className={croppedTextStyle.whole}>{this.props.children}</div>
+                <div className={croppedTextStyle.front} aria-hidden={true}>{frontText}</div>
+                <div className={croppedTextStyle.back} aria-hidden={true}><span>{backText}</span></div>
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/README.md
@@ -1,0 +1,7 @@
+The component crops a given string in the middle, if it gets too long. It even is responsive.
+
+```
+<div style={{maxWidth: '400px'}}>
+    <CroppedText>The next sentence is false. The previous sentence is true.</CroppedText>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/croppedText.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/croppedText.scss
@@ -1,0 +1,39 @@
+$lineHeight: 1.2em;
+
+.cropped-text {
+    width: 100%;
+    max-height: $lineHeight;
+    line-height: $lineHeight;
+    overflow: hidden;
+    display: inline-flex;
+    flex-wrap: nowrap;
+    position: relative;
+
+    .whole {
+        position: absolute;
+        top: 0;
+        left: 0;
+        color: transparent;
+    }
+
+    .front {
+        flex-grow: 0;
+        flex-shrink: 1;
+        flex-basis: content;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: pre;
+    }
+
+    .back {
+        flex-grow: 0;
+        flex-shrink: 1;
+        flex-basis: content;
+        overflow: hidden;
+
+        span {
+            float: right;
+            white-space: pre;
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/index.js
@@ -1,0 +1,4 @@
+// @flow
+import CroppedText from './CroppedText';
+
+export default CroppedText;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/tests/CroppedText.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/tests/CroppedText.test.js
@@ -1,0 +1,8 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import {render} from 'enzyme';
+import CroppedText from '../CroppedText';
+
+test('CroppedText should render', () => {
+    expect(render(<CroppedText>This is a text which will get cropped.</CroppedText>)).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/tests/__snapshots__/CroppedText.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/tests/__snapshots__/CroppedText.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CroppedText should render 1`] = `
+<div
+  aria-label="This is a text which will get cropped."
+  class="croppedText"
+  title="This is a text which will get cropped."
+>
+  <div
+    class="whole"
+  >
+    This is a text which will get cropped.
+  </div>
+  <div
+    aria-hidden="true"
+    class="front"
+  >
+    This is a text whic
+  </div>
+  <div
+    aria-hidden="true"
+    class="back"
+  >
+    <span>
+      h will get cropped.
+    </span>
+  </div>
+</div>
+`;


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

A component which crops text if it gets to long.

#### Why?

The issue that text can be to long for the given space is present in plenty components. This PR introduces a feature which copes with this issue.

#### Example Usage

~~~javascript
<CroppedText>The next sentence is false. The previous sentence is true.</CroppedText>
~~~
