### PR TITLE
moved registry tests to correct folders

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/registries/FieldRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/registries/FieldRegistry.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import fieldRegistry from '../registries/FieldRegistry';
+import fieldRegistry from '../../registries/FieldRegistry';
 
 beforeEach(() => {
     fieldRegistry.clear();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/registries/ViewRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/registries/ViewRegistry.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import viewRegistry from '../registries/ViewRegistry';
+import viewRegistry from '../../registries/ViewRegistry';
 
 beforeEach(() => {
     viewRegistry.clear();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/registries/RouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/registries/RouteRegistry.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import routeRegistry from '../registries/RouteRegistry';
+import routeRegistry from '../../registries/RouteRegistry';
 
 beforeEach(() => {
     routeRegistry.clear();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #3559
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The folder structure in the tests for registries was not aligned with the actual code.

#### Why?

We want the folder structures to reflect each other.