### PR TITLE
Fixed deindex of medias

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -10,6 +10,7 @@ disabled:
     - phpdoc_align
     - phpdoc_indent
     - phpdoc_to_comment
+    - blank_line_before_break
     - blankline_after_open_tag
     - function_declaration
     - single_line_class_definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * HOTFIX      #3501 [AdminBundle]             Updated husky to avoid html/js injection
     * HOTFIX      #3492 [ContentBundle]           Fixed smart-content categories load
+    * HOTFIX      #3499 [MediaBundle]             Fixed deindex of medias
 
 * 1.6.3 (2017-08-17)
     * HOTFIX      #3484 [TestBundle]              Fix doctrine errors for mysql older than 5.7

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -355,6 +355,7 @@ class MediaManager implements MediaManagerInterface
             /** @var FileVersion $fileVersion */
             if ($version == $fileVersion->getVersion()) {
                 $currentFileVersion = $fileVersion;
+
                 break;
             }
         }
@@ -552,39 +553,51 @@ class MediaManager implements MediaManagerInterface
                 switch ($attribute) {
                     case 'size':
                         $media->setSize($value);
+
                         break;
                     case 'title':
                         $media->setTitle($value);
+
                         break;
                     case 'description':
                         $media->setDescription($value);
+
                         break;
                     case 'copyright':
                         $media->setCopyright($value);
+
                         break;
                     case 'credits':
                         $media->setCredits($value);
+
                         break;
                     case 'version':
                         $media->setVersion($value);
+
                         break;
                     case 'name':
                         $media->setName($value);
+
                         break;
                     case 'url':
                         $media->setUrl($value);
+
                         break;
                     case 'formats':
                         $media->setFormats($value);
+
                         break;
                     case 'storageOptions':
                         $media->setStorageOptions($value);
+
                         break;
                     case 'publishLanguages':
                         $media->setPublishLanguages($value);
+
                         break;
                     case 'contentLanguages':
                         $media->setContentLanguages($value);
+
                         break;
                     case 'tags':
                         $media->removeTags();
@@ -594,12 +607,15 @@ class MediaManager implements MediaManagerInterface
                                 $media->addTag($tagEntity);
                             }
                         }
+
                         break;
                     case 'properties':
                         $media->setProperties($value);
+
                         break;
                     case 'changed':
                         $media->setChanged($value);
+
                         break;
                     case 'created':
                         break;
@@ -607,14 +623,17 @@ class MediaManager implements MediaManagerInterface
                         if ($value instanceof UserInterface) {
                             $media->setChanger($value);
                         }
+
                         break;
                     case 'creator':
                         if ($value instanceof UserInterface) {
                             $media->setCreator($value);
                         }
+
                         break;
                     case 'mimeType':
                         $media->setMimeType($value);
+
                         break;
                     case 'collection':
                         $collectionEntity = $this->getCollectionById($value);
@@ -625,6 +644,7 @@ class MediaManager implements MediaManagerInterface
                             $type = $this->typeManager->get($value['id']);
                             $media->setType($type);
                         }
+
                         break;
                     case 'categories':
                         $categoryIds = $value;
@@ -638,6 +658,7 @@ class MediaManager implements MediaManagerInterface
                                 $media->addCategory($category);
                             }
                         }
+
                         break;
                     case 'targetGroups':
                         $targetGroupIds = $value;
@@ -650,12 +671,15 @@ class MediaManager implements MediaManagerInterface
                                 $media->addTargetGroup($targetGroup);
                             }
                         }
+
                         break;
                     case 'focusPointX':
                         $media->setFocusPointX($value);
+
                         break;
                     case 'focusPointY':
                         $media->setFocusPointY($value);
+
                         break;
                 }
             }
@@ -712,6 +736,11 @@ class MediaManager implements MediaManagerInterface
                 );
 
                 $this->storage->remove($fileVersion->getStorageOptions());
