### PR TITLE
Fix router binding query parameter when changing views

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -81,4 +81,6 @@ router.bindQuery('value', value, 'default');
 value.get(); // returns something
 
 value.set('anything'); // will navigate to /page?value=anything
+
+router.unbindQuery('value', value); // unbind to avoid leaking listeners
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -51,7 +51,11 @@ export default class Router {
         this.queryBindDefaults.set(key, defaultValue);
     }
 
-    @action unbindQuery(key: string) {
+    @action unbindQuery(key: string, value: observable) {
+        if (this.queryBinds.get(key) !== value) {
+            return;
+        }
+
         this.queryBinds.delete(key);
         this.queryBindDefaults.delete(key);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -117,7 +117,7 @@ export default class Router {
             const value = observableValue.get();
             if (value == this.queryBindDefaults.get(key)) {
                 searchParameters.delete(key);
-                break;
+                continue;
             }
 
             searchParameters.set(key, value);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -328,17 +328,41 @@ test('Bound query parameter should update state in router', () => {
         },
     });
 
-    const value = observable(1);
+    const page = observable(1);
 
     const history = createHistory();
     const router = new Router(history);
 
     router.navigate('list', {}, {page: 1});
-    router.bindQuery('page', value);
+    router.bindQuery('page', page);
     expect(router.query.page).toBe('1');
 
-    value.set(2);
+    page.set(2);
     expect(router.query.page).toBe('2');
+});
+
+test('Bound query parameter should update state in router with other default query parameters', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+        },
+    });
+
+    const page = observable();
+    const locale = observable('en');
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bindQuery('page', page, '1');
+    router.bindQuery('locale', locale);
+    router.navigate('list');
+
+    locale.set('de');
+    expect(history.location.search).toBe('?locale=de');
+    expect(router.query.locale).toBe('de');
 });
 
 test('Unbind query should remove query binding', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -374,8 +374,22 @@ test('Unbind query should remove query binding', () => {
     router.bindQuery('remove', value);
     expect(router.queryBinds.has('remove')).toBe(true);
 
-    router.unbindQuery('remove');
+    router.unbindQuery('remove', value);
     expect(router.queryBinds.has('remove')).toBe(false);
+});
+
+test('Unbind query should not remove query binding if it is assigned to a new observable', () => {
+    const history = createHistory();
+    const router = new Router(history);
+
+    const value = observable();
+    router.bindQuery('remove', value);
+    expect(router.queryBinds.get('remove')).toBe(value);
+
+    const newValue = observable();
+    router.bindQuery('remove', newValue);
+    router.unbindQuery('remove', value);
+    expect(router.queryBinds.get('remove')).toBe(newValue);
 });
 
 test('Do not add parameter to URL if undefined', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -40,7 +40,7 @@ class Form extends React.PureComponent<ViewProps> {
 
     componentWillUnmount() {
         this.formStore.destroy();
-        this.props.router.unbindQuery('locale');
+        this.props.router.unbindQuery('locale', this.formStore.locale);
     }
 
     handleSubmit = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -298,9 +298,10 @@ test('Should unbind the query parameter and destroy the store on unmount', () =>
     };
 
     const form = mount(<Form router={router} />);
+    const locale = form.find('Form').at(1).prop('store').locale;
 
-    expect(router.bindQuery).toBeCalledWith('locale', form.find('Form').at(1).prop('store').locale);
+    expect(router.bindQuery).toBeCalledWith('locale', locale);
 
     form.unmount();
-    expect(router.unbindQuery).toBeCalledWith('locale');
+    expect(router.unbindQuery).toBeCalledWith('locale', locale);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -54,9 +54,9 @@ class List extends React.PureComponent<ViewProps> {
             },
         } = router;
         this.datagridStore.destroy();
-        router.unbindQuery('page');
+        router.unbindQuery('page', this.page);
         if (locales) {
-            router.unbindQuery('locale');
+            router.unbindQuery('locale', this.locale);
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -149,8 +149,8 @@ test('Should unbind the query parameter and destroy the store on unmount', () =>
     expect(router.bindQuery).toBeCalledWith('locale', locale);
 
     list.unmount();
-    expect(router.unbindQuery).toBeCalledWith('page');
-    expect(router.unbindQuery).toBeCalledWith('locale');
+    expect(router.unbindQuery).toBeCalledWith('page', page);
+    expect(router.unbindQuery).toBeCalledWith('locale', locale);
 });
 
 test('Should unbind the query parameter and destroy the store on unmount without locale', () => {
@@ -173,7 +173,7 @@ test('Should unbind the query parameter and destroy the store on unmount without
     expect(router.bindQuery).not.toBeCalledWith('locale');
 
     list.unmount();
-    expect(router.unbindQuery).toBeCalledWith('page');
+    expect(router.unbindQuery).toBeCalledWith('page', page);
     expect(router.unbindQuery).not.toBeCalledWith('locale');
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -31,8 +31,8 @@ class MediaOverview extends React.PureComponent<ViewProps> {
     componentWillUnmount() {
         const {router} = this.props;
         this.disposer();
-        router.unbindQuery('locale');
-        router.unbindQuery('page');
+        router.unbindQuery('locale', this.page);
+        router.unbindQuery('page', this.locale);
         this.collectionStore.destroy();
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a second parameter in `unbindQuery`, which is the observable to delete. This should avoid deleting the wrong observable as binding by accident.

#### Why

This PR fixes two different bugs:

* In the `List` view the locale changer does not change the URL when the first page is loaded.
* When switching between `List` and `Form` the locale switcher does not update the URL anymore.

#### BC Breaks/Deprecations

The `router.unbindQuery` method takes another parameter.