### PR TITLE
Add excluded ids parameter to media api

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -118,8 +118,9 @@ class MediaController extends AbstractMediaController implements
         $locale = $this->getRequestParameter($request, 'locale', true);
         $fieldDescriptors = $this->getFieldDescriptors($locale, false);
         $ids = array_filter(explode(',', $request->get('ids')));
+        $excluded = array_filter(explode(',', $request->get('excluded')));
         $types = array_filter(explode(',', $request->get('types')));
-        $listBuilder = $this->getListBuilder($request, $fieldDescriptors, $ids, $types);
+        $listBuilder = $this->getListBuilder($request, $fieldDescriptors, $ids, $excluded, $types);
         $listResponse = $listBuilder->execute();
         $count = $listBuilder->count();
 
@@ -174,11 +175,12 @@ class MediaController extends AbstractMediaController implements
      * @param Request $request
      * @param FieldDescriptorInterface[] $fieldDescriptors
      * @param array $ids
+     * @param array $excludedIds
      * @param array $types
      *
      * @return DoctrineListBuilder
      */
-    private function getListBuilder(Request $request, array $fieldDescriptors, $ids, $types)
+    private function getListBuilder(Request $request, array $fieldDescriptors, $ids, $excludedIds, $types)
     {
         $restHelper = $this->get('sulu_core.doctrine_rest_helper');
         $factory = $this->get('sulu_core.doctrine_list_builder_factory');
@@ -214,6 +216,10 @@ class MediaController extends AbstractMediaController implements
             }
 
             $listBuilder->in($fieldDescriptors['id'], $ids);
