### PR TITLE
Added option to decorate index name for document types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 CHANGELOG for Sulu
 ==================
 
-
 * dev-master
+    * ENHANCEMENT #3557 [ContentBundle]           Added option to decorate index name for document types
     * ENHANCEMENT #3554 [WebsiteBundle]           Return webspaceKey on StructureResolver
 
 * 1.6.5 (2017-10-04)

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->children()
                                     ->scalarNode('index')->info('Name of index to use')->isRequired()->end()
+                                    ->booleanNode('decorate_index')->info('Decorate Index name')->defaultFalse()->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/SuluContentExtension.php
@@ -99,7 +99,7 @@ class SuluContentExtension extends Extension implements PrependExtensionInterfac
                 [
                     'search' => [
                         'mapping' => [
-                            PageDocument::class => ['index' => 'page'],
+                            PageDocument::class => ['index' => 'page', 'decorate_index' => true],
                         ],
                     ],
                 ]

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -123,6 +123,7 @@ class StructureProvider implements ProviderInterface
         $indexMeta->setLocaleField($this->factory->createMetadataField('originalLocale'));
 
         $indexName = 'page';
+        $decorate = false;
 
         // See if the mapping overrides the default index and category name
         foreach ($this->mapping as $className => $mapping) {
@@ -134,20 +135,12 @@ class StructureProvider implements ProviderInterface
             }
 
             $indexName = $mapping['index'];
+            if ($mapping['decorate_index']) {
+                $decorate = true;
+            }
         }
 
-        if ($indexName === 'page') {
-            $indexMeta->setIndexName(
-                new Expression(
-                    sprintf(
-                        '"page_"~object.getWebspaceName()~(object.getWorkflowStage() == %s ? "_published" : "")',
-                        WorkflowStage::PUBLISHED
-                    )
-                )
-            );
-        } else {
-            $indexMeta->setIndexName(new Value($indexName));
-        }
+        $indexMeta->setIndexName($this->createIndexNameField($documentMetadata, $indexName, $decorate));
 
         foreach ($structure->getProperties() as $property) {
             if ($property instanceof BlockMetadata) {
@@ -433,5 +426,22 @@ EOT;
                 'indexed' => false,
             ]
         );
+    }
+
+    private function createIndexNameField(Metadata $documentMetadata, $indexName, $decorate)
+    {
+        if (!$decorate) {
+            return new Value($indexName);
+        }
+
+        $expression = '"' . $indexName . '"';
+        if ($documentMetadata->getReflectionClass()->isSubclassOf(WebspaceBehavior::class)) {
+            $expression .= '~"_"~object.getWebspaceName()';
+        }
+        if ($documentMetadata->getReflectionClass()->isSubclassOf(WorkflowStageBehavior::class)) {
+            $expression .= '~(object.getWorkflowStage() == ' . WorkflowStage::PUBLISHED . ' ? "_published" : "")';
+        }
+
+        return new Expression($expression);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/SuluArticleBundle#226
| Related issues/PRs | https://github.com/sulu/SuluArticleBundle/pull/257
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR introduces a config value to allow decorating index name (e.g. `article_published`) for different document types than `page`.

#### Why?

This is needed to index articles properly.
