### PR TITLE
Move webpack configuration to this repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tests/app/logs
 /tests/Resources/cache
 /vendor
+/web
 
 # Composer
 /composer.lock

--- a/bin/travis/script_js.sh
+++ b/bin/travis/script_js.sh
@@ -4,6 +4,7 @@ EXIT_STATUS=0
 npm run lint:js || EXIT_STATUS=$?
 npm run lint:scss || EXIT_STATUS=$?
 npm run flow || EXIT_STATUS=$?
+npm run styleguide:build || EXIT_STATUS=$?
 npm test || EXIT_STATUS=$?
 
 exit $EXIT_STATUS

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "sulu-media-bundle": "file:src/Sulu/Bundle/MediaBundle/Resources/js"
     },
     "devDependencies": {
+        "autoprefixer": "^7.1.5",
         "babel-core": "^6.25.0",
         "babel-eslint": "^7.2.3",
         "babel-loader": "^7.1.1",
@@ -38,6 +39,7 @@
         "jest": "^21.1.0",
         "mobx": "^3.2.2",
         "null-loader": "^0.1.1",
+        "postcss-calc": "^6.0.1",
         "postcss-hexrgba": "^1.0.0",
         "postcss-import": "^10.0.0",
         "postcss-loader": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu.git",
     "scripts": {
+        "build": "webpack -p",
         "lint:js": "eslint .",
         "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
         "flow": "flow",
@@ -32,6 +33,7 @@
         "eslint-plugin-flowtype": "^2.34.0",
         "eslint-plugin-import": "^2.7.0",
         "eslint-plugin-react": "^7.0.1",
+        "extract-text-webpack-plugin": "^3.0.1",
         "file-loader": "^0.11.2",
         "flow-bin": "^0.54.0",
         "glob": "^7.1.2",
@@ -50,7 +52,9 @@
         "react-test-renderer": "^15.6.1",
         "stylelint": "^7.12.0",
         "stylelint-config-standard": "^16.0.0",
-        "webpack": "^3.5.6"
+        "webpack": "^3.5.6",
+        "webpack-clean-obsolete-chunks": "^0.2.0",
+        "webpack-manifest-plugin": "^1.3.2"
     },
     "jest": {
         "moduleNameMapper": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,11 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+module.exports = { //eslint-disable-line no-undef
+    plugins: {
+        'postcss-import': {},
+        'postcss-nested': {},
+        'postcss-simple-vars': {},
+        'postcss-calc': {},
+        'postcss-hexrgba': {},
+        'autoprefixer': {},
+    },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,100 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+/* eslint-disable import/no-nodejs-modules*/
+const path = require('path');
+const CleanObsoleteChunksPlugin = require('webpack-clean-obsolete-chunks');
+const webpack = require('webpack');
+const glob = require('glob');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const ManifestPlugin = require('webpack-manifest-plugin');
+
+const entries = glob.sync(
+    path.resolve(__dirname, 'src/Sulu/Bundle/*/Resources/js/index.js') // eslint-disable-line no-undef
+);
+const entriesCount = entries.length;
+const basePath = 'adminV2';
+
+entries.unshift('core-js/fn/array/includes');
+entries.unshift('core-js/fn/array/from');
+entries.unshift('core-js/fn/promise');
+entries.unshift('core-js/fn/symbol');
+entries.unshift('whatwg-fetch');
+entries.unshift('url-search-params-polyfill');
+
+module.exports = { // eslint-disable-line no-undef
+    entry: entries,
+    output: {
+        path: path.resolve('web'),
+        filename: basePath + '/[name].[chunkhash].js',
+    },
+    module: {
+        loaders: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                loader: 'babel-loader',
+            },
+            {
+                test: /\.(scss)$/,
+                use: ExtractTextPlugin.extract({
+                    use: [
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                modules: true,
+                                importLoaders: 1,
+                                camelCase: true,
+                                localIdentName: '[local]--[hash:base64:10]',
+                            },
+                        },
+                        'postcss-loader',
+                    ],
+                }),
+            },
+            {
+                test: /\.css/,
+                use: ExtractTextPlugin.extract({
+                    use: [
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                modules: false,
+                            },
+                        },
+                    ],
+                }),
+            },
+            {
+                test:/\.(jpg|gif|png)(\?.*$|$)/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: '/' + basePath + '/images/[name].[hash].[ext]',
+                        },
+                    },
+                ],
+            },
+            {
+                test:/\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: '/' + basePath + '/fonts/[name].[hash].[ext]',
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+    plugins: [
+        new CleanObsoleteChunksPlugin(),
+        new webpack.DefinePlugin({
+            BUNDLE_ENTRIES_COUNT: entriesCount,
+        }),
+        new ManifestPlugin({
+            fileName: basePath + '/manifest.json',
+        }),
+        new ExtractTextPlugin(basePath + '/main.[hash].css'),
+    ],
+};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR moves the webpack configuration from sulu-minimal to this repository. The postcss configuration can be moved completely to this repository, because it is loaded relatively from the basepath of the CSS file.

#### Why?

This is required for a functional testing setup (we need a javascript build in this repository to make acceptance tests using http://www.nightmarejs.org/).

#### To Do

- [x] Move webpack configuration
