### PR TITLE
fix cache clear command for preview

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
+++ b/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\PreviewBundle\Command;
 use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand as BaseCacheClearCommand;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
+++ b/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
@@ -44,14 +44,6 @@ class CacheClearCommand extends BaseCacheClearCommand
         $kernel = $this->getContainer()->get('kernel');
         $context = $this->getContainer()->getParameter('sulu.context');
 
-        $io->comment(sprintf('Clearing the <info>%s cache</info> for the <info>%s</info> environment with debug <info>%s</info>',
-            $context, $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
-
-        parent::execute($input, $nullOutput);
-
-        $io->success(sprintf('%s cache for the "%s" environment (debug=%s) was successfully cleared.',
-            ucfirst($context), $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
-
         if (SuluKernel::CONTEXT_ADMIN === $context) {
             /** @var KernelFactoryInterface $kernelFactory */
             $kernelFactory = $this->getContainer()->get('sulu_preview.preview.kernel_factory');
@@ -68,5 +60,13 @@ class CacheClearCommand extends BaseCacheClearCommand
             $io->success(sprintf('Preview cache for the "%s" environment (debug=%s) was successfully cleared.',
                 $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
         }
+
+        $io->comment(sprintf('Clearing the <info>%s cache</info> for the <info>%s</info> environment with debug <info>%s</info>',
+            $context, $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+        parent::execute($input, $nullOutput);
+
+        $io->success(sprintf('%s cache for the "%s" environment (debug=%s) was successfully cleared.',
+            ucfirst($context), $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
+++ b/src/Sulu/Bundle/PreviewBundle/Command/CacheClearCommand.php
@@ -44,13 +44,13 @@ class CacheClearCommand extends BaseCacheClearCommand
         $kernel = $this->getContainer()->get('kernel');
         $context = $this->getContainer()->getParameter('sulu.context');
 
-        $applicationKernelReflection = new \ReflectionProperty(get_class($this->getApplication()), 'kernel');
-        $applicationKernelReflection->setAccessible(true);
-
         if (SuluKernel::CONTEXT_ADMIN === $context) {
             /** @var KernelFactoryInterface $kernelFactory */
             $kernelFactory = $this->getContainer()->get('sulu_preview.preview.kernel_factory');
             $previewKernel = $kernelFactory->create($kernel->getEnvironment());
+
+            $applicationKernelReflection = new \ReflectionProperty(get_class($this->getApplication()), 'kernel');
+            $applicationKernelReflection->setAccessible(true);
 
             // set preview container
             $container = $kernel->getContainer();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #3664
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The preview cache will be cleared before the admin cache.

#### Why?

Because with Symfony 3.4 it doesn't work the other way round anymore.