### PR TITLE
Share data between snippet tabs

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/README.md
@@ -32,8 +32,9 @@ const router = {
 ```
 
 The `ViewRegistry` can also handle the parent and children relation ships built on top of routes. It will nest the
-route's views in each other, whereby the parent route's view gets the children route's view via the children property.
-In order to get the corresponding route to the view, the route is passed via the `route` property.
+route's views in each other, whereby the parent route's view gets the children route's view via the `children`
+property. The `children` property is a function, which returns the corresponding view. It takes an object as only
+argument, which will be merged with the passed `route` and `router` props from the view.
 
 ```
 const viewRegistry = require('./registries/ViewRegistry').default;
@@ -42,12 +43,13 @@ viewRegistry.clear();
 const Parent = ({route, children}) => (
     <div>
         <h1>{route.name}</h1>
-        {children}
+        {children({value: 'bla'})}
     </div>
 );
 
-const Child = ({route}) => (
+const Child = ({route, value}) => (
     <h2>{route.name}</h2>
+    <p>{value}</p>
 );
 
 viewRegistry.add('parent', Parent);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -19,7 +19,7 @@ export default class ViewRenderer extends React.PureComponent<Props> {
             throw new Error('View "' + view + '" has not been found');
         }
 
-        const element = <View router={router} route={route}>{child}</View>;
+        const element = <View router={router} route={route}>{(props) => React.cloneElement(child, props)}</View>;
 
         if (!route.parent) {
             return element;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -19,7 +19,11 @@ export default class ViewRenderer extends React.PureComponent<Props> {
             throw new Error('View "' + view + '" has not been found');
         }
 
-        const element = <View router={router} route={route}>{(props) => React.cloneElement(child, props)}</View>;
+        const element = (
+            <View router={router} route={route}>
+                {(props) => child ? React.cloneElement(child, props) : null}
+            </View>
+        );
 
         if (!route.parent) {
             return element;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -69,7 +69,7 @@ test('Render view with parents should nest rendered views', () => {
                         <div>
                             <h2>Form</h2>
                             {props.route.name}
-                            {props.children}
+                            {props.children()}
                         </div>
                     );
                 };
@@ -79,7 +79,62 @@ test('Render view with parents should nest rendered views', () => {
                         <div>
                             <h1>App</h1>
                             {props.route.name}
-                            {props.children}
+                            {props.children()}
+                        </div>
+                    );
+                };
+        }
+    });
+
+    expect(render(<ViewRenderer router={router} />)).toMatchSnapshot();
+});
+
+test('Render view with parents should nest rendered views and correctly pass children arguments', () => {
+    const router = {
+        route: {
+            name: 'sulu_admin.form_tab',
+            view: 'form_tab',
+            parent: {
+                name: 'sulu_admin.form',
+                view: 'form',
+                parent: {
+                    name: 'sulu_admin.app',
+                    view: 'app',
+                },
+            },
+        },
+    };
+
+    viewRegistry.get.mockImplementation((view) => {
+        switch (view) {
+            case 'form_tab':
+                return function FormTab(props) {
+                    return (
+                        <div>
+                            <h3>Form Tab</h3>
+                            <p>{props.route.name}</p>
+                            <p>{props.form}</p>
+                        </div>
+                    );
+                };
+            case 'form':
+                return function Form(props) {
+                    return (
+                        <div>
+                            <h2>Form</h2>
+                            <p>{props.route.name}</p>
+                            <p>{props.app}</p>
+                            {props.children({form: 'Form'})}
+                        </div>
+                    );
+                };
+            case 'app':
+                return function App(props) {
+                    return (
+                        <div>
+                            <h1>App</h1>
+                            <p>{props.route.name}</p>
+                            {props.children({app: 'App'})}
                         </div>
                     );
                 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
@@ -32,3 +32,36 @@ exports[`Render view with parents should nest rendered views 1`] = `
   </div>
 </div>
 `;
+
+exports[`Render view with parents should nest rendered views and correctly pass children arguments 1`] = `
+<div>
+  <h1>
+    App
+  </h1>
+  <p>
+    sulu_admin.app
+  </p>
+  <div>
+    <h2>
+      Form
+    </h2>
+    <p>
+      sulu_admin.form
+    </p>
+    <p>
+      App
+    </p>
+    <div>
+      <h3>
+        Form Tab
+      </h3>
+      <p>
+        sulu_admin.form_tab
+      </p>
+      <p>
+        Form
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -6,7 +6,7 @@ import type {Route} from '../../services/Router';
 export type ViewProps = {
     router: Router,
     route: Route,
-    children: Element<View> | null,
+    children: (Object) => Element<View> | null,
 };
 
 export type View = ComponentType<ViewProps>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -6,7 +6,7 @@ import type {Route} from '../../services/Router';
 export type ViewProps = {
     router: Router,
     route: Route,
-    children: (Object) => Element<View> | null,
+    children: (?Object) => Element<View> | null,
 };
 
 export type View = ComponentType<ViewProps>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import {default as FormContainer} from '../../containers/Form';
-import ResourceStore from '../../stores/ResourceStore';
-import {translate} from '../../services/Translator';
 import {withToolbar} from '../../containers/Toolbar';
 import type {ViewProps} from '../../containers/ViewRenderer';
+import {translate} from '../../services/Translator';
+import ResourceStore from '../../stores/ResourceStore';
 import formStyles from './form.scss';
 
 const schema = {
@@ -18,34 +18,25 @@ const schema = {
     },
 };
 
-class Form extends React.PureComponent<ViewProps> {
+type Props = ViewProps & {
+    resourceStore: ResourceStore,
+};
+
+class Form extends React.PureComponent<Props> {
     form: ?FormContainer;
-    resourceStore: ResourceStore;
 
     componentWillMount() {
         const {router} = this.props;
-        const {
-            route: {
-                options: {
-                    resourceKey,
-                },
-            },
-            attributes: {
-                id,
-            },
-        } = router;
-        this.resourceStore = new ResourceStore(resourceKey, id);
-        this.resourceStore.changeSchema(schema);
-        router.bindQuery('locale', this.resourceStore.locale);
+        this.props.resourceStore.changeSchema(schema);
+        router.bindQuery('locale', this.props.resourceStore.locale);
     }
 
     componentWillUnmount() {
-        this.resourceStore.destroy();
-        this.props.router.unbindQuery('locale', this.resourceStore.locale);
+        this.props.router.unbindQuery('locale', this.props.resourceStore.locale);
     }
 
     handleSubmit = () => {
-        this.resourceStore.save();
+        this.props.resourceStore.save();
     };
 
     setFormRef = (form) => {
@@ -57,7 +48,7 @@ class Form extends React.PureComponent<ViewProps> {
             <div className={formStyles.form}>
                 <FormContainer
                     ref={this.setFormRef}
-                    store={this.resourceStore}
+                    store={this.props.resourceStore}
                     onSubmit={this.handleSubmit}
                     schema={schema}
                 />
@@ -73,15 +64,15 @@ export default withToolbar(Form, function() {
     const backButton = backRoute
         ? {
             onClick: () => {
-                router.navigate(backRoute, {}, {locale: this.resourceStore.locale.get()});
+                router.navigate(backRoute, {}, {locale: this.props.resourceStore.locale.get()});
             },
         }
         : undefined;
     const locale = locales
         ? {
-            value: this.resourceStore.locale.get(),
+            value: this.props.resourceStore.locale.get(),
             onChange: (locale) => {
-                this.resourceStore.setLocale(locale);
+                this.props.resourceStore.setLocale(locale);
             },
             options: locales.map((locale) => ({
                 value: locale,
@@ -98,8 +89,8 @@ export default withToolbar(Form, function() {
                 type: 'button',
                 value: translate('sulu_admin.save'),
                 icon: 'floppy-o',
-                disabled: !this.resourceStore.dirty,
-                loading: this.resourceStore.saving,
+                disabled: !this.props.resourceStore.dirty,
+                loading: this.props.resourceStore.saving,
                 onClick: () => {
                     this.form.submit();
                 },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/README.md
@@ -1,8 +1,9 @@
 The form is registered with the key `sulu_admin.form`. It shows a Form with a toolbar. The location to which the back
-button redirects can be configured using the route's options.
+button redirects can be configured using the route's options. In addition to that it also takes the locales, which
+should be shown in the toolbar and an instance of the `ResourceStore`, which allows to load and save data.
 
-| Option      | Description                                                                                           |
-|-------------|-------------------------------------------------------------------------------------------------------|
-| backRoute   | The route to which the user will be navigate when the back button is clicked.                         |
-| resourceKey | The resourceKey for the type of entity which will be managed by this specific form.                   |
-| locales     | Defines which locales are available in the locale chooser of this form.                               |
+| Option        | Description                                                                                         |
+|---------------|-----------------------------------------------------------------------------------------------------|
+| backRoute     | The route to which the user will be navigate when the back button is clicked.                       |
+| locales       | Defines which locales are available in the locale chooser of this form.                             |
+| resourceStore | The store which allows to save and load data from the given type of resources                       |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -42,7 +42,9 @@ beforeEach(() => {
 test('Should navigate to defined route on back button click', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('test', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -55,8 +57,8 @@ test('Should navigate to defined route on back button click', () => {
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
-    form.resourceStore.setLocale('de');
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
+    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form);
     toolbarConfig.backButton.onClick();
@@ -66,7 +68,9 @@ test('Should navigate to defined route on back button click', () => {
 test('Should not render back button when no editLink is configured', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('test', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -78,7 +82,7 @@ test('Should not render back button when no editLink is configured', () => {
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
 
     const toolbarConfig = toolbarFunction.call(form);
     expect(toolbarConfig.backButton).toBe(undefined);
@@ -87,7 +91,9 @@ test('Should not render back button when no editLink is configured', () => {
 test('Should change locale in form store via locale chooser', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('test', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -100,18 +106,20 @@ test('Should change locale in form store via locale chooser', () => {
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
-    form.resourceStore.locale.set('de');
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
+    resourceStore.locale.set('de');
 
     const toolbarConfig = toolbarFunction.call(form);
     toolbarConfig.locale.onChange('en');
-    expect(form.resourceStore.locale.get()).toBe('en');
+    expect(resourceStore.locale.get()).toBe('en');
 });
 
 test('Should show locales from router options in toolbar', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('test', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -123,7 +131,7 @@ test('Should show locales from router options in toolbar', () => {
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
 
     const toolbarConfig = toolbarFunction.call(form);
     expect(toolbarConfig.locale.options).toEqual([
@@ -135,7 +143,9 @@ test('Should show locales from router options in toolbar', () => {
 test('Should not show a locale chooser if no locales are passed in router options', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('test', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -145,7 +155,7 @@ test('Should not show a locale chooser if no locales are passed in router option
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
 
     const toolbarConfig = toolbarFunction.call(form);
     expect(toolbarConfig.locale).toBe(undefined);
@@ -153,12 +163,13 @@ test('Should not show a locale chooser if no locales are passed in router option
 
 test('Should initialize the ResourceStore with a schema', () => {
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
         bindQuery: jest.fn(),
         route: {
             options: {
-                resourceKey: 'snippets',
                 locales: [],
             },
         },
@@ -167,10 +178,10 @@ test('Should initialize the ResourceStore with a schema', () => {
         },
     };
 
-    const form = mount(<Form router={router} />).get(0);
-    expect(form.resourceStore.resourceKey).toBe('snippets');
-    expect(form.resourceStore.id).toBe(12);
-    expect(form.resourceStore.data).toEqual({
+    mount(<Form router={router} resourceStore={resourceStore} />).get(0);
+    expect(resourceStore.resourceKey).toBe('snippets');
+    expect(resourceStore.id).toBe(12);
+    expect(resourceStore.data).toEqual({
         title: null,
         slogan: null,
     });
@@ -183,7 +194,9 @@ test('Should render save button disabled only if form is not dirty', () => {
 
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
         bindQuery: jest.fn(),
@@ -195,11 +208,11 @@ test('Should render save button disabled only if form is not dirty', () => {
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
 
     expect(getSaveItem().disabled).toBe(true);
 
-    form.resourceStore.dirty = true;
+    resourceStore.dirty = true;
     expect(getSaveItem().disabled).toBe(false);
 });
 
@@ -207,13 +220,14 @@ test('Should save form when submitted', () => {
     const ResourceRequester = require('../../../services/ResourceRequester');
     ResourceRequester.put.mockReturnValue(Promise.resolve());
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 8);
 
     const router = {
         bindQuery: jest.fn(),
         navigate: jest.fn(),
         route: {
             options: {
-                resourceKey: 'snippets',
                 locales: [],
             },
         },
@@ -221,8 +235,7 @@ test('Should save form when submitted', () => {
             id: 8,
         },
     };
-    const form = mount(<Form router={router} />);
-    const resourceStore = form.get(0).resourceStore;
+    const form = mount(<Form router={router} resourceStore={resourceStore} />);
     resourceStore.locale.set('en');
     resourceStore.data = {value: 'Value'};
     resourceStore.loading = false;
@@ -233,6 +246,8 @@ test('Should save form when submitted', () => {
 
 test('Should pass store, schema and onSubmit handler to FormContainer', () => {
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
         bindQuery: jest.fn(),
@@ -245,7 +260,7 @@ test('Should pass store, schema and onSubmit handler to FormContainer', () => {
         attributes: {},
     };
 
-    const form = shallow(<Form router={router} />);
+    const form = shallow(<Form router={router} resourceStore={resourceStore} />);
     const formContainer = form.find('Form');
 
     expect(formContainer.prop('store').data).toEqual({
@@ -264,6 +279,8 @@ test('Should render save button loading only if form is not saving', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
         bindQuery: jest.fn(),
@@ -275,16 +292,18 @@ test('Should render save button loading only if form is not saving', () => {
         },
         attributes: {},
     };
-    const form = mount(<Form router={router} />).get(0);
+    const form = mount(<Form router={router} resourceStore={resourceStore} />).get(0);
 
     expect(getSaveItem().loading).toBe(false);
 
-    form.resourceStore.saving = true;
+    resourceStore.saving = true;
     expect(getSaveItem().loading).toBe(true);
 });
 
 test('Should unbind the query parameter and destroy the store on unmount', () => {
     const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
     const router = {
         bindQuery: jest.fn(),
         unbindQuery: jest.fn(),
@@ -297,7 +316,7 @@ test('Should unbind the query parameter and destroy the store on unmount', () =>
         attributes: {},
     };
 
-    const form = mount(<Form router={router} />);
+    const form = mount(<Form router={router} resourceStore={resourceStore} />);
     const locale = form.find('Form').at(1).prop('store').locale;
 
     expect(router.bindQuery).toBeCalledWith('locale', locale);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/README.md
@@ -1,3 +1,7 @@
 The `ResourceTabs` view shows all the children of its defined route as a [`Tab`](#tab), and uses their `tabTitle`
 option as the title for the tab. This is enabled by the [`Router`](#router) with handling children and parent routes
 and by the [`ViewRenderer`](#viewrenderer) with nesting these routes into different views.
+
+| Option        | Description                                                                                         |
+|---------------|-----------------------------------------------------------------------------------------------------|
+| resourceKey   | The resourceKey for the type of entity which will be managed by the given tabs.                     |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -12,9 +12,10 @@ export default class ResourceTabs extends React.PureComponent<ViewProps> {
 
     render() {
         const {children, route} = this.props;
+        const ChildComponent = children();
 
-        const selectedRouteIndex = children
-            ? route.children.findIndex((childRoute) => childRoute === children.props.route)
+        const selectedRouteIndex = ChildComponent
+            ? route.children.findIndex((childRoute) => childRoute === ChildComponent.props.route)
             : undefined;
 
         return (
@@ -29,7 +30,7 @@ export default class ResourceTabs extends React.PureComponent<ViewProps> {
                         );
                     })}
                 </Tabs>
-                {children}
+                {ChildComponent}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -3,8 +3,30 @@ import React from 'react';
 import Tabs from '../../components/Tabs';
 import type {ViewProps} from '../../containers/ViewRenderer';
 import {translate} from '../../services/Translator';
+import ResourceStore from '../../stores/ResourceStore';
 
 export default class ResourceTabs extends React.PureComponent<ViewProps> {
+    resourceStore: ResourceStore;
+
+    componentWillMount() {
+        const {router, route} = this.props;
+        const {
+            attributes: {
+                id,
+            },
+        } = router;
+        const {
+            options: {
+                resourceKey,
+            },
+        } = route;
+        this.resourceStore = new ResourceStore(resourceKey, id);
+    }
+
+    componentWillUnmount() {
+        this.resourceStore.destroy();
+    }
+
     handleSelect = (index: number) => {
         const {router, route} = this.props;
         router.navigate(route.children[index].name, router.attributes, router.query);
@@ -12,7 +34,7 @@ export default class ResourceTabs extends React.PureComponent<ViewProps> {
 
     render() {
         const {children, route} = this.props;
-        const ChildComponent = children();
+        const ChildComponent = children ? children({resourceStore: this.resourceStore}) : null;
 
         const selectedRouteIndex = ChildComponent
             ? route.children.findIndex((childRoute) => childRoute === ChildComponent.props.route)

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -29,7 +29,7 @@ export default class ResourceTabs extends React.PureComponent<ViewProps> {
                         );
                     })}
                 </Tabs>
-                {this.props.children}
+                {children}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -2,6 +2,7 @@
 import {mount, render} from 'enzyme';
 import React from 'react';
 import ResourceTabs from '../ResourceTabs';
+import ResourceStore from '../../../stores/ResourceStore';
 
 jest.mock('../../../services/Translator', () => ({
     translate: function(key) {
@@ -14,8 +15,13 @@ jest.mock('../../../services/Translator', () => ({
     },
 }));
 
+jest.mock('../../../stores/ResourceStore');
+
 test('Should render the child components after the tabs', () => {
     const route = {
+        options: {
+            resourceKey: 'test',
+        },
         children: [
             {
                 name: 'Tab 1',
@@ -31,9 +37,16 @@ test('Should render the child components after the tabs', () => {
             },
         ],
     };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route,
+    };
+
     const Child = () => (<h1>Child</h1>);
 
-    expect(render(<ResourceTabs route={route}>{() => (<Child />)}</ResourceTabs>)).toMatchSnapshot();
+    expect(render(<ResourceTabs router={router} route={route}>{() => (<Child />)}</ResourceTabs>)).toMatchSnapshot();
 });
 
 test('Should mark the currently active child route as selected tab', () => {
@@ -51,15 +64,25 @@ test('Should mark the currently active child route as selected tab', () => {
     };
 
     const route = {
+        options: {
+            resourceKey: 'test',
+        },
         children: [
             childRoute1,
             childRoute2,
         ],
     };
 
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route,
+    };
+
     const Child = () => (<h1>Child</h1>);
 
-    expect(render(<ResourceTabs route={route}>{() => (<Child route={childRoute2} />)}</ResourceTabs>))
+    expect(render(<ResourceTabs router={router} route={route}>{() => (<Child route={childRoute2} />)}</ResourceTabs>))
         .toMatchSnapshot();
 });
 
@@ -73,6 +96,9 @@ test('Should navigate to child route if tab is clicked', () => {
         options: {},
     };
     const route = {
+        options: {
+            resourceKey: 'test',
+        },
         children: [
             childRoute1,
             childRoute2,
@@ -88,6 +114,7 @@ test('Should navigate to child route if tab is clicked', () => {
 
     const router = {
         navigate: jest.fn(),
+        route,
         attributes,
         query,
     };
@@ -98,4 +125,48 @@ test('Should navigate to child route if tab is clicked', () => {
     resourceTabs.find('Tab button').at(1).simulate('click');
 
     expect(router.navigate).toBeCalledWith('route2', attributes, query);
+});
+
+test('Should create a ResourceStore on mount and destroy it on unmount', () => {
+    const route = {
+        children: [],
+        options: {
+            resourceKey: 'snippets',
+        },
+    };
+    const router = {
+        route,
+        attributes: {
+            id: 5,
+        },
+    };
+
+    const resourceTabs = mount(<ResourceTabs router={router} route={route}>{() => null}</ResourceTabs>);
+    const resourceStoreConstructorCall = ResourceStore.mock.calls;
+    expect(resourceStoreConstructorCall[0]).toEqual(['snippets', 5]);
+
+    resourceTabs.unmount();
+    expect(ResourceStore.mock.instances[0].destroy).toBeCalled();
+});
+
+test('Should pass the ResourceStore to child components', () => {
+    const route = {
+        children: [],
+        options: {
+            resourceKey: 'snippets',
+        },
+    };
+    const router = {
+        route,
+        attributes: {
+            id: 5,
+        },
+    };
+
+    const ChildComponent = jest.fn(() => null);
+    const resourceTabs = mount(
+        <ResourceTabs router={router} route={route}>{(props) => (<ChildComponent {...props} />)}</ResourceTabs>
+    ).get(0);
+
+    expect(ChildComponent.mock.calls[0][0].resourceStore).toBe(resourceTabs.resourceStore);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -33,7 +33,7 @@ test('Should render the child components after the tabs', () => {
     };
     const Child = () => (<h1>Child</h1>);
 
-    expect(render(<ResourceTabs route={route}><Child /></ResourceTabs>)).toMatchSnapshot();
+    expect(render(<ResourceTabs route={route}>{() => (<Child />)}</ResourceTabs>)).toMatchSnapshot();
 });
 
 test('Should mark the currently active child route as selected tab', () => {
@@ -59,7 +59,8 @@ test('Should mark the currently active child route as selected tab', () => {
 
     const Child = () => (<h1>Child</h1>);
 
-    expect(render(<ResourceTabs route={route}><Child route={childRoute2} /></ResourceTabs>)).toMatchSnapshot();
+    expect(render(<ResourceTabs route={route}>{() => (<Child route={childRoute2} />)}</ResourceTabs>))
+        .toMatchSnapshot();
 });
 
 test('Should navigate to child route if tab is clicked', () => {
@@ -92,7 +93,7 @@ test('Should navigate to child route if tab is clicked', () => {
     };
 
     const Child = () => (<h1>Child</h1>);
-    const resourceTabs = mount(<ResourceTabs router={router} route={route}><Child /></ResourceTabs>);
+    const resourceTabs = mount(<ResourceTabs router={router} route={route}>{() => (<Child />)}</ResourceTabs>);
 
     resourceTabs.find('Tab button').at(1).simulate('click');
 

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -99,11 +99,11 @@ class SnippetAdmin extends Admin
             (new Route('sulu_snippet.list', '/snippets', 'sulu_admin.list'))
                 ->addOption('title', 'sulu_snippet.snippets')
                 ->addOption('resourceKey', 'snippets')
-                ->addOption('editRoute', 'sulu_snippet.form')
+                ->addOption('editRoute', 'sulu_snippet.form.detail')
                 ->addOption('locales', $snippetLocales),
-            new Route('sulu_snippet.form', '/snippets/:id', 'sulu_admin.resource_tabs'),
+            (new Route('sulu_snippet.form', '/snippets/:id', 'sulu_admin.resource_tabs'))
+                ->addOption('resourceKey', 'snippets'),
             (new Route('sulu_snippet.form.detail', '/details', 'sulu_admin.form'))
-                ->addOption('resourceKey', 'snippets')
                 ->addOption('tabTitle', 'sulu_snippet.details')
                 ->addOption('backRoute', 'sulu_snippet.list')
                 ->addOption('locales', $snippetLocales)

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -68,14 +68,13 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame([
             'title' => 'sulu_snippet.snippets',
             'resourceKey' => 'snippets',
-            'editRoute' => 'sulu_snippet.form',
+            'editRoute' => 'sulu_snippet.form.detail',
             'locales' => array_keys($locales),
         ], 'options', $listRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'name', $formRoute);
         $this->assertAttributeEquals('sulu_snippet.form.detail', 'name', $detailRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'parent', $detailRoute);
         $this->assertAttributeSame([
-            'resourceKey' => 'snippets',
             'tabTitle' => 'sulu_snippet.details',
             'backRoute' => 'sulu_snippet.list',
             'locales' => array_keys($locales),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to share data between tabs by allowing tabs to call its children as a function and pass more props.

#### Why?

Because we want to share data between multiple tabs when implementing forms.

#### To Do

- [x] Implement children rendering as functions
