### PR TITLE
Refactored with-toolbar to use inheritance-inversion

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
@@ -1,9 +1,9 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import {mount, render} from 'enzyme';
 import React from 'react';
+import {observable} from 'mobx';
+import {mount, render} from 'enzyme';
 import toolbarStorePool, {DEFAULT_STORE_KEY} from '../stores/ToolbarStorePool';
 import withToolbar from '../withToolbar';
-import {observable} from 'mobx';
 
 jest.mock('../stores/ToolbarStorePool', () => ({
     setToolbarConfig: jest.fn(),
@@ -63,10 +63,9 @@ test('Call life-cycle events of rendered component', () => {
         render = jest.fn();
     };
 
-    const ComponentWithToolbar = withToolbar(Component, () => {
-    });
+    const ComponentWithToolbar = withToolbar(Component, () => {});
 
-    let component = mount(<ComponentWithToolbar/>);
+    let component = mount(<ComponentWithToolbar />);
     expect(component.instance().componentWillMount).toBeCalled();
     expect(component.instance().render).toBeCalled();
 
@@ -85,17 +84,34 @@ test('Recall toolbar-function when changing observable', () => {
     };
 
     const ComponentWithToolbar = withToolbar(Component, function() {
-        return {disableAll: this.test}
+        return {disableAll: this.test};
     });
 
-    let component = mount(<ComponentWithToolbar/>);
+    let component = mount(<ComponentWithToolbar />);
 
     expect(toolbarStorePool.setToolbarConfig).toBeCalledWith(DEFAULT_STORE_KEY, {
-        disableAll: true
+        disableAll: true,
     });
 
     component.instance().test = false;
     expect(toolbarStorePool.setToolbarConfig).toBeCalledWith(DEFAULT_STORE_KEY, {
-        disableAll: false
+        disableAll: false,
     });
+});
+
+test('Throw error when component has property toolbarDisposer', () => {
+    const Component = class Component extends React.Component {
+        toolbarDisposer = true;
+
+        render() {
+            return <h1>Test</h1>;
+        }
+    };
+
+    const ComponentWithToolbar = withToolbar(Component, function() {
+        return {disableAll: this.test};
+    });
+
+    expect(() => mount(<ComponentWithToolbar />))
+        .toThrowError('Component passed to withToolbar cannot declare a property called "toolbarDisposer".');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -1,7 +1,7 @@
 // @flow
 import {autorun} from 'mobx';
-import React from 'react';
 import type {ComponentType} from 'react';
+import React from 'react';
 import {buildHocDisplayName} from '../../services/react';
 import type {ToolbarConfig} from './types';
 import toolbarStorePool, {DEFAULT_STORE_KEY} from './stores/ToolbarStorePool';
@@ -11,23 +11,29 @@ export default function withToolbar(
     toolbar: () => ToolbarConfig,
     toolbarStoreKey: string = DEFAULT_STORE_KEY
 ) {
-    const WithToolbarComponent = class extends React.Component<*> {
-        disposer: Function;
+    const WithToolbarComponent = class extends Component {
+        toolbarDisposer: Function;
 
-        setToolbarConfig = (component: React$Element<*>) => {
-            this.disposer = autorun(() => {
-                if (component) {
-                    toolbarStorePool.setToolbarConfig(toolbarStoreKey, toolbar.call(component));
-                }
+        componentWillMount() {
+            if (super.componentWillMount) {
+                super.componentWillMount();
+            }
+
+            this.toolbarDisposer = autorun(() => {
+                toolbarStorePool.setToolbarConfig(toolbarStoreKey, toolbar.call(this));
             });
-        };
+        }
 
         componentWillUnmount() {
-            this.disposer();
+            if (super.componentWillUnmount) {
+                super.componentWillUnmount();
+            }
+
+            this.toolbarDisposer();
         }
 
         render() {
-            return <Component ref={this.setToolbarConfig} {...this.props} />;
+            return super.render();
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -1,13 +1,12 @@
 // @flow
 import {autorun} from 'mobx';
-import type {ComponentType} from 'react';
-import React from 'react';
+import type {Component} from 'react';
 import {buildHocDisplayName} from '../../services/react';
 import type {ToolbarConfig} from './types';
 import toolbarStorePool, {DEFAULT_STORE_KEY} from './stores/ToolbarStorePool';
 
 export default function withToolbar(
-    Component: ComponentType<*>,
+    Component: Class<Component<*, *>>,
     toolbar: () => ToolbarConfig,
     toolbarStoreKey: string = DEFAULT_STORE_KEY
 ) {
@@ -15,6 +14,10 @@ export default function withToolbar(
         toolbarDisposer: Function;
 
         componentWillMount() {
+            if (super.hasOwnProperty('toolbarDisposer')) {
+                throw new Error('Component passed to withToolbar cannot declare a property called "toolbarDisposer".');
+            }
+
             if (super.componentWillMount) {
                 super.componentWillMount();
             }
@@ -30,10 +33,6 @@ export default function withToolbar(
             }
 
             this.toolbarDisposer();
-        }
-
-        render() {
-            return super.render();
         }
     };
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR refactors the `withToolbar` high-order-component to use inheritance inversion.

 #### Why?

This improves the stackability of such functions (in favor of upcoming `withSidebar` function).

See https://medium.com/@franleplant/react-higher-order-components-in-depth-cf9032ee6c3e
