### PR TITLE
Fixed sulu_content_load throwing exception when reference was deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3647 [WebsiteBundle]           Fixed sulu_content_load throwing exception when reference was deleted
+
 * 1.6.8 (2017-11-21)
     * BUGFIX      #3629 [WebsiteBundle]           home page route not matched
     * FEATURE     #3602 [ContentBundle]           Editable time field in author-selection overlay

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrade
 
+## dev-master
+We have changed the behaviour of the `sulu_content_load()` twig extension. Instead of throwing an exception when the given parameter
+cannot be resolved to a valid document, it will now just log the exception and return null, so you can gracefully handle this case
+in your twig template.
+
+```
+{% set content = sulu_content_load(null) %}
+{# content is now null #}
+
+{% set content = sulu_content_load('not-existing-guid') %}
+{# content is now null #}
+```
+
 ## 1.6.7
 
 ### Custom Analytics

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -109,6 +109,7 @@
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+            <argument type="service" id="logger"/>
         </service>
         <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
             <argument type="service" id="sulu_website.twig.content"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -169,6 +169,30 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['title' => []], $result['view']);
     }
 
+    public function testLoadNull()
+    {
+        $extension = new ContentTwigExtension(
+            $this->contentMapper->reveal(),
+            $this->structureResolver,
+            $this->sessionManager->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $this->assertNull($extension->load(null));
+    }
+
+    public function testLoadNotExistingDocument()
+    {
+        $extension = new ContentTwigExtension(
+            $this->contentMapper->reveal(),
+            $this->structureResolver,
+            $this->sessionManager->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $this->assertNull($extension->load('999-999-999'));
+    }
+
     public function testLoadParent()
     {
         $this

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\WebsiteBundle\Twig;
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension;
@@ -22,6 +24,7 @@ use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Content\Types\TextLine;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
@@ -94,6 +97,11 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private $startPageNode;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     protected function setUp()
     {
         parent::setUp();
@@ -107,6 +115,7 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
         $this->node = $this->prophesize(NodeInterface::class);
         $this->parentNode = $this->prophesize(NodeInterface::class);
         $this->startPageNode = $this->prophesize(NodeInterface::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
 
         $webspace = new Webspace();
         $webspace->setKey('sulu_test');
@@ -152,7 +161,8 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
             $this->contentMapper->reveal(),
             $this->structureResolver,
             $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal()
+            $this->requestAnalyzer->reveal(),
+            $this->logger->reveal()
         );
 
         $result = $extension->load('123-123-123');
@@ -180,7 +190,8 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
             $this->contentMapper->reveal(),
             $this->structureResolver,
             $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal()
+            $this->requestAnalyzer->reveal(),
+            $this->logger->reveal()
         );
 
         $this->assertNull($extension->load(null));
@@ -197,7 +208,8 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
             $this->contentMapper->reveal(),
             $this->structureResolver,
             $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal()
+            $this->requestAnalyzer->reveal(),
+            $this->logger->reveal()
         );
 
         $this->assertNull($extension->load('999-999-999'));
@@ -214,7 +226,8 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
             $this->contentMapper->reveal(),
             $this->structureResolver,
             $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal()
+            $this->requestAnalyzer->reveal(),
+            $this->logger->reveal()
         );
 
         $result = $extension->loadParent('123-123-123');
@@ -242,7 +255,8 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
             $this->contentMapper->reveal(),
             $this->structureResolver,
             $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal()
+            $this->requestAnalyzer->reveal(),
+            $this->logger->reveal()
         );
 
         $extension->loadParent('321-321-321');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -171,6 +171,11 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadNull()
     {
+        $this
+            ->contentMapper
+            ->load(Argument::cetera())
+            ->shouldNotBeCalled();
+
         $extension = new ContentTwigExtension(
             $this->contentMapper->reveal(),
             $this->structureResolver,
@@ -183,6 +188,11 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadNotExistingDocument()
     {
+        $this
+            ->contentMapper
+            ->load(Argument::cetera())
+            ->willThrow($this->prophesize(DocumentNotFoundException::class)->reveal());
+        
         $extension = new ContentTwigExtension(
             $this->contentMapper->reveal(),
             $this->structureResolver,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -199,10 +199,13 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadNotExistingDocument()
     {
+        $documentNotFoundException = $this->prophesize(DocumentNotFoundException::class);
+        $documentNotFoundException->__toString()->willReturn('something');
+
         $this
             ->contentMapper
             ->load(Argument::cetera())
-            ->willThrow($this->prophesize(DocumentNotFoundException::class)->reveal());
+            ->willThrow($documentNotFoundException->reveal());
 
         $extension = new ContentTwigExtension(
             $this->contentMapper->reveal(),

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -192,7 +192,7 @@ class ContentTwigExtensionTest extends \PHPUnit_Framework_TestCase
             ->contentMapper
             ->load(Argument::cetera())
             ->willThrow($this->prophesize(DocumentNotFoundException::class)->reveal());
-        
+
         $extension = new ContentTwigExtension(
             $this->contentMapper->reveal(),
             $this->structureResolver,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -95,7 +95,7 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
 
             return $this->structureResolver->resolve($contentStructure);
         } catch (DocumentNotFoundException $e) {
-            $this->logger->error((string)$e);
+            $this->logger->error((string) $e);
 
             return;
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
@@ -73,13 +74,22 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
      */
     public function load($uuid)
     {
-        $contentStructure = $this->contentMapper->load(
-            $uuid,
-            $this->requestAnalyzer->getWebspace()->getKey(),
-            $this->requestAnalyzer->getCurrentLocalization()->getLocale()
-        );
 
-        return $this->structureResolver->resolve($contentStructure);
+        if (!$uuid) {
+            return;
+        }
+
+        try {
+            $contentStructure = $this->contentMapper->load(
+                $uuid,
+                $this->requestAnalyzer->getWebspace()->getKey(),
+                $this->requestAnalyzer->getCurrentLocalization()->getLocale()
+            );
+
+            return $this->structureResolver->resolve($contentStructure);
+        } catch (DocumentNotFoundException $e) {
+            return;
+        }
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
+use Psr\Log\LoggerInterface;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
@@ -44,18 +45,25 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
     private $sessionManager;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Constructor.
      */
     public function __construct(
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver,
         SessionManagerInterface $sessionManager,
-        RequestAnalyzerInterface $requestAnalyzer
+        RequestAnalyzerInterface $requestAnalyzer,
+        LoggerInterface $logger
     ) {
         $this->contentMapper = $contentMapper;
         $this->structureResolver = $structureResolver;
         $this->sessionManager = $sessionManager;
         $this->requestAnalyzer = $requestAnalyzer;
+        $this->logger = $logger;
     }
 
     /**
@@ -74,7 +82,6 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
      */
     public function load($uuid)
     {
-
         if (!$uuid) {
             return;
         }
@@ -88,6 +95,8 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
 
             return $this->structureResolver->resolve($contentStructure);
         } catch (DocumentNotFoundException $e) {
+            $this->logger->error((string)$e);
+
             return;
         }
     }


### PR DESCRIPTION
Fixed sulu_content_load throwing exception when reference was deleted

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3050 
| License | MIT

#### What's in this PR?

This fixes #3050. When sulu_content_load is used with a non-existing guid, it just returns null instead of throwing an exception (which is not catchable and breaks the page)

#### Why?

You are not able to catch exceptions in twig. This breaks the page when a referenced node is deleted.

#### Example Usage

~~~twig
{% set content = sulu_content_load(null) %}
{# content is now null #}

{% set content = sulu_content_load('not-existing-guid') %}
{# content is now null #}

~~~

#### ---
Would be nice if this could be also released in the 1.4.x branch as we have existing installations and no resources to upgrade them to 1.6.x at the moment.

### TODO

- [x] Tests need a helping hand