### PR TITLE
Added downloadlist to mediacard

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "styleguide:build": "styleguidist build"
     },
     "dependencies": {
-        "sulu-admin-bundle": "file:src/Sulu/Bundle/AdminBundle/Resources/js"
+        "sulu-admin-bundle": "file:src/Sulu/Bundle/AdminBundle/Resources/js",
+        "sulu-media-bundle": "file:src/Sulu/Bundle/MediaBundle/Resources/js"
     },
     "devDependencies": {
         "babel-core": "^6.25.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
@@ -3,14 +3,18 @@ import {arrayMove} from 'react-sortable-hoc';
 import Checkbox from './Checkbox';
 import CroppedText from './CroppedText';
 import Icon from './Icon';
+import Menu from './Menu';
 import Masonry from './Masonry';
 import MultiItemSelection from './MultiItemSelection';
+import Popover from './Popover';
 
 export {
     arrayMove,
     Checkbox,
     CroppedText,
     Icon,
+    Menu,
     Masonry,
     MultiItemSelection,
+    Popover,
 };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
@@ -2,12 +2,14 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 import {Menu, Popover} from 'sulu-admin-bundle/components';
+import DownloadListItem from './DownloadListItem';
 
 type Props = {
     open: boolean,
     onClose: () => void,
     buttonRef: ElementRef<'button'>,
     imageSizes: Array<{url: string, label: string}>,
+    copyInfo: string,
 };
 
 export default class DownloadList extends React.PureComponent<Props> {
@@ -15,14 +17,16 @@ export default class DownloadList extends React.PureComponent<Props> {
         this.props.onClose();
     };
 
-    handleDownloadLinkCopied = () => {
+    handleDownloadItemCopy = () => {
         this.props.onClose();
     };
 
     render() {
         const {
             open,
+            copyInfo,
             buttonRef,
+            imageSizes,
         } = this.props;
 
         return (
@@ -36,7 +40,16 @@ export default class DownloadList extends React.PureComponent<Props> {
                         style={popoverStyle}
                         menuRef={setPopoverRef}
                     >
-                        <li>Hallo</li>
+                        {imageSizes.map((imageSize, index) => (
+                            <DownloadListItem
+                                key={index}
+                                url={imageSize.url}
+                                onCopy={this.handleDownloadItemCopy}
+                                copyInfo={copyInfo}
+                            >
+                                {imageSize.label}
+                            </DownloadListItem>
+                        ))}
                     </Menu>
                 )}
             </Popover>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
@@ -3,14 +3,11 @@ import React from 'react';
 import type {ElementRef} from 'react';
 import {Menu, Popover} from 'sulu-admin-bundle/components';
 
-const HORIZONTAL_OFFSET = 20;
-const VERTICAL_OFFSET = 10;
-
 type Props = {
     open: boolean,
     onClose: () => void,
     buttonRef: ElementRef<'button'>,
-    imageSizes: Array<{value: string | number, label: string}>,
+    imageSizes: Array<{url: string | number, label: string}>,
 };
 
 export default class DownloadList extends React.PureComponent<Props> {
@@ -18,7 +15,7 @@ export default class DownloadList extends React.PureComponent<Props> {
         this.props.onClose();
     };
 
-    handleDownloadLinkCopied = (value: string | number) => {
+    handleDownloadLinkCopied = () => {
         this.props.onClose();
     };
 
@@ -33,15 +30,13 @@ export default class DownloadList extends React.PureComponent<Props> {
                 open={open}
                 onClose={this.handleClose}
                 anchorElement={buttonRef}
-                verticalOffset={VERTICAL_OFFSET}
-                horizontalOffset={HORIZONTAL_OFFSET}
             >
                 {(setPopoverRef, popoverStyle) => (
                     <Menu
                         style={popoverStyle}
                         menuRef={setPopoverRef}
                     >
-                        <li>Hello</li>
+                        <li>Hallo</li>
                     </Menu>
                 )}
             </Popover>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
@@ -1,0 +1,50 @@
+// @flow
+import React from 'react';
+import type {ElementRef} from 'react';
+import {Menu, Popover} from 'sulu-admin-bundle/components';
+
+const HORIZONTAL_OFFSET = 20;
+const VERTICAL_OFFSET = 10;
+
+type Props = {
+    open: boolean,
+    onClose: () => void,
+    buttonRef: ElementRef<'button'>,
+    imageSizes: Array<{value: string | number, label: string}>,
+};
+
+export default class DownloadList extends React.PureComponent<Props> {
+    handleClose = () => {
+        this.props.onClose();
+    };
+
+    handleDownloadLinkCopied = (value: string | number) => {
+        this.props.onClose();
+    };
+
+    render() {
+        const {
+            open,
+            buttonRef,
+        } = this.props;
+
+        return (
+            <Popover
+                open={open}
+                onClose={this.handleClose}
+                anchorElement={buttonRef}
+                verticalOffset={VERTICAL_OFFSET}
+                horizontalOffset={HORIZONTAL_OFFSET}
+            >
+                {(setPopoverRef, popoverStyle) => (
+                    <Menu
+                        style={popoverStyle}
+                        menuRef={setPopoverRef}
+                    >
+                        <li>Hello</li>
+                    </Menu>
+                )}
+            </Popover>
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
@@ -7,7 +7,7 @@ type Props = {
     open: boolean,
     onClose: () => void,
     buttonRef: ElementRef<'button'>,
-    imageSizes: Array<{url: string | number, label: string}>,
+    imageSizes: Array<{url: string, label: string}>,
 };
 
 export default class DownloadList extends React.PureComponent<Props> {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadList.js
@@ -9,7 +9,7 @@ type Props = {
     onClose: () => void,
     buttonRef: ElementRef<'button'>,
     imageSizes: Array<{url: string, label: string}>,
-    copyInfo: string,
+    copyText: string,
 };
 
 export default class DownloadList extends React.PureComponent<Props> {
@@ -24,7 +24,7 @@ export default class DownloadList extends React.PureComponent<Props> {
     render() {
         const {
             open,
-            copyInfo,
+            copyText,
             buttonRef,
             imageSizes,
         } = this.props;
@@ -45,7 +45,7 @@ export default class DownloadList extends React.PureComponent<Props> {
                                 key={index}
                                 url={imageSize.url}
                                 onCopy={this.handleDownloadItemCopy}
-                                copyInfo={copyInfo}
+                                copyText={copyText}
                             >
                                 {imageSize.label}
                             </DownloadListItem>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadListItem.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadListItem.js
@@ -1,0 +1,64 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import {action, observable} from 'mobx';
+import classNames from 'classnames';
+import ClipboardButton from 'react-clipboard.js';
+import downloadListItemStyles from './downloadListItem.scss';
+
+type Props = {
+    url: string,
+    onCopy: () => void,
+    copyInfo: string,
+    children: string,
+};
+
+@observer
+export default class DownloadListItem extends React.PureComponent<Props> {
+    @observable copying = false;
+
+    @action copyUrl() {
+        this.copying = true;
+    }
+
+    handleCopySuccess = () => {
+        this.copyUrl();
+    };
+
+    handleCopyAnimationEnd = () => {
+        this.props.onCopy();
+    };
+
+    render() {
+        const {
+            url,
+            children,
+            copyInfo,
+        } = this.props;
+        const itemClass = classNames(
+            downloadListItemStyles.item,
+            {
+                [downloadListItemStyles.copying]: this.copying,
+            }
+        );
+
+        return (
+            <li
+                className={itemClass}
+                onAnimationEnd={this.handleCopyAnimationEnd}
+            >
+                <ClipboardButton
+                    onSuccess={this.handleCopySuccess}
+                    data-clipboard-text={url}
+                >
+                    <span className={downloadListItemStyles.itemContent}>
+                        {children}
+                        <span className={downloadListItemStyles.copyInfo}>
+                            {copyInfo}
+                        </span>
+                    </span>
+                </ClipboardButton>
+            </li>
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadListItem.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadListItem.js
@@ -9,7 +9,7 @@ import downloadListItemStyles from './downloadListItem.scss';
 type Props = {
     url: string,
     onCopy: () => void,
-    copyInfo: string,
+    copyText: string,
     children: string,
 };
 
@@ -33,7 +33,7 @@ export default class DownloadListItem extends React.PureComponent<Props> {
         const {
             url,
             children,
-            copyInfo,
+            copyText,
         } = this.props;
         const itemClass = classNames(
             downloadListItemStyles.item,
@@ -53,8 +53,8 @@ export default class DownloadListItem extends React.PureComponent<Props> {
                 >
                     <span className={downloadListItemStyles.itemContent}>
                         {children}
-                        <span className={downloadListItemStyles.copyInfo}>
-                            {copyInfo}
+                        <span className={downloadListItemStyles.copyText}>
+                            {copyText}
                         </span>
                     </span>
                 </ClipboardButton>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -25,9 +25,9 @@ type Props = {
     /** The URL of the presented image */
     image: string,
     /** List of available image sizes */
-    sizes: Array<{value: string | number, label: string}>,
+    sizes?: Array<{value: string | number, label: string}>,
     /** Called when a size was clicked */
-    onDownloadClicked: (value: string | number) => void,
+    onDownloadClicked?: (value: string | number) => void,
 };
 
 @observer

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
 import {Icon, Checkbox, CroppedText} from 'sulu-admin-bundle/components';
+import DownloadList from './DownloadList';
 import mediaCardStyles from './mediaCard.scss';
 
 const DOWNLOAD_ICON = 'cloud-download';
@@ -25,9 +26,7 @@ type Props = {
     /** The URL of the presented image */
     image: string,
     /** List of available image sizes */
-    sizes?: Array<{value: string | number, label: string}>,
-    /** Called when a size was clicked */
-    onDownloadClicked?: (value: string | number) => void,
+    imageSizes?: Array<{url: string | number, label: string}>,
 };
 
 @observer
@@ -36,11 +35,21 @@ export default class MediaCard extends React.PureComponent<Props> {
         selected: false,
     };
 
-    @observable downloadButtonRef: ElementRef<'div'>;
+    @observable downloadButtonRef: ElementRef<'button'>;
 
-    @action setDownloadButtonRef = (ref: ElementRef<'div'>) => {
+    @observable downloadListOpen: boolean = false;
+
+    @action setDownloadButtonRef = (ref: ElementRef<'button'>) => {
         this.downloadButtonRef = ref;
     };
+
+    @action openDownloadList() {
+        this.downloadListOpen = true;
+    }
+
+    @action closeDownloadList() {
+        this.downloadListOpen = false;
+    }
 
     handleClick = () => {
         const {
@@ -65,6 +74,14 @@ export default class MediaCard extends React.PureComponent<Props> {
         }
     };
 
+    handleDownloadButtonClick = () => {
+        this.openDownloadList();
+    };
+
+    handleDownloadListClose = () => {
+        this.closeDownloadList();
+    };
+
     render() {
         const {
             id,
@@ -73,6 +90,7 @@ export default class MediaCard extends React.PureComponent<Props> {
             title,
             image,
             selected,
+            imageSizes,
         } = this.props;
         const masonryClass = classNames(
             mediaCardStyles.mediaCard,
@@ -105,10 +123,17 @@ export default class MediaCard extends React.PureComponent<Props> {
                     </div>
                     <button
                         ref={this.setDownloadButtonRef}
+                        onClick={this.handleDownloadButtonClick}
                         className={mediaCardStyles.downloadButton}
                     >
                         <Icon name={DOWNLOAD_ICON} />
                     </button>
+                    <DownloadList
+                        open={this.downloadListOpen}
+                        onClose={this.handleDownloadListClose}
+                        buttonRef={this.downloadButtonRef}
+                        imageSizes={imageSizes}
+                    />
                 </div>
                 <div
                     className={mediaCardStyles.media}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -26,13 +26,14 @@ type Props = {
     /** The URL of the presented image */
     image: string,
     /** List of available image sizes */
-    imageSizes?: Array<{url: string, label: string}>,
+    imageSizes: Array<{url: string, label: string}>,
 };
 
 @observer
 export default class MediaCard extends React.PureComponent<Props> {
     static defaultProps = {
         selected: false,
+        imageSizes: [],
     };
 
     @observable downloadButtonRef: ElementRef<'button'>;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -1,8 +1,13 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import classNames from 'classnames';
+import {observer} from 'mobx-react';
+import {action, observable} from 'mobx';
 import {Icon, Checkbox, CroppedText} from 'sulu-admin-bundle/components';
 import mediaCardStyles from './mediaCard.scss';
+
+const DOWNLOAD_ICON = 'cloud-download';
 
 type Props = {
     id: string | number,
@@ -19,11 +24,22 @@ type Props = {
     icon?: string,
     /** The URL of the presented image */
     image: string,
+    /** List of available image sizes */
+    sizes: Array<{value: string | number, label: string}>,
+    /** Called when a size was clicked */
+    onDownloadClicked: (value: string | number) => void,
 };
 
+@observer
 export default class MediaCard extends React.PureComponent<Props> {
     static defaultProps = {
         selected: false,
+    };
+
+    @observable downloadButtonRef: ElementRef<'div'>;
+
+    @action setDownloadButtonRef = (ref: ElementRef<'div'>) => {
+        this.downloadButtonRef = ref;
     };
 
     handleClick = () => {
@@ -67,24 +83,32 @@ export default class MediaCard extends React.PureComponent<Props> {
 
         return (
             <div className={masonryClass}>
-                <div
-                    className={mediaCardStyles.header}
-                    onClick={this.handleHeaderClick}
-                >
-                    <div className={mediaCardStyles.title}>
-                        <Checkbox
-                            value={id}
-                            checked={!!selected}
-                            className={mediaCardStyles.checkbox}
-                        >
-                            <div className={mediaCardStyles.titleText}>
-                                <CroppedText>{title}</CroppedText>
-                            </div>
-                        </Checkbox>
+                <div className={mediaCardStyles.header}>
+                    <div
+                        className={mediaCardStyles.description}
+                        onClick={this.handleHeaderClick}
+                    >
+                        <div className={mediaCardStyles.title}>
+                            <Checkbox
+                                value={id}
+                                checked={!!selected}
+                                className={mediaCardStyles.checkbox}
+                            >
+                                <div className={mediaCardStyles.titleText}>
+                                    <CroppedText>{title}</CroppedText>
+                                </div>
+                            </Checkbox>
+                        </div>
+                        <div className={mediaCardStyles.meta}>
+                            {meta}
+                        </div>
                     </div>
-                    <div className={mediaCardStyles.meta}>
-                        {meta}
-                    </div>
+                    <button
+                        ref={this.setDownloadButtonRef}
+                        className={mediaCardStyles.downloadButton}
+                    >
+                        <Icon name={DOWNLOAD_ICON} />
+                    </button>
                 </div>
                 <div
                     className={mediaCardStyles.media}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -28,7 +28,7 @@ type Props = {
     /** List of available image sizes */
     imageSizes: Array<{url: string, label: string}>,
     /** Info text which is shown, when a download link is hovered */
-    downloadCopyInfo: string,
+    downloadCopyText: string,
     /** When true the cover is permanently shown */
     showCover: boolean,
 };
@@ -39,7 +39,7 @@ export default class MediaCard extends React.PureComponent<Props> {
         selected: false,
         showCover: false,
         imageSizes: [],
-        downloadCopyInfo: '',
+        downloadCopyText: '',
     };
 
     @observable downloadButtonRef: ElementRef<'button'>;
@@ -99,9 +99,9 @@ export default class MediaCard extends React.PureComponent<Props> {
             selected,
             showCover,
             imageSizes,
-            downloadCopyInfo,
+            downloadCopyText,
         } = this.props;
-        const masonryClass = classNames(
+        const mediaCardClass = classNames(
             mediaCardStyles.mediaCard,
             {
                 [mediaCardStyles.selected]: !!selected,
@@ -117,7 +117,7 @@ export default class MediaCard extends React.PureComponent<Props> {
         );
 
         return (
-            <div className={masonryClass}>
+            <div className={mediaCardClass}>
                 <div className={mediaCardStyles.header}>
                     <div
                         className={mediaCardStyles.description}
@@ -152,7 +152,7 @@ export default class MediaCard extends React.PureComponent<Props> {
                                 onClose={this.handleDownloadListClose}
                                 buttonRef={this.downloadButtonRef}
                                 imageSizes={imageSizes}
-                                copyInfo={downloadCopyInfo}
+                                copyText={downloadCopyText}
                             />
                         </div>
                     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -27,13 +27,19 @@ type Props = {
     image: string,
     /** List of available image sizes */
     imageSizes: Array<{url: string, label: string}>,
+    /** Info text which is shown, when a download link is hovered */
+    downloadCopyInfo: string,
+    /** When true the cover is permanently shown */
+    showCover: boolean,
 };
 
 @observer
 export default class MediaCard extends React.PureComponent<Props> {
     static defaultProps = {
         selected: false,
+        showCover: false,
         imageSizes: [],
+        downloadCopyInfo: '',
     };
 
     @observable downloadButtonRef: ElementRef<'button'>;
@@ -91,12 +97,22 @@ export default class MediaCard extends React.PureComponent<Props> {
             title,
             image,
             selected,
+            showCover,
             imageSizes,
+            downloadCopyInfo,
         } = this.props;
         const masonryClass = classNames(
             mediaCardStyles.mediaCard,
             {
-                [mediaCardStyles.selected]: selected,
+                [mediaCardStyles.selected]: !!selected,
+                [mediaCardStyles.showCover]: !!showCover,
+                [mediaCardStyles.noDownloadList]: !imageSizes.length,
+            }
+        );
+        const downloadButtonClass = classNames(
+            mediaCardStyles.downloadButton,
+            {
+                [mediaCardStyles.active]: !!this.downloadListOpen,
             }
         );
 
@@ -122,26 +138,31 @@ export default class MediaCard extends React.PureComponent<Props> {
                             {meta}
                         </div>
                     </div>
-                    <button
-                        ref={this.setDownloadButtonRef}
-                        onClick={this.handleDownloadButtonClick}
-                        className={mediaCardStyles.downloadButton}
-                    >
-                        <Icon name={DOWNLOAD_ICON} />
-                    </button>
-                    <DownloadList
-                        open={this.downloadListOpen}
-                        onClose={this.handleDownloadListClose}
-                        buttonRef={this.downloadButtonRef}
-                        imageSizes={imageSizes}
-                    />
+                    {!!imageSizes.length &&
+                        <div>
+                            <button
+                                ref={this.setDownloadButtonRef}
+                                onClick={this.handleDownloadButtonClick}
+                                className={downloadButtonClass}
+                            >
+                                <Icon name={DOWNLOAD_ICON} />
+                            </button>
+                            <DownloadList
+                                open={this.downloadListOpen}
+                                onClose={this.handleDownloadListClose}
+                                buttonRef={this.downloadButtonRef}
+                                imageSizes={imageSizes}
+                                copyInfo={downloadCopyInfo}
+                            />
+                        </div>
+                    }
                 </div>
                 <div
                     className={mediaCardStyles.media}
                     onClick={this.handleClick}
                 >
                     <img alt={title} src={image} />
-                    <div className={mediaCardStyles.mediaOverlay}>
+                    <div className={mediaCardStyles.cover}>
                         {!!icon &&
                             <Icon name={icon} className={mediaCardStyles.mediaIcon} />
                         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -26,7 +26,7 @@ type Props = {
     /** The URL of the presented image */
     image: string,
     /** List of available image sizes */
-    imageSizes?: Array<{url: string | number, label: string}>,
+    imageSizes?: Array<{url: string, label: string}>,
 };
 
 @observer

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
@@ -22,7 +22,7 @@ const handleClick = (id) => {
     onClick={handleClick}
     selected={state.selected}
     meta="image/png, 3,2 MB"
-    title="Lorempixel"
+    title="Lorempixel sdsdasdsd sdadasd asdasd"
     image={'http://lorempixel.com/300/200'}
 />
 ```

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
@@ -27,13 +27,15 @@ const handleSelection = () => {
 };
 
 const handleClick = (id) => {
-    alert(`You clicked me and my id is "${id}"`);
+    setState({
+        selected: !state.selected,
+    });
 };
 
 <div style={{backgroundColor: '#e5e5e5', padding: 20}}>
     <MediaCard
         id="What is luv?"
-        icon="pencil"
+        icon="check"
         onSelectionChange={handleSelection}
         onClick={handleClick}
         selected={state.selected}
@@ -41,6 +43,8 @@ const handleClick = (id) => {
         title="Lorempixel sdsdasdsd sdadasd asdasd"
         image={'http://lorempixel.com/300/200'}
         imageSizes={imageSizes}
+        downloadCopyInfo="Copy URL"
+        showCover={state.selected}
     />
 </div>
 ```

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
@@ -44,7 +44,7 @@ const handleClick = (id) => {
         title="Lorempixel sdsdasdsd sdadasd asdasd"
         image={'http://lorempixel.com/300/200'}
         imageSizes={imageSizes}
-        downloadCopyInfo="Copy URL"
+        downloadCopyText="Copy URL"
         showCover={state.selected}
     />
 </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
@@ -1,4 +1,5 @@
-The `MediaCard` is useful for displaying a list of selectable images.
+The `MediaCard` is useful for displaying a list of selectable images. When the `imageSizes` property is set a button
+will be shown in the header of the `MediaCard` which will open a list of copyable URLs on click.
 
 ```
 initialState = {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
@@ -30,15 +30,17 @@ const handleClick = (id) => {
     alert(`You clicked me and my id is "${id}"`);
 };
 
-<MediaCard
-    id="What is luv?"
-    icon="pencil"
-    onSelectionChange={handleSelection}
-    onClick={handleClick}
-    selected={state.selected}
-    meta="image/png, 3,2 MB"
-    title="Lorempixel sdsdasdsd sdadasd asdasd"
-    image={'http://lorempixel.com/300/200'}
-    imageSizes={imageSizes}
-/>
+<div style={{backgroundColor: '#e5e5e5', padding: 20}}>
+    <MediaCard
+        id="What is luv?"
+        icon="pencil"
+        onSelectionChange={handleSelection}
+        onClick={handleClick}
+        selected={state.selected}
+        meta="image/png, 3,2 MB"
+        title="Lorempixel sdsdasdsd sdadasd asdasd"
+        image={'http://lorempixel.com/300/200'}
+        imageSizes={imageSizes}
+    />
+</div>
 ```

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/README.md
@@ -5,6 +5,21 @@ initialState = {
     selected: false,
 };
 
+const imageSizes = [
+    {
+        url: 'http://lorempixel.com/300/200',
+        label: '300/200',
+    },
+    {
+        url: 'http://lorempixel.com/600/300',
+        label: '600/300',
+    },
+    {
+        url: 'http://lorempixel.com/150/200',
+        label: '150/200',
+    }
+];
+
 const handleSelection = () => {
     setState({
         selected: !state.selected,
@@ -24,5 +39,6 @@ const handleClick = (id) => {
     meta="image/png, 3,2 MB"
     title="Lorempixel sdsdasdsd sdadasd asdasd"
     image={'http://lorempixel.com/300/200'}
+    imageSizes={imageSizes}
 />
 ```

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/downloadListItem.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/downloadListItem.scss
@@ -1,0 +1,54 @@
+@import 'sulu-admin-bundle/containers/Application/colors.scss';
+
+$itemTextColor: $black;
+$itemTextColorActive: $shakespeare;
+
+.item {
+    display: block;
+
+    button {
+        cursor: pointer;
+        border: 0;
+        color: $itemTextColor;
+        background: transparent;
+
+        &:hover {
+            color: $itemTextColorActive;
+
+            .copy-info {
+                opacity: 1;
+            }
+        }
+    }
+
+    &.copying {
+        button {
+            animation: blink .2s step-start 0s 2;
+        }
+    }
+}
+
+.item-content {
+    min-width: 200px;
+    padding: 5px 20px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.copy-info {
+    opacity: 0;
+}
+
+@keyframes blink {
+    0% {
+        color: $itemTextColorActive;
+    }
+
+    50% {
+        color: $itemTextColor;
+    }
+
+    100% {
+        color: $itemTextColorActive;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/downloadListItem.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/downloadListItem.scss
@@ -15,7 +15,7 @@ $itemTextColorActive: $shakespeare;
         &:hover {
             color: $itemTextColorActive;
 
-            .copy-info {
+            .copy-text {
                 opacity: 1;
             }
         }
@@ -35,7 +35,7 @@ $itemTextColorActive: $shakespeare;
     justify-content: space-between;
 }
 
-.copy-info {
+.copy-text {
     opacity: 0;
 }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -44,7 +44,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     border-radius: $mediaCardBorderRadius 0 0 0;
     background-color: $headerBackgroundColor;
 
-    .noDownloadList & {
+    .no-download-list & {
         border-radius: $mediaCardBorderRadius $mediaCardBorderRadius 0 0;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -18,6 +18,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     border-radius: $containerBorderRadius;
     border: 1px solid $mediaCardBorderColor;
     background-color: $containerBackgroundColor;
+    overflow: hidden;
 
     &:hover,
     &.selected {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -7,6 +7,12 @@ $mediaOverlayBackgroundColor: rgba($black, .5);
 $mediaOverlayIconTextColor: $white;
 $containerBorderRadius: 3px;
 $imageBorderRadiusBottom: $containerBorderRadius;
+$downloadButtonBackgroundColor: $white;
+$downloadButtonBackgroundColorActive: $shakespeare;
+$downloadButtonTextColor: $alto;
+$downloadButtonTextColorActive: $white;
+$downloadButtonBorderColor: $alto;
+$downloadButtonBorderColorActive: $shakespeare;
 
 .media-card {
     width: 260px;
@@ -23,8 +29,8 @@ $imageBorderRadiusBottom: $containerBorderRadius;
 }
 
 .header {
+    display: flex;
     position: relative;
-    padding: 20px;
     cursor: pointer;
 }
 
@@ -34,6 +40,28 @@ $imageBorderRadiusBottom: $containerBorderRadius;
     left: 0;
     width: 100%;
     height: 100%;
+}
+
+.description {
+    width: 230px;
+    padding: 20px;
+}
+
+.download-button {
+    width: 32px;
+    border: 0;
+    font-size: 12px;
+    cursor: pointer;
+    background-color: $downloadButtonBackgroundColor;
+    color: $downloadButtonTextColor;
+    border-left: 1px solid $downloadButtonBorderColor;
+
+    &:hover,
+    &:active {
+        background-color: $downloadButtonBackgroundColorActive;
+        color: $downloadButtonTextColorActive;
+        border-left: 1px solid $downloadButtonBorderColorActive;
+    }
 }
 
 .checkbox {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -1,13 +1,12 @@
 @import 'sulu-admin-bundle/containers/Application/colors.scss';
 
 $mediaCardBorderColor: $alto;
-$containerBackgroundColor: $white;
+$headerBackgroundColor: $white;
 $metaInfoTextColor: $silverChalice;
-$mediaOverlayBackgroundColor: rgba($black, .5);
-$mediaOverlayIconTextColor: $white;
-$containerBorderRadius: 3px;
-$imageBorderRadiusBottom: $containerBorderRadius;
-$downloadButtonBackgroundColor: $white;
+$coverBackgroundColor: rgba($black, .5);
+$coverIconTextColor: $white;
+$mediaCardBorderRadius: 3px;
+$downloadButtonBackgroundColor: $headerBackgroundColor;
 $downloadButtonBackgroundColorActive: $shakespeare;
 $downloadButtonTextColor: $alto;
 $downloadButtonTextColorActive: $white;
@@ -15,10 +14,6 @@ $downloadButtonBorderColorActive: $shakespeare;
 
 .media-card {
     width: 260px;
-    border-radius: $containerBorderRadius;
-    border: 1px solid $mediaCardBorderColor;
-    background-color: $containerBackgroundColor;
-    overflow: hidden;
 
     &:hover,
     &.selected {
@@ -32,7 +27,6 @@ $downloadButtonBorderColorActive: $shakespeare;
     display: flex;
     position: relative;
     cursor: pointer;
-    border-bottom: 1px solid $mediaCardBorderColor;
 }
 
 .header-click-area {
@@ -44,24 +38,35 @@ $downloadButtonBorderColorActive: $shakespeare;
 }
 
 .description {
-    width: 230px;
+    width: 100%;
     padding: 20px;
+    border-bottom: 1px solid $mediaCardBorderColor;
+    border-radius: $mediaCardBorderRadius 0 0 0;
+    background-color: $headerBackgroundColor;
+
+    .noDownloadList & {
+        border-radius: $mediaCardBorderRadius $mediaCardBorderRadius 0 0;
+    }
 }
 
 .download-button {
     width: 32px;
+    height: 100%;
     border: 0;
     font-size: 12px;
     cursor: pointer;
     background-color: $downloadButtonBackgroundColor;
     color: $downloadButtonTextColor;
-    border-left: 1px solid $mediaCardBorderColor;
+    border-width: 0 0 1px 1px;
+    border-style: solid;
+    border-color: $mediaCardBorderColor;
+    border-radius: 0 $mediaCardBorderRadius 0 0;
 
     &:hover,
-    &:active {
+    &.active {
         background-color: $downloadButtonBackgroundColorActive;
         color: $downloadButtonTextColorActive;
-        border-left: 1px solid $downloadButtonBorderColorActive;
+        border-color: $downloadButtonBackgroundColorActive;
     }
 }
 
@@ -89,21 +94,22 @@ $downloadButtonBorderColorActive: $shakespeare;
 }
 
 .media {
-    overflow: hidden;
     position: relative;
     cursor: pointer;
     background-image: url("./checkerBackground.gif");
+    overflow: hidden;
 
     img {
         width: 100%;
         display: block;
         transform: scale(1);
-        border-radius: 0 0 $imageBorderRadiusBottom;
         transition: transform .2s linear;
+        border-radius: 0 0 $mediaCardBorderRadius $mediaCardBorderRadius;
     }
 
-    &:hover {
-        .media-overlay {
+    &:hover,
+    .show-cover & {
+        .cover {
             opacity: 1;
         }
 
@@ -113,7 +119,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     }
 }
 
-.media-overlay {
+.cover {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -123,12 +129,12 @@ $downloadButtonBorderColorActive: $shakespeare;
     width: 100%;
     height: 100%;
     opacity: 0;
-    background-color: $mediaOverlayBackgroundColor;
+    background-color: $coverBackgroundColor;
     transition: opacity .2s linear;
 }
 
 .media-icon {
     display: flex;
-    color: $mediaOverlayIconTextColor;
+    color: $coverIconTextColor;
     font-size: 20px;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -1,7 +1,7 @@
 @import 'sulu-admin-bundle/containers/Application/colors.scss';
 
+$mediaCardBorderColor: $alto;
 $containerBackgroundColor: $white;
-$containerBorderColor: $alto;
 $metaInfoTextColor: $silverChalice;
 $mediaOverlayBackgroundColor: rgba($black, .5);
 $mediaOverlayIconTextColor: $white;
@@ -11,13 +11,12 @@ $downloadButtonBackgroundColor: $white;
 $downloadButtonBackgroundColorActive: $shakespeare;
 $downloadButtonTextColor: $alto;
 $downloadButtonTextColorActive: $white;
-$downloadButtonBorderColor: $alto;
 $downloadButtonBorderColorActive: $shakespeare;
 
 .media-card {
     width: 260px;
     border-radius: $containerBorderRadius;
-    border: 1px solid $containerBorderColor;
+    border: 1px solid $mediaCardBorderColor;
     background-color: $containerBackgroundColor;
 
     &:hover,
@@ -32,6 +31,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     display: flex;
     position: relative;
     cursor: pointer;
+    border-bottom: 1px solid $mediaCardBorderColor;
 }
 
 .header-click-area {
@@ -54,7 +54,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     cursor: pointer;
     background-color: $downloadButtonBackgroundColor;
     color: $downloadButtonTextColor;
-    border-left: 1px solid $downloadButtonBorderColor;
+    border-left: 1px solid $mediaCardBorderColor;
 
     &:hover,
     &:active {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
@@ -35,7 +35,7 @@ test('Render a MediaCard with download list', () => {
             title="Test"
             meta="Test/Test"
             imageSizes={imageSizes}
-            downloadCopyInfo="Copy URL"
+            downloadCopyText="Copy URL"
             image="http://lorempixel.com/300/200"
         />
     );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import {mount, render} from 'enzyme';
+import pretty from 'pretty';
 import React from 'react';
 import MediaCard from '../MediaCard';
 
@@ -8,10 +9,39 @@ test('Render a simple MediaCard component', () => {
         <MediaCard
             title="Test"
             meta="Test/Test"
-        >
-            <img src="http://lorempixel.com/300/200" />
-        </MediaCard>
+            image="http://lorempixel.com/300/200"
+        />
     )).toMatchSnapshot();
+});
+
+test('Render a MediaCard with download list', () => {
+    const imageSizes = [
+        {
+            url: 'http://lorempixel.com/300/200',
+            label: '300/200',
+        },
+        {
+            url: 'http://lorempixel.com/600/300',
+            label: '600/300',
+        },
+        {
+            url: 'http://lorempixel.com/150/200',
+            label: '150/200',
+        },
+    ];
+
+    const masonry = mount(
+        <MediaCard
+            title="Test"
+            meta="Test/Test"
+            imageSizes={imageSizes}
+            downloadCopyInfo="Copy URL"
+            image="http://lorempixel.com/300/200"
+        />
+    );
+
+    masonry.instance().openDownloadList();
+    expect(pretty(document.body.innerHTML)).toMatchSnapshot();
 });
 
 test('Clicking on an item should call the responsible handler on the MediaCard component', () => {
@@ -19,21 +49,20 @@ test('Clicking on an item should call the responsible handler on the MediaCard c
     const selectionSpy = jest.fn();
     const itemId = 'test';
 
-    const masonry = mount(
+    const mediaCard = mount(
         <MediaCard
             id={itemId}
             title="Test"
             meta="Test/Test"
             onClick={clickSpy}
             onSelectionChange={selectionSpy}
-        >
-            <img src="http://lorempixel.com/300/200" />
-        </MediaCard>
+            image="http://lorempixel.com/300/200"
+        />
     );
 
-    masonry.find('MediaCard .media').simulate('click');
+    mediaCard.find('MediaCard .media').simulate('click');
     expect(clickSpy).toHaveBeenCalledWith(itemId);
 
-    masonry.find('MediaCard .header').simulate('click');
+    mediaCard.find('MediaCard .description').simulate('click');
     expect(selectionSpy).toHaveBeenCalledWith(itemId, true);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -5,15 +5,15 @@ exports[`Render a MediaCard with download list 1`] = `
   <div data-reactroot=\\"\\" class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
       <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"itemContent\\"><!-- react-text: 6 -->300/200<!-- /react-text --><span class=\\"copyText\\"></span></span>
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"itemContent\\"><!-- react-text: 6 -->300/200<!-- /react-text --><span class=\\"copyText\\">Copy URL</span></span>
         </button>
       </li>
       <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"itemContent\\"><!-- react-text: 11 -->600/300<!-- /react-text --><span class=\\"copyText\\"></span></span>
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"itemContent\\"><!-- react-text: 11 -->600/300<!-- /react-text --><span class=\\"copyText\\">Copy URL</span></span>
         </button>
       </li>
       <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"itemContent\\"><!-- react-text: 16 -->150/200<!-- /react-text --><span class=\\"copyText\\"></span></span>
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"itemContent\\"><!-- react-text: 16 -->150/200<!-- /react-text --><span class=\\"copyText\\">Copy URL</span></span>
         </button>
       </li>
     </ul>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -5,15 +5,15 @@ exports[`Render a MediaCard with download list 1`] = `
   <div data-reactroot=\\"\\" class=\\"container\\">
     <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
       <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"itemContent\\"><!-- react-text: 6 -->300/200<!-- /react-text --><span class=\\"copyInfo\\">Copy URL</span></span>
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"itemContent\\"><!-- react-text: 6 -->300/200<!-- /react-text --><span class=\\"copyText\\"></span></span>
         </button>
       </li>
       <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"itemContent\\"><!-- react-text: 11 -->600/300<!-- /react-text --><span class=\\"copyInfo\\">Copy URL</span></span>
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"itemContent\\"><!-- react-text: 11 -->600/300<!-- /react-text --><span class=\\"copyText\\"></span></span>
         </button>
       </li>
       <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"itemContent\\"><!-- react-text: 16 -->150/200<!-- /react-text --><span class=\\"copyInfo\\">Copy URL</span></span>
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"itemContent\\"><!-- react-text: 16 -->150/200<!-- /react-text --><span class=\\"copyText\\"></span></span>
         </button>
       </li>
     </ul>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -1,63 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render a MediaCard with download list 1`] = `
+"<div>
+  <div data-reactroot=\\"\\" class=\\"container\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; max-height: 0px; position: fixed; pointer-events: auto; left: 10px;\\">
+      <li class=\\"item\\">
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"itemContent\\"><!-- react-text: 6 -->300/200<!-- /react-text --><span class=\\"copyInfo\\">Copy URL</span></span>
+        </button>
+      </li>
+      <li class=\\"item\\">
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"itemContent\\"><!-- react-text: 11 -->600/300<!-- /react-text --><span class=\\"copyInfo\\">Copy URL</span></span>
+        </button>
+      </li>
+      <li class=\\"item\\">
+        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"itemContent\\"><!-- react-text: 16 -->150/200<!-- /react-text --><span class=\\"copyInfo\\">Copy URL</span></span>
+        </button>
+      </li>
+    </ul>
+  </div>
+</div>
+<div>
+  <div data-reactroot=\\"\\" class=\\"backdrop\\"></div>
+</div>"
+`;
+
 exports[`Render a simple MediaCard component 1`] = `
 <div
-  class="mediaCard"
+  class="mediaCard noDownloadList"
 >
   <div
     class="header"
   >
     <div
-      class="title"
+      class="description"
     >
-      <label
-        class="label"
+      <div
+        class="title"
       >
-        <span
-          class="switch checkbox dark checkbox"
+        <label
+          class="label"
         >
-          <input
-            type="checkbox"
-          />
-          <span />
-        </span>
-        <div>
-          <div
-            class="titleText"
+          <span
+            class="switch checkbox dark checkbox"
           >
+            <input
+              type="checkbox"
+            />
+            <span />
+          </span>
+          <div>
             <div
-              aria-label="Test"
-              class="croppedText"
-              title="Test"
+              class="titleText"
             >
               <div
-                aria-hidden="true"
-                class="front"
+                aria-label="Test"
+                class="croppedText"
+                title="Test"
               >
-                Te
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  st
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Test
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Te
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    st
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Test
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </label>
-    </div>
-    <div
-      class="meta"
-    >
-      Test/Test
+        </label>
+      </div>
+      <div
+        class="meta"
+      >
+        Test/Test
+      </div>
     </div>
   </div>
   <div
@@ -65,9 +93,10 @@ exports[`Render a simple MediaCard component 1`] = `
   >
     <img
       alt="Test"
+      src="http://lorempixel.com/300/200"
     />
     <div
-      class="mediaOverlay"
+      class="cover"
     />
   </div>
 </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
@@ -4,13 +4,15 @@
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu.git",
     "dependencies": {
-        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js",
-        "react": "^15.6.0",
         "classnames": "^2.2.5",
-        "mobx-react": "^4.2.1"
+        "mobx-react": "^4.2.1",
+        "react": "^15.6.0",
+        "react-clipboard.js": "^1.1.2",
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
     },
     "devDependencies": {
-        "enzyme": "^2.9.1"
+        "enzyme": "^2.9.1",
+        "pretty": "^2.0.0"
     },
     "peerDependencies": {
         "mobx": ">=3.2.2"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

A dropdown inside the `MediaCard` component which contains the download urls for the different sizes of the image.

#### Why?

URLs of the different image sizes need to be copyable.

#### Example Usage

~~~js
const imageSizes = [
    {
        url: 'http://lorempixel.com/300/200',
        label: '300/200',
    },
    {
        url: 'http://lorempixel.com/600/300',
        label: '600/300',
    },
    {
        url: 'http://lorempixel.com/150/200',
        label: '150/200',
    }
];

<div style={{backgroundColor: '#e5e5e5', padding: 20}}>
    <MediaCard
        id="What is luv?"
        icon="check"
        onSelectionChange={handleSelection}
        onClick={handleClick}
        selected={state.selected}
        meta="image/png, 3,2 MB"
        title="Lorempixel sdsdasdsd sdadasd asdasd"
        image={'http://lorempixel.com/300/200'}
        imageSizes={imageSizes}
        downloadCopyInfo="Copy URL"
        showCover={state.selected}
    />
</div>
~~~

#### BC Breaks/Deprecations

Following `props` were added:

- imageSizes: Array<{url: string, label: string}> 
- downloadCopyInfo: string
- showCover: boolean

Additionally the  styling of the component changed as the result of adding the download dropdown button.
