### PR TITLE
build form using metadata

### DIFF
--- a/flow-typed/npm/jest_v21.x.x.js
+++ b/flow-typed/npm/jest_v21.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 65527f14a5f7e89fb28d0a29f45dc848
-// flow-typed version: c7c67b81c1/jest_v21.x.x/flow_>=v0.39.x
+// flow-typed signature: 107cf7068b8835594e97f938e8848244
+// flow-typed version: 8b4dd96654/jest_v21.x.x/flow_>=v0.39.x
 
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
@@ -258,7 +258,7 @@ type JestExpectType = {
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */
-  toMatchObject(object: Object): void,
+  toMatchObject(object: Object | Array<Object>): void,
   /**
    * This ensures that a React component matches the most recent snapshot.
    */
@@ -271,8 +271,8 @@ type JestExpectType = {
    *
    * Alias: .toThrowError
    */
-  toThrow(message?: string | Error | RegExp): void,
-  toThrowError(message?: string | Error | RegExp): void,
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
   /**
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
@@ -420,7 +420,12 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn<any, any>
+  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType
 };
 
 type JestSpyType = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -88,7 +88,7 @@ export default class Datagrid extends React.PureComponent<Props> {
                         <Adapter
                             data={store.data}
                             selections={store.selections}
-                            schema={store.getFields()}
+                            schema={store.getSchema()}
                             onItemClick={onItemClick}
                             onItemSelectionChange={this.handleItemSelectionChange}
                             onAllSelectionChange={this.handleAllSelectionChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -43,8 +43,8 @@ export default class DatagridStore {
         }
     };
 
-    getFields() {
-        return metadataStore.getFields(this.resourceKey);
+    getSchema() {
+        return metadataStore.getSchema(this.resourceKey);
     }
 
     sendRequest = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/MetadataStore.js
@@ -3,7 +3,7 @@ import resourceMetadataStore from '../../../stores/ResourceMetadataStore';
 import type {Schema} from '../types';
 
 class MetadataStore {
-    getFields(resourceKey: string): Schema {
+    getSchema(resourceKey: string): Schema {
         const metadata = resourceMetadataStore.loadConfiguration(resourceKey);
         if (!('list' in metadata)) {
             throw new Error('There are no list metadata for the resourceKey "' + resourceKey + '"');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {mount, shallow} from 'enzyme';
 import React from 'react';
 import Datagrid from '../Datagrid';
@@ -13,7 +13,7 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.data = [{title: 'value', id: 1}];
     this.selections = [];
     this.loading = false;
-    this.getFields = jest.fn().mockReturnValue({test: {}});
+    this.getSchema = jest.fn().mockReturnValue({test: {}});
     this.select = jest.fn();
     this.deselect = jest.fn();
     this.selectEntirePage = jest.fn();
@@ -46,14 +46,14 @@ beforeEach(() => {
 });
 
 test('Change page in DatagridStore on pagination click', () => {
-    const datagridStore = new DatagridStore('test');
+    const datagridStore = new DatagridStore('test', {page: null});
     const datagrid = mount(<Datagrid views={['table']} store={datagridStore} />);
     datagrid.find('Pagination').find('.next').simulate('click');
     expect(datagridStore.setPage).toBeCalledWith(datagridStore.getPage() + 1);
 });
 
 test ('Render Pagination with correct values', () => {
-    const datagridStore = new DatagridStore('test');
+    const datagridStore = new DatagridStore('test', {page: null});
 
     const datagrid = mount(<Datagrid views={['table']} store={datagridStore} />);
     const pagination = datagrid.find('Pagination');
@@ -63,7 +63,7 @@ test ('Render Pagination with correct values', () => {
 });
 
 test('Render TableAdapter with correct values', () => {
-    const datagridStore = new DatagridStore('test');
+    const datagridStore = new DatagridStore('test', {page: null});
     datagridStore.selections.push(1);
     datagridStore.selections.push(3);
     const editClickSpy = jest.fn();
@@ -78,7 +78,7 @@ test('Render TableAdapter with correct values', () => {
 });
 
 test('Selecting and deselecting items should update store', () => {
-    const datagridStore = new DatagridStore('test');
+    const datagridStore = new DatagridStore('test', {page: null});
     datagridStore.data = [
         {id: 1},
         {id: 2},
@@ -99,7 +99,7 @@ test('Selecting and deselecting items should update store', () => {
 });
 
 test('Selecting and unselecting all items on current page should update store', () => {
-    const datagridStore = new DatagridStore('test');
+    const datagridStore = new DatagridStore('test', {page: null});
     datagridStore.data = [
         {id: 1},
         {id: 2},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import 'url-search-params-polyfill';
-import {when, observable} from 'mobx';
+import {observable, toJS, when} from 'mobx';
 import DatagridStore from '../../stores/DatagridStore';
 import metadataStore from '../../stores/MetadataStore';
 import ResourceRequester from '../../../../services/ResourceRequester';
@@ -10,7 +10,7 @@ jest.mock('../../../../services/ResourceRequester', () => ({
 }));
 
 jest.mock('../../stores/MetadataStore', () => ({
-    getFields: jest.fn(),
+    getSchema: jest.fn(),
 }));
 
 test('Do not send request without defined page parameter', () => {
@@ -38,7 +38,7 @@ test('Send request with default parameters', (done) => {
     when(
         () => !datagridStore.loading,
         () => {
-            expect(datagridStore.data.toJS()).toEqual([{id: 1}]);
+            expect(toJS(datagridStore.data)).toEqual([{id: 1}]);
             expect(datagridStore.pageCount).toEqual(3);
             datagridStore.destroy();
             done();
@@ -132,14 +132,14 @@ test('Get fields from MetadataStore for correct resourceKey', () => {
     const fields = {
         test: {},
     };
-    metadataStore.getFields.mockReturnValue(fields);
+    metadataStore.getSchema.mockReturnValue(fields);
 
     const page = observable();
     const datagridStore = new DatagridStore('tests', {
         page,
     });
-    expect(datagridStore.getFields()).toBe(fields);
-    expect(metadataStore.getFields).toBeCalledWith('tests');
+    expect(datagridStore.getSchema()).toBe(fields);
+    expect(metadataStore.getSchema).toBeCalledWith('tests');
     datagridStore.destroy();
 });
 
@@ -159,10 +159,10 @@ test('Select an item', () => {
     });
     datagridStore.select(1);
     datagridStore.select(2);
-    expect(datagridStore.selections.toJS()).toEqual([1, 2]);
+    expect(toJS(datagridStore.selections)).toEqual([1, 2]);
 
     datagridStore.deselect(1);
-    expect(datagridStore.selections.toJS()).toEqual([2]);
+    expect(toJS(datagridStore.selections)).toEqual([2]);
     datagridStore.destroy();
 });
 
@@ -174,7 +174,7 @@ test('Deselect an item that has not been selected yet', () => {
     datagridStore.select(1);
     datagridStore.deselect(2);
 
-    expect(datagridStore.selections.toJS()).toEqual([1]);
+    expect(toJS(datagridStore.selections)).toEqual([1]);
     datagridStore.destroy();
 });
 
@@ -199,7 +199,7 @@ test('Select the entire page', (done) => {
         () => !datagridStore.loading,
         () => {
             datagridStore.selectEntirePage();
-            expect(datagridStore.selections.toJS()).toEqual([1, 7, 2, 3]);
+            expect(toJS(datagridStore.selections)).toEqual([1, 7, 2, 3]);
             datagridStore.destroy();
             done();
         }
@@ -227,7 +227,7 @@ test('Deselect the entire page', (done) => {
         () => !datagridStore.loading,
         () => {
             datagridStore.deselectEntirePage();
-            expect(datagridStore.selections.toJS()).toEqual([7]);
+            expect(toJS(datagridStore.selections)).toEqual([7]);
             datagridStore.destroy();
             done();
         }
@@ -269,7 +269,7 @@ test('The data should be appended when the appendData flag is true', () => {
         },
     });
 
-    expect(datagridStore.data.toJS()).toEqual([
+    expect(toJS(datagridStore.data)).toEqual([
         {id: 1},
         {id: 2},
         {id: 3},
@@ -285,7 +285,7 @@ test('The data should be appended when the appendData flag is true', () => {
         },
     });
 
-    expect(datagridStore.data.toJS()).toEqual([
+    expect(toJS(datagridStore.data)).toEqual([
         {id: 1},
         {id: 2},
         {id: 3},
@@ -323,7 +323,7 @@ test('When appendRequest is set, changing the locale observable resets the data 
     locale.set(2);
 
     expect(page.get()).toBe(1);
-    expect(datagridStore.data.toJS()).toEqual([]);
+    expect(toJS(datagridStore.data)).toEqual([]);
 
     datagridStore.destroy();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/MetadataStore.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import metadataStore from '../../stores/MetadataStore';
 import resourceMetadataStore from '../../../../stores/ResourceMetadataStore';
 
@@ -30,12 +30,12 @@ test('Return list fields for given resourceKey from ResourceMetadataStore', () =
     };
     resourceMetadataStore.loadConfiguration.mockImplementation((resourceKey) => resourceMetadata[resourceKey]);
 
-    const snippetFields = metadataStore.getFields('snippets');
+    const snippetFields = metadataStore.getSchema('snippets');
     expect(Object.keys(snippetFields)).toHaveLength(2);
     expect(snippetFields.id).toEqual({});
     expect(snippetFields.title).toEqual({sortable: true});
 
-    const contactFields = metadataStore.getFields('contacts');
+    const contactFields = metadataStore.getSchema('contacts');
     expect(Object.keys(contactFields)).toHaveLength(3);
     expect(contactFields.id).toEqual({});
     expect(contactFields.firstName).toEqual({sortable: true});
@@ -49,6 +49,6 @@ test('Throw exception if no list fields for given resourceKey are available', ()
     };
     resourceMetadataStore.loadConfiguration.mockImplementation((resourceKey) => resourceMetadata[resourceKey]);
 
-    expect(() => metadataStore.getFields('snippets')).toThrow(/"snippets"/);
-    expect(() => metadataStore.getFields('contacts')).toThrow(/"contacts"/);
+    expect(() => metadataStore.getSchema('snippets')).toThrow(/"snippets"/);
+    expect(() => metadataStore.getSchema('contacts')).toThrow(/"contacts"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -4,11 +4,10 @@ import type {ElementRef} from 'react';
 import React from 'react';
 import Loader from '../../components/Loader';
 import ResourceStore from '../../stores/ResourceStore';
-import type {Schema} from '../../stores/ResourceStore/types';
 import Renderer from './Renderer';
+import metadataStore from './stores/MetadataStore';
 
 type Props = {
-    schema: Schema,
     store: ResourceStore,
     onSubmit: () => void,
 };
@@ -39,7 +38,9 @@ export default class Form extends React.PureComponent<Props> {
     };
 
     render() {
-        const {schema, store} = this.props;
+        const {store} = this.props;
+        const schema = metadataStore.getFields(store.resourceKey);
+
         return store.loading
             ? <Loader />
             : <Renderer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -18,7 +18,7 @@ export default class Form extends React.PureComponent<Props> {
 
     componentWillMount() {
         const {store} = this.props;
-        const schema = metadataStore.getFields(store.resourceKey);
+        const schema = metadataStore.getSchema(store.resourceKey);
         store.changeSchema(schema);
     }
 
@@ -45,7 +45,7 @@ export default class Form extends React.PureComponent<Props> {
 
     render() {
         const {store} = this.props;
-        const schema = metadataStore.getFields(store.resourceKey);
+        const schema = metadataStore.getSchema(store.resourceKey);
 
         return store.loading
             ? <Loader />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -16,6 +16,12 @@ type Props = {
 export default class Form extends React.PureComponent<Props> {
     renderer: ?ElementRef<typeof Renderer>;
 
+    componentWillMount() {
+        const {store} = this.props;
+        const schema = metadataStore.getFields(store.resourceKey);
+        store.changeSchema(schema);
+    }
+
     /** @public */
     submit = () => {
         if (!this.renderer) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/README.md
@@ -1,21 +1,16 @@
-The `Form` component allows to show a form based on a schema. This schema defines which fields the form should display.
-In addition to that the component receives a `FormStore` and an `onSubmit` callback. The `FormStore` holds all the
-current data displayed in the form. The `Form` component will update this store everytime something changes.
+The `Form` component allows to show a form based on a `FormStore`. This store holds the schema, which defines which
+fields the form should display.  The `FormStore` also holds all the current data displayed in the form. The `Form`
+component will update this store everytime something changes.
 
-The `onSubmit` callback will be executed when the `Form` is submitted. The data of the form can then be taken from the
-passed `FormStore`.
+In addition that it also takes an `onSubmit` callback, which will be executed when the `Form` is submitted. The data of
+the form can then be taken from the passed `FormStore`.
 
 ```javascript static
-const schema = {
-    title: {},
-    description: {},
-};
 const store = new FormStore('snippets');
-store.changeSchema(schema);
 
 function handleSubmit() {
     console.log(store.data);
 }
 
-<Form schema={schema} store={store} onSubmit={handleSubmit} />
+<Form store={store} onSubmit={handleSubmit} />
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MetadataStore.js
@@ -1,0 +1,16 @@
+// @flow
+import resourceMetadataStore from '../../../stores/ResourceMetadataStore';
+import type {Schema} from '../../../stores/ResourceStore/types';
+
+class MetadataStore {
+    getFields(resourceKey: string): Schema {
+        const metadata = resourceMetadataStore.loadConfiguration(resourceKey);
+        if (!('form' in metadata)) {
+            throw new Error('There are no form metadata for the resourceKey "' + resourceKey + '"');
+        }
+
+        return metadata.form;
+    }
+}
+
+export default new MetadataStore();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MetadataStore.js
@@ -3,7 +3,7 @@ import resourceMetadataStore from '../../../stores/ResourceMetadataStore';
 import type {Schema} from '../../../stores/ResourceStore/types';
 
 class MetadataStore {
-    getFields(resourceKey: string): Schema {
+    getSchema(resourceKey: string): Schema {
         const metadata = resourceMetadataStore.loadConfiguration(resourceKey);
         if (!('form' in metadata)) {
             throw new Error('There are no form metadata for the resourceKey "' + resourceKey + '"');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -1,39 +1,57 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import React from 'react';
 import {mount, render, shallow} from 'enzyme';
 import Form from '../Form';
+import ResourceStore from '../../../stores/ResourceStore';
+import metadataStore from '../stores/MetadataStore';
+
+jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey) {
+    this.resourceKey = resourceKey;
+    this.set = jest.fn();
+}));
+
+jest.mock('../stores/MetadataStore', () => ({
+    getFields: jest.fn(),
+}));
 
 test('Should render form using renderer', () => {
-    const form = render(<Form schema={{}} store={{}} />);
+    const submitSpy = jest.fn();
+    const store = new ResourceStore('snippet', '1');
+    metadataStore.getFields.mockReturnValue({});
+
+    const form = render(<Form store={store} onSubmit={submitSpy} />);
     expect(form).toMatchSnapshot();
 });
 
 test('Should call onSubmit callback on submit', () => {
     const submitSpy = jest.fn();
-    const form = mount(<Form schema={{}} onSubmit={submitSpy} store={{}} />);
+    const store = new ResourceStore('snippet', '1');
+    metadataStore.getFields.mockReturnValue({});
+
+    const form = mount(<Form onSubmit={submitSpy} store={store} />);
     form.instance().submit();
 
     expect(submitSpy).toBeCalled();
 });
 
 test('Should pass schema and data to renderer', () => {
+    const submitSpy = jest.fn();
     const schema = {};
-    const data = {
+    const store = new ResourceStore('snippet', '1');
+    store.data = {
         title: 'Title',
         description: 'Description',
     };
-    const store = {data};
-    const form = shallow(<Form schema={schema} store={store} />);
+    metadataStore.getFields.mockReturnValue(schema);
+    const form = shallow(<Form onSubmit={submitSpy} store={store} />);
 
     expect(form.find('Renderer').props().schema).toBe(schema);
 });
 
 test('Should set data on store when changed', () => {
-    const schema = {};
-    const store = {
-        set: jest.fn(),
-    };
-    const form = shallow(<Form schema={schema} store={store} />);
+    const submitSpy = jest.fn();
+    const store = new ResourceStore('snippet', '1');
+    const form = shallow(<Form onSubmit={submitSpy} store={store} />);
 
     form.find('Renderer').simulate('change', 'field', 'value');
     expect(store.set).toBeCalledWith('field', 'value');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -17,13 +17,13 @@ jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey) {
 }));
 
 jest.mock('../stores/MetadataStore', () => ({
-    getFields: jest.fn(),
+    getSchema: jest.fn(),
 }));
 
 test('Should render form using renderer', () => {
     const submitSpy = jest.fn();
     const store = new ResourceStore('snippet', '1');
-    metadataStore.getFields.mockReturnValue({});
+    metadataStore.getSchema.mockReturnValue({});
 
     const form = render(<Form store={store} onSubmit={submitSpy} />);
     expect(form).toMatchSnapshot();
@@ -32,7 +32,7 @@ test('Should render form using renderer', () => {
 test('Should call onSubmit callback on submit', () => {
     const submitSpy = jest.fn();
     const store = new ResourceStore('snippet', '1');
-    metadataStore.getFields.mockReturnValue({});
+    metadataStore.getSchema.mockReturnValue({});
 
     const form = mount(<Form onSubmit={submitSpy} store={store} />);
     form.instance().submit();
@@ -48,7 +48,7 @@ test('Should pass schema and data to renderer', () => {
         title: 'Title',
         description: 'Description',
     };
-    metadataStore.getFields.mockReturnValue(schema);
+    metadataStore.getSchema.mockReturnValue(schema);
     const form = shallow(<Form onSubmit={submitSpy} store={store} />);
 
     expect(form.find('Renderer').props().schema).toBe(schema);
@@ -67,7 +67,7 @@ test('Should initialize resourceStore with correct schema', () => {
         title: 'Title',
         slogan: 'Slogan',
     };
-    metadataStore.getFields.mockReturnValue(schema);
+    metadataStore.getSchema.mockReturnValue(schema);
     mount(<Form onSubmit={submitSpy} store={store} />);
 
     expect(store.changeSchema).toBeCalledWith(schema);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -4,10 +4,16 @@ import {mount, render, shallow} from 'enzyme';
 import Form from '../Form';
 import ResourceStore from '../../../stores/ResourceStore';
 import metadataStore from '../stores/MetadataStore';
+import fieldRegistry from '../registries/FieldRegistry';
+
+jest.mock('../registries/FieldRegistry', () => ({
+    get: jest.fn(),
+}));
 
 jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey) {
     this.resourceKey = resourceKey;
     this.set = jest.fn();
+    this.changeSchema = jest.fn();
 }));
 
 jest.mock('../stores/MetadataStore', () => ({
@@ -46,6 +52,25 @@ test('Should pass schema and data to renderer', () => {
     const form = shallow(<Form onSubmit={submitSpy} store={store} />);
 
     expect(form.find('Renderer').props().schema).toBe(schema);
+});
+
+test('Should initialize resourceStore with correct schema', () => {
+    fieldRegistry.get.mockReturnValue(() => null);
+    const submitSpy = jest.fn();
+    const store = new ResourceStore('snippet', '1');
+    const schema = {
+        title: {},
+        slogan: {},
+    };
+
+    store.data = {
+        title: 'Title',
+        slogan: 'Slogan',
+    };
+    metadataStore.getFields.mockReturnValue(schema);
+    mount(<Form onSubmit={submitSpy} store={store} />);
+
+    expect(store.changeSchema).toBeCalledWith(schema);
 });
 
 test('Should set data on store when changed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
@@ -30,12 +30,12 @@ test('Return form fields for given resourceKey from ResourceMetadataStore', () =
     };
     resourceMetadataStore.loadConfiguration.mockImplementation((resourceKey) => resourceMetadata[resourceKey]);
 
-    const snippetFields = metadataStore.getFields('snippets');
+    const snippetFields = metadataStore.getSchema('snippets');
     expect(Object.keys(snippetFields)).toHaveLength(2);
     expect(snippetFields.id).toEqual({});
     expect(snippetFields.title).toEqual({highlight: true});
 
-    const contactFields = metadataStore.getFields('contacts');
+    const contactFields = metadataStore.getSchema('contacts');
     expect(Object.keys(contactFields)).toHaveLength(3);
     expect(contactFields.id).toEqual({});
     expect(contactFields.firstName).toEqual({highlight: true});
@@ -49,6 +49,6 @@ test('Throw exception if no form fields for given resourceKey are available', ()
     };
     resourceMetadataStore.loadConfiguration.mockImplementation((resourceKey) => resourceMetadata[resourceKey]);
 
-    expect(() => metadataStore.getFields('snippets')).toThrow(/"snippets"/);
-    expect(() => metadataStore.getFields('contacts')).toThrow(/"contacts"/);
+    expect(() => metadataStore.getSchema('snippets')).toThrow(/"snippets"/);
+    expect(() => metadataStore.getSchema('contacts')).toThrow(/"contacts"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
@@ -1,0 +1,54 @@
+// @flow
+import metadataStore from '../../stores/MetadataStore';
+import resourceMetadataStore from '../../../../stores/ResourceMetadataStore';
+
+jest.mock('../../../../stores/ResourceMetadataStore', () => ({
+    loadConfiguration: jest.fn(),
+}));
+
+test('Return form fields for given resourceKey from ResourceMetadataStore', () => {
+    const resourceMetadata = {
+        snippets: {
+            form: {
+                id: {},
+                title: {
+                    highlight: true,
+                },
+            },
+        },
+        contacts: {
+            form: {
+                id: {},
+                firstName: {
+                    highlight: true,
+                },
+                lastName: {
+                    highlight: true,
+                },
+            },
+        },
+    };
+    resourceMetadataStore.loadConfiguration.mockImplementation((resourceKey) => resourceMetadata[resourceKey]);
+
+    const snippetFields = metadataStore.getFields('snippets');
+    expect(Object.keys(snippetFields)).toHaveLength(2);
+    expect(snippetFields.id).toEqual({});
+    expect(snippetFields.title).toEqual({highlight: true});
+
+    const contactFields = metadataStore.getFields('contacts');
+    expect(Object.keys(contactFields)).toHaveLength(3);
+    expect(contactFields.id).toEqual({});
+    expect(contactFields.firstName).toEqual({highlight: true});
+    expect(contactFields.lastName).toEqual({highlight: true});
+});
+
+test('Throw exception if no form fields for given resourceKey are available', () => {
+    const resourceMetadata = {
+        snippets: {},
+        contacts: {},
+    };
+    resourceMetadataStore.loadConfiguration.mockImplementation((resourceKey) => resourceMetadata[resourceKey]);
+
+    expect(() => metadataStore.getFields('snippets')).toThrow(/"snippets"/);
+    expect(() => metadataStore.getFields('contacts')).toThrow(/"contacts"/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceMetadataStore/ResourceMetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceMetadataStore/ResourceMetadataStore.js
@@ -21,6 +21,16 @@ class ResourceMetadataStore {
                 changed: {},
                 created: {},
             },
+            form: {
+                title: {
+                    label: 'Title',
+                    type: 'text_line',
+                },
+                slogan: {
+                    label: 'Slogan',
+                    type: 'text_line',
+                },
+            },
         },
         contacts: {
             list: {
@@ -29,6 +39,16 @@ class ResourceMetadataStore {
                 lastName: {},
                 title: {},
                 fullName: {},
+            },
+            form: {
+                firstName: {
+                    label: 'First Name',
+                    type: 'text_line',
+                },
+                lastName: {
+                    label: 'Last Name',
+                    type: 'text_line',
+                },
             },
         },
         accounts: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceMetadataStore/tests/ResourceMetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceMetadataStore/tests/ResourceMetadataStore.test.js
@@ -18,6 +18,16 @@ test('Load configuration for given key', () => {
             changed: {},
             created: {},
         },
+        form: {
+            title: {
+                label: 'Title',
+                type: 'text_line',
+            },
+            slogan: {
+                label: 'Slogan',
+                type: 'text_line',
+            },
+        },
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -55,7 +55,7 @@ export default class ResourceStore {
             }));
     }
 
-    changeSchema(schema: Schema) {
+    @action changeSchema(schema: Schema) {
         const schemaFields = Object.keys(schema).reduce((object, key) => {
             object[key] = null;
             return object;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -7,17 +7,6 @@ import {translate} from '../../services/Translator';
 import ResourceStore from '../../stores/ResourceStore';
 import formStyles from './form.scss';
 
-const schema = {
-    title: {
-        label: 'Title',
-        type: 'text_line',
-    },
-    slogan: {
-        label: 'Slogan',
-        type: 'text_line',
-    },
-};
-
 type Props = ViewProps & {
     resourceStore: ResourceStore,
 };
@@ -26,9 +15,8 @@ class Form extends React.PureComponent<Props> {
     form: ?FormContainer;
 
     componentWillMount() {
-        const {router} = this.props;
-        this.props.resourceStore.changeSchema(schema);
-        router.bind('locale', this.props.resourceStore.locale);
+        const {resourceStore, router} = this.props;
+        router.bind('locale', resourceStore.locale);
     }
 
     componentWillUnmount() {
@@ -50,7 +38,6 @@ class Form extends React.PureComponent<Props> {
                     ref={this.setFormRef}
                     store={this.props.resourceStore}
                     onSubmit={this.handleSubmit}
-                    schema={schema}
                 />
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -36,7 +36,7 @@ jest.mock('../../../services/ResourceRequester', () => ({
 }));
 
 jest.mock('../../../containers/Form/stores/MetadataStore', () => ({
-    getFields: jest.fn().mockReturnValue({}),
+    getSchema: jest.fn().mockReturnValue({}),
 }));
 
 beforeEach(() => {
@@ -183,7 +183,7 @@ test('Should initialize the ResourceStore with a schema', () => {
         },
     };
 
-    metadataStore.getFields.mockReturnValue({
+    metadataStore.getSchema.mockReturnValue({
         title: {},
         slogan: {},
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -165,10 +165,11 @@ test('Should not show a locale chooser if no locales are passed in router option
     expect(toolbarConfig.locale).toBe(undefined);
 });
 
-test.skip('Should initialize the ResourceStore with a schema', () => {
+test('Should initialize the ResourceStore with a schema', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 12);
+    const metadataStore = require('../../../containers/Form/stores/MetadataStore');
 
     const router = {
         bind: jest.fn(),
@@ -182,6 +183,10 @@ test.skip('Should initialize the ResourceStore with a schema', () => {
         },
     };
 
+    metadataStore.getFields.mockReturnValue({
+        title: {},
+        slogan: {},
+    });
     mount(<Form router={router} resourceStore={resourceStore} />).get(0);
     expect(resourceStore.resourceKey).toBe('snippets');
     expect(resourceStore.id).toBe(12);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -35,6 +35,10 @@ jest.mock('../../../services/ResourceRequester', () => ({
     put: jest.fn(),
 }));
 
+jest.mock('../../../containers/Form/stores/MetadataStore', () => ({
+    getFields: jest.fn().mockReturnValue({}),
+}));
+
 beforeEach(() => {
     jest.resetModules();
 });
@@ -44,7 +48,7 @@ test('Should navigate to defined route on back button click', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('test', 1);
+    const resourceStore = new ResourceStore('snippet', 1);
 
     const router = {
         restore: jest.fn(),
@@ -70,7 +74,7 @@ test('Should not render back button when no editLink is configured', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('test', 1);
+    const resourceStore = new ResourceStore('snippet', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -93,7 +97,7 @@ test('Should change locale in form store via locale chooser', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('test', 1);
+    const resourceStore = new ResourceStore('snippet', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -119,7 +123,7 @@ test('Should show locales from router options in toolbar', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('test', 1);
+    const resourceStore = new ResourceStore('snippet', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -145,7 +149,7 @@ test('Should not show a locale chooser if no locales are passed in router option
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
-    const resourceStore = new ResourceStore('test', 1);
+    const resourceStore = new ResourceStore('snippet', 1);
 
     const router = {
         navigate: jest.fn(),
@@ -161,7 +165,7 @@ test('Should not show a locale chooser if no locales are passed in router option
     expect(toolbarConfig.locale).toBe(undefined);
 });
 
-test('Should initialize the ResourceStore with a schema', () => {
+test.skip('Should initialize the ResourceStore with a schema', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 12);
@@ -244,7 +248,7 @@ test('Should save form when submitted', () => {
     expect(ResourceRequester.put).toBeCalledWith('snippets', 8, {value: 'Value'}, {locale: 'en'});
 });
 
-test('Should pass store, schema and onSubmit handler to FormContainer', () => {
+test('Should pass store and schema handler to FormContainer', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 12);
@@ -263,12 +267,8 @@ test('Should pass store, schema and onSubmit handler to FormContainer', () => {
     const form = shallow(<Form router={router} resourceStore={resourceStore} />);
     const formContainer = form.find('Form');
 
-    expect(formContainer.prop('store').data).toEqual({
-        title: null,
-        slogan: null,
-    });
+    expect(formContainer.prop('store')).toEqual(resourceStore);
     expect(formContainer.prop('onSubmit')).toBeInstanceOf(Function);
-    expect(Object.keys(formContainer.prop('schema'))).toEqual(['title', 'slogan']);
 });
 
 test('Should render save button loading only if form is not saving', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -24,7 +24,7 @@ jest.mock('../../../containers/Datagrid/stores/DatagridStore', () => jest.fn(fun
     ];
     this.selections = [];
     this.getPage = jest.fn().mockReturnValue(2);
-    this.getFields = jest.fn().mockReturnValue({
+    this.getSchema = jest.fn().mockReturnValue({
         title: {},
         description: {},
     });

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -66,7 +66,14 @@ class ContactAdmin extends Admin
         return [
             (new Route('sulu_contact.contacts_list', '/contacts', 'sulu_admin.list'))
                 ->addOption('title', 'sulu_contact.persons')
+                ->addOption('resourceKey', 'contacts')
+                ->addOption('editRoute', 'sulu_contact.form.detail'),
+            (new Route('sulu_contact.form', '/contacts/:id', 'sulu_admin.resource_tabs'))
                 ->addOption('resourceKey', 'contacts'),
+            (new Route('sulu_contact.form.detail', '/details', 'sulu_admin.form'))
+                ->addOption('tabTitle', 'sulu_contact.details')
+                ->addOption('backRoute', 'sulu_contact.contacts_list')
+                ->setParent('sulu_contact.form'),
             (new Route('sulu_contact.accounts_list', '/accounts', 'sulu_admin.list'))
                 ->addOption('title', 'sulu_contact.organizations')
                 ->addOption('resourceKey', 'accounts'),

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -60,7 +60,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                 : mediaData;
             this.selections = [];
             this.getPage = jest.fn().mockReturnValue(2);
-            this.getFields = jest.fn().mockReturnValue({
+            this.getSchema = jest.fn().mockReturnValue({
                 title: {},
                 description: {},
             });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -56,7 +56,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                 : mediaData;
             this.selections = [];
             this.getPage = jest.fn().mockReturnValue(2);
-            this.getFields = jest.fn().mockReturnValue({
+            this.getSchema = jest.fn().mockReturnValue({
                 title: {},
                 description: {},
             });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes it possible to load the form using the metadata from the `ResourceMetadataStore` instead of being hardcoded in the `Form` view.

#### Why?

Because we want to load different forms.

#### To Do

- [x] Update documentation
- [x] Fix skipped test