+        }
+
+        if (count($excludedIds)) {
+            $listBuilder->notIn($fieldDescriptors['id'], $excludedIds);
         }
 
         // set the types

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -527,6 +527,7 @@ class MediaControllerTest extends SuluTestCase
     public function testCget()
     {
         $this->createMedia('photo');
+        $this->createMedia('photo2');
         $client = $this->createAuthenticatedClient();
 
         $client->request(
@@ -538,7 +539,31 @@ class MediaControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertNotEmpty($response);
-        $this->assertEquals(1, $response->total);
+        $this->assertEquals(2, $response->total);
+    }
+
+    /**
+     * Test GET all Media.
+     */
+    public function testCgetExcluded()
+    {
+        $media = $this->createMedia('photo');
+        $this->createMedia('photo1');
+        $media2 = $this->createMedia('photo2');
+        $this->createMedia('photo3');
+        $client = $this->createAuthenticatedClient();
+        $excluded = implode(',', [$media->getId(), $media2->getId()]);
+
+        $client->request(
+            'GET',
+            '/api/media?locale=en-gb&excluded=' . $excluded
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertNotEmpty($response);
+        $this->assertEquals(2, $response->total);
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -306,6 +306,15 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function notIn(FieldDescriptorInterface $fieldDescriptor, array $values)
+    {
+        $this->expressions[] = $this->createNotExpression($this->createInExpression($fieldDescriptor, $values));
+        $this->addFieldDescriptor($fieldDescriptor);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function between(FieldDescriptorInterface $fieldDescriptor, array $values)
     {
         $this->expressions[] = $this->createBetweenExpression($fieldDescriptor, $values);

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -25,9 +25,11 @@ use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\AbstractDoctrineExpressi
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineAndExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineBetweenExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineInExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineNotExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineOrExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineWhereExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Exception\InvalidExpressionArgumentException;
+use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityRepositoryTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -483,6 +485,18 @@ class DoctrineListBuilder extends AbstractListBuilder
                     break;
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNotExpression(ExpressionInterface $expression)
+    {
+        if (!$expression instanceof AbstractDoctrineExpression) {
+            throw new InvalidExpressionArgumentException('not', 'expression');
+        }
+
+        return new DoctrineNotExpression($expression);
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineBetweenExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineBetweenExpression.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
 
 use Doctrine\ORM\QueryBuilder;
-use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\AbstractDoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\BetweenExpressionInterface;
 
 /**
@@ -23,7 +23,7 @@ class DoctrineBetweenExpression extends AbstractDoctrineExpression implements Be
     /**
      * Field descriptor used for comparison.
      *
-     * @var AbstractDoctrineFieldDescriptor
+     * @var DoctrineFieldDescriptorInterface
      */
     protected $field;
 
@@ -40,11 +40,11 @@ class DoctrineBetweenExpression extends AbstractDoctrineExpression implements Be
     /**
      * DoctrineInExpression constructor.
      *
-     * @param AbstractDoctrineFieldDescriptor $field
+     * @param DoctrineFieldDescriptorInterface $field
      * @param $start
      * @param $end
      */
-    public function __construct(AbstractDoctrineFieldDescriptor $field, $start, $end)
+    public function __construct(DoctrineFieldDescriptorInterface $field, $start, $end)
     {
         $this->start = $start;
         $this->end = $end;

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineNotExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineNotExpression.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Represents a NOT expression for doctrine - needs another expression to negate.
+ */
+class DoctrineNotExpression extends AbstractDoctrineExpression
+{
+    /**
+     * @var AbstractDoctrineExpression
+     */
+    private $expression;
+
+    /**
+     * DoctrineNotExpression constructor.
+     *
+     * @param AbstractDoctrineExpression $expression
+     */
+    public function __construct(AbstractDoctrineExpression $expression)
+    {
+        $this->expression = $expression;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatement(QueryBuilder $queryBuilder)
+    {
+        return 'NOT(' . $this->expression->getStatement($queryBuilder) . ')';
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineWhereExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineWhereExpression.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
 
 use Doctrine\ORM\QueryBuilder;
-use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\AbstractDoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\WhereExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 
@@ -24,7 +24,7 @@ class DoctrineWhereExpression extends AbstractDoctrineExpression implements Wher
     /**
      * Field descriptor used for comparison.
      *
-     * @var AbstractDoctrineFieldDescriptor
+     * @var DoctrineFieldDescriptorInterface
      */
     protected $field;
 
@@ -38,12 +38,12 @@ class DoctrineWhereExpression extends AbstractDoctrineExpression implements Wher
     /**
      * Comparator to compare values.
      *
-     * @var AbstractDoctrineFieldDescriptor
+     * @var DoctrineFieldDescriptorInterface
      */
     protected $comparator;
 
     public function __construct(
-        AbstractDoctrineFieldDescriptor $field,
+        DoctrineFieldDescriptorInterface $field,
         $value,
         $comparator = ListbuilderInterface::WHERE_COMPARATOR_EQUAL
     ) {

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -208,6 +208,14 @@ interface ListBuilderInterface
     public function in(FieldDescriptorInterface $fieldDescriptor, array $values);
 
     /**
+     * Defines an NOT IN constraint.
+     *
+     * @param FieldDescriptorInterface $fieldDescriptor
+     * @param array $values
+     */
+    public function notIn(FieldDescriptorInterface $fieldDescriptor, array $values);
+
+    /**
      * Defines a between constraint.
      *
      * @param FieldDescriptorInterface $fieldDescriptor
@@ -284,6 +292,13 @@ interface ListBuilderInterface
      * @return mixed
      */
     public function createWhereExpression(FieldDescriptorInterface $fieldDescriptor, $value, $comparator);
+
+    /**
+     * Creates a negation of the given expression.
+     *
+     * @return mixed
+     */
+    public function createNotExpression(ExpressionInterface $createInExpression);
 
     /**
      * Creates an and expression with the given expressions.

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineNotExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineNotExpressionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineInExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineNotExpression;
+
+class DoctrineNotExpressionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    private static $entityName = 'SuluCoreBundle:Example';
+
+    /**
+     * http://php.net/manual/en/function.uniqid.php
+     * With an empty prefix, the returned string will be 13 characters long. If more_entropy is TRUE,
+     * it will be 23 characters.
+     *
+     * @var int
+     */
+    private $uniqueIdLength = 23;
+
+    /**
+     * @var QueryBuilder
+     */
+    private $queryBuilder;
+
+    public function setUp()
+    {
+        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->queryBuilder->expects($this->any())->method('setParameter')->willReturnSelf();
+    }
+
+    public function testNotInStatement()
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $values = [1, 2, 3];
+        $whereExpression = new DoctrineInExpression($fieldDescriptor, $values);
+
+        $notExpression = new DoctrineNotExpression($whereExpression);
+        $result = preg_match(
+            '/^NOT\(SuluCoreBundle:Example\.name IN \(:name\S{' . $this->uniqueIdLength . '}\)\)/',
+            $notExpression->getStatement($this->queryBuilder)
+        );
+
+        $this->assertEquals(1, $result);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add excluded ids parameter to media api.

#### Why?

To show only unselected items in the media selection.

#### Example Usage

`/api/media?locale=en&excluded-ids=1,2,3`


