### PR TITLE
Added value as second parameter of the checkbox change callback

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
@@ -7,25 +7,24 @@ import checkboxStyles from './checkbox.scss';
 
 type Props = {
     checked: boolean,
-    value: string | true,
+    value: string,
     skin: 'dark' | 'light',
     className: string,
-    onChange?: (value: string | boolean) => void,
+    onChange?: (checked: boolean, value?: string) => void,
 };
 
 export default class Checkbox extends React.PureComponent<Props> {
     input: ElementRef<'input'>;
 
     static defaultProps = {
-        value: true,
+        value: '',
         skin: 'dark',
         className: '',
     };
 
     handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
         if (this.props.onChange) {
-            const value = event.currentTarget.checked ? this.props.value : false;
-            this.props.onChange(value);
+            this.props.onChange(event.currentTarget.checked, this.props.value);
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/README.md
@@ -1,11 +1,10 @@
 The custom checkbox has no internal state and has to be managed, like shown in the following example.
-The change callback receives the value property when the checkbox is checked (default is `true`) or `false`
-if the checkbox gets unchecked.
+The change callback receives the value as an optional second parameter.
 
 ```
 initialState = {checked: false};
-onChange = (checked) => setState({checked});
-<Checkbox checked={state.checked} onChange={onChange} />
+onChange = (checked, value) => setState({checked});
+<Checkbox value="my-value" checked={state.checked} onChange={onChange} />
 ```
 
 The checkbox also comes with a light skin.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/Checkbox.test.js
@@ -27,16 +27,16 @@ test('A click on the checkbox should trigger the change callback', () => {
     const onChangeSpy = jest.fn();
     const checkbox = shallow(<Checkbox checked={false} onChange={onChangeSpy} />);
     checkbox.find('input').simulate('change', {currentTarget: {checked: true}});
-    expect(onChangeSpy).toHaveBeenCalledWith(true);
+    expect(onChangeSpy).toHaveBeenCalledWith(true, '');
     checkbox.find('input').simulate('change', {currentTarget: {checked: false}});
-    expect(onChangeSpy).toHaveBeenCalledWith(false);
+    expect(onChangeSpy).toHaveBeenCalledWith(false, '');
 });
 
 test('A click on the checkbox should trigger the change callback with the value', () => {
     const onChangeSpy = jest.fn();
     const checkbox = shallow(<Checkbox checked={false} value="my-value" onChange={onChangeSpy} />);
     checkbox.find('input').simulate('change', {currentTarget: {checked: true}});
-    expect(onChangeSpy).toHaveBeenCalledWith('my-value');
+    expect(onChangeSpy).toHaveBeenCalledWith(true, 'my-value');
     checkbox.find('input').simulate('change', {currentTarget: {checked: false}});
-    expect(onChangeSpy).toHaveBeenCalledWith(false);
+    expect(onChangeSpy).toHaveBeenCalledWith(false, 'my-value');
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The value property gets passed to the change callback as a second optional parameter.

### Example Usage

~~~javascript
initialState = {checked: false};
onChange = (checked, value) => setState({checked});
<Checkbox value="my-value" checked={state.checked} onChange={onChange} />
~~~
