### PR TITLE
Bugfix/3629 home page route not matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG for Sulu
 ==================
 
+    * BUGFIX      #3629 [WebsiteBundle]           home page route not matched
+
 * 1.6.7 (2017-11-14)
     * BUGFIX      #3614 [WebsiteBundle]           Fixed content-route tests for umlauts
     * ENHANCEMENT #3608 [WebsiteBundle]           Analytics: Added possibility to determine the position of content (head open, head close, body open, body close)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
     * BUGFIX      #3629 [WebsiteBundle]           home page route not matched
 
 * 1.6.7 (2017-11-14)

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -280,8 +280,8 @@ class ContentRouteProvider implements RouteProviderInterface
      */
     private function decodePathInfo($pathInfo)
     {
-        if ('' === $pathInfo) {
-            return $pathInfo;
+        if (null === $pathInfo || '' === $pathInfo) {
+            return '';
         }
 
         return '/' . ltrim(rawurldecode($pathInfo), '/');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -157,7 +157,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $attributes->getAttribute('portal', null)->willReturn($portal);
 
         $attributes->getAttribute('matchType', null)->willReturn(RequestAnalyzer::MATCH_TYPE_FULL);
-        $attributes->getAttribute('resourceLocator', null)->willReturn('');
+        $attributes->getAttribute('resourceLocator', null)->willReturn(null);
         $attributes->getAttribute('resourceLocatorPrefix', null)->willReturn('/de');
 
         $this->resourceLocatorStrategy->loadByResourceLocator('', 'webspace', 'de')->willReturn('some-uuid');
@@ -326,7 +326,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $attributes->getAttribute('portal', null)->willReturn($portal);
 
         $attributes->getAttribute('matchType', null)->willReturn(RequestAnalyzer::MATCH_TYPE_FULL);
-        $attributes->getAttribute('resourceLocator', null)->willReturn('');
+        $attributes->getAttribute('resourceLocator', null)->willReturn(null);
         $attributes->getAttribute('resourceLocatorPrefix', null)->willReturn('/de');
 
         $this->resourceLocatorStrategy->loadByResourceLocator('', 'webspace', 'de')->willReturn('some-uuid');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3629 
| Related issues/PRs | #3614
| License | MIT
| Documentation PR | 

#### What's in this PR?
Reproduces the bug by changing the Unit test of ContentRouteProvider to mimic real behavior of Attribute instance. The returned value of the resourceLocator Attribute is null in case of the homepage REQUEST_URI "/de".

The homepage route of localized webspace portals could not be matched due to prior change of decodePathInfo Method in ContentRouteProvider (see #3614). Implemented old behavior in case pathInfo Parameter is null.