### PR TITLE
Fix deletion of tag when referenced by media file version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3509 [MediaBundle]             Fixed deletion of tag when referenced in media fileversion
     * HOTFIX      #3504 [SnippetBundle]           Fixed snippet areas with uppercases
     * HOTFIX      #3501 [AdminBundle]             Updated husky to avoid html/js injection
     * HOTFIX      #3492 [ContentBundle]           Fixed smart-content categories load

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,23 @@
 # Upgrade
 
+## 1.6.4
+
+### File Version - Tag Cascading
+
+That its possible to delete a Tag, which is referenced in a Media FileVersion, a `on-delete CASCADE` need to be added to the database.
+Run the following command:
+
+```bash
+php bin/console doctrine:schema:update --force
+```
+
+or the following SQL statements on your database:
+
+```sql
+ALTER TABLE me_file_version_tags DROP FOREIGN KEY FK_150A30BE1C41CAB8;
+ALTER TABLE me_file_version_tags ADD CONSTRAINT FK_150A30BE1C41CAB8 FOREIGN KEY (idTags) REFERENCES ta_tags (id) ON DELETE CASCADE;
+```
+
 ## 1.6.0
 
 ### Default Snippets

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -73,7 +73,7 @@
                     <join-column name="idFileVersions" referenced-column-name="id" on-delete="CASCADE"/>
                 </join-columns>
                 <inverse-join-columns>
-                    <join-column name="idTags" referenced-column-name="id"/>
+                    <join-column name="idTags" referenced-column-name="id" on-delete="CASCADE"/>
                 </inverse-join-columns>
             </join-table>
         </many-to-many>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It activated on-delete cascade so when a tag is deleted a tag-fileversion media relation is also deleted.

#### Why?

Currently its not possible to remove a Tag which is referenced in a media FileVersion entity.
