### PR TITLE
Fixed "awkward" state of documents after copy-locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * ENHANCEMENT #3557 [ContentBundle]           Added option to decorate index name for document types
+    * HOTFIX      #3555 [ContentBundle]           Fixed "awkward" state of documents after copy-locale
     * ENHANCEMENT #3554 [WebsiteBundle]           Return webspaceKey on StructureResolver
 
 * 1.6.5 (2017-10-04)

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -37,6 +37,7 @@ use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\RedirectType;
+use Sulu\Component\Content\Document\Subscriber\WorkflowStageSubscriber;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Exception\InvalidOrderPositionException;
 use Sulu\Component\Content\Exception\TranslatedNodeNotFoundException;
@@ -47,6 +48,7 @@ use Sulu\Component\Content\Metadata\Factory\Exception\StructureTypeNotFoundExcep
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\Content\Types\ResourceLocatorInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -493,6 +495,11 @@ class ContentMapper implements ContentMapperInterface
             $destDocument->setLocale($destLocale);
             $destDocument->setTitle($document->getTitle());
             $destDocument->getStructure()->bind($document->getStructure()->toArray());
+
+            if ($document instanceof WorkflowStageBehavior) {
+                $documentAccessor = new DocumentAccessor($destDocument);
+                $documentAccessor->set(WorkflowStageSubscriber::PUBLISHED_FIELD, null);
+            }
 
             // TODO: This can be removed if RoutingAuto replaces the ResourceLocator code.
             if ($destDocument instanceof ResourceSegmentBehavior) {

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -1438,6 +1438,19 @@ class ContentMapperTest extends SuluTestCase
         $this->assertEquals('/page-1', $result->url);
     }
 
+    public function testLanguageCopyPublishedDocument()
+    {
+        $data = $this->prepareSinglePageTestData(WorkflowStage::PUBLISHED);
+
+        $this->mapper->copyLanguage($data->getUuid(), 1, 'sulu_io', 'de', 'en');
+
+        $result = $this->mapper->load($data->getUuid(), 'sulu_io', 'en');
+
+        $this->assertEquals('Page-1', $result->title);
+        $this->assertEquals('/page-1', $result->url);
+        $this->assertNull($result->getPublished());
+    }
+
     public function testMultipleLanguagesCopy()
     {
         $data = $this->prepareSinglePageTestData();
@@ -1956,14 +1969,14 @@ class ContentMapperTest extends SuluTestCase
         $this->assertEquals('Test', $structure3->getNodeName());
     }
 
-    private function prepareSinglePageTestData()
+    private function prepareSinglePageTestData($workflowStage = WorkflowStage::TEST)
     {
         $data = [
             'title' => 'Page-1',
             'url' => '/page-1',
         ];
 
-        $data = $this->save($data, 'overview', 'sulu_io', 'de', 1);
+        $data = $this->save($data, 'overview', 'sulu_io', 'de', 1, true, null, null, $workflowStage);
 
         return $data;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/SuluArticleBundle/issues/185
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR set the published datetime to null when copying from one locale to another.

#### Why?

The state of the document is "published" and has a "draft" but is not present in the live workspace.
