### PR TITLE
change closing brackets rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,7 +90,7 @@
         ],
         "react/jsx-closing-bracket-location": [
             "error",
-            "after-props"
+            "line-aligned"
         ],
         "react/jsx-wrap-multilines": "error",
         "react/jsx-pascal-case": "error",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
@@ -33,7 +33,8 @@ export default class Checkbox extends React.PureComponent<Props> {
                 value={value}
                 name={name}
                 icon={checked ? CHECKED_ICON : undefined}
-                onChange={onChange}>
+                onChange={onChange}
+            >
                 {children}
             </Switch>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/tests/Checkbox.test.js
@@ -20,7 +20,10 @@ test('The component pass the props correctly to the generic checkbox', () => {
             onChange={onChange}
             value="my-value"
             name="my-name"
-            checked={true}>My label</Checkbox>
+            checked={true}
+        >
+            My label
+        </Checkbox>
     );
     const switchComponent = checkbox.find('Switch');
     expect(switchComponent.props().value).toBe('my-value');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/CroppedText.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CroppedText/CroppedText.js
@@ -16,7 +16,8 @@ export default class CroppedText extends React.PureComponent<Props> {
             <div
                 title={this.props.children}
                 aria-label={this.props.children}
-                className={croppedTextStyle.croppedText}>
+                className={croppedTextStyle.croppedText}
+            >
                 <div className={croppedTextStyle.front} aria-hidden={true}>{frontText}</div>
                 <div className={croppedTextStyle.back} aria-hidden={true}><span>{backText}</span></div>
                 <div className={croppedTextStyle.whole}>{this.props.children}</div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/DisplayValue.js
@@ -37,7 +37,8 @@ export default class DisplayValue extends React.PureComponent<Props> {
             <button
                 ref={this.setButton}
                 onClick={onClick}
-                className={displayValueClass}>
+                className={displayValueClass}
+            >
                 {!!icon &&
                     <Icon className={displayValueStyles.frontIcon} name={icon} />
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/GenericSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/GenericSelect.js
@@ -68,7 +68,8 @@ export default class GenericSelect extends React.PureComponent<Props> {
                 <DisplayValue
                     ref={this.setDisplayValue}
                     icon={icon}
-                    onClick={this.handleDisplayValueClick}>
+                    onClick={this.handleDisplayValueClick}
+                >
                     {displayValue}
                 </DisplayValue>
                 <OverlayList
@@ -78,7 +79,8 @@ export default class GenericSelect extends React.PureComponent<Props> {
                     anchorHeight={displayValueDimensions.height}
                     open={this.open}
                     centeredChildIndex={this.centeredChildIndex}
-                    onClose={this.handleListClose}>
+                    onClose={this.handleListClose}
+                >
                     {listChildren}
                 </OverlayList>
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/Option.js
@@ -77,7 +77,8 @@ export default class Option extends React.PureComponent<Props> {
                     className={optionClass}
                     ref={this.setButton}
                     onClick={this.handleButtonClick}
-                    disabled={disabled}>
+                    disabled={disabled}
+                >
                     {this.renderSelectedVisualization()}
                     {children}
                 </button>
@@ -94,7 +95,8 @@ export default class Option extends React.PureComponent<Props> {
             <Checkbox
                 onChange={this.handleButtonClick}
                 className={optionStyles.input}
-                checked={this.props.selected} />
+                checked={this.props.selected}
+            />
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/OverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/OverlayList.js
@@ -128,7 +128,8 @@ export default class OverlayList extends React.PureComponent<Props> {
                         <ul
                             ref={this.readOffsetDimensions}
                             style={style}
-                            className={overlayListStyles.list}>
+                            className={overlayListStyles.list}
+                        >
                             {this.renderChildrenWithFocusSet()}
                         </ul>
                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/tests/GenericSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/tests/GenericSelect.test.js
@@ -18,7 +18,8 @@ test('The component should render with the list closed', () => {
         <GenericSelect
             onSelect={onSelect}
             isOptionSelected={isOptionSelected}
-            displayValue="My text">
+            displayValue="My text"
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -38,7 +39,8 @@ test('The component should render with an icon', () => {
             icon="plus"
             onSelect={onSelect}
             isOptionSelected={isOptionSelected}
-            displayValue="My text">
+            displayValue="My text"
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -57,7 +59,8 @@ test('The component should open the list when the display value is clicked', () 
         <GenericSelect
             onSelect={onSelect}
             isOptionSelected={isOptionSelected}
-            displayValue="My text">
+            displayValue="My text"
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -77,7 +80,8 @@ test('The component should trigger the select callback and close the list when a
         <GenericSelect
             onSelect={onSelectSpy}
             isOptionSelected={isOptionSelected}
-            displayValue="My text">
+            displayValue="My text"
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -97,7 +101,8 @@ test('The component should pass the centered child index to the overlay list', (
         <GenericSelect
             onSelect={onSelect}
             isOptionSelected={isOptionSelected}
-            displayValue="My text">
+            displayValue="My text"
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -116,7 +121,8 @@ test('The component should pass the selected property to the options', () => {
         <GenericSelect
             onSelect={onSelect}
             isOptionSelected={isOptionSelected}
-            displayValue="My text">
+            displayValue="My text"
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -100,11 +100,13 @@ export class ImageRectangleSelection extends React.PureComponent<Props> {
                 minWidth={minWidth}
                 minHeight={minHeight}
                 onChange={this.handleRectangleSelectionChange}
-                round={false}>
+                round={false}
+            >
                 <img
                     width={this.imageResizedWidth}
                     height={this.imageResizedHeight}
-                    src={this.props.src} />
+                    src={this.props.src}
+                />
             </RectangleSelection>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
@@ -34,7 +34,8 @@ test('The component should calculate the selection with respect to the image', (
             containerWidth={640}
             containerHeight={360}
             onChange={onChangeSpy}
-            src="//:0" />
+            src="//:0"
+        />
     );
 });
 
@@ -54,7 +55,8 @@ test('The component should render with initial selection', (done) => {
             src="//:0"
             containerWidth={640}
             containerHeight={360}
-            initialSelection={{width: 1500, height: 800, top: 200, left: 300}} />
+            initialSelection={{width: 1500, height: 800, top: 200, left: 300}}
+        />
     );
 });
 
@@ -74,6 +76,7 @@ test('The component should render with minWidth and minHeight', (done) => {
             containerWidth={640}
             containerHeight={360}
             minHeight={300}
-            minWidth={600} />
+            minWidth={600}
+        />
     );
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -40,7 +40,8 @@ export default class Input extends React.PureComponent<Props> {
                     type={type}
                     value={value}
                     placeholder={placeholder}
-                    onChange={this.handleChange} />
+                    onChange={this.handleChange}
+                />
             </label>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -70,7 +70,8 @@ export default class MultiSelect extends React.PureComponent<Props> {
                 closeOnSelect={false}
                 displayValue={this.displayValue}
                 selectedVisualization="checkbox"
-                isOptionSelected={this.isOptionSelected}>
+                isOptionSelected={this.isOptionSelected}
+            >
                 {children}
             </GenericSelect>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
@@ -12,7 +12,8 @@ test('The component should render a generic select', () => {
         <MultiSelect
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChange}>
+            onChange={onChange}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -28,7 +29,8 @@ test('The component should pass the correct display value if nothing is selected
         <MultiSelect
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChange}>
+            onChange={onChange}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -46,7 +48,8 @@ test('The component should pass the correct display value if everything is selec
             values={['option-1', 'option-2', 'option-3']}
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChange}>
+            onChange={onChange}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -64,7 +67,8 @@ test('The component should pass the correct display value if some options are se
             values={['option-1', 'option-2']}
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChange}>
+            onChange={onChange}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -82,7 +86,8 @@ test('The component should select the correct option', () => {
             values={['option-1', 'option-2']}
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChange}>
+            onChange={onChange}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -102,7 +107,8 @@ test('The component should trigger the change callback on select with an added v
             values={['option-1', 'option-2']}
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChangeSpy}>
+            onChange={onChangeSpy}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />
@@ -120,7 +126,8 @@ test('The component should trigger the change callback on select with a removed 
             values={['option-1', 'option-2']}
             noneSelectedText="None selected"
             allSelectedText="All selected"
-            onChange={onChangeSpy}>
+            onChange={onChangeSpy}
+        >
             <Option value="option-1">Option 1</Option>
             <Option value="option-2">Option 2</Option>
             <Divider />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Actions.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Actions.js
@@ -22,7 +22,10 @@ export default class Actions extends React.PureComponent<Props> {
                         <button
                             key={index}
                             className={actionsStyles.action}
-                            onClick={handleButtonClick}>{action.title}</button>
+                            onClick={handleButtonClick}
+                        >
+                            {action.title}
+                        </button>
                     );
                 })}
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -99,7 +99,8 @@ export default class Overlay extends React.PureComponent<Props> {
             <Portal isOpened={open || this.openHasChanged}>
                 <div
                     className={containerClass}
-                    onTransitionEnd={this.handleTransitionEnd}>
+                    onTransitionEnd={this.handleTransitionEnd}
+                >
                     <div className={overlayStyles.overlay}>
                         <section className={overlayStyles.content}>
                             <header>
@@ -107,7 +108,8 @@ export default class Overlay extends React.PureComponent<Props> {
                                 <Icon
                                     name={CLOSE_ICON}
                                     className={overlayStyles.icon}
-                                    onClick={this.handleIconClick} />
+                                    onClick={this.handleIconClick}
+                                />
                             </header>
                             <article>{children}</article>
                             <footer>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
@@ -15,7 +15,8 @@ test('The component should render in body when open', () => {
             title="My overlay title"
             onClose={onClose}
             confirmText="Apply"
-            open={true}>
+            open={true}
+        >
             <p>My overlay content</p>
         </Overlay>
     ).render();
@@ -37,7 +38,8 @@ test('The component should render in body with actions when open', () => {
             onClose={onClose}
             confirmText="Apply"
             actions={actions}
-            open={true}>
+            open={true}
+        >
             <p>My overlay content</p>
         </Overlay>
     ).render();
@@ -54,7 +56,8 @@ test('The component should not render in body when closed', () => {
             title="My overlay title"
             onClose={onClose}
             confirmText="Apply"
-            open={false}>
+            open={false}
+        >
             <p>My overlay content</p>
         </Overlay>
     ).render();
@@ -69,7 +72,8 @@ test('The component should request to be closed on click on backdrop', () => {
             title="My overlay title"
             onClose={closeSpy}
             confirmText="Apply"
-            open={true}>
+            open={true}
+        >
             <p>My overlay content</p>
         </Overlay>
     );
@@ -88,7 +92,8 @@ test('The component should request to be closed when the close icon is clicked',
             title="My overlay title"
             onClose={closeSpy}
             confirmText="Apply"
-            open={true}>
+            open={true}
+        >
             <p>My overlay content</p>
         </Overlay>
     );
@@ -105,7 +110,8 @@ test('The component should request to be closed when the esc key is pressed', ()
             title="My overlay title"
             onClose={closeSpy}
             confirmText="Apply"
-            open={true}>
+            open={true}
+        >
             <p>My overlay content</p>
         </Overlay>
     );
@@ -123,7 +129,8 @@ test('The component should call the callback when the confirm button is clicked'
             title="My title"
             onClose={onClose}
             onConfirm={onConfirm}
-            confirmText="Alright mate!">
+            confirmText="Alright mate!"
+        >
             <p>My overlay content</p>
         </Overlay>
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -35,7 +35,8 @@ export default class Radio extends React.PureComponent<Props> {
                 value={value}
                 name={name}
                 onChange={this.handleChange}
-                type="radio">
+                type="radio"
+            >
                 {children}
             </Switch>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/Radio.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/tests/Radio.test.js
@@ -18,7 +18,10 @@ test('The component pass the props correctly to the generic checkbox', () => {
         <Radio
             value="my-value"
             name="my-name"
-            checked={true}>My label</Radio>
+            checked={true}
+        >
+            My label
+        </Radio>
     );
     const switchComponent = checkbox.find('Switch');
     expect(switchComponent.props().value).toBe('my-value');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
@@ -101,13 +101,16 @@ export default class ModifiableRectangle extends React.PureComponent<Props> {
                 className={modifiableRectangleStyles.rectangle}
                 onMouseDown={this.handleMoveMouseDown}
                 onDoubleClick={this.handleDoubleClick}
-                style={style}>
+                style={style}
+            >
                 <div
                     className={modifiableRectangleStyles.resizeHandle}
-                    onMouseDown={this.handleResizeMouseDown} />
+                    onMouseDown={this.handleResizeMouseDown}
+                />
                 <div
                     className={modifiableRectangleStyles.backdrop}
-                    style={{outlineWidth: this.props.backdropSize + 'px'}} />
+                    style={{outlineWidth: this.props.backdropSize + 'px'}}
+                />
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -153,7 +153,8 @@ export class RectangleSelection extends React.PureComponent<Props> {
                     top={this.selection.top}
                     width={this.selection.width}
                     height={this.selection.height}
-                    backdropSize={backdropSize} />
+                    backdropSize={backdropSize}
+                />
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/RectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/RectangleSelection.test.js
@@ -35,7 +35,8 @@ test('The component should render with initial selection', (done) => {
             containerWidth={2000}
             containerHeight={1000}
             mountSpy={spy}
-            initialSelection={{width: 1, height: 2, top: 3, left: 4}}>
+            initialSelection={{width: 1, height: 2, top: 3, left: 4}}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );
@@ -68,7 +69,8 @@ test('The component should center and maximize the selection when a minHeight an
             minHeight={200}
             minWidth={50}
             containerWidth={2000}
-            containerHeight={1000}>
+            containerHeight={1000}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );
@@ -78,7 +80,8 @@ test('The component should center and maximize the selection when a minHeight an
             minHeight={50}
             minWidth={200}
             containerWidth={2000}
-            containerHeight={1000}>
+            containerHeight={1000}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );
@@ -99,7 +102,8 @@ test('The component should publish the new selection when the rectangle changes'
             mountSpy={spy}
             onChange={setSelection}
             containerWidth={2000}
-            containerHeight={1000}>
+            containerHeight={1000}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );
@@ -137,7 +141,8 @@ test('The component should not allow the selection to be bigger than the contain
             mountSpy={spy}
             onChange={setSelection}
             containerWidth={2000}
-            containerHeight={1000}>
+            containerHeight={1000}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );
@@ -160,7 +165,8 @@ test('The component should enforce a ratio on the selection if minWidth and minH
             minWidth={10}
             minHeight={20}
             mountSpy={spy}
-            onChange={setSelection}>
+            onChange={setSelection}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );
@@ -187,7 +193,8 @@ test('The component should should not round if told by the properties', (done) =
             minWidth={3}
             minHeight={1}
             mountSpy={spy}
-            onChange={setSelection}>
+            onChange={setSelection}
+        >
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -44,7 +44,8 @@ export default class Select extends React.PureComponent<Props> {
                 icon={icon}
                 onSelect={this.handleSelect}
                 displayValue={this.displayValue}
-                isOptionSelected={this.isOptionSelected}>
+                isOptionSelected={this.isOptionSelected}
+            >
                 {children}
             </GenericSelect>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
@@ -37,7 +37,8 @@ export default class Switch extends React.PureComponent<Props> {
                         type={type}
                         name={name}
                         checked={checked}
-                        onChange={this.handleChange} />
+                        onChange={this.handleChange}
+                    />
                     <span>
                         {icon &&
                             <Icon name={icon} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
@@ -35,7 +35,8 @@ export default class Cell extends React.PureComponent<Props> {
         return (
             <td
                 colSpan={colspan}
-                className={cellClass}>
+                className={cellClass}
+            >
                 {children}
             </td>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
@@ -87,7 +87,8 @@ export default class Header extends React.PureComponent<Props> {
             return (
                 <HeaderCell
                     key={key}
-                    className={tableStyles.headerButtonCell}>
+                    className={tableStyles.headerButtonCell}
+                >
                     <Icon name={button.icon} />
                 </HeaderCell>
             );
@@ -102,7 +103,8 @@ export default class Header extends React.PureComponent<Props> {
                 <Checkbox
                     skin="light"
                     checked={!!this.props.allSelected}
-                    onChange={this.handleAllSelectionChange} />
+                    onChange={this.handleAllSelectionChange}
+                />
             </HeaderCell>
         );
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
@@ -62,7 +62,8 @@ export default class HeaderCell extends React.PureComponent<Props> {
                 }
                 {onClick &&
                     <button
-                        onClick={this.handleOnClick}>
+                        onClick={this.handleOnClick}
+                    >
                         <span>{children}</span>
                         {this.getSortModeIcon()}
                     </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -84,12 +84,14 @@ export default class Row extends React.PureComponent<Props> {
         return (
             <Cell
                 key={key}
-                small={true}>
+                small={true}
+            >
                 <Radio
                     skin="dark"
                     value={identifier}
                     checked={!!selected}
-                    onChange={this.handleSingleSelectionChange} />
+                    onChange={this.handleSingleSelectionChange}
+                />
             </Cell>
         );
     };
@@ -102,12 +104,14 @@ export default class Row extends React.PureComponent<Props> {
         return (
             <Cell
                 key={key}
-                small={true}>
+                small={true}
+            >
                 <Checkbox
                     skin="dark"
                     value={identifier}
                     checked={!!selected}
-                    onChange={this.handleMultipleSelectionChange} />
+                    onChange={this.handleMultipleSelectionChange}
+                />
             </Cell>
         );
     };
@@ -130,7 +134,8 @@ export default class Row extends React.PureComponent<Props> {
                     key={key}
                     icon={button.icon}
                     rowId={identifier}
-                    onClick={handleClick} />
+                    onClick={handleClick}
+                />
             );
         });
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/Toggler.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/Toggler.js
@@ -17,7 +17,8 @@ export default class Toggler extends React.PureComponent<Props> {
                 checked={checked}
                 value={value}
                 name={name}
-                onChange={onChange}>
+                onChange={onChange}
+            >
                 {children}
             </Switch>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/test/Toggler.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/test/Toggler.test.js
@@ -10,7 +10,10 @@ test('The component pass the props correctly to the generic checkbox', () => {
             onChange={onChange}
             value="my-value"
             name="my-name"
-            checked={true}>My label</Toggler>
+            checked={true}
+        >
+            My label
+        </Toggler>
     );
     const switchComponent = toggler.find('Switch');
     expect(switchComponent.props().value).toBe('my-value');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -24,7 +24,8 @@ export default class Application extends React.PureComponent<Props> {
                         <ViewRenderer
                             key={router.route.name}
                             name={router.route.view}
-                            router={router} />
+                            router={router}
+                        />
                     }
                 </main>
                 <SplitView />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Button.js
@@ -41,7 +41,8 @@ export default class Button extends React.PureComponent<ButtonProps> {
                 disabled={disabled}
                 className={buttonClass}
                 onClick={this.handleOnClick}
-                value={value}>
+                value={value}
+            >
                 {icon &&
                     <Icon name={icon} className={buttonStyles.icon} />
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Dropdown.js
@@ -66,12 +66,14 @@ export default class Dropdown extends React.PureComponent<DropdownProps> {
                     value={label}
                     onClick={this.handleButtonClick}
                     active={this.open}
-                    hasOptions={true} />
+                    hasOptions={true}
+                />
                 {this.open &&
                     <OptionList
                         options={options}
                         onOptionClick={this.handleOptionListClick}
-                        onClose={this.handleOptionListClose} />
+                        onClose={this.handleOptionListClose}
+                    />
                 }
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Option.js
@@ -41,7 +41,8 @@ export default class Option extends React.PureComponent<Props> {
             <li className={optionClass}>
                 <button
                     disabled={disabled}
-                    onClick={this.handleOnClick}>
+                    onClick={this.handleOnClick}
+                >
                     {selected &&
                         <Icon name={ICON_CHECKMARK} className={optionStyles.selectedIcon} />
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/OptionList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/OptionList.js
@@ -58,7 +58,8 @@ export default class OptionList extends React.PureComponent<Props> {
                                     label={option.label}
                                     disabled={option.disabled}
                                     selected={selected}
-                                    onClick={this.handleOptionClick} />
+                                    onClick={this.handleOptionClick}
+                                />
                             );
                         })
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Select.js
@@ -72,14 +72,16 @@ export default class Select extends React.PureComponent<SelectProps> {
                     value={buttonValue}
                     onClick={this.handleButtonClick}
                     active={this.open}
-                    hasOptions={true} />
+                    hasOptions={true}
+                />
                 {this.open &&
                     <OptionList
                         size={size}
                         value={value}
                         options={options}
                         onOptionClick={this.handleOptionClick}
-                        onClose={this.handleOptionListClose} />
+                        onClose={this.handleOptionListClose}
+                    />
                 }
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Dropdown.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Dropdown.test.js
@@ -21,7 +21,8 @@ test('Render disabled dropdown', () => {
     expect(render(
         <Dropdown
             {...dropdownPropsMock}
-            disabled={true} />
+            disabled={true}
+        />
     )).toMatchSnapshot();
 });
 
@@ -29,7 +30,8 @@ test('Render dropdown with a prepended icon', () => {
     expect(render(
         <Dropdown
             {...dropdownPropsMock}
-            icon="floppy-o" />
+            icon="floppy-o"
+        />
     )).toMatchSnapshot();
 });
 
@@ -37,7 +39,8 @@ test('Render dropdown with a different size', () => {
     expect(render(
         <Dropdown
             {...dropdownPropsMock}
-            size="small" />
+            size="small"
+        />
     )).toMatchSnapshot();
 });
 
@@ -53,7 +56,8 @@ test('Disabled dropdown will not open', () => {
     const dropdown = mount(
         <Dropdown
             {...dropdownPropsMock}
-            disabled={true} />
+            disabled={true}
+        />
     );
 
     expect(dropdown.find('.optionList').length).toBe(0);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Select.test.js
@@ -22,7 +22,8 @@ test('Render disabled select', () => {
     expect(render(
         <Select
             {...selectPropsMock}
-            disabled={true} />
+            disabled={true}
+        />
     )).toMatchSnapshot();
 });
 
@@ -30,7 +31,8 @@ test('Render select with a prepended icon', () => {
     expect(render(
         <Select
             {...selectPropsMock}
-            icon="floppy-o" />
+            icon="floppy-o"
+        />
     )).toMatchSnapshot();
 });
 
@@ -38,7 +40,8 @@ test('Render select with a different size', () => {
     expect(render(
         <Select
             {...selectPropsMock}
-            size="small" />
+            size="small"
+        />
     )).toMatchSnapshot();
 });
 
@@ -54,7 +57,8 @@ test('Disabled select will not open', () => {
     const select = mount(
         <Select
             {...selectPropsMock}
-            disabled={true} />
+            disabled={true}
+        />
     );
 
     expect(select.find('.optionList').length).toBe(0);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the `closing-bracket-location` to `line-aligned`, this means instead of 
```javascript
<Component
    prop1={true} />
```

```javascript
<Component
    prop1={true}
/>
```
#### Why?

This way of writing JSX has the advantage, that you can easily delete a single prop using a "Delete line" statement of your IDE.