### PR TITLE
Added reference-store to snippet data-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG for Sulu
     * HOTFIX      #3541 [CategoryBundle]          Fixed category-list for null selected value
     * HOTFIX      #3543 [PreviewBundle]           Fixed rerender preview if html is the same
     * HOTFIX      #3543 [ContentBundle]           Fixed update resource-locator with date content type
+    * ENHANCEMENT #3544 [SnippetBundle]           Added reference-store to snippet data-provider
 
 * 1.6.4 (2017-09-14)
     * HOTFIX      #3509 [MediaBundle]             Fixed deletion of tag when referenced in media fileversion

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -263,7 +263,8 @@ class SnippetDataProvider implements DataProviderInterface
         }
 
         if (array_key_exists('exclude_duplicates', $propertyParameter)
-            && $propertyParameter['exclude_duplicates']->getValue()) {
+            && $propertyParameter['exclude_duplicates']->getValue()
+        ) {
             $excluded = array_merge($excluded, $this->referenceStore->getAll());
         }
 

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -46,6 +46,8 @@
             <argument type="service" id="sulu.util.node_helper"/>
             <argument type="service" id="sulu_content.smart_content.data_provider.content.proxy_factory"/>
             <argument type="service" id="sulu_document_manager.document_manager"/>
+            <argument type="service" id="sulu_snippet.reference_store.snippet"/>
+
             <tag name="sulu.smart_content.data_provider" alias="snippet"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
@@ -11,8 +11,12 @@
 
 namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Import;
 
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\Snippet\Import\SnippetImport;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -25,20 +29,35 @@ class SnippetImportTest extends SuluTestCase
      * @var DocumentManagerInterface
      */
     private $documentManager;
+
     /**
-     * @var object
+     * @var SnippetImport
      */
-    private $parent;
     private $snippetImporter;
+
+    /**
+     * @var SnippetDocument[]
+     */
     private $snippets = [];
-    protected $distPath = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff.dist';
-    protected $path = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff';
+
+    /**
+     * @var string
+     */
+    protected $distPath;
+
+    /**
+     * @var string
+     */
+    protected $path;
 
     /**
      * Setup data for import.
      */
     protected function setUp()
     {
+        $this->distPath = __DIR__ . '/../../app/Resources/import/export.xliff.dist';
+        $this->path = __DIR__ . '/../../app/Resources/import/export.xliff';
+
         $this->initPhpcr();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->snippetImporter = $this->getContainer()->get('sulu_snippet.import.snippet');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3439
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces the `exclude_duplicates` configuration to `SnippetDataProvider`.

#### Why?

This is missing in the data-provider.
