### PR TITLE
Fixed bug with json routes for route-bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * HOTFIX      #3647 [WebsiteBundle]           Fixed sulu_content_load throwing exception when reference was deleted
     * HOTFIX      #3646 [ContentBundle]           Fixed xss attack for seo description
+    * HOTFIX      #3652 [RouteBundle]             Fixed bug with json routes for route-bundle
 
 * 1.6.8 (2017-11-21)
     * BUGFIX      #3629 [WebsiteBundle]           Homepage route not matched

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -68,6 +68,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn('/de/test');
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $this->routeRepository->findByPath('/test', 'de')->willReturn(null);
 
@@ -81,6 +82,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn('/de/test');
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getId()->willReturn(1);
@@ -100,6 +102,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn('/de/test');
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
@@ -123,6 +126,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn('/de/test');
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
@@ -146,11 +150,41 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
     }
 
+    public function testGetRouteCollectionForRequestWithFormat()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/de/test.json');
+        $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('json');
+
+        $routeEntity = $this->prophesize(RouteInterface::class);
+        $routeEntity->getEntityClass()->willReturn('Example');
+        $routeEntity->getEntityId()->willReturn('1');
+        $routeEntity->getId()->willReturn(1);
+        $routeEntity->getPath()->willReturn('/test');
+        $routeEntity->isHistory()->willReturn(false);
+        $routeEntity->getLocale()->willReturn('de');
+
+        $this->routeRepository->findByPath('/test', 'de')->willReturn($routeEntity->reveal());
+        $this->defaultsProvider->supports('Example')->willReturn(true);
+        $this->defaultsProvider->isPublished('Example', '1', 'de')->willReturn(true);
+        $this->defaultsProvider->getByEntity('Example', '1', 'de')->willReturn(['test' => 1]);
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(1, $collection);
+        $routes = array_values(iterator_to_array($collection->getIterator()));
+
+        $this->assertEquals('/de/test.json', $routes[0]->getPath());
+        $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
+    }
+
     public function testGetRouteCollectionForRequestWithUmlauts()
     {
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn(rawurlencode('/de/käße'));
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
@@ -179,6 +213,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn('/de/test');
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $routeEntity = $this->prophesize(RouteInterface::class);
         $routeEntity->getEntityClass()->willReturn('Example');
@@ -210,6 +245,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request->getLocale()->willReturn('de');
         $request->getQueryString()->willReturn('test=1');
         $request->getSchemeAndHttpHost()->willReturn('http://www.sulu.io');
+        $request->getRequestFormat()->willReturn('html');
 
         $targetEntity = $this->prophesize(RouteInterface::class);
         $targetEntity->getPath()->willReturn('/test-2');
@@ -246,6 +282,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request->getLocale()->willReturn('de');
         $request->getQueryString()->willReturn(null);
         $request->getSchemeAndHttpHost()->willReturn('http://www.sulu.io');
+        $request->getRequestFormat()->willReturn('html');
 
         $targetEntity = $this->prophesize(RouteInterface::class);
         $targetEntity->getPath()->willReturn('/test-2');
@@ -280,6 +317,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getPathInfo()->willReturn('/test');
         $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('html');
 
         $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn(null);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3579
| Related issues/PRs | replaces https://github.com/sulu/sulu/pull/3591
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR allows to open articles in different formats and create templates with ending `.*.twig`.
