### PR TITLE
Merge options of routes with parent options

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Admin;
 
+use Sulu\Bundle\AdminBundle\Admin\Routing\Route;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 
 /**
@@ -55,7 +56,41 @@ class AdminPool
             $routes = array_merge($routes, $admin->getRoutes());
         });
 
-        return $routes;
+        array_walk($routes, function(&$route, $index) {
+            $route = clone $route;
+        });
+
+        return $this->mergeRouteOptions($routes);
+    }
+
+    private function mergeRouteOptions(array $routes, string $parent = null)
+    {
+        /** @var Route[] $childRoutes */
+        $childRoutes = array_filter($routes, function(Route $route) use($parent) {
+            return $route->getParent() === $parent;
+        });
+
+        if (empty($childRoutes)) {
+            return [];
+        }
+
+        /** @var Route $parentRoute */
+        $parentRoutes = array_values(array_filter($routes, function(Route $route) use($parent) {
+            return $route->getName() === $parent;
+        }));
+
+        $parentRoute = null;
+        if (!empty($parentRoutes)) {
+            $parentRoute = $parentRoutes[0];
+        }
+
+        $mergedRoutes = [];
+        foreach ($childRoutes as $childRoute) {
+            $mergedRoutes[] = $parentRoute ? $childRoute->mergeRoute($parentRoute) : $childRoute;
+            $mergedRoutes = array_merge($mergedRoutes, $this->mergeRouteOptions($routes, $childRoute->getName()));
+        }
+
+        return $mergedRoutes;
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -66,7 +66,7 @@ class AdminPool
     private function mergeRouteOptions(array $routes, string $parent = null)
     {
         /** @var Route[] $childRoutes */
-        $childRoutes = array_filter($routes, function(Route $route) use($parent) {
+        $childRoutes = array_filter($routes, function(Route $route) use ($parent) {
             return $route->getParent() === $parent;
         });
 
@@ -75,7 +75,7 @@ class AdminPool
         }
 
         /** @var Route $parentRoute */
-        $parentRoutes = array_values(array_filter($routes, function(Route $route) use($parent) {
+        $parentRoutes = array_values(array_filter($routes, function(Route $route) use ($parent) {
             return $route->getName() === $parent;
         }));
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -53,9 +53,20 @@ class Route
         $this->view = $view;
     }
 
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
     public function addOption(string $key, $value): self
     {
         $this->options[$key] = $value;
+
+        return $this;
+    }
+
+    public function mergeRoute(self $route): self {
+        $this->options = array_merge($route->options, $this->options);
 
         return $this;
     }
@@ -72,5 +83,10 @@ class Route
         $this->parent = $parent;
 
         return $this;
+    }
+
+    public function getParent(): ?string
+    {
+        return $this->parent;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -65,7 +65,8 @@ class Route
         return $this;
     }
 
-    public function mergeRoute(self $route): self {
+    public function mergeRoute(self $route): self
+    {
         $this->options = array_merge($route->options, $this->options);
 
         return $this;

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -235,6 +235,8 @@ class AdminController
      * Returns a array of all bundles.
      *
      * @return JsonResponse
+     *
+     * @deprecated Will not be needed anymore with the new version of the admin and be removed in 2.0
      */
     public function bundlesAction()
     {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
@@ -75,6 +75,50 @@ class AdminPoolTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($route3, $routes);
     }
 
+    public function testRoutesMergeOptions()
+    {
+        $route1 = new Route('test1', '/test1', 'test1');
+        $route1->addOption('route1', 'test1');
+        $route1->addOption('override', 'override');
+        $route1_1 = new Route('test1_1', '/test1_1', 'test1_1');
+        $route1_1->addOption('route1_1', 'test1_1');
+        $route1_1->setParent('test1');
+        $route1_1_1 = new Route('test1_1_1', '/test1_1_1', 'test1_1_1');
+        $route1_1_1->addOption('override', 'overriden-value');
+        $route1_1_1->addOption('route1_1_1', 'test1_1_1');
+        $route1_1_1->setParent('test1_1');
+        $route2 = new Route('test2', '/test2', 'test2');
+        $route2->addOption('value', 'test');
+
+        $this->admin1->getRoutes()->willReturn([$route1, $route1_1, $route1_1_1, $route2]);
+        $this->admin2->getRoutes()->willReturn([]);
+
+        $routes = $this->adminPool->getRoutes();
+        $this->assertCount(4, $routes);
+        $this->assertAttributeEquals(
+            ['route1' => 'test1', 'override' => 'override'],
+            'options',
+            $routes[0]
+        );
+        $this->assertAttributeEquals(
+            ['route1' => 'test1', 'route1_1' => 'test1_1', 'override' => 'override'],
+            'options',
+            $routes[1]
+        );
+        $this->assertAttributeEquals(
+            [
+                'route1' => 'test1',
+                'route1_1' => 'test1_1',
+                'route1_1_1' => 'test1_1_1',
+                'override' => 'overriden-value'
+            ],
+            'options',
+            $routes[2]
+        );
+        $this->assertAttributeEquals(['value' => 'test'], 'options', $routes[3]);
+
+    }
+
     public function testNavigation()
     {
         $rootItem1 = new NavigationItem('Root');

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
@@ -70,9 +70,9 @@ class AdminPoolTest extends \PHPUnit_Framework_TestCase
 
         $routes = $this->adminPool->getRoutes();
         $this->assertCount(3, $routes);
-        $this->assertContains($route1, $routes);
-        $this->assertContains($route2, $routes);
-        $this->assertContains($route3, $routes);
+        $this->assertEquals($route1, $routes[0]);
+        $this->assertEquals($route2, $routes[1]);
+        $this->assertEquals($route3, $routes[2]);
     }
 
     public function testRoutesMergeOptions()
@@ -110,13 +110,12 @@ class AdminPoolTest extends \PHPUnit_Framework_TestCase
                 'route1' => 'test1',
                 'route1_1' => 'test1_1',
                 'route1_1_1' => 'test1_1_1',
-                'override' => 'overriden-value'
+                'override' => 'overriden-value',
             ],
             'options',
             $routes[2]
         );
         $this->assertAttributeEquals(['value' => 'test'], 'options', $routes[3]);
-
     }
 
     public function testNavigation()

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -76,7 +76,6 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('sulu_snippet.form.detail', 'name', $detailRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'parent', $detailRoute);
         $this->assertAttributeSame([
-            'resourceKey' => 'snippets',
             'tabTitle' => 'sulu_snippet.details',
             'backRoute' => 'sulu_snippet.list',
             'locales' => array_keys($locales),

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -76,6 +76,7 @@ class SnippetAdminTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('sulu_snippet.form.detail', 'name', $detailRoute);
         $this->assertAttributeEquals('sulu_snippet.form', 'parent', $detailRoute);
         $this->assertAttributeSame([
+            'resourceKey' => 'snippets',
             'tabTitle' => 'sulu_snippet.details',
             'backRoute' => 'sulu_snippet.list',
             'locales' => array_keys($locales),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #3549 
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR merges the options of the routes from the `Admin` with the options from the parent route. 

#### Why?

This will enable e.g. #3549 to remove the `locales` from the `sulu_snippet.form.detail` route, because it will be taken from `sulu_snippet.form`.