### PR TITLE
Created AutoComplete component without Tagging

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
@@ -17,7 +17,7 @@ const POPOVER_VERTICAL_OFFSET = -2;
 
 type Props = {
     children: ChildrenArray<Element<typeof Suggestion>>,
-    /** The value inside the input field */
+    /** The value of the selected "Suggestion" */
     value: string,
     placeholder?: string,
     /** Shows the loading indicator when true */
@@ -36,15 +36,15 @@ export default class AutoComplete extends React.PureComponent<Props> {
 
     static Suggestion = Suggestion;
 
-    @observable inputRef: ElementRef<*>;
+    @observable inputRef: ElementRef<'input'>;
 
     @observable inputValue: string = this.props.value;
 
-    dirtyValue: boolean = false;
+    overrideValue: boolean = false;
 
     componentWillReceiveProps(nextProps: Props) {
-        if (this.dirtyValue) {
-            this.dirtyValue = false;
+        if (this.overrideValue) {
+            this.overrideValue = false;
             this.setInputValue(nextProps.value);
         }
     }
@@ -95,7 +95,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
     }, DEBOUNCE_TIME);
 
     handleSuggestionSelection = (value: string | number) => {
-        this.dirtyValue = true;
+        this.overrideValue = true;
         this.props.onChange(value);
     };
 
@@ -109,7 +109,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
         const firstSuggestion = React.Children.toArray(children)[0];
 
         if (firstSuggestion && firstSuggestion.props) {
-            this.dirtyValue = true;
+            this.overrideValue = true;
             this.props.onChange(firstSuggestion.props.value);
         }
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
@@ -1,0 +1,14 @@
+// @flow
+import React from 'react';
+import Popover from '../Popover';
+
+type Props = {
+};
+
+export default class AutoComplete extends React.PureComponent<Props> {
+    render() {
+        return (
+            <div />
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
@@ -1,14 +1,157 @@
 // @flow
 import React from 'react';
+import type {ChildrenArray, ElementRef} from 'react';
+import {observer} from 'mobx-react';
+import {action, observable} from 'mobx';
+import Input from '../Input';
 import Popover from '../Popover';
+import autoCompleteStyles from './autoComplete.scss';
+
+const POPOVER_HORIZONTAL_OFFSET = 5;
+const POPOVER_VERTICAL_OFFSET = -2;
 
 type Props = {
+    children: ChildrenArray<*>,
+    onChange: (value: string) => void,
+    value: string,
+    threshold: number,
+    inputIcon?: string,
+    placeholder?: string,
+    noSuggestionsMessage?: string,
 };
 
+@observer
 export default class AutoComplete extends React.PureComponent<Props> {
-    render() {
+    static defaultProps = {
+        value: '',
+        threshold: 0,
+    };
+
+    @observable open: boolean = false;
+
+    inputRef: ElementRef<'label'>;
+
+    @action openSuggestions() {
+        this.open = true;
+    }
+
+    @action closeSuggestions() {
+        this.open = false;
+    }
+
+    componentWillReceiveProps(nextProps: Props) {
+        const {value} = nextProps;
+
+        if (this.hasReachedThreshold(value)) {
+            this.openSuggestions();
+        } else if (this.open) {
+            this.closeSuggestions();
+        }
+    }
+
+    createSuggestions(children: ChildrenArray<*>) {
+        const {value} = this.props;
+
+        return React.Children.map(children, (child, index: number) => {
+            return (
+                <li>
+                    {
+                        React.cloneElement(child, {
+                            key: index,
+                            query: value,
+                            onSelection: this.handleSuggestionSelection,
+                        })
+                    }
+                </li>
+            );
+        });
+    }
+
+    createNoSuggestionsMessage() {
+        const {noSuggestionsMessage} = this.props;
+
+        if (!noSuggestionsMessage) {
+            return null;
+        }
+
         return (
-            <div />
+            <li className={autoCompleteStyles.noSuggestions}>
+                {noSuggestionsMessage}
+            </li>
+        );
+    }
+
+    hasReachedThreshold(value: string) {
+        return value && value.length >= this.props.threshold;
+    }
+
+    setInputRef = (inputRef: ElementRef<'label'>) => {
+        if (inputRef) {
+            this.inputRef = inputRef;
+        }
+    };
+
+    handleSuggestionSelection = (value: string) => {
+        this.props.onChange(value);
+        this.closeSuggestions();
+    };
+
+    handleChange = (value: string) => {
+        this.props.onChange(value);
+    };
+
+    handleInputFocus = () => {
+        const {value} = this.props;
+
+        if (this.hasReachedThreshold(value)) {
+            this.openSuggestions();
+        }
+    };
+
+    handlePopoverClose = () => {
+        this.closeSuggestions();
+    };
+
+    render() {
+        const {
+            value,
+            children,
+            inputIcon,
+            placeholder,
+        } = this.props;
+        const suggestions = this.createSuggestions(children);
+        const noSuggestions = !React.Children.count(suggestions);
+        const noSuggestionsMessage = this.createNoSuggestionsMessage();
+        const suggestionListMinWidth = (this.inputRef) ? this.inputRef.scrollWidth - POPOVER_HORIZONTAL_OFFSET * 2: 0;
+        const suggestionListStyle = {
+            minWidth: suggestionListMinWidth,
+        };
+
+        return (
+            <div className={autoCompleteStyles.autoComplete}>
+                <Input
+                    inputRef={this.setInputRef}
+                    onFocus={this.handleInputFocus}
+                    icon={inputIcon}
+                    value={value}
+                    placeholder={placeholder}
+                    onChange={this.handleChange} />
+                <Popover
+                    open={this.open}
+                    anchorEl={this.inputRef}
+                    onClose={this.handlePopoverClose}
+                    horizontalOffset={POPOVER_HORIZONTAL_OFFSET}
+                    verticalOffset={POPOVER_VERTICAL_OFFSET}>
+                    <ul
+                        className={autoCompleteStyles.suggestions}
+                        style={suggestionListStyle}>
+                        {suggestions}
+                        {noSuggestions &&
+                            noSuggestionsMessage
+                        }
+                    </ul>
+                </Popover>
+            </div>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
@@ -57,7 +57,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
         const suggestionListMinWidth = (this.inputRef) ? this.inputRef.scrollWidth - POPOVER_HORIZONTAL_OFFSET * 2: 0;
 
         return {
-            minWidth: suggestionListMinWidth,
+            minWidth: Math.max(suggestionListMinWidth, 0),
         };
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
@@ -47,7 +47,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
     previousSuggestionListChildrenCount: number = 0;
 
     componentWillUnmount() {
-        this.debouncedUpdateSuggestions.clear();
+        this.debouncedChange.clear();
     }
 
     @action openSuggestions() {
@@ -110,7 +110,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
         }
     };
 
-    debouncedUpdateSuggestions = debounce((value: string) => {
+    debouncedChange = debounce((value: string) => {
         this.props.onDebouncedChange(value);
     }, DEBOUNCE_TIME);
 
@@ -126,8 +126,8 @@ export default class AutoComplete extends React.PureComponent<Props> {
             this.closeSuggestions();
         }
 
-        this.debouncedUpdateSuggestions(value);
         this.props.onChange(value);
+        this.debouncedChange(value);
     };
 
     handlePopoverClose = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/AutoComplete.js
@@ -30,7 +30,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
 
     @observable open: boolean = false;
 
-    @observable inputRef: ElementRef<'label'>;
+    @observable inputRef: ElementRef<*>;
 
     @action openSuggestions() {
         this.open = true;
@@ -63,7 +63,7 @@ export default class AutoComplete extends React.PureComponent<Props> {
 
         return React.Children.map(children, (child, index: number) => {
             return (
-                <li>
+                <li style={this.suggestionStyle}>
                     {
                         React.cloneElement(child, {
                             key: index,
@@ -86,7 +86,8 @@ export default class AutoComplete extends React.PureComponent<Props> {
         return (
             <li
                 style={this.suggestionStyle}
-                className={autoCompleteStyles.noSuggestions}>
+                className={autoCompleteStyles.noSuggestions}
+            >
                 {noSuggestionsMessage}
             </li>
         );
@@ -142,21 +143,25 @@ export default class AutoComplete extends React.PureComponent<Props> {
                     icon={inputIcon}
                     value={value}
                     placeholder={placeholder}
-                    onChange={this.handleChange} />
+                    onChange={this.handleChange}
+                />
                 <Popover
                     open={this.open}
-                    anchorEl={this.inputRef}
+                    anchorElement={this.inputRef}
                     onClose={this.handlePopoverClose}
                     horizontalOffset={POPOVER_HORIZONTAL_OFFSET}
-                    verticalOffset={POPOVER_VERTICAL_OFFSET}>
+                    verticalOffset={POPOVER_VERTICAL_OFFSET}
+                >
                     {
                         (setPopoverElementRef, popoverStyle) => (
                             <Menu
                                 menuRef={setPopoverElementRef}
-                                style={popoverStyle}>
-                                {!noSuggestions
-                                    ? suggestions
-                                    : noSuggestionsMessage}
+                                style={popoverStyle}
+                            >
+                                {noSuggestions
+                                    ? noSuggestionsMessage
+                                    : suggestions
+                                }
                             </Menu>
                         )
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -6,7 +6,7 @@ of the `Suggestion`. In that case you have to use the `highlight` function to hi
 
 Here a basic example (Pssh, look for your favourite Harry Potter character):
 
-```
+```javascript
 const Suggestion = AutoComplete.Suggestion;
 
 initialState = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -40,37 +40,39 @@ const data = [
     'Godric Gryffindor',
 ];
 
-const handleChange = (value) => {
-    setState(() => ({
-        value: value,
-        loading: !!value,
-    }));
-};
-
-const handleUpdate = (value) => {
+const handleSearch = (value) => {
     const regexp = new RegExp(value, 'gi');
-    
+
     setState(() => ({
-        loading: false,
-        suggestions: data.filter((suggestion) => suggestion.match(regexp))
+        loading: !!value,
+        suggestions: [],
     }));
+    
+    if (value) {
+        // Fake Request
+        setTimeout(() => {
+            setState(() => ({
+                loading: false,
+                suggestions: data.filter((suggestion) => suggestion.match(regexp))
+            }));
+        }, 500);
+    }
 };
 
-const handleSelection = (value) => {
+const handleChange = (value) => {
+    console.log(value);
     setState(() => ({
         value: value,
-        loading: false,
+        suggestions: [],
     }));
 };
 
 <AutoComplete
     value={state.value}
     onChange={handleChange}
-    onDebouncedChange={handleUpdate}
-    onSuggestionSelection={handleSelection}
+    onSearch={handleSearch}
     loading={state.loading}
     placeholder="Enter something fun..."
-    noSuggestionsMessage="Nothing found..."
 >
     {
         state.suggestions.map((suggestion, index) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -1,3 +1,9 @@
+The AutoComplete is an input-field with auto-completation feature. The AutoComplete has no filter logic. That has to be 
+done inside a HoC which afterwards will adjust the list of suggestions based on the entered input. To display the 
+suggestions you can use the Suggestion component.
+
+Here a basic example (Pssh, look for your favourite Harry Potter character):
+
 ```
 const Suggestion = require('./Suggestion').default;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -1,8 +1,8 @@
 The AutoComplete is an input-field with auto-completion feature. The AutoComplete has no filter logic. That has to be 
 done inside another component which afterwards will adjust the list of suggestions based on the entered input. 
-To display the suggestions you can use the Suggestion component. The displayed value of a `Suggestion` can be a simple 
-text or if you need further customization you can wrap HTML markup into a function and place that as the child of the 
-`Suggestion`. In that case you have to use the `highlight` function to highlight the matched suggestion text.
+To display the suggestions you can use the `Suggestion` component. The displayed value of a `Suggestion` can be a 
+simple text or if you need further customization you can wrap HTML markup into a function and place that as the child 
+of the `Suggestion`. In that case you have to use the `highlight` function to highlight the matched suggestion text.
 
 Here a basic example (Pssh, look for your favourite Harry Potter character):
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -60,7 +60,6 @@ const handleSearch = (value) => {
 };
 
 const handleChange = (value) => {
-    console.log(value);
     setState(() => ({
         value: value,
         suggestions: [],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -1,0 +1,61 @@
+```
+const Suggestion = require('./Suggestion').default;
+
+initialState = {
+    value: '',
+    suggestions: [],
+}
+
+const data = [
+    'Donald Duck',
+    'Mickey Mouse',
+    'Dagobert Duck',
+    'Tick Duck',
+    'Trick Duck',
+    'Track Duck',
+    'Minney Mouse',
+    'Goofey',
+    'Superman',
+    'Batman',
+    'Harry Potter',
+    'Lilly Potter',
+    'James Potter',
+    'Albus Dumbledore',
+    'Severus Snape',
+    'Ron Weasly',
+    'Hermoine Granger',
+    'Tom Riddle',
+    'Bathilda Bagshot',
+    'Susan Bones',
+    'Marvolo Gaunt',
+    'Godric Gryffindor',
+];
+
+const handleChange = (value) => {
+    const regexp = new RegExp(value, 'gi');
+
+    setState(() => ({
+        value: value,
+        suggestions: data.filter((suggestion) => suggestion.match(regexp))
+    }));
+};
+
+<AutoComplete
+    placeholder="Enter something fun..."
+    value={state.value}
+    threshold={1}
+    inputIcon="search"
+    noSuggestionsMessage="Nothing found..."
+    onChange={handleChange}>
+    {
+        state.suggestions.map((suggestion, index) => {
+            return (
+                <Suggestion
+                    key={index}
+                    icon="ticket"
+                    value={suggestion} />
+            );
+        })
+    }
+</AutoComplete>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -47,12 +47,13 @@ const handleChange = (value) => {
 };
 
 <AutoComplete
-    placeholder="Enter something fun..."
+    icon="search"
     value={state.value}
+    onChange={handleChange}
     threshold={1}
-    inputIcon="search"
+    placeholder="Enter something fun..."
     noSuggestionsMessage="Nothing found..."
-    onChange={handleChange}>
+>
     {
         state.suggestions.map((suggestion, index) => {
             return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/README.md
@@ -1,14 +1,17 @@
-The AutoComplete is an input-field with auto-completation feature. The AutoComplete has no filter logic. That has to be 
-done inside a HoC which afterwards will adjust the list of suggestions based on the entered input. To display the 
-suggestions you can use the Suggestion component.
+The AutoComplete is an input-field with auto-completion feature. The AutoComplete has no filter logic. That has to be 
+done inside another component which afterwards will adjust the list of suggestions based on the entered input. 
+To display the suggestions you can use the Suggestion component. The displayed value of a `Suggestion` can be a simple 
+text or if you need further customization you can wrap HTML markup into a function and place that as the child of the 
+`Suggestion`. In that case you have to use the `highlight` function to highlight the matched suggestion text.
 
 Here a basic example (Pssh, look for your favourite Harry Potter character):
 
 ```
-const Suggestion = require('./Suggestion').default;
+const Suggestion = AutoComplete.Suggestion;
 
 initialState = {
     value: '',
+    loading: false,
     suggestions: [],
 }
 
@@ -38,19 +41,34 @@ const data = [
 ];
 
 const handleChange = (value) => {
-    const regexp = new RegExp(value, 'gi');
-
     setState(() => ({
         value: value,
+        loading: !!value,
+    }));
+};
+
+const handleUpdate = (value) => {
+    const regexp = new RegExp(value, 'gi');
+    
+    setState(() => ({
+        loading: false,
         suggestions: data.filter((suggestion) => suggestion.match(regexp))
     }));
 };
 
+const handleSelection = (value) => {
+    setState(() => ({
+        value: value,
+        loading: false,
+    }));
+};
+
 <AutoComplete
-    icon="search"
     value={state.value}
     onChange={handleChange}
-    threshold={1}
+    onDebouncedChange={handleUpdate}
+    onSuggestionSelection={handleSelection}
+    loading={state.loading}
     placeholder="Enter something fun..."
     noSuggestionsMessage="Nothing found..."
 >
@@ -60,7 +78,12 @@ const handleChange = (value) => {
                 <Suggestion
                     key={index}
                     icon="ticket"
-                    value={suggestion} />
+                    value={suggestion}
+                >
+                    {(highlight) => (
+                        <div>{highlight(suggestion)}</div>
+                    )}
+                </Suggestion>
             );
         })
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -26,7 +26,7 @@ export default class Suggestion extends React.PureComponent<Props> {
 
         let matchIndex = 0;
         const highlightedMatches = value.replace(regex, () => {
-            return `<strong>${matches[matchIndex++]}</strong>`
+            return `<strong>${matches[matchIndex++]}</strong>`;
         });
 
         return (
@@ -55,17 +55,19 @@ export default class Suggestion extends React.PureComponent<Props> {
         const prepardedValue = this.prepareValue(value);
 
         return (
-            <div
-                onClick={this.handleClick}
-                className={suggestionStyles.suggestion}>
+            <button
+                className={suggestionStyles.suggestion}
+                onClick={this.handleClick}>
                 {
                     icon &&
-                    <Icon name={icon} className={suggestionStyles.icon} />
+                    <Icon
+                        name={icon}
+                        className={suggestionStyles.icon} />
                 }
-                <div className={suggestionStyles.value}>
+                <span>
                     {prepardedValue}
-                </div>
-            </div>
+                </span>
+            </button>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 import suggestionStyles from './suggestion.scss';
 
 type Props = {
-    value: string,
+    value: string | number,
     query: string,
     icon?: string,
     children: string | (highlight: (text: string) => Node) => Node,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -1,0 +1,71 @@
+// @flow
+import React from 'react';
+import Icon from '../Icon';
+import suggestionStyles from './suggestion.scss';
+
+type Props = {
+    value: string,
+    query: string,
+    icon?: string,
+    onSelection?: (value: string) => void,
+};
+
+export default class Suggestion extends React.PureComponent<Props> {
+    static defaultProps = {
+        query: '',
+    };
+
+    prepareValue(value: string) {
+        const {query} = this.props;
+        const regex = new RegExp(query, 'gi');
+        const matches = value.match(regex);
+
+        if (!matches) {
+            return value;
+        }
+
+        let matchIndex = 0;
+        const highlightedMatches = value.replace(regex, () => {
+            return `<strong>${matches[matchIndex++]}</strong>`
+        });
+
+        return (
+            <span dangerouslySetInnerHTML={{
+                __html: highlightedMatches,
+            }} />
+        );
+    }
+
+    handleClick = () => {
+        const {
+            value,
+            onSelection,
+        } = this.props;
+
+        if (onSelection) {
+            onSelection(value);
+        }
+    };
+
+    render() {
+        const {
+            icon,
+            value,
+        } = this.props;
+        const prepardedValue = this.prepareValue(value);
+
+        return (
+            <div
+                onClick={this.handleClick}
+                className={suggestionStyles.suggestion}>
+                {
+                    icon &&
+                    <Icon name={icon} className={suggestionStyles.icon} />
+                }
+                <div className={suggestionStyles.value}>
+                    {prepardedValue}
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {Node} from 'react';
 import Icon from '../Icon';
 import suggestionStyles from './suggestion.scss';
 
@@ -7,6 +8,7 @@ type Props = {
     value: string,
     query: string,
     icon?: string,
+    children: Node | (highlight: (text: string) => Node) => Node,
     onSelection?: (value: string) => void,
 };
 
@@ -15,27 +17,28 @@ export default class Suggestion extends React.PureComponent<Props> {
         query: '',
     };
 
-    prepareValue(value: string) {
+    highlightMatchingTextPart = (text: string) => {
+        if (!text) {
+            return;
+        }
+
         const {query} = this.props;
         const regex = new RegExp(query, 'gi');
-        const matches = value.match(regex);
+        const matches = text.match(regex);
 
         if (!matches || query.length === 0) {
-            return value;
+            return text;
         }
 
         let matchIndex = 0;
-        const highlightedMatches = value.replace(regex, () => {
+        const highlightedMatches = text.replace(regex, () => {
             return `<strong>${matches[matchIndex++]}</strong>`;
         });
 
         return (
-            <span dangerouslySetInnerHTML={{
-                __html: highlightedMatches,
-            }}
-            />
+            <span dangerouslySetInnerHTML={{ __html: highlightedMatches }} />
         );
-    }
+    };
 
     handleClick = () => {
         const {
@@ -51,25 +54,26 @@ export default class Suggestion extends React.PureComponent<Props> {
     render() {
         const {
             icon,
-            value,
+            children,
         } = this.props;
-        const prepardedValue = this.prepareValue(value);
 
         return (
             <button
                 className={suggestionStyles.suggestion}
                 onClick={this.handleClick}
             >
-                {
-                    icon &&
+                {icon &&
                     <Icon
                         name={icon}
                         className={suggestionStyles.icon}
                     />
                 }
-                <span>
-                    {prepardedValue}
-                </span>
+                {typeof children === 'string' &&
+                    this.highlightMatchingTextPart(children)
+                }
+                {typeof children === 'function' &&
+                    children(this.highlightMatchingTextPart)
+                }
             </button>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -8,7 +8,7 @@ type Props = {
     value: string,
     query: string,
     icon?: string,
-    children: Node | (highlight: (text: string) => Node) => Node,
+    children: string | (highlight: (text: string) => Node) => Node,
     onSelection?: (value: string) => void,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -20,7 +20,7 @@ export default class Suggestion extends React.PureComponent<Props> {
         const regex = new RegExp(query, 'gi');
         const matches = value.match(regex);
 
-        if (!matches) {
+        if (!matches || query.length === 0) {
             return value;
         }
 
@@ -32,7 +32,8 @@ export default class Suggestion extends React.PureComponent<Props> {
         return (
             <span dangerouslySetInnerHTML={{
                 __html: highlightedMatches,
-            }} />
+            }}
+            />
         );
     }
 
@@ -57,12 +58,14 @@ export default class Suggestion extends React.PureComponent<Props> {
         return (
             <button
                 className={suggestionStyles.suggestion}
-                onClick={this.handleClick}>
+                onClick={this.handleClick}
+            >
                 {
                     icon &&
                     <Icon
                         name={icon}
-                        className={suggestionStyles.icon} />
+                        className={suggestionStyles.icon}
+                    />
                 }
                 <span>
                     {prepardedValue}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/Suggestion.js
@@ -9,7 +9,7 @@ type Props = {
     query: string,
     icon?: string,
     children: string | (highlight: (text: string) => Node) => Node,
-    onSelection?: (value: string) => void,
+    onSelection?: (value: string | number) => void,
 };
 
 export default class Suggestion extends React.PureComponent<Props> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
@@ -1,5 +1,4 @@
 .auto-complete {
-    display: inline-block;
     position: relative;
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
@@ -8,3 +8,7 @@
     padding: 5px 10px;
     text-align: center;
 }
+
+.suggestion-item {
+    display: block;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
@@ -1,0 +1,16 @@
+.auto-complete {
+    display: inline-block;
+    position: relative;
+    z-index: 1;
+}
+
+.suggestions {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.no-suggestions {
+    padding: 5px 10px;
+    text-align: center;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
@@ -4,12 +4,6 @@
     z-index: 1;
 }
 
-.suggestions {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
 .no-suggestions {
     padding: 5px 10px;
     text-align: center;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/autoComplete.scss
@@ -1,12 +1,6 @@
 .auto-complete {
     display: inline-block;
     position: relative;
-    z-index: 1;
-}
-
-.no-suggestions {
-    padding: 5px 10px;
-    text-align: center;
 }
 
 .suggestion-item {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/index.js
@@ -1,0 +1,4 @@
+// @flow
+import AutoComplete from './AutoComplete';
+
+export default AutoComplete;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/index.js
@@ -1,4 +1,8 @@
 // @flow
 import AutoComplete from './AutoComplete';
+import Suggestion from './Suggestion';
 
-export default AutoComplete;
+export {
+    AutoComplete,
+    Suggestion,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/index.js
@@ -1,8 +1,4 @@
 // @flow
 import AutoComplete from './AutoComplete';
-import Suggestion from './Suggestion';
 
-export {
-    AutoComplete,
-    Suggestion,
-};
+export default AutoComplete;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
@@ -5,6 +5,7 @@ $suggestionTextColorActive: $shakespeare;
 $suggestionTextColorDisabled: rgba($suggestionTextColor, .3);
 
 .suggestion {
+    display: flex;
     cursor: pointer;
     padding: 5px 20px 5px 40px;
     width: 100%;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
@@ -1,14 +1,26 @@
 @import '../../containers/Application/colors.scss';
 
+$suggestionTextColor: $blueZodiac;
 $suggestionTextColorActive: $shakespeare;
+$suggestionTextColorDisabled: rgba($suggestionTextColor, .3);
 
 .suggestion {
     cursor: pointer;
     display: flex;
     padding: 5px 20px 5px 40px;
-    
-    &:hover {
+    width: 100%;
+    color: $suggestionTextColor;
+    border: none;
+    background: transparent;
+    text-align: left;
+
+    &:not(:disabled):hover {
         color: $suggestionTextColorActive;
+    }
+
+    &:disabled {
+        color: $suggestionTextColorDisabled;
+        cursor: default;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
@@ -1,0 +1,17 @@
+@import '../../containers/Application/colors.scss';
+
+$suggestionTextColorActive: $shakespeare;
+
+.suggestion {
+    cursor: pointer;
+    display: flex;
+    padding: 5px 20px 5px 40px;
+    
+    &:hover {
+        color: $suggestionTextColorActive;
+    }
+}
+
+.icon {
+    margin-right: 15px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/suggestion.scss
@@ -6,7 +6,6 @@ $suggestionTextColorDisabled: rgba($suggestionTextColor, .3);
 
 .suggestion {
     cursor: pointer;
-    display: flex;
     padding: 5px 20px 5px 40px;
     width: 100%;
     color: $suggestionTextColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
@@ -34,7 +34,9 @@ test('AutoComplete should render', () => {
 
 test('Render the AutoComplete with open suggestions list', () => {
     const autoComplete = mount(
-        <AutoComplete>
+        <AutoComplete
+            value="Test"
+        >
             <Suggestion
                 icon="ticket"
                 value="suggestion-1"
@@ -56,17 +58,17 @@ test('Render the AutoComplete with open suggestions list', () => {
         </AutoComplete>
     );
 
-    autoComplete.instance().openSuggestions();
     expect(autoComplete.render()).toMatchSnapshot();
     expect(pretty(document.body.innerHTML)).toMatchSnapshot();
 });
 
-test('Clicking on a suggestion should close the AutoComplete list and call the onSuggestionSelection handler', () => {
-    const onSuggestionSelectionSpy = jest.fn();
+test('Clicking on a suggestion should call the onChange handler with the value of the selected Suggestion', () => {
+    const onChangeSpy = jest.fn();
     const testValue = 'suggestion-1';
-    const autoComplete = mount(
+    mount(
         <AutoComplete
-            onSuggestionSelection={onSuggestionSelectionSpy}
+            value="Test"
+            onChange={onChangeSpy}
         >
             <Suggestion
                 icon="ticket"
@@ -89,8 +91,6 @@ test('Clicking on a suggestion should close the AutoComplete list and call the o
         </AutoComplete>
     );
 
-    autoComplete.instance().openSuggestions();
     document.body.querySelector('.suggestion:first-child').click();
-    expect(onSuggestionSelectionSpy).toHaveBeenCalledWith(testValue);
-    expect(document.body.innerHTML).toBe('');
+    expect(onChangeSpy).toHaveBeenCalledWith(testValue);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
@@ -1,0 +1,103 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import {render, mount, shallow} from 'enzyme';
+import pretty from 'pretty';
+import AutoComplete from '../AutoComplete';
+import Suggestion from '../Suggestion';
+
+afterEach(() => document.body.innerHTML = '');
+
+test('AutoComplete should render', () => {
+    expect(render(
+        <AutoComplete>
+            <Suggestion
+                icon="ticket"
+                value="suggestion-1"
+            />
+            <Suggestion
+                icon="ticket"
+                value="suggestion-2"
+            />
+            <Suggestion
+                icon="ticket"
+                value="suggestion-3"
+            />
+        </AutoComplete>
+    )).toMatchSnapshot();
+});
+
+test('Render the AutoComplete with open suggestions list', () => {
+    const autoComplete = mount(
+        <AutoComplete>
+            <Suggestion
+                icon="ticket"
+                value="suggestion-1"
+            />
+            <Suggestion
+                icon="ticket"
+                value="suggestion-2"
+            />
+            <Suggestion
+                icon="ticket"
+                value="suggestion-3"
+            />
+        </AutoComplete>
+    );
+
+    autoComplete.instance().openSuggestions();
+    expect(autoComplete.render()).toMatchSnapshot();
+    expect(pretty(document.body.innerHTML)).toMatchSnapshot();
+});
+
+test('Render the AutoComplete with the placeholder text', () => {
+    const autoComplete = mount(
+        <AutoComplete
+            noSuggestionsMessage="Nothing found, sadface..."
+        />
+    );
+
+    autoComplete.instance().openSuggestions();
+    expect(autoComplete.render()).toMatchSnapshot();
+    expect(pretty(document.body.innerHTML)).toMatchSnapshot();
+});
+
+test('The threshold check should return true or false based on the threshold property', () => {
+    const testValue1 = 'abc';
+    const testValue2 = 'abcd';
+    const autoComplete = shallow(
+        <AutoComplete
+            threshold="4"
+        />
+    );
+
+    expect(autoComplete.instance().hasReachedThreshold(testValue1)).toBe(false);
+    expect(autoComplete.instance().hasReachedThreshold(testValue2)).toBe(true);
+});
+
+test('Clicking on a suggestion should close the AutoComplete list and call the onChange handler', () => {
+    const onChangeSpy = jest.fn();
+    const testValue = 'suggestion-1';
+    const autoComplete = mount(
+        <AutoComplete
+            onChange={onChangeSpy}
+        >
+            <Suggestion
+                icon="ticket"
+                value={testValue}
+            />
+            <Suggestion
+                icon="ticket"
+                value="suggestion-2"
+            />
+            <Suggestion
+                icon="ticket"
+                value="suggestion-3"
+            />
+        </AutoComplete>
+    );
+
+    autoComplete.instance().openSuggestions();
+    document.body.querySelector('.suggestion:first-child').click();
+    expect(onChangeSpy).toHaveBeenCalledWith(testValue);
+    expect(document.body.innerHTML).toBe('');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
@@ -1,11 +1,15 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import React from 'react';
 import {render, mount} from 'enzyme';
 import pretty from 'pretty';
 import AutoComplete from '../AutoComplete';
 import Suggestion from '../Suggestion';
 
-afterEach(() => document.body.innerHTML = '');
+afterEach(() => {
+    if (document.body) {
+        document.body.innerHTML = '';
+    }
+});
 
 test('AutoComplete should render', () => {
     expect(render(
@@ -59,7 +63,7 @@ test('Render the AutoComplete with open suggestions list', () => {
     );
 
     expect(autoComplete.render()).toMatchSnapshot();
-    expect(pretty(document.body.innerHTML)).toMatchSnapshot();
+    expect(pretty(document.body ? document.body.innerHTML : '')).toMatchSnapshot();
 });
 
 test('Clicking on a suggestion should call the onChange handler with the value of the selected Suggestion', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
@@ -61,18 +61,6 @@ test('Render the AutoComplete with open suggestions list', () => {
     expect(pretty(document.body.innerHTML)).toMatchSnapshot();
 });
 
-test('Render the AutoComplete with the placeholder text', () => {
-    const autoComplete = mount(
-        <AutoComplete
-            noSuggestionsMessage="Nothing found, sadface..."
-        />
-    );
-
-    autoComplete.instance().openSuggestions();
-    expect(autoComplete.render()).toMatchSnapshot();
-    expect(pretty(document.body.innerHTML)).toMatchSnapshot();
-});
-
 test('Clicking on a suggestion should close the AutoComplete list and call the onSuggestionSelection handler', () => {
     const onSuggestionSelectionSpy = jest.fn();
     const testValue = 'suggestion-1';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
@@ -12,8 +12,14 @@ afterEach(() => {
 });
 
 test('AutoComplete should render', () => {
+    const changeSpy = jest.fn();
+    const searchSpy = jest.fn();
     expect(render(
-        <AutoComplete>
+        <AutoComplete
+            value="Test"
+            onChange={changeSpy}
+            onSearch={searchSpy}
+        >
             <Suggestion
                 icon="ticket"
                 value="suggestion-1"
@@ -37,9 +43,13 @@ test('AutoComplete should render', () => {
 });
 
 test('Render the AutoComplete with open suggestions list', () => {
+    const searchSpy = jest.fn();
+    const changeSpy = jest.fn();
     const autoComplete = mount(
         <AutoComplete
             value="Test"
+            onChange={changeSpy}
+            onSearch={searchSpy}
         >
             <Suggestion
                 icon="ticket"
@@ -67,12 +77,14 @@ test('Render the AutoComplete with open suggestions list', () => {
 });
 
 test('Clicking on a suggestion should call the onChange handler with the value of the selected Suggestion', () => {
-    const onChangeSpy = jest.fn();
+    const changeSpy = jest.fn();
+    const searchSpy = jest.fn();
     const testValue = 'suggestion-1';
     mount(
         <AutoComplete
             value="Test"
-            onChange={onChangeSpy}
+            onChange={changeSpy}
+            onSearch={searchSpy}
         >
             <Suggestion
                 icon="ticket"
@@ -95,6 +107,11 @@ test('Clicking on a suggestion should call the onChange handler with the value o
         </AutoComplete>
     );
 
-    document.body.querySelector('.suggestion:first-child').click();
-    expect(onChangeSpy).toHaveBeenCalledWith(testValue);
+    const suggestion = document.body ? document.body.querySelector('.suggestion:first-child') : null;
+
+    if (suggestion) {
+        suggestion.click();
+    }
+
+    expect(changeSpy).toHaveBeenCalledWith(testValue);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/AutoComplete.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import {render, mount, shallow} from 'enzyme';
+import {render, mount} from 'enzyme';
 import pretty from 'pretty';
 import AutoComplete from '../AutoComplete';
 import Suggestion from '../Suggestion';
@@ -13,15 +13,21 @@ test('AutoComplete should render', () => {
             <Suggestion
                 icon="ticket"
                 value="suggestion-1"
-            />
+            >
+                Suggestion 1
+            </Suggestion>
             <Suggestion
                 icon="ticket"
                 value="suggestion-2"
-            />
+            >
+                Suggestion 2
+            </Suggestion>
             <Suggestion
                 icon="ticket"
                 value="suggestion-3"
-            />
+            >
+                Suggestion 3
+            </Suggestion>
         </AutoComplete>
     )).toMatchSnapshot();
 });
@@ -32,15 +38,21 @@ test('Render the AutoComplete with open suggestions list', () => {
             <Suggestion
                 icon="ticket"
                 value="suggestion-1"
-            />
+            >
+                Suggestion 1
+            </Suggestion>
             <Suggestion
                 icon="ticket"
                 value="suggestion-2"
-            />
+            >
+                Suggestion 2
+            </Suggestion>
             <Suggestion
                 icon="ticket"
                 value="suggestion-3"
-            />
+            >
+                Suggestion 3
+            </Suggestion>
         </AutoComplete>
     );
 
@@ -61,43 +73,36 @@ test('Render the AutoComplete with the placeholder text', () => {
     expect(pretty(document.body.innerHTML)).toMatchSnapshot();
 });
 
-test('The threshold check should return true or false based on the threshold property', () => {
-    const testValue1 = 'abc';
-    const testValue2 = 'abcd';
-    const autoComplete = shallow(
-        <AutoComplete
-            threshold="4"
-        />
-    );
-
-    expect(autoComplete.instance().hasReachedThreshold(testValue1)).toBe(false);
-    expect(autoComplete.instance().hasReachedThreshold(testValue2)).toBe(true);
-});
-
-test('Clicking on a suggestion should close the AutoComplete list and call the onChange handler', () => {
-    const onChangeSpy = jest.fn();
+test('Clicking on a suggestion should close the AutoComplete list and call the onSuggestionSelection handler', () => {
+    const onSuggestionSelectionSpy = jest.fn();
     const testValue = 'suggestion-1';
     const autoComplete = mount(
         <AutoComplete
-            onChange={onChangeSpy}
+            onSuggestionSelection={onSuggestionSelectionSpy}
         >
             <Suggestion
                 icon="ticket"
                 value={testValue}
-            />
+            >
+                Suggestion 1
+            </Suggestion>
             <Suggestion
                 icon="ticket"
                 value="suggestion-2"
-            />
+            >
+                Suggestion 2
+            </Suggestion>
             <Suggestion
                 icon="ticket"
                 value="suggestion-3"
-            />
+            >
+                Suggestion 3
+            </Suggestion>
         </AutoComplete>
     );
 
     autoComplete.instance().openSuggestions();
     document.body.querySelector('.suggestion:first-child').click();
-    expect(onChangeSpy).toHaveBeenCalledWith(testValue);
+    expect(onSuggestionSelectionSpy).toHaveBeenCalledWith(testValue);
     expect(document.body.innerHTML).toBe('');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/Suggestion.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/Suggestion.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import React from 'react';
 import {render, shallow} from 'enzyme';
 import Suggestion from '../Suggestion';
@@ -43,4 +43,22 @@ test('Clicking on a suggestion should call the onClick handler', () => {
 
     suggestion.simulate('click');
     expect(onClickSpy).toHaveBeenCalledTimes(1);
+});
+
+test('Should highlight the part of the suggestion text which matches the query prop', () => {
+    const onClickSpy = jest.fn();
+    const suggestion = shallow(
+        <Suggestion
+            query="sug"
+            icon="ticket"
+            value="suggestion-1"
+            onSelection={onClickSpy}
+        >
+            {(highlight) => (
+                <div>{highlight('Suggestion 3')}</div>
+            )}
+        </Suggestion>
+    );
+
+    expect(suggestion.render()).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/Suggestion.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/Suggestion.test.js
@@ -1,0 +1,38 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import {render, shallow} from 'enzyme';
+import Suggestion from '../Suggestion';
+
+test('Suggestion should render', () => {
+    expect(render(
+        <Suggestion
+            icon="ticket"
+            value="suggestion-1"
+        />
+    )).toMatchSnapshot();
+});
+
+test('Suggestion should render strong-tags around found chars', () => {
+    expect(render(
+        <Suggestion
+            query="sug"
+            icon="ticket"
+            value="suggestion-1"
+        />
+    )).toMatchSnapshot();
+});
+
+test('Clicking on a suggestion should call the onClick handler', () => {
+    const onClickSpy = jest.fn();
+    const suggestion = shallow(
+        <Suggestion
+            query="sug"
+            icon="ticket"
+            value="suggestion-1"
+            onSelection={onClickSpy}
+        />
+    );
+
+    suggestion.simulate('click');
+    expect(onClickSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/Suggestion.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/Suggestion.test.js
@@ -8,7 +8,9 @@ test('Suggestion should render', () => {
         <Suggestion
             icon="ticket"
             value="suggestion-1"
-        />
+        >
+            Suggestion 1
+        </Suggestion>
     )).toMatchSnapshot();
 });
 
@@ -18,7 +20,9 @@ test('Suggestion should render strong-tags around found chars', () => {
             query="sug"
             icon="ticket"
             value="suggestion-1"
-        />
+        >
+            Suggestion 2
+        </Suggestion>
     )).toMatchSnapshot();
 });
 
@@ -30,7 +34,11 @@ test('Clicking on a suggestion should call the onClick handler', () => {
             icon="ticket"
             value="suggestion-1"
             onSelection={onClickSpy}
-        />
+        >
+            {() => (
+                <div>Suggestion 3</div>
+            )}
+        </Suggestion>
     );
 
     suggestion.simulate('click');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -40,7 +40,7 @@ exports[`Render the AutoComplete with open suggestions list 1`] = `
     </div>
     <input
       type="text"
-      value=""
+      value="Test"
     />
   </label>
   <div />
@@ -51,61 +51,24 @@ exports[`Render the AutoComplete with open suggestions list 2`] = `
 "<div>
   <div data-reactroot=\\"\\" class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
+      <li class=\\"suggestionItem\\" style=\\"min-width: 0;\\">
         <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-label=\\"ticket\\"></span>
           <!-- react-text: 6 -->Suggestion 1
           <!-- /react-text -->
         </button>
       </li>
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
+      <li class=\\"suggestionItem\\" style=\\"min-width: 0;\\">
         <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-label=\\"ticket\\"></span>
           <!-- react-text: 10 -->Suggestion 2
           <!-- /react-text -->
         </button>
       </li>
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
+      <li class=\\"suggestionItem\\" style=\\"min-width: 0;\\">
         <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-label=\\"ticket\\"></span>
           <!-- react-text: 14 -->Suggestion 3
           <!-- /react-text -->
         </button>
       </li>
-    </ul>
-  </div>
-</div>
-<div>
-  <div data-reactroot=\\"\\" class=\\"backdrop\\"></div>
-</div>"
-`;
-
-exports[`Render the AutoComplete with the placeholder text 1`] = `
-<div
-  class="autoComplete"
->
-  <label
-    class="input"
-  >
-    <div
-      class="prependedContainer"
-    >
-      <span
-        aria-label="search"
-        class="icon fa fa-search"
-      />
-    </div>
-    <input
-      type="text"
-      value=""
-    />
-  </label>
-  <div />
-</div>
-`;
-
-exports[`Render the AutoComplete with the placeholder text 2`] = `
-"<div>
-  <div data-reactroot=\\"\\" class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
-      <li class=\\"noSuggestions\\" style=\\"min-width: -10px;\\">Nothing found, sadface...</li>
     </ul>
   </div>
 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -27,16 +27,14 @@ exports[`Render the AutoComplete with open suggestions list 1`] = `
       value=""
     />
   </label>
-  <div>
-    
-  </div>
+  <div />
 </div>
 `;
 
 exports[`Render the AutoComplete with open suggestions list 2`] = `
 "<div>
   <div data-reactroot=\\"\\" class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; max-height: -12px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
       <li style=\\"min-width: -10px;\\">
         <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-1</span></button>
       </li>
@@ -66,16 +64,14 @@ exports[`Render the AutoComplete with the placeholder text 1`] = `
       value=""
     />
   </label>
-  <div>
-    
-  </div>
+  <div />
 </div>
 `;
 
 exports[`Render the AutoComplete with the placeholder text 2`] = `
 "<div>
   <div data-reactroot=\\"\\" class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; max-height: -12px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
       <li class=\\"noSuggestions\\" style=\\"min-width: -10px;\\">Nothing found, sadface...</li>
     </ul>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutoComplete should render 1`] = `
+<div
+  class="autoComplete"
+>
+  <label
+    class="input"
+  >
+    <input
+      type="text"
+      value=""
+    />
+  </label>
+</div>
+`;
+
+exports[`Render the AutoComplete with open suggestions list 1`] = `
+<div
+  class="autoComplete"
+>
+  <label
+    class="input"
+  >
+    <input
+      type="text"
+      value=""
+    />
+  </label>
+  <div>
+    
+  </div>
+</div>
+`;
+
+exports[`Render the AutoComplete with open suggestions list 2`] = `
+"<div>
+  <div data-reactroot=\\"\\" class=\\"container\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; max-height: -12px; position: fixed; pointer-events: auto; left: 10px;\\">
+      <li style=\\"min-width: -10px;\\">
+        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-1</span></button>
+      </li>
+      <li style=\\"min-width: -10px;\\">
+        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-2</span></button>
+      </li>
+      <li style=\\"min-width: -10px;\\">
+        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-3</span></button>
+      </li>
+    </ul>
+  </div>
+</div>
+<div>
+  <div data-reactroot=\\"\\" class=\\"backdrop\\"></div>
+</div>"
+`;
+
+exports[`Render the AutoComplete with the placeholder text 1`] = `
+<div
+  class="autoComplete"
+>
+  <label
+    class="input"
+  >
+    <input
+      type="text"
+      value=""
+    />
+  </label>
+  <div>
+    
+  </div>
+</div>
+`;
+
+exports[`Render the AutoComplete with the placeholder text 2`] = `
+"<div>
+  <div data-reactroot=\\"\\" class=\\"container\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; max-height: -12px; position: fixed; pointer-events: auto; left: 10px;\\">
+      <li class=\\"noSuggestions\\" style=\\"min-width: -10px;\\">Nothing found, sadface...</li>
+    </ul>
+  </div>
+</div>
+<div>
+  <div data-reactroot=\\"\\" class=\\"backdrop\\"></div>
+</div>"
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -49,6 +49,9 @@ exports[`Render the AutoComplete with open suggestions list 1`] = `
 
 exports[`Render the AutoComplete with open suggestions list 2`] = `
 "<div>
+  <div data-reactroot=\\"\\" class=\\"backdrop\\"></div>
+</div>
+<div>
   <div data-reactroot=\\"\\" class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
       <li class=\\"suggestionItem\\" style=\\"min-width: 0;\\">
@@ -71,8 +74,5 @@ exports[`Render the AutoComplete with open suggestions list 2`] = `
       </li>
     </ul>
   </div>
-</div>
-<div>
-  <div data-reactroot=\\"\\" class=\\"backdrop\\"></div>
 </div>"
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -7,6 +7,14 @@ exports[`AutoComplete should render 1`] = `
   <label
     class="input"
   >
+    <div
+      class="prependedContainer"
+    >
+      <span
+        aria-label="search"
+        class="icon fa fa-search"
+      />
+    </div>
     <input
       type="text"
       value=""
@@ -22,6 +30,14 @@ exports[`Render the AutoComplete with open suggestions list 1`] = `
   <label
     class="input"
   >
+    <div
+      class="prependedContainer"
+    >
+      <span
+        aria-label="search"
+        class="icon fa fa-search"
+      />
+    </div>
     <input
       type="text"
       value=""
@@ -35,14 +51,23 @@ exports[`Render the AutoComplete with open suggestions list 2`] = `
 "<div>
   <div data-reactroot=\\"\\" class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
-      <li style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-1</span></button>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
+        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-label=\\"ticket\\"></span>
+          <!-- react-text: 6 -->Suggestion 1
+          <!-- /react-text -->
+        </button>
       </li>
-      <li style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-2</span></button>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
+        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-label=\\"ticket\\"></span>
+          <!-- react-text: 10 -->Suggestion 2
+          <!-- /react-text -->
+        </button>
       </li>
-      <li style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-hidden=\\"true\\"></span><span>suggestion-3</span></button>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
+        <button class=\\"suggestion\\"><span class=\\"icon fa fa-ticket\\" aria-label=\\"ticket\\"></span>
+          <!-- react-text: 14 -->Suggestion 3
+          <!-- /react-text -->
+        </button>
       </li>
     </ul>
   </div>
@@ -59,6 +84,14 @@ exports[`Render the AutoComplete with the placeholder text 1`] = `
   <label
     class="input"
   >
+    <div
+      class="prependedContainer"
+    >
+      <span
+        aria-label="search"
+        class="icon fa fa-search"
+      />
+    </div>
     <input
       type="text"
       value=""

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -17,7 +17,7 @@ exports[`AutoComplete should render 1`] = `
     </div>
     <input
       type="text"
-      value=""
+      value="Test"
     />
   </label>
 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/Suggestion.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/Suggestion.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Suggestion should render 1`] = `
+<button
+  class="suggestion"
+>
+  <span
+    aria-hidden="true"
+    class="icon fa fa-ticket"
+  />
+  <span>
+    suggestion-1
+  </span>
+</button>
+`;
+
+exports[`Suggestion should render strong-tags around found chars 1`] = `
+<button
+  class="suggestion"
+>
+  <span
+    aria-hidden="true"
+    class="icon fa fa-ticket"
+  />
+  <span>
+    <span>
+      <strong>
+        sug
+      </strong>
+      gestion-1
+    </span>
+  </span>
+</button>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/Suggestion.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/Suggestion.test.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Should highlight the part of the suggestion text which matches the query prop 1`] = `
+<button
+  class="suggestion"
+>
+  <span
+    aria-label="ticket"
+    class="icon fa fa-ticket"
+  />
+  <div>
+    <span>
+      <strong>
+        Sug
+      </strong>
+      gestion 3
+    </span>
+  </div>
+</button>
+`;
+
 exports[`Suggestion should render 1`] = `
 <button
   class="suggestion"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/Suggestion.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoComplete/tests/__snapshots__/Suggestion.test.js.snap
@@ -5,12 +5,10 @@ exports[`Suggestion should render 1`] = `
   class="suggestion"
 >
   <span
-    aria-hidden="true"
+    aria-label="ticket"
     class="icon fa fa-ticket"
   />
-  <span>
-    suggestion-1
-  </span>
+  Suggestion 1
 </button>
 `;
 
@@ -19,16 +17,14 @@ exports[`Suggestion should render strong-tags around found chars 1`] = `
   class="suggestion"
 >
   <span
-    aria-hidden="true"
+    aria-label="ticket"
     class="icon fa fa-ticket"
   />
   <span>
-    <span>
-      <strong>
-        sug
-      </strong>
-      gestion-1
-    </span>
+    <strong>
+      Sug
+    </strong>
+    gestion 2
   </span>
 </button>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/Backdrop.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/Backdrop.test.js
@@ -1,16 +1,20 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {mount, shallow} from 'enzyme';
 import React from 'react';
 import pretty from 'pretty';
 import Backdrop from '../Backdrop';
 
-afterEach(() => document.body.innerHTML = '');
+afterEach(() => {
+    if (document.body) {
+        document.body.innerHTML = '';
+    }
+});
 
 test('The component should render in body when open', () => {
     const body = document.body;
     const view = mount(<Backdrop open={true} />).render();
     expect(view.html()).toBe(null);
-    expect(pretty(body.innerHTML)).toMatchSnapshot();
+    expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
 test('The component should not render in body when local property is set', () => {
@@ -22,7 +26,7 @@ test('The component should not render in the body when closed', () => {
     const body = document.body;
     const view = mount(<Backdrop open={false} />).render();
     expect(view.html()).toBe(null);
-    expect(body.innerHTML).toBe('');
+    expect(body ? body.innerHTML : '').toBe('');
 });
 
 test('The component should call a function when clicked', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -58,10 +58,7 @@ export default class Input extends React.PureComponent<Props> {
                 }
                 {loading &&
                     <div className={inputStyles.prependedContainer}>
-                        <Loader
-                            size={LOADER_SIZE}
-                            className={inputStyles.loader}
-                        />
+                        <Loader size={LOADER_SIZE} />
                     </div>
                 }
                 <input

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -32,12 +32,6 @@ export default class Input extends React.PureComponent<Props> {
         }
     };
 
-    handleFocus = () => {
-        if (this.props.onFocus) {
-            this.props.onFocus();
-        }
-    };
-
     render() {
         const {
             name,
@@ -60,7 +54,6 @@ export default class Input extends React.PureComponent<Props> {
                     type={type}
                     value={value || ''}
                     placeholder={placeholder}
-                    onFocus={this.handleFocus}
                     onChange={this.handleChange}
                 />
             </label>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -2,13 +2,17 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 import Icon from '../Icon';
+import Loader from '../Loader';
 import inputStyles from './input.scss';
+
+const LOADER_SIZE = 22;
 
 type Props = {
     name?: string,
     icon?: string,
     type: string,
     value: ?string,
+    loading?: boolean,
     placeholder?: string,
     onChange: (value: string) => void,
     inputRef?: (ref: ElementRef<'label'>) => void,
@@ -38,6 +42,7 @@ export default class Input extends React.PureComponent<Props> {
             icon,
             type,
             value,
+            loading,
             placeholder,
         } = this.props;
 
@@ -46,9 +51,17 @@ export default class Input extends React.PureComponent<Props> {
                 className={inputStyles.input}
                 ref={this.setRef}
             >
-                {icon &&
-                    <Icon className={inputStyles.icon} name={icon} />
-                }
+                <div className={inputStyles.prependedContainer}>
+                    {!loading && icon &&
+                        <Icon className={inputStyles.icon} name={icon} />
+                    }
+                    {loading &&
+                        <Loader
+                            size={LOADER_SIZE}
+                            className={inputStyles.loader}
+                        />
+                    }
+                </div>
                 <input
                     name={name}
                     type={type}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 import Loader from '../Loader';
 import inputStyles from './input.scss';
 
-const LOADER_SIZE = 22;
+const LOADER_SIZE = 20;
 
 type Props = {
     name?: string,
@@ -51,17 +51,19 @@ export default class Input extends React.PureComponent<Props> {
                 className={inputStyles.input}
                 ref={this.setRef}
             >
-                <div className={inputStyles.prependedContainer}>
-                    {!loading && icon &&
+                {!loading && icon &&
+                    <div className={inputStyles.prependedContainer}>
                         <Icon className={inputStyles.icon} name={icon} />
-                    }
-                    {loading &&
+                    </div>
+                }
+                {loading &&
+                    <div className={inputStyles.prependedContainer}>
                         <Loader
                             size={LOADER_SIZE}
                             className={inputStyles.loader}
                         />
-                    }
-                </div>
+                    </div>
+                }
                 <input
                     name={name}
                     type={type}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -31,9 +31,7 @@ export default class Input extends React.PureComponent<Props> {
     };
 
     handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
-        if (this.props.onChange) {
-            this.props.onChange(event.currentTarget.value);
-        }
+        this.props.onChange(event.currentTarget.value);
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import Icon from '../Icon';
 import inputStyles from './input.scss';
 
@@ -10,6 +11,8 @@ type Props = {
     value: ?string,
     placeholder?: string,
     onChange: (value: string) => void,
+    inputRef?: (ref: ElementRef<'label'>) => void,
+    onFocus?: () => void,
 };
 
 export default class Input extends React.PureComponent<Props> {
@@ -17,8 +20,22 @@ export default class Input extends React.PureComponent<Props> {
         type: 'text',
     };
 
+    setRef = (ref: ElementRef<'label'>) => {
+        if (this.props.inputRef) {
+            this.props.inputRef(ref);
+        }
+    };
+
     handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
-        this.props.onChange(event.currentTarget.value);
+        if (this.props.onChange) {
+            this.props.onChange(event.currentTarget.value);
+        }
+    };
+
+    handleFocus = () => {
+        if (this.props.onFocus) {
+            this.props.onFocus();
+        }
     };
 
     render() {
@@ -31,7 +48,10 @@ export default class Input extends React.PureComponent<Props> {
         } = this.props;
 
         return (
-            <label className={inputStyles.input}>
+            <label
+                className={inputStyles.input}
+                ref={this.setRef}
+            >
                 {icon &&
                     <Icon className={inputStyles.icon} name={icon} />
                 }
@@ -40,6 +60,7 @@ export default class Input extends React.PureComponent<Props> {
                     type={type}
                     value={value || ''}
                     placeholder={placeholder}
+                    onFocus={this.handleFocus}
                     onChange={this.handleChange}
                 />
             </label>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -44,8 +44,8 @@ $placeholderColor: $dustyGray;
 
 .loader {
     position: absolute;
-    top: -1px;
-    left: 5px;
+    top: 0;
+    left: 7px;
 }
 
 .icon {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -9,6 +9,7 @@ $inputFontSize: 12px;
 $iconColor: $dustyGray;
 $iconBorderPadding: 5px;
 $placeholderColor: $dustyGray;
+$backgroundColor: $white;
 
 .input {
     border: $inputBorderWidth solid $inputBorderColor;
@@ -17,6 +18,7 @@ $placeholderColor: $dustyGray;
     align-items: center;
     height: $inputHeight;
     width: 100%;
+    background-color: $backgroundColor;
 
     input {
         width: 100%;
@@ -37,7 +39,7 @@ $placeholderColor: $dustyGray;
 
 .prepended-container {
     position: relative;
-    width: 34px;
+    flex: 0 0 34px;
     height: calc($inputHeight - 2 * $iconBorderPadding);
     box-shadow: $inputBorderWidth 0 0 $inputBorderColor;
     display: flex;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -1,18 +1,18 @@
 @import '../../containers/Application/colors.scss';
 
-$borderColor: $silver;
-$iconColor: $dustyGray;
-$iconBorderPadding: 5px;
-$placeholderColor: $dustyGray;
-$borderWidth: 1px;
-$borderRadius: 3px;
+$inputBorderColor: $silver;
+$inputBorderWidth: 1px;
+$inputBorderRadius: 3px;
 $inputHeight: 30px;
 $inputColor: $black;
 $inputFontSize: 12px;
+$iconColor: $dustyGray;
+$iconBorderPadding: 5px;
+$placeholderColor: $dustyGray;
 
 .input {
-    border: $borderWidth solid $borderColor;
-    border-radius: $borderRadius;
+    border: $inputBorderWidth solid $inputBorderColor;
+    border-radius: $inputBorderRadius;
     display: inline-flex;
     align-items: center;
     height: $inputHeight;
@@ -22,9 +22,8 @@ $inputFontSize: 12px;
         width: 100%;
         flex-grow: 1;
         border: none;
-        border-radius: $borderRadius;
-        line-height: calc($inputHeight - 2 * $borderWidth);
-        height: calc($inputHeight - 2 * $borderWidth);
+        line-height: calc($inputHeight - 2 * $inputBorderWidth);
+        height: calc($inputHeight - 2 * $inputBorderWidth);
         padding-left: 10px;
         font-size: $inputFontSize;
         color: $inputColor;
@@ -36,12 +35,21 @@ $inputFontSize: 12px;
     }
 }
 
+.prepended-container {
+    position: relative;
+    width: 34px;
+    height: calc($inputHeight - 2 * $iconBorderPadding);
+    border-right: $inputBorderWidth solid $inputBorderColor;
+}
+
+.loader {
+    position: absolute;
+    top: -1px;
+    left: 5px;
+}
+
 .icon {
-    display: block;
     font-size: 14px;
-    flex-grow: 0;
-    color: $iconColor;
     padding: 0 10px;
-    border-right: $borderWidth solid $borderColor;
-    line-height: calc($inputHeight - 2 * $iconBorderPadding);
+    color: $iconColor;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -39,17 +39,13 @@ $placeholderColor: $dustyGray;
     position: relative;
     width: 34px;
     height: calc($inputHeight - 2 * $iconBorderPadding);
-    border-right: $inputBorderWidth solid $inputBorderColor;
-}
-
-.loader {
-    position: absolute;
-    top: 0;
-    left: 7px;
+    box-shadow: $inputBorderWidth 0 0 $inputBorderColor;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .icon {
     font-size: 14px;
-    padding: 0 10px;
     color: $iconColor;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -41,6 +41,6 @@ test('Input should call the callback when the input changes', () => {
 });
 
 test('Input should render with a loader', () => {
-    const onChange = () => {};
-    expect(render(<Input loader={true} onChange={onChange} />)).toMatchSnapshot();
+    const onChange = jest.fn();
+    expect(render(<Input value={null} loader={true} onChange={onChange} />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -39,3 +39,8 @@ test('Input should call the callback when the input changes', () => {
     input.find('input').simulate('change', {currentTarget: {value: 'my-value'}});
     expect(onChange).toHaveBeenCalledWith('my-value');
 });
+
+test('Input should render with a loader', () => {
+    const onChange = () => {};
+    expect(render(<Input loader={true} onChange={onChange} />)).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -6,7 +6,7 @@ exports[`Input should render 1`] = `
 >
   <input
     type="text"
-    value=""
+    value="My value"
   />
 </label>
 `;
@@ -17,7 +17,7 @@ exports[`Input should render null value as empty string 1`] = `
 >
   <input
     type="text"
-    value="My value"
+    value=""
   />
 </label>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -4,6 +4,9 @@ exports[`Input should render 1`] = `
 <label
   class="input"
 >
+  <div
+    class="prependedContainer"
+  />
   <input
     type="text"
     value="My value"
@@ -26,10 +29,14 @@ exports[`Input should render with icon 1`] = `
 <label
   class="input"
 >
-  <span
-    aria-label="my-icon"
-    class="icon fa fa-my-icon"
-  />
+  <div
+    class="prependedContainer"
+  >
+    <span
+      aria-label="my-icon"
+      class="icon fa fa-my-icon"
+    />
+  </div>
   <input
     type="text"
     value="My value"
@@ -41,6 +48,9 @@ exports[`Input should render with placeholder 1`] = `
 <label
   class="input"
 >
+  <div
+    class="prependedContainer"
+  />
   <input
     placeholder="My placeholder"
     type="text"
@@ -53,6 +63,9 @@ exports[`Input should render with type 1`] = `
 <label
   class="input"
 >
+  <div
+    class="prependedContainer"
+  />
   <input
     type="password"
     value="My value"
@@ -64,6 +77,9 @@ exports[`Input should render with value 1`] = `
 <label
   class="input"
 >
+  <div
+    class="prependedContainer"
+  />
   <input
     type="text"
     value="My value"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -4,9 +4,16 @@ exports[`Input should render 1`] = `
 <label
   class="input"
 >
-  <div
-    class="prependedContainer"
+  <input
+    type="text"
   />
+</label>
+`;
+
+exports[`Input should render with a loader 1`] = `
+<label
+  class="input"
+>
   <input
     type="text"
     value="My value"
@@ -48,9 +55,6 @@ exports[`Input should render with placeholder 1`] = `
 <label
   class="input"
 >
-  <div
-    class="prependedContainer"
-  />
   <input
     placeholder="My placeholder"
     type="text"
@@ -63,9 +67,6 @@ exports[`Input should render with type 1`] = `
 <label
   class="input"
 >
-  <div
-    class="prependedContainer"
-  />
   <input
     type="password"
     value="My value"
@@ -77,9 +78,6 @@ exports[`Input should render with value 1`] = `
 <label
   class="input"
 >
-  <div
-    class="prependedContainer"
-  />
   <input
     type="text"
     value="My value"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -6,11 +6,12 @@ exports[`Input should render 1`] = `
 >
   <input
     type="text"
+    value=""
   />
 </label>
 `;
 
-exports[`Input should render with a loader 1`] = `
+exports[`Input should render null value as empty string 1`] = `
 <label
   class="input"
 >
@@ -21,7 +22,7 @@ exports[`Input should render with a loader 1`] = `
 </label>
 `;
 
-exports[`Input should render null value as empty string 1`] = `
+exports[`Input should render with a loader 1`] = `
 <label
   class="input"
 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Loader/tests/__snapshots__/Loader.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Loader/tests/__snapshots__/Loader.test.js.snap
@@ -44,3 +44,17 @@ exports[`Render loader with other dimensions 1`] = `
   />
 </div>
 `;
+
+exports[`Render loader with other dimensions 1`] = `
+<div
+  class="spinner"
+  style="width:50px;height:50px;"
+>
+  <div
+    class="doubleBounce1"
+  />
+  <div
+    class="doubleBounce2"
+  />
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Loader/tests/__snapshots__/Loader.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Loader/tests/__snapshots__/Loader.test.js.snap
@@ -18,23 +18,6 @@ exports[`Render loader with additional classname 1`] = `
 <div
   class="spinner test"
   style="width:40px;height:40px;"
-<<<<<<< HEAD
->
-  <div
-    class="doubleBounce1"
-  />
-  <div
-    class="doubleBounce2"
-  />
-</div>
-`;
-
-exports[`Render loader with other dimensions 1`] = `
-<div
-  class="spinner"
-  style="width:50px;height:50px;"
-=======
->>>>>>> updated loader size in toolbar
 >
   <div
     class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Loader/tests/__snapshots__/Loader.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Loader/tests/__snapshots__/Loader.test.js.snap
@@ -18,6 +18,7 @@ exports[`Render loader with additional classname 1`] = `
 <div
   class="spinner test"
   style="width:40px;height:40px;"
+<<<<<<< HEAD
 >
   <div
     class="doubleBounce1"
@@ -32,6 +33,8 @@ exports[`Render loader with other dimensions 1`] = `
 <div
   class="spinner"
   style="width:50px;height:50px;"
+=======
+>>>>>>> updated loader size in toolbar
 >
   <div
     class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -35,6 +35,8 @@ export default class Popover extends React.PureComponent<Props> {
 
     @observable popoverHeight: number;
 
+    childNodesCount: number;
+
     componentDidMount() {
         window.addEventListener('blur', this.close);
         window.addEventListener('resize', this.close);
@@ -46,11 +48,17 @@ export default class Popover extends React.PureComponent<Props> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        if (this.popoverChildRef && !prevProps.open && this.props.open) {
+        if (!this.popoverChildRef) {
+            return;
+        }
+
+        if (!prevProps.open && this.props.open) {
             afterElementsRendered(() => {
                 this.popoverChildRef.scrollTop = this.dimensions.scrollTop;
             });
         }
+
+        this.handleChildrenCountChange();
     }
 
     close = () => {
@@ -58,6 +66,16 @@ export default class Popover extends React.PureComponent<Props> {
             this.props.onClose();
         }
     };
+
+    handleChildrenCountChange() {
+        const childNodesCount = (this.popoverChildRef.childNodes) ? this.popoverChildRef.childNodes.length : 0;
+        
+        if (this.childNodesCount !== childNodesCount) {
+            this.updateDimensions();
+        }
+
+        this.childNodesCount = childNodesCount;
+    }
 
     @computed get dimensions(): PopoverDimensions {
         const {
@@ -89,7 +107,11 @@ export default class Popover extends React.PureComponent<Props> {
         );
     }
 
-    updateDimensions() {
+    updateDimensions = () => {
+        if (!this.popoverChildRef) {
+            return;
+        }
+
         const {
             offsetWidth,
             offsetHeight,
@@ -107,7 +129,7 @@ export default class Popover extends React.PureComponent<Props> {
             outerWidth,
             outerHeight
         );
-    }
+    };
 
     @action setPopoverSize(width: number, height: number) {
         this.popoverWidth = width;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -18,7 +18,6 @@ type Props = {
     anchorElement: ElementRef<*>,
     centerChildElement?: ElementRef<*>,
     horizontalOffset: number,
-    /** The vertical offset of the popover relative to the anchor element */
     verticalOffset: number,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -15,7 +15,6 @@ type Props = {
     children?: (
         setPopoverElementRef: (ref: ElementRef<*>) => void,
         style: Object,
-        triggerResize: () => void,
     ) => Node,
     onClose?: () => void,
     /** This element will be used to position the popover */
@@ -39,8 +38,6 @@ export default class Popover extends React.PureComponent<Props> {
 
     @observable popoverHeight: number;
 
-    shouldUpdateDimensions: boolean;
-
     componentDidMount() {
         window.addEventListener('blur', this.close);
         window.addEventListener('resize', this.close);
@@ -52,18 +49,11 @@ export default class Popover extends React.PureComponent<Props> {
     }
 
     componentDidUpdate() {
-        if (!this.popoverChildRef) {
-            return;
+        if (this.popoverChildRef) {
+            afterElementsRendered(() => {
+                this.popoverChildRef.scrollTop = this.dimensions.scrollTop;
+            });
         }
-
-        afterElementsRendered(() => {
-            this.popoverChildRef.scrollTop = this.dimensions.scrollTop;
-
-            if (this.shouldUpdateDimensions) {
-                this.updateDimensions();
-                this.shouldUpdateDimensions = false;
-            }
-        });
     }
 
     close = () => {
@@ -126,10 +116,6 @@ export default class Popover extends React.PureComponent<Props> {
         );
     };
 
-    triggerResize = () => {
-        this.shouldUpdateDimensions = true;
-    };
-
     @action setPopoverSize(width: number, height: number) {
         this.popoverWidth = width;
         this.popoverHeight = height;
@@ -168,7 +154,7 @@ export default class Popover extends React.PureComponent<Props> {
                 <Portal isOpened={open}>
                     <div className={popoverStyles.container}>
                         {children &&
-                            children(this.setPopoverChildRef, styles, this.triggerResize)
+                            children(this.setPopoverChildRef, styles)
                         }
                     </div>
                 </Portal>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -18,6 +18,7 @@ type Props = {
     anchorElement: ElementRef<*>,
     centerChildElement?: ElementRef<*>,
     horizontalOffset: number,
+    /** The vertical offset of the popover relative to the anchor element */
     verticalOffset: number,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/README.md
@@ -8,7 +8,7 @@ const Menu = require('../Menu').default;
 const Option = require('../Select').default.Option;
 
 initialState = {
-    open: true,
+    open: false,
     anchorElement: null,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/popover.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/popover.scss
@@ -1,9 +1,3 @@
-@import '../../containers/Application/colors.scss';
-
-$popoverBorderColor: $frenchGray;
-$popoverBackgroundColor: $wildSand;
-$popoverBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
-
 /* to disable scrolling */
 .container {
     position: fixed;
@@ -13,19 +7,4 @@ $popoverBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
     height: 100%;
     z-index: 100;
     pointer-events: none;
-}
-
-.popover {
-    position: fixed;
-    border-radius: 2px;
-    padding: 5px 0;
-    font-size: 12px;
-    margin: 0;
-    overflow: auto;
-    pointer-events: auto;
-    background: $popoverBackgroundColor;
-    box-shadow: $popoverBoxShadow;
-
-    /* border width need to be the same on all edges for the layouting-calculations to work  */
-    border: 1px solid $popoverBorderColor;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/popover.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/popover.scss
@@ -1,3 +1,9 @@
+@import '../../containers/Application/colors.scss';
+
+$popoverBorderColor: $frenchGray;
+$popoverBackgroundColor: $wildSand;
+$popoverBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
+
 /* to disable scrolling */
 .container {
     position: fixed;
@@ -7,4 +13,17 @@
     height: 100%;
     z-index: 100;
     pointer-events: none;
+}
+
+.popover {
+    position: fixed;
+    border-radius: 2px;
+    padding: 5px 0;
+    font-size: 12px;
+    margin: 0;
+    overflow: auto;
+    pointer-events: auto;
+    background: $popoverBackgroundColor;
+    border: 1px solid $popoverBorderColor;
+    box-shadow: $popoverBoxShadow;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/popover.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/popover.scss
@@ -24,6 +24,8 @@ $popoverBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
     overflow: auto;
     pointer-events: auto;
     background: $popoverBackgroundColor;
-    border: 1px solid $popoverBorderColor;
     box-shadow: $popoverBoxShadow;
+
+    /* border width need to be the same on all edges for the layouting-calculations to work  */
+    border: 1px solid $popoverBorderColor;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/types.js
@@ -11,7 +11,7 @@ export type PopoverStyle = {
     top: string,
     left: string,
     maxHeight: string,
-}
+};
 
 export type VerticalCrop = {
     dimensions: PopoverDimensions,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Button.js
@@ -6,6 +6,7 @@ import Loader from '../Loader';
 import type {Button as ButtonProps} from './types';
 import buttonStyles from './button.scss';
 
+const LOADER_SIZE= 20;
 const ICON_ARROW_DOWN = 'chevron-down';
 
 export default class Button extends React.PureComponent<ButtonProps> {
@@ -49,7 +50,7 @@ export default class Button extends React.PureComponent<ButtonProps> {
                 value={value}
             >
                 {loading &&
-                    <Loader className={loaderClass} />
+                    <Loader size={LOADER_SIZE} className={loaderClass} />
                 }
                 {icon &&
                     <Icon name={icon} className={buttonStyles.icon} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/button.scss
@@ -86,7 +86,7 @@ $primaryBackgroundColor: $shakespeare;
 
 .loader {
     position: absolute;
-    top: 10px;
+    top: 20px;
     left: 0;
     right: 0;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Button.test.js.snap
@@ -72,11 +72,7 @@ exports[`Render loading button 1`] = `
 >
   <div
     class="spinner loader"
-<<<<<<< HEAD:src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Button.test.js.snap
-    style="width:40px;height:40px;"
-=======
     style="width:20px;height:20px;"
->>>>>>> updated loader size in toolbar:src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Button.test.js.snap
   >
     <div
       class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Button.test.js.snap
@@ -72,7 +72,11 @@ exports[`Render loading button 1`] = `
 >
   <div
     class="spinner loader"
+<<<<<<< HEAD:src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Button.test.js.snap
     style="width:40px;height:40px;"
+=======
+    style="width:20px;height:20px;"
+>>>>>>> updated loader size in toolbar:src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Button.test.js.snap
   >
     <div
       class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
@@ -99,7 +99,11 @@ exports[`Render loading dropdown 1`] = `
   >
     <div
       class="spinner loader"
+<<<<<<< HEAD:src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
       style="width:40px;height:40px;"
+=======
+      style="width:20px;height:20px;"
+>>>>>>> updated loader size in toolbar:src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
     >
       <div
         class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
@@ -99,11 +99,7 @@ exports[`Render loading dropdown 1`] = `
   >
     <div
       class="spinner loader"
-<<<<<<< HEAD:src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
-      style="width:40px;height:40px;"
-=======
       style="width:20px;height:20px;"
->>>>>>> updated loader size in toolbar:src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Dropdown.test.js.snap
     >
       <div
         class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
@@ -32,11 +32,7 @@ exports[`Render loading select 1`] = `
   >
     <div
       class="spinner loader"
-<<<<<<< HEAD:src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
-      style="width:40px;height:40px;"
-=======
       style="width:20px;height:20px;"
->>>>>>> updated loader size in toolbar:src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Select.test.js.snap
     >
       <div
         class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
@@ -32,7 +32,11 @@ exports[`Render loading select 1`] = `
   >
     <div
       class="spinner loader"
+<<<<<<< HEAD:src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Select.test.js.snap
       style="width:40px;height:40px;"
+=======
+      style="width:20px;height:20px;"
+>>>>>>> updated loader size in toolbar:src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Select.test.js.snap
     >
       <div
         class="doubleBounce1"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #3508
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR contains an AutoComplete component.

#### Why?

We need an AutoComplete

#### Example Usage

~~~js
<AutoComplete
    placeholder="Enter something fun..."
    value={state.value}
    threshold={1}
    inputIcon="search"
    noSuggestionsMessage="Nothing found..."
    onChange={handleChange}>
    {
        state.suggestions.map((suggestion, index) => {
            return (
                <Suggestion
                    key={index}
                    icon="ticket"
                    value={suggestion} />
            );
        })
    }
</AutoComplete>
~~~
