### PR TITLE
[WIP] Added templates property to content-data-provider

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/smart_content.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_content.extension.manager"/>
             <argument type="service" id="sulu.phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.property_encoder"/>
             <argument>%sulu.content.language.namespace%</argument>
         </service>
         <service id="sulu_content.smart_content.data_provider.content"

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -37,6 +37,7 @@
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_content.extension.manager"/>
             <argument type="service" id="sulu.phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.property_encoder"/>
             <argument>%sulu.content.language.namespace%</argument>
         </service>
         <service id="sulu_snippet.smart_content.snippet_data_provider"

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
@@ -31,14 +31,17 @@ class SnippetImportTest extends SuluTestCase
     private $parent;
     private $snippetImporter;
     private $snippets = [];
-    protected $distPath = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff.dist';
-    protected $path = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff';
+    protected $distPath;
+    protected $path;
 
     /**
      * Setup data for import.
      */
     protected function setUp()
     {
+        $this->distPath = __DIR__ . '/../../app/Resources/import/export.xliff.dist';
+        $this->path = __DIR__ . '/../../app/Resources/import/export.xliff';
+
         $this->initPhpcr();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->snippetImporter = $this->getContainer()->get('sulu_snippet.import.snippet');

--- a/src/Sulu/Component/Content/SmartContent/ContentDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/ContentDataProvider.php
@@ -148,6 +148,7 @@ class ContentDataProvider implements DataProviderInterface, DataProviderAliasInt
     {
         return [
             'properties' => new PropertyParameter('properties', [], 'collection'),
+            'templates' => new PropertyParameter('templates', [], 'collection'),
         ];
     }
 
@@ -269,6 +270,7 @@ class ContentDataProvider implements DataProviderInterface, DataProviderAliasInt
             $excluded = array_merge($excluded, $this->referenceStore->getAll());
         }
 
+        $filters['templates'] = $this->getTemplates($properties);
         $this->contentQueryBuilder->init(
             [
                 'config' => $filters,
@@ -415,5 +417,22 @@ class ContentDataProvider implements DataProviderInterface, DataProviderAliasInt
     public function getAlias()
     {
         return 'content';
+    }
+
+    /**
+     * Extracts templates from given property-parameters.
+     *
+     * @param PropertyParameter[] $propertyParameter
+     *
+     * @return array
+     */
+    private function getTemplates(array $propertyParameter)
+    {
+        $templates = '';
+        if (array_key_exists('templates', $propertyParameter)) {
+            $templates = $propertyParameter['templates']->getValue();
+        }
+
+        return array_filter(explode(',', $templates));
     }
 }

--- a/src/Sulu/Component/Content/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRule;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupWebspace;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -31,6 +32,7 @@ use Sulu\Component\Content\Query\ContentQueryExecutor;
 use Sulu\Component\Content\SmartContent\QueryBuilder as SmartContentQueryBuilder;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
+use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Webspace;
@@ -66,6 +68,11 @@ class SmartContentQueryBuilderTest extends SuluTestCase
      * @var SessionManagerInterface
      */
     private $sessionManager;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
 
     /**
      * @var string
@@ -111,11 +118,12 @@ class SmartContentQueryBuilderTest extends SuluTestCase
         $this->contentQuery = $this->getContainer()->get('sulu.content.query_executor');
         $this->tagRepository = $this->getContainer()->get('sulu.repository.tag');
         $this->audienceTargetGroupRepository = $this->getContainer()->get('sulu.repository.target_group');
+        $this->propertyEncoder = $this->getContainer()->get('sulu_document_manager.property_encoder');
 
         $this->languageNamespace = $this->getContainer()->getParameter('sulu.content.language.namespace');
 
         $em = $this->getContainer()->get('doctrine')->getManager();
-        $user = $em->getRepository('Sulu\Bundle\SecurityBundle\Entity\User')->findOneByUsername('test');
+        $user = $em->getRepository(User::class)->findOneByUsername('test');
 
         $this->tag1 = $this->tagRepository->createNew();
         $this->tag1->setName('test1');
@@ -200,6 +208,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         $builder->init(
@@ -289,6 +298,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         // test news
@@ -323,6 +333,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         $builder->init(['config' => ['dataSource' => $root->getIdentifier(), 'includeSubFolders' => true]]);
@@ -391,6 +402,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -475,6 +487,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -627,6 +640,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -673,6 +687,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -763,6 +778,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -863,6 +879,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -997,6 +1014,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -1050,6 +1068,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
 
@@ -1097,6 +1116,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         $builder->init(
@@ -1128,6 +1148,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         $builder->init(['ids' => [array_keys($nodes)[0], array_keys($nodes)[1]]]);
@@ -1150,6 +1171,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         $builder->init(['excluded' => [$uuids[0]]]);
@@ -1331,6 +1353,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->structureManager,
             $this->extensionManager,
             $this->sessionManager,
+            $this->propertyEncoder,
             $this->languageNamespace
         );
         $builder->init(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3418
| Related issues/PRs | none
| License | MIT
| Documentation PR | TODO

#### What's in this PR?

This PR introduces a new param to filter for `templates`

#### Example Usage

~~~xml
<property name="smart_content" type="smart_content">
    <meta>
        <title lang="en">Smart Content</title>
    </meta>

    <params>
        <param name="templates" value="default,overview"/>
    </params>
</property>
~~~

#### To Do

- [ ] Tests
- [ ] Snippet
- [ ] Articles (in the other repository)
- [ ] Docs
