### PR TITLE
Removed redundancy from .gitignore, restructured it and added some comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,32 +1,45 @@
-/vendor/
-/composer.phar
-/composer.lock
-/tests/Resources/cache/*
-/tests/app/cache/*
-/tests/app/logs/*
-/tests/app/data/*
-/src/Sulu/Bundle/*/vendor
-/src/Sulu/Bundle/*/Tests/app/cache
-/src/Sulu/Bundle/*/Tests/app/logs
-/src/Sulu/Bundle/*/Tests/app/data
-/src/Sulu/Bundle/TestBundle/Resources/app/cache
-/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/cache
+# Vendor, logs and cache
+/src/Sulu/Bundle/*/Tests/app/cache/
+/src/Sulu/Bundle/*/Tests/app/data/
+/src/Sulu/Bundle/*/Tests/app/logs/
+/src/Sulu/Bundle/*/vendor/
 /src/Sulu/Bundle/TestBundle/Resources/app/cache/
+/src/Sulu/Bundle/TestBundle/Resources/app/cache/
+/src/Sulu/Component/Rest/Tests/Functional/ListBuilder/Metadata/cache/
+/tests/app/cache/
+/tests/app/data/
+/tests/app/logs/
+/tests/Resources/cache/
+/vendor/
+
+# Composer
+/composer.lock
+/composer.phar
+
+# Text editors backup files
 *~
 
-/node_modules/
+# Meld
+*.orig
+
+# OS generated files
+._*
+.DS_Store
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# NPM
 **/node_modules
 **/package-lock.json
-package-lock.json
 npm-debug.log
-package-lock.json
 
 # .DS_Store
 .DS_Store
 
 # IDEs
-.idea/*
-*.iml
+.idea
 
 # PHPunit
 phpunit.xml
@@ -34,7 +47,3 @@ phpunit.xml
 # Jackrabbit
 jackrabbit-standalone*
 jackrabbit/*
-
-# phpunit
-/phpunit.xml
-

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ Thumbs.db
 **/package-lock.json
 npm-debug.log
 
-# .DS_Store
-.DS_Store
-
 # IDEs
 .idea
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### Why?

Today we were discussing how to update our .gitignore and I used sulus as example. By this we found some doublications and restructured the whole file.

#### Vendor, logs and cache

I changed those to folder rules as I believe it is a more cleare statement and those folders will be generated during run time. But this means no .gitkeep would keep those folders.

#### Composer
Moved composer to it's own section

#### Text editors backup files
I didn't know what that ~* really meant and added a headline to make this clear.

#### Meld
At least I do use meld and the .orig files should be excluded.

#### OS generated files
Same as before.

#### NPM
Added headline and package-lock.json was excluded three times.

#### IDEs
*.iml are intelliJ files and should only appear inside the .idea folder.

#### PHPunit
Was there twice.

#### Jackrabbit
As before.


