### PR TITLE
Fixed override route when using "tree_full_edit"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * HOTFIX      #3535 [Content]                 Fix bug in structure bridge when no document is available
+    * HOTFIX      #3514 [ContentBundle]           Fixed override route when using "tree_full_edit"
 
 * 1.6.4 (2017-09-14)
     * HOTFIX      #3509 [MediaBundle]             Fixed deletion of tag when referenced in media fileversion

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/document.xml
@@ -112,6 +112,7 @@
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
             <argument type="service" id="sulu.phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.node_manager"/>
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a problem when using the `tree_full_edit`.

#### Why?

Use following config in your webspace.xml:

```
    <resource-locator>
        <strategy>tree_full_edit</strategy>
    </resource-locator>
```

Create a page tree like:

* page 1
  * page 1.1
  * page 1.2
* page 2

Change the resource-locator of `page 1.1` to `page-3/page-1-1` and click "save and publish".

Go to `page 1` and change the resource-locator to `page-3` and see the exception because the resource-locator is already in use.

#### To Do

- [x] Test if there are problems because of this fix
