### PR TITLE
Fix misleading security warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX     #3598 [SecurityBundle]          Fixed misleading security warning message
     * HOTFIX     #3573 [RouteBundle]             Added rawurldecode to decode path-info before searching for route
     * HOTFIX     #3573 [ContentBundle]           Added rawurldecode to decode path-info before searching for route
     * HOTFIX     #3573 [CustomUrlBundle]         Added rawurldecode to decode path-info before searching for route

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.de.xlf
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414bc0685517c721d" resname="security.warning">
                 <source>security.warning</source>
-                <target>Um die Änderungen an den Sicherheitseinstellungen zu sehen, muss das System neu geladen werden.</target>
+                <target>Um die Änderungen an den Sicherheitseinstellungen zu sehen, muss der Browser neu geladen werden.</target>
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414ba0685517c632c" resname="sulu-security.role.removed">
                 <source>sulu-security.role.removed</source>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.en.xlf
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414bc0685517c721d" resname="security.warning">
                 <source>security.warning</source>
-                <target>To see the changes of the security settings the system has to be reloaded.</target>
+                <target>To see the changes of the security settings the browser has to be reloaded.</target>
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414ba0685517c632c" resname="sulu-security.role.removed">
                 <source>sulu-security.role.removed</source>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.fr.xlf
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414bc0685517c721d" resname="security.warning">
                 <source>security.warning</source>
-                <target>Pour voir les changements des paramètres de sécurité ,  il faut recharger  le système.</target>
+                <target>Pour voir les changements des paramètres de sécurité, il faut recharger le navigateur.</target>
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414ba0685517c632c" resname="sulu-security.role.removed">
                 <source>sulu-security.role.removed</source>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.nl.xlf
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414bc0685517c721d" resname="security.warning">
                 <source>security.warning</source>
-                <target>Om de gewijzigde veiligheidsinstellingen te zien moet het browser opnieuw geladen worden.</target>
+                <target>Om de gewijzigde veiligheidsinstellingen te zien moet de browser opnieuw geladen worden.</target>
             </trans-unit>
 
             <trans-unit id="1cd67d24ab0a432414ba0685517c632c" resname="sulu-security.role.removed">

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/sulu/backend.nl.xlf
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="1cd67d24ab0a432414bc0685517c721d" resname="security.warning">
                 <source>security.warning</source>
-                <target>Om de gewijzigde veiligheidsinstellingen te zien moet het systeem opnieuw geladen worden.</target>
+                <target>Om de gewijzigde veiligheidsinstellingen te zien moet het browser opnieuw geladen worden.</target>
             </trans-unit>
 
             <trans-unit id="1cd67d24ab0a432414ba0685517c632c" resname="sulu-security.role.removed">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Change the security warning message to reload the browser instead of system.

#### Why?

From a slack discussion I was asked by a user which system he now need to reload after he changed the permissions. So this message seems to be misleading the user.

