### PR TITLE
Added rawurldecode to decode path-info before searching for route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX     #3573 [RouteBundle]             Added rawurldecode to decode path-info before searching for route
+    * HOTFIX     #3573 [ContentBundle]           Added rawurldecode to decode path-info before searching for route
+    * HOTFIX     #3573 [CustomUrlBundle]         Added rawurldecode to decode path-info before searching for route
+
 * 1.6.6 (2017-10-12)
     * ENHANCEMENT #3557 [ContentBundle]           Added option to decorate index name for document types
     * HOTFIX      #3555 [ContentBundle]           Fixed "awkward" state of documents after copy-locale

--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -64,7 +64,7 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
      */
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
-        $url = rtrim(sprintf('%s%s', $request->getHost(), $request->getRequestUri()), '/');
+        $url = $this->decodeUrl(rtrim(sprintf('%s%s', $request->getHost(), $request->getRequestUri()), '/'));
         if (substr($url, -5, 5) === '.html') {
             $url = substr($url, 0, -5);
         }
@@ -116,7 +116,7 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
     {
         $webspace = $portalInformation->getWebspace();
         $routeDocument = $this->customUrlManager->findRouteByUrl(
-            $url,
+            rawurldecode($url),
             $webspace->getKey()
         );
 
@@ -128,7 +128,7 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
         }
 
         $customUrlDocument = $this->customUrlManager->findByUrl(
-            $url,
+            rawurldecode($url),
             $webspace->getKey(),
             $routeDocument->getTargetDocument()->getTargetLocale()
         );
@@ -165,5 +165,18 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
                 $customUrlDocument->getDomainParts()
             ),
         ];
+    }
+
+    /**
+     * Server encodes the url and symfony does not encode it
+     * Symfony decodes this data here https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L91.
+     *
+     * @param $pathInfo
+     *
+     * @return string
+     */
+    private function decodeUrl($pathInfo)
+    {
+        return rawurldecode($pathInfo);
     }
 }

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Unit/Request/CustomUrlRequestProcessorTest.php
@@ -32,14 +32,15 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
     public function dataProvider()
     {
         return [
-            ['sulu.io', '/test', 'sulu.io/test', false],
-            ['sulu.io', '/test.html', 'sulu.io/test', false],
-            ['sulu.io', '/test.html', 'sulu.io/test', true, true],
-            ['sulu.io', '/test.html', 'sulu.io/test', true, false, false],
-            ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, false],
-            ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, false, true],
-            ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, true, false, WorkflowStage::PUBLISHED],
-            ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, true, false, WorkflowStage::TEST],
+            ['sulu.io', 'test', 'sulu.io/test', false],
+            ['sulu.io', 'täst', 'sulu.io/täst', false],
+            ['sulu.io', 'test.html', 'sulu.io/test', false],
+            ['sulu.io', 'test.html', 'sulu.io/test', true, true],
+            ['sulu.io', 'test.html', 'sulu.io/test', true, false, false],
+            ['sulu.io', 'test.html', 'sulu.io/test', true, false, true, false],
+            ['sulu.io', 'test.html', 'sulu.io/test', true, false, true, false, true],
+            ['sulu.io', 'test.html', 'sulu.io/test', true, false, true, true, false, WorkflowStage::PUBLISHED],
+            ['sulu.io', 'test.html', 'sulu.io/test', true, false, true, true, false, WorkflowStage::TEST],
         ];
     }
 
@@ -67,10 +68,10 @@ class CustomUrlRequestProcessorTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->prophesize(Request::class);
         $request->getHost()->willReturn($host);
-        $request->getRequestUri()->willReturn($requestedUri);
-        $request->getPathInfo()->willReturn($requestedUri);
+        $request->getRequestUri()->willReturn('/' . rawurlencode($requestedUri));
+        $request->getPathInfo()->willReturn('/' . rawurlencode($requestedUri));
         $request->getScheme()->willReturn('http');
