### PR TITLE
Fix bug in structure bridge when no document is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3535 [Content]                 Fix bug in structure bridge when no document is available
+
 * 1.6.4 (2017-09-14)
     * HOTFIX      #3509 [MediaBundle]             Fixed deletion of tag when referenced in media fileversion
     * HOTFIX      #3504 [SnippetBundle]           Fixed snippet areas with uppercases

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -639,8 +639,12 @@ class StructureBridge implements StructureInterface
 
     public function getIsShadow()
     {
+        if (!$this->document) {
+            return false;
+        }
+
         $document = $this->getDocument();
-        if (!$document || !$document instanceof ShadowLocaleBehavior) {
+        if (!$document instanceof ShadowLocaleBehavior) {
             return false;
         }
 

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -123,6 +123,10 @@ class StructureBridge implements StructureInterface
      */
     public function getWebspaceKey()
     {
+        if (!$this->document) {
+            return null;
+        }
+
         return $this->inspector->getWebspace($this->getDocument());
     }
 
@@ -636,7 +640,7 @@ class StructureBridge implements StructureInterface
     public function getIsShadow()
     {
         $document = $this->getDocument();
-        if (!$document instanceof ShadowLocaleBehavior) {
+        if (!$document || !$document instanceof ShadowLocaleBehavior) {
             return false;
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/StructureBridgeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/StructureBridgeTest.php
@@ -166,4 +166,21 @@ class StructureBridgeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($structure->getIsShadow());
         $this->assertNull($structure->getShadowBaseLanguage());
     }
+
+    public function testWithoutDocument()
+    {
+        $metadata = $this->prophesize(StructureMetadata::class);
+        $inspector = $this->prophesize(DocumentInspector::class);
+        $propertyFactory = $this->prophesize(LegacyPropertyFactory::class);
+
+        $structure = new StructureBridge(
+            $metadata->reveal(),
+            $inspector->reveal(),
+            $propertyFactory->reveal(),
+            null
+        );
+
+        $this->assertNull($structure->getWebspaceKey());
+        $this->assertFalse($structure->getIsShadow());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

StructureBridge shouldn't crash when no document is attached.
