### PR TITLE
fix page reset when locale is changed in table

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RatioNormalizer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RatioNormalizer.test.js
@@ -24,7 +24,7 @@ test('The RatioNormalizer should keep width and height in the same ratio', () =>
     expect(selection).toEqual({width: 25, height: 50, left: 0, top: 0});
 });
 
-test.only('The RatioNormalizer should not change an already valid selection', () => {
+test('The RatioNormalizer should not change an already valid selection', () => {
     const ratio = new RatioNormalizer(1000, 500, 3, 2);
 
     let selection = ratio.normalize({width: 300, height: 200, left: 0, top: 0});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -48,7 +48,7 @@ export default class DatagridStore {
             this.localeInterceptionDisposer();
         }
 
-        if ('infiniteScroll' === this.loadingStrategy && !this.localeInterceptionDisposer) {
+        if ('infiniteScroll' === this.loadingStrategy) {
             this.localeInterceptionDisposer = intercept(this.observableOptions.locale, this.handleLocaleChanges);
         }
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -44,6 +44,10 @@ export default class DatagridStore {
         this.setPage(1);
         this.loadingStrategy = loadingStrategy;
 
+        if (this.localeInterceptionDisposer) {
+            this.localeInterceptionDisposer();
+        }
+
         if ('infiniteScroll' === this.loadingStrategy && !this.localeInterceptionDisposer) {
             this.localeInterceptionDisposer = intercept(this.observableOptions.locale, this.handleLocaleChanges);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -261,11 +261,12 @@ test('Clear the selection', () => {
     expect(datagridStore.selections).toHaveLength(0);
 });
 
-test('The data should be appended when the appendData flag is true', () => {
+test('The data should be appended when the loading strategy is infiniteScroll', () => {
     const loadingStrategy = 'infiniteScroll';
     const page = observable();
     const locale = observable();
-    const datagridStore = new DatagridStore('tests',
+    const datagridStore = new DatagridStore(
+        'tests',
         {
             page,
             locale,
@@ -313,7 +314,41 @@ test('The data should be appended when the appendData flag is true', () => {
     datagridStore.destroy();
 });
 
-test('When appendRequest is set, changing the locale observable resets the data property and sets page to 1', () => {
+test('When loading strategy is infiniteScroll, changing the locale resets the data property and sets page to 1', () => {
+    ResourceRequester.getList.mockReturnValue(
+        Promise.resolve({
+            _embedded: {
+                tests: [
+                    {id: 1},
+                    {id: 2},
+                    {id: 3},
+                ],
+            },
+        })
+    );
+
+    const page = observable();
+    const locale = observable();
+    const datagridStore = new DatagridStore(
+        'tests',
+        {
+            page,
+            locale,
+        },
+        {}
+    );
+    datagridStore.init('infiniteScroll');
+
+    page.set(3);
+    locale.set('en');
+
+    expect(page.get()).toBe(1);
+    expect(toJS(datagridStore.data)).toEqual([]);
+
+    datagridStore.destroy();
+});
+
+test('When loading strategy was changed to pagination, changing the locale should not reset page to 1', () => {
     ResourceRequester.getList.mockReturnValue(Promise.resolve({
         _embedded: {
             tests: [
@@ -335,11 +370,12 @@ test('When appendRequest is set, changing the locale observable resets the data 
         {}
     );
     datagridStore.init('infiniteScroll');
+    datagridStore.updateLoadingStrategy('pagination');
 
     page.set(3);
-    locale.set(2);
+    locale.set('en');
 
-    expect(page.get()).toBe(1);
+    expect(page.get()).toBe(3);
     expect(toJS(datagridStore.data)).toEqual([]);
 
     datagridStore.destroy();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | merge after #3638 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR disposes the interceptor of the `DatagridStore` when a new loading strategy was chosen.

#### Why?

Because reseting the page is not intended on the table adapter, but it happens if the media card adapter was chosen first, then to the table adapter is switched, and the locale is changed afterwards.