-        $request->getUri()->willReturn('http://' . $host . $requestedUri);
+        $request->getUri()->willReturn('http://' . $host . '/' . rawurlencode($requestedUri));
         $request->reveal()->query = new ParameterBag();
         $request->reveal()->request = new ParameterBag();
 

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -95,8 +95,11 @@ class RouteProvider implements RouteProviderInterface
      */
     public function getRouteCollectionForRequest(Request $request)
     {
+        // server encodes the url and symfony does not encode it
+        // symfony decodes this data here https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L91
+        $path = rawurldecode($request->getPathInfo());
+
         $collection = new RouteCollection();
-        $path = $request->getPathInfo();
         $prefix = $this->requestAnalyzer->getResourceLocatorPrefix();
 
         if (!empty($prefix) && strpos($path, $prefix) === 0) {

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -146,6 +146,34 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
     }
 
+    public function testGetRouteCollectionForRequestWithUmlauts()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn(rawurlencode('/de/käße'));
+        $request->getLocale()->willReturn('de');
+
+        $routeEntity = $this->prophesize(RouteInterface::class);
+        $routeEntity->getEntityClass()->willReturn('Example');
+        $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/käße');
+        $routeEntity->isHistory()->willReturn(false);
+        $routeEntity->getLocale()->willReturn('de');
+
+        $this->routeRepository->findByPath('/käße', 'de')->willReturn($routeEntity->reveal());
+        $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(true);
+        $this->defaultsProvider->getByEntity('Example', '1', 'de')->willReturn(['test' => 1]);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(1, $collection);
+        $routes = array_values(iterator_to_array($collection->getIterator()));
+
+        $this->assertEquals('/de/käße', $routes[0]->getPath());
+        $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
+    }
+
     public function testGetRouteCollectionForRequestTwice()
     {
         $request = $this->prophesize(Request::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -102,7 +102,7 @@ class ContentRouteProvider implements RouteProviderInterface
             return $collection;
         }
 
-        $resourceLocator = $attributes->getAttribute('resourceLocator');
+        $resourceLocator = $this->decodePathInfo($attributes->getAttribute('resourceLocator'));
         $prefix = $attributes->getAttribute('resourceLocatorPrefix');
 
         $pathInfo = $this->decodePathInfo($request->getPathInfo());

--- a/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
+++ b/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
@@ -41,11 +41,8 @@ class CustomUrlRouteProvider implements RouteProviderInterface
      */
     private $environment;
 
-    public function __construct(
-        RequestAnalyzerInterface $requestAnalyzer,
-        PathBuilder $pathBuilder,
-        $environment
-    ) {
+    public function __construct(RequestAnalyzerInterface $requestAnalyzer, PathBuilder $pathBuilder, $environment)
+    {
         $this->requestAnalyzer = $requestAnalyzer;
         $this->pathBuilder = $pathBuilder;
         $this->environment = $environment;
@@ -93,7 +90,7 @@ class CustomUrlRouteProvider implements RouteProviderInterface
         $collection->add(
             uniqid('custom_url_route_', true),
             new Route(
-                $request->getPathInfo(),
+                $this->decodePathInfo($request->getPathInfo()),
                 [
                     '_custom_url' => $customUrlDocument,
                     '_webspace' => $this->requestAnalyzer->getWebspace(),
@@ -147,7 +144,7 @@ class CustomUrlRouteProvider implements RouteProviderInterface
         $collection->add(
             uniqid('custom_url_route_', true),
             new Route(
-                $request->getPathInfo(),
+                $this->decodePathInfo($request->getPathInfo()),
                 [
                     '_controller' => 'SuluWebsiteBundle:Redirect:redirect',
                     '_finalized' => true,
@@ -169,5 +166,18 @@ class CustomUrlRouteProvider implements RouteProviderInterface
     private function getRoutesPath($webspaceKey)
     {
         return $this->pathBuilder->build(['%base%', $webspaceKey, '%custom_urls%', '%custom_urls_routes%']);
+    }
+
+    /**
+     * Server encodes the url and symfony does not encode it
+     * Symfony decodes this data here https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L91.
+     *
+     * @param $pathInfo
+     *
+     * @return string
+     */
+    private function decodePathInfo($pathInfo)
+    {
+        return rawurldecode($pathInfo);
     }
 }

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/CustomUrlRouteProviderTest.php
@@ -22,7 +22,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
 
-class RouteProviderTest extends \PHPUnit_Framework_TestCase
+class CustomUrlRouteProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function dataProvider()
     {
@@ -34,6 +34,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
             ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, false],
             ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, true, WorkflowStage::PUBLISHED],
             ['sulu.io', '/test.html', 'sulu.io/test', true, false, true, true, WorkflowStage::TEST],
+            ['sulu.io', '/käße.html', 'sulu.io/kaese', true, false, true, true, WorkflowStage::TEST],
         ];
     }
 
@@ -66,7 +67,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $request->getHost()->willReturn($host);
         $request->getRequestUri()->willReturn($requestedUri);
-        $request->getPathInfo()->willReturn($requestedUri);
+        $request->getPathInfo()->willReturn(rawurlencode($requestedUri));
         $request->getScheme()->willReturn('http');
 
         if (!$exists) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes an issue with umlauts in the source. The server encodes the URL and Symfony returns this in getPathInfo. We use this to find the redirect-route. This leads into a not found route.

#### Why?

Routes with `ß` or umlauts does not work.

#### To Do

- [x] Is it needed for content?
- [x] Tests
