### PR TITLE
Implement default values for attributes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 **/node_modules/
 **/vendor/
-/web
+**/flow-typed/
 
 # TODO Remove these rules once the old code is removed
 Gruntfile.js

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 /tests/app/logs
 /tests/Resources/cache
 /vendor
-/web
 
 # Composer
 /composer.lock

--- a/flow-typed/npm/jest_v21.x.x.js
+++ b/flow-typed/npm/jest_v21.x.x.js
@@ -1,0 +1,579 @@
+// flow-typed signature: 65527f14a5f7e89fb28d0a29f45dc848
+// flow-typed version: c7c67b81c1/jest_v21.x.x/flow_>=v0.39.x
+
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+  (...args: TArguments): TReturn,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<TArguments>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: Array<TReturn>
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): void,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): void,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): void,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean
+};
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void
+};
+
+type JestExpectType = {
+  not: JestExpectType & EnzymeMatchersType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | RegExp): void,
+  toThrowError(message?: string | Error | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void
+};
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+    implementation?: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
+  /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn<any, any>
+};
+
+type JestSpyType = {
+  calls: JestCallsType
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: string, fn: () => void): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: string, fn: () => void): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: string, fn: () => void): void
+};
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  (
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Only run this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  only(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Skip running this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  skip(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Run the test concurrently
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  concurrent(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void
+};
+declare function fit(
+  name: string,
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu.git",
     "scripts": {
-        "build": "webpack -p",
         "lint:js": "eslint .",
         "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
         "flow": "flow",

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -37,6 +37,11 @@ class Route
     private $options = [];
 
     /**
+     * @var array
+     */
+    private $attributeDefaults = [];
+
+    /**
      * @var string
      */
     private $parent;
@@ -51,6 +56,13 @@ class Route
     public function addOption(string $key, $value): self
     {
         $this->options[$key] = $value;
+
+        return $this;
+    }
+
+    public function addAttributeDefault(string $key, string $value): self
+    {
+        $this->attributeDefaults[$key] = $value;
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -10,13 +10,17 @@ routeRegistry.addCollection([
         options: {
             type: 'contacts',
         },
+        attributeDefaults: {},
     },
     {
         name: 'sulu_contact.form',
-        path: '/contacts/:id',
+        path: '/contacts/:locale/:id',
         view: 'sulu_admin.form',
         options: {
             type: 'contact',
+        },
+        attributeDefaults: {
+            locale: 'en',
         },
     },
     {
@@ -27,6 +31,7 @@ routeRegistry.addCollection([
         options: {
             tabTitle: 'Contacts',
         },
+        attributeDefaults: {},
     },
 ]);
 ```
@@ -41,26 +46,23 @@ This means that the path is prepended by the path of the parent. The routes acce
 access to its relatives: The `parent` key there is a reference to its parent route, and there is also a `children` key
 containing all the children of this route.
 
-The `Router` tries to imitate the naming of [Symfony](https://symfony.com/doc/current/components/http_foundation.html),
-therefore it has three different properties, which are observable, to retrieve routing parameters - `attributes` and
-`query`. In addition to that there is a `route` parameter allowing to access the route options. The following examples
-illustrate the values for each query based on the routes defined above:
+The router also has an `attributes` property, which allows to access the parameters defined in the URL (identified by a
+colon in the path) and the query parameters resp. search string of the URL. There is also the `route` propery on the
+router, which allows to access its options.
 
 ```javascript static
-// URL: #/snippets
-router.route.options;        // returns {type: 'snippets'}
+// URL: #/contacts
+router.route.options;        // returns {type: 'contacts'}
 router.attributes;           // returns {}
 router.query;                // returns {}
 
-// URL: #/snippets?page=1
-router.route.options;        // returns {type: 'snippets'}
-router.attributes;           // returns {}
-router.query;                // returns {page: '1'}
+// URL: #/contacts?page=1
+router.route.options;        // returns {type: 'contacts'}
+router.attributes;           // returns {page: '1'}
 
 // URL: #/contacts/5
 router.route.options;        // returns {type: 'contacts'}
 router.attributes;           // returns {id: 5}
-router.query;                // returns {}
 
 // URL: #/contacts/5/detail
 router.route.options;        // returns {tabTitle: 'Contacts'}
@@ -72,24 +74,24 @@ The service also allows to navigate using the `navigate` method. This is where t
 
 ```javascript static
 // route to a standard route
-router.navigate('sulu_contact.form', {id: 7}, {admin: true}); // redirects to #/contacts/7?admin=true
+router.navigate('sulu_contact.form', {id: 7, admin: true}); // redirects to #/contacts/7?admin=true
 // route to a child route (mind that there is no knowledge of the parent necessary)
-router.navigate('sulu_contact.form.detail', {id: 2}, {admin: true}); // redirects to #/contacts/2/detail?admin=true
+router.navigate('sulu_contact.form.detail', {id: 2, admin: true}); // redirects to #/contacts/2/detail?admin=true
 ```
 
-Something especially useful is the ability to bind any observable to a query parameter of the router. The `bindQuery`
-method takes the name of the query parameter in the URL, the observable and a default value. The default value will be
-set if the value in the URL is not defined. Any change in the URL will be immediately reflected in that observable and
-the other way round.
+Something especially useful is the ability to bind any observable to a query parameter of the router. The `bind` method
+takes the name of a route attribute in the URL, the observable and a default value. The default value will be set if
+the value in the URL is not defined. Any change in the URL will be immediately reflected in that observable and the
+other way round.
 
 ```javascript static
 const value = observable(1);
-router.bindQuery('value', value, 'default');
+router.bind('value', value, 'default');
 
 // user navigates to /page?value=something
 value.get(); // returns something
 
 value.set('anything'); // will navigate to /page?value=anything
 
-router.unbindQuery('value', value); // unbind to avoid leaking listeners
+router.unbind('value', value); // unbind to avoid leaking listeners
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -100,7 +100,12 @@ export default class Router {
         this.attributes = attributes;
 
         for (const [key, observableValue] of this.bindings.entries()) {
-            observableValue.set(this.attributes[key] || this.bindingDefaults.get(key));
+            const value = this.attributes[key] || this.bindingDefaults.get(key);
+
+            // Type unsafe comparison to not trigger a new navigation when only data type changes
+            if (value != observableValue.get()) {
+                observableValue.set(value);
+            }
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -127,6 +127,8 @@ export default class Router {
 
         const attributeDefaults = this.route.attributeDefaults;
         Object.keys(attributeDefaults).forEach((key) => {
+            // set default attributes if not passed, to automatically set important omitted attributes everywhere
+            // e.g. allows to always pass the default locale if nothing is passed
             if (attributes[key] !== undefined) {
                 return;
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -120,6 +120,14 @@ export default class Router {
             attributes[key] = value;
         }
 
+        const attributeDefaults = this.route.attributeDefaults;
+        Object.keys(attributeDefaults).forEach((key) => {
+            if (typeof attributes[key] !== 'undefined') {
+                return;
+            }
+            attributes[key] = attributeDefaults[key];
+        });
+
         const url = compile(path)(attributes);
         const searchParameters = new URLSearchParams();
         Object.keys(attributes).forEach((key) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -41,7 +41,7 @@ export default class Router {
             value.set(this.attributes[key]);
         }
 
-        if (typeof(value.get()) === 'undefined') {
+        if (value.get() === undefined) {
             // when the observable value is not set we want it to be the default value
             value.set(defaultValue);
         }
@@ -127,7 +127,7 @@ export default class Router {
 
         const attributeDefaults = this.route.attributeDefaults;
         Object.keys(attributeDefaults).forEach((key) => {
-            if (typeof attributes[key] !== 'undefined') {
+            if (attributes[key] !== undefined) {
                 return;
             }
             attributes[key] = attributeDefaults[key];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import 'url-search-params-polyfill';
 import createHistory from 'history/createMemoryHistory';
 import {extendObservable, observable, isObservable} from 'mobx';
@@ -52,13 +52,13 @@ test('Navigate to route with search parameters using state', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.navigate('page', {uuid: 'some-uuid'}, {page: '1', sort: 'title'});
+    router.navigate('page', {uuid: 'some-uuid', page: '1', sort: 'title'});
     expect(isObservable(router.route)).toBe(true);
     expect(router.route.view).toBe('form');
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
-    expect(router.query.page).toBe('1');
-    expect(router.query.sort).toBe('title');
+    expect(router.attributes.page).toBe('1');
+    expect(router.attributes.sort).toBe('title');
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?page=1&sort=title');
 });
@@ -122,8 +122,8 @@ test('Navigate to route using URL with search parameters', () => {
     expect(router.route.options.type).toBe('page');
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(router.attributes.test).toBe('value');
-    expect(router.query.page).toBe('1');
-    expect(router.query.sort).toBe('date');
+    expect(router.attributes.page).toBe('1');
+    expect(router.attributes.sort).toBe('date');
     expect(history.location.pathname).toBe('/pages/some-uuid/value');
     expect(history.location.search).toBe('?page=1&sort=date');
 });
@@ -197,11 +197,11 @@ test('Navigate to route changing only search parameters', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.navigate('page', {uuid: 'some-uuid'}, {sort: 'date'});
+    router.navigate('page', {uuid: 'some-uuid', sort: 'date'});
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?sort=date');
 
-    router.navigate('page', {uuid: 'some-uuid'}, {sort: 'title'});
+    router.navigate('page', {uuid: 'some-uuid', sort: 'title'});
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?sort=title');
 });
@@ -218,11 +218,11 @@ test('Navigate to route by adding search parameters', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.navigate('page', {uuid: 'some-uuid'}, {sort: 'date'});
+    router.navigate('page', {uuid: 'some-uuid', sort: 'date'});
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?sort=date');
 
-    router.navigate('page', {uuid: 'some-uuid'}, {sort: 'date', order: 'asc'});
+    router.navigate('page', {uuid: 'some-uuid', sort: 'date', order: 'asc'});
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?sort=date&order=asc');
 });
@@ -239,11 +239,11 @@ test('Navigate to route by removing search parameters', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.navigate('page', {uuid: 'some-uuid'}, {sort: 'date', order: 'asc'});
+    router.navigate('page', {uuid: 'some-uuid', sort: 'date', order: 'asc'});
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?sort=date&order=asc');
 
-    router.navigate('page', {uuid: 'some-uuid'}, {sort: 'date'});
+    router.navigate('page', {uuid: 'some-uuid', sort: 'date'});
     expect(history.location.pathname).toBe('/pages/some-uuid');
     expect(history.location.search).toBe('?sort=date');
 });
@@ -307,19 +307,19 @@ test('Use current route from URL', () => {
     expect(router.route.name).toBe('page');
 });
 
-test('Bound query parameter should update passed observable', () => {
+test('Binding should update passed observable', () => {
     const value = observable();
 
     const history = createHistory();
     const router = new Router(history);
 
-    router.bindQuery('page', value);
-    router.navigate('list', {}, {page: 2});
+    router.bind('page', value);
+    router.navigate('list', {page: 2});
 
     expect(value.get()).toBe(2);
 });
 
-test('Bound query parameter should update state in router', () => {
+test('Binding should update state in router', () => {
     routeRegistry.getAll.mockReturnValue({
         list: {
             name: 'list',
@@ -333,15 +333,58 @@ test('Bound query parameter should update state in router', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.navigate('list', {}, {page: 1});
-    router.bindQuery('page', page);
-    expect(router.query.page).toBe('1');
+    router.navigate('list', {page: 1});
+    router.bind('page', page);
+    expect(router.attributes.page).toBe('1');
 
     page.set(2);
-    expect(router.query.page).toBe('2');
+    expect(router.attributes.page).toBe('2');
 });
 
-test('Bound query parameter should update state in router with other default query parameters', () => {
+test('Binding should set default attribute', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            view: 'page',
+            path: '/page/:locale',
+        },
+    });
+
+    const locale = observable();
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bind('locale', locale, 'en');
+    router.navigate('page');
+    expect(router.attributes.locale).toBe('en');
+    expect(router.url).toBe('/page/en');
+});
+
+test('Binding should update URL with fixed attributes', () => {
+    routeRegistry.getAll.mockReturnValue({
+        page: {
+            name: 'page',
+            view: 'page',
+            path: '/page/:uuid',
+        },
+    });
+
+    const uuid = observable(1);
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.navigate('page', {uuid: 1, locale: 'de'});
+    router.bind('uuid', uuid);
+    expect(router.attributes.uuid).toBe('1');
+    expect(router.url).toBe('/page/1?locale=de');
+
+    uuid.set(2);
+    expect(router.attributes.uuid).toBe('2');
+});
+
+test('Binding should update state in router with other default bindings', () => {
     routeRegistry.getAll.mockReturnValue({
         list: {
             name: 'list',
@@ -356,40 +399,40 @@ test('Bound query parameter should update state in router with other default que
     const history = createHistory();
     const router = new Router(history);
 
-    router.bindQuery('page', page, '1');
-    router.bindQuery('locale', locale);
+    router.bind('page', page, '1');
+    router.bind('locale', locale);
     router.navigate('list');
 
     locale.set('de');
     expect(history.location.search).toBe('?locale=de');
-    expect(router.query.locale).toBe('de');
+    expect(router.attributes.locale).toBe('de');
 });
 
-test('Unbind query should remove query binding', () => {
+test('Unbind should remove binding', () => {
     const value = observable();
 
     const history = createHistory();
     const router = new Router(history);
 
-    router.bindQuery('remove', value);
-    expect(router.queryBinds.has('remove')).toBe(true);
+    router.bind('remove', value);
+    expect(router.bindings.has('remove')).toBe(true);
 
-    router.unbindQuery('remove', value);
-    expect(router.queryBinds.has('remove')).toBe(false);
+    router.unbind('remove', value);
+    expect(router.bindings.has('remove')).toBe(false);
 });
 
-test('Unbind query should not remove query binding if it is assigned to a new observable', () => {
+test('Unbind query should not remove binding if it is assigned to a new observable', () => {
     const history = createHistory();
     const router = new Router(history);
 
     const value = observable();
-    router.bindQuery('remove', value);
-    expect(router.queryBinds.get('remove')).toBe(value);
+    router.bind('remove', value);
+    expect(router.bindings.get('remove')).toBe(value);
 
     const newValue = observable();
-    router.bindQuery('remove', newValue);
-    router.unbindQuery('remove', value);
-    expect(router.queryBinds.get('remove')).toBe(newValue);
+    router.bind('remove', newValue);
+    router.unbind('remove', value);
+    expect(router.bindings.get('remove')).toBe(newValue);
 });
 
 test('Do not add parameter to URL if undefined', () => {
@@ -406,7 +449,7 @@ test('Do not add parameter to URL if undefined', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.bindQuery('page', value);
+    router.bind('page', value);
     history.push('/list');
     expect(history.location.search).toBe('');
 });
@@ -425,7 +468,7 @@ test('Set state to undefined if parameter is removed from URL', () => {
     const history = createHistory();
     const router = new Router(history);
 
-    router.bindQuery('page', value);
+    router.bind('page', value);
     history.push('/list');
     expect(value.get()).toBe(undefined);
 });
@@ -444,7 +487,7 @@ test('Bound query should update state to default value if removed from URL', () 
     const history = createHistory();
     const router = new Router(history);
 
-    router.bindQuery('page', value, '1');
+    router.bind('page', value, '1');
     history.push('/list');
     expect(value.get()).toBe('1');
 });
@@ -464,7 +507,7 @@ test('Bound query should omit URL parameter if set to default value', () => {
     const router = new Router(history);
     router.navigate('list');
 
-    router.bindQuery('page', value, '1');
+    router.bind('page', value, '1');
     value.set('1');
     expect(history.location.search).toBe('');
 });
@@ -483,7 +526,7 @@ test('Bound query should initially not be set to undefined in URL', () => {
     const history = createHistory();
     history.push('/list');
     const router = new Router(history);
-    router.bindQuery('page', value, '1');
+    router.bind('page', value, '1');
 
     expect(history.location.search).toBe('');
 });
@@ -502,7 +545,7 @@ test('Bound query should be set to initial passed value from URL', () => {
     const history = createHistory();
     history.push('/list?page=2');
     const router = new Router(history);
-    router.bindQuery('page', value, '1');
+    router.bind('page', value, '1');
 
     expect(value.get()).toBe('2');
     expect(history.location.search).toBe('?page=2');
@@ -556,11 +599,15 @@ test('Navigate to child route using state', () => {
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(history.location.pathname).toBe('/snippets/some-uuid/detail');
 
-    expect(router.route.parent.view).toBe('sulu_admin.tab');
-    expect(router.route.parent.options.resourceKey).toBe('snippet');
-    expect(router.route.parent.children).toHaveLength(2);
-    expect(router.route.parent.children[0]).toBe(router.route);
-    expect(router.route.parent.children[1].options.tabTitle).toBe('Taxonomies');
+    const parent = router.route.parent;
+    if (!parent) {
+        throw new Error('Parent must be set!');
+    }
+    expect(parent.view).toBe('sulu_admin.tab');
+    expect(parent.options.resourceKey).toBe('snippet');
+    expect(parent.children).toHaveLength(2);
+    expect(parent.children[0]).toBe(router.route);
+    expect(parent.children[1].options.tabTitle).toBe('Taxonomies');
 });
 
 test('Navigate to child route using URL', () => {
@@ -611,9 +658,13 @@ test('Navigate to child route using URL', () => {
     expect(router.attributes.uuid).toBe('some-uuid');
     expect(history.location.pathname).toBe('/snippets/some-uuid/detail');
 
-    expect(router.route.parent.view).toBe('sulu_admin.tab');
-    expect(router.route.parent.options.resourceKey).toBe('snippet');
-    expect(router.route.parent.children).toHaveLength(2);
-    expect(router.route.parent.children[0]).toBe(router.route);
-    expect(router.route.parent.children[1].options.tabTitle).toBe('Taxonomies');
+    const parent = router.route.parent;
+    if (!parent) {
+        throw new Error('Parent must be set!');
+    }
+    expect(parent.view).toBe('sulu_admin.tab');
+    expect(parent.options.resourceKey).toBe('snippet');
+    expect(parent.children).toHaveLength(2);
+    expect(parent.children[0]).toBe(router.route);
+    expect(parent.children[1].options.tabTitle).toBe('Taxonomies');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -23,6 +23,7 @@ test('Navigate to route using state', () => {
             options: {
                 type: 'page',
             },
+            attributeDefaults: {},
         },
     });
 
@@ -46,6 +47,7 @@ test('Navigate to route with search parameters using state', () => {
             options: {
                 type: 'page',
             },
+            attributeDefaults: {},
         },
     });
 
@@ -69,6 +71,7 @@ test('Navigate to route without parameters using state', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -77,6 +80,106 @@ test('Navigate to route without parameters using state', () => {
 
     router.navigate('page', {uuid: 'some-uuid'});
     expect(router.route.name).toBe('page');
+});
+
+test('Navigate to route with default attribute', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list/:locale',
+            attributeDefaults: {
+                locale: 'en',
+            },
+        },
+    });
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.navigate('list');
+    expect(router.attributes.locale).toBe('en');
+    expect(history.location.pathname).toBe('/list/en');
+});
+
+test('Navigate to route without default attribute when observable is changed', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list/:locale',
+            attributeDefaults: {
+                locale: 'en',
+            },
+        },
+    });
+
+    const locale = observable();
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bind('locale', locale);
+
+    router.navigate('list');
+    expect(router.attributes.locale).toBe('en');
+    expect(history.location.pathname).toBe('/list/en');
+
+    locale.set('de');
+    expect(router.attributes.locale).toBe('de');
+    expect(history.location.pathname).toBe('/list/de');
+});
+
+test('Update observable attribute on route change', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list/:locale',
+            attributeDefaults: {
+                locale: 'en',
+            },
+        },
+    });
+
+    const locale = observable();
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bind('locale', locale);
+
+    router.navigate('list');
+    expect(router.attributes.locale).toBe('en');
+    expect(history.location.pathname).toBe('/list/en');
+
+    history.push('/list/de');
+    expect(router.attributes.locale).toBe('de');
+    expect(history.location.pathname).toBe('/list/de');
+});
+
+test('Navigate to route without default attribute when default observable is set', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list/:locale',
+            attributeDefaults: {
+                locale: 'en',
+            },
+        },
+    });
+
+    const locale = observable();
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bind('locale', locale, 'de');
+
+    router.navigate('list');
+    expect(router.attributes.locale).toBe('de');
+    expect(history.location.pathname).toBe('/list/de');
 });
 
 test('Navigate to route using URL', () => {
@@ -88,6 +191,7 @@ test('Navigate to route using URL', () => {
             options: {
                 type: 'page',
             },
+            attributeDefaults: {},
         },
     });
 
@@ -111,6 +215,7 @@ test('Navigate to route using URL with search parameters', () => {
             options: {
                 type: 'page',
             },
+            attributeDefaults: {},
         },
     });
 
@@ -134,6 +239,7 @@ test('Navigate to route changing only parameters', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -153,6 +259,7 @@ test('Navigate to route by adding parameters', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid/:value?',
+            attributeDefaults: {},
         },
     });
 
@@ -172,6 +279,7 @@ test('Navigate to route by removing parameters', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid/:value?',
+            attributeDefaults: {},
         },
     });
 
@@ -191,6 +299,7 @@ test('Navigate to route changing only search parameters', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -212,6 +321,7 @@ test('Navigate to route by adding search parameters', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -233,6 +343,7 @@ test('Navigate to route by removing search parameters', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -254,11 +365,13 @@ test('Navigate to route and let history react', () => {
             name: 'home',
             view: 'home',
             path: '/',
+            attributeDefaults: {},
         },
         page: {
             name: 'page',
             view: 'page',
             path: '/page',
+            attributeDefaults: {},
         },
     });
 
@@ -276,6 +389,7 @@ test('Do not navigate if all parameters are equal', () => {
             name: 'page',
             view: 'form',
             path: '/pages/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -296,6 +410,7 @@ test('Use current route from URL', () => {
             name: 'page',
             view: 'page',
             path: '/page',
+            attributeDefaults: {},
         },
     });
 
@@ -325,6 +440,7 @@ test('Binding should update state in router', () => {
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -347,6 +463,7 @@ test('Binding should set default attribute', () => {
             name: 'page',
             view: 'page',
             path: '/page/:locale',
+            attributeDefaults: {},
         },
     });
 
@@ -367,6 +484,7 @@ test('Binding should update URL with fixed attributes', () => {
             name: 'page',
             view: 'page',
             path: '/page/:uuid',
+            attributeDefaults: {},
         },
     });
 
@@ -390,6 +508,7 @@ test('Binding should update state in router with other default bindings', () => 
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -441,6 +560,7 @@ test('Do not add parameter to URL if undefined', () => {
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -460,6 +580,7 @@ test('Set state to undefined if parameter is removed from URL', () => {
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -479,6 +600,7 @@ test('Bound query should update state to default value if removed from URL', () 
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -498,6 +620,7 @@ test('Bound query should omit URL parameter if set to default value', () => {
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -518,6 +641,7 @@ test('Bound query should initially not be set to undefined in URL', () => {
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -537,6 +661,7 @@ test('Bound query should be set to initial passed value from URL', () => {
             name: 'list',
             view: 'list',
             path: '/list',
+            attributeDefaults: {},
         },
     });
 
@@ -559,6 +684,7 @@ test('Navigate to child route using state', () => {
         options: {
             resourceKey: 'snippet',
         },
+        attributeDefaults: {},
     });
 
     const detailRoute = extendObservable({
@@ -569,6 +695,7 @@ test('Navigate to child route using state', () => {
         options: {
             tabTitle: 'Detail',
         },
+        attributeDefaults: {},
     });
 
     const taxonomyRoute = extendObservable({
@@ -579,6 +706,7 @@ test('Navigate to child route using state', () => {
         options: {
             tabTitle: 'Taxonomies',
         },
+        attributeDefaults: {},
     });
 
     formRoute.children = [detailRoute, taxonomyRoute];
@@ -618,6 +746,7 @@ test('Navigate to child route using URL', () => {
         options: {
             resourceKey: 'snippet',
         },
+        attributeDefaults: {},
     });
 
     const detailRoute = extendObservable({
@@ -628,6 +757,7 @@ test('Navigate to child route using URL', () => {
         options: {
             tabTitle: 'Detail',
         },
+        attributeDefaults: {},
     });
 
     const taxonomyRoute = extendObservable({
@@ -638,6 +768,7 @@ test('Navigate to child route using URL', () => {
         options: {
             tabTitle: 'Taxonomies',
         },
+        attributeDefaults: {},
     });
 
     formRoute.children = [detailRoute, taxonomyRoute];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -655,7 +655,7 @@ test('Bound query should initially not be set to undefined in URL', () => {
     expect(history.location.search).toBe('');
 });
 
-test('Bound query should be set to initial passed value from URL', () => {
+test('Binding should be set to initial passed value from URL', () => {
     routeRegistry.getAll.mockReturnValue({
         list: {
             name: 'list',
@@ -674,6 +674,32 @@ test('Bound query should be set to initial passed value from URL', () => {
 
     expect(value.get()).toBe('2');
     expect(history.location.search).toBe('?page=2');
+});
+
+test('Binding should not be updated if only data type changes', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+            attributeDefaults: {},
+        },
+    });
+
+    const page = jest.fn(() => ({
+        get: jest.fn(),
+        set: jest.fn(),
+    }))();
+
+    const history = createHistory();
+    const router = new Router(history);
+    router.bind('page', page);
+
+    router.navigate('list', {page: 2});
+    page.get.mockReturnValue(2);
+
+    router.navigate('list', {page: '2'});
+    expect(page.set.mock.calls).not.toContainEqual(['2']);
 });
 
 test('Navigate to child route using state', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -5,6 +5,7 @@ export type RouteConfig = {
     view: string,
     path: string,
     options: Object,
+    attributeDefaults: Object,
 };
 
 export type Route = {
@@ -14,6 +15,7 @@ export type Route = {
     view: string,
     path: string,
     options: Object,
+    attributeDefaults: Object,
 };
 
 export type RouteMap = {[string]: Route};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -28,11 +28,11 @@ class Form extends React.PureComponent<Props> {
     componentWillMount() {
         const {router} = this.props;
         this.props.resourceStore.changeSchema(schema);
-        router.bindQuery('locale', this.props.resourceStore.locale);
+        router.bind('locale', this.props.resourceStore.locale);
     }
 
     componentWillUnmount() {
-        this.props.router.unbindQuery('locale', this.props.resourceStore.locale);
+        this.props.router.unbind('locale', this.props.resourceStore.locale);
     }
 
     handleSubmit = () => {
@@ -64,7 +64,7 @@ export default withToolbar(Form, function() {
     const backButton = backRoute
         ? {
             onClick: () => {
-                router.navigate(backRoute, {}, {locale: this.props.resourceStore.locale.get()});
+                router.navigate(backRoute, {locale: this.props.resourceStore.locale.get()});
             },
         }
         : undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -48,7 +48,7 @@ test('Should navigate to defined route on back button click', () => {
 
     const router = {
         navigate: jest.fn(),
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 backRoute: 'test_route',
@@ -62,7 +62,7 @@ test('Should navigate to defined route on back button click', () => {
 
     const toolbarConfig = toolbarFunction.call(form);
     toolbarConfig.backButton.onClick();
-    expect(router.navigate).toBeCalledWith('test_route', {}, {locale: 'de'});
+    expect(router.navigate).toBeCalledWith('test_route', {locale: 'de'});
 });
 
 test('Should not render back button when no editLink is configured', () => {
@@ -74,7 +74,7 @@ test('Should not render back button when no editLink is configured', () => {
 
     const router = {
         navigate: jest.fn(),
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 locales: [],
@@ -97,7 +97,7 @@ test('Should change locale in form store via locale chooser', () => {
 
     const router = {
         navigate: jest.fn(),
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 backRoute: 'test_route',
@@ -123,7 +123,7 @@ test('Should show locales from router options in toolbar', () => {
 
     const router = {
         navigate: jest.fn(),
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 locales: ['en', 'de'],
@@ -149,7 +149,7 @@ test('Should not show a locale chooser if no locales are passed in router option
 
     const router = {
         navigate: jest.fn(),
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {},
         },
@@ -167,7 +167,7 @@ test('Should initialize the ResourceStore with a schema', () => {
     const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 locales: [],
@@ -199,7 +199,7 @@ test('Should render save button disabled only if form is not dirty', () => {
     const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         navigate: jest.fn(),
         route: {
             options: {
@@ -224,7 +224,7 @@ test('Should save form when submitted', () => {
     const resourceStore = new ResourceStore('snippets', 8);
 
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         navigate: jest.fn(),
         route: {
             options: {
@@ -250,7 +250,7 @@ test('Should pass store, schema and onSubmit handler to FormContainer', () => {
     const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         navigate: jest.fn(),
         route: {
             options: {
@@ -283,7 +283,7 @@ test('Should render save button loading only if form is not saving', () => {
     const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         navigate: jest.fn(),
         route: {
             options: {
@@ -300,13 +300,13 @@ test('Should render save button loading only if form is not saving', () => {
     expect(getSaveItem().loading).toBe(true);
 });
 
-test('Should unbind the query parameter and destroy the store on unmount', () => {
+test('Should unbind the binding and destroy the store on unmount', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 12);
     const router = {
-        bindQuery: jest.fn(),
-        unbindQuery: jest.fn(),
+        bind: jest.fn(),
+        unbind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -319,8 +319,8 @@ test('Should unbind the query parameter and destroy the store on unmount', () =>
     const form = mount(<Form router={router} resourceStore={resourceStore} />);
     const locale = form.find('Form').at(1).prop('store').locale;
 
-    expect(router.bindQuery).toBeCalledWith('locale', locale);
+    expect(router.bind).toBeCalledWith('locale', locale);
 
     form.unmount();
-    expect(router.unbindQuery).toBeCalledWith('locale', locale);
+    expect(router.unbind).toBeCalledWith('locale', locale);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -34,11 +34,11 @@ class List extends React.PureComponent<ViewProps> {
 
         const observableOptions = {};
 
-        router.bindQuery('page', this.page, '1');
+        router.bind('page', this.page, '1');
         observableOptions.page = this.page;
 
         if (locales) {
-            router.bindQuery('locale', this.locale);
+            router.bind('locale', this.locale);
             observableOptions.locale = this.locale;
         }
 
@@ -55,15 +55,15 @@ class List extends React.PureComponent<ViewProps> {
             },
         } = router;
         this.datagridStore.destroy();
-        router.unbindQuery('page', this.page);
+        router.unbind('page', this.page);
         if (locales) {
-            router.unbindQuery('locale', this.locale);
+            router.unbind('locale', this.locale);
         }
     }
 
     handleEditClick = (rowId) => {
         const {router} = this.props;
-        router.navigate(router.route.options.editRoute, {id: rowId}, {locale: this.locale.get()});
+        router.navigate(router.route.options.editRoute, {id: rowId, locale: this.locale.get()});
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -71,7 +71,7 @@ beforeEach(() => {
 test('Should render the datagrid with the correct resourceKey', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -86,7 +86,7 @@ test('Should render the datagrid with the correct resourceKey', () => {
 test('Should render the list with a title', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -102,7 +102,7 @@ test('Should render the list with a title', () => {
 test('Should render the datagrid with the pencil icon if a editRoute has been passed', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -126,11 +126,11 @@ test('Should throw an error when no resourceKey is defined in the route options'
     expect(() => render(<List router={router} />)).toThrow(/mandatory resourceKey option/);
 });
 
-test('Should unbind the query parameter and destroy the store on unmount', () => {
+test('Should unbind the binding and destroy the store on unmount', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
-        unbindQuery: jest.fn(),
+        bind: jest.fn(),
+        unbind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -140,24 +140,24 @@ test('Should unbind the query parameter and destroy the store on unmount', () =>
     };
 
     const list = mount(<List router={router} />);
-    const page = router.bindQuery.mock.calls[0][1];
-    const locale = router.bindQuery.mock.calls[1][1];
+    const page = router.bind.mock.calls[0][1];
+    const locale = router.bind.mock.calls[1][1];
 
     expect(page.get()).toBe(undefined);
     expect(locale.get()).toBe(undefined);
-    expect(router.bindQuery).toBeCalledWith('page', page, '1');
-    expect(router.bindQuery).toBeCalledWith('locale', locale);
+    expect(router.bind).toBeCalledWith('page', page, '1');
+    expect(router.bind).toBeCalledWith('locale', locale);
 
     list.unmount();
-    expect(router.unbindQuery).toBeCalledWith('page', page);
-    expect(router.unbindQuery).toBeCalledWith('locale', locale);
+    expect(router.unbind).toBeCalledWith('page', page);
+    expect(router.unbind).toBeCalledWith('locale', locale);
 });
 
-test('Should unbind the query parameter and destroy the store on unmount without locale', () => {
+test('Should unbind the binding and destroy the store on unmount without locale', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
-        unbindQuery: jest.fn(),
+        bind: jest.fn(),
+        unbind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -166,22 +166,22 @@ test('Should unbind the query parameter and destroy the store on unmount without
     };
 
     const list = mount(<List router={router} />);
-    const page = router.bindQuery.mock.calls[0][1];
+    const page = router.bind.mock.calls[0][1];
 
     expect(page.get()).toBe(undefined);
-    expect(router.bindQuery).toBeCalledWith('page', page, '1');
-    expect(router.bindQuery).not.toBeCalledWith('locale');
+    expect(router.bind).toBeCalledWith('page', page, '1');
+    expect(router.bind).not.toBeCalledWith('locale');
 
     list.unmount();
-    expect(router.unbindQuery).toBeCalledWith('page', page);
-    expect(router.unbindQuery).not.toBeCalledWith('locale');
+    expect(router.unbind).toBeCalledWith('page', page);
+    expect(router.unbind).not.toBeCalledWith('locale');
 });
 
 test('Should navigate when pencil button is clicked', () => {
     const List = require('../List').default;
     const router = {
         navigate: jest.fn(),
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 editRoute: 'editRoute',
@@ -197,7 +197,7 @@ test('Should navigate when pencil button is clicked', () => {
         },
     };
     listWrapper.find('ButtonCell button').at(0).simulate('click');
-    expect(router.navigate).toBeCalledWith('editRoute', {id: 1}, {locale: 'de'});
+    expect(router.navigate).toBeCalledWith('editRoute', {id: 1, locale: 'de'});
 });
 
 test('Should render the delete item enabled only if something is selected', () => {
@@ -205,7 +205,7 @@ test('Should render the delete item enabled only if something is selected', () =
     const List = require('../List').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'test',
@@ -232,7 +232,7 @@ test('Should render the locale dropdown with the options from router', () => {
     const List = require('../List').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'test',
@@ -259,7 +259,7 @@ test('Should render the locale dropdown with the options from router', () => {
 test('Should pass locale and page observables to the DatagridStore', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'test',
@@ -278,7 +278,7 @@ test('Should pass locale and page observables to the DatagridStore', () => {
 test('Should not pass the locale observable to the DatagridStore if no locales are defined', () => {
     const List = require('../List').default;
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'test',
@@ -303,7 +303,7 @@ test('Should delete selected items when click on delete button', () => {
     const ResourceRequester = require('../../../services/ResourceRequester');
     const toolbarFunction = withToolbar.mock.calls[0][1];
     const router = {
-        bindQuery: jest.fn(),
+        bind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'test',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -29,7 +29,7 @@ export default class ResourceTabs extends React.PureComponent<ViewProps> {
 
     handleSelect = (index: number) => {
         const {router, route} = this.props;
-        router.navigate(route.children[index].name, router.attributes, router.query);
+        router.navigate(route.children[index].name, router.attributes);
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -108,15 +108,11 @@ test('Should navigate to child route if tab is clicked', () => {
     const attributes = {
         attribute: 'value',
     };
-    const query = {
-        query: 'value',
-    };
 
     const router = {
         navigate: jest.fn(),
         route,
         attributes,
-        query,
     };
 
     const Child = () => (<h1>Child</h1>);
@@ -124,7 +120,7 @@ test('Should navigate to child route if tab is clicked', () => {
 
     resourceTabs.find('Tab button').at(1).simulate('click');
 
-    expect(router.navigate).toBeCalledWith('route2', attributes, query);
+    expect(router.navigate).toBeCalledWith('route2', attributes);
 });
 
 test('Should create a ResourceStore on mount and destroy it on unmount', () => {

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -79,8 +79,9 @@ class MediaAdmin extends Admin
         );
 
         return [
-            (new Route('sulu_media.overview', '/collections/:id?', 'sulu_media.overview'))
-                ->addOption('locales', $mediaLocales),
+            (new Route('sulu_media.overview', '/collections/:locale/:id?', 'sulu_media.overview'))
+                ->addOption('locales', $mediaLocales)
+                ->addAttributeDefault('locale', 'en'),
         ];
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -23,8 +23,8 @@ class MediaOverview extends React.PureComponent<ViewProps> {
     componentWillMount() {
         const {router} = this.props;
 
-        router.bindQuery('page', this.page, '1');
-        router.bindQuery('locale', this.locale);
+        router.bind('page', this.page, '1');
+        router.bind('locale', this.locale);
 
         this.disposer = autorun(this.load);
     }
@@ -32,8 +32,8 @@ class MediaOverview extends React.PureComponent<ViewProps> {
     componentWillUnmount() {
         const {router} = this.props;
         this.disposer();
-        router.unbindQuery('locale', this.page);
-        router.unbindQuery('page', this.locale);
+        router.unbind('locale', this.page);
+        router.unbind('page', this.locale);
         this.collectionStore.destroy();
     }
 
@@ -89,7 +89,7 @@ class MediaOverview extends React.PureComponent<ViewProps> {
 
     handleOpenFolder = (collectionId) => {
         const {router} = this.props;
-        router.navigate(COLLECTION_ROUTE, {id: collectionId}, {page: '1', locale: this.locale.get()});
+        router.navigate(COLLECTION_ROUTE, {id: collectionId, page: '1', locale: this.locale.get()});
     };
 
     render() {

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -96,12 +96,13 @@ class SnippetAdmin extends Admin
         );
 
         return [
-            (new Route('sulu_snippet.list', '/snippets', 'sulu_admin.list'))
+            (new Route('sulu_snippet.list', '/snippets/:locale', 'sulu_admin.list'))
                 ->addOption('title', 'sulu_snippet.snippets')
                 ->addOption('resourceKey', 'snippets')
                 ->addOption('editRoute', 'sulu_snippet.form.detail')
-                ->addOption('locales', $snippetLocales),
-            (new Route('sulu_snippet.form', '/snippets/:id', 'sulu_admin.resource_tabs'))
+                ->addOption('locales', $snippetLocales)
+                ->addAttributeDefault('locale', $snippetLocales[0]),
+            (new Route('sulu_snippet.form', '/snippets/:locale/:id', 'sulu_admin.resource_tabs'))
                 ->addOption('resourceKey', 'snippets'),
             (new Route('sulu_snippet.form.detail', '/details', 'sulu_admin.form'))
                 ->addOption('tabTitle', 'sulu_snippet.details')

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -71,6 +71,7 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
             'editRoute' => 'sulu_snippet.form.detail',
             'locales' => array_keys($locales),
         ], 'options', $listRoute);
+        $this->assertAttributeSame(['locale' => array_keys($locales)[0]], 'attributeDefaults', $listRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'name', $formRoute);
         $this->assertAttributeEquals('sulu_snippet.form.detail', 'name', $detailRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'parent', $detailRoute);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will implement the possibility to add default values for attributes. This can be done on the serverside with the new `addAttributeDefault` function of the route.

It also combines the `attributes` and `query` from the router to just `query`.

#### Why?

Because we want to be able to set a default locale for every section, which means that navigating always works for these routes.

And we combined `attributes` and `query`, because this way the caller doesn't need to know where to place the arguments.

#### BC Breaks/Deprecations

The `navigate` function has no `query` parameter anymore and the 

#### To Do

- [ ] Create documentation
- [x] Convert this change: https://github.com/sulu/sulu/pull/3565/files#diff-27a1dff25d6e65d97354f899a6bd59beR109
- [x] Implement default values
