### PR TITLE
Restore routes instead of navigate when clicking back button

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -79,6 +79,25 @@ router.navigate('sulu_contact.form', {id: 7, admin: true}); // redirects to #/co
 router.navigate('sulu_contact.form.detail', {id: 2, admin: true}); // redirects to #/contacts/2/detail?admin=true
 ```
 
+Instead of `navigate` you can also use the `restore` function. `restore` takes the same parameters, but the difference
+is that the attributes and query parameter will be merged with the previous values of this route. So this is especially
+useful when implementing functionality like a `back` button, since using it will e.g. bring you back to the same page
+of a paginated list.
+
+```javascript static
+// navigates to #/contacts?page=3
+router.navigate('sulu_contact.list', {page: 3, locale: 'en'});
+
+// navigates to #/contacts/7/detail?locale=en
+router.navigate('sulu_contact.form.detail', {id: 7, locale: 'en'});
+
+// navigates to #/contacts/7/detail?locale=de
+router.navigate('sulu_contact.form.detail', {id: 7, locale: 'de'});
+
+// navigates to #/contacts?page=3&locale=de
+router.restore('sulu_contact.list', locale: 'de'});
+```
+
 Something especially useful is the ability to bind any observable to a query parameter of the router. The `bind` method
 takes the name of a route attribute in the URL, the observable and a default value. The default value will be set if
 the value in the URL is not defined. Any change in the URL will be immediately reflected in that observable and the

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -87,8 +87,6 @@ export default class Router {
     }
 
     @action navigate(name: string, attributes: Object = {}, createHistory: boolean = true) {
-        const route = routeRegistry.get(name);
-
         if (!this.isRouteChanging(name, attributes)) {
             return;
         }
@@ -97,7 +95,26 @@ export default class Router {
             this.createAttributesHistory();
         }
 
-        this.route = route;
+        this.update(name, attributes);
+    }
+
+    restore(name: string, attributes: Object = {}) {
+        if (!this.isRouteChanging(name, attributes)) {
+            return;
+        }
+
+        if (!this.attributesHistory[name] || this.attributesHistory[name].length === 0) {
+            this.navigate(name, attributes);
+            return;
+        }
+
+        const attributesHistory = this.attributesHistory[name].pop();
+
+        this.navigate(name, {...attributesHistory, ...attributes}, false);
+    }
+
+    update(name: string,attributes: Object) {
+        this.route = routeRegistry.get(name);
         this.attributes = attributes;
 
         for (const [key, observableValue] of this.bindings.entries()) {
@@ -108,17 +125,6 @@ export default class Router {
                 observableValue.set(value);
             }
         }
-    }
-
-    restore(name: string, attributes: Object = {}) {
-        if (!this.attributesHistory[name] || this.attributesHistory[name].length === 0) {
-            this.navigate(name, attributes);
-            return;
-        }
-
-        const attributesHistory = this.attributesHistory[name].pop();
-
-        this.navigate(name, {...attributesHistory, ...attributes}, false);
     }
 
     @computed get url(): string {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -89,11 +89,7 @@ export default class Router {
     @action navigate(name: string, attributes: Object = {}, createHistory: boolean = true) {
         const route = routeRegistry.get(name);
 
-        if (this.route
-            && route
-            && this.route.name === route.name
-            && equal(this.attributes, attributes)
-        ) {
+        if (!this.isRouteChanging(name, attributes)) {
             return;
         }
 
@@ -176,6 +172,16 @@ export default class Router {
         }
 
         this.attributesHistory[this.route.name].push(toJS(this.attributes));
+    }
+
+    isRouteChanging(name: string, attributes: Object) {
+        const route = routeRegistry.get(name);
+
+        return !(
+            this.route
+            && this.route.name === route.name
+            && equal(this.attributes, attributes)
+        );
     }
 
     static getRoutePath(route: Route) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -112,6 +112,17 @@ export default class Router {
 
     @action update(name: string, attributes: Object) {
         this.route = routeRegistry.get(name);
+
+        const attributeDefaults = this.route.attributeDefaults;
+        Object.keys(attributeDefaults).forEach((key) => {
+            // set default attributes if not passed, to automatically set important omitted attributes everywhere
+            // e.g. allows to always pass the default locale if nothing is passed
+            if (attributes[key] !== undefined) {
+                return;
+            }
+            attributes[key] = attributeDefaults[key];
+        });
+
         this.attributes = attributes;
 
         for (const [key, observableValue] of this.bindings.entries()) {
@@ -139,16 +150,6 @@ export default class Router {
             const value = observableValue.get();
             attributes[key] = value;
         }
-
-        const attributeDefaults = this.route.attributeDefaults;
-        Object.keys(attributeDefaults).forEach((key) => {
-            // set default attributes if not passed, to automatically set important omitted attributes everywhere
-            // e.g. allows to always pass the default locale if nothing is passed
-            if (attributes[key] !== undefined) {
-                return;
-            }
-            attributes[key] = attributeDefaults[key];
-        });
 
         const url = compile(path)(attributes);
         const searchParameters = new URLSearchParams();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -86,34 +86,31 @@ export default class Router {
         }
     }
 
-    @action navigate(name: string, attributes: Object = {}, createHistory: boolean = true) {
+    navigate(name: string, attributes: Object = {}) {
         if (!this.isRouteChanging(name, attributes)) {
             return;
         }
 
-        if (createHistory) {
-            this.createAttributesHistory();
-        }
-
+        this.createAttributesHistory();
         this.update(name, attributes);
     }
 
     restore(name: string, attributes: Object = {}) {
-        if (!this.isRouteChanging(name, attributes)) {
-            return;
-        }
-
         if (!this.attributesHistory[name] || this.attributesHistory[name].length === 0) {
             this.navigate(name, attributes);
             return;
         }
 
+        if (!this.isRouteChanging(name, attributes)) {
+            return;
+        }
+
         const attributesHistory = this.attributesHistory[name].pop();
 
-        this.navigate(name, {...attributesHistory, ...attributes}, false);
+        this.update(name, {...attributesHistory, ...attributes});
     }
 
-    update(name: string,attributes: Object) {
+    @action update(name: string, attributes: Object) {
         this.route = routeRegistry.get(name);
         this.attributes = attributes;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -11,7 +11,7 @@ export default class Router {
     @observable route: Route;
     @observable attributes: Object = {};
     @observable bindings: Map<string, observable> = new Map();
-    bindingDefaults: Map<string, ?string> = new Map();
+    bindingDefaults: Map<string, ?string | number> = new Map();
     attributesHistory: {[string]: Array<AttributeMap>} = {};
 
     constructor(history: Object) {
@@ -35,7 +35,7 @@ export default class Router {
         });
     }
 
-    @action bind(key: string, value: observable, defaultValue: ?string = undefined) {
+    @action bind(key: string, value: observable, defaultValue: ?string | number = undefined) {
         if (key in this.attributes) {
             // when the bound parameter is bound set the state of the passed observable to the current value once
             // required because otherwise the parameter will be overridden on the initial start of the application
@@ -72,12 +72,12 @@ export default class Router {
 
             const attributes = {};
             for (let i= 1; i < match.length; i++) {
-                attributes[names[i - 1].name] = match[i];
+                attributes[names[i - 1].name] = Router.tryParseNumber(match[i]);
             }
 
             const search = new URLSearchParams(queryString);
             search.forEach((value, key) => {
-                attributes[key] = value;
+                attributes[key] = Router.tryParseNumber(value);
             });
 
             this.navigate(name, attributes);
@@ -194,5 +194,13 @@ export default class Router {
         }
 
         return Router.getRoutePath(route.parent) + route.path;
+    }
+
+    static tryParseNumber(value: string) {
+        if (isNaN(value)) {
+            return value;
+        }
+
+        return parseFloat(value);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -97,7 +97,7 @@ export default class Router {
 
     restore(name: string, attributes: Object = {}) {
         if (!this.attributesHistory[name] || this.attributesHistory[name].length === 0) {
-            this.navigate(name, attributes);
+            this.update(name, attributes);
             return;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -158,30 +158,6 @@ test('Update observable attribute on route change', () => {
     expect(history.location.pathname).toBe('/list/de');
 });
 
-test('Navigate to route without default attribute when default observable is set', () => {
-    routeRegistry.getAll.mockReturnValue({
-        list: {
-            name: 'list',
-            view: 'list',
-            path: '/list/:locale',
-            attributeDefaults: {
-                locale: 'en',
-            },
-        },
-    });
-
-    const locale = observable();
-
-    const history = createHistory();
-    const router = new Router(history);
-
-    router.bind('locale', locale, 'de');
-
-    router.navigate('list');
-    expect(router.attributes.locale).toBe('de');
-    expect(history.location.pathname).toBe('/list/de');
-});
-
 test('Navigate to route using URL', () => {
     routeRegistry.getAll.mockReturnValue({
         page: {
@@ -423,6 +399,15 @@ test('Use current route from URL', () => {
 });
 
 test('Binding should update passed observable', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
     const value = observable();
 
     const history = createHistory();
@@ -871,6 +856,35 @@ test('Navigating should store the old route information', () => {
         {
             uuid: 'snippet-uuid',
             locale: 'de',
+        },
+    ]);
+});
+
+test('Navigating to route with defaults should store the old route information once', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            view: 'form',
+            path: '/pages/:locale/:uuid',
+            options: {
+                type: 'page',
+            },
+            attributeDefaults: {
+                locale: 'en',
+            },
+        },
+    });
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.navigate('page', {uuid: 'page-uuid'});
+    router.navigate('page', {uuid: 'page-uuid', locale: 'de'});
+
+    expect(router.attributesHistory['page']).toEqual([
+        {
+            uuid: 'page-uuid',
+            locale: 'en',
         },
     ]);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -54,12 +54,12 @@ test('Navigate to route with search parameters using state', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.navigate('page', {uuid: 'some-uuid', page: '1', sort: 'title'});
+    router.navigate('page', {uuid: 'some-uuid', page: 1, sort: 'title'});
     expect(isObservable(router.route)).toBe(true);
     expect(router.route.view).toBe('form');
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
-    expect(router.attributes.page).toBe('1');
+    expect(router.attributes.page).toBe(1);
     expect(router.attributes.sort).toBe('title');
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?page=1&sort=title');
@@ -203,7 +203,7 @@ test('Navigate to route using URL with search parameters', () => {
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(router.attributes.test).toBe('value');
-    expect(router.attributes.page).toBe('1');
+    expect(router.attributes.page).toBe(1);
     expect(router.attributes.sort).toBe('date');
     expect(history.location.pathname).toBe('/pages/some-uuid/value');
     expect(history.location.search).toBe('?page=1&sort=date');
@@ -436,10 +436,10 @@ test('Binding should update state in router', () => {
 
     router.navigate('list', {page: 1});
     router.bind('page', page);
-    expect(router.attributes.page).toBe('1');
+    expect(router.attributes.page).toBe(1);
 
     page.set(2);
-    expect(router.attributes.page).toBe('2');
+    expect(router.attributes.page).toBe(2);
 });
 
 test('Binding should set default attribute', () => {
@@ -480,11 +480,35 @@ test('Binding should update URL with fixed attributes', () => {
 
     router.navigate('page', {uuid: 1, locale: 'de'});
     router.bind('uuid', uuid);
-    expect(router.attributes.uuid).toBe('1');
+    expect(router.attributes.uuid).toBe(1);
     expect(router.url).toBe('/page/1?locale=de');
 
     uuid.set(2);
-    expect(router.attributes.uuid).toBe('2');
+    expect(router.attributes.uuid).toBe(2);
+});
+
+test('Binding should update URL with fixed attributes as string if not a number', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            view: 'page',
+            path: '/page/:uuid',
+            attributeDefaults: {},
+        },
+    });
+
+    const uuid = observable(1);
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.navigate('page', {uuid: 'some-uuid', locale: 'de'});
+    router.bind('uuid', uuid);
+    expect(router.attributes.uuid).toBe('some-uuid');
+    expect(router.url).toBe('/page/some-uuid?locale=de');
+
+    uuid.set('another-uuid');
+    expect(router.attributes.uuid).toBe('another-uuid');
 });
 
 test('Binding should update state in router with other default bindings', () => {
@@ -655,9 +679,9 @@ test('Binding should be set to initial passed value from URL', () => {
     const history = createHistory();
     history.push('/list?page=2');
     const router = new Router(history);
-    router.bind('page', value, '1');
+    router.bind('page', value, 1);
 
-    expect(value.get()).toBe('2');
+    expect(value.get()).toBe(2);
     expect(history.location.search).toBe('?page=2');
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -5,7 +5,7 @@ export type RouteConfig = {
     view: string,
     path: string,
     options: Object,
-    attributeDefaults: Object,
+    attributeDefaults: AttributeMap,
 };
 
 export type Route = {
@@ -15,7 +15,9 @@ export type Route = {
     view: string,
     path: string,
     options: Object,
-    attributeDefaults: Object,
+    attributeDefaults: AttributeMap,
 };
+
+export type AttributeMap = {[string]: string};
 
 export type RouteMap = {[string]: Route};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -64,7 +64,7 @@ export default withToolbar(Form, function() {
     const backButton = backRoute
         ? {
             onClick: () => {
-                router.navigate(backRoute, {locale: this.props.resourceStore.locale.get()});
+                router.restore(backRoute, {locale: this.props.resourceStore.locale.get()});
             },
         }
         : undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -47,7 +47,7 @@ test('Should navigate to defined route on back button click', () => {
     const resourceStore = new ResourceStore('test', 1);
 
     const router = {
-        navigate: jest.fn(),
+        restore: jest.fn(),
         bind: jest.fn(),
         route: {
             options: {
@@ -62,7 +62,7 @@ test('Should navigate to defined route on back button click', () => {
 
     const toolbarConfig = toolbarFunction.call(form);
     toolbarConfig.backButton.onClick();
-    expect(router.navigate).toBeCalledWith('test_route', {locale: 'de'});
+    expect(router.restore).toBeCalledWith('test_route', {locale: 'de'});
 });
 
 test('Should not render back button when no editLink is configured', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -3,5 +3,7 @@
     "sulu_admin.delete": "Löschen",
     "sulu_admin.of": "von",
     "sulu_admin.page": "Seite",
-    "sulu_admin.save": "Speichern"
+    "sulu_admin.save": "Speichern",
+    "sulu_admin.object": "Objekt",
+    "sulu_admin.objects": "Objekte"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -3,5 +3,7 @@
     "sulu_admin.delete": "Delete",
     "sulu_admin.of": "of",
     "sulu_admin.page": "Page",
-    "sulu_admin.save": "Save"
+    "sulu_admin.save": "Save",
+    "sulu_admin.object": "Object",
+    "sulu_admin.objects": "Objects"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -65,7 +65,7 @@ class MediaOverview extends React.PureComponent<ViewProps> {
 
     getTitle() {
         if (!this.collectionId) {
-            return translate('sulu_admin.all_media');
+            return translate('sulu_media.all_media');
         }
 
         return this.title;
@@ -136,7 +136,7 @@ export default withToolbar(MediaOverview, function() {
         backButton: (this.collectionId !== undefined)
             ? {
                 onClick: () => {
-                    router.navigate(COLLECTION_ROUTE, {id: this.parentId}, {locale: this.locale.get(), page: 1});
+                    router.restore(COLLECTION_ROUTE, {id: this.parentId, locale: this.locale.get()});
                 },
             }
             : undefined,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -89,7 +89,7 @@ class MediaOverview extends React.PureComponent<ViewProps> {
 
     handleOpenFolder = (collectionId) => {
         const {router} = this.props;
-        router.navigate(COLLECTION_ROUTE, {id: collectionId, page: '1', locale: this.locale.get()});
+        router.navigate(COLLECTION_ROUTE, {id: collectionId, locale: this.locale.get()});
     };
 
     render() {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -1,0 +1,49 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import {mount} from 'enzyme';
+
+jest.mock('sulu-admin-bundle/services/Translator', () => ({
+    translate: function(key) {
+        switch (key) {
+            case 'sulu_admin.add':
+                return 'Add';
+            case 'sulu_admin.delete':
+                return 'Delete';
+        }
+    },
+}));
+
+jest.mock('sulu-admin-bundle/containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
+
+jest.mock('sulu-admin-bundle/containers/Datagrid/registries/DatagridAdapterRegistry', () => ({
+    get: jest.fn().mockReturnValue(function() {
+        return null;
+    }),
+    has: jest.fn().mockReturnValue(function() {
+        return false;
+    }),
+}));
+
+test('Should navigate to defined route on back button click', () => {
+    const withToolbar = require('sulu-admin-bundle/containers/Toolbar/withToolbar');
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = withToolbar.mock.calls[0][1];
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+            },
+        },
+        attributes: {},
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />).get(0);
+    mediaOverview.collectionId = 4;
+    mediaOverview.locale.set('de');
+
+    const toolbarConfig = toolbarFunction.call(mediaOverview);
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('sulu_media.overview', {locale: 'de'});
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -1,5 +1,3 @@
 {
-    "sulu_admin.object": "Objekt",
-    "sulu_admin.objects": "Objekte",
-    "sulu_admin.all_media": "Alle Medien"
+    "sulu_media.all_media": "Alle Medien"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -1,5 +1,3 @@
 {
-    "sulu_admin.object": "Object",
-    "sulu_admin.objects": "Objects",
-    "sulu_admin.all_media": "All media"    
+    "sulu_media.all_media": "All media"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a history function to the router. It therefore keeps an object, which keeps track of the previous routes to which have been navigated. Then there is the `restore` function on the router, which allows to restore these old attributes and queries, which are merged with the additional passed parameters.

#### Why?

Because this way we can implement the back button correctly. All the parameters like for pagination will be taken from the old storage.

#### Example Usage

~~~javascript
router.restore('page', {uuid: '123'}, {locale: 'de'});
~~~

#### To Do

- [x] Document the restore function
- [ ] Fix bug in media overview, where not identical types (7 !== '7') cause too many histories to be written
- [x] Defaults should be written on `navigate`, because otherwise `navigate` is executed twice (once without and once with the defaults)
- [x] Introduce `navigateWithoutCreatingHistory`