### PR TITLE
Fix structure internal flag and add webspace validate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-release/1.5
     * HOTFIX      #3789 [MediaBundle]           Check if current user is sulu user to avoid errors
+    * BUGFIX      #3639 [ContentBundle]         Fix structure internal flag and add webspace validate command
     * ENHANCEMENT #3764 [Component]             Allow dynamic order of elements in webspace xml
     * HOTFIX      #3752 [ContentBundle]         Overwrite 'doctrine:phpcr:workspace:import' set default to throw
     * ENHANCEMENT #3775 [Component]             Use is iterable instead of custom is_array twig function in webspace dumper

--- a/src/Sulu/Bundle/ContentBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ValidateWebspacesCommand.php
@@ -1,0 +1,345 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Command;
+
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Validates pages.
+ */
+class ValidateWebspacesCommand extends ContainerAwareCommand
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
+
+    /**
+     * @var StructureMetadataFactoryInterface
+     */
+    private $structureMetadataFactory;
+
+    /**
+     * @var ControllerNameParser
+     */
+    private $controllerNameConverter;
+
+    /**
+     * @var StructureManagerInterface
+     */
+    private $structureManager;
+
+    /**
+     * @var WebspaceStructureProvider
+     */
+    private $structureProvider;
+
+    /**
+     * @var array
+     */
+    private $errors = [];
+
+    /**
+     * @var string
+     */
+    private $activeTheme;
+
+    protected function configure()
+    {
+        $this->setName('sulu:content:validate:webspaces')
+            ->setDescription('Dumps webspaces and will show an error when template could not be loaded');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+        $this->twig = $this->getContainer()->get('twig');
+        $this->structureMetadataFactory = $this->getContainer()->get('sulu_content.structure.factory');
+        $this->controllerNameConverter = $this->getContainer()->get('controller_name_converter');
+        $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');
+        $this->structureProvider = $this->getContainer()->get('sulu.content.webspace_structure_provider');
+
+        if ($this->getContainer()->has('liip_theme.active_theme')) {
+            $this->activeTheme = $this->getContainer()->get('liip_theme.active_theme');
+        }
+
+        $webspaceManager = $this->getContainer()->get('sulu_core.webspace.webspace_manager');
+
+        /** @var Webspace[] $webspaces */
+        $webspaces = $webspaceManager->getWebspaceCollection();
+
+        $messages = '';
+
+        foreach ($webspaces as $webspace) {
+            if (null !== $this->activeTheme) {
+                $this->activeTheme->setName($webspace->getTheme());
+            }
+
+            $this->outputWebspace($webspace);
+        }
+
+        $output->writeln($messages);
+
+        if (count($this->errors)) {
+            $this->output->writeln(sprintf('<error>%s Errors found.</error>', count($this->errors)));
+
+            return 1;
+        }
+    }
+
+    /**
+     * Output webspace.
+     *
+     * @param Webspace $webspace
+     */
+    private function outputWebspace(Webspace $webspace)
+    {
+        $this->output->writeln(
+            sprintf(
+                '<info>%s</info> - <info>%s</info>',
+                $webspace->getKey(),
+                $webspace->getName()
+            )
+        );
+
+        $this->outputWebspaceDefaultTemplates($webspace);
+        $this->outputWebspacePageTemplates($webspace);
+        $this->outputWebspaceTemplates($webspace);
+        $this->outputWebspaceLocalizations($webspace);
+    }
+
+    /**
+     * Output webspace default templates.
+     *
+     * @param Webspace $webspace
+     */
+    private function outputWebspaceDefaultTemplates(Webspace $webspace)
+    {
+        $this->output->writeln('Default Templates:');
+
+        foreach ($webspace->getDefaultTemplates() as $type => $template) {
+            $this->validatePageTemplate($type, $template);
+        }
+    }
+
+    /**
+     * Output webspace page templates.
+     *
+     * @param Webspace $webspace
+     */
+    private function outputWebspacePageTemplates(Webspace $webspace)
+    {
+        $this->output->writeln('Page Templates:');
+
+        $structures = $this->structureManager->getStructures();
+
+        $checkedTemplates = [];
+
+        foreach ($webspace->getDefaultTemplates() as $template) {
+            $checkedTemplates[] = $template;
+        }
+
+        foreach ($structures as $structure) {
+            $template = $structure->getKey();
+
+            if (!$structure->getInternal() && !in_array($template, $checkedTemplates)) {
+                $this->validatePageTemplate('page', $structure->getKey());
+            }
+        }
+    }
+
+    /**
+     * Output webspace default templates.
+     *
+     * @param Webspace $webspace
+     */
+    private function outputWebspaceTemplates(Webspace $webspace)
+    {
+        $this->output->writeln('Templates:');
+
+        foreach ($webspace->getTemplates() as $type => $template) {
+            $this->validateTemplate($type, $template);
+        }
+    }
+
+    /**
+     * Output webspace localizations.
+     *
+     * @param Webspace $webspace
+     */
+    private function outputWebspaceLocalizations(Webspace $webspace)
+    {
+        $this->output->writeln('Localizations:');
+
+        foreach ($webspace->getAllLocalizations() as $localization) {
+            $this->output->writeln(
+                sprintf(
+                    '    %s',
+                    $localization->getLocale()
+                )
+            );
+        }
+    }
+
+    /**
+     * Validate page templates.
+     *
+     * @param string $type
+     * @param string $template
+     */
+    private function validatePageTemplate($type, $template)
+    {
+        $status = '<info>ok</info>';
+
+        try {
+            $this->validateStructure($type, $template);
+        } catch (\Exception $e) {
+            $status = sprintf('<error>failed: %s</error>', $e->getMessage());
+            $this->errors[] = $e->getMessage();
+        }
+
+        $this->output->writeln(
+            sprintf(
+                '    %s: %s -> %s',
+                $type,
+                $template,
+                $status
+            )
+        );
+    }
+
+    /**
+     * Is template valid.
+     *
+     * @param string $type
+     * @param string $template
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    private function validateStructure($type, $template)
+    {
+        $valid = true;
+
+        $metadata = $this->structureMetadataFactory->getStructureMetadata($type, $template);
+
+        if (!$metadata) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Structure meta data not found for "%s".',
+                    $type,
+                    $template
+                )
+            );
+        }
+
+        foreach (['title', 'url'] as $property) {
+            if (!$metadata->hasProperty($property)) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'No property "%s" found in "%s" template.',
+                        $property,
+                        $metadata->getName()
+                    )
+                );
+            }
+        }
+
+        $this->validateTwigTemplate($metadata->view . '.html.twig');
+        $this->validateControllerAction($metadata->controller);
+
+        return $valid;
+    }
+
+    /**
+     * Validate template.
+     *
+     * @param string $type
+     * @param string $template
+     */
+    private function validateTemplate($type, $template)
+    {
+        $status = '<info>ok</info>';
+
+        try {
+            $this->validateTwigTemplate($template);
+        } catch (\Exception $e) {
+            $status = sprintf('<error>failed: %s</error>', $e->getMessage());
+            $this->errors[] = $e->getMessage();
+        }
+
+        $this->output->writeln(
+            sprintf(
+                '    %s: %s -> %s',
+                $type,
+                $template,
+                $status
+            )
+        );
+    }
+
+    /**
+     * Validate twig template.
+     *
+     * @param string $template
+     *
+     * @throws \Exception
+     */
+    private function validateTwigTemplate($template)
+    {
+        $loader = $this->twig->getLoader();
+        if (!$loader->exists($template)) {
+            throw new \Exception(sprintf(
+                'Unable to find template "%s".',
+                $template
+            ));
+        }
+    }
+
+    /**
+     * Validate controller action.
+     *
+     * @param string $controllerAction
+     *
+     * @throws \Exception
+     */
+    private function validateControllerAction($controllerAction)
+    {
+        $result = $this->controllerNameConverter->parse($controllerAction);
+
+        list($class, $method) = explode('::', $result);
+
+        if (!method_exists($class, $method)) {
+            $reflector = new \ReflectionClass($class);
+
+            throw new \Exception(sprintf(
+                'Controller Action "%s" not exist in "%s" (looked into: %s).',
+                $method,
+                $class,
+                $reflector->getFileName()
+            ));
+        }
+    }
+}

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Command;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\DocumentManager\DocumentManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ValidateWebspacesCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    public function setUp()
+    {
+        $application = new Application($this->getContainer()->get('kernel'));
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
+
+        $command = new ValidateWebspacesCommand();
+        $command->setApplication($application);
+        $command->setContainer($this->getContainer());
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testExecute()
+    {
+        $this->tester->execute([]);
+        $output = $this->tester->getDisplay();
+
+        $this->assertContains('sulu_io', $output);
+        $this->assertContains('Default Templates:', $output);
+        $this->assertContains('Page Templates:', $output);
+        $this->assertContains('Templates:', $output);
+        $this->assertContains('Localizations:', $output);
+    }
+}

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -309,12 +309,23 @@ class StructureSubscriber implements EventSubscriberInterface
      * @param bool $ignoreRequired
      *
      * @throws MandatoryPropertyException
