### PR TITLE
Fixed RouteProvider for get articles in different formats

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -215,7 +215,7 @@ class RouteProvider implements RouteProviderInterface
         /** @var RequestAttributes $attributes */
         $attributes = $request->get('_sulu');
 
-        if($attributes && $route->getPath() !== $attributes->getAttribute('requestUri')) {
+        if ($attributes && $route->getPath() !== $attributes->getAttribute('requestUri')) {
             $routePath = $attributes->getAttribute('requestUri');
         }
 

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\RouteBundle\Entity\Route as SuluRoute;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Bundle\RouteBundle\Routing\Defaults\RouteDefaultsProviderInterface;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -102,8 +103,15 @@ class RouteProvider implements RouteProviderInterface
         $collection = new RouteCollection();
         $prefix = $this->requestAnalyzer->getResourceLocatorPrefix();
 
+        /** @var RequestAttributes $attributes */
+        $attributes = $request->get('_sulu');
+
         if (!empty($prefix) && strpos($path, $prefix) === 0) {
             $path = PathHelper::relativizePath($path, $prefix);
+        }
+
+        if ($attributes->getAttribute('format')) {
+            $path = substr($path, 0, strpos($path, $attributes->getAttribute('format')) - 1);
         }
 
         $route = $this->findRouteByPath($path, $request->getLocale());
@@ -203,6 +211,13 @@ class RouteProvider implements RouteProviderInterface
     protected function createRoute(RouteInterface $route, Request $request)
     {
         $routePath = $this->requestAnalyzer->getResourceLocatorPrefix() . $route->getPath();
+
+        /** @var RequestAttributes $attributes */
+        $attributes = $request->get('_sulu');
+
+        if($attributes && $route->getPath() !== $attributes->getAttribute('requestUri')) {
+            $routePath = $attributes->getAttribute('requestUri');
+        }
 
         if ($route->isHistory()) {
             return new Route(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3579 
| Related issues/PRs | #3579 
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fixed issue for getting articles in different formats. The solution was to strip format from end of the url and then will be found by RouteRepository. The next was necessary to correct RouteCollection for later usage in Symfony UrlMacher.

#### Why?

The problem was that RouteRepository was not able to find path in Route entity with different format as html. Response was No route found.

#### Example Usage

https://domain/locale/blog/some-seo-url-name.json|rss|xml