### PR TITLE
Renamed argument in `onChange` of `Input` component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -9,7 +9,7 @@ type Props = {
     type: string,
     value?: string,
     placeholder?: string,
-    onChange: (password: string) => void,
+    onChange: (value: string) => void,
 };
 
 export default class Input extends React.PureComponent<Props> {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Renamed argument in `onChange`prop of `Input` component from `password` to `value` 

#### Why?

The `Input` can have different `types`. Calling the argument `password` makes no sense.