+     * @throws \RuntimeException
      */
     private function mapContentToNode($document, NodeInterface $node, $locale, $ignoreRequired)
     {
         $structure = $document->getStructure();
         $webspaceName = $this->inspector->getWebspace($document);
         $metadata = $this->inspector->getStructureMetadata($document);
+
+        if (!$metadata) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Metadata for Structure Type "%s" was not found, does the file "%s.xml" exists?',
+                    $document->getStructureType(),
+                    $document->getStructureType()
+                )
+            );
+        }
 
         foreach ($metadata->getProperties() as $propertyName => $structureProperty) {
             if (TitleSubscriber::PROPERTY_NAME === $propertyName) {

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -36,7 +36,7 @@ class XmlLoader extends XmlLegacyLoader
         $structure->name = $data['key'];
         $structure->cacheLifetime = $data['cacheLifetime'];
         $structure->controller = $data['controller'];
-        $structure->internal = 'true' === $data['internal'];
+        $structure->internal = $data['internal'];
         $structure->view = $data['view'];
         $structure->tags = $data['tags'];
         $structure->parameters = $data['params'];

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLegacyLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLegacyLoaderTest.php
@@ -1170,6 +1170,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
             ],
             'tags' => [],
             'meta' => [],
+            'internal' => false,
         ];
 
         $result = $this->loadFixture('template_meta_params.xml');