+
+                foreach ($fileVersion->getMeta() as $fileVersionMeta) {
+                    // this will trigger massive-search deindex
+                    $this->em->remove($fileVersionMeta);
+                }
             }
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -553,51 +553,39 @@ class MediaManager implements MediaManagerInterface
                 switch ($attribute) {
                     case 'size':
                         $media->setSize($value);
-
                         break;
                     case 'title':
                         $media->setTitle($value);
-
                         break;
                     case 'description':
                         $media->setDescription($value);
-
                         break;
                     case 'copyright':
                         $media->setCopyright($value);
-
                         break;
                     case 'credits':
                         $media->setCredits($value);
-
                         break;
                     case 'version':
                         $media->setVersion($value);
-
                         break;
                     case 'name':
                         $media->setName($value);
-
                         break;
                     case 'url':
                         $media->setUrl($value);
-
                         break;
                     case 'formats':
                         $media->setFormats($value);
-
                         break;
                     case 'storageOptions':
                         $media->setStorageOptions($value);
-
                         break;
                     case 'publishLanguages':
                         $media->setPublishLanguages($value);
-
                         break;
                     case 'contentLanguages':
                         $media->setContentLanguages($value);
-
                         break;
                     case 'tags':
                         $media->removeTags();
@@ -607,15 +595,12 @@ class MediaManager implements MediaManagerInterface
                                 $media->addTag($tagEntity);
                             }
                         }
-
                         break;
                     case 'properties':
                         $media->setProperties($value);
-
                         break;
                     case 'changed':
                         $media->setChanged($value);
-
                         break;
                     case 'created':
                         break;
@@ -623,17 +608,14 @@ class MediaManager implements MediaManagerInterface
                         if ($value instanceof UserInterface) {
                             $media->setChanger($value);
                         }
-
                         break;
                     case 'creator':
                         if ($value instanceof UserInterface) {
                             $media->setCreator($value);
                         }
-
                         break;
                     case 'mimeType':
                         $media->setMimeType($value);
-
                         break;
                     case 'collection':
                         $collectionEntity = $this->getCollectionById($value);
@@ -644,7 +626,6 @@ class MediaManager implements MediaManagerInterface
                             $type = $this->typeManager->get($value['id']);
                             $media->setType($type);
                         }
-
                         break;
                     case 'categories':
                         $categoryIds = $value;
@@ -658,7 +639,6 @@ class MediaManager implements MediaManagerInterface
                                 $media->addCategory($category);
                             }
                         }
-
                         break;
                     case 'targetGroups':
                         $targetGroupIds = $value;
@@ -671,15 +651,12 @@ class MediaManager implements MediaManagerInterface
                                 $media->addTargetGroup($targetGroup);
                             }
                         }
-
                         break;
                     case 'focusPointX':
                         $media->setFocusPointX($value);
-
                         break;
                     case 'focusPointY':
                         $media->setFocusPointY($value);
-
                         break;
                 }
             }

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -355,7 +355,6 @@ class MediaManager implements MediaManagerInterface
             /** @var FileVersion $fileVersion */
             if ($version == $fileVersion->getVersion()) {
                 $currentFileVersion = $fileVersion;
-
                 break;
             }
         }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -228,7 +228,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $fileVersion->getStorageOptions()->willReturn(json_encode(['segment' => '01', 'fileName' => 'test.jpg']));
 
         $fileVersionMeta = $this->prophesize(FileVersionMeta::class);
-        $fileVersion->getMeta()->willReturn($fileVersionMeta);
+        $fileVersion->getMeta()->willReturn([$fileVersionMeta->reveal()]);
 
         $media = $this->prophesize(Media::class);
         $media->getCollection()->willReturn($collection);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -23,6 +23,7 @@ use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
@@ -226,6 +227,9 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $fileVersion->getMimeType()->willReturn('image/png');
         $fileVersion->getStorageOptions()->willReturn(json_encode(['segment' => '01', 'fileName' => 'test.jpg']));
 
+        $fileVersionMeta = $this->prophesize(FileVersionMeta::class);
+        $fileVersion->getMeta()->willReturn($fileVersionMeta);
+
         $media = $this->prophesize(Media::class);
         $media->getCollection()->willReturn($collection);
         $media->getFiles()->willReturn([$file->reveal()]);
@@ -245,6 +249,10 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         )->shouldBeCalled();
 
         $this->storage->remove(json_encode(['segment' => '01', 'fileName' => 'test.jpg']))->shouldBeCalled();
+
+        $this->em->remove($media->reveal())->shouldBeCalled();
+        $this->em->remove($fileVersionMeta->reveal())->shouldBeCalled();
+        $this->em->flush()->shouldBeCalled();
 
         $this->mediaManager->delete(1, true);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | fixes https://github.com/sulu/sulu/issues/3493
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the remove call for `FileVersionMeta` - this will trigger the `onRemove` event of doctrine to deindex the media from massive-search index.