### PR TITLE
refactoring component export

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Checkbox/Checkbox.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import Switch from '../Switch';
-import type {SwitchProps} from '../Switch/types';
+import type {SwitchProps} from '../Switch';
 import checkboxStyles from './checkbox.scss';
 
 type Props = SwitchProps & {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/__snapshots__/Folder.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/__snapshots__/Folder.test.js.snap
@@ -10,7 +10,7 @@ exports[`Render a Folder component 1`] = `
     class="iconContainer"
   >
     <span
-      aria-hidden="true"
+      aria-label="folder-o"
       class="fa fa-folder-o"
     />
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/__snapshots__/FolderList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/FolderList/tests/__snapshots__/FolderList.test.js.snap
@@ -14,7 +14,7 @@ exports[`Render a FolderList with Folder components inside 1`] = `
         class="iconContainer"
       >
         <span
-          aria-hidden="true"
+          aria-label="folder-o"
           class="fa fa-folder-o"
         />
       </div>
@@ -44,7 +44,7 @@ exports[`Render a FolderList with Folder components inside 1`] = `
         class="iconContainer"
       >
         <span
-          aria-hidden="true"
+          aria-label="folder-o"
           class="fa fa-folder-o"
         />
       </div>
@@ -74,7 +74,7 @@ exports[`Render a FolderList with Folder components inside 1`] = `
         class="iconContainer"
       >
         <span
-          aria-hidden="true"
+          aria-label="folder-o"
           class="fa fa-folder-o"
         />
       </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/GenericSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/GenericSelect.js
@@ -7,6 +7,7 @@ import Popover from '../Popover';
 import Menu from '../Menu';
 import Action from './Action';
 import Option from './Option';
+import Divider from './Divider';
 import type {OptionSelectedVisualization, SelectChildren, SelectProps} from './types';
 import DisplayValue from './DisplayValue';
 import genericSelectStyles from './genericSelect.scss';
@@ -27,6 +28,12 @@ export default class GenericSelect extends React.PureComponent<Props> {
     static defaultProps = {
         closeOnSelect: true,
     };
+
+    static Action = Action;
+
+    static Divider = Divider;
+
+    static Option = Option;
 
     @observable displayValueRef: ?ElementRef<'button'>;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/Option.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import {afterElementsRendered} from '../../services/DOM';
 import Icon from '../Icon';
 import Checkbox from '../Checkbox';
-import type {OptionSelectedVisualization} from '../GenericSelect/types';
+import type {OptionSelectedVisualization} from './types';
 import optionStyles from './option.scss';
 
 type Props = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/index.js
@@ -3,6 +3,12 @@ import Action from './Action';
 import Divider from './Divider';
 import GenericSelect from './GenericSelect';
 import Option from './Option';
+import type {SelectProps} from './types';
 
-export {Action, Divider, Option};
 export default GenericSelect;
+export {
+    Action,
+    Divider,
+    Option,
+};
+export type {SelectProps};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GenericSelect/index.js
@@ -1,14 +1,6 @@
 // @flow
-import Action from './Action';
-import Divider from './Divider';
 import GenericSelect from './GenericSelect';
-import Option from './Option';
 import type {SelectProps} from './types';
 
 export default GenericSelect;
-export {
-    Action,
-    Divider,
-    Option,
-};
 export type {SelectProps};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -3,9 +3,8 @@ import {action, computed, observable} from 'mobx';
 import log from 'loglevel';
 import {observer} from 'mobx-react';
 import React from 'react';
-import RectangleSelection from '../RectangleSelection';
-import RoundingNormalizer from '../RectangleSelection/normalizers/RoundingNormalizer';
-import type {SelectionData} from '../RectangleSelection/types';
+import RectangleSelection, {RoundingNormalizer} from '../RectangleSelection';
+import type {SelectionData} from '../RectangleSelection';
 import withContainerSize from '../withContainerSize';
 import imageRectangleSelectionStyles from './imageRectangleSelection.scss';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Menu/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Menu/README.md
@@ -4,7 +4,9 @@ different `Select` component types and as the container for the `Suggestions` of
 Example:
 
 ```
-const Option = require('../GenericSelect').Option;
+const GenericSelect = require('../GenericSelect').default;
+
+const Option = GenericSelect.Option;
 
 <Menu style={{maxWidth: '200px'}}>
     <Option>Item 1</Option>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import type {Element} from 'react';
-import type {SelectProps} from '../GenericSelect/types';
+import type {SelectProps} from '../GenericSelect';
 import GenericSelect, {Option} from '../GenericSelect';
 
 type Props = SelectProps & {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {Element} from 'react';
 import type {SelectProps} from '../GenericSelect';
-import GenericSelect, {Option} from '../GenericSelect';
+import GenericSelect from '../GenericSelect';
 
 type Props = SelectProps & {
     values: Array<string>,
@@ -16,12 +16,18 @@ export default class MultiSelect extends React.PureComponent<Props> {
         values: [],
     };
 
+    static Action = GenericSelect.Action;
+
+    static Option = GenericSelect.Option;
+
+    static Divider = GenericSelect.Divider;
+
     get displayValue(): string {
         let selectedValues = [];
         let countOptions = 0;
 
         React.Children.forEach(this.props.children, (child: any) => {
-            if (child.type !== Option) {
+            if (child.type !== MultiSelect.Option) {
                 return;
             }
 
@@ -43,7 +49,7 @@ export default class MultiSelect extends React.PureComponent<Props> {
         return selectedValues.join(', ');
     }
 
-    isOptionSelected = (option: Element<typeof Option>): boolean => {
+    isOptionSelected = (option: Element<typeof MultiSelect.Option>): boolean => {
         return this.props.values.includes(option.props.value);
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/README.md
@@ -5,9 +5,9 @@ The component itself holds no internal state and is solely dependent on the pass
 Moreover, it provides a possibility to pass a callback which gets called when the user changes an option.
 
 ```
-const Action = require('../MultiSelect').Action;
-const Divider = require('../MultiSelect').Divider;
-const Option = require('../MultiSelect').Option;
+const Action = MultiSelect.Action;
+const Option = MultiSelect.Option;
+const Divider = MultiSelect.Divider;
 
 initialState = {contributors: []};
 const onChange = (contributors) => setState({contributors});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/index.js
@@ -1,10 +1,4 @@
 // @flow
-import {Action, Divider, Option} from '../GenericSelect';
 import MultiSelect from './MultiSelect';
 
 export default MultiSelect;
-export {
-    Action,
-    Divider,
-    Option,
-};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/index.js
@@ -2,5 +2,9 @@
 import {Action, Divider, Option} from '../GenericSelect';
 import MultiSelect from './MultiSelect';
 
-export {Action, Divider, Option};
 export default MultiSelect;
+export {
+    Action,
+    Divider,
+    Option,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
@@ -2,7 +2,10 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 import GenericSelect from '../../GenericSelect';
-import MultiSelect, {Divider, Option} from '../../MultiSelect';
+import MultiSelect from '../../MultiSelect';
+
+const Option = MultiSelect.Option;
+const Divider = MultiSelect.Divider;
 
 jest.mock('../../GenericSelect');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import Switch from '../Switch';
-import type {SwitchProps} from '../Switch/types';
+import type {SwitchProps} from '../Switch';
 import radioStyles from './radio.scss';
 
 type Props = SwitchProps & {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/index.js
@@ -2,4 +2,7 @@
 import Radio from './Radio';
 import RadioGroup from './RadioGroup';
 
-export {RadioGroup, Radio};
+export {
+    Radio,
+    RadioGroup,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/index.js
@@ -1,4 +1,16 @@
 // @flow
 import RectangleSelection from './RectangleSelection';
+import SizeNormalizer from './normalizers/SizeNormalizer';
+import RatioNormalizer from './normalizers/RatioNormalizer';
+import RoundingNormalizer from './normalizers/RoundingNormalizer';
+import PositionNormalizer from './normalizers/PositionNormalizer';
+import type {SelectionData} from './types';
 
 export default RectangleSelection;
+export {
+    SizeNormalizer,
+    RatioNormalizer,
+    RoundingNormalizer,
+    PositionNormalizer,
+};
+export type {SelectionData};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/README.md
@@ -3,9 +3,9 @@ The component follows the [recommendation of React for form components](https://
 The Select itself holds no internal state and is solely dependent on the passed properties. Moreover, it provides
 a possibility to pass a callback which gets called when the user selects an option.
 ```
-const Action = require('../Select').Action;
-const Divider = require('../Select').Divider;
-const Option = require('../Select').Option;
+const Action = Select.Action;
+const Option = Select.Option;
+const Divider = Select.Divider;
 
 initialState = {selectValue: 'page-1'};
 const onChange = (selectValue) => setState({selectValue});
@@ -21,9 +21,11 @@ const onChange = (selectValue) => setState({selectValue});
 ```
 
 Also a lot of options are possible and correctly handled as well as neatly styled.
+
 ```
-const Divider = require('../Select').Divider;
-const Option = require('../Select').Option;
+const Action = Select.Action;
+const Option = Select.Option;
+const Divider = Select.Divider;
 
 initialState = {selectValue: null};
 const onChange = (value) => setState({selectValue: value});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import type {Element} from 'react';
-import type {SelectProps} from '../GenericSelect/types';
+import type {SelectProps} from '../GenericSelect';
 import GenericSelect, {Option} from '../GenericSelect';
 
 type Props = SelectProps & {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {Element} from 'react';
 import type {SelectProps} from '../GenericSelect';
-import GenericSelect, {Option} from '../GenericSelect';
+import GenericSelect from '../GenericSelect';
 
 type Props = SelectProps & {
     value?: string,
@@ -10,11 +10,17 @@ type Props = SelectProps & {
 };
 
 export default class Select extends React.PureComponent<Props> {
+    static Action = GenericSelect.Action;
+
+    static Option = GenericSelect.Option;
+
+    static Divider = GenericSelect.Divider;
+
     get displayValue(): string {
         let displayValue = '';
 
         React.Children.forEach(this.props.children, (child: any) => {
-            if (child.type !== Option) {
+            if (child.type !== Select.Option) {
                 return;
             }
 
@@ -26,7 +32,7 @@ export default class Select extends React.PureComponent<Props> {
         return displayValue;
     }
 
-    isOptionSelected = (option: Element<typeof Option>): boolean => {
+    isOptionSelected = (option: Element<typeof Select.Option>): boolean => {
         return option.props.value === this.props.value && !option.props.disabled;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/index.js
@@ -2,5 +2,9 @@
 import {Action, Divider, Option} from '../GenericSelect';
 import Select from './Select';
 
-export {Action, Divider, Option};
 export default Select;
+export {
+    Action,
+    Divider,
+    Option,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/index.js
@@ -1,10 +1,4 @@
 // @flow
-import {Action, Divider, Option} from '../GenericSelect';
 import Select from './Select';
 
 export default Select;
-export {
-    Action,
-    Divider,
-    Option,
-};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Select.test.js
@@ -2,7 +2,10 @@
 import {shallow} from 'enzyme';
 import React from 'react';
 import GenericSelect from '../../GenericSelect';
-import Select, {Divider, Option} from '../../Select';
+import Select from '../../Select';
+
+const Option = Select.Option;
+const Divider = Select.Option;
 
 jest.mock('../../GenericSelect');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/Switch.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import classNames from 'classnames';
-import Icon from '../Icon/index';
+import Icon from '../Icon';
 import type {SwitchProps} from './types';
 import switchStyles from './switch.scss';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/index.js
@@ -1,4 +1,6 @@
 // @flow
 import Switch from './Switch';
+import type {SwitchProps} from './types';
 
 export default Switch;
+export type {SwitchProps};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/README.md
@@ -7,12 +7,11 @@ components as direct children. This is due to the fact that the `Table` componen
 header.
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 <Table>
     <Header>
@@ -78,12 +77,11 @@ const HeaderCell = require('./HeaderCell').default;
 An empty table component will be rendered as follows. You can set a `placeholderText`.
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 const buttons = [{
     icon: 'heart',
@@ -114,12 +112,11 @@ like it is done in the example below.
 Hover the first cell and click on the button to change the boring text inside each row.
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 initialState = {
     rows: [
@@ -174,12 +171,11 @@ distinguishes between `single` and `multiple` selection mode. The single selecti
 to each row as you can see in the following example.
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 initialState = {
     rows: [1, 2, 3, 4, 5],
@@ -227,12 +223,11 @@ The multiple selection mode prepends the `Checkbox` component to each row and al
 header.
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 initialState = {
     rows: [1, 2, 3, 4, 5],
@@ -312,12 +307,11 @@ component. In addition with the `sortMode` property this can be used to change t
 If the `sortMode` property is set, an indicator appears next to the header cell.
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 initialState = {
     rows: [
@@ -369,12 +363,11 @@ const handleSortColumnA = () => {
 Here a more complex example of the Table component with most of its features:
 
 ```
-const Table = require('./Table').default;
-const Header = require('./Header').default;
-const Body = require('./Body').default;
-const Row = require('./Row').default;
-const Cell = require('./Cell').default;
-const HeaderCell = require('./HeaderCell').default;
+const Header = Table.Header;
+const Body = Table.Body;
+const Row = Table.Row;
+const Cell = Table.Cell;
+const HeaderCell = Table.HeaderCell;
 
 initialState = {
     rows: [1, 2, 3, 4, 5],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
@@ -5,6 +5,9 @@ import type {ChildrenArray, Element} from 'react';
 import Icon from '../Icon';
 import Header from './Header';
 import Body from './Body';
+import Row from './Row';
+import Cell from './Cell';
+import HeaderCell from './HeaderCell';
 import type {ButtonConfig, SelectMode} from './types';
 import tableStyles from './table.scss';
 
@@ -32,6 +35,16 @@ export default class Table extends React.PureComponent<Props> {
     static defaultProps = {
         selectMode: 'none',
     };
+
+    static Header = Header;
+
+    static Body = Body;
+
+    static Row = Row;
+
+    static Cell = Cell;
+
+    static HeaderCell = HeaderCell;
 
     cloneHeader = (originalHeader?: Element<typeof Header>, allSelected: boolean) => {
         if (!originalHeader) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/index.js
@@ -1,16 +1,4 @@
 // @flow
 import Table from './Table';
-import Header from './Header';
-import Body from './Body';
-import Row from './Row';
-import Cell from './Cell';
-import HeaderCell from './HeaderCell';
 
-export {
-    Table,
-    Header,
-    Body,
-    Row,
-    Cell,
-    HeaderCell,
-};
+export default Table;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/Toggler.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toggler/Toggler.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import Switch from '../Switch';
-import type {SwitchProps} from '../Switch/types';
+import type {SwitchProps} from '../Switch';
 import togglerStyles from './toggler.scss';
 
 type Props = SwitchProps & {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TableAdapter.js
@@ -1,7 +1,7 @@
 // @flow
 import {observer} from 'mobx-react';
 import React from 'react';
-import {Body, Cell, Header, HeaderCell, Row, Table} from '../../../components/Table';
+import Table from '../../../components/Table';
 import type {DataItem, Schema} from '../types';
 
 type Props = {
@@ -34,16 +34,20 @@ export default class TableAdapter extends React.Component<Props> {
                 onRowSelectionChange={onRowSelectionChange}
                 onAllSelectionChange={onAllSelectionChange}
             >
-                <Header>
-                    {schemaKeys.map((schemaKey) => <HeaderCell key={schemaKey}>{schemaKey}</HeaderCell>)}
-                </Header>
-                <Body>
-                    {data.map((item) => (
-                        <Row key={item.id} id={item.id} selected={selections.includes(item.id)}>
-                            {schemaKeys.map((schemaKey) => <Cell key={item.id + schemaKey}>{item[schemaKey]}</Cell>)}
-                        </Row>
+                <Table.Header>
+                    {schemaKeys.map((schemaKey) => (
+                        <Table.HeaderCell key={schemaKey}>{schemaKey}</Table.HeaderCell>
                     ))}
-                </Body>
+                </Table.Header>
+                <Table.Body>
+                    {data.map((item) => (
+                        <Table.Row key={item.id} id={item.id} selected={selections.includes(item.id)}>
+                            {schemaKeys.map((schemaKey) => (
+                                <Table.Cell key={item.id + schemaKey}>{item[schemaKey]}</Table.Cell>
+                            ))}
+                        </Table.Row>
+                    ))}
+                </Table.Body>
             </Table>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/index.js
@@ -3,5 +3,8 @@ import Toolbar from './Toolbar';
 import toolbarStore from './stores/ToolbarStore';
 import withToolbar from './withToolbar';
 
-export {toolbarStore, withToolbar};
 export default Toolbar;
+export {
+    withToolbar,
+    toolbarStore,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/index.js
@@ -2,5 +2,5 @@
 import Router from './Router';
 import routeStore from './stores/RouteStore';
 
-export {routeStore};
 export default Router;
+export {routeStore};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Translator/Translator.js
@@ -21,4 +21,8 @@ function translate(key: string) {
     return translationMap[key];
 }
 
-export {setTranslations, clearTranslations, translate};
+export {
+    translate,
+    setTranslations,
+    clearTranslations,
+};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

In this PR all child components which had to be imported on their own for usage can now be accessed as static properties through their parent component. Imports and exports of components and other JavaScript modules are now more consistent.

#### Why?

To provide a better API for developers using components with child components.

#### Example Usage

~~~php
import Table from './Table';

const Header = Table.Header;
const Body = Table.Body;
const Row = Table.Row;
const Cell = Table.Cell;
const HeaderCell = Table.HeaderCell;

<Table>
    <Header>
        <HeaderCell>Column 1</HeaderCell>
        <HeaderCell>Column 2</HeaderCell>
        <HeaderCell>Column 3</HeaderCell>
    </Header>
    <Body>
        <Row>
            <Cell>Content 1</Cell>
            <Cell>Content 2</Cell>
            <Cell>Content 3</Cell>
        </Row>
        <Row>
            <Cell>Content 1</Cell>
            <Cell>Content 2</Cell>
            <Cell>Content 3</Cell>
        </Row>
        <Row>
            <Cell>Content 1</Cell>
            <Cell>Content 2</Cell>
            <Cell>Content 3</Cell>
        </Row>
        <Row>
            <Cell>Content 1</Cell>
            <Cell>Content 2</Cell>
            <Cell>Content 3</Cell>
        </Row>
    </Body>
</Table>
~~~

#### BC Breaks/Deprecations

- Now components offer a different API to make their child/sub components available.
- A module should only be accessed by its index.js file
