### PR TITLE
fixed table header sizing issue for empty tables

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/README.md
@@ -85,17 +85,24 @@ const Row = require('./Row').default;
 const Cell = require('./Cell').default;
 const HeaderCell = require('./HeaderCell').default;
 
-<Table placeholderText="Awwww, this little fella has no entries...">
+const buttons = [{
+    icon: 'heart',
+    onClick: (rowId) => {
+        state.rows[rowId] = state.rows[rowId].map((cell) => 'You are awesome 😘');
+        const newRows = state.rows;
+
+        setState({
+            rows: newRows,
+        })
+    },
+}];
+
+<Table buttons={buttons} placeholderText="Awwww, this little fella has no entries...">
     <Header>
         <HeaderCell>Column 1</HeaderCell>
         <HeaderCell>Column 2</HeaderCell>
         <HeaderCell>Column 3</HeaderCell>
         <HeaderCell>Column 4</HeaderCell>
-        <HeaderCell>Column 5</HeaderCell>
-        <HeaderCell>Column 6</HeaderCell>
-        <HeaderCell>Column 7</HeaderCell>
-        <HeaderCell>Column 8</HeaderCell>
-        <HeaderCell>Column 9</HeaderCell>
     </Header>
     <Body></Body>
 </Table>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -12,6 +12,7 @@ $cellBorderColorActive: $shakespeare;
 $cellBackgroundColorActive: $shakespeare;
 $buttonCellBorderColor: $white;
 $emptyMessageColor: $silver;
+$rowHeight: 40px;
 
 .table {
     border-collapse: separate;
@@ -24,7 +25,7 @@ $emptyMessageColor: $silver;
 .header {
     color: $headerTextColor;
 
-    .row {
+    & > tr {
         height: 60px;
     }
 }
@@ -74,19 +75,25 @@ $emptyMessageColor: $silver;
 }
 
 .header-button-cell {
+    width: 1px;
     border-right: 1px solid $headerButtonCellBorderColor;
     color: $headerButtonCellTextColor;
     text-align: center;
 }
 
 .row {
-    height: 40px;
+    height: $rowHeight;
 
     &:hover {
         .cell {
             border-color: $cellBorderColorActive;
         }
     }
+}
+
+.button-cell,
+.header-button-cell {
+    width: 56px;
 }
 
 .cell,
@@ -120,7 +127,6 @@ $emptyMessageColor: $silver;
     background-color: $cellBackgroundColor;
     color: $cellTextColorActive;
     text-align: center;
-    width: 1px;
 
     &:hover {
         button {
@@ -132,8 +138,8 @@ $emptyMessageColor: $silver;
 
     button {
         visibility: hidden;
-        width: 55px;
-        height: 38px;
+        width: 100%;
+        height: $rowHeight;
         border: none;
         color: inherit;
         cursor: pointer;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

A fix for the table header button cells issue which was spotted by @chirimoya. The button cells, which are marking the columns of clickable buttons did't have a fixed width. For tables with content the issue didn't occur because the header button cells got the same width as the underneath columns inside the table body. For empty tables (tables with an empty body) the width of the header button cell was flexible.

Also the height of the table row inside the header was set back to the height used inside the design.

#### Why?

See above
