### PR TITLE
Fixed sulu_content_load throwing exception when reference was deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * BUGFIX      #     [WebsiteBundle]           Fixed sulu_content_load throwing exception when reference was deleted
+
 * 1.6.8 (2017-11-21)
     * BUGFIX      #3629 [WebsiteBundle]           home page route not matched
     * FEATURE     #3602 [ContentBundle]           Editable time field in author-selection overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-develop
-    * BUGFIX      #     [WebsiteBundle]           Fixed sulu_content_load throwing exception when reference was deleted
+    * BUGFIX      #3647 [WebsiteBundle]           Fixed sulu_content_load throwing exception when reference was deleted
 
 * 1.6.8 (2017-11-21)
     * BUGFIX      #3629 [WebsiteBundle]           home page route not matched

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -169,6 +169,30 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['title' => []], $result['view']);
     }
 
+    public function testLoadNull()
+    {
+        $extension = new ContentTwigExtension(
+            $this->contentMapper->reveal(),
+            $this->structureResolver,
+            $this->sessionManager->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $this->assertNull($extension->load(null));
+    }
+
+    public function testLoadNotExistingDocument()
+    {
+        $extension = new ContentTwigExtension(
+            $this->contentMapper->reveal(),
+            $this->structureResolver,
+            $this->sessionManager->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $this->assertNull($extension->load('999-999-999'));
+    }
+
     public function testLoadParent()
     {
         $this

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
@@ -73,13 +74,17 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
      */
     public function load($uuid)
     {
-        $contentStructure = $this->contentMapper->load(
-            $uuid,
-            $this->requestAnalyzer->getWebspace()->getKey(),
-            $this->requestAnalyzer->getCurrentLocalization()->getLocale()
-        );
+        try {
+            $contentStructure = $this->contentMapper->load(
+                $uuid,
+                $this->requestAnalyzer->getWebspace()->getKey(),
+                $this->requestAnalyzer->getCurrentLocalization()->getLocale()
+            );
 
-        return $this->structureResolver->resolve($contentStructure);
+            return $this->structureResolver->resolve($contentStructure);
+        } catch (DocumentNotFoundException $e) {
+            return;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed sulu_content_load throwing exception when reference was deleted

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3050 
| License | MIT

#### What's in this PR?

This fixes #3050. When sulu_content_load is used with a non-existing guid, it just returns null instead of throwing an exception (which is not catchable and breaks the page)

#### Why?

You are not able to catch exceptions in twig. This breaks the page when a referenced node is deleted.

#### Example Usage

~~~twig
{% set content = sulu_content_load(null) %}
{# content is now null #}

{% set content = sulu_content_load('not-existing-guid') %}
{# content is now null #}

~~~

#### ---
Would be nice if this could be also released in the 1.4.x branch as we have existing installations and no resources to upgrade them to 1.6.x at the moment.

### TODO

- [ ] Tests need a helping hand