### PR TITLE
Added infinite scroller component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
@@ -1,0 +1,108 @@
+// @flow
+import React from 'react';
+import debounce from 'debounce';
+import type {Element, ElementRef} from 'react';
+
+const THRESHOLD = 100;
+
+type Props = {
+    children: Element<*>,
+    onLoad: (loadedPage: number) => void,
+    current: number,
+    total: number,
+};
+
+export default class InfiniteScroller extends React.PureComponent<Props> {
+    elementRef: ElementRef<'div'>;
+
+    scrollContainer: ElementRef<*>;
+
+    componentDidMount() {
+        this.scrollContainer = this.getScrollContainer(this.elementRef.parentNode);
+
+        this.bindScrollListener();
+    }
+
+    componentWillUnmount() {
+        this.unbindScrollListener();
+    }
+
+    componentDidUpdate() {
+        this.bindScrollListener();
+    }
+
+    getScrollContainer(parentContainer: ElementRef<*>) {
+        if (!parentContainer) {
+            return window.document.body;
+        }
+
+        if (this.scrollAble(parentContainer)) {
+            return parentContainer;
+        }
+
+        return this.getScrollContainer(parentContainer.parentNode);
+    }
+
+    // We have to check for the overflow property inside the styling to detect if the container is scrollable
+    // otherwise (using scrollHeight) we would have issues with async content loads leading to wrong container sizes. 
+    scrollAble(el: ElementRef<*>): boolean {
+        const overflowY = window.getComputedStyle(el)['overflow-y'];
+
+        return overflowY === 'auto' || overflowY === 'scroll';
+    }
+
+    setRef = (ref: ElementRef<'div'>) => {
+        this.elementRef = ref;
+    };
+
+    bindScrollListener() {
+        const {
+            total,
+            current,
+        } = this.props;
+
+        if (current >= total) {
+            return;
+        }
+
+        this.scrollContainer.addEventListener('resize', this.scrollListener, false);
+        this.scrollContainer.addEventListener('scroll', this.scrollListener, false);
+    }
+
+    unbindScrollListener() {
+        this.scrollContainer.removeEventListener('resize', this.scrollListener, false);
+        this.scrollContainer.removeEventListener('scroll', this.scrollListener, false);
+    }
+
+    scrollListener = debounce(() => {
+        const {
+            onLoad,
+            current,
+        } = this.props;
+        const {
+            bottom: scrollContainerOffsetBottom,
+        } = this.scrollContainer.getBoundingClientRect();
+        const {
+            bottom: elementOffsetBottom,
+        } = this.elementRef.getBoundingClientRect();
+
+        if ((elementOffsetBottom - scrollContainerOffsetBottom) < THRESHOLD)  {
+            const nextPage = current + 1;
+
+            onLoad(nextPage);
+            this.unbindScrollListener();
+        }
+    }, 200);
+
+    render() {
+        const {
+            children,
+        } = this.props;
+
+        return (
+            <div className="test" ref={this.setRef}>
+                {children}
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
@@ -36,7 +36,7 @@ export default class InfiniteScroller extends React.PureComponent<Props> {
             return window.document.body;
         }
 
-        if (this.scrollAble(parentContainer)) {
+        if (this.isScrollAble(parentContainer)) {
             return parentContainer;
         }
 
@@ -45,7 +45,7 @@ export default class InfiniteScroller extends React.PureComponent<Props> {
 
     // We have to check for the overflow property inside the styling to detect if the container is scrollable
     // otherwise (using scrollHeight) we would have issues with async content loads leading to wrong container sizes. 
-    scrollAble(el: ElementRef<*>): boolean {
+    isScrollAble(el: ElementRef<*>): boolean {
         const overflowY = window.getComputedStyle(el)['overflow-y'];
 
         return overflowY === 'auto' || overflowY === 'scroll';
@@ -100,7 +100,7 @@ export default class InfiniteScroller extends React.PureComponent<Props> {
         } = this.props;
 
         return (
-            <div className="test" ref={this.setRef}>
+            <div ref={this.setRef}>
                 {children}
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/InfiniteScroller.js
@@ -36,7 +36,7 @@ export default class InfiniteScroller extends React.PureComponent<Props> {
             return window.document.body;
         }
 
-        if (this.isScrollAble(parentContainer)) {
+        if (this.isScrollable(parentContainer)) {
             return parentContainer;
         }
 
@@ -45,7 +45,7 @@ export default class InfiniteScroller extends React.PureComponent<Props> {
 
     // We have to check for the overflow property inside the styling to detect if the container is scrollable
     // otherwise (using scrollHeight) we would have issues with async content loads leading to wrong container sizes. 
-    isScrollAble(el: ElementRef<*>): boolean {
+    isScrollable(el: ElementRef<*>): boolean {
         const overflowY = window.getComputedStyle(el)['overflow-y'];
 
         return overflowY === 'auto' || overflowY === 'scroll';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/README.md
@@ -1,0 +1,22 @@
+The 'InfiniteScroller' component enables a pagination where the user will need to scroll to the bottom of the page to 
+receive further content. The component finds its scrollable container automatically by traversing the DOM-Tree upwards
+until it detects a container with the styling `overflow: scroll` or `overflow: auto` applied.
+
+```javascript static
+const handleLoad = (pageToLoad) => {
+    // do something
+};
+
+<div id="scrollable">
+    <InfiniteScroller
+        total={10}
+        current={1}
+        onLoad={handleLoad}
+    >
+        <div className="content-item" />
+        <div className="content-item" />
+        <div className="content-item" />
+        <div className="content-item" />
+    </InfiniteScroller>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/README.md
@@ -2,21 +2,78 @@ The 'InfiniteScroller' component enables a pagination where the user will need t
 receive further content. The component finds its scrollable container automatically by traversing the DOM-Tree upwards
 until it detects a container with the styling `overflow: scroll` or `overflow: auto` applied.
 
-```javascript static
-const handleLoad = (pageToLoad) => {
-    // do something
+```
+const getBackgroundColor = () => {
+    const colors = [
+        '#7CB9E8',
+        '#E52B50',
+        '#FFBF00',
+        '#9966CC',
+        '#007FFF',
+        '#FF91AF',
+    ];
+
+    return colors[Math.floor(Math.random() * colors.length)]
 };
 
-<div id="scrollable">
+initialState = {
+    page: 1,
+    items: [1, 2, 3, 4, 5, 6, 7, 8, 9].map(() => getBackgroundColor(), []),
+    loading: false,
+};
+
+const handleLoad = (pageToLoad) => {
+    setState({
+        page: pageToLoad,
+        loading: true,
+    });
+
+    setTimeout(() => {
+        const newItems = [];
+        const length = state.items.length;
+
+        for (let i = length; i < length + 5; i++) {
+            newItems.push(getBackgroundColor());
+        }
+
+        state.items.push(...newItems);
+
+        setState({
+            items: state.items,
+            loading: false,
+        });
+    }, 1000);
+};
+
+const containerStyle = {
+    height: 600,
+    overflow: 'scroll',
+};
+
+const itemStyle = {
+    height: 150,
+    marginBottom: 5,
+};
+
+const loadingContainerStyle = {
+    paddingTop: 20,
+    height: 100,
+};
+
+<div style={containerStyle}>
     <InfiniteScroller
         total={10}
-        current={1}
+        current={state.page}
         onLoad={handleLoad}
     >
-        <div className="content-item" />
-        <div className="content-item" />
-        <div className="content-item" />
-        <div className="content-item" />
+        {state.items.map((value, index) => (
+            <div key={index} style={{...itemStyle, backgroundColor: value}} />
+        ))}
     </InfiniteScroller>
+    <div style={loadingContainerStyle}>
+        {state.loading &&
+            <Loader size={20} />
+        }
+    </div>
 </div>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/index.js
@@ -1,0 +1,4 @@
+// @flow
+import InfiniteScroller from './InfiniteScroller';
+
+export default InfiniteScroller;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -11,7 +11,7 @@ test('InfiniteScroller traverses the dom upwards until it finds a scroll contain
     });
 
     const loadSpy = jest.fn();
-    const infiniteScroller = mount(
+    const infiniteScrollerWrapper = mount(
         <div id="scrollable">
             <InfiniteScroller
                 onLoad={loadSpy}
@@ -21,7 +21,7 @@ test('InfiniteScroller traverses the dom upwards until it finds a scroll contain
         </div>
     );
 
-    expect(infiniteScroller.find('InfiniteScroller').get(0).scrollContainer.id).toBe('scrollable');
+    expect(infiniteScrollerWrapper.find('InfiniteScroller').get(0).scrollContainer.id).toBe('scrollable');
 });
 
 test('InfiniteScroller should call onLoad if the the bottom of the content is reached', (done) => {
@@ -30,7 +30,7 @@ test('InfiniteScroller should call onLoad if the the bottom of the content is re
     });
 
     const loadSpy = jest.fn();
-    const infiniteScroller = mount(
+    const infiniteScrollerWrapper = mount(
         <div id="scrollable">
             <InfiniteScroller
                 total={10}
@@ -42,18 +42,19 @@ test('InfiniteScroller should call onLoad if the the bottom of the content is re
         </div>
     );
 
-    infiniteScroller.find('InfiniteScroller').get(0).scrollContainer = {
+    const infiniteScroller = infiniteScrollerWrapper.find('InfiniteScroller').get(0);
+
+    infiniteScroller.scrollContainer = {
         getBoundingClientRect: () => ({
             bottom: 260,
         }),
     };
-    infiniteScroller.find('InfiniteScroller').get(0).elementRef = {
+    infiniteScroller.elementRef = {
         getBoundingClientRect: () => ({
             bottom: 300,
         }),
     };
-    infiniteScroller.find('InfiniteScroller').get(0).unbindScrollListener = jest.fn();
-    infiniteScroller.find('InfiniteScroller').get(0).scrollListener();
+    infiniteScroller.scrollListener();
 
     setTimeout(() => {
         expect(loadSpy).toBeCalledWith(2);
@@ -68,7 +69,7 @@ test('InfiniteScroller should unbind scroll and resize event on unmount', () => 
 
     const loadSpy = jest.fn();
     const removeEventListenerSpy = jest.fn();
-    const infiniteScroller = mount(
+    const infiniteScrollerWrapper = mount(
         <div id="scrollable">
             <InfiniteScroller
                 total={10}
@@ -80,10 +81,13 @@ test('InfiniteScroller should unbind scroll and resize event on unmount', () => 
         </div>
     );
 
-    infiniteScroller.find('InfiniteScroller').get(0).scrollContainer = {
+    const infiniteScroller = infiniteScrollerWrapper.find('InfiniteScroller').get(0);
+
+    infiniteScroller.scrollContainer = {
         removeEventListener: removeEventListenerSpy,
     };
 
-    infiniteScroller.unmount();
-    expect(removeEventListenerSpy).toBeCalled();
+    infiniteScrollerWrapper.unmount();
+    expect(removeEventListenerSpy).toBeCalledWith('resize', infiniteScroller.scrollListener, false);
+    expect(removeEventListenerSpy).toBeCalledWith('scroll', infiniteScroller.scrollListener, false);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -67,7 +67,7 @@ test('InfiniteScroller should unbind scroll and resize event on unmount', () => 
     });
 
     const loadSpy = jest.fn();
-    const unbindSpy = jest.fn();
+    const removeEventListenerSpy = jest.fn();
     const infiniteScroller = mount(
         <div id="scrollable">
             <InfiniteScroller
@@ -80,8 +80,10 @@ test('InfiniteScroller should unbind scroll and resize event on unmount', () => 
         </div>
     );
 
-    infiniteScroller.find('InfiniteScroller').get(0).unbindScrollListener = unbindSpy;
-    infiniteScroller.unmount();
+    infiniteScroller.find('InfiniteScroller').get(0).scrollContainer = {
+        removeEventListener: removeEventListenerSpy,
+    };
 
-    expect(unbindSpy).toBeCalled();
+    infiniteScroller.unmount();
+    expect(removeEventListenerSpy).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -1,0 +1,87 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import {mount} from 'enzyme';
+import React from 'react';
+import InfiniteScroller from '../InfiniteScroller';
+
+window.getComputedStyle = jest.fn();
+
+test('InfiniteScroller traverses the dom upwards until it finds a scroll container', () => {
+    window.getComputedStyle.mockReturnValue({
+        'overflow-y': 'auto',
+    });
+
+    const loadSpy = jest.fn();
+    const infiniteScroller = mount(
+        <div id="scrollable">
+            <InfiniteScroller
+                onLoad={loadSpy}
+            >
+                <div />
+            </InfiniteScroller>
+        </div>
+    );
+
+    expect(infiniteScroller.find('InfiniteScroller').get(0).scrollContainer.id).toBe('scrollable');
+});
+
+test('InfiniteScroller should call onLoad if the the bottom of the content is reached', (done) => {
+    window.getComputedStyle.mockReturnValue({
+        'overflow-y': 'auto',
+    });
+
+    const loadSpy = jest.fn();
+    const infiniteScroller = mount(
+        <div id="scrollable">
+            <InfiniteScroller
+                total={10}
+                startPage={1}
+                onLoad={loadSpy}
+            >
+                <div />
+            </InfiniteScroller>
+        </div>
+    );
+
+    infiniteScroller.find('InfiniteScroller').get(0).scrollContainer = {
+        getBoundingClientRect: () => ({
+            bottom: 260,
+        }),
+    };
+    infiniteScroller.find('InfiniteScroller').get(0).elementRef = {
+        getBoundingClientRect: () => ({
+            bottom: 300,
+        }),
+    };
+    infiniteScroller.find('InfiniteScroller').get(0).unbindScrollListener = jest.fn();
+    infiniteScroller.find('InfiniteScroller').get(0).scrollListener();
+
+    setTimeout(() => {
+        expect(loadSpy).toBeCalledWith(2);
+        done();
+    }, 250);
+});
+
+test('InfiniteScroller should unbind scroll and resize event on unmount', () => {
+    window.getComputedStyle.mockReturnValue({
+        'overflow-y': 'auto',
+    });
+
+    const loadSpy = jest.fn();
+    const unbindSpy = jest.fn();
+    const infiniteScroller = mount(
+        <div id="scrollable">
+            <InfiniteScroller
+                total={10}
+                startPage={1}
+                onLoad={loadSpy}
+            >
+                <div />
+            </InfiniteScroller>
+        </div>
+    );
+
+    infiniteScroller.find('InfiniteScroller').get(0).unbindScrollListener = unbindSpy;
+    infiniteScroller.unmount();
+
+    expect(unbindSpy).toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/InfiniteScroller/tests/InfiniteScroller.test.js
@@ -34,7 +34,7 @@ test('InfiniteScroller should call onLoad if the the bottom of the content is re
         <div id="scrollable">
             <InfiniteScroller
                 total={10}
-                startPage={1}
+                current={1}
                 onLoad={loadSpy}
             >
                 <div />
@@ -72,7 +72,7 @@ test('InfiniteScroller should unbind scroll and resize event on unmount', () => 
         <div id="scrollable">
             <InfiniteScroller
                 total={10}
-                startPage={1}
+                current={1}
                 onLoad={loadSpy}
             >
                 <div />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -5,6 +5,7 @@
     "repository": "https://github.com/sulu/sulu.git",
     "dependencies": {
         "classnames": "^2.2.5",
+        "debounce": "^1.0.2",
         "fast-deep-equal": "^1.0.0",
         "font-awesome": "^4.7.0",
         "history": "^4.6.3",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR adds an infinite scroll component

#### Why?

We need one to load content inside the masonry view.

#### Example Usage

~~~js
const handleLoad = (pageToLoad) => {
    // do something
};

<div id="scrollable">
    <InfiniteScroller
        total={10}
        current={1}
        onLoad={handleLoad}
    >
        <div className="content-item" />
        <div className="content-item" />
        <div className="content-item" />
        <div className="content-item" />
    </InfiniteScroller>
</div>
~~~