### PR TITLE
Reintroduce cache builder for bc promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3682 [CoreBundle]              Reintroduce cache builder for sulu:build command
+
 * 1.6.9 (2017-12-04)
     * ENHANCEMENT #3665 [CategoryBundle]          Added keywords to category serialization
     * HOTFIX      #3671 [CoreBundle]              Remove cache builder from sulu:build command

--- a/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Build;
+
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @deprecated The cache clear builder will be remove with sulu 2.0 use the symfony commands instead.
+ *
+ * Builder for clearing the cache.
+ */
+class CacheBuilder extends SuluBuilder
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'cache';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build()
+    {
+        @trigger_error(
+            'CacheBuilder is deprecated since version 1.6.10 and will be removed in 2.0 use the default symfony command cache:clear instead.',
+            E_USER_DEPRECATED
+        );
+
+        if (version_compare(Kernel::VERSION, '3.4.0') >= 0) {
+            @trigger_error(
+                'Skip clearing the cache with sulu:build as it is not longer supported with Symfony >=3.4 use cache:clear command instead.',
+                E_USER_DEPRECATED
+            );
+
+            return;
+        }
+
+        $options = [
+            '--no-optional-warmers' => true,
+            '--no-debug' => true,
+            '--no-interaction' => true,
+        ];
+
+        $this->execCommand('Deleting symfony cache', 'cache:clear', $options);
+    }
+}
+

--- a/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
@@ -42,14 +42,15 @@ class CacheBuilder extends SuluBuilder
     public function build()
     {
         @trigger_error(
-            'CacheBuilder is deprecated since version 1.6.10 and will be removed in 2.0 use the default symfony command cache:clear instead.',
+            'CacheBuilder is deprecated since version 1.6.10 and will be removed in 2.0 use the default symfony command "cache:clear" instead.',
             E_USER_DEPRECATED
         );
 
         if (version_compare(Kernel::VERSION, '3.4.0') >= 0) {
-            @trigger_error(
-                'Skip clearing the cache with sulu:build as it is not longer supported with Symfony >=3.4 use cache:clear command instead.',
-                E_USER_DEPRECATED
+            $this->output->writeln(
+                '<comment>Skip clearing the cache.' . PHP_EOL
+                . 'This is not longer supported with Symfony >=3.4 use "cache:clear" command instead.</comment>'
+                . PHP_EOL
             );
 
             return;

--- a/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/CacheBuilder.php
@@ -64,4 +64,3 @@ class CacheBuilder extends SuluBuilder
         $this->execCommand('Deleting symfony cache', 'cache:clear', $options);
     }
 }
-

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
@@ -21,6 +21,10 @@
             <tag name="massive_build.builder" />
         </service>
 
+        <service id="sulu_core.build.builder.cache" class="%sulu_core.build.builder.cache.class%">
+            <tag name="massive_build.builder" />
+        </service>
+
         <service id="sulu_core.build.builder.fixtures" class="%sulu_core.build.builder.fixtures.class%">
             <tag name="massive_build.builder" />
         </service>

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
@@ -50,7 +50,7 @@ class SystemCollectionBuilder implements BuilderInterface, ContainerAwareInterfa
      */
     public function getDependencies()
     {
-        return ['cache', 'database', 'fixtures'];
+        return ['database', 'fixtures'];
     }
 
     /**

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionBuilder.php
@@ -50,7 +50,7 @@ class SystemCollectionBuilder implements BuilderInterface, ContainerAwareInterfa
      */
     public function getDependencies()
     {
-        return ['database', 'fixtures'];
+        return ['cache', 'database', 'fixtures'];
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Reintroduce cache builder. And skip the cache clear for symfony >= 3.4.0

#### Why?

It was removed in https://github.com/sulu/sulu/pull/3671/files but it should just be deprecated and only be removed in develop branch. For bc promise we introduce this service. To avoid crashes with e.g. old article bundle versions.