@@ -1220,7 +1221,7 @@ class XmlLegacyLoaderTest extends \PHPUnit_Framework_TestCase
         );
 
         // no exception should be thrown
-        $this->assertNotNull($result);
+        $this->assertTrue($result['internal']);
     }
 
     public function testWithoutRlpTagTypeHome()

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
@@ -39,6 +39,18 @@ class XmlLoaderTest extends \PHPUnit_Framework_TestCase
             ->willReturn(true);
 
         $result = $this->load('template.xml');
+
+        $this->assertFalse($result->internal);
+    }
+
+    public function testLoadInternalTemplate()
+    {
+        $this->cacheLifetimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
+            ->willReturn(true);
+
+        $result = $this->load('template_load_internal.xml');
+
+        $this->assertTrue($result->internal);
     }
 
     public function testLoadBlockMetaTitles()

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -514,7 +514,7 @@ class Webspace implements ArrayableInterface
     /**
      * Returns a array of default template.
      *
-     * @return string
+     * @return string[]
      */
     public function getDefaultTemplates()
     {

--- a/tests/Resources/DataFixtures/Page/template_load_internal.xml
+++ b/tests/Resources/DataFixtures/Page/template_load_internal.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluContentBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+    <index name="foo_index" />
+
+    <internal>true</internal>
+
+    <meta>
+        <title lang="de">Das ist das Template 1</title>
+        <title lang="en">That´s the template 1</title>
+    </meta>
+
+    <tag name="some.random.structure.tag" foo="bar" bar="foo"/>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Titel</title>
+                <title lang="en">Title</title>
+
+                <info_text lang="de">Titel-Info-DE</info_text>
+                <info_text lang="en">Title-Info-EN</info_text>
+
+                <placeholder lang="de">Platzhalter-Info-DE</placeholder>
+                <placeholder lang="en">Placeholder-Info-EN</placeholder>
+            </meta>
+
+            <indexField />
+
+            <tag name="sulu.node.title" priority="10"/>
+
+            <tag name="some.random.tag" one="1" two="2" three="three" />
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp" priority="1"/>
+        </property>
+
+        <property name="article" type="text_area" mandatory="false">
+            <tag name="sulu.node.title" priority="5"/>
+        </property>
+
+        <property name="pages" type="smart_content_selection" mandatory="false">
+            <tag name="sulu.node.title"/>
+        </property>
+
+        <property name="article_number" type="text_line" multilingual="false"/>
+
+        <property name="images" type="image_selection" minOccurs="0" maxOccurs="2">
+            <params>
+                <param name="minLinks" value="1"/>
+                <param name="maxLinks" value="10"/>
+                <param name="displayOptions" type="collection">
+                    <param name="leftTop" value="true"/>
+                    <param name="top" value="false"/>
+                    <param name="rightTop" value="true"/>
+                    <param name="left" value="false"/>
+                    <param name="middle" value="false"/>
+                    <param name="right" value="false"/>
+                    <param name="leftBottom" value="true"/>
+                    <param name="bottom" value="false"/>
+                    <param name="rightBottom" value="true"/>
+                </param>
+            </params>
+        </property>
+    </properties>
+</template>

--- a/tests/Resources/DataFixtures/Page/template_meta_params.xml
+++ b/tests/Resources/DataFixtures/Page/template_meta_params.xml
@@ -8,6 +8,7 @@
     <view>page.html.twig</view>
     <controller>SuluContentBundle:Default:index</controller>
     <cacheLifetime>2400</cacheLifetime>
+    <internal>false</internal>
 
     <properties>
         <property name="title" type="text_line" mandatory="true">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation | https://github.com/sulu/sulu-docs/pull/364

#### What's in this PR?

Fix structure internal flag as it is readed as boolean not string.

Also add better error message when structure metadata could not be found.

Also a command to validate the webspaces was added. It checks if the xml exists, view exists and controller exists.

#### Why?

Currently the excerpt.xml and other internal structure the internal flag is not correctly read and is false instead of true.

Currently error message was `Calling getProperties() on null`.

There was currently no way to validate the webspace configuration is ok.

#### Example Usage

Exception: Change default template of webspace to a none exist and run sulu:build dev.
Command: `bin/adminconsole sulu:content:validate:webspaces`:

Output:

<img width="469" alt="bildschirmfoto 2018-02-23 um 20 01 06" src="https://user-images.githubusercontent.com/1698337/36611627-6bb6d950-18d4-11e8-9cfd-860b4cf5c862.png">


#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [x] Create a documentation PR