### PR TITLE
build locale-less form for contact

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -47,8 +47,9 @@ export default class ResourceStore {
     @action setLocale(locale: string) {
         const {locale: observableLocale} = this.observableOptions;
         if (!observableLocale) {
-            // TODO Should there really be a silent return, or should we throw an exception instead?
-            return;
+            throw new Error(
+                '"setLocale" should not be called on a ResourceStore which got no locale passed in the constructor'
+            );
         }
 
         observableLocale.set(locale);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -56,7 +56,12 @@ export default class ResourceStore {
 
     @action save() {
         this.saving = true;
-        ResourceRequester.put(this.resourceKey, this.id, this.data, {locale: this.locale.get()})
+        const {locale} = this.observableOptions;
+        const options = {};
+        if (locale) {
+            options.locale = locale.get();
+        }
+        ResourceRequester.put(this.resourceKey, this.id, this.data, options)
             .then(action((response) => {
                 this.data = response;
                 this.saving = false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -135,6 +135,15 @@ test('Save the store should send a PUT request', () => {
     expect(ResourceRequester.put).toBeCalledWith('snippets', '3', {title: 'Title'}, {locale: 'de'});
 });
 
+test('Save the store should send a PUT request without a locale', () => {
+    ResourceRequester.put.mockReturnValue(Promise.resolve());
+    const resourceStore = new ResourceStore('snippets', '3', {});
+    resourceStore.data = {title: 'Title'};
+    resourceStore.dirty = false;
+
+    resourceStore.save();
+    expect(ResourceRequester.put).toBeCalledWith('snippets', '3', {title: 'Title'}, {});
+});
 test('Saving flag should be set to true when saving', () => {
     ResourceRequester.put.mockReturnValue(Promise.resolve());
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable()});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -1,5 +1,5 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
-import {when} from 'mobx';
+// @flow
+import {observable, when} from 'mobx';
 import ResourceStore from '../ResourceStore';
 import ResourceRequester from '../../../services/ResourceRequester';
 
@@ -10,10 +10,16 @@ jest.mock('../../../services/ResourceRequester', () => ({
 
 test('Create data object for schema', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve());
-    const resourceStore = new ResourceStore();
+    const resourceStore = new ResourceStore('snippets', '1');
     resourceStore.changeSchema({
-        title: {},
-        description: {},
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
     });
 
     expect(Object.keys(resourceStore.data)).toHaveLength(2);
@@ -23,20 +29,29 @@ test('Create data object for schema', () => {
     });
 
     resourceStore.changeSchema({
-        text: {},
+        text: {
+            label: 'Text',
+            type: 'text_line',
+        },
     });
 });
 
 test('Change schema should keep data', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve());
-    const resourceStore = new ResourceStore();
+    const resourceStore = new ResourceStore('snippets', '1');
     resourceStore.data = {
         title: 'Title',
         slogan: 'Slogan',
     };
     resourceStore.changeSchema({
-        title: {},
-        description: {},
+        title: {
+            label: 'Title',
+            type: 'text_line',
+        },
+        description: {
+            label: 'Description',
+            type: 'text_line',
+        },
     });
 
     expect(Object.keys(resourceStore.data)).toHaveLength(3);
@@ -50,7 +65,7 @@ test('Change schema should keep data', () => {
 test('Should be marked dirty when value is changed', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve());
 
-    const resourceStore = new ResourceStore();
+    const resourceStore = new ResourceStore('snippets', '1');
     expect(resourceStore.dirty).toBe(false);
     resourceStore.set('test', 'value');
 
@@ -61,17 +76,34 @@ test('Should be marked dirty when value is changed', () => {
 test('Should load the data with the ResourceRequester', () => {
     const promise = Promise.resolve({value: 'Value'});
     ResourceRequester.get.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', 3);
+    const resourceStore = new ResourceStore('snippets', '3', {locale: observable()});
     resourceStore.setLocale('en');
-    expect(ResourceRequester.get).toBeCalledWith('snippets', 3, {locale: 'en'});
+    expect(ResourceRequester.get).toBeCalledWith('snippets', '3', {locale: 'en'});
     return promise.then(() => {
         expect(resourceStore.data).toEqual({value: 'Value'});
     });
 });
 
+test('Should load without locale the data with the ResourceRequester', () => {
+    const promise = Promise.resolve({value: 'Value'});
+    ResourceRequester.get.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', '3');
+    expect(ResourceRequester.get).toBeCalledWith('snippets', '3', {});
+    return promise.then(() => {
+        expect(resourceStore.data).toEqual({value: 'Value'});
+    });
+});
+
+test('Should not load the data with the ResourceRequester if locale should be provided but is not', () => {
+    const promise = Promise.resolve({value: 'Value'});
+    ResourceRequester.get.mockReturnValue(promise);
+    new ResourceStore('snippets', '3', {locale: observable()});
+    expect(ResourceRequester.get).not.toBeCalled();
+});
+
 test('Loading flag should be set to true when loading', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve());
-    const resourceStore = new ResourceStore('snippets', 1);
+    const resourceStore = new ResourceStore('snippets', '1');
     resourceStore.loading = false;
     resourceStore.setLocale('en');
 
@@ -82,7 +114,7 @@ test('Loading flag should be set to true when loading', () => {
 test('Loading flag should be set to false when loading has finished', () => {
     const promise = Promise.resolve();
     ResourceRequester.get.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', 1);
+    const resourceStore = new ResourceStore('snippets', '1');
     resourceStore.setLocale('en');
     resourceStore.loading = true;
 
@@ -94,18 +126,18 @@ test('Loading flag should be set to false when loading has finished', () => {
 
 test('Save the store should send a PUT request', () => {
     ResourceRequester.put.mockReturnValue(Promise.resolve());
-    const resourceStore = new ResourceStore('snippets', 3);
+    const resourceStore = new ResourceStore('snippets', '3', {locale: observable()});
     resourceStore.locale.set('de');
     resourceStore.data = {title: 'Title'};
     resourceStore.dirty = false;
 
     resourceStore.save();
-    expect(ResourceRequester.put).toBeCalledWith('snippets', 3, {title: 'Title'}, {locale: 'de'});
+    expect(ResourceRequester.put).toBeCalledWith('snippets', '3', {title: 'Title'}, {locale: 'de'});
 });
 
 test('Saving flag should be set to true when saving', () => {
     ResourceRequester.put.mockReturnValue(Promise.resolve());
-    const resourceStore = new ResourceStore('snippets', 1);
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable()});
     resourceStore.saving = false;
 
     resourceStore.save();
@@ -116,7 +148,7 @@ test('Saving and dirty flag should be set and data should be updated to false wh
     const data = {changed: 'later'};
     const promise = Promise.resolve(data);
     ResourceRequester.put.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', 1);
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable()});
     resourceStore.saving = true;
     resourceStore.dirty = true;
 
@@ -133,7 +165,7 @@ test('Saving and dirty flag should be set to false when saving has failed', (don
     const promise = Promise.reject(new Error('An error occured!'));
     ResourceRequester.get.mockReturnValue(Promise.resolve({title: 'Title to stay!'}));
     ResourceRequester.put.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', 1);
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable()});
     resourceStore.locale.set('en');
     resourceStore.saving = true;
     resourceStore.dirty = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -103,7 +103,7 @@ test('Should not load the data with the ResourceRequester if locale should be pr
 
 test('Loading flag should be set to true when loading', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve());
-    const resourceStore = new ResourceStore('snippets', '1');
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable()});
     resourceStore.loading = false;
     resourceStore.setLocale('en');
 
@@ -114,7 +114,7 @@ test('Loading flag should be set to true when loading', () => {
 test('Loading flag should be set to false when loading has finished', () => {
     const promise = Promise.resolve();
     ResourceRequester.get.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', '1');
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable()});
     resourceStore.setLocale('en');
     resourceStore.loading = true;
 
@@ -192,4 +192,9 @@ test('Saving and dirty flag should be set to false when saving has failed', (don
             }
         );
     });
+});
+
+test('Calling setLocale on a non-localizable ResourceStore should throw an exception', () => {
+    const resourceStore = new ResourceStore('snippets', '1', {});
+    expect(() => resourceStore.setLocale('de')).toThrow();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/types.js
@@ -1,4 +1,6 @@
 // @flow
+import {observable} from 'mobx';
+
 export type SchemaEntry = {
     label: string,
     type: string,
@@ -6,4 +8,8 @@ export type SchemaEntry = {
 
 export type Schema = {
     [string]: SchemaEntry,
+};
+
+export type ObservableOptions = {
+    locale?: observable,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -16,30 +16,16 @@ class Form extends React.PureComponent<Props> {
 
     componentWillMount() {
         const {resourceStore, router} = this.props;
-        const {
-            route: {
-                options: {
-                    locales,
-                },
-            },
-        } = router;
 
-        if (locales) {
+        if (resourceStore.locale) {
             router.bind('locale', resourceStore.locale);
         }
     }
 
     componentWillUnmount() {
         const {resourceStore, router} = this.props;
-        const {
-            route: {
-                options: {
-                    locales,
-                },
-            },
-        } = router;
 
-        if (locales) {
+        if (resourceStore.locale) {
             router.unbind('locale', resourceStore.locale);
         }
     }
@@ -72,7 +58,13 @@ export default withToolbar(Form, function() {
     const backButton = backRoute
         ? {
             onClick: () => {
-                router.restore(backRoute, {locale: this.props.resourceStore.locale.get()});
+                const {resourceStore} = this.props;
+
+                const options = {};
+                if (resourceStore.locale) {
+                    options.locale = resourceStore.locale.get();
+                }
+                router.restore(backRoute, options);
             },
         }
         : undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -16,11 +16,32 @@ class Form extends React.PureComponent<Props> {
 
     componentWillMount() {
         const {resourceStore, router} = this.props;
-        router.bind('locale', resourceStore.locale);
+        const {
+            route: {
+                options: {
+                    locales,
+                },
+            },
+        } = router;
+
+        if (locales) {
+            router.bind('locale', resourceStore.locale);
+        }
     }
 
     componentWillUnmount() {
-        this.props.router.unbind('locale', this.props.resourceStore.locale);
+        const {resourceStore, router} = this.props;
+        const {
+            route: {
+                options: {
+                    locales,
+                },
+            },
+        } = router;
+
+        if (locales) {
+            router.unbind('locale', resourceStore.locale);
+        }
     }
 
     handleSubmit = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
+import {observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
 
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
@@ -48,7 +49,7 @@ test('Should navigate to defined route on back button click', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('snippet', 1);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable()});
 
     const router = {
         restore: jest.fn(),
@@ -104,9 +105,7 @@ test('Should not render back button when no editLink is configured', () => {
         navigate: jest.fn(),
         bind: jest.fn(),
         route: {
-            options: {
-                locales: [],
-            },
+            options: {},
         },
         attributes: {},
     };
@@ -121,7 +120,7 @@ test('Should change locale in form store via locale chooser', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('snippet', 1);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable()});
 
     const router = {
         navigate: jest.fn(),
@@ -147,7 +146,7 @@ test('Should show locales from router options in toolbar', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('snippet', 1);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable()});
 
     const router = {
         navigate: jest.fn(),
@@ -235,9 +234,7 @@ test('Should render save button disabled only if form is not dirty', () => {
         bind: jest.fn(),
         navigate: jest.fn(),
         route: {
-            options: {
-                locales: [],
-            },
+            options: {},
         },
         attributes: {},
     };
@@ -254,7 +251,7 @@ test('Should save form when submitted', () => {
     ResourceRequester.put.mockReturnValue(Promise.resolve());
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
-    const resourceStore = new ResourceStore('snippets', 8);
+    const resourceStore = new ResourceStore('snippets', 8, {locale: observable()});
 
     const router = {
         bind: jest.fn(),
@@ -300,7 +297,7 @@ test('Should pass store and schema handler to FormContainer', () => {
     expect(formContainer.prop('onSubmit')).toBeInstanceOf(Function);
 });
 
-test('Should render save button loading only if form is not saving', () => {
+test('Should render save button loading only if form is saving', () => {
     function getSaveItem() {
         return toolbarFunction.call(form).items.find((item) => item.value === 'Save');
     }
@@ -315,9 +312,7 @@ test('Should render save button loading only if form is not saving', () => {
         bind: jest.fn(),
         navigate: jest.fn(),
         route: {
-            options: {
-                locales: [],
-            },
+            options: {},
         },
         attributes: {},
     };
@@ -332,7 +327,7 @@ test('Should render save button loading only if form is not saving', () => {
 test('Should unbind the binding and destroy the store on unmount', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
-    const resourceStore = new ResourceStore('snippets', 12);
+    const resourceStore = new ResourceStore('snippets', 12, {locale: observable()});
     const router = {
         bind: jest.fn(),
         unbind: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -69,6 +69,30 @@ test('Should navigate to defined route on back button click', () => {
     expect(router.restore).toBeCalledWith('test_route', {locale: 'de'});
 });
 
+test('Should navigate to defined route on back button click without locale', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('snippet', 1);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                backRoute: 'test_route',
+            },
+        },
+        attributes: {},
+    };
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
+
+    const toolbarConfig = toolbarFunction.call(form);
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('test_route', {});
+});
+
 test('Should not render back button when no editLink is configured', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -353,3 +353,26 @@ test('Should unbind the binding and destroy the store on unmount', () => {
     form.unmount();
     expect(router.unbind).toBeCalledWith('locale', locale);
 });
+
+test('Should not bind the locale if no locales have been passed via options', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
+    const router = {
+        bind: jest.fn(),
+        unbind: jest.fn(),
+        route: {
+            options: {
+                resourceKey: 'snippets',
+            },
+        },
+        attributes: {},
+    };
+
+    const form = mount(<Form router={router} resourceStore={resourceStore} />);
+
+    expect(router.bind).not.toBeCalled();
+
+    form.unmount();
+    expect(router.unbind).not.toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -181,7 +181,31 @@ test('Should unbind the binding and destroy the store on unmount without locale'
     expect(router.unbind).not.toBeCalledWith('locale');
 });
 
-test('Should navigate when pencil button is clicked', () => {
+test('Should navigate when pencil button is clicked and locales have been passed in options', () => {
+    const List = require('../List').default;
+    const router = {
+        navigate: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                editRoute: 'editRoute',
+                resourceKey: 'test',
+                locales: ['de', 'en'],
+            },
+        },
+    };
+
+    const listWrapper = mount(<List router={router} />);
+    listWrapper.find('List').get(0).locale = {
+        get: function() {
+            return 'de';
+        },
+    };
+    listWrapper.find('ButtonCell button').at(0).simulate('click');
+    expect(router.navigate).toBeCalledWith('editRoute', {id: 1, locale: 'de'});
+});
+
+test('Should navigate without locale when pencil button is clicked', () => {
     const List = require('../List').default;
     const router = {
         navigate: jest.fn(),
@@ -195,13 +219,13 @@ test('Should navigate when pencil button is clicked', () => {
     };
 
     const listWrapper = mount(<List router={router} />);
-    listWrapper.find('List').get(0).locale = {
+    listWrapper.find('List').get(0).datagridStore.locale = {
         get: function() {
             return 'de';
         },
     };
     listWrapper.find('ButtonCell button').at(0).simulate('click');
-    expect(router.navigate).toBeCalledWith('editRoute', {id: 1, locale: 'de'});
+    expect(router.navigate).toBeCalledWith('editRoute', {id: 1});
 });
 
 test('Should render the delete item enabled only if something is selected', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {observable} from 'mobx';
 import Tabs from '../../components/Tabs';
 import type {ViewProps} from '../../containers/ViewRenderer';
 import {translate} from '../../services/Translator';
@@ -18,9 +19,16 @@ export default class ResourceTabs extends React.PureComponent<ViewProps> {
         const {
             options: {
                 resourceKey,
+                locales,
             },
         } = route;
-        this.resourceStore = new ResourceStore(resourceKey, id);
+
+        const options = {};
+        if (locales) {
+            options.locale = observable();
+        }
+
+        this.resourceStore = new ResourceStore(resourceKey, id, options);
     }
 
     componentWillUnmount() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -139,7 +139,34 @@ test('Should create a ResourceStore on mount and destroy it on unmount', () => {
 
     const resourceTabs = mount(<ResourceTabs router={router} route={route}>{() => null}</ResourceTabs>);
     const resourceStoreConstructorCall = ResourceStore.mock.calls;
-    expect(resourceStoreConstructorCall[0]).toEqual(['snippets', 5]);
+    expect(resourceStoreConstructorCall[0][0]).toEqual('snippets');
+    expect(resourceStoreConstructorCall[0][1]).toEqual(5);
+    expect(resourceStoreConstructorCall[0][2].locale).not.toBeDefined();
+
+    resourceTabs.unmount();
+    expect(ResourceStore.mock.instances[0].destroy).toBeCalled();
+});
+
+test('Should create a ResourceStore with locale on mount if locales have been passed in route options', () => {
+    const route = {
+        children: [],
+        options: {
+            resourceKey: 'snippets',
+            locales: ['de', 'en'],
+        },
+    };
+    const router = {
+        route,
+        attributes: {
+            id: 5,
+        },
+    };
+
+    const resourceTabs = mount(<ResourceTabs router={router} route={route}>{() => null}</ResourceTabs>);
+    const resourceStoreConstructorCall = ResourceStore.mock.calls;
+    expect(resourceStoreConstructorCall[0][0]).toEqual('snippets');
+    expect(resourceStoreConstructorCall[0][1]).toEqual(5);
+    expect(resourceStoreConstructorCall[0][2].locale).toBeDefined();
 
     resourceTabs.unmount();
     expect(ResourceStore.mock.instances[0].destroy).toBeCalled();

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -1,4 +1,5 @@
 {
     "sulu_contact.organizations": "Organisationen",
-    "sulu_contact.persons": "Personen"
+    "sulu_contact.persons": "Personen",
+    "sulu_contact.details": "Details"
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
@@ -1,4 +1,5 @@
 {
     "sulu_contact.organizations": "Organizations",
-    "sulu_contact.persons": "Persons"
+    "sulu_contact.persons": "Persons",
+    "sulu_contact.details": "Details"
 }

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -103,11 +103,13 @@ class SnippetAdmin extends Admin
                 ->addOption('locales', $snippetLocales)
                 ->addAttributeDefault('locale', $snippetLocales[0]),
             (new Route('sulu_snippet.form', '/snippets/:locale/:id', 'sulu_admin.resource_tabs'))
-                ->addOption('resourceKey', 'snippets'),
+                ->addOption('resourceKey', 'snippets')
+                ->addOption('locales', $snippetLocales)
+                ->addAttributeDefault('locale', $snippetLocales[0]),
             (new Route('sulu_snippet.form.detail', '/details', 'sulu_admin.form'))
                 ->addOption('tabTitle', 'sulu_snippet.details')
                 ->addOption('backRoute', 'sulu_snippet.list')
-                ->addOption('locales', $snippetLocales)
+                ->addOption('locales', $snippetLocales) // TODO should be removed?
                 ->setParent('sulu_snippet.form'),
             (new Route('sulu_snippet.form.taxonomies', '/taxonomies', 'sulu_admin.list'))
                 ->addOption('resourceKey', 'snippets')

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -109,13 +109,11 @@ class SnippetAdmin extends Admin
             (new Route('sulu_snippet.form.detail', '/details', 'sulu_admin.form'))
                 ->addOption('tabTitle', 'sulu_snippet.details')
                 ->addOption('backRoute', 'sulu_snippet.list')
-                ->addOption('locales', $snippetLocales) // TODO should be removed?
                 ->setParent('sulu_snippet.form'),
             (new Route('sulu_snippet.form.taxonomies', '/taxonomies', 'sulu_admin.list'))
                 ->addOption('resourceKey', 'snippets')
                 ->addOption('tabTitle', 'sulu_snippet.taxonomies')
                 ->addOption('backRoute', 'sulu_snippet.list')
-                ->addOption('locales', $snippetLocales)
                 ->setParent('sulu_snippet.form'),
         ];
     }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -73,6 +73,10 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
         ], 'options', $listRoute);
         $this->assertAttributeSame(['locale' => array_keys($locales)[0]], 'attributeDefaults', $listRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'name', $formRoute);
+        $this->assertAttributeEquals([
+            'resourceKey' => 'snippets',
+            'locales' => array_keys($locales),
+        ], 'options', $formRoute);
         $this->assertAttributeEquals('sulu_snippet.form.detail', 'name', $detailRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'parent', $detailRoute);
         $this->assertAttributeSame([

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -82,7 +82,6 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame([
             'tabTitle' => 'sulu_snippet.details',
             'backRoute' => 'sulu_snippet.list',
-            'locales' => array_keys($locales),
         ], 'options', $detailRoute);
         $this->assertAttributeEquals('sulu_snippet.form.taxonomies', 'name', $taxonomiesRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'parent', $taxonomiesRoute);
@@ -90,7 +89,6 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
             'resourceKey' => 'snippets',
             'tabTitle' => 'sulu_snippet.taxonomies',
             'backRoute' => 'sulu_snippet.list',
-            'locales' => array_keys($locales),
         ], 'options', $taxonomiesRoute);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | parts of #3548 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR implements a form for the contacts, because contacts are not translated. So this complements #3489.

#### Why?

Because we need locale-less forms anyway, and there are some obstacles for implementing them. So we are doing this quite early.

#### To Do

- [x] Create contact form
- [x] Navigation should also include locale if required for that part of the application