### PR TITLE
Trim trailing slash

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/type/piwik.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Analytics/type/piwik.html.twig
@@ -3,11 +3,11 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-        var u="{{ analytics.content.url }}";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        var u="{{ analytics.content.url|trim('/') }}";
+        _paq.push(['setTrackerUrl', u+'/piwik.php']);
         _paq.push(['setSiteId', '{{ analytics.content.siteId }}']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
     })();
 </script>
-<noscript><p><img src="{{ analytics.content.url }}/piwik.php?idsite={{ analytics.content.siteId }}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="{{ analytics.content.url|trim('/') }}/piwik.php?idsite={{ analytics.content.siteId }}" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
Trim trailing slash to avoid double slashes and to always get a correct URL.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Replaces double slashes in piwik tracker url

