### PR TITLE
Add parameter binding to router

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import 'url-search-params-polyfill';
 import createHistory from 'history/createMemoryHistory';
-import {autorun, observable, isObservable} from 'mobx';
+import {observable, isObservable} from 'mobx';
 import Router from '../Router';
 import routeStore from '../stores/RouteStore';
 
@@ -390,4 +390,82 @@ test('Set state to undefined if parameter is removed from URL', () => {
     router.bindQuery('page', value);
     history.push('/list');
     expect(value.get()).toBe(undefined);
+});
+
+test('Bound query should update state to default value if removed from URL', () => {
+    routeStore.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+        },
+    });
+
+    const value = observable(5);
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bindQuery('page', value, '1');
+    history.push('/list');
+    expect(value.get()).toBe('1');
+});
+
+test('Bound query should omit URL parameter if set to default value', () => {
+    routeStore.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+        },
+    });
+
+    const value = observable(5);
+
+    const history = createHistory();
+    const router = new Router(history);
+    router.navigate('list');
+
+    router.bindQuery('page', value, '1');
+    value.set('1');
+    expect(history.location.search).toBe('');
+});
+
+test('Bound query should initially not be set to undefined in URL', () => {
+    routeStore.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+        },
+    });
+
+    const value = observable();
+
+    const history = createHistory();
+    history.push('/list');
+    const router = new Router(history);
+    router.bindQuery('page', value, '1');
+
+    expect(history.location.search).toBe('');
+});
+
+test('Bound query should be set to initial passed value from URL', () => {
+    routeStore.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+        },
+    });
+
+    const value = observable();
+
+    const history = createHistory();
+    history.push('/list?page=2');
+    const router = new Router(history);
+    router.bindQuery('page', value, '1');
+
+    expect(value.get()).toBe('2');
+    expect(history.location.search).toBe('?page=2');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -9,6 +9,7 @@ import type {ViewProps} from '../../containers/ViewRenderer/types';
 
 @observer
 class List extends React.PureComponent<ViewProps> {
+    page = observable();
     @observable tableData = {
         header: [
             'Type of',
@@ -78,10 +79,19 @@ class List extends React.PureComponent<ViewProps> {
         ],
     };
 
+    componentWillMount() {
+        this.props.router.bindQuery('page', this.page);
+        window.page = this.page;
+    }
+
+    componentWillUnmount() {
+        this.props.router.unbindQuery('page');
+    }
+
     render() {
         return (
             <div>
-                <h1>List</h1>
+                <h1>List - Page {this.page.get()}</h1>
                 <a href="#/snippets/123">To the Form</a>
                 <Table>
                     <Header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -80,8 +80,7 @@ class List extends React.PureComponent<ViewProps> {
     };
 
     componentWillMount() {
-        this.props.router.bindQuery('page', this.page);
-        window.page = this.page;
+        this.props.router.bindQuery('page', this.page, '1');
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #3457, depends on https://github.com/sulu/sulu-minimal/pull/64
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to bind certain observable values to a parameter of the query string using the Router.

#### Why?

Because this way it is possible to implement the datagrid without any knowledge of the routing, and the parent of the datagrid can decide to "sync" the value to the URL.

#### Example Usage

~~~php
const page = observable(1);
router.bind('page', page);

page.set(2); // this will also change the URL
~~~