### PR TITLE
Fixed snippet area with upper case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * HOTFIX      #TODO [SnippetBundle]           Fixed snippet areas with uppercases
+    * HOTFIX      #3504 [SnippetBundle]           Fixed snippet areas with uppercases
     * HOTFIX      #3501 [AdminBundle]             Updated husky to avoid html/js injection
     * HOTFIX      #3492 [ContentBundle]           Fixed smart-content categories load
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #TODO [SnippetBundle]           Fixed snippet areas with uppercases
     * HOTFIX      #3501 [AdminBundle]             Updated husky to avoid html/js injection
     * HOTFIX      #3492 [ContentBundle]           Fixed smart-content categories load
 

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
@@ -59,7 +59,7 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         $this->documentManager = $documentManager;
         $this->webspaceManager = $webspaceManager;
         $this->registry = $registry;
-        $this->areas = new FrozenParameterBag($areas);
+        $this->areas = new FrozenParameterBag(array_change_key_case($areas));
     }
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/DefaultSnippetManagerTest.php
@@ -42,6 +42,14 @@ class DefaultSnippetManagerTest extends \PHPUnit_Framework_TestCase
                 'de' => 'Test Homepage DE',
             ],
         ],
+        'testCase' => [
+            'key' => 'testCase',
+            'template' => 'test',
+            'title' => [
+                'en' => 'Test Case EN',
+                'de' => 'Test Case DE',
+            ],
+        ],
     ];
 
     public function saveDataProvider()
@@ -55,6 +63,10 @@ class DefaultSnippetManagerTest extends \PHPUnit_Framework_TestCase
             ['sulu_io', 'de', 'test', 'test_homepage', '123-123-123', false],
             ['sulu_io', 'de', 'test', 'test_homepage', '123-123-123', true, false],
             ['sulu_io', 'de', 'test', 'test_homepage', '123-123-123', false, false],
+            ['sulu_io', 'de', 'test', 'testCase', '123-123-123'],
+            ['sulu_io', 'de', 'test', 'testCase', '123-123-123', false],
+            ['sulu_io', 'de', 'test', 'testCase', '123-123-123', true, false],
+            ['sulu_io', 'de', 'test', 'testCase', '123-123-123', false, false],
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixed a problem with the symfony frozen parameters bag that `get` converts the given parameter to `strtolower` but the constructor of the FrozenParameterBag doesn't. 

#### Why?

It need to be fixed here as discussed in symfony/symfony#24065 they will not fix it in the FrozenParametersBag.

#### To Do

- [x] Test Case
