### PR TITLE
[RFC] Use doctrine iterator with a generator for list builder results

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,10 @@ Follow upgrade path of following libraries:
 
 The api endpoint for `/admin/api/nodes/filter` was removed and replaced by `/admin/api/items`.
 
+### ListBuilder
+
+The `ListBuilderInterface::execute` function will not longer return the whole result array instead for performance improvements it returns a ˚\Generator` this means a `count()` on the result is not longer possible. If you need to count the result items you need todo this in a loop on the generator object for the total result call the `$listBuilder->count()` function.
+
 ## 1.6.9
 
 ### CacheBuilder

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Component\Rest\ListBuilder\AbstractListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
@@ -178,7 +179,15 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         $this->queryBuilder->distinct($this->distinct);
 
-        return $this->queryBuilder->getQuery()->getArrayResult();
+        $iterableResult = $this->queryBuilder->getQuery()->iterate(null, Query::HYDRATE_ARRAY);
+
+        foreach ($iterableResult as $rows) {
+            foreach ($rows as $row) {
+                if (false) {
+                    yield $row;
+                }
+            }
+        }
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -235,7 +235,7 @@ interface ListBuilderInterface
     /**
      * Returns the objects for the built query.
      *
-     * @return mixed
+     * @return \Generator
      */
     public function execute();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| License | MIT

#### What's in this PR?

Change the list builder to return a generator instead of the whole array result.

#### Why?

That the listbuilder does not load all entities into the memory in a future step for example a streamed response could be generated for big CSV exports.

Inspired by Doctrine recommendation: http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/reference/batch-processing.html#iterating-large-results-for-data-processing

#### Example Usage

~~~php
$generator = $listBuilder->execute();

// ... do more
~~~

#### BC Breaks/Deprecations

The biggest BC Break is that a `\Generator` is not countable a `count` on `\Generator` always returns 1. In some cases I used a count on the listBuilder result to avoid the COUNT QUERY in case of there exist only a first page or the result was the last page as you see in the following code.

```php
$list = $listBuilder->execute();

// The following code is not longer possible as count will always return 1
$count = count($list);
$offset = ($listBuilder->getCurrentPage() - 1) * $listBuilder->getLimit();
$total = $offset + $count;

if ($count >= $limit) {
     // This if avoids a count request on the first page if there exist no more pages ($total = count)
     // Also it avoids a count request for the last page as it can be calculated with the offset ($total = $offset + $count)
     $total = $listBuilder->count();
}
```

