### PR TITLE
Fixed permissions for user with no role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * HOTFIX      #3551 [SecurityBundle]        Fixed permissions for user with no role
+
 * 1.5.6 (2017-09-14)
     * HOTFIX      #3511 [MediaBundle]           Fixed disappearing of selected medias
 

--- a/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
@@ -70,6 +70,9 @@ class SecurityContextVoter implements VoterInterface
         }
 
         $userPermissions = $this->accessControlManager->getUserPermissions($object, $user);
+        if (0 === count($userPermissions)) {
+            return VoterInterface::ACCESS_DENIED;
+        }
 
         // only if all attributes are granted the access is granted
         foreach ($attributes as $attribute) {

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityContextVoterTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/SecurityContextVoterTest.php
@@ -129,6 +129,21 @@ class SecurityContextVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $access);
     }
 
+    public function testNoUserPermissions()
+    {
+        $securityCondition = new SecurityCondition('sulu.security.roles');
+
+        $this->accessControlManager->getUserPermissions($securityCondition, $this->user)->willReturn([]);
+
+        $access = $this->voter->vote(
+            $this->token->reveal(),
+            $securityCondition,
+            ['view']
+        );
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $access);
+    }
+
     public function testNegativeVote()
     {
         $securityCondition = new SecurityCondition('sulu.security.roles');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug with the security system. When the user has no role the user has all roles. This happens when you remove all roles from a user and the user reset his password. The autologin then logs in the user and then the user has then all rights in the system.

