### PR TITLE
Fixed exception of blame for none sulu users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* 1.5.8 (unreleased)
+    * HOTFIX      #3584 [SuluPresistanceBUndle] Fixed exception of blame for none sulu users
+
 * 1.5.7 (2017-10-12)
     * HOTFIX      #3551 [SecurityBundle]        Fixed permissions for user with no role
     * HOTFIX      #3553 [SecurityBundle]        Added system check for password reset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.5.8 (unreleased)
-    * HOTFIX      #3584 [SuluPresistanceBUndle] Fixed exception of blame for none sulu users
+    * HOTFIX      #3584 [PersistanceBundle]     Fixed exception of blame for none sulu users
 
 * 1.5.7 (2017-10-12)
     * HOTFIX      #3551 [SecurityBundle]        Fixed permissions for user with no role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.5.8 (unreleased)
-    * HOTFIX      #3584 [PersistanceBundle]     Fixed exception of blame for none sulu users
+    * HOTFIX      #3585 [PersistanceBundle]     Fixed exception of blame for none sulu users
 
 * 1.5.7 (2017-10-12)
     * HOTFIX      #3551 [SecurityBundle]        Fixed permissions for user with no role

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -143,6 +143,11 @@ class UserBlameSubscriber implements EventSubscriber
 
             if (null === $user) {
                 $user = $this->getUser($token);
+
+                if (!$user instanceof UserInterface) {
+                    // if no sulu user is available avoid looping through all entities
+                    return;
+                }
             }
 
             $meta = $manager->getClassMetadata(get_class($blameEntity));
@@ -214,10 +219,7 @@ class UserBlameSubscriber implements EventSubscriber
         $user = $token->getUser();
 
         if (!$user instanceof UserInterface) {
-            throw new \RuntimeException(sprintf(
-                'Expected user object to be an instance of (Sulu) UserInterface. Got "%s"',
-                is_object($user) ? get_class($user) : gettype($user)
-            ));
+            return;
         }
 
         return $user;

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Persistence\EventSubscriber\ORM;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
@@ -42,11 +41,6 @@ class UserBlameSubscriber implements EventSubscriber
      * @var string
      */
     private $userClass;
-
-    /**
-     * @var object[]
-     */
-    private $blameQueue = [];
 
     /**
      * @param TokenStorage $tokenStorage
@@ -183,28 +177,6 @@ class UserBlameSubscriber implements EventSubscriber
                 $unitOfWork->recomputeSingleEntityChangeSet($meta, $blameEntity);
             }
         }
-
-        $this->blameQueue = [];
-    }
-
-    /**
-     * Record the creating and changing user on the
-     * entity based on the logged-in user.
-     *
-     * If the creator is null, then the creator will be
-     * set. The changer will always be overwritten.
-     *
-     * @param LifecycleEventArgs $event
-     */
-    private function handleUserBlame(LifecycleEventArgs $event)
-    {
-        $entity = $event->getObject();
-
-        if (!$entity instanceof UserBlameInterface) {
-            return;
-        }
-
-        $this->blameQueue[] = $entity;
     }
 
     /**

--- a/src/Sulu/Component/Persistence/Tests/Functional/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Functional/EventSubscriber/ORM/UserBlameSubscriberIntegrationTest.php
@@ -75,13 +75,11 @@ class UserBlameSubscriberIntegrationTest extends SuluTestCase
         $contact->setPosition('CEO');
         $contact->setSalutation('Sehr geehrter Herr Dr Mustermann');
 
-        $this->setExpectedExceptionRegExp(
-            'RuntimeException',
-            '/Expected user object to be an instance of \(Sulu\) UserInterface\./'
-        );
-
         $this->getEntityManager()->persist($contact);
         $this->getEntityManager()->flush();
+
+        $this->assertNull($contact->getCreator());
+        $this->assertNull($contact->getChanger());
     }
 
     public function testExternalUserNoBlame()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It avoids to throw an exception in the blame subscriber when the current user is not a sulu user.

#### Why?

If the website user is not a sulu user it will throw `RuntimeException: Expected user object to be an instance of (Sulu) UserInterface` currently. It should just ignore this user and don't set changer or creator for this entity.

#### BC Breaks/Deprecations

BlameSubscriber will not longer throw an exception when symfony returns a none sulu user.

#### To Do

- [x] Testcase
