### PR TITLE
Return webspaceKey on StructureResolver

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -67,6 +67,7 @@ class StructureResolver implements StructureResolverInterface
             $data['urls'] = $structure->getUrls();
             $data['published'] = $structure->getPublished();
             $data['shadowBaseLocale'] = $structure->getShadowBaseLanguage();
+            $data['webspaceKey'] => $structure->getWebspaceKey();
 
             foreach ($data['extension'] as $name => $value) {
                 $extension = $this->extensionManager->getExtension($structure->getKey(), $name);

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -67,7 +67,7 @@ class StructureResolver implements StructureResolverInterface
             $data['urls'] = $structure->getUrls();
             $data['published'] = $structure->getPublished();
             $data['shadowBaseLocale'] = $structure->getShadowBaseLanguage();
-            $data['webspaceKey'] => $structure->getWebspaceKey();
+            $data['webspaceKey'] = $structure->getWebspaceKey();
 
             foreach ($data['extension'] as $name => $value) {
                 $extension = $this->extensionManager->getExtension($structure->getKey(), $name);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
@@ -82,6 +82,7 @@ class StructureResolverTest extends \PHPUnit_Framework_TestCase
         $structure->getPath()->willReturn('test-path');
         $structure->getUrls()->willReturn(['en' => '/description', 'de' => '/beschreibung', 'es' => null]);
         $structure->getShadowBaseLanguage()->willReturn('en');
+        $structure->getWebspaceKey()->willReturn('test');
 
         $authored = new \DateTime();
 
@@ -112,6 +113,7 @@ class StructureResolverTest extends \PHPUnit_Framework_TestCase
             'shadowBaseLocale' => 'en',
             'authored' => $authored,
             'author' => 1,
+            'webspaceKey' => 'test',
         ];
 
         $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal()));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

On 'single_internal_link' the webspace key is not accessible and we need it to set link to another webspace.

#### Example Usage

~~~twig
{% set target = sulu_content_load(content.myLink) %}
{{ sulu_content_path(target.path, target.webspaceKey) }}
~~~

#### To Do

- [ ] Create a documentation PR
