### PR TITLE
Fixed deprecation: starting with "%" in yml file

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
@@ -1,5 +1,5 @@
 sulu_media.website.image.proxy:
-    path: '%sulu_media.format_cache.media_proxy_path%'
+    path: "%sulu_media.format_cache.media_proxy_path%"
     defaults:
         _controller: SuluMediaBundle:MediaStream:getImage
         _requestAnalyzer: false
@@ -7,7 +7,7 @@ sulu_media.website.image.proxy:
         slug: .*
 
 sulu_media.website.media.download:
-    path: '%sulu_media.media_manager.media_download_path%'
+    path: "%sulu_media.media_manager.media_download_path%"
     defaults:
         _controller: SuluMediaBundle:MediaStream:download
         _requestAnalyzer: false

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
@@ -1,5 +1,5 @@
 sulu_media.website.image.proxy:
-    path: %sulu_media.format_cache.media_proxy_path%
+    path: '%sulu_media.format_cache.media_proxy_path%'
     defaults:
         _controller: SuluMediaBundle:MediaStream:getImage
         _requestAnalyzer: false
@@ -7,7 +7,7 @@ sulu_media.website.image.proxy:
         slug: .*
 
 sulu_media.website.media.download:
-    path: %sulu_media.media_manager.media_download_path%
+    path: '%sulu_media.media_manager.media_download_path%'
     defaults:
         _controller: SuluMediaBundle:MediaStream:download
         _requestAnalyzer: false


### PR DESCRIPTION
Starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes N/A
| Related issues/PRs | N/A
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

A deprecation fix

#### Why?

Because without fixing deprecations things will break in in newer symfony releases.

#### BC Breaks/Deprecations

Not quoting the scalar "%sulu_media.format_cache.media_proxy_path%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0
