### PR TITLE
Fix admin session cookie path conflict

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -10,6 +10,7 @@ disabled:
     - phpdoc_align
     - phpdoc_indent
     - phpdoc_to_comment
+    - blank_line_before_break
     - blankline_after_open_tag
     - function_declaration
     - single_line_class_definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.5.8 (unreleased)
+    * HOTFIX      #3684 [SecurityBundle]        Fixed conflict between admin and website session cookie
     * HOTFIX      #3585 [PersistanceBundle]     Fixed exception of blame for none sulu users
 
 * 1.5.7 (2017-10-12)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 build: false
 
 init:
-  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;c:\cygwin\bin;%PATH%
+  - SET PATH=%PATH%;C:\Program Files\OpenSSL;c:\tools\php;c:\cygwin\bin
 
   # uncomment to allow remote desktop connection
   #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/doctrine-cache-bundle": "~1.1",
         "friendsofsymfony/http-cache": "~1.4",
-        "jms/serializer-bundle": "^1.1",
+        "jms/serializer-bundle": "^1.2",
         "friendsofsymfony/rest-bundle": "~1.5",
         "guzzlehttp/guzzle": "^6.2",
-        "imagine/imagine": "~0.6.1",
+        "imagine/imagine": "~0.6.1 || ~0.7.0",
         "massive/search-bundle": "0.16.*",
         "sulu/document-manager": "~0.9.1",
         "sensio/framework-extra-bundle": "3.0.*",
@@ -54,15 +54,17 @@
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.3",
         "phpunit/phpunit": "^4.8.31",
         "phpspec/prophecy": "^1.4",
-        "symfony/phpunit-bridge": "~2.8.7, !=2.8.10",
-        "sensio/framework-extra-bundle": "~3.0",
-        "symfony/monolog-bundle": "~2.8 || ~3.0",
+        "symfony/phpunit-bridge": "~2.8.7",
+        "symfony/monolog-bundle": "~2.8.7 || ~3.0",
         "zendframework/zend-stdlib": "~2.3",
         "zendframework/zendsearch": "@dev",
         "doctrine/doctrine-fixtures-bundle": "~2.2"
     },
     "conflict": {
-        "jackalope/jackalope": "1.2.8"
+        "symfony/symfony": "2.8.10",
+        "symfony/phpunit-bridge": "2.8.10",
+        "symfony/monolog-bundle": "2.8.10",
+        "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1"
     },
     "replace": {
         "sulu/media-bundle": "self.version",
@@ -79,9 +81,6 @@
         "sulu/location-bundle": "self.version",
         "sulu/translate-bundle": "self.version",
         "sulu/content-bundle": "self.version"
-    },
-    "conflict": {
-        "jackalope/jackalope": "1.2.8"
     },
     "suggest": {
         "sensio/framework-extra-bundle": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "doctrine/orm": "^2.5.3",
         "doctrine/annotations": "^1.2",
         "doctrine/phpcr-bundle": "^1.3.5",
-        "doctrine/doctrine-bundle": "~1.0",
+        "doctrine/doctrine-bundle": "~1.4",
         "doctrine/doctrine-cache-bundle": "~1.1",
         "friendsofsymfony/http-cache": "~1.4",
         "jms/serializer-bundle": "^1.2",

--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -56,7 +56,7 @@ class AdminPool
         $navigation = null;
         foreach ($this->pool as $admin) {
             /* @var Admin $admin */
-            if ($navigation == null) {
+            if (null == $navigation) {
                 $navigation = $admin->getNavigation();
             } else {
                 $navigation = $navigation->merge($admin->getNavigation());

--- a/src/Sulu/Bundle/AdminBundle/Behat/AdminContext.php
+++ b/src/Sulu/Bundle/AdminBundle/Behat/AdminContext.php
@@ -579,6 +579,7 @@ if (el !== null) {
 EOT;
 
             $script = sprintf($script, $parentSelector, $propertyName, $name, $value);
+
             try {
                 $this->getSession()->executeScript($script);
 

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -153,7 +153,7 @@ class AdminController
         $jsConfig = $this->jsConfigPool->getConfigParams();
 
         // render template
-        if ($this->environment === 'dev') {
+        if ('dev' === $this->environment) {
             $template = 'SuluAdminBundle:Admin:index.html.twig';
         } else {
             $template = 'SuluAdminBundle:Admin:index.html.dist.twig';
@@ -189,7 +189,7 @@ class AdminController
 
         foreach ($this->adminPool->getAdmins() as $admin) {
             $name = $admin->getJsBundleName();
-            if ($name !== null) {
+            if (null !== $name) {
                 $admins[] = $name;
             }
         }

--- a/src/Sulu/Bundle/AdminBundle/Controller/SecurityController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/SecurityController.php
@@ -74,7 +74,7 @@ class SecurityController extends Controller
      */
     protected function getTemplate()
     {
-        if ($this->get('kernel')->getEnvironment() === 'dev') {
+        if ('dev' === $this->get('kernel')->getEnvironment()) {
             return 'SuluAdminBundle:Security:login.html.twig';
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Controller/WidgetGroupsController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/WidgetGroupsController.php
@@ -47,7 +47,7 @@ class WidgetGroupsController extends Controller
                 $request->query->all()
             );
 
-            return new Response($content, $content !== '' ? 200 : 204);
+            return new Response($content, '' !== $content ? 200 : 204);
         } catch (WidgetException $ex) {
             return new Response($ex->getMessage(), 400);
         }
@@ -60,7 +60,7 @@ class WidgetGroupsController extends Controller
      */
     private function getWidgetsHandler()
     {
-        if ($this->widgetsHandler === null) {
+        if (null === $this->widgetsHandler) {
             $this->widgetsHandler = $this->get('sulu_admin.widgets_handler');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Navigation/DisplayCondition.php
+++ b/src/Sulu/Bundle/AdminBundle/Navigation/DisplayCondition.php
@@ -17,6 +17,7 @@ namespace Sulu\Bundle\AdminBundle\Navigation;
 class DisplayCondition implements \JsonSerializable
 {
     const OPERATOR_EQUAL = 'eq';
+
     const OPERATOR_NOT_EQUAL = 'neq';
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Navigation/Navigation.php
+++ b/src/Sulu/Bundle/AdminBundle/Navigation/Navigation.php
@@ -20,7 +20,7 @@ class Navigation
 
     public function __construct(NavigationItem $root = null)
     {
-        if ($root == null) {
+        if (null == $root) {
             $root = new NavigationItem('');
         }
         $this->root = $root;
@@ -42,7 +42,7 @@ class Navigation
      *
      * @return Navigation
      */
-    public function merge(Navigation $navigation)
+    public function merge(self $navigation)
     {
         return new self($this->getRoot()->merge($navigation->getRoot()));
     }

--- a/src/Sulu/Bundle/AdminBundle/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Navigation/NavigationItem.php
@@ -117,7 +117,7 @@ class NavigationItem implements \Iterator
         $this->name = $name;
         $this->disabled = false;
 
-        if ($parent != null) {
+        if (null != $parent) {
             $parent->addChild($this);
         }
     }
@@ -239,7 +239,7 @@ class NavigationItem implements \Iterator
      *
      * @param NavigationItem $child
      */
-    public function addChild(NavigationItem $child)
+    public function addChild(self $child)
     {
         $this->children[] = $child;
     }
@@ -390,7 +390,7 @@ class NavigationItem implements \Iterator
      *
      * @return bool True if the NavigationItems are equal, otherwise false
      */
-    public function equalsChildless(NavigationItem $other)
+    public function equalsChildless(self $other)
     {
         return $this->getName() == $other->getName();
     }
@@ -427,7 +427,7 @@ class NavigationItem implements \Iterator
      *
      * @return NavigationItem|null Null if the NavigationItem is not found, otherwise the found NavigationItem
      */
-    public function findChildren(NavigationItem $navigationItem)
+    public function findChildren(self $navigationItem)
     {
         foreach ($this->getChildren() as $child) {
             /** @var NavigationItem $child */
@@ -447,7 +447,7 @@ class NavigationItem implements \Iterator
      *
      * @return NavigationItem
      */
-    public function merge(NavigationItem $other = null)
+    public function merge(self $other = null)
     {
         // Create new item
         $new = $this->copyChildless();
@@ -455,11 +455,11 @@ class NavigationItem implements \Iterator
         // Add all children from this item
         foreach ($this->getChildren() as $child) {
             /* @var NavigationItem $child */
-            $new->addChild($child->merge(($other != null) ? $other->findChildren($child) : null));
+            $new->addChild($child->merge((null != $other) ? $other->findChildren($child) : null));
         }
 
         // Add all children from the other item
-        if ($other != null) {
+        if (null != $other) {
             foreach ($other->getChildren() as $child) {
                 /** @var NavigationItem $child */
                 if (!$new->find($child)) {
@@ -543,10 +543,10 @@ class NavigationItem implements \Iterator
             'eventArguments' => $this->getEventArguments(),
             'hasSettings' => $this->getHasSettings(),
             'disabled' => $this->getDisabled(),
-            'id' => ($this->getId() != null) ? $this->getId() : str_replace('.', '', uniqid('', true)), //FIXME don't use uniqid()
+            'id' => (null != $this->getId()) ? $this->getId() : str_replace('.', '', uniqid('', true)), //FIXME don't use uniqid()
         ];
 
-        if ($this->getHeaderIcon() != null || $this->getHeaderTitle() != null) {
+        if (null != $this->getHeaderIcon() || null != $this->getHeaderTitle()) {
             $array['header'] = [
                 'title' => $this->getHeaderTitle(),
                 'logo' => $this->getHeaderIcon(),

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
@@ -19,10 +19,12 @@ class NavigationItemTest extends \PHPUnit_Framework_TestCase
      * @var NavigationItem
      */
     protected $navigationItem;
+
     /**
      * @var NavigationItem
      */
     protected $item1;
+
     /**
      * @var NavigationItem
      */

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationTest.php
@@ -20,14 +20,17 @@ class NavigationTest extends \PHPUnit_Framework_TestCase
      * @var Navigation
      */
     protected $navigation1;
+
     /**
      * @var NavigationItem
      */
     protected $root1;
+
     /**
      * @var Navigation
      */
     protected $navigation2;
+
     /**
      * @var NavigationItem
      */

--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -82,7 +82,7 @@ class Category extends ApiEntityWrapper
      */
     public function getName()
     {
-        if (($translation = $this->getTranslation(true)) === null) {
+        if (null === ($translation = $this->getTranslation(true))) {
             return;
         }
 
@@ -100,7 +100,7 @@ class Category extends ApiEntityWrapper
      */
     public function getDescription()
     {
-        if (($translation = $this->getTranslation(true)) === null) {
+        if (null === ($translation = $this->getTranslation(true))) {
             return;
         }
 
@@ -118,7 +118,7 @@ class Category extends ApiEntityWrapper
      */
     public function getMediasRawData()
     {
-        if (($translation = $this->getTranslation(true)) === null) {
+        if (null === ($translation = $this->getTranslation(true))) {
             return ['ids' => []];
         }
 
@@ -137,7 +137,7 @@ class Category extends ApiEntityWrapper
      */
     public function getMedias()
     {
-        if (($translation = $this->getTranslation(true)) === null) {
+        if (null === ($translation = $this->getTranslation(true))) {
             return [];
         }
 
@@ -160,7 +160,7 @@ class Category extends ApiEntityWrapper
      */
     public function getLocale()
     {
-        if (($translation = $this->getTranslation(true)) === null) {
+        if (null === ($translation = $this->getTranslation(true))) {
             return;
         }
 
@@ -179,7 +179,7 @@ class Category extends ApiEntityWrapper
     public function getMeta()
     {
         $arrReturn = [];
-        if ($this->entity->getMeta() !== null) {
+        if (null !== $this->entity->getMeta()) {
             foreach ($this->entity->getMeta() as $meta) {
                 if (!$meta->getLocale() || $meta->getLocale() === $this->locale) {
                     array_push(
@@ -307,7 +307,7 @@ class Category extends ApiEntityWrapper
         $translationEntity->setTranslation($translation->getTranslation());
         $translationEntity->setLocale($translation->getLocale());
 
-        if ($this->getId() === null && $this->getDefaultLocale() === null) {
+        if (null === $this->getId() && null === $this->getDefaultLocale()) {
             // new entity and new translation
             // save first locale as default
             $this->entity->setDefaultLocale($translationEntity->getLocale());
@@ -430,7 +430,7 @@ class Category extends ApiEntityWrapper
      */
     private function getSingleMetaById($meta, $id)
     {
-        if ($id !== null) {
+        if (null !== $id) {
             foreach ($meta as $singleMeta) {
                 if ($singleMeta->getId() === $id) {
                     return $singleMeta;
@@ -470,7 +470,7 @@ class Category extends ApiEntityWrapper
     {
         $translation = $this->getTranslationByLocale($this->locale);
 
-        if (true === $withDefault && null === $translation && $this->getDefaultLocale() !== null) {
+        if (true === $withDefault && null === $translation && null !== $this->getDefaultLocale()) {
             return $this->getTranslationByLocale($this->getDefaultLocale());
         }
 
@@ -486,7 +486,7 @@ class Category extends ApiEntityWrapper
      */
     private function getTranslationByLocale($locale)
     {
-        if ($locale !== null) {
+        if (null !== $locale) {
             foreach ($this->entity->getTranslations() as $translation) {
                 if ($translation->getLocale() == $locale) {
                     return $translation;

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -39,6 +39,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class CategoryManager implements CategoryManagerInterface
 {
     public static $categoryEntityName = CategoryInterface::class;
+
     public static $catTranslationEntityName = CategoryTranslationInterface::class;
 
     /**
@@ -505,7 +506,7 @@ class CategoryManager implements CategoryManagerInterface
     public function find($parent = null, $depth = null, $sortBy = null, $sortOrder = null)
     {
         @trigger_error(
-            __method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenByParentId() instead.',
+            __METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenByParentId() instead.',
             E_USER_DEPRECATED
         );
 
@@ -522,7 +523,7 @@ class CategoryManager implements CategoryManagerInterface
     public function findChildren($key, $sortBy = null, $sortOrder = null)
     {
         @trigger_error(
-            __method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenByParentKey() instead.',
+            __METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenByParentKey() instead.',
             E_USER_DEPRECATED
         );
 

--- a/src/Sulu/Bundle/CategoryBundle/Category/KeywordManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/KeywordManager.php
@@ -64,14 +64,14 @@ class KeywordManager implements KeywordManagerInterface
             throw new KeywordIsMultipleReferencedException($keyword);
         }
 
-        if ($keyword->getId() !== null
-            && $force !== self::FORCE_MERGE
-            && $this->keywordRepository->findByKeyword($keyword->getKeyword(), $keyword->getLocale()) !== null
+        if (null !== $keyword->getId()
+            && self::FORCE_MERGE !== $force
+            && null !== $this->keywordRepository->findByKeyword($keyword->getKeyword(), $keyword->getLocale())
         ) {
             throw new KeywordNotUniqueException($keyword);
         }
 
-        if ($force === self::FORCE_DETACH || $force === self::FORCE_MERGE) {
+        if (self::FORCE_DETACH === $force || self::FORCE_MERGE === $force) {
             return $this->handleDetach($keyword, $category);
         }
 

--- a/src/Sulu/Bundle/CategoryBundle/Category/KeywordManagerInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/KeywordManagerInterface.php
@@ -20,7 +20,9 @@ use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
 interface KeywordManagerInterface
 {
     const FORCE_OVERWRITE = 'overwrite';
+
     const FORCE_DETACH = 'detach';
+
     const FORCE_MERGE = 'merge';
 
     /**

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -59,7 +59,7 @@ class RecoverCommand extends ContainerAwareCommand
         $success = false;
 
         // fix nested tree
-        if ($verify !== true) {
+        if (true !== $verify) {
             $output->writeln(sprintf('<comment>%s errors were found.</comment>', count($verify)));
 
             if ($force) {
@@ -110,7 +110,7 @@ class RecoverCommand extends ContainerAwareCommand
             $output->writeln(sprintf('Call this command with <info>--force</info> option to perform recovery.'));
         }
 
-        if ($success === true) {
+        if (true === $success) {
             $output->writeln('<info>Recovery complete<info>');
         }
     }

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -107,7 +107,7 @@ class CategoryController extends RestController implements ClassResourceInterfac
     {
         $locale = $this->getRequestParameter($request, 'locale', true);
 
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             // check if parent exists
             $this->getCategoryManager()->findById($parentId);
             $list = $this->getListRepresentation($request, $locale, $parentId);
@@ -135,7 +135,7 @@ class CategoryController extends RestController implements ClassResourceInterfac
         $locale = $this->getRequestParameter($request, 'locale', true);
         $rootKey = $request->get('rootKey');
 
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             $rootId = ($rootKey) ? $this->getCategoryManager()->findByKey($rootKey)->getId() : null;
             $expandIds = array_filter(explode(',', $request->get('expandIds')));
             $list = $this->getListRepresentation($request, $locale, $rootId, $expandIds);

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -36,7 +36,9 @@ use Symfony\Component\HttpFoundation\Response;
 class KeywordController extends RestController implements ClassResourceInterface, SecuredControllerInterface
 {
     const FORCE_OVERWRITE = 'overwrite';
+
     const FORCE_DETACH = 'detach';
+
     const FORCE_MERGE = 'merge';
 
     /**

--- a/src/Sulu/Bundle/CategoryBundle/Entity/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/Category.php
@@ -357,7 +357,7 @@ class Category implements CategoryInterface
      */
     public function addChildren(CategoryInterface $child)
     {
-        @trigger_error(__method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use addChild() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use addChild() instead.', E_USER_DEPRECATED);
 
         $this->addChild($child);
     }
@@ -377,7 +377,7 @@ class Category implements CategoryInterface
      */
     public function removeChildren(CategoryInterface $child)
     {
-        @trigger_error(__method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use removeChild() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use removeChild() instead.', E_USER_DEPRECATED);
 
         $this->removeChild($child);
     }

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryInterface.php
@@ -176,7 +176,7 @@ interface CategoryInterface extends AuditableInterface
      *
      * @deprecated use Category::addChild instead
      */
-    public function addChildren(CategoryInterface $child);
+    public function addChildren(self $child);
 
     /**
      * Add children.
@@ -185,21 +185,21 @@ interface CategoryInterface extends AuditableInterface
      *
      * @return CategoryInterface
      */
-    public function addChild(CategoryInterface $child);
+    public function addChild(self $child);
 
     /**
      * {@see Category::removeChild}.
      *
      * @deprecated use Category::removeChild instead
      */
-    public function removeChildren(CategoryInterface $child);
+    public function removeChildren(self $child);
 
     /**
      * Remove children.
      *
      * @param CategoryInterface $child
      */
-    public function removeChild(CategoryInterface $child);
+    public function removeChild(self $child);
 
     /**
      * Get children.
@@ -215,7 +215,7 @@ interface CategoryInterface extends AuditableInterface
      *
      * @return CategoryInterface
      */
-    public function setParent(CategoryInterface $parent = null);
+    public function setParent(self $parent = null);
 
     /**
      * Get parent.

--- a/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/CategoryRepository.php
@@ -105,7 +105,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
     {
         $queryBuilder = $this->getCategoryQuery();
 
-        if ($parentId === null) {
+        if (null === $parentId) {
             $queryBuilder->andWhere('category.parent IS NULL');
         } else {
             $queryBuilder->andWhere('categoryParent.id = :parentId');
@@ -113,7 +113,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
 
         $query = $queryBuilder->getQuery();
 
-        if ($parentId !== null) {
+        if (null !== $parentId) {
             $query->setParameter('parentId', $parentId);
         }
 
@@ -127,7 +127,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
     {
         $queryBuilder = $this->getCategoryQuery();
 
-        if ($parentKey === null) {
+        if (null === $parentKey) {
             $queryBuilder->andWhere('category.parent IS NULL');
         } else {
             $queryBuilder->andWhere('categoryParent.key = :parentKey');
@@ -135,7 +135,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
 
         $query = $queryBuilder->getQuery();
 
-        if ($parentKey !== null) {
+        if (null !== $parentKey) {
             $query->setParameter('parentKey', $parentKey);
         }
 
@@ -205,7 +205,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
      */
     public function findCategoryByIds(array $ids)
     {
-        @trigger_error(__method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findCategoriesByIds() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findCategoriesByIds() instead.', E_USER_DEPRECATED);
 
         return $this->findCategoriesByIds($ids);
     }
@@ -215,15 +215,15 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
      */
     public function findCategories($parent = null, $depth = null, $sortBy = null, $sortOrder = null)
     {
-        @trigger_error(__method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenCategoriesByParentId() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenCategoriesByParentId() instead.', E_USER_DEPRECATED);
 
         $queryBuilder = $this->getCategoryQuery();
         $queryBuilder->andWhere('category.parent IS NULL');
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $queryBuilder->andWhere('categoryParent.id = :parentId');
         }
-        if ($depth !== null) {
+        if (null !== $depth) {
             $queryBuilder->andWhere('category.depth = :depth');
         }
 
@@ -233,10 +233,10 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
         }
 
         $query = $queryBuilder->getQuery();
-        if ($parent !== null) {
+        if (null !== $parent) {
             $query->setParameter('parentId', $parent);
         }
-        if ($depth !== null) {
+        if (null !== $depth) {
             $query->setParameter('depth', $depth);
         }
 
@@ -248,7 +248,7 @@ class CategoryRepository extends NestedTreeRepository implements CategoryReposit
      */
     public function findChildren($key, $sortBy = null, $sortOrder = null)
     {
-        @trigger_error(__method__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenCategoriesByParentKey() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated since version 1.4 and will be removed in 2.0. Use findChildrenCategoriesByParentKey() instead.', E_USER_DEPRECATED);
 
         $queryBuilder = $this->getCategoryQuery()
             ->from('SuluCategoryBundle:Category', 'parent')

--- a/src/Sulu/Bundle/CategoryBundle/Entity/KeywordInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Entity/KeywordInterface.php
@@ -121,5 +121,5 @@ interface KeywordInterface extends AuditableInterface
      *
      * @return bool
      */
-    public function equals(KeywordInterface $keyword);
+    public function equals(self $keyword);
 }

--- a/src/Sulu/Bundle/ContactBundle/Api/AccountAddress.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/AccountAddress.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Api;
 
-use Doctrine\Entity;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;

--- a/src/Sulu/Bundle/ContactBundle/Api/ContactAddress.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/ContactAddress.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Api;
 
-use Doctrine\Entity;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;

--- a/src/Sulu/Bundle/ContactBundle/Api/ContactLocale.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/ContactLocale.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Api;
 
-use Doctrine\Entity;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
@@ -27,7 +26,7 @@ class ContactLocale extends ApiWrapper
     /**
      * @param ContactLocale $contactLocale
      */
-    public function __construct(ContactLocale $contactLocale)
+    public function __construct(self $contactLocale)
     {
         $this->entity = $contactLocale;
     }

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -58,7 +58,7 @@ class AccountRecoverCommand extends ContainerAwareCommand
         $success = false;
 
         // fix nested tree
-        if ($verify !== true) {
+        if (true !== $verify) {
             $output->writeln(sprintf('<comment>%s errors were found.</comment>', count($verify)));
 
             if ($force) {
@@ -109,7 +109,7 @@ class AccountRecoverCommand extends ContainerAwareCommand
             $output->writeln(sprintf('Call this command with <info>--force</info> option to perform recovery.'));
         }
 
-        if ($success === true) {
+        if (true === $success) {
             $output->writeln('<info>Recovery complete<info>');
         }
     }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -43,17 +43,29 @@ abstract class AbstractContactManager implements ContactManagerInterface
     use RelationTrait;
 
     protected static $accountContactEntityName = 'SuluContactBundle:AccountContact';
+
     protected static $positionEntityName = 'SuluContactBundle:Position';
+
     protected static $addressTypeEntityName = 'SuluContactBundle:AddressType';
+
     protected static $urlTypeEntityName = 'SuluContactBundle:UrlType';
+
     protected static $emailTypeEntityName = 'SuluContactBundle:EmailType';
+
     protected static $faxTypeEntityName = 'SuluContactBundle:FaxType';
+
     protected static $phoneTypeEntityName = 'SuluContactBundle:PhoneType';
+
     protected static $addressEntityName = 'SuluContactBundle:Address';
+
     protected static $countryEntityName = 'SuluContactBundle:Country';
+
     protected static $emailEntityName = 'SuluContactBundle:Email';
+
     protected static $urlEntityName = 'SuluContactBundle:Url';
+
     protected static $phoneEntityName = 'SuluContactBundle:Phone';
+
     protected static $categoryEntityName = CategoryInterface::class;
 
     /**
@@ -95,7 +107,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         if ($arrayCollection && !$arrayCollection->isEmpty()) {
             return $arrayCollection->forAll(
                 function ($index, $entry) {
-                    if ($entry->getMain() === true) {
+                    if (true === $entry->getMain()) {
                         $entry->setMain(false);
 
                         return false;
@@ -134,7 +146,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
                 function ($index, $entity) {
                     $mainEntity = $entity;
 
-                    return $entity->getMain() === true;
+                    return true === $entity->getMain();
                 }
             );
         }
@@ -555,7 +567,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
             }
             if ($force) {
                 // return main or first address
-                if ($main === null && $addresses->first()) {
+                if (null === $main && $addresses->first()) {
                     return $addresses->first()->getAddress();
                 }
             }
@@ -636,7 +648,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         }
 
         // process details
-        if ($this->getProperty($data, 'bankAccounts') !== null) {
+        if (null !== $this->getProperty($data, 'bankAccounts')) {
             $this->processBankAccounts($contact, $this->getProperty($data, 'bankAccounts', []));
         }
     }
@@ -1290,11 +1302,11 @@ abstract class AbstractContactManager implements ContactManagerInterface
     protected function getBooleanValue($value)
     {
         if (is_string($value)) {
-            return $value === 'true' ? true : false;
+            return 'true' === $value ? true : false;
         } elseif (is_bool($value)) {
             return $value;
         } elseif (is_numeric($value)) {
-            return $value === 1 ? true : false;
+            return 1 === $value ? true : false;
         }
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -192,7 +192,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
      */
     public function getByIds($ids, $locale)
     {
-        if (!is_array($ids) || count($ids) === 0) {
+        if (!is_array($ids) || 0 === count($ids)) {
             return [];
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -106,7 +106,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
      */
     public function getByIds($ids, $locale)
     {
-        if (!is_array($ids) || count($ids) === 0) {
+        if (!is_array($ids) || 0 === count($ids)) {
             return [];
         }
 
@@ -152,14 +152,14 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             $phones = $contact->getPhones()->toArray();
             /** @var Phone $phone */
             foreach ($phones as $phone) {
-                if ($phone->getAccounts()->count() == 0 && $phone->getContacts()->count() == 1) {
+                if (0 == $phone->getAccounts()->count() && 1 == $phone->getContacts()->count()) {
                     $this->em->remove($phone);
                 }
             }
             $emails = $contact->getEmails()->toArray();
             /** @var Email $email */
             foreach ($emails as $email) {
-                if ($email->getAccounts()->count() == 0 && $email->getContacts()->count() == 1) {
+                if (0 == $email->getAccounts()->count() && 1 == $email->getContacts()->count()) {
                     $this->em->remove($email);
                 }
             }
@@ -167,7 +167,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             $urls = $contact->getUrls()->toArray();
             /** @var Url $url */
             foreach ($urls as $url) {
-                if ($url->getAccounts()->count() == 0 && $url->getContacts()->count() == 1) {
+                if (0 == $url->getAccounts()->count() && 1 == $url->getContacts()->count()) {
                     $this->em->remove($url);
                 }
             }
@@ -175,7 +175,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             $faxes = $contact->getFaxes()->toArray();
             /** @var Fax $fax */
             foreach ($faxes as $fax) {
-                if ($fax->getAccounts()->count() == 0 && $fax->getContacts()->count() == 1) {
+                if (0 == $fax->getAccounts()->count() && 1 == $fax->getContacts()->count()) {
                     $this->em->remove($fax);
                 }
             }
@@ -183,7 +183,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             $notes = $contact->getNotes()->toArray();
             /** @var Note $note */
             foreach ($notes as $note) {
-                if ($note->getAccounts()->count() == 0 && $note->getContacts()->count() == 1) {
+                if (0 == $note->getAccounts()->count() && 1 == $note->getContacts()->count()) {
                     $this->em->remove($note);
                 }
             }
@@ -261,16 +261,16 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             $contact = $this->contactRepository->createNew();
         }
 
-        if (!$patch || $this->getProperty($data, 'firstName') !== null) {
+        if (!$patch || null !== $this->getProperty($data, 'firstName')) {
             $contact->setFirstName($this->getProperty($data, 'firstName'));
         }
-        if (!$patch || $this->getProperty($data, 'lastName') !== null) {
+        if (!$patch || null !== $this->getProperty($data, 'lastName')) {
             $contact->setLastName($this->getProperty($data, 'lastName'));
         }
-        if (!$patch || $this->getProperty($data, 'avatar') !== null) {
+        if (!$patch || null !== $this->getProperty($data, 'avatar')) {
             $this->setAvatar($contact, $this->getProperty($data, 'avatar'));
         }
-        if (!$patch || $this->getProperty($data, 'medias') !== null) {
+        if (!$patch || null !== $this->getProperty($data, 'medias')) {
             $this->setMedias($contact, $this->getProperty($data, 'medias', []));
         }
 
@@ -301,10 +301,10 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
 
         if (!$id) {
             $parentData = $this->getProperty($data, 'account');
-            if ($parentData != null &&
-                $parentData['id'] != null &&
-                $parentData['id'] != 'null' &&
-                $parentData['id'] != ''
+            if (null != $parentData &&
+                null != $parentData['id'] &&
+                'null' != $parentData['id'] &&
+                '' != $parentData['id']
             ) {
                 /** @var AccountInterface $parent */
                 $parent = $this->accountRepository->findAccountById($parentData['id']);

--- a/src/Sulu/Bundle/ContactBundle/Contact/CustomerManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/CustomerManager.php
@@ -64,7 +64,7 @@ class CustomerManager implements CustomerManagerInterface
      */
     public function findByIds($ids)
     {
-        if (count($ids) === 0) {
+        if (0 === count($ids)) {
             return [];
         }
 
@@ -94,7 +94,7 @@ class CustomerManager implements CustomerManagerInterface
      */
     private function findAccountsByIds($ids)
     {
-        if (count($ids) === 0) {
+        if (0 === count($ids)) {
             return [];
         }
 
@@ -118,7 +118,7 @@ class CustomerManager implements CustomerManagerInterface
      */
     private function findContactsByIds($ids)
     {
-        if (count($ids) === 0) {
+        if (0 === count($ids)) {
             return [];
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
@@ -115,7 +115,7 @@ class ContactSelectionContentType extends ComplexContentType implements ContentT
         $segmentKey
     ) {
         $value = $property->getValue();
-        $node->setProperty($property->getName(), ($value === null ? [] : $value));
+        $node->setProperty($property->getName(), (null === $value ? [] : $value));
     }
 
     /**
@@ -141,7 +141,7 @@ class ContactSelectionContentType extends ComplexContentType implements ContentT
         $value = $property->getValue();
         $locale = $property->getStructure()->getLanguageCode();
 
-        if ($value === null || !is_array($value) || count($value) === 0) {
+        if (null === $value || !is_array($value) || 0 === count($value)) {
             return [];
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -30,10 +30,15 @@ use Sulu\Component\Rest\RestHelperInterface;
 abstract class AbstractMediaController extends RestController
 {
     protected static $collectionEntityName = 'SuluMediaBundle:Collection';
+
     protected static $fileVersionEntityName = 'SuluMediaBundle:FileVersion';
+
     protected static $fileEntityName = 'SuluMediaBundle:File';
+
     protected static $fileVersionMetaEntityName = 'SuluMediaBundle:FileVersionMeta';
+
     protected static $mediaEntityKey = 'media';
+
     protected $fieldDescriptors = null;
 
     /**
@@ -152,7 +157,7 @@ abstract class AbstractMediaController extends RestController
         try {
             $locale = $this->getUser()->getLocale();
 
-            if ($request->get('flat') === 'true') {
+            if ('true' === $request->get('flat')) {
                 /** @var RestHelperInterface $restHelper */
                 $restHelper = $this->get('sulu_core.doctrine_rest_helper');
 
@@ -210,7 +215,7 @@ abstract class AbstractMediaController extends RestController
      */
     private function getFieldDescriptors($entityName, $id)
     {
-        if ($this->fieldDescriptors === null) {
+        if (null === $this->fieldDescriptors) {
             $this->initFieldDescriptors($entityName, $id);
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -44,11 +44,17 @@ class AccountController extends RestController implements ClassResourceInterface
      * {@inheritdoc}
      */
     protected static $entityKey = 'accounts';
+
     protected static $positionEntityName = 'SuluContactBundle:Position';
+
     protected static $contactEntityKey = 'contacts';
+
     protected static $accountContactEntityName = 'SuluContactBundle:AccountContact';
+
     protected static $addressEntityName = 'SuluContactBundle:Address';
+
     protected static $accountAddressEntityName = 'SuluContactBundle:AccountAddress';
+
     protected static $countryEntityName = 'SuluContactBundle:Country';
 
     protected static $accountSerializationGroups = [
@@ -68,15 +74,19 @@ class AccountController extends RestController implements ClassResourceInterface
      * @var AccountManager
      */
     protected $accountManager;
+
     protected $locale;
 
     // TODO: Move the field descriptors to a manager -
     // or better -> refactor the whole file!
+
     /**
      * @var DoctrineFieldDescriptor[]
      */
     protected $fieldDescriptors;
+
     protected $accountContactFieldDescriptors;
+
     protected $accountAddressesFieldDescriptors;
 
     /**
@@ -133,7 +143,7 @@ class AccountController extends RestController implements ClassResourceInterface
      */
     public function getContactsAction($id, Request $request)
     {
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /* @var AccountInterface $account */
             $account = $this->getDoctrine()
                 ->getRepository($this->getAccountEntityName())
@@ -162,7 +172,7 @@ class AccountController extends RestController implements ClassResourceInterface
                 $value['id'] = $value['contactId'];
                 unset($value['contactId']);
 
-                if ($account->getMainContact() != null && $value['id'] === $account->getMainContact()->getId()) {
+                if (null != $account->getMainContact() && $value['id'] === $account->getMainContact()->getId()) {
                     $value['isMainContact'] = true;
                 } else {
                     $value['isMainContact'] = false;
@@ -200,7 +210,7 @@ class AccountController extends RestController implements ClassResourceInterface
      */
     public function getAddressesAction($id, Request $request)
     {
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /** @var RestHelperInterface $restHelper */
             $restHelper = $this->getRestHelper();
 
@@ -372,7 +382,7 @@ class AccountController extends RestController implements ClassResourceInterface
         $locale = $this->getUser()->getLocale();
         $filter = $this->retrieveFilter($request, $numberIdsFilter);
 
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /** @var RestHelperInterface $restHelper */
             $restHelper = $this->get('sulu_core.doctrine_rest_helper');
 
@@ -486,7 +496,7 @@ class AccountController extends RestController implements ClassResourceInterface
         $name = $request->get('name');
 
         try {
-            if ($name == null) {
+            if (null == $name) {
                 throw new RestException('There is no name for the account given');
             }
 
@@ -527,7 +537,7 @@ class AccountController extends RestController implements ClassResourceInterface
         $account->setName($request->get('name'));
         $account->setCorporation($request->get('corporation'));
 
-        if ($request->get('uid') !== null) {
+        if (null !== $request->get('uid')) {
             $account->setUid($request->get('uid'));
         }
 
@@ -609,7 +619,7 @@ class AccountController extends RestController implements ClassResourceInterface
         $account->setCorporation($request->get('corporation'));
         $accountManager = $this->getAccountManager();
 
-        if ($request->get('uid') !== null) {
+        if (null !== $request->get('uid')) {
             $account->setUid($request->get('uid'));
         }
 
@@ -647,7 +657,7 @@ class AccountController extends RestController implements ClassResourceInterface
      */
     private function setParent($parentData, AccountInterface $account)
     {
-        if ($parentData != null && isset($parentData['id']) && $parentData['id'] != 'null' && $parentData['id'] != '') {
+        if (null != $parentData && isset($parentData['id']) && 'null' != $parentData['id'] && '' != $parentData['id']) {
             $parent = $this->getDoctrine()
                 ->getRepository($this->getAccountEntityName())
                 ->findAccountById($parentData['id']);
@@ -713,27 +723,27 @@ class AccountController extends RestController implements ClassResourceInterface
     protected function doPatch(AccountInterface $account, Request $request, ObjectManager $entityManager)
     {
         $accountManager = $this->getAccountManager();
-        if ($request->get('uid') !== null) {
+        if (null !== $request->get('uid')) {
             $account->setUid($request->get('uid'));
         }
-        if ($request->get('registerNumber') !== null) {
+        if (null !== $request->get('registerNumber')) {
             $account->setRegisterNumber($request->get('registerNumber'));
         }
-        if ($request->get('number') !== null) {
+        if (null !== $request->get('number')) {
             $account->setNumber($request->get('number'));
         }
-        if ($request->get('placeOfJurisdiction') !== null) {
+        if (null !== $request->get('placeOfJurisdiction')) {
             $account->setPlaceOfJurisdiction($request->get('placeOfJurisdiction'));
         }
         if (array_key_exists('id', $request->get('logo', []))) {
             $accountManager->setLogo($account, $request->get('logo')['id']);
         }
-        if ($request->get('medias') !== null) {
+        if (null !== $request->get('medias')) {
             $accountManager->setMedias($account, $request->get('medias'));
         }
 
         // Check if mainContact is set
-        if (($mainContactRequest = $request->get('mainContact')) !== null) {
+        if (null !== ($mainContactRequest = $request->get('mainContact'))) {
             $mainContact = $entityManager->getRepository(
                 $this->container->getParameter('sulu.model.contact.class')
             )->find($mainContactRequest['id']);
@@ -743,7 +753,7 @@ class AccountController extends RestController implements ClassResourceInterface
         }
 
         // Process details
-        if ($request->get('bankAccounts') !== null) {
+        if (null !== $request->get('bankAccounts')) {
             $accountManager->processBankAccounts($account, $request->get('bankAccounts', []));
         }
     }
@@ -779,8 +789,8 @@ class AccountController extends RestController implements ClassResourceInterface
             }
 
             // Remove related contacts if removeContacts is true.
-            if ($request->get('removeContacts') !== null &&
-                $request->get('removeContacts') == 'true'
+            if (null !== $request->get('removeContacts') &&
+                'true' == $request->get('removeContacts')
             ) {
                 foreach ($account->getAccountContacts() as $accountContact) {
                     $em->remove($accountContact->getContact());
@@ -851,12 +861,12 @@ class AccountController extends RestController implements ClassResourceInterface
             ->getRepository($this->getAccountEntityName())
             ->findChildrenAndContacts($id);
 
-        if ($account != null) {
+        if (null != $account) {
             // Return a maximum of 3 accounts.
             $slicedContacts = [];
             $accountContacts = $account->getAccountContacts();
             $numContacts = 0;
-            if ($accountContacts !== null) {
+            if (null !== $accountContacts) {
                 foreach ($accountContacts as $accountContact) {
                     /* @var AccountContactEntity $accountContact */
                     $contactId = $accountContact->getContact()->getId();
@@ -924,7 +934,7 @@ class AccountController extends RestController implements ClassResourceInterface
 
     protected function getFieldDescriptors()
     {
-        if ($this->fieldDescriptors === null) {
+        if (null === $this->fieldDescriptors) {
             $this->initFieldDescriptors();
         }
 
@@ -936,7 +946,7 @@ class AccountController extends RestController implements ClassResourceInterface
      */
     protected function getAccountContactFieldDescriptors()
     {
-        if ($this->accountContactFieldDescriptors === null) {
+        if (null === $this->accountContactFieldDescriptors) {
             $this->initAccountContactFieldDescriptors();
         }
 
@@ -948,7 +958,7 @@ class AccountController extends RestController implements ClassResourceInterface
      */
     protected function getAccountAddressesFieldDescriptors()
     {
-        if ($this->accountAddressesFieldDescriptors === null) {
+        if (null === $this->accountAddressesFieldDescriptors) {
             $this->initAccountAddressesFieldDescriptors();
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -41,7 +41,9 @@ class ContactController extends RestController implements ClassResourceInterface
      * {@inheritdoc}
      */
     protected static $entityKey = 'contacts';
+
     protected static $accountContactEntityName = 'SuluContactBundle:AccountContact';
+
     protected static $positionEntityName = 'SuluContactBundle:Position';
 
     // serialization groups for contact
@@ -64,6 +66,7 @@ class ContactController extends RestController implements ClassResourceInterface
     protected $bundlePrefix = 'contact.contacts.';
 
     // TODO: move the field descriptors to a manager
+
     /**
      * @var DoctrineFieldDescriptor[]
      */
@@ -81,7 +84,7 @@ class ContactController extends RestController implements ClassResourceInterface
 
     protected function getFieldDescriptors()
     {
-        if ($this->fieldDescriptors === null) {
+        if (null === $this->fieldDescriptors) {
             $this->initFieldDescriptors();
         }
 
@@ -90,7 +93,7 @@ class ContactController extends RestController implements ClassResourceInterface
 
     protected function getAccountContactFieldDescriptors()
     {
-        if ($this->accountContactFieldDescriptors === null) {
+        if (null === $this->accountContactFieldDescriptors) {
             $this->initFieldDescriptors();
         }
 
@@ -203,10 +206,10 @@ class ContactController extends RestController implements ClassResourceInterface
         $serializationGroups = [];
         $locale = $this->getLocale($request);
 
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             $list = $this->getList($request, $locale);
         } else {
-            if ($request->get('bySystem') == true) {
+            if (true == $request->get('bySystem')) {
                 $contacts = $this->getContactsByUserSystem();
                 $serializationGroups[] = 'select';
             } else {
@@ -291,18 +294,18 @@ class ContactController extends RestController implements ClassResourceInterface
     {
         $idsParameter = $request->get('ids');
         $ids = array_filter(explode(',', $idsParameter));
-        if ($idsParameter !== null && count($ids) === 0) {
+        if (null !== $idsParameter && 0 === count($ids)) {
             return [];
         }
 
-        if ($idsParameter !== null) {
+        if (null !== $idsParameter) {
             $listBuilder->in($this->fieldDescriptors['id'], $ids);
         }
 
         $listResponse = $listBuilder->execute();
         $listResponse = $this->addAvatars($listResponse, $locale);
 
-        if ($idsParameter !== null) {
+        if (null !== $idsParameter) {
             $comparator = $this->getComparator();
             // the @ is necessary in case of a PHP bug https://bugs.php.net/bug.php?id=50688
             @usort(
@@ -527,13 +530,13 @@ class ContactController extends RestController implements ClassResourceInterface
 
     private function checkArguments(Request $request)
     {
-        if ($request->get('firstName') == null) {
+        if (null == $request->get('firstName')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.contact.class'), 'username');
         }
-        if ($request->get('lastName') === null) {
+        if (null === $request->get('lastName')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.contact.class'), 'password');
         }
-        if ($request->get('formOfAddress') == null) {
+        if (null == $request->get('formOfAddress')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.contact.class'), 'contact');
         }
     }

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Controller;
 
-use FOS\RestBundle\Controller\Annotations\Get;
 use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\RouteResource;
 use FOS\RestBundle\Routing\ClassResourceInterface;
@@ -92,7 +91,7 @@ class ContactTitleController extends RestController implements ClassResourceInte
         $name = $request->get('title');
 
         try {
-            if ($name == null) {
+            if (null == $name) {
                 throw new RestException(
                     'There is no title-name for the given title'
                 );
@@ -242,7 +241,7 @@ class ContactTitleController extends RestController implements ClassResourceInte
                 ->getRepository(self::$entityName)
                 ->find($item['id']);
 
-            if ($title == null) {
+            if (null == $title) {
                 throw new EntityNotFoundException(self::$entityName, $item['id']);
             } else {
                 $title->setTitle($item['title']);

--- a/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
@@ -90,7 +90,7 @@ class PositionController extends RestController implements ClassResourceInterfac
         $name = $request->get('position');
 
         try {
-            if ($name == null) {
+            if (null == $name) {
                 throw new RestException(
                     'There is no position-name for the given name'
                 );
@@ -240,7 +240,7 @@ class PositionController extends RestController implements ClassResourceInterfac
                 ->getRepository(self::$entityName)
                 ->find($item['id']);
 
-            if ($position == null) {
+            if (null == $position) {
                 throw new EntityNotFoundException(self::$entityName, $item['id']);
             } else {
                 $position->setPosition($item['position']);

--- a/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadCountries.php
+++ b/src/Sulu/Bundle/ContactBundle/DataFixtures/ORM/LoadCountries.php
@@ -43,10 +43,10 @@ class LoadCountries implements FixtureInterface, OrderedFixtureInterface
                 /** @var $child DOMNode */
                 foreach ($element->childNodes as $child) {
                     if (isset($child->nodeName)) {
-                        if ($child->nodeName == 'Name') {
+                        if ('Name' == $child->nodeName) {
                             $countryName = $child->nodeValue;
                         }
-                        if ($child->nodeName == 'Code') {
+                        if ('Code' == $child->nodeName) {
                             $countryCode = $child->nodeValue;
                         }
                     }

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -117,7 +117,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
      */
     private function setDefaultForFormOfAddress($config)
     {
-        if (!array_key_exists('form_of_address', $config) || count($config['form_of_address']) == 0) {
+        if (!array_key_exists('form_of_address', $config) || 0 == count($config['form_of_address'])) {
             $config['form_of_address'] = [
                 'male' => [
                     'id' => 0,

--- a/src/Sulu/Bundle/ContactBundle/Entity/AccountInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AccountInterface.php
@@ -325,7 +325,7 @@ interface AccountInterface
      *
      * @return Account
      */
-    public function setParent(AccountInterface $parent = null);
+    public function setParent(self $parent = null);
 
     /**
      * Get parent.
@@ -592,14 +592,14 @@ interface AccountInterface
      *
      * @return Account
      */
-    public function addChild(AccountInterface $child);
+    public function addChild(self $child);
 
     /**
      * Remove children.
      *
      * @param AccountInterface $child
      */
-    public function removeChild(AccountInterface $child);
+    public function removeChild(self $child);
 
     /**
      * Add categories.

--- a/src/Sulu/Bundle/ContactBundle/Entity/AccountRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AccountRepository.php
@@ -116,7 +116,7 @@ class AccountRepository extends NestedTreeRepository implements DataProviderRepo
                 ->addSelect('medias')
                 ->where('account.id = :accountId');
 
-            if ($contacts === true) {
+            if (true === $contacts) {
                 $qb->leftJoin('account.accountContacts', 'accountContacts')
                     ->leftJoin('accountContacts.contact', 'contacts')
                     ->leftJoin('accountContacts.position', 'position')
@@ -143,7 +143,7 @@ class AccountRepository extends NestedTreeRepository implements DataProviderRepo
      */
     public function findByIds($ids)
     {
-        if (count($ids) === 0) {
+        if (0 === count($ids)) {
             return [];
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -100,7 +100,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
      */
     public function findByIds($ids)
     {
-        if (count($ids) === 0) {
+        if (0 === count($ids)) {
             return [];
         }
 
@@ -361,7 +361,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
      */
     private function addWhere($qb, $where, $prefix = '')
     {
-        $prefix = $prefix !== '' ? $prefix . '.' : '';
+        $prefix = '' !== $prefix ? $prefix . '.' : '';
         $and = $qb->expr()->andX();
         foreach ($where as $k => $v) {
             $and->add($qb->expr()->eq($prefix . $k, "'" . $v . "'"));

--- a/src/Sulu/Bundle/ContactBundle/EventListener/AccountListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/AccountListener.php
@@ -26,7 +26,7 @@ class AccountListener
         if ($entity instanceof AccountInterface) {
             $entityManager = $args->getEntityManager();
             // after saving account check if number is set, else set a new one
-            if ($entity->getNumber() === null) {
+            if (null === $entity->getNumber()) {
                 $entity->setNumber(sprintf('%05d', $entity->getId()));
                 $entityManager->flush();
             }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1383,7 +1383,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('sulu-100x100', $response->logo->thumbnails);
         $this->assertTrue(is_string($response->logo->thumbnails->{'sulu-100x100'}));
 
-        if ($response->addresses[0]->street === 'Bahnhofstraße') {
+        if ('Bahnhofstraße' === $response->addresses[0]->street) {
             $this->assertEquals(2, count($response->addresses));
             $this->assertEquals('Bahnhofstraße', $response->addresses[0]->street);
             $this->assertEquals('2', $response->addresses[0]->number);
@@ -1484,7 +1484,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('sulu-100x100', $response->logo->thumbnails);
         $this->assertTrue(is_string($response->logo->thumbnails->{'sulu-100x100'}));
 
-        if ($response->addresses[0]->street === 'Bahnhofstraße') {
+        if ('Bahnhofstraße' === $response->addresses[0]->street) {
             $this->assertEquals(2, count($response->addresses));
             $this->assertEquals('Bahnhofstraße', $response->addresses[0]->street);
             $this->assertEquals('2', $response->addresses[0]->number);
@@ -2263,7 +2263,7 @@ class AccountControllerTest extends SuluTestCase
         $client->request('GET', '/api/accounts/' . $response->id);
         $response = json_decode($client->getResponse()->getContent());
 
-        if ($response->addresses[0]->number == 1) {
+        if (1 == $response->addresses[0]->number) {
             $this->assertEquals(false, $response->addresses[0]->primaryAddress);
             $this->assertEquals(true, $response->addresses[1]->primaryAddress);
         } else {
@@ -2410,7 +2410,7 @@ class AccountControllerTest extends SuluTestCase
     public function sortAddressesPrimaryLast()
     {
         return function ($a, $b) {
-            if ($a->primaryAddress === true && $b->primaryAddress === false) {
+            if (true === $a->primaryAddress && false === $b->primaryAddress) {
                 return true;
             }
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -2370,7 +2370,7 @@ class ContactControllerTest extends SuluTestCase
     public function sortAddressesPrimaryLast()
     {
         return function ($a, $b) {
-            if ($a->primaryAddress === true && $b->primaryAddress === false) {
+            if (true === $a->primaryAddress && false === $b->primaryAddress) {
                 return true;
             }
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/CustomerControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/CustomerControllerTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 class CustomerControllerTest extends SuluTestCase
 {
     private $contacts = [];
+
     private $accounts = [];
 
     public function setUp()

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -60,7 +60,7 @@ class ContactTwigExtension extends \Twig_Extension
         }
 
         $contact = $this->contactRepository->find($id);
-        if ($contact === null) {
+        if (null === $contact) {
             return;
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Behat/BaseStructureContext.php
+++ b/src/Sulu/Bundle/ContentBundle/Behat/BaseStructureContext.php
@@ -80,7 +80,7 @@ class BaseStructureContext extends BaseContext implements SnippetAcceptingContex
             $parentUuid = null;
 
             if ($structureData['parent']) {
-                $parentPath = $type === 'page' ? '/cmf/sulu_io/contents' : '/cmf/snippets';
+                $parentPath = 'page' === $type ? '/cmf/sulu_io/contents' : '/cmf/snippets';
                 $parentNode = $this->getPhpcrSession()->getNode($parentPath . $structureData['parent']);
                 $parentUuid = $parentNode->getIdentifier();
             }
@@ -104,7 +104,7 @@ class BaseStructureContext extends BaseContext implements SnippetAcceptingContex
             }
 
             $persistOptions = [];
-            if ($type === 'page') {
+            if ('page' === $type) {
                 if ($parentUuid) {
                     $document->setParent($this->getDocumentManager()->find($parentUuid, 'de'));
                 } else {
@@ -160,7 +160,7 @@ class BaseStructureContext extends BaseContext implements SnippetAcceptingContex
 
         $paths = $paths[$type];
 
-        if (count($paths) == 0) {
+        if (0 == count($paths)) {
             throw new \Exception(sprintf(
                 'No "%s" paths configured in container parameter "sulu.content.structure.paths',
                 $type

--- a/src/Sulu/Bundle/ContentBundle/Behat/ContentContext.php
+++ b/src/Sulu/Bundle/ContentBundle/Behat/ContentContext.php
@@ -151,7 +151,7 @@ EOT;
      */
     public function iExpectThePageStateToBe($state)
     {
-        if ($state === 'Published') {
+        if ('Published' === $state) {
             $this->assertSelector('[data-id=\'statePublished\']:visible');
             $this->assertSelectorIsHidden('[data-id=\'stateTest\']');
         } else {

--- a/src/Sulu/Bundle/ContentBundle/Command/CleanupHistoryCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/CleanupHistoryCommand.php
@@ -87,7 +87,7 @@ EOT
         $dryRun = $input->getOption('dry-run');
 
         $path = $this->sessionManager->getRoutePath($webspaceKey, $locale);
-        $relativePath = ($basePath !== null ? '/' . ltrim($basePath, '/') : '/');
+        $relativePath = (null !== $basePath ? '/' . ltrim($basePath, '/') : '/');
         $fullPath = rtrim($path . $relativePath, '/');
 
         $this->cleanSession($output, $this->defaultSession, $fullPath, $dryRun);
@@ -150,7 +150,7 @@ EOT
             return;
         }
 
-        if ($dryRun === false) {
+        if (false === $dryRun) {
             $node->remove();
         }
         $output->writeln('<info>Processing: </info>/' . $path);

--- a/src/Sulu/Bundle/ContentBundle/Command/ContentLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ContentLocaleCopyCommand.php
@@ -137,7 +137,7 @@ EOT
         if (!$overwrite) {
             $destStructure = $this->contentMapper->load($structure->getUuid(), $webspaceKey, $destLocale, true);
 
-            if (!($destStructure->getType() && $destStructure->getType()->getName() === 'ghost')) {
+            if (!($destStructure->getType() && 'ghost' === $destStructure->getType()->getName())) {
                 $this->output->writeln(
                     '<info>Processing aborted: </info>' .
                     $structure->getPath() . ' <comment>(use overwrite option to force)</comment>'
@@ -147,7 +147,7 @@ EOT
             }
         }
 
-        if ($structure->getType() && $structure->getType()->getName() === 'ghost') {
+        if ($structure->getType() && 'ghost' === $structure->getType()->getName()) {
             $this->output->writeln(
                 '<info>Processing aborted: </info>' .
                 $structure->getPath() . ' <comment>(source language does not exist)</comment>'

--- a/src/Sulu/Bundle/ContentBundle/Command/MaintainResourceLocatorCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/MaintainResourceLocatorCommand.php
@@ -153,18 +153,18 @@ class MaintainResourceLocatorCommand extends Command
         }
 
         $nodeType = $node->getPropertyValue($this->propertyEncoder->localizedSystemName('nodeType', $locale));
-        if ($property->getContentTypeName() !== 'resource_locator' && $nodeType !== Structure::NODE_TYPE_CONTENT) {
+        if ('resource_locator' !== $property->getContentTypeName() && Structure::NODE_TYPE_CONTENT !== $nodeType) {
             return;
         }
 
         $baseRoutePath = $this->sessionManager->getRoutePath($webspace->getKey(), $localization->getLocale());
         foreach ($node->getReferences('sulu:content') as $routeProperty) {
-            if (strpos($routeProperty->getPath(), $baseRoutePath) !== 0) {
+            if (0 !== strpos($routeProperty->getPath(), $baseRoutePath)) {
                 continue;
             }
 
             $routeNode = $routeProperty->getParent();
-            if ($routeNode->getPropertyValue('sulu:history') === true) {
+            if (true === $routeNode->getPropertyValue('sulu:history')) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/ContentBundle/Command/ValidatePagesCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ValidatePagesCommand.php
@@ -92,12 +92,12 @@ class ValidatePagesCommand extends ContainerAwareCommand
             foreach ($headers as $header) {
                 $template = $row->getValue($header);
                 $tableRow[] = $template;
-                if ($template !== '' && !in_array($template, $structures)) {
+                if ('' !== $template && !in_array($template, $structures)) {
                     $tableRow[0] = 'X';
                     $descriptions[] = sprintf('Language "%s" contains a not existing xml-template', $header);
                     ++$result;
                 }
-                if ($template !== '' && !in_array($template, $availableStructureKeys)) {
+                if ('' !== $template && !in_array($template, $availableStructureKeys)) {
                     $tableRow[0] = 'X';
                     $descriptions[] = sprintf(
                         'Language "%s" contains a not implemented xml-template in webspace "%s"',

--- a/src/Sulu/Bundle/ContentBundle/Command/WebspaceExportCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/WebspaceExportCommand.php
@@ -41,7 +41,7 @@ class WebspaceExportCommand extends ContainerAwareCommand
     {
         $webspaceKey = $input->getArgument('webspace');
         $target = $input->getArgument('target');
-        if (!strpos($target, '/') === 0) {
+        if (0 === !strpos($target, '/')) {
             $target = getcwd() . '/' . $target;
         }
         $locale = $input->getArgument('locale');

--- a/src/Sulu/Bundle/ContentBundle/Command/WebspaceImportCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/WebspaceImportCommand.php
@@ -41,7 +41,7 @@ class WebspaceImportCommand extends ContainerAwareCommand
     {
         $webspaceKey = $input->getArgument('webspace');
         $filePath = $input->getArgument('file');
-        if (!strpos($filePath, '/') === 0) {
+        if (0 === !strpos($filePath, '/')) {
             $filePath = getcwd() . '/' . $filePath;
         }
         $locale = $input->getArgument('locale');

--- a/src/Sulu/Bundle/ContentBundle/Content/InternalLinksContainer.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/InternalLinksContainer.php
@@ -15,7 +15,6 @@ use JMS\Serializer\Annotation\Exclude;
 use Psr\Log\LoggerInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
-use Sulu\Component\Content\Query\ContentQueryExecutor;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
 use Sulu\Component\Util\ArrayableInterface;
 
@@ -120,7 +119,7 @@ class InternalLinksContainer implements ArrayableInterface
      */
     public function getData()
     {
-        if ($this->data === null) {
+        if (null === $this->data) {
             $this->data = $this->loadData();
         }
 
@@ -133,7 +132,7 @@ class InternalLinksContainer implements ArrayableInterface
     private function loadData()
     {
         $result = [];
-        if ($this->ids !== null && count($this->ids) > 0) {
+        if (null !== $this->ids && count($this->ids) > 0) {
             $this->contentQueryBuilder->init(
                 [
                     'ids' => $this->ids,
@@ -183,7 +182,7 @@ class InternalLinksContainer implements ArrayableInterface
      */
     public function __isset($name)
     {
-        return $name == 'data';
+        return 'data' == $name;
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
@@ -230,7 +230,7 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
      */
     private function getExcerptStructure($locale = null)
     {
-        if ($locale === null) {
+        if (null === $locale) {
             $locale = $this->languageCode;
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/SeoStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/SeoStructureExtension.php
@@ -161,13 +161,13 @@ class SeoStructureExtension extends AbstractExtension implements ExportExtension
      */
     protected function convertCheckboxData(&$data, $key, $default = false)
     {
-        if ($data[$key] === '0') {
+        if ('0' === $data[$key]) {
             $data[$key] = false;
 
             return;
         }
 
-        if ($data[$key] === '1') {
+        if ('1' === $data[$key]) {
             $data[$key] = true;
 
             return;

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/Checkbox.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/Checkbox.php
@@ -47,7 +47,7 @@ class Checkbox extends SimpleContentType
     ) {
         $value = $property->getValue();
 
-        if ($value !== null && $value !== false && $value !== 'false' && $value !== '') {
+        if (null !== $value && false !== $value && 'false' !== $value && '' !== $value) {
             $node->setProperty($property->getName(), true);
         } else {
             $node->setProperty($property->getName(), false);
@@ -88,7 +88,7 @@ class Checkbox extends SimpleContentType
     ) {
         $preparedValue = true;
 
-        if ($value === '0') {
+        if ('0' === $value) {
             $preparedValue = false;
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/Date.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/Date.php
@@ -42,7 +42,7 @@ class Date extends SimpleContentType
         $segmentKey
     ) {
         $value = $property->getValue();
-        if ($value != null) {
+        if (null != $value) {
             $value = \DateTime::createFromFormat('Y-m-d', $value);
 
             $node->setProperty($property->getName(), $value);

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/InternalLinks.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/InternalLinks.php
@@ -32,6 +32,7 @@ class InternalLinks extends ComplexContentType implements ContentTypeExportInter
      * @var ContentQueryExecutorInterface
      */
     private $contentQueryExecutor;
+
     /**
      * @var ContentQueryBuilderInterface
      */

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
@@ -42,7 +42,7 @@ class SingleInternalLink extends SimpleContentType
     ) {
         $value = $property->getValue();
 
-        if ($node->getIdentifier() !== null && $value === $node->getIdentifier()) {
+        if (null !== $node->getIdentifier() && $value === $node->getIdentifier()) {
             throw new \InvalidArgumentException('Internal link node cannot reference itself');
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -52,6 +52,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
     use RequestParametersTrait;
 
     const WEBSPACE_NODE_SINGLE = 'single';
+
     const WEBSPACE_NODES_ALL = 'all';
 
     private static $relationName = 'nodes';
@@ -133,7 +134,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
      */
     public function getAction(Request $request, $uuid)
     {
-        if ($request->get('fields') !== null) {
+        if (null !== $request->get('fields')) {
             return $this->getContent($request, $uuid);
         }
 
@@ -300,7 +301,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $excludeShadows = $this->getBooleanRequestParameter($request, 'exclude-shadows', false, false);
 
         try {
-            if ($uuid !== null && $uuid !== '') {
+            if (null !== $uuid && '' !== $uuid) {
                 $result = $this->getRepository()->getNodesTree(
                     $uuid,
                     $webspace,
@@ -308,7 +309,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
                     $excludeGhosts,
                     $excludeShadows
                 );
-            } elseif ($webspace !== null) {
+            } elseif (null !== $webspace) {
                 $result = $this->getRepository()->getWebspaceNode($webspace, $language);
             } else {
                 $result = $this->getRepository()->getWebspaceNodes($language);
@@ -382,7 +383,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
      */
     public function cgetAction(Request $request)
     {
-        if ($request->get('fields') !== null) {
+        if (null !== $request->get('fields')) {
             return $this->cgetContent($request);
         }
 
@@ -406,9 +407,9 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $tree = $this->getBooleanRequestParameter($request, 'tree', false, false);
         $ids = $this->getRequestParameter($request, 'ids');
 
-        if ($tree === true) {
+        if (true === $tree) {
             return $this->getTreeForUuid($request, $this->getRequestParameter($request, 'id', false, null));
-        } elseif ($ids !== null) {
+        } elseif (null !== $ids) {
             return $this->getNodesByIds($request, $ids);
         }
 
@@ -420,7 +421,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $depth = $request->get('depth', 1);
         $depth = intval($depth);
         $flat = $request->get('flat', 'true');
-        $flat = ($flat === 'true');
+        $flat = ('true' === $flat);
 
         // TODO pagination
         $result = $this->getRepository()->getNodes(
@@ -565,7 +566,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
             $webspaceKey,
             true,
             true,
-            $exclude !== null ? [$exclude] : []
+            null !== $exclude ? [$exclude] : []
         );
 
         return $this->handleView($this->view($content));
@@ -781,7 +782,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
             }
 
             // prepare view
-            $view = $this->view($data, $data !== null ? 200 : 204);
+            $view = $this->view($data, null !== $data ? 200 : 204);
             $view->setSerializationContext(SerializationContext::create()->setGroups(['defaultPage']));
         } catch (RestException $exc) {
             $view = $this->view($exc->toArray(), 400);
@@ -844,7 +845,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
 
         if (null !== ($uuid = $request->get('uuid'))) {
             $id = $uuid;
-        } elseif (null !== ($parent = $request->get('parent')) && $request->getMethod() !== Request::METHOD_GET) {
+        } elseif (null !== ($parent = $request->get('parent')) && Request::METHOD_GET !== $request->getMethod()) {
             // the user is always allowed to get the children of a node
             // so the security check only applies for requests not being GETs
             $id = $parent;

--- a/src/Sulu/Bundle/ContentBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/SmartContentItemController.php
@@ -85,7 +85,7 @@ class SmartContentItemController extends RestController
         $result = [];
         foreach ($params as $name => $item) {
             $value = $item['value'];
-            if ($item['type'] === 'collection') {
+            if ('collection' === $item['type']) {
                 $value = $this->getParams($value);
             }
 

--- a/src/Sulu/Bundle/ContentBundle/Controller/TemplateController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/TemplateController.php
@@ -52,7 +52,7 @@ class TemplateController extends Controller
 
         $type = $request->get('type', Structure::TYPE_PAGE);
 
-        if ($type === Structure::TYPE_PAGE) {
+        if (Structure::TYPE_PAGE === $type) {
             $structureProvider = $this->get('sulu.content.webspace_structure_provider');
             $structures = $structureProvider->getStructures($request->get('webspace'));
         } else {
@@ -62,7 +62,7 @@ class TemplateController extends Controller
 
         $templates = [];
         foreach ($structures as $structure) {
-            if (false === $structure->getInternal() || $internal !== false) {
+            if (false === $structure->getInternal() || false !== $internal) {
                 $templates[] = [
                     'internal' => $structure->getInternal(),
                     'template' => $structure->getKey(),
@@ -100,8 +100,8 @@ class TemplateController extends Controller
         $uuid = $request->get('uuid');
         $type = $request->get('type', 'page');
 
-        if ($key === null) {
-            if ($type === 'page') {
+        if (null === $key) {
+            if ('page' === $type) {
                 $webspaceManager = $this->container->get('sulu_core.webspace.webspace_manager');
                 $key = $webspaceManager->findWebspaceByKey($webspace)->getDefaultTemplate($type);
                 $fireEvent = true;

--- a/src/Sulu/Bundle/ContentBundle/Controller/VersionController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/VersionController.php
@@ -127,7 +127,7 @@ class VersionController extends FOSRestController implements
                 break;
         }
 
-        $view = $this->view($data, $data !== null ? 200 : 204);
+        $view = $this->view($data, null !== $data ? 200 : 204);
         $view->setSerializationContext(SerializationContext::create()->setGroups(['defaultPage']));
 
         return $this->handleView($view);

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class ContentExportCompilerPass implements CompilerPassInterface
 {
     const CONTENT_EXPORT_SERVICE_ID = 'sulu_content.export.manager';
+
     const STRUCTURE_EXTENSION_TAG = 'sulu.content.export';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class SmartContentDataProviderCompilerPass implements CompilerPassInterface
 {
     const POOL_SERVICE_ID = 'sulu_content.smart_content.data_provider_pool';
+
     const STRUCTURE_EXTENSION_TAG = 'sulu.smart_content.data_provider';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class StructureExtensionCompilerPass implements CompilerPassInterface
 {
     const STRUCTURE_MANAGER_ID = 'sulu_content.extension.manager';
+
     const STRUCTURE_EXTENSION_TAG = 'sulu.structure.extension';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Document/Subscriber/PublishSubscriber.php
@@ -254,6 +254,7 @@ class PublishSubscriber implements EventSubscriberInterface
 
             if ($currentLiveNode->hasNode($pathSegment)) {
                 $currentLiveNode = $currentLiveNode->getNode($pathSegment);
+
                 continue;
             }
 

--- a/src/Sulu/Bundle/ContentBundle/DocumentManager/ContentInitializer.php
+++ b/src/Sulu/Bundle/ContentBundle/DocumentManager/ContentInitializer.php
@@ -67,6 +67,7 @@ class ContentInitializer implements InitializerInterface
         ] as $prefix => $uri) {
             if (in_array($prefix, $existingPrefixes)) {
                 $output->writeln(sprintf('  [ ] %s:%s', $prefix, $uri));
+
                 continue;
             }
 

--- a/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
@@ -21,7 +21,9 @@ use Sulu\Bundle\MarkupBundle\Tag\TagInterface;
 class LinkTag implements TagInterface
 {
     const VALIDATE_UNPUBLISHED = 'unpublished';
+
     const VALIDATE_REMOVED = 'removed';
+
     const DEFAULT_PROVIDER = 'page';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -168,12 +168,12 @@ class NodeRepository implements NodeRepositoryInterface
         $result['_links'] = [
             'self' => [
                 'href' => $this->apiBasePath . '/' . $structure->getUuid() .
-                    ($extension !== null ? '/' . $extension : ''),
+                    (null !== $extension ? '/' . $extension : ''),
             ],
             'children' => [
                 'href' => $this->apiBasePath . '?parent=' . $structure->getUuid() . '&depth=' . $depth .
                     '&webspace=' . $webspaceKey . '&language=' . $languageCode .
-                    ($excludeGhosts === true ? '&exclude-ghosts=true' : ''),
+                    (true === $excludeGhosts ? '&exclude-ghosts=true' : ''),
             ],
         ];
 
@@ -350,7 +350,7 @@ class NodeRepository implements NodeRepositoryInterface
         $data['_links'] = [
             'self' => [
                 'href' => $this->apiBasePath . '/entry?depth=' . $depth . '&webspace=' . $webspaceKey .
-                    '&language=' . $languageCode . ($excludeGhosts === true ? '&exclude-ghosts=true' : ''),
+                    '&language=' . $languageCode . (true === $excludeGhosts ? '&exclude-ghosts=true' : ''),
             ],
         ];
 
@@ -416,7 +416,7 @@ class NodeRepository implements NodeRepositoryInterface
             '_links' => [
                 'children' => [
                     'href' => $this->apiBasePath . '?depth=' . $depth . '&webspace=' . $webspaceKey .
-                        '&language=' . $languageCode . ($excludeGhosts === true ? '&exclude-ghosts=true' : ''),
+                        '&language=' . $languageCode . (true === $excludeGhosts ? '&exclude-ghosts=true' : ''),
                 ],
             ],
         ];
@@ -451,7 +451,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         if ($api) {
             if (isset($filterConfig['dataSource'])) {
-                if ($this->webspaceManager->findWebspaceByKey($filterConfig['dataSource']) !== null) {
+                if (null !== $this->webspaceManager->findWebspaceByKey($filterConfig['dataSource'])) {
                     $node = $this->sessionManager->getContentNode($filterConfig['dataSource']);
                 } else {
                     $node = $this->sessionManager->getSession()->getNodeByIdentifier($filterConfig['dataSource']);
@@ -483,7 +483,7 @@ class NodeRepository implements NodeRepositoryInterface
      */
     private function getParentNode($parent, $webspaceKey, $languageCode)
     {
-        if ($parent != null) {
+        if (null != $parent) {
             return $this->getMapper()->load($parent, $webspaceKey, $languageCode);
         } else {
             return $this->getMapper()->loadStartPage($webspaceKey, $languageCode);
@@ -513,10 +513,10 @@ class NodeRepository implements NodeRepositoryInterface
         $results = [];
         foreach ($nodes as $node) {
             $result = $this->prepareNode($node, $webspaceKey, $languageCode, 1, $complete, $excludeGhosts);
-            if ($maxDepth !== null &&
+            if (null !== $maxDepth &&
                 $currentDepth < $maxDepth &&
                 $node->getHasChildren() &&
-                $node->getChildren() != null
+                null != $node->getChildren()
             ) {
                 $result['_embedded']['nodes'] = $this->prepareNodesTree(
                     $node->getChildren(),
@@ -565,7 +565,7 @@ class NodeRepository implements NodeRepositoryInterface
         $result['_links'] = [
             'self' => [
                 'href' => $this->apiBasePath . '/tree?uuid=' . $uuid . '&webspace=' . $webspaceKey . '&language=' .
-                    $languageCode . ($excludeGhosts === true ? '&exclude-ghosts=true' : ''),
+                    $languageCode . (true === $excludeGhosts ? '&exclude-ghosts=true' : ''),
             ],
         ];
 
@@ -600,11 +600,11 @@ class NodeRepository implements NodeRepositoryInterface
             foreach ($descendant->getChildren() as $child) {
                 $type = $child->getType();
 
-                if ($excludeShadows && $type !== null && $type->getName() === 'shadow') {
+                if ($excludeShadows && null !== $type && 'shadow' === $type->getName()) {
                     continue;
                 }
 
-                if ($excludeGhosts && $type !== null && $type->getName() === 'ghost') {
+                if ($excludeGhosts && null !== $type && 'ghost' === $type->getName()) {
                     continue;
                 }
 

--- a/src/Sulu/Bundle/ContentBundle/Repository/ResourceLocatorRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/ResourceLocatorRepository.php
@@ -126,7 +126,7 @@ class ResourceLocatorRepository implements ResourceLocatorRepositoryInterface
      */
     private function getBasePath($uuid = null, $default = 1)
     {
-        if ($uuid !== null) {
+        if (null !== $uuid) {
             return str_replace('{uuid}', $uuid, $this->apiBasePath[2]);
         } else {
             return $this->apiBasePath[$default];

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507231648.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201507231648.php
@@ -21,9 +21,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class Version201507231648 implements VersionInterface, ContainerAwareInterface
 {
     const SHADOW_ON_PROPERTY = 'i18n:%s-shadow-on';
+
     const SHADOW_BASE_PROPERTY = 'i18n:%s-shadow-base';
+
     const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
+
     const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
+
     const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201510210733.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201510210733.php
@@ -173,7 +173,7 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
     {
         $structureName = $structureMetadata->getName();
         foreach ($structureMetadata->getProperties() as $property) {
-            if ($property->getType() === 'url') {
+            if ('url' === $property->getType()) {
                 $properties[$structureName][] = $property->getName();
             } elseif ($property instanceof BlockMetadata) {
                 $this->findUrlBlockProperties($property, $structureName, $properties);
@@ -192,7 +192,7 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
     {
         foreach ($property->getComponents() as $component) {
             foreach ($component->getChildren() as $childProperty) {
-                if ($childProperty->getType() === 'url') {
+                if ('url' === $childProperty->getType()) {
                     $properties[$structureName][] = $property->getName();
                 }
             }
@@ -262,7 +262,7 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
         $value = $property->getValue();
         if (is_array($value)) {
             foreach ($value as $key => $entry) {
-                if ($entry['type'] !== 'url') {
+                if ('url' !== $entry['type']) {
                     continue;
                 }
 
@@ -302,7 +302,7 @@ class Version201510210733 implements VersionInterface, ContainerAwareInterface
      */
     private function downgradeUrl(&$value)
     {
-        if (strpos($value, 'http://') === 0) {
+        if (0 === strpos($value, 'http://')) {
             $value = substr($value, 7);
         }
     }

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511171538.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511171538.php
@@ -133,7 +133,7 @@ class Version201511171538 implements VersionInterface, ContainerAwareInterface
     {
         $structureName = $structureMetadata->getName();
         foreach ($structureMetadata->getProperties() as $property) {
-            if ($property->getType() === 'date') {
+            if ('date' === $property->getType()) {
                 $properties[$structureName][] = $property->getName();
             } elseif ($property instanceof BlockMetadata) {
                 $this->findDateBlockProperties($property, $structureName, $properties);
@@ -152,7 +152,7 @@ class Version201511171538 implements VersionInterface, ContainerAwareInterface
     {
         foreach ($property->getComponents() as $component) {
             foreach ($component->getChildren() as $childProperty) {
-                if ($childProperty->getType() === 'date') {
+                if ('date' === $childProperty->getType()) {
                     $properties[$structureName][] = $property->getName();
                 }
             }

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240843.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240843.php
@@ -141,7 +141,7 @@ class Version201511240843 implements VersionInterface, ContainerAwareInterface
     {
         $structureName = $structureMetadata->getName();
         foreach ($structureMetadata->getProperties() as $property) {
-            if ($property->getType() === 'date') {
+            if ('date' === $property->getType()) {
                 $properties[$structureName][] = ['property' => $property];
             } elseif ($property instanceof BlockMetadata) {
                 $this->findDateBlockProperties($property, $structureName, $properties);
@@ -162,7 +162,7 @@ class Version201511240843 implements VersionInterface, ContainerAwareInterface
         foreach ($property->getComponents() as $component) {
             $componentResult = ['component' => $component, 'children' => []];
             foreach ($component->getChildren() as $childProperty) {
-                if ($childProperty->getType() === 'date') {
+                if ('date' === $childProperty->getType()) {
                     $componentResult['children'][$childProperty->getName()] = $childProperty;
                 }
             }

--- a/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240844.php
+++ b/src/Sulu/Bundle/ContentBundle/Resources/phpcr-migrations/Version201511240844.php
@@ -175,7 +175,7 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
     {
         $structureName = $structureMetadata->getName();
         foreach ($structureMetadata->getProperties() as $property) {
-            if ($property->getType() === 'url') {
+            if ('url' === $property->getType()) {
                 $properties[$structureName][] = ['property' => $property];
             } elseif ($property instanceof BlockMetadata) {
                 $this->findUrlBlockProperties($property, $structureName, $properties);
@@ -196,7 +196,7 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
         foreach ($property->getComponents() as $component) {
             $componentResult = ['component' => $component, 'children' => []];
             foreach ($component->getChildren() as $childProperty) {
-                if ($childProperty->getType() === 'url') {
+                if ('url' === $childProperty->getType()) {
                     $componentResult['children'][$childProperty->getName()] = $childProperty;
                 }
             }
@@ -340,12 +340,12 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
     private function upgradeUrl(&$value)
     {
         if (!empty($value)
-            && strpos($value, 'http://') === false
-            && strpos($value, 'https://') === false
-            && strpos($value, 'ftp://') === false
-            && strpos($value, 'ftps://') === false
-            && strpos($value, 'mailto:') === false
-            && strpos($value, '//') === false
+            && false === strpos($value, 'http://')
+            && false === strpos($value, 'https://')
+            && false === strpos($value, 'ftp://')
+            && false === strpos($value, 'ftps://')
+            && false === strpos($value, 'mailto:')
+            && false === strpos($value, '//')
         ) {
             $value = 'http://' . $value;
         }
@@ -362,7 +362,7 @@ class Version201511240844 implements VersionInterface, ContainerAwareInterface
      */
     private function downgradeUrl(&$value)
     {
-        if (strpos($value, 'http://') === 0) {
+        if (0 === strpos($value, 'http://')) {
             $value = substr($value, 7);
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventListener/HitListener.php
@@ -43,7 +43,7 @@ class HitListener
         }
 
         $document = $event->getHit()->getDocument();
-        if ($document->getUrl()[0] !== '/') {
+        if ('/' !== $document->getUrl()[0]) {
             // is absolute URL
 
             return;

--- a/src/Sulu/Bundle/ContentBundle/Search/EventListener/PermissionListener.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/EventListener/PermissionListener.php
@@ -39,7 +39,7 @@ class PermissionListener
 
     public function onPermissionUpdate(PermissionUpdateEvent $permissionUpdateEvent)
     {
-        if ($permissionUpdateEvent->getType() !== SecurityBehavior::class) {
+        if (SecurityBehavior::class !== $permissionUpdateEvent->getType()) {
             return;
         }
 

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -42,7 +42,9 @@ use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
 class StructureProvider implements ProviderInterface
 {
     const FIELD_STRUCTURE_TYPE = '_structure_type';
+
     const FIELD_TEASER_DESCRIPTION = '_teaser_description';
+
     const FIELD_TEASER_MEDIA = '_teaser_media';
 
     /**
@@ -136,7 +138,7 @@ class StructureProvider implements ProviderInterface
             $indexName = $mapping['index'];
         }
 
-        if ($indexName === 'page') {
+        if ('page' === $indexName) {
             $indexMeta->setIndexName(
                 new Expression(
                     sprintf(
@@ -161,7 +163,7 @@ class StructureProvider implements ProviderInterface
                         $tag = $componentProperty->getTag('sulu.search.field');
                         $tagAttributes = $tag['attributes'];
 
-                        if (!isset($tagAttributes['index']) || $tagAttributes['index'] !== 'false') {
+                        if (!isset($tagAttributes['index']) || 'false' !== $tagAttributes['index']) {
                             $propertyMapping->addFieldMapping(
                                 $property->getName() . '.' . $componentProperty->getName(),
                                 [
@@ -384,7 +386,7 @@ EOT;
             return;
         }
 
-        if (!isset($tagAttributes['index']) || $tagAttributes['index'] !== 'false') {
+        if (!isset($tagAttributes['index']) || 'false' !== $tagAttributes['index']) {
             $metadata->addFieldMapping(
                 $property->getName(),
                 [

--- a/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Reindex/StructureProvider.php
@@ -81,7 +81,7 @@ class StructureProvider implements LocalizedReindexProviderInterface
     {
         $document = $this->documentManager->find($this->inspector->getUuid($object), $locale);
 
-        if ($document instanceof WorkflowStageBehavior && $this->context === SuluKernel::CONTEXT_ADMIN) {
+        if ($document instanceof WorkflowStageBehavior && SuluKernel::CONTEXT_ADMIN === $this->context) {
             // set the workflowstage to test, so that the document will be indexed in the index for drafting
             // this change must not be persisted
             // is required because of the expression for the index name uses the workflowstage

--- a/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/LocaleSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/LocaleSubscriber.php
@@ -73,11 +73,11 @@ class LocaleSubscriber implements EventSubscriberInterface
 
         $localizationState = $this->documentInspector->getLocalizationState($document);
 
-        if ($localizationState === LocalizationState::GHOST) {
+        if (LocalizationState::GHOST === $localizationState) {
             $visitor->addData('type', ['name' => 'ghost', 'value' => $document->getLocale()]);
         }
 
-        if ($localizationState === LocalizationState::SHADOW) {
+        if (LocalizationState::SHADOW === $localizationState) {
             $visitor->addData('type', ['name' => 'shadow', 'value' => $document->getLocale()]);
         }
     }

--- a/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/RedirectTypeSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/RedirectTypeSubscriber.php
@@ -54,10 +54,10 @@ class RedirectTypeSubscriber implements EventSubscriberInterface
 
         $redirectType = $document->getRedirectType();
 
-        if ($redirectType == RedirectType::INTERNAL && $document->getRedirectTarget() !== null) {
+        if (RedirectType::INTERNAL == $redirectType && null !== $document->getRedirectTarget()) {
             $visitor->addData('linked', 'internal');
             $visitor->addData('internal_link', $document->getRedirectTarget()->getUuid());
-        } elseif ($redirectType == RedirectType::EXTERNAL) {
+        } elseif (RedirectType::EXTERNAL == $redirectType) {
             $visitor->addData('linked', 'external');
             $visitor->addData('external', $document->getRedirectExternal());
         } else {

--- a/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/StructureSubscriber.php
@@ -94,12 +94,12 @@ class StructureSubscriber implements EventSubscriberInterface
                 )
             );
 
-            if (array_search('defaultPage', $context->attributes->get('groups')->getOrElse([])) !== false) {
+            if (false !== array_search('defaultPage', $context->attributes->get('groups')->getOrElse([]))) {
                 $this->addStructureProperties($structureMetadata, $document, $visitor);
             }
 
             // create bread crumbs
-            if (array_search('breadcrumbPage', $context->attributes->get('groups')->getOrElse([])) !== false) {
+            if (false !== array_search('breadcrumbPage', $context->attributes->get('groups')->getOrElse([]))) {
                 $this->addBreadcrumb($document, $visitor);
             }
         }
@@ -120,7 +120,7 @@ class StructureSubscriber implements EventSubscriberInterface
         $structure = $document->getStructure();
         $data = $structure->toArray();
         foreach ($structureMetadata->getProperties() as $name => $property) {
-            if ($name === 'title' || !array_key_exists($name, $data) || $property->hasTag('sulu.rlp')) {
+            if ('title' === $name || !array_key_exists($name, $data) || $property->hasTag('sulu.rlp')) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Bundle/ContentBundle/Serializer/Subscriber/WorkflowStageSubscriber.php
@@ -52,6 +52,6 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
         }
 
         $visitor = $event->getVisitor();
-        $visitor->addData('publishedState', $document->getWorkflowStage() === WorkflowStage::PUBLISHED);
+        $visitor->addData('publishedState', WorkflowStage::PUBLISHED === $document->getWorkflowStage());
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/DefaultStructureCache.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/DefaultStructureCache.php
@@ -114,7 +114,7 @@ class DefaultStructureCache extends Page
         $this->addChild($prop1);
 
         // section content
-                $section1 = new SectionProperty(
+        $section1 = new SectionProperty(
             'content',
                         [
                 'title' => [

--- a/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/SecondStructureCache.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Fixtures/SecondStructureCache.php
@@ -112,7 +112,7 @@ class SecondStructureCache extends Page
         $this->addChild($prop1);
 
         // section content
-                $section1 = new SectionProperty(
+        $section1 = new SectionProperty(
             'content',
                         [
                 'title' => [

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
@@ -545,7 +545,7 @@ class NodeControllerFieldsTest extends SuluTestCase
         if (!$path) {
             $path = $this->sessionManager->getContentPath('sulu_io') . '/' . $title;
         }
-        if ($parent !== null) {
+        if (null !== $parent) {
             $path = $parent->getPath() . '/' . $title;
             $document->setParent($parent);
         }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceTest.php
@@ -254,10 +254,10 @@ class WebspaceTest extends SuluTestCase
 
             foreach ($page as $name => $property) {
                 if (
-                    strpos($name, 'seo') === false
-                    && strpos($name, 'excerpt') === false
+                    false === strpos($name, 'seo')
+                    && false === strpos($name, 'excerpt')
                 ) {
-                    if ($name === 'block') {
+                    if ('block' === $name) {
                         $blockChildren = [];
                         foreach ($property as $block) {
                             $blockPropertyData = [];
@@ -427,11 +427,11 @@ class WebspaceTest extends SuluTestCase
             'options' => $options,
         ];
 
-        if ($forceValue || $value !== null) {
+        if ($forceValue || null !== $value) {
             $data['value'] = $value;
         }
 
-        if ($children !== null) {
+        if (null !== $children) {
             $data['value'] = $children;
         }
 
@@ -483,7 +483,7 @@ class WebspaceTest extends SuluTestCase
             $document->setShadowLocaleEnabled($isShadow);
         }
 
-        if ($state === null) {
+        if (null === $state) {
             $state = WorkflowStage::PUBLISHED;
         }
         $document->setWorkflowStage($state);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
@@ -59,6 +59,7 @@ class WebspaceImportTest extends SuluTestCase
     public function tearDown()
     {
         $this->removeImportFile();
+        parent::tearDown();
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
@@ -25,13 +25,18 @@ class WebspaceImportTest extends SuluTestCase
      * @var DocumentManagerInterface
      */
     private $documentManager;
+
     /**
      * @var object
      */
     private $parent;
+
     private $pages = [];
+
     private $webspaceImporter;
+
     protected $distPath = './src/Sulu/Bundle/ContentBundle/Tests/app/Resources/import/export.xliff.dist';
+
     protected $path = './src/Sulu/Bundle/ContentBundle/Tests/app/Resources/import/export.xliff';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -542,7 +542,7 @@ class NodeRepositoryTest extends SuluTestCase
             $document->setShadowLocaleEnabled($isShadow);
         }
 
-        if ($state === null) {
+        if (null === $state) {
             $state = WorkflowStage::TEST;
         }
         $document->setWorkflowStage($state);
@@ -583,7 +583,7 @@ class NodeRepositoryTest extends SuluTestCase
         }
 
         $this->documentManager->persist($document, $locale, $persistOptions);
-        if ($state === WorkflowStage::PUBLISHED) {
+        if (WorkflowStage::PUBLISHED === $state) {
             $this->documentManager->publish($document, $locale);
         }
         $this->documentManager->flush();

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/AppKernel.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/AppKernel.php
@@ -18,7 +18,7 @@ class AppKernel extends SuluTestKernel
     {
         parent::registerContainerConfiguration($loader);
 
-        if (getenv('SYMFONY__PHPCR__TRANSPORT') === 'jackrabbit') {
+        if ('jackrabbit' === getenv('SYMFONY__PHPCR__TRANSPORT')) {
             $loader->load(__DIR__ . '/config/versioning.yml');
         }
 

--- a/src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
@@ -24,8 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class SuluBuilder implements ContainerAwareInterface, BuilderInterface
 {
     protected $container;
+
     protected $output;
+
     protected $input;
+
     protected $application;
 
     /**

--- a/src/Sulu/Bundle/CoreBundle/DataFixtures/ReplacerXmlLoader.php
+++ b/src/Sulu/Bundle/CoreBundle/DataFixtures/ReplacerXmlLoader.php
@@ -35,7 +35,7 @@ class ReplacerXmlLoader extends FileLoader
      */
     public function supports($resource, $type = null)
     {
-        return pathinfo($resource, PATHINFO_EXTENSION) === 'xml';
+        return 'xml' === pathinfo($resource, PATHINFO_EXTENSION);
     }
 
     private function parseXml($path)

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class ListBuilderMetadataProviderCompilerPass implements CompilerPassInterface
 {
     const CHAIN_PROVIDER_ID = 'sulu_core.list_builder.metadata.provider.chain';
+
     const PROVIDER_TAG_ID = 'sulu.list-builder.metadata.provider';
 
     /**

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -63,15 +63,15 @@ class CustomUrlAdmin extends Admin
     public function getSecurityContexts()
     {
         $webspaceContexts = [];
-         /* @var Webspace $webspace */
-         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-             $webspaceContexts[self::getCustomUrlSecurityContext($webspace->getKey())] = [
+        /* @var Webspace $webspace */
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $webspaceContexts[self::getCustomUrlSecurityContext($webspace->getKey())] = [
                  PermissionTypes::VIEW,
                  PermissionTypes::ADD,
                  PermissionTypes::EDIT,
                  PermissionTypes::DELETE,
              ];
-         }
+        }
 
         return [
              'Sulu' => [

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
@@ -67,7 +67,7 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($customUrl->getTargetDocument() !== null) {
+        if (null !== $customUrl->getTargetDocument()) {
             $visitor->addData('targetTitle', $customUrl->getTargetDocument()->getTitle());
         }
 

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/RequestAnalyzerLocalizationEnhancer.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/RequestAnalyzerLocalizationEnhancer.php
@@ -28,7 +28,7 @@ class RequestAnalyzerLocalizationEnhancer implements EnhancerInterface
      */
     public function enhance(Request $request, RequestAnalyzerInterface $requestAnalyzer)
     {
-        if ($request->get('_custom_url') === null) {
+        if (null === $request->get('_custom_url')) {
             return;
         }
 

--- a/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Request/CustomUrlRequestProcessor.php
@@ -65,12 +65,12 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
         $url = rtrim(sprintf('%s%s', $request->getHost(), $request->getRequestUri()), '/');
-        if (substr($url, -5, 5) === '.html') {
+        if ('.html' === substr($url, -5, 5)) {
             $url = substr($url, 0, -5);
         }
         $portalInformations = $this->webspaceManager->findPortalInformationsByUrl($url, $this->environment);
 
-        if (count($portalInformations) === 0) {
+        if (0 === count($portalInformations)) {
             return new RequestAttributes();
         }
 
@@ -78,7 +78,7 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
         $portalInformations = array_filter(
             $portalInformations,
             function (PortalInformation $portalInformation) {
-                return $portalInformation->getType() === RequestAnalyzer::MATCH_TYPE_WILDCARD;
+                return RequestAnalyzer::MATCH_TYPE_WILDCARD === $portalInformation->getType();
             }
         );
 
@@ -133,10 +133,10 @@ class CustomUrlRequestProcessor implements RequestProcessorInterface
             $routeDocument->getTargetDocument()->getTargetLocale()
         );
 
-        if ($customUrlDocument === null
-            || $customUrlDocument->isPublished() === false
-            || $customUrlDocument->getTargetDocument() === null
-            || $customUrlDocument->getTargetDocument()->getWorkflowStage() !== WorkflowStage::PUBLISHED
+        if (null === $customUrlDocument
+            || false === $customUrlDocument->isPublished()
+            || null === $customUrlDocument->getTargetDocument()
+            || WorkflowStage::PUBLISHED !== $customUrlDocument->getTargetDocument()->getWorkflowStage()
         ) {
             // error happen because this custom-url is not published => no portal is needed
             return ['customUrlRoute' => $routeDocument, 'customUrl' => $customUrlDocument];

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -121,14 +121,14 @@ class CustomUrlControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode($statusCode, $response);
 
-        if ($statusCode !== 200) {
+        if (200 !== $statusCode) {
             $this->assertEquals($restErrorCode, $responseData['code']);
 
             return;
         }
 
         foreach ($data as $key => $value) {
-            if ($key === 'targetDocument') {
+            if ('targetDocument' === $key) {
                 $this->assertEquals($value['uuid'], $responseData[$key]['id'], $key);
             } else {
                 $this->assertEquals($value, $responseData[$key], $key);
@@ -520,14 +520,14 @@ class CustomUrlControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode($statusCode, $response);
 
-        if ($statusCode !== 200) {
+        if (200 !== $statusCode) {
             $this->assertEquals($restErrorCode, $responseData['code']);
 
             return;
         }
 
         foreach ($data as $key => $value) {
-            if ($key === 'targetDocument') {
+            if ('targetDocument' === $key) {
                 $this->assertEquals($value['uuid'], $responseData[$key]['id'], $key);
             } else {
                 $this->assertEquals($value, $responseData[$key], $key);
@@ -602,7 +602,7 @@ class CustomUrlControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $response);
 
         foreach ($data as $key => $value) {
-            if ($key === 'targetDocument') {
+            if ('targetDocument' === $key) {
                 $this->assertEquals($value['uuid'], $responseData[$key]['id'], $key);
             } else {
                 $this->assertEquals($value, $responseData[$key], $key);

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -41,9 +41,13 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 class DocumentInspector extends BaseDocumentInspector
 {
     private $metadataFactory;
+
     private $structureFactory;
+
     private $namespaceRegistry;
+
     private $encoder;
+
     private $webspaceManager;
 
     public function __construct(

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -80,7 +80,7 @@ class SubscriberDebugCommand extends ContainerAwareCommand
 
     private function resolvePriority($value, $targetMethodName)
     {
-        if (count($value) == 1) {
+        if (1 == count($value)) {
             return 0;
         }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -51,7 +51,7 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
             $defaultSession = $config['default_session'];
         }
 
-        if (!$preview && $context === SuluKernel::CONTEXT_WEBSITE) {
+        if (!$preview && SuluKernel::CONTEXT_WEBSITE === $context) {
             $defaultSession = $liveSession;
         }
 
@@ -171,13 +171,13 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
 
         $container->setParameter(
             'sulu_document_manager.show_drafts',
-            $container->getParameter('sulu.context') === SuluKernel::CONTEXT_ADMIN
+            SuluKernel::CONTEXT_ADMIN === $container->getParameter('sulu.context')
             || ($container->hasParameter('sulu.preview') && $container->getParameter('sulu.preview'))
         );
 
         $container->setParameter(
             'sulu_document_manager.show_drafts',
-            $container->getParameter('sulu.context') === SuluKernel::CONTEXT_ADMIN
+            SuluKernel::CONTEXT_ADMIN === $container->getParameter('sulu.context')
             || ($container->hasParameter('sulu.preview') && $container->getParameter('sulu.preview'))
         );
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 class SecuritySubscriber implements EventSubscriberInterface
 {
     const USER_OPTION = 'user';
+
     /**
      * @var TokenStorageInterface
      */

--- a/src/Sulu/Bundle/DocumentManagerBundle/Routing/Loader/VersionRouteLoader.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Routing/Loader/VersionRouteLoader.php
@@ -49,6 +49,6 @@ class VersionRouteLoader extends Loader
      */
     public function supports($resource, $type = null)
     {
-        return $type === 'versioning_rest';
+        return 'versioning_rest' === $type;
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentFixtureLoaderTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/DataFixtures/DocumentFixtureLoaderTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class DocumentFixtureLoaderTest extends \PHPUnit_Framework_TestCase
 {
     private $container;
+
     private $loader;
 
     public function setUp()

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -74,7 +74,7 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
         // get default
         $proxyClientName = null;
         foreach ($config as $name => $proxyClient) {
-            if ($proxyClient['enabled'] === false) {
+            if (false === $proxyClient['enabled']) {
                 continue;
             }
 
@@ -129,6 +129,7 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
         foreach ($config as $handlerName => $handlerConfig) {
             if (false === $handlerConfig['enabled']) {
                 $container->removeDefinition('sulu_http_cache.handler.' . $handlerName);
+
                 continue;
             }
 

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -99,7 +99,7 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
     public function testHandler($handler)
     {
         $config = [];
-        if ($handler !== 'aggregate') {
+        if ('aggregate' !== $handler) {
             $config = [
                 'handlers' => [
                     $handler => [

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -62,7 +62,7 @@ class GoogleGeolocator implements GeolocatorInterface
             ]
         );
 
-        if ($response->getStatusCode() !== 200) {
+        if (200 !== $response->getStatusCode()) {
             throw new HttpException(
                 $response->getStatusCode(),
                 sprintf(
@@ -75,7 +75,7 @@ class GoogleGeolocator implements GeolocatorInterface
 
         $googleResponse = json_decode($response->getBody(), true);
         $response = new GeolocatorResponse();
-        if ($googleResponse['status'] != 'OK') {
+        if ('OK' != $googleResponse['status']) {
             return $response;
         }
 

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/NominatimGeolocator.php
@@ -61,7 +61,7 @@ class NominatimGeolocator implements GeolocatorInterface
             ]
         );
 
-        if ($response->getStatusCode() != 200) {
+        if (200 != $response->getStatusCode()) {
             throw new HttpException(
                 $response->getStatusCode(),
                 sprintf(

--- a/src/Sulu/Bundle/LocationBundle/Map/MapManager.php
+++ b/src/Sulu/Bundle/LocationBundle/Map/MapManager.php
@@ -17,7 +17,9 @@ namespace Sulu\Bundle\LocationBundle\Map;
 class MapManager
 {
     protected $providers;
+
     protected $geoLocators;
+
     protected $defaultProviderName;
 
     public function registerProvider($name, $options)

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Content/Types/LocationContentTypeTest.php
@@ -17,7 +17,9 @@ use Sulu\Component\Content\Compat\PropertyParameter;
 class LocationContentTypeTest extends \PHPUnit_Framework_TestCase
 {
     protected $nodeRepository;
+
     protected $locationContent;
+
     protected $mapManager;
 
     public function setUp()

--- a/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorManagerTest.php
+++ b/src/Sulu/Bundle/LocationBundle/Tests/Unit/Geolocator/GeolocatorManagerTest.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\LocationBundle\Geolocator\GeolocatorManager;
 class GeolocatorManagerTest extends \PHPUnit_Framework_TestCase
 {
     protected $container;
+
     protected $manager;
 
     public function setUp()

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
@@ -21,7 +21,9 @@ use Symfony\Component\DependencyInjection\Reference;
 class ParserCompilerPass implements CompilerPassInterface
 {
     const SERVICE_ID = 'sulu_markup.response_listener';
+
     const TAG_NAME = 'sulu_markup.parser';
+
     const TYPE_ATTRIBUTE = 'type';
 
     /**

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -21,9 +21,13 @@ use Symfony\Component\DependencyInjection\Reference;
 class TagCompilerPass implements CompilerPassInterface
 {
     const SERVICE_ID = 'sulu_markup.tag.registry';
+
     const TAG_NAME = 'sulu_markup.tag';
+
     const NAMESPACE_ATTRIBUTE = 'namespace';
+
     const TAG_ATTRIBUTE = 'tag';
+
     const TYPE_ATTRIBUTE = 'type';
 
     /**

--- a/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/HtmlTagExtractor.php
@@ -17,7 +17,9 @@ namespace Sulu\Bundle\MarkupBundle\Markup;
 class HtmlTagExtractor implements TagExtractorInterface
 {
     const COUNT_REGEX = '/<%1$s:[a-z]+/';
+
     const ATTRIBUTE_REGEX = '/(?<name>\b[\w-]+\b)\s*=\s*"(?<value>[^"]*)"/';
+
     const TAG_REGEX = '/(?<tag><%1$s:(?<name>[a-z]+)(?<attributes>(?:(?!>|\/>).)*)(?:\/>|>(?<content>(?:(?!<\/%1$s:\2>).)*)<\/%1$s:\2>))/s';
 
     /**
@@ -84,7 +86,7 @@ class HtmlTagExtractor implements TagExtractorInterface
         for ($i = 0, $length = count($matches['name']); $i < $length; ++$i) {
             $value = $matches['value'][$i];
 
-            if ($value === 'true' || $value === 'false') {
+            if ('true' === $value || 'false' === $value) {
                 $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
             }
 

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/HtmlMarkupParserTest.php
@@ -22,6 +22,7 @@ use Sulu\Bundle\MarkupBundle\Tag\TagRegistryInterface;
 class HtmlMarkupParserTest extends \PHPUnit_Framework_TestCase
 {
     const VALIDATE_UNPUBLISHED = 'unpublished';
+
     const VALIDATE_REMOVED = 'removed';
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Api/Collection.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Collection.php
@@ -153,7 +153,7 @@ class Collection extends ApiWrapper
      *
      * @param Collection $child
      */
-    public function addChild(Collection $child)
+    public function addChild(self $child)
     {
         $this->children[] = $child;
     }
@@ -180,7 +180,7 @@ class Collection extends ApiWrapper
      */
     public function getHasSub()
     {
-        if (($children = $this->getEntity()->getChildren()) !== null) {
+        if (null !== ($children = $this->getEntity()->getChildren())) {
             return $children->count() > 0;
         }
 
@@ -233,7 +233,7 @@ class Collection extends ApiWrapper
      */
     public function setParent($parent)
     {
-        if ($parent !== null) {
+        if (null !== $parent) {
             $this->entity->setParent($parent->getEntity());
         } else {
             $this->entity->setParent(null);
@@ -558,7 +558,7 @@ class Collection extends ApiWrapper
     public function getLocked()
     {
         return !$this->entity->getType()
-            || $this->entity->getType()->getKey() === SystemCollectionManagerInterface::COLLECTION_TYPE;
+            || SystemCollectionManagerInterface::COLLECTION_TYPE === $this->entity->getType()->getKey();
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -845,13 +845,13 @@ class Media extends ApiWrapper
      */
     public function getFileVersion()
     {
-        if ($this->fileVersion !== null) {
+        if (null !== $this->fileVersion) {
             return $this->fileVersion;
         }
 
         /** @var File $file */
         foreach ($this->entity->getFiles() as $file) {
-            if ($this->version !== null) {
+            if (null !== $this->version) {
                 $version = $this->version;
             } else {
                 $version = $file->getVersion();
@@ -866,6 +866,7 @@ class Media extends ApiWrapper
             }
             break; // currently only one file per media exists
         }
+
         throw new FileVersionNotFoundException($this->entity->getId(), $this->version);
     }
 
@@ -876,7 +877,7 @@ class Media extends ApiWrapper
      */
     public function getFile()
     {
-        if ($this->file !== null) {
+        if (null !== $this->file) {
             return $this->file;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Behat/MediaContext.php
+++ b/src/Sulu/Bundle/MediaBundle/Behat/MediaContext.php
@@ -160,7 +160,7 @@ class MediaContext extends BaseContext implements SnippetAcceptingContext
 
         $fields = $this->getSession()->getPage()->findAll('css', 'input[type="file"]');
 
-        if (count($fields) == 0) {
+        if (0 == count($fields)) {
             throw new ElementNotFoundException($this->getSession(), 'drop-zone upload field');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -37,9 +37,13 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 class CollectionManager implements CollectionManagerInterface
 {
     private static $entityName = 'SuluMediaBundle:Collection';
+
     private static $entityCollectionType = 'SuluMediaBundle:Collection';
+
     private static $entityCollectionMeta = 'SuluMediaBUndle:CollectionMeta';
+
     private static $entityUser = 'Sulu\Component\Security\Authentication\UserInterface';
+
     private static $entityContact = 'Sulu\Component\Contact\Model\ContactInterface';
 
     /**
@@ -118,7 +122,7 @@ class CollectionManager implements CollectionManagerInterface
     public function getById($id, $locale, $depth = 0, $breadcrumb = false, $filter = [], $sortBy = [])
     {
         $collectionEntity = $this->collectionRepository->findCollectionById($id);
-        if ($collectionEntity === null) {
+        if (null === $collectionEntity) {
             throw new CollectionNotFoundException($id);
         }
         $filter['locale'] = $locale;
@@ -187,7 +191,7 @@ class CollectionManager implements CollectionManagerInterface
 
             $collections[$collection->getId()] = $apiEntity;
 
-            if ($collection->getParent() !== null) {
+            if (null !== $collection->getParent()) {
                 $collections[$collection->getParent()->getId()]->addChild($apiEntity);
             } else {
                 $result[] = $apiEntity;
@@ -222,7 +226,7 @@ class CollectionManager implements CollectionManagerInterface
 
         $collections = [];
         foreach ($entities as $entity) {
-            if ($entity->getParent() === null) {
+            if (null === $entity->getParent()) {
                 $collections[] = $this->getApiEntity($entity, $locale, $entities);
             }
         }
@@ -362,7 +366,7 @@ class CollectionManager implements CollectionManagerInterface
      */
     public function getFieldDescriptors()
     {
-        if ($this->fieldDescriptors === null) {
+        if (null === $this->fieldDescriptors) {
             $this->initializeFieldDescriptors();
         }
 
@@ -542,12 +546,12 @@ class CollectionManager implements CollectionManagerInterface
         try {
             $collectionEntity = $this->collectionRepository->findCollectionById($id);
 
-            if ($collectionEntity === null) {
+            if (null === $collectionEntity) {
                 throw new CollectionNotFoundException($id);
             }
 
             $destinationEntity = null;
-            if ($destinationId !== null) {
+            if (null !== $destinationId) {
                 $destinationEntity = $this->collectionRepository->findCollectionById($destinationId);
             }
 
@@ -630,7 +634,7 @@ class CollectionManager implements CollectionManagerInterface
             if ($meta->getLocale() == $locale) {
                 $title = $meta->getTitle();
                 break;
-            } elseif ($key == 0) { // fallback title
+            } elseif (0 == $key) { // fallback title
                 $title = $meta->getTitle();
             }
         }
@@ -673,20 +677,20 @@ class CollectionManager implements CollectionManagerInterface
 
         $children = [];
 
-        if ($entities !== null) {
+        if (null !== $entities) {
             foreach ($entities as $possibleChild) {
-                if (($parent = $possibleChild->getParent()) !== null && $parent->getId() === $entity->getId()) {
+                if (null !== ($parent = $possibleChild->getParent()) && $parent->getId() === $entity->getId()) {
                     $children[] = $this->getApiEntity($possibleChild, $locale, $entities);
                 }
             }
         }
 
         $apiEntity->setChildren($children);
-        if ($entity->getParent() !== null) {
+        if (null !== $entity->getParent()) {
             $apiEntity->setParent($this->getApiEntity($entity->getParent(), $locale));
         }
 
-        if ($breadcrumbEntities !== null) {
+        if (null !== $breadcrumbEntities) {
             $breadcrumbApiEntities = [];
             foreach ($breadcrumbEntities as $entity) {
                 $breadcrumbApiEntities[] = $this->getApiEntity($entity, $locale);

--- a/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/MediaSelectionContainer.php
@@ -81,7 +81,7 @@ class MediaSelectionContainer implements ArrayableInterface
      */
     public function getData()
     {
-        if ($this->data === null) {
+        if (null === $this->data) {
             $this->data = $this->loadData($this->locale);
         }
 
@@ -156,7 +156,7 @@ class MediaSelectionContainer implements ArrayableInterface
 
     public function __isset($name)
     {
-        return $name == 'data' || $name == 'config' || $name == 'ids' || $name == 'displayOption' || $name == 'types';
+        return 'data' == $name || 'config' == $name || 'ids' == $name || 'displayOption' == $name || 'types' == $name;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -71,7 +71,7 @@ class AbstractMediaController extends RestController
         $uploadedFile = $this->getUploadedFile($request, 'fileVersion');
 
         if ($uploadedFile) {
-            if (strpos($uploadedFile->getClientOriginalName(), '.') === false) {
+            if (false === strpos($uploadedFile->getClientOriginalName(), '.')) {
                 return $uploadedFile->getClientOriginalName();
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -124,10 +124,10 @@ class CollectionController extends RestController implements ClassResourceInterf
                         $depth,
                         $breadcrumb,
                         $filter,
-                        $sortBy !== null ? [$sortBy => $sortOrder] : []
+                        null !== $sortBy ? [$sortBy => $sortOrder] : []
                     );
 
-                    if ($collection->getType()->getKey() === SystemCollectionManagerInterface::COLLECTION_TYPE) {
+                    if (SystemCollectionManagerInterface::COLLECTION_TYPE === $collection->getType()->getKey()) {
                         $this->get('sulu_security.security_checker')->checkPermission(
                             'sulu.media.system_collections',
                             PermissionTypes::VIEW
@@ -177,7 +177,7 @@ class CollectionController extends RestController implements ClassResourceInterf
                     ],
                     $limit,
                     $offset,
-                    $sortBy !== null ? [$sortBy => $sortOrder] : []
+                    null !== $sortBy ? [$sortBy => $sortOrder] : []
                 );
             } else {
                 $collections = $collectionManager->getTree(
@@ -186,7 +186,7 @@ class CollectionController extends RestController implements ClassResourceInterf
                     $limit,
                     $search,
                     $depth,
-                    $sortBy !== null ? [$sortBy => $sortOrder] : [],
+                    null !== $sortBy ? [$sortBy => $sortOrder] : [],
                     $securityChecker->hasPermission('sulu.media.system_collections', 'view')
                 );
             }
@@ -350,8 +350,8 @@ class CollectionController extends RestController implements ClassResourceInterf
         $systemCollectionManager = $this->get('sulu_media.system_collections.manager');
         $parent = $request->get('parent');
 
-        if (($id !== null && $systemCollectionManager->isSystemCollection(intval($id))) ||
-            ($parent !== null && $systemCollectionManager->isSystemCollection(intval($parent)))
+        if ((null !== $id && $systemCollectionManager->isSystemCollection(intval($id))) ||
+            (null !== $parent && $systemCollectionManager->isSystemCollection(intval($parent)))
         ) {
             throw new AccessDeniedException('Permission "update" or "create" is not granted for system collections');
         }
@@ -391,7 +391,7 @@ class CollectionController extends RestController implements ClassResourceInterf
     {
         $page = $request->get('page', 1);
 
-        return ($limit !== null) ? $limit * ($page - 1) : 0;
+        return (null !== $limit) ? $limit * ($page - 1) : 0;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -87,7 +87,7 @@ class MediaController extends AbstractMediaController implements
                     $media = $mediaManager->getById($id, $locale);
                     $collection = $media->getEntity()->getCollection();
 
-                    if ($collection->getType()->getKey() === SystemCollectionManagerInterface::COLLECTION_TYPE) {
+                    if (SystemCollectionManagerInterface::COLLECTION_TYPE === $collection->getType()->getKey()) {
                         $this->getSecurityChecker()->checkPermission(
                             'sulu.media.system_collections',
                             PermissionTypes::VIEW
@@ -193,7 +193,7 @@ class MediaController extends AbstractMediaController implements
         $collectionId = $request->get('collection');
         if ($collectionId) {
             $collectionType = $this->getCollectionRepository()->findCollectionTypeById($collectionId);
-            if ($collectionType === SystemCollectionManagerInterface::COLLECTION_TYPE) {
+            if (SystemCollectionManagerInterface::COLLECTION_TYPE === $collectionType) {
                 $this->getSecurityChecker()->checkPermission(
                     'sulu.media.system_collections',
                     PermissionTypes::VIEW
@@ -300,6 +300,7 @@ class MediaController extends AbstractMediaController implements
                 $this->getMediaManager()->delete($id, true);
             } catch (MediaNotFoundException $e) {
                 $entityName = $this->getParameter('sulu.model.media.class');
+
                 throw new EntityNotFoundException($entityName, $id); // will throw 404 Entity not found
             } catch (MediaException $e) {
                 throw new RestException($e->getMessage(), $e->getCode()); // will throw 400 Bad Request
@@ -384,7 +385,7 @@ class MediaController extends AbstractMediaController implements
     {
         try {
             $mediaManager = $this->getMediaManager();
-            $data = $this->getData($request, $id === null);
+            $data = $this->getData($request, null === $id);
             $data['id'] = $id;
             $uploadedFile = $this->getUploadedFile($request, 'fileVersion');
             $media = $mediaManager->save($uploadedFile, $data, $this->getUser()->getId());

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaPreviewController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaPreviewController.php
@@ -56,7 +56,7 @@ class MediaPreviewController extends AbstractMediaController implements ClassRes
             // Unset id to not overwrite original file
             unset($data['id']);
 
-            if ($mediaEntity->getPreviewImage() !== null) {
+            if (null !== $mediaEntity->getPreviewImage()) {
                 $data['id'] = $mediaEntity->getPreviewImage()->getId();
             }
             $data['collection'] = $systemCollectionManager->getSystemCollection('sulu_media.preview_image');
@@ -101,7 +101,7 @@ class MediaPreviewController extends AbstractMediaController implements ClassRes
             /** @var MediaInterface $mediaEntity */
             $mediaEntity = $media->getEntity();
 
-            if ($mediaEntity->getPreviewImage() !== null) {
+            if (null !== $mediaEntity->getPreviewImage()) {
                 $oldPreviewImageId = $mediaEntity->getPreviewImage()->getId();
 
                 $mediaEntity->setPreviewImage(null);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -163,7 +163,7 @@ class MediaStreamController extends Controller
         }
 
         $currentFileVersion = null;
-        $version = $version === null ? $mediaEntity->getFiles()[0]->getVersion() : $version;
+        $version = null === $version ? $mediaEntity->getFiles()[0]->getVersion() : $version;
 
         $file = $mediaEntity->getFiles()[0];
 
@@ -190,7 +190,7 @@ class MediaStreamController extends Controller
      */
     protected function getCacheManager()
     {
-        if ($this->cacheManager === null) {
+        if (null === $this->cacheManager) {
             $this->cacheManager = $this->get('sulu_media.format_manager');
         }
 
@@ -204,7 +204,7 @@ class MediaStreamController extends Controller
      */
     protected function getMediaManager()
     {
-        if ($this->mediaManager === null) {
+        if (null === $this->mediaManager) {
             $this->mediaManager = $this->get('sulu_media.media_manager');
         }
 
@@ -218,7 +218,7 @@ class MediaStreamController extends Controller
      */
     protected function getStorage()
     {
-        if ($this->storage === null) {
+        if (null === $this->storage) {
             $this->storage = $this->get('sulu_media.storage');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class ImageTransformationCompilerPass implements CompilerPassInterface
 {
     const POOL_SERVICE_ID = 'sulu_media.image.transformation_pool';
+
     const TAG = 'sulu_media.image.transformation';
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -167,7 +167,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
-        if ($config['adapter'] === 'auto') {
+        if ('auto' === $config['adapter']) {
             $container->setAlias(
                 'sulu_media.adapter',
                 'sulu_media.adapter.' . (class_exists('Imagick') ? 'imagick' : 'gd')

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionInterface.php
@@ -159,7 +159,7 @@ interface CollectionInterface extends AuditableInterface, SecuredEntityInterface
      *
      * @return CollectionInterface
      */
-    public function setParent(CollectionInterface $parent = null);
+    public function setParent(self $parent = null);
 
     /**
      * Get parent.

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -53,7 +53,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         $query->setParameter('id', $id);
         $result = $query->getResult();
 
-        if (count($result) === 0) {
+        if (0 === count($result)) {
             return;
         }
 
@@ -87,18 +87,18 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             ->where('collection.id IN (:ids)')
             ->setParameter('ids', $ids);
 
-        if ($sortBy !== null && is_array($sortBy) && count($sortBy) > 0) {
+        if (null !== $sortBy && is_array($sortBy) && count($sortBy) > 0) {
             foreach ($sortBy as $column => $order) {
                 $queryBuilder->addOrderBy(
                     'collectionMeta.' . $column,
-                    (strtolower($order) === 'asc' ? 'ASC' : 'DESC')
+                    ('asc' === strtolower($order) ? 'ASC' : 'DESC')
                 );
             }
         }
 
         $queryBuilder->addOrderBy('collection.id', 'ASC');
 
-        if ($user !== null && $permission != null) {
+        if (null !== $user && null != $permission) {
             $this->addAccessControl($queryBuilder, $user, $permission, Collection::class, 'collection');
         }
 
@@ -111,6 +111,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
     public function count($depth = 0, $filter = [], CollectionInterface $collection = null)
     {
         $ids = $this->getIdsQuery($depth, $filter, [], $collection, 'DISTINCT collection.id')->getScalarResult();
+
         try {
             return count($ids);
         } catch (NoResultException $e) {
@@ -178,37 +179,37 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
                 ->addSelect('parent')
                 ->addSelect('children');
 
-            if ($sortBy !== null && is_array($sortBy) && count($sortBy) > 0) {
+            if (null !== $sortBy && is_array($sortBy) && count($sortBy) > 0) {
                 foreach ($sortBy as $column => $order) {
-                    $qb->addOrderBy('collectionMeta.' . $column, strtolower($order) === 'asc' ? 'ASC' : 'DESC');
+                    $qb->addOrderBy('collectionMeta.' . $column, 'asc' === strtolower($order) ? 'ASC' : 'DESC');
                 }
             }
             $qb->addOrderBy('collection.id', 'ASC');
 
-            if ($parent !== null) {
+            if (null !== $parent) {
                 $qb->andWhere('parent.id = :parent');
             }
-            if ($depth !== null) {
+            if (null !== $depth) {
                 $qb->andWhere('collection.depth <= :depth');
             }
-            if ($search !== null) {
+            if (null !== $search) {
                 $qb->andWhere('collectionMeta.title LIKE :search');
             }
-            if ($offset !== null) {
+            if (null !== $offset) {
                 $qb->setFirstResult($offset);
             }
-            if ($limit !== null) {
+            if (null !== $limit) {
                 $qb->setMaxResults($limit);
             }
 
             $query = $qb->getQuery();
-            if ($parent !== null) {
+            if (null !== $parent) {
                 $query->setParameter('parent', $parent);
             }
-            if ($depth !== null) {
+            if (null !== $depth) {
                 $query->setParameter('depth', intval($depth));
             }
-            if ($search !== null) {
+            if (null !== $search) {
                 $query->setParameter('search', '%' . $search . '%');
             }
 
@@ -331,17 +332,17 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             ->select($select)
             ->where('collection.depth <= :depth');
 
-        $collectionDepth = $collection !== null ? $collection->getDepth() : 0;
+        $collectionDepth = null !== $collection ? $collection->getDepth() : 0;
         $queryBuilder->setParameter('depth', $collectionDepth + $depth);
 
-        if ($collection !== null) {
+        if (null !== $collection) {
             $queryBuilder->andWhere('collection.lft BETWEEN :lft AND :rgt AND collection.id != :id');
             $queryBuilder->setParameter('lft', $collection->getLft());
             $queryBuilder->setParameter('rgt', $collection->getRgt());
             $queryBuilder->setParameter('id', $collection->getId());
         }
 
-        if (array_key_exists('search', $filter) && $filter['search'] !== null ||
+        if (array_key_exists('search', $filter) && null !== $filter['search'] ||
             array_key_exists('locale', $filter) ||
             count($sortBy) > 0
         ) {
@@ -349,7 +350,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             $queryBuilder->leftJoin('collection.defaultMeta', 'defaultMeta');
         }
 
-        if (array_key_exists('search', $filter) && $filter['search'] !== null) {
+        if (array_key_exists('search', $filter) && null !== $filter['search']) {
             $queryBuilder->andWhere('collectionMeta.title LIKE :search OR defaultMeta.locale != :locale');
             $queryBuilder->setParameter('search', '%' . $filter['search'] . '%');
         }
@@ -369,7 +370,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             foreach ($sortBy as $column => $order) {
                 $queryBuilder->addOrderBy(
                     'collectionMeta.' . $column,
-                    (strtolower($order) === 'asc' ? 'ASC' : 'DESC')
+                    ('asc' === strtolower($order) ? 'ASC' : 'DESC')
                 );
             }
         }

--- a/src/Sulu/Bundle/MediaBundle/Entity/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/Media.php
@@ -256,7 +256,7 @@ class Media implements MediaInterface
      *
      * @return Media
      */
-    public function setPreviewImage(Media $previewImage = null)
+    public function setPreviewImage(self $previewImage = null)
     {
         $this->previewImage = $previewImage;
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
@@ -66,13 +66,13 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
     public function findByFilters($filters, $page, $pageSize, $limit, $locale, $options = [])
     {
         if (!array_key_exists('dataSource', $filters) ||
-            $filters['dataSource'] === '' ||
-            ($limit !== null && $limit < 1)
+            '' === $filters['dataSource'] ||
+            (null !== $limit && $limit < 1)
         ) {
             return [];
         }
 
-        if ($filters['dataSource'] === 'root') {
+        if ('root' === $filters['dataSource']) {
             // if root collection is selected remove filter for data-source
             $filters['dataSource'] = null;
         }

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -138,7 +138,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ) = $this->extractFilterVars($filter);
 
         // if empty array of ids is requested return empty array of medias
-        if ($ids !== null && count($ids) === 0) {
+        if (null !== $ids && 0 === count($ids)) {
             return [];
         }
 
@@ -188,14 +188,14 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ->addSelect('creatorContact')
             ->addSelect('changerContact');
 
-        if ($ids !== null) {
+        if (null !== $ids) {
             $queryBuilder->andWhere('media.id IN (:mediaIds)');
             $queryBuilder->setParameter('mediaIds', $ids);
         }
 
         $queryBuilder->addOrderBy($orderBy, $orderSort);
 
-        if ($user !== null && $permission !== null) {
+        if (null !== $user && null !== $permission) {
             $this->addAccessControl($queryBuilder, $user, $permission, Collection::class, 'collection');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidator.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidator.php
@@ -55,7 +55,7 @@ class FileValidator implements FileValidatorInterface
             throw new InvalidFileException(sprintf('The file upload had an error("%s: %s")', $file->getError(), $file->getErrorMessage()));
         }
 
-        if (in_array(self::VALIDATOR_FILE_SET, $methods) && $file->getFilename() == '') {
+        if (in_array(self::VALIDATOR_FILE_SET, $methods) && '' == $file->getFilename()) {
             throw new UploadFileNotSetException(sprintf('No file "%s" was set', $file->getFilename()));
         }
 
@@ -63,7 +63,7 @@ class FileValidator implements FileValidatorInterface
             throw new InvalidFileTypeException(sprintf('The file type "%s" was blocked', $file->getMimeType()));
         }
 
-        if (in_array(self::VALIDATOR_MAX_FILE_SIZE, $methods) && $this->maxFileSize !== null && $file->getSize() >= $this->maxFileSize) {
+        if (in_array(self::VALIDATOR_MAX_FILE_SIZE, $methods) && null !== $this->maxFileSize && $file->getSize() >= $this->maxFileSize) {
             throw new MaxFileSizeExceededException(sprintf('File "%s" exceeds the configured maximum filesize of "%s"', $file->getFilename(), $this->maxFilesize));
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidatorInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FileValidator/FileValidatorInterface.php
@@ -20,8 +20,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 interface FileValidatorInterface
 {
     const VALIDATOR_FILE_SET = 'FILE_SET';
+
     const VALIDATOR_FILE_ERRORS = 'FILE_ERRORS';
+
     const VALIDATOR_BLOCK_FILE_TYPES = 'BLOCK_FILE_TYPES';
+
     const VALIDATOR_MAX_FILE_SIZE = 'MAX_FILE_SIZE';
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -93,7 +93,7 @@ abstract class BaseXmlFormatLoader extends FileLoader
         $namespace = substr($namespaces, $start);
 
         $end = strpos($namespace, ' ');
-        if ($end !== false) {
+        if (false !== $end) {
             $namespace = substr($namespace, 0, $end);
         }
 
@@ -182,7 +182,7 @@ abstract class BaseXmlFormatLoader extends FileLoader
      */
     protected function getParametersFromNode($node, $parameterName = 'parameter')
     {
-        if ($node === null) {
+        if (null === $node) {
             return [];
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -70,7 +70,7 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
     {
         foreach ($this->xpath->query('x:commands/x:command', $formatNode) as $commandNode) {
             $action = $this->xpath->query('x:action', $commandNode)->item(0)->nodeValue;
-            if ($action === 'scale' || $action === 'resize') {
+            if ('scale' === $action || 'resize' === $action) {
                 $xNode = $this->xpath->query('x:parameters/x:parameter[@name = "x"]', $commandNode)->item(0);
                 $yNode = $this->xpath->query('x:parameters/x:parameter[@name = "y"]', $commandNode)->item(0);
                 $modeNode = $this->xpath->query('x:parameters/x:parameter[@name = "mode"]', $commandNode)->item(0);
@@ -84,27 +84,27 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
                 $yValue = null;
                 $forceRatio = static::SCALE_FORCE_RATIO_DEFAULT;
                 $retina = static::SCALE_RETINA_DEFAULT;
-                if ($xNode !== null && $xNode->nodeValue !== '') {
+                if (null !== $xNode && '' !== $xNode->nodeValue) {
                     $xValue = intval($xNode->nodeValue);
                 }
-                if ($yNode !== null && $yNode->nodeValue !== '') {
+                if (null !== $yNode && '' !== $yNode->nodeValue) {
                     $yValue = intval($yNode->nodeValue);
                 }
-                if ($xValue === null && $yValue === null) {
+                if (null === $xValue && null === $yValue) {
                     throw new MissingScaleDimensionException();
                 }
 
-                if ($forceRatioNode !== null && $forceRatioNode->nodeValue === 'false') {
+                if (null !== $forceRatioNode && 'false' === $forceRatioNode->nodeValue) {
                     $forceRatio = false;
                 }
-                if ($retinaNode !== null && $retinaNode->nodeValue === 'true') {
+                if (null !== $retinaNode && 'true' === $retinaNode->nodeValue) {
                     $retina = true;
                 }
 
                 return [
                     'x' => $xValue,
                     'y' => $yValue,
-                    'mode' => ($modeNode !== null) ? $modeNode->nodeValue : static::SCALE_MODE_DEFAULT,
+                    'mode' => (null !== $modeNode) ? $modeNode->nodeValue : static::SCALE_MODE_DEFAULT,
                     'retina' => $retina,
                     'forceRatio' => $forceRatio,
                 ];
@@ -123,7 +123,7 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
 
         foreach ($this->xpath->query('x:commands/x:command', $formatNode) as $commandNode) {
             $action = $this->xpath->query('x:action', $commandNode)->item(0)->nodeValue;
-            if ($action === 'scale' || $action === 'resize') {
+            if ('scale' === $action || 'resize' === $action) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
@@ -41,7 +41,7 @@ class XmlFormatLoader11 extends BaseXmlFormatLoader
             return false;
         }
 
-        return $internalNode->nodeValue === 'true';
+        return 'true' === $internalNode->nodeValue;
     }
 
     /**
@@ -69,29 +69,29 @@ class XmlFormatLoader11 extends BaseXmlFormatLoader
         $scale = null;
 
         $formatScaleNode = $this->xpath->query('x:scale', $formatNode)->item(0);
-        if ($formatScaleNode !== null) {
+        if (null !== $formatScaleNode) {
             $xNode = $this->xpath->query('@x', $formatScaleNode)->item(0);
             $yNode = $this->xpath->query('@y', $formatScaleNode)->item(0);
             $modeNode = $this->xpath->query('@mode', $formatScaleNode)->item(0);
             $retinaNode = $this->xpath->query('@retina', $formatScaleNode)->item(0);
             $forceRatioNode = $this->xpath->query('@forceRatio', $formatScaleNode)->item(0);
-            if ($xNode === null && $yNode === null) {
+            if (null === $xNode && null === $yNode) {
                 throw new MissingScaleDimensionException();
             }
 
             $forceRatio = static::SCALE_FORCE_RATIO_DEFAULT;
             $retina = static::SCALE_RETINA_DEFAULT;
-            if ($forceRatioNode !== null && $forceRatioNode->nodeValue === 'false') {
+            if (null !== $forceRatioNode && 'false' === $forceRatioNode->nodeValue) {
                 $forceRatio = false;
             }
-            if ($retinaNode !== null && $retinaNode->nodeValue === 'true') {
+            if (null !== $retinaNode && 'true' === $retinaNode->nodeValue) {
                 $retina = false;
             }
 
             $scale = [
-                'x' => ($xNode !== null) ? intval($xNode->nodeValue) : null,
-                'y' => ($yNode !== null) ? intval($yNode->nodeValue) : null,
-                'mode' => ($modeNode !== null) ? $modeNode->nodeValue : static::SCALE_MODE_DEFAULT,
+                'x' => (null !== $xNode) ? intval($xNode->nodeValue) : null,
+                'y' => (null !== $yNode) ? intval($yNode->nodeValue) : null,
+                'mode' => (null !== $modeNode) ? $modeNode->nodeValue : static::SCALE_MODE_DEFAULT,
                 'retina' => $retina,
                 'forceRatio' => $forceRatio,
             ];

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -92,7 +92,7 @@ class FormatManager implements FormatManagerInterface
         $this->mediaRepository = $mediaRepository;
         $this->formatCache = $formatCache;
         $this->converter = $converter;
-        $this->saveImage = $saveImage == 'true' ? true : false;
+        $this->saveImage = 'true' == $saveImage ? true : false;
         $this->responseHeaders = $responseHeaders;
         $this->fileSystem = new Filesystem();
         $this->formats = $formats;

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Focus/Focus.php
@@ -55,13 +55,13 @@ class Focus implements FocusInterface
      */
     public function focus(ImageInterface $image, $x, $y, $width, $height)
     {
-        $x = ($x !== null) ? $x : static::FOCUS_CENTER;
-        $y = ($y !== null) ? $y : static::FOCUS_MIDDLE;
+        $x = (null !== $x) ? $x : static::FOCUS_CENTER;
+        $y = (null !== $y) ? $y : static::FOCUS_MIDDLE;
         $imageSize = $image->getSize();
 
         $currentRatio = $imageSize->getWidth() / $imageSize->getHeight();
         $targetRatio = $currentRatio;
-        if ($width !== null && $height !== null) {
+        if (null !== $width && null !== $height) {
             $targetRatio = $width / $height;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -145,7 +145,7 @@ class ImagineImageConverter implements ImageConverterInterface
         $image->strip();
 
         // Set Interlacing to plane for smaller image size.
-        if (count($image->layers()) == 1) {
+        if (1 == count($image->layers())) {
             $image->interlace(ImageInterface::INTERLACE_PLANE);
         }
 
@@ -272,7 +272,7 @@ class ImagineImageConverter implements ImageConverterInterface
      */
     private function toRGB(ImageInterface $image)
     {
-        if ($image->palette()->name() == 'cmyk') {
+        if ('cmyk' == $image->palette()->name()) {
             $image->usePalette(new RGB());
         }
 
@@ -334,7 +334,7 @@ class ImagineImageConverter implements ImageConverterInterface
             foreach ($image->layers() as $layer) {
                 $countLayer += 1;
                 $layer = call_user_func($modifier, $layer);
-                if ($countLayer === 1) {
+                if (1 === $countLayer) {
                     $temporaryImage = $layer; // use first layer as main image
                 } else {
                     $temporaryImage->layers()->add($layer);
@@ -376,7 +376,7 @@ class ImagineImageConverter implements ImageConverterInterface
     private function getOptionsFromImage(ImageInterface $image, $imageExtension, $imagineOptions)
     {
         $options = [];
-        if (count($image->layers()) > 1 && $imageExtension == 'gif') {
+        if (count($image->layers()) > 1 && 'gif' == $imageExtension) {
             $options['animated'] = true;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -56,15 +56,15 @@ class MediaImageExtractor implements MediaImageExtractorInterface
         $finfo = new \finfo();
         $mimeType = $finfo->buffer($content, FILEINFO_MIME_TYPE);
 
-        if ($mimeType === 'application/pdf') {
+        if ('application/pdf' === $mimeType) {
             return $this->convertPdfToImage($content);
         }
 
-        if ($mimeType === 'image/vnd.adobe.photoshop') {
+        if ('image/vnd.adobe.photoshop' === $mimeType) {
             return $this->convertPsdToImage($content);
         }
 
-        if ($mimeType === 'image/svg+xml') {
+        if ('image/svg+xml' === $mimeType) {
             return $this->convertSvgToImage($content);
         }
 
@@ -129,6 +129,7 @@ class MediaImageExtractor implements MediaImageExtractorInterface
             return $image->get('png');
         } catch (RuntimeException $e) {
             unlink($temporaryFilePath);
+
             throw new InvalidMimeTypeForPreviewException('image/vnd.adobe.photoshop');
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Scaler/Scaler.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Scaler/Scaler.php
@@ -78,7 +78,7 @@ class Scaler implements ScalerInterface
         // if image is smaller keep ratio
         // e.g. when a square image is requested (200x200) and the original image is smaller (150x100)
         //      it still returns a squared image (100x100)
-        if ($mode === ImageInterface::THUMBNAIL_OUTBOUND && $forceRatio) {
+        if (ImageInterface::THUMBNAIL_OUTBOUND === $mode && $forceRatio) {
             if ($newWidth > $size->getWidth()) {
                 list($newHeight, $newWidth) = $this->getSizeInSameRatio(
                     $newHeight,

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/CropTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/CropTransformation.php
@@ -31,7 +31,7 @@ class CropTransformation implements TransformationInterface
             'CropTransformation is deprecated since version 1.4. Use the scale config instead',
             E_USER_DEPRECATED
         );
-        $retina = isset($parameters['retina']) && $parameters['retina'] != 'false' ? 2 : 1;
+        $retina = isset($parameters['retina']) && 'false' != $parameters['retina'] ? 2 : 1;
         $x = isset($parameters['x']) ? intval($parameters['x']) * $retina : 0;
         $y = isset($parameters['y']) ? intval($parameters['y']) * $retina : 0;
         $width = isset($parameters['w']) ? intval($parameters['w']) : 0;

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -530,14 +530,14 @@ class MediaManager implements MediaManagerInterface
     {
         foreach ($data as $attribute => $value) {
             if ($value ||
-                ($attribute === 'tags' && $value !== null) ||
-                ($attribute === 'size' && $value !== null) ||
-                ($attribute === 'description' && $value !== null) ||
-                ($attribute === 'copyright' && $value !== null) ||
-                ($attribute === 'credits' && $value !== null) ||
-                ($attribute === 'categories' && $value !== null) ||
-                ($attribute === 'focusPointX' && $value !== null) ||
-                ($attribute === 'focusPointY' && $value !== null)
+                ('tags' === $attribute && null !== $value) ||
+                ('size' === $attribute && null !== $value) ||
+                ('description' === $attribute && null !== $value) ||
+                ('copyright' === $attribute && null !== $value) ||
+                ('credits' === $attribute && null !== $value) ||
+                ('categories' === $attribute && null !== $value) ||
+                ('focusPointX' === $attribute && null !== $value) ||
+                ('focusPointY' === $attribute && null !== $value)
             ) {
                 switch ($attribute) {
                     case 'size':
@@ -705,7 +705,7 @@ class MediaManager implements MediaManagerInterface
         try {
             $mediaEntity = $this->mediaRepository->findMediaById($id);
 
-            if ($mediaEntity === null) {
+            if (null === $mediaEntity) {
                 throw new MediaNotFoundException($id);
             }
 
@@ -778,7 +778,7 @@ class MediaManager implements MediaManagerInterface
         /** @var \Sulu\Bundle\MediaBundle\Entity\MediaInterface $previewImage */
         $previewImage = $media->getEntity()->getPreviewImage();
 
-        if ($previewImage !== null) {
+        if (null !== $previewImage) {
             /** @var FileVersion $latestVersion */
             $latestVersion = null;
 
@@ -790,7 +790,7 @@ class MediaManager implements MediaManagerInterface
                 break;
             }
 
-            if ($latestVersion !== null) {
+            if (null !== $latestVersion) {
                 $media->setFormats(
                     $this->formatManager->getFormats(
                         $previewImage->getId(),
@@ -830,7 +830,7 @@ class MediaManager implements MediaManagerInterface
 
         // set properties
         $properties = $media->getFileVersion()->getProperties();
-        if ($properties !== null) {
+        if (null !== $properties) {
             $media->setProperties($properties);
         }
 
@@ -899,7 +899,7 @@ class MediaManager implements MediaManagerInterface
      */
     private function getNormalizedFileName($originalFileName)
     {
-        if (strpos($originalFileName, '.') !== false) {
+        if (false !== strpos($originalFileName, '.')) {
             $pathParts = pathinfo($originalFileName);
             $fileName = $this->pathCleaner->cleanup($pathParts['filename']);
             $fileName .= '.' . $pathParts['extension'];

--- a/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/TypeManager/TypeManagerInterface.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\MediaBundle\Entity\MediaType;
 interface TypeManagerInterface
 {
     const ENTITY_CLASS_MEDIATYPE = 'Sulu\Bundle\MediaBundle\Entity\MediaType';
+
     const ENTITY_NAME_MEDIATYPE = 'SuluMediaBundle:MediaType';
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Video/VideoThumbnailService.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Video/VideoThumbnailService.php
@@ -60,7 +60,7 @@ class VideoThumbnailService implements VideoThumbnailServiceInterface
         array $times,
         $destinationPath
     ) {
-        if ($this->ffmpeg !== null) {
+        if (null !== $this->ffmpeg) {
             $failed = [];
             foreach ($times as $time) {
                 $filename = $destinationPath . DIRECTORY_SEPARATOR . $time . '.jpg';

--- a/src/Sulu/Bundle/MediaBundle/Search/EventListener/PermissionListener.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/EventListener/PermissionListener.php
@@ -46,7 +46,7 @@ class PermissionListener
      */
     public function onPermissionUpdate(PermissionUpdateEvent $event)
     {
-        if ($event->getType() !== Collection::class) {
+        if (Collection::class !== $event->getType()) {
             return;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
@@ -96,7 +96,7 @@ class MediaSearchSubscriber implements EventSubscriberInterface
 
         if (
             false === $reflection->isSubclassOf(FileVersionMeta::class)
-            && $metadata->getName() !== FileVersionMeta::class) {
+            && FileVersionMeta::class !== $metadata->getName()) {
             return;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/DefaultStructureCache.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/DefaultStructureCache.php
@@ -114,7 +114,7 @@ class DefaultStructureCache extends \Sulu\Component\Content\Metadata
         $this->addChild($prop1);
 
         // section content
-                $section1 = new SectionProperty(
+        $section1 = new SectionProperty(
             'content',
                         [
                 'title' => [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -85,7 +85,7 @@ class CollectionControllerTest extends SuluTestCase
     {
         $amount = 1; // 1 root collection
 
-        if ($depth > 0 || $depth === null) {
+        if ($depth > 0 || null === $depth) {
             $amount += $this->iterateOverSystemCollections($this->systemCollectionConfig, $depth);
         }
 
@@ -104,7 +104,7 @@ class CollectionControllerTest extends SuluTestCase
     {
         $amount = count($config);
 
-        if ($depth > 0 || $depth === null) {
+        if ($depth > 0 || null === $depth) {
             foreach ($config as $child) {
                 if (array_key_exists('collections', $child)) {
                     $amount += $this->iterateOverSystemCollections($child['collections'], $depth - 1);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -120,7 +120,7 @@ class MediaControllerTest extends SuluTestCase
             }
         }
 
-        if ($counter != 0) {
+        if (0 != $counter) {
             rmdir($directory);
         }
     }
@@ -222,15 +222,15 @@ class MediaControllerTest extends SuluTestCase
     {
         $media = new Media();
 
-        if ($type === 'image') {
+        if ('image' === $type) {
             $media->setType($this->imageType);
             $extension = 'jpeg';
             $mimeType = 'image/jpg';
-        } elseif ($type === 'audio') {
+        } elseif ('audio' === $type) {
             $media->setType($this->audioType);
             $extension = 'mp3';
             $mimeType = 'audio/mp3';
-        } elseif ($type === 'video') {
+        } elseif ('video' === $type) {
             $media->setType($this->videoType);
             $extension = 'mp4';
             $mimeType = 'video/mp4';

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
@@ -113,7 +113,7 @@ class MediaRedirectControllerTest extends SuluTestCase
             }
         }
 
-        if ($counter != 0) {
+        if (0 != $counter) {
             rmdir($directory);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/CollectionRepositoryTest.php
@@ -120,7 +120,7 @@ class CollectionRepositoryTest extends SuluTestCase
         $collectionMeta->setCollection($collection);
         $collection->addMeta($collectionMeta);
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $collection->setParent($this->collections[$parent]);
             $this->collections[$parent]->addChildren($collection);
         }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -133,7 +133,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         $collectionMeta->setCollection($collection);
         $collection->addMeta($collectionMeta);
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $collection->setParent($this->collections[$parent]);
             $this->collections[$parent]->addChildren($collection);
         }
@@ -512,7 +512,7 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
         $repository = $this->getContainer()->get('sulu_media.smart_content.data_provider.media.repository');
 
         // if data-source isset replace the index with the id
-        if (array_key_exists('dataSource', $filters) && $filters['dataSource'] !== 'root') {
+        if (array_key_exists('dataSource', $filters) && 'root' !== $filters['dataSource']) {
             $filters['dataSource'] = $this->collections[$filters['dataSource']]->getId();
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
@@ -83,7 +83,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
         $entity->getMeta()->willReturn([$entityMeta->reveal()]);
         $entity->getId()->willReturn($id);
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $parentEntity = $this->prophesize(Collection::class);
             $parentEntity->getId()->willReturn($parent);
             $entity->getParent()->willReturn($parentEntity->reveal());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
@@ -30,16 +30,27 @@ use Sulu\Bundle\SearchBundle\Search\Document;
 class MediaSearchSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     private $mediaManager;
+
     private $subscriber;
+
     private $metadata;
+
     private $indexMetadata;
+
     private $fileVersionMeta;
+
     private $fileVersion;
+
     private $file;
+
     private $media;
+
     private $event;
+
     private $document;
+
     private $reflection;
+
     private $factory;
 
     public function setUp()

--- a/src/Sulu/Bundle/MediaBundle/Twig/DispositionTypeTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/DispositionTypeTwigExtension.php
@@ -63,7 +63,7 @@ class DispositionTypeTwigExtension extends \Twig_Extension
 
         $url = $media->getUrl();
 
-        if ($dispositionType === ResponseHeaderBag::DISPOSITION_INLINE) {
+        if (ResponseHeaderBag::DISPOSITION_INLINE === $dispositionType) {
             $url .= (false === strpos($url, '?') ? '?inline=1' : '&inline=1');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -81,7 +81,7 @@ class MediaTwigExtension extends \Twig_Extension
      */
     public function resolveMediasFunction($medias, $locale)
     {
-        if (count($medias) === 0) {
+        if (0 === count($medias)) {
             return [];
         }
 

--- a/src/Sulu/Bundle/PreviewBundle/Preview/RdfaExtractor.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/RdfaExtractor.php
@@ -83,13 +83,13 @@ class RdfaExtractor
                     // check if one parent is property exclude it
                     $parents->each(
                         function ($node) use (&$count) {
-                            if (null !== $node->attr('property') && $node->attr('typeof') === 'collection') {
+                            if (null !== $node->attr('property') && 'collection' === $node->attr('typeof')) {
                                 ++$count;
                             }
                         }
                     );
 
-                    return $count === 0;
+                    return 0 === $count;
                 }
             );
         }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -130,7 +130,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $request = [];
         $cookies = [];
         $currentRequest = $this->requestStack->getCurrentRequest();
-        if ($currentRequest !== null) {
+        if (null !== $currentRequest) {
             $query = $currentRequest->query->all();
             $request = $currentRequest->request->all();
             $cookies = $currentRequest->cookies->all();

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/WebsiteKernelFactory.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/WebsiteKernelFactory.php
@@ -21,7 +21,7 @@ class WebsiteKernelFactory implements KernelFactoryInterface
      */
     public function create($environment)
     {
-        $kernel = new PreviewKernel($environment, $environment === 'dev');
+        $kernel = new PreviewKernel($environment, 'dev' === $environment);
         $kernel->boot();
 
         return $kernel;

--- a/src/Sulu/Bundle/ResourceBundle/Controller/FilterController.php
+++ b/src/Sulu/Bundle/ResourceBundle/Controller/FilterController.php
@@ -41,7 +41,9 @@ class FilterController extends RestController implements ClassResourceInterface
     use RequestParametersTrait;
 
     protected static $groupConditionEntityName = 'SuluResourceBundle:GroupCondition';
+
     protected static $entityName = 'SuluResourceBundle:Filter';
+
     protected static $entityKey = 'filters';
 
     /**
@@ -86,7 +88,7 @@ class FilterController extends RestController implements ClassResourceInterface
                 throw new MissingFeatureException($context, 'filters');
             }
 
-            if ($request->get('flat') == 'true') {
+            if ('true' == $request->get('flat')) {
                 $list = $this->getListRepresentation($request);
             } else {
                 $list = new CollectionRepresentation(

--- a/src/Sulu/Bundle/ResourceBundle/DependencyInjection/SuluResourceExtension.php
+++ b/src/Sulu/Bundle/ResourceBundle/DependencyInjection/SuluResourceExtension.php
@@ -78,7 +78,7 @@ class SuluResourceExtension extends Extension
     {
         if (!array_key_exists('filters', $config) ||
             !array_key_exists('conjunctions', $config['filters']) ||
-            count($config['filters']['conjunctions']) === 0
+            0 === count($config['filters']['conjunctions'])
         ) {
             $config['filters'] = [];
             $config['filters']['conjunctions'] = [

--- a/src/Sulu/Bundle/ResourceBundle/Entity/Condition.php
+++ b/src/Sulu/Bundle/ResourceBundle/Entity/Condition.php
@@ -17,7 +17,9 @@ namespace Sulu\Bundle\ResourceBundle\Entity;
 class Condition
 {
     const TYPE_STRING = 1;
+
     const TYPE_NUMBER = 2;
+
     const TYPE_DATETIME = 3;
 
     /**

--- a/src/Sulu/Bundle/ResourceBundle/Resource/DataTypes.php
+++ b/src/Sulu/Bundle/ResourceBundle/Resource/DataTypes.php
@@ -19,11 +19,17 @@ final class DataTypes
 {
     /** Types used by operators and conditions */
     const UNDEFINED_TYPE = 0;
+
     const STRING_TYPE = 1;
+
     const NUMBER_TYPE = 2;
+
     const DATETIME_TYPE = 3;
+
     const BOOLEAN_TYPE = 4;
+
     const TAGS_TYPE = 5;
+
     const AUTO_COMPLETE_TYPE = 6;
 
     /**

--- a/src/Sulu/Bundle/ResourceBundle/Resource/Exception/FilterDependencyNotFoundException.php
+++ b/src/Sulu/Bundle/ResourceBundle/Resource/Exception/FilterDependencyNotFoundException.php
@@ -23,6 +23,7 @@ class FilterDependencyNotFoundException extends FilterException
      * @var string
      */
     private $entityName;
+
     /**
      * The id of the object not found.
      *

--- a/src/Sulu/Bundle/ResourceBundle/Resource/FilterListBuilder.php
+++ b/src/Sulu/Bundle/ResourceBundle/Resource/FilterListBuilder.php
@@ -121,7 +121,7 @@ class FilterListBuilder implements FilterListBuilderInterface
     protected function createConjunctionExpression(array $expressions, $conjunction)
     {
         // create the appropriate expression
-        if (strtoupper($conjunction) === ListBuilderInterface::CONJUNCTION_AND) {
+        if (ListBuilderInterface::CONJUNCTION_AND === strtoupper($conjunction)) {
             return $this->listBuilder->createAndExpression($expressions);
         }
 
@@ -145,7 +145,7 @@ class FilterListBuilder implements FilterListBuilderInterface
             throw new ConditionFieldNotFoundException($condition->getField());
         }
 
-        if (count($conditionGroup->getConditions()) === 1) {
+        if (1 === count($conditionGroup->getConditions())) {
             $this->createExpression($condition, $fieldDescriptor);
         } elseif (count($conditionGroup->getConditions()) > 1) {
             // TODO implement if needed
@@ -164,7 +164,7 @@ class FilterListBuilder implements FilterListBuilderInterface
         $value = $this->getValue($condition);
 
         // relative date for cases like "within a week" or "within this month"
-        if ($condition->getOperator() === 'between' && $condition->getType() === DataTypes::DATETIME_TYPE) {
+        if ('between' === $condition->getOperator() && DataTypes::DATETIME_TYPE === $condition->getType()) {
             $this->expressions[] = $this->listBuilder->createBetweenExpression($fieldDescriptor, [$value, new \Datetime()]);
         } else {
             $this->expressions[] = $this->listBuilder->createWhereExpression(
@@ -199,6 +199,7 @@ class FilterListBuilder implements FilterListBuilderInterface
                 if (is_numeric($value)) {
                     return floatval($value);
                 }
+
                 throw new ConditionTypeMismatchException($condition->getId(), $value, $type);
             case DataTypes::BOOLEAN_TYPE:
                 return $this->getBoolean($value);
@@ -222,6 +223,6 @@ class FilterListBuilder implements FilterListBuilderInterface
      */
     protected function getBoolean($value)
     {
-        return $value === 'true' || $value === 1 || $value === true ? true : false;
+        return 'true' === $value || 1 === $value || true === $value ? true : false;
     }
 }

--- a/src/Sulu/Bundle/ResourceBundle/Resource/FilterManager.php
+++ b/src/Sulu/Bundle/ResourceBundle/Resource/FilterManager.php
@@ -39,9 +39,13 @@ class FilterManager implements FilterManagerInterface
     use RelationTrait;
 
     protected static $filterEntityName = 'SuluResourceBundle:Filter';
+
     protected static $userEntityName = 'SuluSecurityBundle:User';
+
     protected static $conditionGroupEntityName = 'SuluResourceBundle:ConditionGroup';
+
     protected static $conditionEntityName = 'SuluResourceBundle:Condition';
+
     protected static $filterTranslationEntityName = 'SuluResourceBundle:FilterTranslation';
 
     /**
@@ -235,7 +239,7 @@ class FilterManager implements FilterManagerInterface
             }
         }
 
-        if (array_key_exists('private', $data) && $data['private'] === true) {
+        if (array_key_exists('private', $data) && true === $data['private']) {
             $filter->setPrivate($data['private']);
             $filter->setUser($user);
         } else {
@@ -354,7 +358,7 @@ class FilterManager implements FilterManagerInterface
     protected function getValueForCondition($value, $type)
     {
         // check if date and not a relative value like -1 week
-        if ($type === DataTypes::DATETIME_TYPE && !preg_match('/[A-Za-z]{3,}/', $value)) {
+        if (DataTypes::DATETIME_TYPE === $type && !preg_match('/[A-Za-z]{3,}/', $value)) {
             return (new \DateTime($value))->format(\DateTime::ISO8601);
         }
 
@@ -448,7 +452,7 @@ class FilterManager implements FilterManagerInterface
     protected function checkDataSet(array $data, $key, $create)
     {
         $keyExists = array_key_exists($key, $data);
-        if (($create && !($keyExists && $data[$key] !== null)) || (!$keyExists || $data[$key] === null)) {
+        if (($create && !($keyExists && null !== $data[$key])) || (!$keyExists || null === $data[$key])) {
             throw new MissingFilterAttributeException($key);
         }
 
@@ -553,7 +557,7 @@ class FilterManager implements FilterManagerInterface
     public function isFeatureEnabled($context, $feature)
     {
         if ($this->hasContext($context) &&
-            array_search($feature, $this->getFeaturesForContext($context)) !== false
+            false !== array_search($feature, $this->getFeaturesForContext($context))
         ) {
             return true;
         }

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
@@ -21,7 +21,9 @@ use Symfony\Component\DependencyInjection\Reference;
 class RouteGeneratorCompilerPass implements CompilerPassInterface
 {
     const TAG_NAME = 'sulu.route_generator';
+
     const SERVICE_ID = 'sulu_route.manager.route_manager';
+
     const PARAMETER_NAME = 'sulu_route.mappings';
 
     /**

--- a/src/Sulu/Bundle/RouteBundle/Model/RouteInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Model/RouteInterface.php
@@ -119,7 +119,7 @@ interface RouteInterface
      *
      * @return RouteInterface
      */
-    public function setTarget(RouteInterface $target);
+    public function setTarget(self $target);
 
     /**
      * Remove target.
@@ -142,5 +142,5 @@ interface RouteInterface
      *
      * @return RouteInterface
      */
-    public function addHistory(RouteInterface $history);
+    public function addHistory(self $history);
 }

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -99,7 +99,7 @@ class RouteProvider implements RouteProviderInterface
         $path = $request->getPathInfo();
         $prefix = $this->requestAnalyzer->getResourceLocatorPrefix();
 
-        if (!empty($prefix) && strpos($path, $prefix) === 0) {
+        if (!empty($prefix) && 0 === strpos($path, $prefix)) {
             $path = PathHelper::relativizePath($path, $prefix);
         }
 
@@ -155,7 +155,7 @@ class RouteProvider implements RouteProviderInterface
      */
     public function getRouteByName($name)
     {
-        if (strpos($name, self::ROUTE_PREFIX) !== 0) {
+        if (0 !== strpos($name, self::ROUTE_PREFIX)) {
             throw new RouteNotFoundException();
         }
 

--- a/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
@@ -205,13 +205,14 @@ class SearchController
             $indexConfiguration = $this->indexConfigurationProvider->getIndexConfiguration($indexName);
             if (!$indexConfiguration) {
                 $allowedIndexNames[] = $indexName;
+
                 continue;
             }
 
             $contexts = $indexConfiguration->getContexts();
 
             if ($this->securityChecker->hasPermission($indexConfiguration->getSecurityContext(), PermissionTypes::VIEW)
-                && (empty($contexts) || array_search('admin', $contexts) !== false)
+                && (empty($contexts) || false !== array_search('admin', $contexts))
             ) {
                 $allowedIndexNames[] = $indexName;
             }

--- a/src/Sulu/Bundle/SearchBundle/Search/Document.php
+++ b/src/Sulu/Bundle/SearchBundle/Search/Document.php
@@ -176,7 +176,7 @@ class Document extends BaseDocument
 
         foreach ($properties as $key => $field) {
             // remove system fields
-            if (substr($key, 0, 2) == '__') {
+            if ('__' == substr($key, 0, 2)) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/Entity/Product.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/Entity/Product.php
@@ -17,15 +17,25 @@ use Sulu\Component\Persistence\Model\UserBlameInterface;
 class Product implements TimestampableInterface, UserBlameInterface
 {
     public $id;
+
     public $title;
+
     public $body;
+
     public $date;
+
     public $url;
+
     public $locale;
+
     public $image;
+
     public $changed;
+
     public $created;
+
     public $creator;
+
     public $changer;
 
     public function getChanged()

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/EventListener/StructureMetadataLoadListener.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/EventListener/StructureMetadataLoadListener.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\SearchBundle\Search\Event\StructureMetadataLoadEvent;
 class StructureMetadataLoadListener
 {
     public $structure;
+
     public $indexMetadata;
 
     public function handleStructureLoadMetadata(StructureMetadataLoadEvent $event)

--- a/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
+++ b/src/Sulu/Bundle/SecurityBundle/Behat/SecurityContext.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\TestBundle\Behat\BaseContext;
 class SecurityContext extends BaseContext implements SnippetAcceptingContext
 {
     const ADMIN_USERNAME = 'admin';
+
     const ADMIN_PASSWORD = 'admin';
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -225,7 +225,7 @@ class CreateUserCommand extends ContainerAwareCommand
                     if (empty($email)) {
                         $email = null;
                     }
-                    if ($email !== null) {
+                    if (null !== $email) {
                         $users = $userRepository->findBy(['email' => $email]);
                         if (count($users) > 0) {
                             throw new \InvalidArgumentException(sprintf('Email "%s" is not unique', $email));

--- a/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/GroupController.php
@@ -36,6 +36,7 @@ class GroupController extends RestController implements ClassResourceInterface, 
     protected static $entityKey = 'groups';
 
     // TODO: Create a Manager and move the field descriptors to the manager
+
     /**
      * @var array - Holds the field descriptors for the list response
      */
@@ -63,7 +64,7 @@ class GroupController extends RestController implements ClassResourceInterface, 
      */
     public function cgetAction(Request $request)
     {
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /** @var RestHelperInterface $restHelper */
             $restHelper = $this->get('sulu_core.doctrine_rest_helper');
 
@@ -130,7 +131,7 @@ class GroupController extends RestController implements ClassResourceInterface, 
     {
         $name = $request->get('name');
 
-        if ($name != null) {
+        if (null != $name) {
             $em = $this->getDoctrine()->getManager();
 
             $group = new Group();
@@ -310,7 +311,7 @@ class GroupController extends RestController implements ClassResourceInterface, 
     public function setParent($group, Request $request)
     {
         $parentData = $request->get('parent');
-        if ($parentData != null && isset($parentData['id'])) {
+        if (null != $parentData && isset($parentData['id'])) {
             $parent = $this->getDoctrine()
                 ->getRepository(static::$entityName)
                 ->findGroupById($parentData['id']);

--- a/src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
@@ -114,7 +114,7 @@ class PermissionController implements ClassResourceInterface
             // transfer all permission strings to booleans
             foreach ($permissions as &$permission) {
                 array_walk($permission, function (&$permissionLine) {
-                    $permissionLine = $permissionLine === 'true' || $permissionLine === true;
+                    $permissionLine = 'true' === $permissionLine || true === $permissionLine;
                 });
             }
 

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -35,9 +35,13 @@ use Symfony\Component\Translation\Translator;
 class ResettingController extends Controller
 {
     protected static $emailSubjectKey = 'security.reset.mail-subject';
+
     protected static $emailMessageKey = 'security.reset.mail-message';
+
     protected static $translationDomain = 'backend';
+
     protected static $resetRouteId = 'sulu_admin.reset';
+
     const MAX_NUMBER_EMAILS = 3;
 
     /**
@@ -74,7 +78,7 @@ class ResettingController extends Controller
         try {
             /** @var UserInterface $user */
             $user = $this->findUser($request->get('user'));
-            if ($generateNewKey === true) {
+            if (true === $generateNewKey) {
                 $this->generateTokenForUser($user);
             }
             $email = $this->getEmail($user);
@@ -186,7 +190,7 @@ class ResettingController extends Controller
      */
     private function getEmail(UserInterface $user)
     {
-        if ($user->getEmail() !== null) {
+        if (null !== $user->getEmail()) {
             return $user->getEmail();
         }
 
@@ -293,10 +297,10 @@ class ResettingController extends Controller
      */
     private function sendTokenEmail(UserInterface $user, $from, $to)
     {
-        if ($user->getPasswordResetToken() === null) {
+        if (null === $user->getPasswordResetToken()) {
             throw new NoTokenFoundException($user);
         }
-        if ($user->getPasswordResetTokenEmailsSent() === self::MAX_NUMBER_EMAILS) {
+        if (self::MAX_NUMBER_EMAILS === $user->getPasswordResetTokenEmailsSent()) {
             throw new TokenEmailsLimitReachedException(self::MAX_NUMBER_EMAILS, $user);
         }
         $mailer = $this->get('mailer');
@@ -326,7 +330,7 @@ class ResettingController extends Controller
      */
     private function changePassword(UserInterface $user, $password)
     {
-        if ($password === '') {
+        if ('' === $password) {
             throw new MissingPasswordException();
         }
         $em = $this->getDoctrine()->getManager();
@@ -345,7 +349,7 @@ class ResettingController extends Controller
     private function generateTokenForUser(UserInterface $user)
     {
         // if a token was already requested within the request interval time frame
-        if ($user->getPasswordResetToken() !== null &&
+        if (null !== $user->getPasswordResetToken() &&
             $this->dateIsInRequestFrame($user->getPasswordResetTokenExpiresAt())
         ) {
             throw new TokenAlreadyRequestedException(self::getRequestInterval());
@@ -371,7 +375,7 @@ class ResettingController extends Controller
      */
     private function dateIsInRequestFrame(\DateTime $date)
     {
-        if ($date === null) {
+        if (null === $date) {
             return false;
         }
 

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -41,11 +41,17 @@ class RoleController extends RestController implements ClassResourceInterface, S
     const ENTITY_NAME_PERMISSION = 'SuluSecurityBundle:Permission';
 
     protected $fieldsDefault = ['name'];
+
     protected $fieldsExcluded = [];
+
     protected $fieldsHidden = ['changed', 'created'];
+
     protected $fieldsRelations = [];
+
     protected $fieldsSortOrder = [0 => 'id', 1 => 'name'];
+
     protected $fieldsTranslationKeys = [];
+
     protected $bundlePrefix = 'security.roles.';
 
     /**
@@ -138,7 +144,7 @@ class RoleController extends RestController implements ClassResourceInterface, S
      */
     public function cgetAction(Request $request)
     {
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /** @var RestHelperInterface $restHelper */
             $restHelper = $this->get('sulu_core.doctrine_rest_helper');
 
@@ -161,7 +167,7 @@ class RoleController extends RestController implements ClassResourceInterface, S
         } else {
             $roles = $this->getRoleRepository()->findAllRoles();
             $convertedRoles = [];
-            if ($roles != null) {
+            if (null != $roles) {
                 foreach ($roles as $role) {
                     array_push($convertedRoles, $this->convertRole($role));
                 }
@@ -210,10 +216,10 @@ class RoleController extends RestController implements ClassResourceInterface, S
         $system = $request->get('system');
 
         try {
-            if ($name === null) {
+            if (null === $name) {
                 throw new InvalidArgumentException('Role', 'name');
             }
-            if ($system === null) {
+            if (null === $system) {
                 throw new InvalidArgumentException('Role', 'name');
             }
 
@@ -390,7 +396,7 @@ class RoleController extends RestController implements ClassResourceInterface, S
                     ->convertPermissionsToNumber($permissionData['permissions'])
             );
         }
-        if ($alreadyContains === false) {
+        if (false === $alreadyContains) {
             $permission->setRole($role);
             $em->persist($permission);
             $role->addPermission($permission);
@@ -468,7 +474,7 @@ class RoleController extends RestController implements ClassResourceInterface, S
      */
     private function checkSecurityTypeData($securityTypeData)
     {
-        return $securityTypeData != null && $securityTypeData['id'] != null && $securityTypeData['id'] != '';
+        return null != $securityTypeData && null != $securityTypeData['id'] && '' != $securityTypeData['id'];
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -159,6 +159,7 @@ class UserController extends RestController implements ClassResourceInterface, S
     public function postEnableUserAction($id, Request $request)
     {
         $action = $request->get('action');
+
         try {
             switch ($action) {
                 case 'enable':
@@ -265,16 +266,16 @@ class UserController extends RestController implements ClassResourceInterface, S
 
     private function checkArguments(Request $request)
     {
-        if ($request->get('username') == null) {
+        if (null == $request->get('username')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.user.class'), 'username');
         }
-        if ($request->get('password') === null) {
+        if (null === $request->get('password')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.user.class'), 'password');
         }
-        if ($request->get('locale') == null) {
+        if (null == $request->get('locale')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.user.class'), 'locale');
         }
-        if ($request->get('contact') == null) {
+        if (null == $request->get('contact')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.user.class'), 'contact');
         }
     }
@@ -290,7 +291,7 @@ class UserController extends RestController implements ClassResourceInterface, S
     public function cgetAction(Request $request)
     {
         $view = null;
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /** @var RestHelperInterface $restHelper */
             $restHelper = $this->get('sulu_core.doctrine_rest_helper');
 
@@ -313,7 +314,7 @@ class UserController extends RestController implements ClassResourceInterface, S
         } else {
             $contactId = $request->get('contactId');
 
-            if ($contactId != null) {
+            if (null != $contactId) {
                 $entities = [];
                 $entities[] = $this->getDoctrine()->getRepository(
                     $this->container->getParameter('sulu.model.user.class')

--- a/src/Sulu/Bundle/SecurityBundle/DataFixtures/ORM/LoadSecurityTypes.php
+++ b/src/Sulu/Bundle/SecurityBundle/DataFixtures/ORM/LoadSecurityTypes.php
@@ -50,10 +50,10 @@ class LoadSecurityTypes implements FixtureInterface, OrderedFixtureInterface, Co
                 /** @var $child \DOMNode */
                 foreach ($element->childNodes as $child) {
                     if (isset($child->nodeName)) {
-                        if ($child->nodeName == 'id') {
+                        if ('id' == $child->nodeName) {
                             $typeId = $child->nodeValue;
                         }
-                        if ($child->nodeName == 'name') {
+                        if ('name' == $child->nodeName) {
                             $typeName = $child->nodeValue;
                         }
                     }

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SecurityBundle\DependencyInjection;
 
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\SecurityBundle\Exception\RoleNameAlreadyExistsException;
+use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -57,6 +58,22 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
                         'codes' => [
                             RoleNameAlreadyExistsException::class => 409,
                         ],
+                    ],
+                ]
+            );
+        }
+
+        if ($container->hasExtension('framework')
+            && SuluKernel::CONTEXT_ADMIN === $container->getParameter('sulu.context')
+        ) {
+            $container->prependExtensionConfig(
+                'framework',
+                [
+                    'session' => [
+                        'cookie_path' => '/admin',
+                    ],
+                    'fragments' => [
+                        'path' => '/admin/_fragments',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Group.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Group.php
@@ -239,7 +239,7 @@ class Group extends ApiEntity implements AuditableInterface
      *
      * @return Group
      */
-    public function addChildren(Group $children)
+    public function addChildren(self $children)
     {
         $this->children[] = $children;
 
@@ -251,7 +251,7 @@ class Group extends ApiEntity implements AuditableInterface
      *
      * @param Group $children
      */
-    public function removeChildren(Group $children)
+    public function removeChildren(self $children)
     {
         $this->children->removeElement($children);
     }
@@ -307,7 +307,7 @@ class Group extends ApiEntity implements AuditableInterface
      *
      * @return Group
      */
-    public function setParent(Group $parent = null)
+    public function setParent(self $parent = null)
     {
         $this->parent = $parent;
 

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/SuluSecurityListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/SuluSecurityListener.php
@@ -63,7 +63,7 @@ class SuluSecurityListener
                 $permission = PermissionTypes::VIEW;
                 break;
             case 'POST':
-                if ($controllerDefinition[1] == 'postAction') { // means that the ClassResourceInterface has to be used
+                if ('postAction' == $controllerDefinition[1]) { // means that the ClassResourceInterface has to be used
                     $permission = PermissionTypes::ADD;
                 } else {
                     $permission = PermissionTypes::EDIT;
@@ -93,7 +93,7 @@ class SuluSecurityListener
             $securityContext = $controller->getSecurityContext();
         }
 
-        if ($securityContext !== null) {
+        if (null !== $securityContext) {
             $this->securityChecker->checkPermission(
                 new SecurityCondition($securityContext, $locale, $objectType, $objectId),
                 $permission

--- a/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationEntryPoint.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationEntryPoint.php
@@ -39,7 +39,7 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
-        if (strpos($request->getPathInfo(), '/admin/api') === 0 || $request->isXmlHttpRequest()) {
+        if (0 === strpos($request->getPathInfo(), '/admin/api') || $request->isXmlHttpRequest()) {
             $response = new Response('', 401);
         } else {
             $response = new RedirectResponse($this->urlGenerator->generate('sulu_admin.login'));

--- a/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
@@ -58,7 +58,7 @@ class AuthenticationHandler implements AuthenticationSuccessHandlerInterface, Au
     {
         // get url to redirect (or return in the JSON-response)
         if ($this->session->get('_security.admin.target_path')
-            && strpos($this->session->get('_security.admin.target_path'), '#') !== false
+            && false !== strpos($this->session->get('_security.admin.target_path'), '#')
         ) {
             $url = $this->session->get('_security.admin.target_path');
         } else {

--- a/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
@@ -73,8 +73,8 @@ class SecuritySubscriber implements EventSubscriberInterface
         if (!($document instanceof SecurityBehavior
             && $document instanceof LocaleBehavior
             && $document instanceof WebspaceBehavior
-            && $this->tokenStorage !== null
-            && $this->tokenStorage->getToken() !== null
+            && null !== $this->tokenStorage
+            && null !== $this->tokenStorage->getToken()
             && $this->tokenStorage->getToken()->getUser() instanceof UserInterface)
         ) {
             return;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
@@ -121,7 +121,7 @@ class PermissionControllerTest extends \PHPUnit_Framework_TestCase
         array_walk(
             $permissions,
             function (&$permissionLine) {
-                $permissionLine = $permissionLine === 'true' || $permissionLine === true;
+                $permissionLine = 'true' === $permissionLine || true === $permissionLine;
             }
         );
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/DependencyInjection/Compiler/UserManagerCompilerPassTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/DependencyInjection/Compiler/UserManagerCompilerPassTest.php
@@ -22,6 +22,7 @@ class UserManagerCompilerPassTest extends \PHPUnit_Framework_TestCase
      * @var ContainerBuilder
      */
     private $containerBuilder;
+
     /**
      * @var UserManagerCompilerPass
      */

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -60,7 +60,7 @@ class UserTwigExtension extends \Twig_Extension
         }
 
         $user = $this->userRepository->findUserById($id);
-        if ($user === null) {
+        if (null === $user) {
             return;
         }
 

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -176,7 +176,7 @@ class UserManager implements UserManagerInterface
             }
 
             // check if username is already in database and the current user is not the user with this username
-            if (!$patch || $username !== null) {
+            if (!$patch || null !== $username) {
                 if ($user->getUsername() != $username &&
                     !$this->isUsernameUnique($username)
                 ) {
@@ -186,7 +186,7 @@ class UserManager implements UserManagerInterface
             }
 
             // check if password is valid
-            if (!$patch || $password !== null) {
+            if (!$patch || null !== $password) {
                 if ($this->isValidPassword($password)) {
                     $user->setSalt($this->generateSalt());
                     $user->setPassword(
@@ -195,37 +195,38 @@ class UserManager implements UserManagerInterface
                 }
             }
 
-            if (!$patch || $this->getProperty($data, 'userRoles') !== null) {
+            if (!$patch || null !== $this->getProperty($data, 'userRoles')) {
                 if (!$this->processUserRoles($user, $this->getProperty($data, 'userRoles', []))) {
                     throw new \Exception('Could not update dependencies!');
                 }
             }
 
-            if (!$patch || $this->getProperty($data, 'userGroups') !== null) {
+            if (!$patch || null !== $this->getProperty($data, 'userGroups')) {
                 if (!$this->processUserGroups($user, $this->getProperty($data, 'userGroups', []))) {
                     throw new \Exception('Could not update dependencies!');
                 }
             }
 
-            if (!$patch || $contact !== null) {
+            if (!$patch || null !== $contact) {
                 $user->setContact($this->getContact($contact['id']));
             }
 
-            if (!$patch || $locale !== null) {
+            if (!$patch || null !== $locale) {
                 $user->setLocale($locale);
             }
 
-            if ($enabled !== null) {
+            if (null !== $enabled) {
                 $user->setEnabled($enabled);
             }
 
-            if ($locked !== null) {
+            if (null !== $locked) {
                 $user->setLocked($locked);
             }
         } catch (\Exception $re) {
             if (isset($user)) {
                 $this->em->remove($user);
             }
+
             throw $re;
         }
 
@@ -475,7 +476,7 @@ class UserManager implements UserManagerInterface
             }
         }
 
-        if ($alreadyContains === false) {
+        if (false === $alreadyContains) {
             $userRole = new UserRole();
             $userRole->setUser($user);
             $userRole->setRole($role);
@@ -628,20 +629,20 @@ class UserManager implements UserManagerInterface
     {
         if ($contact) {
             // if no email passed try to use the contact's first email
-            if ($email === null &&
+            if (null === $email &&
                 array_key_exists('emails', $contact) && count($contact['emails']) > 0 &&
                 $this->isEmailUnique($contact['emails'][0]['email'])
             ) {
                 $email = $contact['emails'][0]['email'];
             }
-            if ($email !== null) {
+            if (null !== $email) {
                 if (!$this->isEmailUnique($email)) {
                     throw new EmailNotUniqueException($email);
                 }
                 $user->setEmail($email);
             }
         } else {
-            if ($email !== null) {
+            if (null !== $email) {
                 if ($email !== $user->getEmail() &&
                     !$this->isEmailUnique($email)
                 ) {

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
@@ -37,7 +37,7 @@ class SnippetImportCommand extends ContainerAwareCommand
     {
         $filePath = $input->getArgument('file');
 
-        if (!strpos($filePath, '/') === 0) {
+        if (0 === !strpos($filePath, '/')) {
             $filePath = getcwd() . '/' . $filePath;
         }
 

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
@@ -136,7 +136,7 @@ EOT
         if (!$overwrite) {
             $destStructure = $this->contentMapper->load($document->getUuid(), null, $destLocale, true);
 
-            if (!($destStructure->getType() && $destStructure->getType()->getName() === 'ghost')) {
+            if (!($destStructure->getType() && 'ghost' === $destStructure->getType()->getName())) {
                 $this->output->writeln(
                     '<info>Processing aborted: </info>' .
                     $document->getNodeName() . ' <comment>(use overwrite option to force)</comment>'

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -307,7 +307,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
             // prepare view
             $view = View::create(
                 $this->decorateSnippet($snippet->toArray(), $locale),
-                $snippet !== null ? 200 : 204
+                null !== $snippet ? 200 : 204
             );
         } catch (RestException $exc) {
             $view = View::create($exc->toArray(), 400);
@@ -387,16 +387,16 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     /**
     * Returns user.
     */
-   private function getUser()
-   {
-       $token = $this->tokenStorage->getToken();
+    private function getUser()
+    {
+        $token = $this->tokenStorage->getToken();
 
-       if (null === $token) {
-           throw new \InvalidArgumentException('No user is set');
-       }
+        if (null === $token) {
+            throw new \InvalidArgumentException('No user is set');
+        }
 
-       return $token->getUser();
-   }
+        return $token->getUser();
+    }
 
     /**
      * Decorate snippet for HATEOAS.

--- a/src/Sulu/Bundle/SnippetBundle/Document/SnippetDocument.php
+++ b/src/Sulu/Bundle/SnippetBundle/Document/SnippetDocument.php
@@ -40,19 +40,33 @@ class SnippetDocument implements
     LocalizedTitleBehavior
 {
     private $created;
+
     private $changed;
+
     private $creator;
+
     private $changer;
+
     private $parent;
+
     private $title;
+
     private $workflowStage;
+
     private $published;
+
     private $uuid;
+
     private $structureType;
+
     private $structure;
+
     private $locale;
+
     private $originalLocale;
+
     private $path;
+
     private $nodeName;
 
     public function __construct()

--- a/src/Sulu/Bundle/SnippetBundle/Document/SnippetInitializer.php
+++ b/src/Sulu/Bundle/SnippetBundle/Document/SnippetInitializer.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class SnippetInitializer implements InitializerInterface
 {
     private $nodeManager;
+
     private $pathBuilder;
 
     public function __construct(

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetRepository.php
@@ -277,12 +277,12 @@ class SnippetRepository
         // Title is a mandatory property for snippets
         // NOTE: Prefixing the language code and namespace here is bad. But the solution is
         //       refactoring (i.e. a node property name translator service).
-        $sortOrder = ($sortOrder !== null ? strtoupper($sortOrder) : 'ASC');
-        $sortBy = ($sortBy !== null ? $sortBy : 'title');
+        $sortOrder = (null !== $sortOrder ? strtoupper($sortOrder) : 'ASC');
+        $sortBy = (null !== $sortBy ? $sortBy : 'title');
 
         $qb->orderBy(
             $qb->qomf()->propertyValue('a', 'i18n:' . $locale . '-' . $sortBy),
-            $sortOrder !== null ? strtoupper($sortOrder) : 'ASC'
+            null !== $sortOrder ? strtoupper($sortOrder) : 'ASC'
         );
 
         return $qb->getQuery();

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -52,11 +52,11 @@ class SnippetResolver implements SnippetResolverInterface
             if (!array_key_exists($uuid, $this->snippetCache)) {
                 $snippet = $this->contentMapper->load($uuid, $webspaceKey, $locale);
 
-                if (!$snippet->getHasTranslation() && $shadowLocale !== null) {
+                if (!$snippet->getHasTranslation() && null !== $shadowLocale) {
                     $snippet = $this->contentMapper->load($uuid, $webspaceKey, $shadowLocale);
                 }
 
-                $snippet->setIsShadow($shadowLocale !== null);
+                $snippet->setIsShadow(null !== $shadowLocale);
                 $snippet->setShadowBaseLanguage($shadowLocale);
 
                 $resolved = $this->structureResolver->resolve($snippet);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/ContentOnPageTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Content/ContentOnPageTest.php
@@ -134,7 +134,7 @@ class ContentOnPageTest extends BaseFunctionalTestCase
         $this->assertEquals($templateKey, $page->getKey());
 
         foreach ($data as $key => $value) {
-            if ($key === 'hotels') {
+            if ('hotels' === $key) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -25,6 +25,7 @@ class SnippetControllerTest extends SuluTestCase
      * @var Client
      */
     protected $client;
+
     /**
      * @var SnippetDocument
      */

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
@@ -26,14 +26,17 @@ class SnippetTest extends SuluTestCase
      * @var SnippetExportInterface
      */
     private $snippetExporter;
+
     /**
      * @var DocumentManagerInterface
      */
     private $documentManager;
+
     /**
      * @var ExtensionManagerInterface
      */
     private $extensionManager;
+
     /**
      * @var int
      */

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
@@ -25,13 +25,18 @@ class SnippetImportTest extends SuluTestCase
      * @var DocumentManagerInterface
      */
     private $documentManager;
+
     /**
      * @var object
      */
     private $parent;
+
     private $snippetImporter;
+
     private $snippets = [];
+
     protected $distPath = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff.dist';
+
     protected $path = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff';
 
     /**

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
@@ -111,6 +111,7 @@ class SnippetRepositoryTest extends BaseFunctionalTestCase
             if (isset($this->{$snippetVarName})) {
                 $snippet = $this->{$snippetVarName};
                 $uuids[] = $snippet->getUuid();
+
                 continue;
             }
 

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
@@ -64,7 +64,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
      */
     public function loadSnippet($uuid, $locale = null)
     {
-        if ($locale === null) {
+        if (null === $locale) {
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
         }
 

--- a/src/Sulu/Bundle/TagBundle/Content/Types/TagList.php
+++ b/src/Sulu/Bundle/TagBundle/Content/Types/TagList.php
@@ -75,7 +75,7 @@ class TagList extends ComplexContentType implements ContentTypeExportInterface
         $segmentKey
     ) {
         $tagIds = [];
-        $tags = $property->getValue() === null ? [] : $property->getValue();
+        $tags = null === $property->getValue() ? [] : $property->getValue();
 
         foreach ($tags as $tag) {
             $tagIds[] = $this->tagManager->findOrCreateByName($tag, $userId)->getId();

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -64,9 +64,11 @@ class TagController extends RestController implements ClassResourceInterface, Se
         'creator_contact_lastName',
         'changed',
     ];
+
     protected $fieldsRelations = [
         'creator_contact_lastName',
     ];
+
     protected $fieldsSortOrder = [
         '0' => 'name',
         '1' => 'creator_contact_lastName',
@@ -130,7 +132,7 @@ class TagController extends RestController implements ClassResourceInterface, Se
      */
     public function cgetAction(Request $request)
     {
-        if ($request->get('flat') == 'true') {
+        if ('true' == $request->get('flat')) {
             /** @var RestHelperInterface $restHelper */
             $restHelper = $this->get('sulu_core.doctrine_rest_helper');
 
@@ -187,7 +189,7 @@ class TagController extends RestController implements ClassResourceInterface, Se
         $name = $request->get('name');
 
         try {
-            if ($name == null) {
+            if (null == $name) {
                 throw new MissingArgumentException(self::$entityName, 'name');
             }
 
@@ -225,7 +227,7 @@ class TagController extends RestController implements ClassResourceInterface, Se
         $name = $request->get('name');
 
         try {
-            if ($name == null) {
+            if (null == $name) {
                 throw new MissingArgumentException(self::$entityName, 'name');
             }
 

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
@@ -31,7 +31,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class TagManager implements TagManagerInterface
 {
     protected static $tagEntityName = 'SuluTagBundle:Tag';
+
     protected static $userEntityName = 'Sulu\Component\Security\Authentication\UserInterface';
+
     protected static $contactEntityName = 'Sulu\Component\Contact\Model\ContactInterface';
 
     /**
@@ -254,7 +256,7 @@ class TagManager implements TagManagerInterface
 
         foreach ($tagIds as $tagId) {
             $tag = $this->findById($tagId);
-            if ($tag !== null) {
+            if (null !== $tag) {
                 $resolvedTags[] = $tag->getName();
             }
         }
@@ -275,7 +277,7 @@ class TagManager implements TagManagerInterface
 
         foreach ($tagNames as $tagName) {
             $tag = $this->findByName($tagName);
-            if ($tag !== null) {
+            if (null !== $tag) {
                 $resolvedTags[] = $tag->getId();
             }
         }

--- a/src/Sulu/Bundle/TestBundle/Behat/BaseContext.php
+++ b/src/Sulu/Bundle/TestBundle/Behat/BaseContext.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 abstract class BaseContext extends RawMinkContext implements Context, KernelAwareContext
 {
     const LONG_WAIT_TIME = 30000;
+
     const MEDIUM_WAIT_TIME = 5000;
 
     /**
@@ -86,7 +87,7 @@ abstract class BaseContext extends RawMinkContext implements Context, KernelAwar
         $output = new StreamOutput(fopen('php://memory', 'w', false));
         $exitCode = $application->run($input, $output);
 
-        if ($exitCode !== 0) {
+        if (0 !== $exitCode) {
             rewind($output->getStream());
             $output = stream_get_contents($output->getStream());
 

--- a/src/Sulu/Bundle/TestBundle/Behat/DefaultContext.php
+++ b/src/Sulu/Bundle/TestBundle/Behat/DefaultContext.php
@@ -215,7 +215,7 @@ EOT;
     {
         $active = (int) $this->getSession()->evaluateScript('$.active');
 
-        if ($active === 0) {
+        if (0 === $active) {
             $this->getSession()->wait(1000, '$.active > 0');
         }
 
@@ -234,7 +234,7 @@ EOT;
         $this->spin(function (RawMinkContext $context) use ($selector) {
             $element = $context->getSession()->getPage()->find('css', $selector);
 
-            if ($element === null) {
+            if (null === $element) {
                 throw new \Exception('Element not found');
             }
 

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -68,12 +68,12 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
         ];
 
-        if ($this->getContext() === self::CONTEXT_WEBSITE) {
+        if (self::CONTEXT_WEBSITE === $this->getContext()) {
             // smyfony-cmf
             $bundles[] = new \Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle();
         }
 
-        if ($this->getContext() === self::CONTEXT_ADMIN) {
+        if (self::CONTEXT_ADMIN === $this->getContext()) {
             // rest
             $bundles[] = new \Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle();
             $bundles[] = new \FOS\RestBundle\FOSRestBundle();

--- a/src/Sulu/Bundle/TestBundle/Testing/PHPCRImporter.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/PHPCRImporter.php
@@ -51,7 +51,7 @@ class PHPCRImporter
             do {
                 $path = '/' . XmlUtil::getValueFromXPath('@sv:name', $xpath, $parent) . $path;
                 $parent = $parent->parentNode;
-            } while (XmlUtil::getValueFromXPath('@sv:name', $xpath, $parent) !== 'contents');
+            } while ('contents' !== XmlUtil::getValueFromXPath('@sv:name', $xpath, $parent));
 
             $data[] = [
                 'id' => XmlUtil::getValueFromXPath('sv:property[@sv:name="jcr:uuid"]/sv:value', $xpath, $node),

--- a/src/Sulu/Bundle/TranslateBundle/Translate/Export.php
+++ b/src/Sulu/Bundle/TranslateBundle/Translate/Export.php
@@ -25,9 +25,13 @@ use Symfony\Component\Translation\Translator;
 class Export
 {
     const XLIFF = 0;
+
     const JSON = 1;
+
     const BACKEND_DOMAIN = 'backend';
+
     const FRONTEND_DOMAIN = 'frontend';
+
     const DEFAULT_LOCALE = 'en';
 
     /**
@@ -210,7 +214,7 @@ class Export
      */
     public function getPath()
     {
-        return ($this->path != null) ? $this->path : getcwd();
+        return (null != $this->path) ? $this->path : getcwd();
     }
 
     /**
@@ -290,7 +294,7 @@ class Export
      */
     private function newFileDumper()
     {
-        if ($this->getFormat() === self::XLIFF) {
+        if (self::XLIFF === $this->getFormat()) {
             return new XliffFileDumper();
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
@@ -83,13 +83,13 @@ class ExceptionController
         if ($webspace = $this->requestAnalyzer->getWebspace()) {
             $template = $webspace->getTemplate('error-' . $code);
 
-            if ($template === null) {
+            if (null === $template) {
                 $template = $webspace->getTemplate('error');
             }
         }
 
         $showException = $request->attributes->get('showException', $this->debug);
-        if ($showException || $request->getRequestFormat() !== 'html' || $template === null) {
+        if ($showException || 'html' !== $request->getRequestFormat() || null === $template) {
             return $this->exceptionController->showAction($request, $exception, $logger);
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
@@ -105,7 +105,7 @@ class RedirectController extends Controller
             && (
                 // if requested url not starting with redirectUrl it need to be added
                 !isset($requestInfo['path'])
-                || strpos($requestInfo['path'], $redirectInfo['path'] . '/') !== 0
+                || 0 !== strpos($requestInfo['path'], $redirectInfo['path'] . '/')
             )
         ) {
             $url .= $redirectInfo['path'];

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -102,6 +102,7 @@ abstract class WebsiteController extends Controller
 
         $level = ob_get_level();
         ob_start();
+
         try {
             $rendered = $template->renderBlock($block, $attributes);
             ob_end_clean();

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
@@ -27,7 +27,7 @@ class RouteProviderCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->getParameter('sulu.context') === SuluKernel::CONTEXT_WEBSITE) {
+        if (SuluKernel::CONTEXT_WEBSITE === $container->getParameter('sulu.context')) {
             $container->setDefinition(
                 'sulu_website.provider.content',
                 new Definition('Sulu\Bundle\WebsiteBundle\Routing\ContentRouteProvider', [

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -76,7 +76,7 @@ class AppendAnalyticsListener
     {
         if ($this->preview
             || 0 !== strpos($event->getResponse()->headers->get('Content-Type'), 'text/html')
-            || $this->requestAnalyzer->getPortalInformation() === null
+            || null === $this->requestAnalyzer->getPortalInformation()
         ) {
             return;
         }

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -57,7 +57,7 @@ class RouterListener implements EventSubscriberInterface
         // Would be nice to also only call this if the _requestAnalyzer attribute is set, but it's set on the next line
         $this->requestAnalyzer->analyze($request);
         $this->baseRouteListener->onKernelRequest($event);
-        if ($request->attributes->get(static::REQUEST_ANALYZER, true) !== false) {
+        if (false !== $request->attributes->get(static::REQUEST_ANALYZER, true)) {
             $this->requestAnalyzer->validate($request);
         }
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationItem.php
@@ -55,7 +55,7 @@ class NavigationItem
         $this->nodeType = $nodeType;
         $this->excerpt = $excerpt;
 
-        $this->uuid = ($uuid === null ? uniqid() : $uuid);
+        $this->uuid = (null === $uuid ? uniqid() : $uuid);
 
         $this->children = $children;
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationMapper.php
@@ -239,12 +239,12 @@ class NavigationMapper implements NavigationMapperInterface
     {
         $contexts = $content->getNavContexts();
 
-        if ($content->getNodeState() !== Structure::STATE_PUBLISHED) {
+        if (Structure::STATE_PUBLISHED !== $content->getNodeState()) {
             // if node state is not published do not show page
             return false;
         }
 
-        if (is_array($contexts) && ($context === null || in_array($context, $contexts))) {
+        if (is_array($contexts) && (null === $context || in_array($context, $contexts))) {
             // all contexts or content has context
             return true;
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationQueryBuilder.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationQueryBuilder.php
@@ -36,10 +36,10 @@ class NavigationQueryBuilder extends ContentQueryBuilder
     protected function buildWhere($webspaceKey, $locale)
     {
         $where = [];
-        if ($this->context !== null) {
+        if (null !== $this->context) {
             $where[] = sprintf("page.[i18n:%s-navContexts] = '%s'", $locale, $this->context);
         }
-        if ($this->parent !== null) {
+        if (null !== $this->parent) {
             $where[] = sprintf("ISDESCENDANTNODE(page, '%s')", $this->parent);
         } else {
             $where[] = sprintf("ISDESCENDANTNODE(page, '%s')", '/cmf/' . $webspaceKey . '/contents');

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
@@ -53,7 +53,7 @@ class ParameterResolver implements ParameterResolverInterface
         StructureInterface $structure = null,
         $preview = false
     ) {
-        if ($structure !== null) {
+        if (null !== $structure) {
             $structureData = $this->structureResolver->resolve($structure);
         } else {
             $structureData = [];

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -132,7 +132,7 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
             foreach ($portalInformations as $portalInformation) {
                 if (
                     $portalInformation->getPortalKey() === $this->requestAnalyzer->getPortal()->getKey()
-                    && $portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_FULL
+                    && RequestAnalyzerInterface::MATCH_TYPE_FULL === $portalInformation->getType()
                 ) {
                     if (isset($routeParams['prefix'])) {
                         $routeParams['prefix'] = $portalInformation->getPrefix();

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -112,9 +112,9 @@ class ContentRouteProvider implements RouteProviderInterface
         $collection = new RouteCollection();
 
         // no portal information without localization supported
-        if ($this->requestAnalyzer->getCurrentLocalization() === null
-            && $this->requestAnalyzer->getMatchType() !== RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
-            && $this->requestAnalyzer->getMatchType() !== RequestAnalyzerInterface::MATCH_TYPE_REDIRECT
+        if (null === $this->requestAnalyzer->getCurrentLocalization()
+            && RequestAnalyzerInterface::MATCH_TYPE_PARTIAL !== $this->requestAnalyzer->getMatchType()
+            && RequestAnalyzerInterface::MATCH_TYPE_REDIRECT !== $this->requestAnalyzer->getMatchType()
         ) {
             return $collection;
         }
@@ -123,8 +123,8 @@ class ContentRouteProvider implements RouteProviderInterface
         $resourceLocator = $this->requestAnalyzer->getResourceLocator();
 
         if (
-            $this->requestAnalyzer->getMatchType() == RequestAnalyzerInterface::MATCH_TYPE_REDIRECT
-            || $this->requestAnalyzer->getMatchType() == RequestAnalyzerInterface::MATCH_TYPE_PARTIAL
+            RequestAnalyzerInterface::MATCH_TYPE_REDIRECT == $this->requestAnalyzer->getMatchType()
+            || RequestAnalyzerInterface::MATCH_TYPE_PARTIAL == $this->requestAnalyzer->getMatchType()
         ) {
             // redirect webspace correctly with locale
             $collection->add(
@@ -132,7 +132,7 @@ class ContentRouteProvider implements RouteProviderInterface
                 $this->getRedirectWebSpaceRoute()
             );
         } elseif (
-            $request->getRequestFormat() === 'html' &&
+            'html' === $request->getRequestFormat() &&
             substr($request->getPathInfo(), -strlen($htmlExtension)) === $htmlExtension
         ) {
             // redirect *.html to * (without url)
@@ -182,7 +182,7 @@ class ContentRouteProvider implements RouteProviderInterface
                             $this->requestAnalyzer->getResourceLocatorPrefix() . rtrim($resourceLocator, '/')
                         )
                     );
-                } elseif ($document->getRedirectType() === RedirectType::INTERNAL) {
+                } elseif (RedirectType::INTERNAL === $document->getRedirectType()) {
                     // redirect internal link
                     $redirectUrl = $this->requestAnalyzer->getResourceLocatorPrefix()
                         . $document->getRedirectTarget()->getResourceSegment();
@@ -198,7 +198,7 @@ class ContentRouteProvider implements RouteProviderInterface
                             $redirectUrl
                         )
                     );
-                } elseif ($document->getRedirectType() === RedirectType::EXTERNAL) {
+                } elseif (RedirectType::EXTERNAL === $document->getRedirectType()) {
                     $collection->add(
                         $document->getStructureType() . '_' . $document->getUuid(),
                         $this->getRedirectRoute($request, $document->getRedirectExternal())
@@ -295,7 +295,7 @@ class ContentRouteProvider implements RouteProviderInterface
      */
     private function checkResourceLocator()
     {
-        return !($this->requestAnalyzer->getResourceLocator() === '/'
+        return !('/' === $this->requestAnalyzer->getResourceLocator()
             && $this->requestAnalyzer->getResourceLocatorPrefix());
     }
 
@@ -355,7 +355,7 @@ class ContentRouteProvider implements RouteProviderInterface
             $request->getPathInfo(), [
                 '_controller' => $content->getController(),
                 'structure' => $content,
-                'partial' => $request->get('partial', 'false') === 'true',
+                'partial' => 'true' === $request->get('partial', 'false'),
             ]
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
@@ -63,6 +63,6 @@ class PortalLoader extends Loader
      */
     public function supports($resource, $type = null)
     {
-        return $type === 'portal';
+        return 'portal' === $type;
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -37,9 +37,6 @@ class RequestListener
         $this->requestAnalyzer = $requestAnalyzer;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function onRequest(GetResponseEvent $event)
     {
         $context = $this->router->getContext();

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/Provider/PagesSitemapProvider.php
@@ -56,7 +56,7 @@ class PagesSitemapProvider implements SitemapProviderInterface
         foreach ($pages as $contentPage) {
             if (!$contentPage->getUrl()
                 || true === $contentPage['seo-hideInSitemap']
-                || $contentPage->getNodeType() !== RedirectType::NONE
+                || RedirectType::NONE !== $contentPage->getNodeType()
             ) {
                 continue;
             }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGenerator.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGenerator.php
@@ -65,7 +65,7 @@ class SitemapGenerator implements SitemapGeneratorInterface
     {
         $webspaceSitemapInformation = $this->getWebspaceSitemap($webspaceKey);
         $sitemap = $this->generateByLocals($webspaceKey, [$locale], $flat);
-        if (count($sitemap) === 1 && !$flat) {
+        if (1 === count($sitemap) && !$flat) {
             $sitemap = $sitemap[0];
         }
         $webspaceSitemapInformation->setSitemap(

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
@@ -20,11 +20,17 @@ class SitemapUrl
      * Constants which indicates the change frequency (google will use them).
      */
     const CHANGE_FREQUENCY_ALWAYS = 'always';
+
     const CHANGE_FREQUENCY_HOURLY = 'hourly';
+
     const CHANGE_FREQUENCY_DAILY = 'daily';
+
     const CHANGE_FREQUENCY_WEEKLY = 'weekly';
+
     const CHANGE_FREQUENCY_MONTHLY = 'monthly';
+
     const CHANGE_FREQUENCY_YEARLY = 'yearly';
+
     const CHANGE_FREQUENCY_NEVER = 'never';
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Analytics/AnalyticsManagerTest.php
@@ -168,7 +168,7 @@ class AnalyticsManagerTest extends BaseFunctional
 
         $accessor = PropertyAccess::createPropertyAccessor();
         foreach ($data as $key => $value) {
-            if ($key === 'domains') {
+            if ('domains' === $key) {
                 continue;
             }
             $this->assertEquals($value, $accessor->getValue($result, $key));
@@ -200,7 +200,7 @@ class AnalyticsManagerTest extends BaseFunctional
 
         $accessor = PropertyAccess::createPropertyAccessor();
         foreach ($data as $key => $value) {
-            if ($key === 'domains') {
+            if ('domains' === $key) {
                 continue;
             }
             $this->assertEquals($value, $accessor->getValue($result, $key));

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
@@ -96,7 +96,7 @@ class ExceptionControllerTest extends \PHPUnit_Framework_TestCase
         $this->twig->render(Argument::containingString($expectedExceptionFormat), Argument::any())->shouldBeCalled();
         $this->loader->exists(Argument::any())->willReturn($templateAvailable);
 
-        if ($retrievedFormat === 'html') {
+        if ('html' === $retrievedFormat) {
             $this->parameterResolver->resolve(Argument::cetera())->shouldBeCalled()->willReturn([]);
         } else {
             $this->parameterResolver->resolve(Argument::cetera())->shouldNotBeCalled();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
@@ -610,7 +610,7 @@ class ExcerptStructureExtension extends AbstractExtension
         // lazy load excerpt structure to avoid redeclaration of classes
         // should be done before parent::setLanguageCode because it uses the $thi<->properties
         // which will be set in initExcerptStructure
-        if ($this->excerptStructure === null) {
+        if (null === $this->excerptStructure) {
             $this->excerptStructure = $this->initExcerptStructure();
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -53,7 +53,7 @@ class RequestAnalyzerResolverTest extends \PHPUnit_Framework_TestCase
 
     protected function prepareWebspaceManager()
     {
-        if ($this->webspaceManager === null) {
+        if (null === $this->webspaceManager) {
             $webspace = new Webspace();
             $en = new Localization();
             $en->setLanguage('en');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -127,7 +127,7 @@ class SitemapGeneratorTest extends SuluTestCase
 
     protected function prepareWebspaceManager()
     {
-        if ($this->webspaceManager !== null) {
+        if (null !== $this->webspaceManager) {
             return;
         }
 
@@ -466,7 +466,7 @@ class ExcerptStructureExtension extends AbstractExtension
         // lazy load excerpt structure to avoid redeclaration of classes
         // should be done before parent::setLanguageCode because it uses the $thi<->properties
         // which will be set in initExcerptStructure
-        if ($this->excerptStructure === null) {
+        if (null === $this->excerptStructure) {
             $this->excerptStructure = $this->initExcerptStructure();
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslator.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Translator/RequestAnalyzerTranslator.php
@@ -83,7 +83,7 @@ class RequestAnalyzerTranslator implements TranslatorInterface
 
     private function initialize()
     {
-        if ($this->initialized || $this->requestAnalyzer->getCurrentLocalization() === null) {
+        if ($this->initialized || null === $this->requestAnalyzer->getCurrentLocalization()) {
             return;
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -62,7 +62,7 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
     {
         // if the request analyzer null or a route is passed which is relative or inclusive a domain nothing should be
         // done (this is important for external-links in navigations)
-        if (!$this->requestAnalyzer || strpos($route, '/') !== 0) {
+        if (!$this->requestAnalyzer || 0 !== strpos($route, '/')) {
             return $route;
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -75,7 +75,7 @@ class MetaTwigExtension extends \Twig_Extension
         $currentPortal = $this->requestAnalyzer->getPortal();
 
         $defaultLocale = null;
-        if ($currentPortal !== null && ($defaultLocale = $currentPortal->getXDefaultLocalization()) !== null) {
+        if (null !== $currentPortal && null !== ($defaultLocale = $currentPortal->getXDefaultLocalization())) {
             $defaultLocale = $defaultLocale->getLocalization();
         }
 
@@ -83,7 +83,7 @@ class MetaTwigExtension extends \Twig_Extension
         foreach ($urls as $locale => $url) {
             // url = '/' means that there is no translation for this page
             // the only exception is the homepage where the requested resource-locator is '/'
-            if ($url !== '/' || $this->requestAnalyzer->getResourceLocator() === '/') {
+            if ('/' !== $url || '/' === $this->requestAnalyzer->getResourceLocator()) {
                 if ($locale === $defaultLocale) {
                     $result[] = $this->getAlternate($url, $webspaceKey, $locale, true);
                 }
@@ -117,8 +117,8 @@ class MetaTwigExtension extends \Twig_Extension
 
         // fallback for seo description
         if (
-            (!array_key_exists('description', $seo) || $seo['description'] === '') &&
-            array_key_exists('description', $excerpt) && $excerpt['description'] !== ''
+            (!array_key_exists('description', $seo) || '' === $seo['description']) &&
+            array_key_exists('description', $excerpt) && '' !== $excerpt['description']
         ) {
             $seo['description'] = strip_tags($excerpt['description']);
         }
@@ -127,8 +127,8 @@ class MetaTwigExtension extends \Twig_Extension
 
         // generate robots content
         $robots = [];
-        $robots[] = (array_key_exists('noIndex', $seo) && $seo['noIndex'] === true) ? 'noIndex' : 'index';
-        $robots[] = (array_key_exists('noFollow', $seo) && $seo['noFollow'] === true) ? 'noFollow' : 'follow';
+        $robots[] = (array_key_exists('noIndex', $seo) && true === $seo['noIndex']) ? 'noIndex' : 'index';
+        $robots[] = (array_key_exists('noFollow', $seo) && true === $seo['noFollow']) ? 'noFollow' : 'follow';
 
         // build meta tags
         $result = [];

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -90,7 +90,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
-        if ($level !== null) {
+        if (null !== $level) {
             $breadcrumb = $this->contentMapper->loadBreadcrumb(
                 $uuid,
                 $locale,
@@ -116,7 +116,7 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
 
-        if ($level !== null) {
+        if (null !== $level) {
             $breadcrumb = $this->contentMapper->loadBreadcrumb(
                 $uuid,
                 $locale,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
@@ -68,11 +68,11 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
      */
     public function sitemapUrlFunction($url, $locale = null, $webspaceKey = null)
     {
-        if ($webspaceKey === null) {
+        if (null === $webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         }
 
-        if ($locale === null) {
+        if (null === $locale) {
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
         }
 
@@ -89,11 +89,11 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
      */
     public function sitemapFunction($locale = null, $webspaceKey = null)
     {
-        if ($webspaceKey === null) {
+        if (null === $webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         }
 
-        if ($locale === null) {
+        if (null === $locale) {
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocalization();
         }
 

--- a/src/Sulu/Bundle/WebsocketBundle/App/WebsocketApp.php
+++ b/src/Sulu/Bundle/WebsocketBundle/App/WebsocketApp.php
@@ -120,7 +120,7 @@ class WebsocketApp
             $decorated = $controller;
         }
 
-        if ($httpHost === null) {
+        if (null === $httpHost) {
             $httpHost = $this->httpHost;
         }
 

--- a/src/Sulu/Component/Cache/DataCache.php
+++ b/src/Sulu/Component/Cache/DataCache.php
@@ -53,6 +53,7 @@ class DataCache implements CacheInterface
         $umask = umask();
         $filesystem = new Filesystem();
         $filesystem->dumpFile($this->file, serialize($data), null);
+
         try {
             $filesystem->chmod($this->file, $mode, $umask);
         } catch (IOException $e) {

--- a/src/Sulu/Component/Cache/Memoize.php
+++ b/src/Sulu/Component/Cache/Memoize.php
@@ -67,7 +67,7 @@ class Memoize implements MemoizeInterface
     public function memoizeById($id, $arguments, $compute, $lifeTime = null)
     {
         // determine lifetime
-        if ($lifeTime === null) {
+        if (null === $lifeTime) {
             $lifeTime = $this->defaultLifeTime;
         }
 

--- a/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
@@ -33,7 +33,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
      */
     public function getCategories($categoriesParameter = 'categories')
     {
-        if ($this->requestStack->getCurrentRequest() !== null) {
+        if (null !== $this->requestStack->getCurrentRequest()) {
             $categories = $this->requestStack->getCurrentRequest()->get($categoriesParameter, '');
         } else {
             $categories = '';

--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -217,7 +217,7 @@ class BlockProperty extends Property implements BlockPropertyInterface
             $items = $value->getValue();
         }
 
-        if ($items == null) {
+        if (null == $items) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Compat/Block/BlockPropertyType.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockPropertyType.php
@@ -99,6 +99,7 @@ class BlockPropertyType
                 return $child;
             }
         }
+
         throw new NoSuchPropertyException();
     }
 

--- a/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
@@ -52,7 +52,7 @@ class BlockPropertyWrapper implements PropertyInterface
     {
         return $this->block->getName() . '-' .
         $this->property->getName() .
-        ($this->index !== null ? '#' . $this->index : '');
+        (null !== $this->index ? '#' . $this->index : '');
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/LocalizationFinder.php
+++ b/src/Sulu/Component/Content/Compat/LocalizationFinder.php
@@ -91,7 +91,7 @@ class LocalizationFinder implements LocalizationFinderInterface
 
             // try to load parent and stop if there is no parent
             $localization = $localization->getParent();
-        } while ($localization != null);
+        } while (null != $localization);
 
         return;
     }

--- a/src/Sulu/Component/Content/Compat/PropertyParameter.php
+++ b/src/Sulu/Component/Content/Compat/PropertyParameter.php
@@ -109,7 +109,7 @@ class PropertyParameter implements \JsonSerializable
      */
     public function hasTitle($languageCode)
     {
-        return $this->metadata->get('title', $languageCode) !== null;
+        return null !== $this->metadata->get('title', $languageCode);
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/Structure.php
+++ b/src/Sulu/Component/Content/Compat/Structure.php
@@ -457,7 +457,7 @@ abstract class Structure implements StructureInterface
     {
         $result = $this->findProperty($name);
 
-        if ($result !== null) {
+        if (null !== $result) {
             return $result;
         } elseif (isset($this->properties[$name])) {
             return $this->properties[$name];
@@ -479,7 +479,7 @@ abstract class Structure implements StructureInterface
     public function getPropertyByTagName($tagName, $highest = true)
     {
         if (array_key_exists($tagName, $this->tags)) {
-            return $this->tags[$tagName][$highest === true ? 'highest' : 'lowest'];
+            return $this->tags[$tagName][true === $highest ? 'highest' : 'lowest'];
         } else {
             throw new NoSuchPropertyException($tagName);
         }
@@ -536,7 +536,7 @@ abstract class Structure implements StructureInterface
      */
     public function hasProperty($name)
     {
-        return $this->findProperty($name) !== null;
+        return null !== $this->findProperty($name);
     }
 
     /**
@@ -596,7 +596,7 @@ abstract class Structure implements StructureInterface
      */
     public function getPublishedState()
     {
-        return $this->nodeState === StructureInterface::STATE_PUBLISHED;
+        return StructureInterface::STATE_PUBLISHED === $this->nodeState;
     }
 
     /**
@@ -684,7 +684,7 @@ abstract class Structure implements StructureInterface
      */
     public function getProperties($flatten = false)
     {
-        if ($flatten === false) {
+        if (false === $flatten) {
             return $this->properties;
         } else {
             $result = [];
@@ -764,8 +764,8 @@ abstract class Structure implements StructureInterface
     public function getNodeName()
     {
         if (
-            $this->getNodeType() === self::NODE_TYPE_INTERNAL_LINK &&
-            $this->getInternalLinkContent() !== null &&
+            self::NODE_TYPE_INTERNAL_LINK === $this->getNodeType() &&
+            null !== $this->getInternalLinkContent() &&
             $this->getInternalLinkContent()->hasProperty('title')
         ) {
             return $this->internalLinkContent->getPropertyValue('title');
@@ -843,7 +843,7 @@ abstract class Structure implements StructureInterface
      */
     public function __isset($property)
     {
-        if ($this->findProperty($property) !== null) {
+        if (null !== $this->findProperty($property)) {
             return true;
         } else {
             return isset($this->$property);
@@ -876,13 +876,13 @@ abstract class Structure implements StructureInterface
                 'changed' => $this->changed,
             ];
 
-            if ($this->type !== null) {
+            if (null !== $this->type) {
                 $result['type'] = $this->getType()->toArray();
             }
 
-            if ($this->nodeType === self::NODE_TYPE_INTERNAL_LINK) {
+            if (self::NODE_TYPE_INTERNAL_LINK === $this->nodeType) {
                 $result['linked'] = 'internal';
-            } elseif ($this->nodeType === self::NODE_TYPE_EXTERNAL_LINK) {
+            } elseif (self::NODE_TYPE_EXTERNAL_LINK === $this->nodeType) {
                 $result['linked'] = 'external';
             }
 
@@ -900,13 +900,13 @@ abstract class Structure implements StructureInterface
                 'title' => $this->getProperty('title')->toArray(),
             ];
 
-            if ($this->type !== null) {
+            if (null !== $this->type) {
                 $result['type'] = $this->getType()->toArray();
             }
 
-            if ($this->nodeType === self::NODE_TYPE_INTERNAL_LINK) {
+            if (self::NODE_TYPE_INTERNAL_LINK === $this->nodeType) {
                 $result['linked'] = 'internal';
-            } elseif ($this->nodeType === self::NODE_TYPE_EXTERNAL_LINK) {
+            } elseif (self::NODE_TYPE_EXTERNAL_LINK === $this->nodeType) {
                 $result['linked'] = 'external';
             }
 

--- a/src/Sulu/Component/Content/Compat/Structure/PageBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/PageBridge.php
@@ -43,7 +43,7 @@ class PageBridge extends StructureBridge implements PageInterface
         }
 
         // return original locale for shadow or ghost pages
-        if ($this->getIsShadow() || ($this->getType() && $this->getType()->getName() === 'ghost')) {
+        if ($this->getIsShadow() || ($this->getType() && 'ghost' === $this->getType()->getName())) {
             return $this->inspector->getOriginalLocale($this->getDocument());
         }
 

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -314,7 +314,7 @@ class StructureBridge implements StructureInterface
      */
     public function getPublishedState()
     {
-        return $this->getWorkflowDocument(__METHOD__)->getWorkflowStage() === WorkflowStage::PUBLISHED;
+        return WorkflowStage::PUBLISHED === $this->getWorkflowDocument(__METHOD__)->getWorkflowStage();
     }
 
     /**
@@ -365,11 +365,11 @@ class StructureBridge implements StructureInterface
         $document = $this->getDocument();
         $localizationState = $this->inspector->getLocalizationState($document);
 
-        if ($localizationState === LocalizationState::GHOST) {
+        if (LocalizationState::GHOST === $localizationState) {
             return StructureType::getGhost($this->getDocument()->getLocale());
         }
 
-        if ($this->inspector->getLocalizationState($document) === LocalizationState::SHADOW) {
+        if (LocalizationState::SHADOW === $this->inspector->getLocalizationState($document)) {
             return StructureType::getShadow($this->getDocument()->getLocale());
         }
     }
@@ -431,17 +431,17 @@ class StructureBridge implements StructureInterface
         if ($document instanceof RedirectTypeBehavior) {
             $redirectType = $document->getRedirectType();
             $result['linked'] = null;
-            if ($redirectType == RedirectType::INTERNAL && $document->getRedirectTarget() !== null) {
+            if (RedirectType::INTERNAL == $redirectType && null !== $document->getRedirectTarget()) {
                 $result['linked'] = 'internal';
                 $result['internal_link'] = $document->getRedirectTarget()->getUuid();
-            } elseif ($redirectType == RedirectType::EXTERNAL) {
+            } elseif (RedirectType::EXTERNAL == $redirectType) {
                 $result['linked'] = 'external';
                 $result['external'] = $document->getRedirectExternal();
             }
         }
 
         if ($document instanceof WorkflowStageBehavior) {
-            $result['publishedState'] = $document->getWorkflowStage() === WorkflowStage::PUBLISHED;
+            $result['publishedState'] = WorkflowStage::PUBLISHED === $document->getWorkflowStage();
             $result['published'] = $document->getPublished();
         }
 
@@ -558,8 +558,8 @@ class StructureBridge implements StructureInterface
     public function getNodeName()
     {
         if ($this->document instanceof RedirectTypeBehavior &&
-            $this->document->getRedirectType() == RedirectType::INTERNAL &&
-            $this->document->getRedirectTarget() !== null
+            RedirectType::INTERNAL == $this->document->getRedirectType() &&
+            null !== $this->document->getRedirectTarget()
         ) {
             return $this->getDocument()->getRedirectTarget()->getTitle();
         }
@@ -656,11 +656,11 @@ class StructureBridge implements StructureInterface
     public function getResourceLocator()
     {
         $document = $this->getDocument();
-        if ($document->getRedirectType() == RedirectType::EXTERNAL) {
+        if (RedirectType::EXTERNAL == $document->getRedirectType()) {
             return $document->getRedirectExternal();
         }
 
-        if ($document->getRedirectType() === RedirectType::INTERNAL) {
+        if (RedirectType::INTERNAL === $document->getRedirectType()) {
             $target = $document->getRedirectTarget();
 
             if (!$target) {

--- a/src/Sulu/Component/Content/Compat/StructureInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureInterface.php
@@ -20,6 +20,7 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 interface StructureInterface extends \JsonSerializable
 {
     const STATE_TEST = 1;
+
     const STATE_PUBLISHED = 2;
 
     /**
@@ -330,5 +331,5 @@ interface StructureInterface extends \JsonSerializable
      *
      * @param StructureInterface $structure
      */
-    public function copyFrom(StructureInterface $structure);
+    public function copyFrom(self $structure);
 }

--- a/src/Sulu/Component/Content/Compat/StructureManager.php
+++ b/src/Sulu/Component/Content/Compat/StructureManager.php
@@ -27,8 +27,11 @@ class StructureManager implements StructureManagerInterface
     use ContainerAwareTrait;
 
     private $structureFactory;
+
     private $inspector;
+
     private $propertyFactory;
+
     private $typeMap;
 
     /**

--- a/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
+++ b/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
@@ -90,6 +90,6 @@ class ExtensionContainer implements \ArrayAccess, \Iterator
 
     public function valid()
     {
-        return isset($this->data) !== null;
+        return null !== isset($this->data);
     }
 }

--- a/src/Sulu/Component/Content/Document/Structure/PropertyValue.php
+++ b/src/Sulu/Component/Content/Document/Structure/PropertyValue.php
@@ -21,6 +21,7 @@ namespace Sulu\Component\Content\Document\Structure;
 class PropertyValue implements \ArrayAccess
 {
     private $value;
+
     private $name;
 
     public function __construct($name, $value = null)

--- a/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
@@ -26,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class AuthorSubscriber implements EventSubscriberInterface
 {
     const AUTHORED_PROPERTY_NAME = 'authored';
+
     const AUTHOR_PROPERTY_NAME = 'author';
 
     /**
@@ -107,7 +108,7 @@ class AuthorSubscriber implements EventSubscriberInterface
         }
 
         // Set default value if authored is not set.
-        if ($document->getAuthored() === null) {
+        if (null === $document->getAuthored()) {
             $document->setAuthored(new \DateTime());
         }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
@@ -29,6 +29,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class BlameSubscriber implements EventSubscriberInterface
 {
     const CREATOR = 'creator';
+
     const CHANGER = 'changer';
 
     /**

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/SuluNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/SuluNode.php
@@ -176,7 +176,7 @@ class SuluNode implements \IteratorAggregate, NodeInterface
     public function setProperty($name, $value, $type = PropertyType::UNDEFINED)
     {
         $oldValue = $this->getPropertyValueWithDefault($name, null);
-        if ($oldValue !== null && gettype($value) !== gettype($oldValue)) {
+        if (null !== $oldValue && gettype($value) !== gettype($oldValue)) {
             $this->node->getProperty($name)->remove();
         }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
@@ -21,7 +21,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class RedirectTypeSubscriber implements EventSubscriberInterface
 {
     const REDIRECT_TYPE_FIELD = 'nodeType';
+
     const INTERNAL_FIELD = 'internal_link';
+
     const EXTERNAL_FIELD = 'external';
 
     public static function getSubscribedEvents()

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -199,7 +199,7 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($document instanceof RedirectTypeBehavior && $document->getRedirectType() !== RedirectType::NONE) {
+        if ($document instanceof RedirectTypeBehavior && RedirectType::NONE !== $document->getRedirectType()) {
             return;
         }
 
@@ -224,7 +224,7 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
         }
 
         $resourceLocatorStrategy = $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey($webspaceKey);
-        if ($resourceLocatorStrategy->getInputType() !== ResourceLocatorStrategyInterface::INPUT_TYPE_LEAF) {
+        if (ResourceLocatorStrategyInterface::INPUT_TYPE_LEAF !== $resourceLocatorStrategy->getInputType()) {
             return;
         }
 
@@ -332,7 +332,7 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
         foreach ($locales as $locale) {
             $localizedDocument = $this->documentManager->find($uuid, $locale);
 
-            if ($localizedDocument->getRedirectType() !== RedirectType::NONE) {
+            if (RedirectType::NONE !== $localizedDocument->getRedirectType()) {
                 continue;
             }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -25,8 +25,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
 {
     const SHADOW_BASE_PROPERTY = 'i18n:*-shadow-base';
+
     const TAGS_PROPERTY = 'i18n:%s-excerpt-tags';
+
     const CATEGORIES_PROPERTY = 'i18n:%s-excerpt-categories';
+
     const NAVIGATION_CONTEXT_PROPERTY = 'i18n:%s-navContexts';
 
     /**

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -26,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class ShadowLocaleSubscriber implements EventSubscriberInterface
 {
     const SHADOW_ENABLED_FIELD = 'shadow-on';
+
     const SHADOW_LOCALE_FIELD = 'shadow-base';
 
     /**
@@ -247,6 +248,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
         $locales = $this->inspector->getConcreteLocales($document);
         if (!in_array($document->getShadowLocale(), $locales)) {
             $this->inspector->getNode($document)->revert();
+
             throw new \RuntimeException(sprintf(
                 'Attempting to create shadow for "%s" on a non-concrete locale "%s" for document at "%s". Concrete languages are "%s"',
                 $document->getLocale(),

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureRemoveSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureRemoveSubscriber.php
@@ -129,7 +129,7 @@ class StructureRemoveSubscriber implements EventSubscriberInterface
             $referrer = $reference->getParent();
             $metadata = $this->metadataFactory->getMetadataForPhpcrNode($referrer);
 
-            if ($metadata->getClass() === RouteDocument::class) {
+            if (RouteDocument::class === $metadata->getClass()) {
                 continue;
             }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -189,7 +189,7 @@ class StructureSubscriber implements EventSubscriberInterface
         $document->setStructureType($structureType);
 
         if (false === $event->getOption('load_ghost_content', false)) {
-            if ($this->inspector->getLocalizationState($document) === LocalizationState::GHOST) {
+            if (LocalizationState::GHOST === $this->inspector->getLocalizationState($document)) {
                 $structureType = null;
             }
         }
@@ -317,7 +317,7 @@ class StructureSubscriber implements EventSubscriberInterface
         $metadata = $this->inspector->getStructureMetadata($document);
 
         foreach ($metadata->getProperties() as $propertyName => $structureProperty) {
-            if ($propertyName === TitleSubscriber::PROPERTY_NAME) {
+            if (TitleSubscriber::PROPERTY_NAME === $propertyName) {
                 continue;
             }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -31,6 +31,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class WorkflowStageSubscriber implements EventSubscriberInterface
 {
     const WORKFLOW_STAGE_FIELD = 'state';
+
     const PUBLISHED_FIELD = 'published';
 
     /**
@@ -250,7 +251,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
         $path = $this->documentInspector->getPath($document);
         $document->setWorkflowStage($workflowStage);
 
-        $updatePublished = !$document->getPublished() && $workflowStage === WorkflowStage::PUBLISHED;
+        $updatePublished = !$document->getPublished() && WorkflowStage::PUBLISHED === $workflowStage;
         if ($updatePublished) {
             $accessor->set(self::PUBLISHED_FIELD, new \DateTime());
         }

--- a/src/Sulu/Component/Content/Exception/StateTransitionException.php
+++ b/src/Sulu/Component/Content/Exception/StateTransitionException.php
@@ -17,6 +17,7 @@ class StateTransitionException extends StateException
      * @var int
      */
     private $from;
+
     /**
      * @var int
      */

--- a/src/Sulu/Component/Content/Export/WebspaceExport.php
+++ b/src/Sulu/Component/Content/Export/WebspaceExport.php
@@ -214,7 +214,7 @@ class WebspaceExport extends Export implements WebspaceExportInterface
         }
 
         $settingOptions = [];
-        if ($this->format === '1.2.xliff') {
+        if ('1.2.xliff' === $this->format) {
             $settingOptions = ['translate' => false];
         }
 

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -148,7 +148,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
 
         foreach ($parsedDataList as $parsedData) {
             // mapping data
-            if ($exportSuluVersion === '1.2') {
+            if ('1.2' === $exportSuluVersion) {
                 $parsedData['structureType'] = $parsedData['data']['template']['value'];
             }
 
@@ -156,6 +156,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
             // !$uuid || isset($parsedData['uuid']) && $parsedData['uuid'] == $uuid
             if ($uuid && (!isset($parsedData['uuid']) || $uuid !== $parsedData['uuid'])) {
                 $progress->advance();
+
                 continue;
             }
 
@@ -200,6 +201,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
         try {
             if (!isset($parsedData['uuid']) || !isset($parsedData['structureType']) || !isset($parsedData['data'])) {
                 $this->addException('uuid, structureType or data for import not found.', 'ignore');
+
                 throw new \Exception('uuid, structureType or data for import not found.');
             }
 
@@ -208,7 +210,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
             $data = $parsedData['data'];
             $documentType = Structure::TYPE_PAGE;
 
-            if ($this->getParser($format)->getPropertyData('url', $data) === '/') {
+            if ('/' === $this->getParser($format)->getPropertyData('url', $data)) {
                 $documentType = 'home'; // TODO no constant
             }
 
@@ -297,7 +299,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
         $state = $this->getParser($format)->getPropertyData('state', $data, null, null, 2);
         $node->setProperty(sprintf('i18n:%s-state', $locale), $state);
 
-        if ($this->getParser($format)->getPropertyData('title', $data) === '') {
+        if ('' === $this->getParser($format)->getPropertyData('title', $data)) {
             $this->addException(sprintf('Document(%s) has not set any title', $document->getUuid()), 'ignore');
 
             return false;
@@ -313,7 +315,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
 
             // don't generate a new url when one exists
             $doImport = true;
-            if ($property->getContentTypeName() == 'resource_locator') {
+            if ('resource_locator' == $property->getContentTypeName()) {
                 $doImport = false;
 
                 if (!$document->getResourceSegment()) {

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -175,7 +175,7 @@ class ContentMapper implements ContentMapperInterface
             ]
         );
 
-        if ($document === null) {
+        if (null === $document) {
             throw new TranslatedNodeNotFoundException($uuid, $locale);
         }
 
@@ -242,7 +242,7 @@ class ContentMapper implements ContentMapperInterface
 
         if ($flat) {
             foreach ($children as $child) {
-                if ($depth === null || $depth > 1) {
+                if (null === $depth || $depth > 1) {
                     $childChildren = $this->loadByParent(
                         $child->getUuid(),
                         $webspaceKey,
@@ -634,7 +634,7 @@ class ContentMapper implements ContentMapperInterface
             foreach ($queryResult->getRows() as $row) {
                 $pageDepth = substr_count($row->getPath('page'), '/') - $rootDepth;
 
-                if ($maxDepth === null || $maxDepth < 0 || ($maxDepth > 0 && $pageDepth <= $maxDepth)) {
+                if (null === $maxDepth || $maxDepth < 0 || ($maxDepth > 0 && $pageDepth <= $maxDepth)) {
                     $item = $this->rowToArray($row, $locale, $webspaceKey, $fields, $onlyPublished);
 
                     if (false === $item || in_array($item, $result)) {
@@ -676,7 +676,7 @@ class ContentMapper implements ContentMapperInterface
 
         $redirectType = $document->getRedirectType();
 
-        if ($redirectType === RedirectType::INTERNAL) {
+        if (RedirectType::INTERNAL === $redirectType) {
             $target = $document->getRedirectTarget();
 
             if ($target) {
@@ -687,7 +687,7 @@ class ContentMapper implements ContentMapperInterface
             }
         }
 
-        if ($redirectType === RedirectType::EXTERNAL) {
+        if (RedirectType::EXTERNAL === $redirectType) {
             $url = $document->getRedirectExternal();
         }
 
@@ -702,7 +702,7 @@ class ContentMapper implements ContentMapperInterface
         }
 
         // if page is not piblished ignore it
-        if ($onlyPublished && $nodeState !== WorkflowStage::PUBLISHED) {
+        if ($onlyPublished && WorkflowStage::PUBLISHED !== $nodeState) {
             return false;
         }
 
@@ -735,7 +735,7 @@ class ContentMapper implements ContentMapperInterface
             'changed' => $document->getChanged(),
             'changer' => $document->getChanger(),
             'created' => $document->getCreated(),
-            'publishedState' => $nodeState === WorkflowStage::PUBLISHED,
+            'publishedState' => WorkflowStage::PUBLISHED === $nodeState,
             'published' => $document->getPublished(),
             'creator' => $document->getCreator(),
             'title' => $originalDocument->getTitle(),
@@ -787,7 +787,7 @@ class ContentMapper implements ContentMapperInterface
             if (!isset($target[$field['name']])) {
                 $target[$field['name']] = '';
             }
-            if (($data = $this->getFieldData(
+            if (null !== ($data = $this->getFieldData(
                     $field,
                     $row,
                     $node,
@@ -795,7 +795,7 @@ class ContentMapper implements ContentMapperInterface
                     $templateKey,
                     $webspaceKey,
                     $locale
-                )) !== null
+                ))
             ) {
                 $target[$field['name']] = $data;
             }
@@ -903,7 +903,7 @@ class ContentMapper implements ContentMapperInterface
 
     private function optionsShouldExcludeDocument($document, array $options = null)
     {
-        if ($options === null) {
+        if (null === $options) {
             return false;
         }
 
@@ -917,11 +917,11 @@ class ContentMapper implements ContentMapperInterface
 
         $state = $this->inspector->getLocalizationState($document);
 
-        if ($options['exclude_ghost'] && $state == LocalizationState::GHOST) {
+        if ($options['exclude_ghost'] && LocalizationState::GHOST == $state) {
             return true;
         }
 
-        if ($options['exclude_ghost'] && $options['exclude_shadow'] && $state == LocalizationState::SHADOW) {
+        if ($options['exclude_ghost'] && $options['exclude_shadow'] && LocalizationState::SHADOW == $state) {
             return true;
         }
 

--- a/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
@@ -83,8 +83,8 @@ class MultipleTranslatedProperties
     public function getName($key)
     {
         // templates do not translate the template key
-        if ($this->structureType === Structure::TYPE_SNIPPET) {
-            if ($key === 'template') {
+        if (Structure::TYPE_SNIPPET === $this->structureType) {
+            if ('template' === $key) {
                 return $key;
             }
         }

--- a/src/Sulu/Component/Content/Mapper/Translation/TranslatedProperty.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/TranslatedProperty.php
@@ -72,10 +72,10 @@ class TranslatedProperty implements PropertyInterface
         if ($this->property->getMultilingual()) {
             return $this->languageNamespace .
             ':' . $this->localization .
-            '-' . ($this->additionalPrefix !== null ? $this->additionalPrefix . '-' : '') .
+            '-' . (null !== $this->additionalPrefix ? $this->additionalPrefix . '-' : '') .
             $this->property->getName();
         } else {
-            return ($this->additionalPrefix !== null ? $this->additionalPrefix . '-' : '') . $this->property->getName();
+            return (null !== $this->additionalPrefix ? $this->additionalPrefix . '-' : '') . $this->property->getName();
         }
     }
 

--- a/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
+++ b/src/Sulu/Component/Content/Metadata/Factory/StructureMetadataFactory.php
@@ -187,7 +187,7 @@ class StructureMetadataFactory implements StructureMetadataFactoryInterface
             foreach ($iterator as $file) {
                 $ext = $file->getExtension();
 
-                if ($ext !== 'xml') {
+                if ('xml' !== $ext) {
                     continue;
                 }
 

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -126,7 +126,7 @@ abstract class ItemMetadata
      *
      * @param ItemMetadata $child
      */
-    public function addChild(ItemMetadata $child)
+    public function addChild(self $child)
     {
         if (isset($this->children[$child->name])) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLegacyLoader.php
@@ -135,7 +135,7 @@ class XmlLegacyLoader implements LoaderInterface
             // check all section properties as well
             foreach ($result['properties'] as $property) {
                 if (!$requiredPropertyNameFound
-                    && $property['type'] == 'section'
+                    && 'section' == $property['type']
                     && array_key_exists($requiredPropertyName, $property['properties'])
                 ) {
                     $requiredPropertyNameFound = true;
@@ -167,7 +167,7 @@ class XmlLegacyLoader implements LoaderInterface
      */
     private function loadTemplateAttributes($resource, \DOMXPath $xpath, $type)
     {
-        if ($type === 'page' || $type === 'home') {
+        if ('page' === $type || 'home' === $type) {
             $result = [
                 'key' => $this->getValueFromXPath('/x:template/x:key', $xpath),
                 'view' => $this->getValueFromXPath('/x:template/x:view', $xpath),
@@ -181,7 +181,7 @@ class XmlLegacyLoader implements LoaderInterface
             $result = array_filter(
                 $result,
                 function ($value) {
-                    return $value !== null;
+                    return null !== $value;
                 }
             );
 
@@ -226,13 +226,13 @@ class XmlLegacyLoader implements LoaderInterface
 
         /** @var \DOMElement $node */
         foreach ($xpath->query($path, $context) as $node) {
-            if ($node->tagName === 'property') {
+            if ('property' === $node->tagName) {
                 $value = $this->loadProperty($templateKey, $xpath, $node, $tags);
                 $result[$value['name']] = $value;
-            } elseif ($node->tagName === 'block') {
+            } elseif ('block' === $node->tagName) {
                 $value = $this->loadBlock($templateKey, $xpath, $node, $tags);
                 $result[$value['name']] = $value;
-            } elseif ($node->tagName === 'section') {
+            } elseif ('section' === $node->tagName) {
                 $value = $this->loadSection($templateKey, $xpath, $node, $tags);
                 $result[$value['name']] = $value;
             }
@@ -545,12 +545,12 @@ class XmlLegacyLoader implements LoaderInterface
     {
         try {
             $result = $xpath->query($path, $context);
-            if ($result->length === 0) {
+            if (0 === $result->length) {
                 return $default;
             }
 
             $item = $result->item(0);
-            if ($item === null) {
+            if (null === $item) {
                 return $default;
             }
 

--- a/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/XmlLoader.php
@@ -36,7 +36,7 @@ class XmlLoader extends XmlLegacyLoader
         $structure->name = $data['key'];
         $structure->cacheLifetime = $data['cacheLifetime'];
         $structure->controller = $data['controller'];
-        $structure->internal = $data['internal'] === 'true';
+        $structure->internal = 'true' === $data['internal'];
         $structure->view = $data['view'];
         $structure->tags = $data['tags'];
         $structure->parameters = $data['params'];
@@ -54,11 +54,11 @@ class XmlLoader extends XmlLegacyLoader
 
     private function createProperty($propertyName, $propertyData)
     {
-        if ($propertyData['type'] === 'block') {
+        if ('block' === $propertyData['type']) {
             return $this->createBlock($propertyName, $propertyData);
         }
 
-        if ($propertyData['type'] === 'section') {
+        if ('section' === $propertyData['type']) {
             return $this->createSection($propertyName, $propertyData);
         }
 
@@ -134,7 +134,7 @@ class XmlLoader extends XmlLegacyLoader
         $property->colSpan = $data['colspan'];
         $property->cssClass = $data['cssClass'];
         $property->tags = $data['tags'];
-        $property->minOccurs = $data['minOccurs'] !== null ? intval($data['minOccurs']) : null;
+        $property->minOccurs = null !== $data['minOccurs'] ? intval($data['minOccurs']) : null;
         $property->maxOccurs = $data['maxOccurs'] ? intval($data['maxOccurs']) : null;
         $property->parameters = $data['params'];
         $this->mapMeta($property, $data['meta']);

--- a/src/Sulu/Component/Content/Metadata/StructureMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/StructureMetadata.php
@@ -111,6 +111,7 @@ class StructureMetadata extends ItemMetadata
         foreach ($this->children as $child) {
             if ($child instanceof SectionMetadata) {
                 $properties = array_merge($properties, $child->getChildren());
+
                 continue;
             }
 

--- a/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
@@ -129,14 +129,14 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
             }
 
             $customSelect = $this->buildSelect($webspaceKey, $locale, $additionalFields);
-            if ($customSelect !== '') {
+            if ('' !== $customSelect) {
                 $select[] = $customSelect;
             }
 
             if ($this->published) {
                 $where .= sprintf(
                     '%s ((page.[%s] = %s OR page.[%s] = %s)',
-                    $where !== '' ? 'OR ' : '',
+                    '' !== $where ? 'OR ' : '',
                     $this->getPropertyName('state'),
                     Structure::STATE_PUBLISHED,
                     $this->getPropertyName('shadow-on'),
@@ -145,8 +145,8 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
             }
 
             $customWhere = $this->buildWhere($webspaceKey, $locale);
-            if ($customWhere !== null && $customWhere !== '') {
-                $where = $where . ($where !== '' ? ' AND ' : '') . $customWhere;
+            if (null !== $customWhere && '' !== $customWhere) {
+                $where = $where . ('' !== $where ? ' AND ' : '') . $customWhere;
             }
 
             if ($this->published) {
@@ -236,7 +236,7 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
             $urlProperty = $structure->getPropertyByTagName('sulu.rlp');
             $name = $this->getTranslatedProperty($urlProperty, $locale)->getName();
 
-            if ($urlProperty->getContentTypeName() !== 'resource_locator' && !in_array($name, $names)) {
+            if ('resource_locator' !== $urlProperty->getContentTypeName() && !in_array($name, $names)) {
                 $names[] = $name;
                 $result .= ', ' . $this->buildSelector($name);
             }

--- a/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryExecutor.php
@@ -86,7 +86,7 @@ class ContentQueryExecutor implements ContentQueryExecutorInterface
         foreach ($queryResult as $row) {
             $pageDepth = substr_count($row->getPath('page'), '/') - $rootDepth;
 
-            if ($depth === null || $depth < 0 || ($depth > 0 && $pageDepth <= $depth)) {
+            if (null === $depth || $depth < 0 || ($depth > 0 && $pageDepth <= $depth)) {
                 $paths[] = $row->getPath('page');
             }
         }

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -128,7 +128,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         $rows = $queryBuilder->execute();
 
-        if (count(iterator_to_array($rows->getRows())) !== 1) {
+        if (1 !== count(iterator_to_array($rows->getRows()))) {
             throw new ItemNotFoundException();
         }
 
@@ -236,7 +236,7 @@ class ContentRepository implements ContentRepositoryInterface
         MappingInterface $mapping,
         UserInterface $user = null
     ) {
-        if (count($uuids) === 0) {
+        if (0 === count($uuids)) {
             return [];
         }
 
@@ -362,7 +362,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         $rows = $queryBuilder->execute();
 
-        if (count(iterator_to_array($rows->getRows())) !== 1) {
+        if (1 !== count(iterator_to_array($rows->getRows()))) {
             throw new ItemNotFoundException();
         }
 
@@ -603,7 +603,7 @@ class ContentRepository implements ContentRepositoryInterface
                 return;
             }
             $type = StructureType::getShadow($row->getValue('shadowBase'));
-        } elseif ($ghostLocale !== null && $ghostLocale !== $originalLocale) {
+        } elseif (null !== $ghostLocale && $ghostLocale !== $originalLocale) {
             if (!$mapping->shouldHydrateGhost()) {
                 return;
             }
@@ -612,9 +612,9 @@ class ContentRepository implements ContentRepositoryInterface
         }
 
         if (
-            $row->getValue('nodeType') === RedirectType::INTERNAL
+            RedirectType::INTERNAL === $row->getValue('nodeType')
             && $mapping->followInternalLink()
-            && $row->getValue('internalLink') !== ''
+            && '' !== $row->getValue('internalLink')
             && $row->getValue('internalLink') !== $row->getValue('uuid')
         ) {
             // TODO collect all internal link contents and query once
@@ -782,7 +782,7 @@ class ContentRepository implements ContentRepositoryInterface
      */
     private function resolveUrl(Row $row, $locale)
     {
-        if ($this->resolveProperty($row, $locale . 'State', $locale) !== WorkflowStage::PUBLISHED) {
+        if (WorkflowStage::PUBLISHED !== $this->resolveProperty($row, $locale . 'State', $locale)) {
             return;
         }
 

--- a/src/Sulu/Component/Content/SimpleContentType.php
+++ b/src/Sulu/Component/Content/SimpleContentType.php
@@ -85,7 +85,7 @@ abstract class SimpleContentType implements ContentTypeInterface, ContentTypeExp
         $segmentKey
     ) {
         $value = $property->getValue();
-        if ($value != null) {
+        if (null != $value) {
             $node->setProperty($property->getName(), $this->removeIllegalCharacters($this->encodeValue($value)));
         } else {
             $this->remove($node, $property, $webspaceKey, $languageCode, $segmentKey);

--- a/src/Sulu/Component/Content/SmartContent/ContentDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/ContentDataProvider.php
@@ -167,7 +167,7 @@ class ContentDataProvider implements DataProviderInterface
             0
         );
 
-        if (count($result) === 0) {
+        if (0 === count($result)) {
             return;
         }
 
@@ -254,8 +254,8 @@ class ContentDataProvider implements DataProviderInterface
         $emptyFilterResult = [[], false];
 
         if (!array_key_exists('dataSource', $filters)
-            || $filters['dataSource'] === ''
-            || ($limit !== null && $limit < 1)
+            || '' === $filters['dataSource']
+            || (null !== $limit && $limit < 1)
         ) {
             return $emptyFilterResult;
         }
@@ -279,7 +279,7 @@ class ContentDataProvider implements DataProviderInterface
         );
 
         $hasNextPage = false;
-        if ($pageSize !== null) {
+        if (null !== $pageSize) {
             $result = $this->loadPaginated($options, $limit, $page, $pageSize);
             $hasNextPage = (count($result) > $pageSize);
             $items = array_splice($result, 0, $pageSize);
@@ -306,7 +306,7 @@ class ContentDataProvider implements DataProviderInterface
         $offset = ($page - 1) * $pageSize;
 
         $position = $pageSize * $page;
-        if ($limit !== null && $position >= $limit) {
+        if (null !== $limit && $position >= $limit) {
             $pageSize = $limit - $offset;
             $loadLimit = $pageSize;
         } else {

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -83,7 +83,7 @@ class QueryBuilder extends ContentQueryBuilder
         // build where clause for datasource
         if ($this->hasConfig('dataSource')) {
             $sql2Where[] = $this->buildDatasourceWhere();
-        } elseif (count($this->ids) === 0) {
+        } elseif (0 === count($this->ids)) {
             $sql2Where[] = sprintf(
                 'ISDESCENDANTNODE(page, "/cmf/%s/contents")',
                 $webspaceKey
@@ -158,7 +158,7 @@ class QueryBuilder extends ContentQueryBuilder
      */
     protected function buildOrder($webspaceKey, $locale)
     {
-        $sortOrder = (isset($this->config['sortMethod']) && strtolower($this->config['sortMethod']) === 'desc')
+        $sortOrder = (isset($this->config['sortMethod']) && 'desc' === strtolower($this->config['sortMethod']))
             ? 'DESC' : 'ASC';
 
         $sql2Order = [];
@@ -202,7 +202,7 @@ class QueryBuilder extends ContentQueryBuilder
             $alias = $parameter->getName();
             $propertyName = $parameter->getValue();
 
-            if (strpos($propertyName, '.') !== false) {
+            if (false !== strpos($propertyName, '.')) {
                 $parts = explode('.', $propertyName);
 
                 $this->buildExtensionSelect($alias, $parts[0], $parts[1], $locale, $additionalFields);
@@ -249,7 +249,7 @@ class QueryBuilder extends ContentQueryBuilder
     {
         $dataSource = $this->getConfig('dataSource');
         $includeSubFolders = $this->getConfig('includeSubFolders', false);
-        $sqlFunction = $includeSubFolders !== false && $includeSubFolders !== 'false' ?
+        $sqlFunction = false !== $includeSubFolders && 'false' !== $includeSubFolders ?
             'ISDESCENDANTNODE' : 'ISCHILDNODE';
 
         $node = $this->sessionManager->getSession()->getNodeByIdentifier($dataSource);

--- a/src/Sulu/Component/Content/Template/TemplateResolver.php
+++ b/src/Sulu/Component/Content/Template/TemplateResolver.php
@@ -21,9 +21,9 @@ class TemplateResolver implements TemplateResolverInterface
      */
     public function resolve($nodeType, $templateKey)
     {
-        if ($nodeType === Structure::NODE_TYPE_EXTERNAL_LINK) {
+        if (Structure::NODE_TYPE_EXTERNAL_LINK === $nodeType) {
             $templateKey = 'external-link';
-        } elseif ($nodeType === Structure::NODE_TYPE_INTERNAL_LINK) {
+        } elseif (Structure::NODE_TYPE_INTERNAL_LINK === $nodeType) {
             $templateKey = 'internal-link';
         }
 

--- a/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Mapper/ContentMapperTest.php
@@ -2633,7 +2633,7 @@ class ContentMapperTest extends SuluTestCase
         }
 
         $this->documentManager->persist($document, $locale, $persistOptions);
-        if ($state == WorkflowStage::PUBLISHED) {
+        if (WorkflowStage::PUBLISHED == $state) {
             $this->documentManager->publish($document, $locale);
         }
         $this->documentManager->flush();

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
@@ -172,6 +172,7 @@ class TreeFullEditStrategyTest extends SuluTestCase
 
         $secret = $this->documentManager->find($secret->getUuid(), 'en');
         $this->assertEquals('/alphabet/secret', $secret->getResourceSegment());
+
         try {
             $this->resourceLocatorStrategy->loadByResourceLocator($secret->getResourceSegment(), 'sulu_io', 'en');
             $this->fail('resource locator found for unpublished page');

--- a/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
@@ -251,6 +251,7 @@ class TreeLeafEditStrategyTest extends SuluTestCase
 
         $secret = $this->documentManager->find($secret->getUuid(), 'en');
         $this->assertEquals('/alphabet/secret', $secret->getResourceSegment());
+
         try {
             $this->resourceLocatorStrategy->loadByResourceLocator($secret->getResourceSegment(), 'sulu_io', 'en');
             $this->fail('resource locator found for unpublished page');

--- a/src/Sulu/Component/Content/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
@@ -334,10 +334,10 @@ class SmartContentQueryBuilderTest extends SuluTestCase
         $t1 = 0;
         $t2 = 0;
         for ($i = 0; $i < $max; ++$i) {
-            if ($i % 3 === 2) {
+            if (2 === $i % 3) {
                 $tags = [$this->tag1->getName()];
                 ++$t1;
-            } elseif ($i % 3 === 1) {
+            } elseif (1 === $i % 3) {
                 $tags = [$this->tag1->getName(), $this->tag2->getName()];
                 ++$t1t2;
             } else {
@@ -1063,7 +1063,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $this->documentManager->persist($document, $locale);
         }
 
-        if ($state === WorkflowStage::PUBLISHED) {
+        if (WorkflowStage::PUBLISHED === $state) {
             $this->documentManager->publish($document, $locale);
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/StructureBridgeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/StructureBridgeTest.php
@@ -68,9 +68,9 @@ class StructureBridgeTest extends \PHPUnit_Framework_TestCase
             Argument::type(StructureBridge::class)
         )->will(
             function ($args) use ($title, $images) {
-                if ($args[0]->getName() === 'title') {
+                if ('title' === $args[0]->getName()) {
                     return $title->reveal();
-                } elseif ($args[0]->getName() === 'images') {
+                } elseif ('images' === $args[0]->getName()) {
                     return $images->reveal();
                 }
             }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/FallbackLocalizationSubscriberTest.php
@@ -24,6 +24,7 @@ use Sulu\Component\Webspace\Webspace;
 class FallbackLocalizationSubscriberTest extends SubscriberTestCase
 {
     const FIX_LOCALE = 'en';
+
     const FIX_WEBSPACE = 'sulu_io';
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/RouteSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/RouteSubscriberTest.php
@@ -41,6 +41,7 @@ class RouteSubscriberTest extends \PHPUnit_Framework_TestCase
      * @var SessionManagerInterface
      */
     private $sessionManager;
+
     /**
      * @var RouteSubscriber
      */

--- a/src/Sulu/Component/Content/Tests/Unit/Form/DataTransformer/DocumentToUuidTransformerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Form/DataTransformer/DocumentToUuidTransformerTest.php
@@ -18,7 +18,9 @@ use Sulu\Component\DocumentManager\DocumentManager;
 class DocumentToUuidTransformerTest extends \PHPUnit_Framework_TestCase
 {
     private $documentManager;
+
     private $node;
+
     private $document;
 
     public function setUp()

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/ContentDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/ContentDataProviderTest.php
@@ -39,7 +39,7 @@ class ContentDataProviderTest extends \PHPUnit_Framework_TestCase
     {
         $mock = $this->prophesize(ContentQueryBuilderInterface::class);
 
-        if ($initValue !== null) {
+        if (null !== $initValue) {
             $mock->init($initValue)->shouldBeCalled();
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/TextEditorTest.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Types\TextEditor;
 class TextEditorTest extends \PHPUnit_Framework_TestCase
 {
     const VALIDATE_REMOVED = 'removed';
+
     const VALIDATE_UNPUBLISHED = 'unpublished';
 
     /**

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Mapper/PhpcrMapper.php
@@ -127,7 +127,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
             $segmentKey
         );
 
-        if ($result !== null) {
+        if (null !== $result) {
             return $result;
         }
 
@@ -269,7 +269,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
                 $this->getWebspaceRouteNodeBasePath($webspaceKey, $languageCode, $segmentKey),
                 $resourceLocator
             );
-            if ($resourceLocator !== '') {
+            if ('' !== $resourceLocator) {
                 // get requested resource locator route node
                 $route = $this->sessionManager->getSession()->getNode($path);
             } else {
@@ -344,7 +344,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
      */
     public function deleteByPath($path, $webspaceKey, $languageCode, $segmentKey = null)
     {
-        if (!is_string($path) || trim($path, '/') == '') {
+        if (!is_string($path) || '' == trim($path, '/')) {
             throw new \InvalidArgumentException(
                 sprintf('The path to delete must be a non-empty string, "%s" given.', $path)
             );
@@ -431,7 +431,7 @@ class PhpcrMapper implements ResourceLocatorMapperInterface
     {
         $basePath = $this->getWebspaceRouteNodeBasePath($webspaceKey, $languageCode, $segmentKey);
 
-        return '/' . ltrim($basePath, '/') . ($relPath !== '' ? '/' . ltrim($relPath, '/') : '');
+        return '/' . ltrim($basePath, '/') . ('' !== $relPath ? '/' . ltrim($relPath, '/') : '');
     }
 
     /**

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
@@ -234,7 +234,7 @@ abstract class ResourceLocatorStrategy implements ResourceLocatorStrategyInterfa
      */
     public function isValid($path, $webspaceKey, $languageCode, $segmentKey = null)
     {
-        return $path !== '/' && $this->cleaner->validate($path);
+        return '/' !== $path && $this->cleaner->validate($path);
     }
 
     /**

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategyInterface.php
@@ -20,6 +20,7 @@ use Sulu\Component\Content\Types\ResourceLocator\ResourceLocatorInformation;
 interface ResourceLocatorStrategyInterface
 {
     const INPUT_TYPE_LEAF = 'leaf';
+
     const INPUT_TYPE_FULL = 'full';
 
     /**

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeGenerator.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeGenerator.php
@@ -22,7 +22,7 @@ class TreeGenerator implements ResourceLocatorGeneratorInterface
     public function generate($title, $parentPath = null)
     {
         // if parent has no resource create a new tree
-        if ($parentPath == null) {
+        if (null == $parentPath) {
             return '/' . $title;
         }
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeLeafEditStrategy.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/TreeLeafEditStrategy.php
@@ -30,7 +30,7 @@ class TreeLeafEditStrategy extends ResourceLocatorStrategy implements ResourceLo
     {
         $divider = strrpos($resourceSegment, '/');
 
-        if ($divider === false) {
+        if (false === $divider) {
             return $resourceSegment;
         }
 
@@ -81,6 +81,7 @@ class TreeLeafEditStrategy extends ResourceLocatorStrategy implements ResourceLo
                 || !($currentResourceLocator = $childDocument->getResourceSegment())
             ) {
                 $this->adaptResourceLocators($childDocument, $userId);
+
                 continue;
             }
 

--- a/src/Sulu/Component/Content/Types/TextEditor.php
+++ b/src/Sulu/Component/Content/Types/TextEditor.php
@@ -71,7 +71,7 @@ class TextEditor extends SimpleContentType
         $segmentKey
     ) {
         $value = $property->getValue();
-        if ($value !== null) {
+        if (null !== $value) {
             $node->setProperty($property->getName(),
                 $this->removeValidation(
                     $this->removeIllegalCharacters($value)

--- a/src/Sulu/Component/CustomUrl/Generator/Generator.php
+++ b/src/Sulu/Component/CustomUrl/Generator/Generator.php
@@ -20,6 +20,7 @@ use Sulu\Component\Webspace\Url\ReplacerInterface;
 class Generator implements GeneratorInterface
 {
     const PREFIX_REGEX = '/^([^\/]*)(\*)(.*)$/';
+
     const POSTFIX_REGEX = '/^.*\/.*\*.*$/';
 
     /**

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -127,7 +127,7 @@ class CustomUrlManager implements CustomUrlManagerInterface
     {
         $routeDocument = $this->findRouteByUrl($url, $webspaceKey, $locale);
 
-        if ($routeDocument === null) {
+        if (null === $routeDocument) {
             return;
         }
 
@@ -290,7 +290,7 @@ class CustomUrlManager implements CustomUrlManagerInterface
             }
 
             $value = $data[$fieldName];
-            if (array_key_exists('type', $mapping) && $mapping['type'] === 'reference') {
+            if (array_key_exists('type', $mapping) && 'reference' === $mapping['type']) {
                 $value = $this->documentManager->find($value['uuid'], $locale, ['load_ghost_content' => true]);
             }
 

--- a/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
+++ b/src/Sulu/Component/CustomUrl/Routing/CustomUrlRouteProvider.php
@@ -80,11 +80,11 @@ class CustomUrlRouteProvider implements RouteProviderInterface
             $customUrlDocument = $routeDocument->getTargetDocument();
         }
 
-        if ($customUrlDocument === null
-            || $customUrlDocument->isPublished() === false
+        if (null === $customUrlDocument
+            || false === $customUrlDocument->isPublished()
             || (
-                $customUrlDocument->getTargetDocument() !== null
-                && $customUrlDocument->getTargetDocument()->getWorkflowStage() !== WorkflowStage::PUBLISHED
+                null !== $customUrlDocument->getTargetDocument()
+                && WorkflowStage::PUBLISHED !== $customUrlDocument->getTargetDocument()->getWorkflowStage()
             )
         ) {
             return $collection;

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/AbstractEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/AbstractEnhancer.php
@@ -26,7 +26,7 @@ abstract class AbstractEnhancer implements RouteEnhancerInterface
      */
     public function enhance(array $defaults, Request $request)
     {
-        if ((array_key_exists('_finalized', $defaults) && $defaults['_finalized'] === true)
+        if ((array_key_exists('_finalized', $defaults) && true === $defaults['_finalized'])
             || !$this->supports($defaults['_custom_url'])
         ) {
             return $defaults;

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/ContentEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/ContentEnhancer.php
@@ -57,7 +57,7 @@ class ContentEnhancer extends AbstractEnhancer
      */
     protected function supports(CustomUrlBehavior $customUrl)
     {
-        return !$customUrl->isRedirect() && $customUrl->getTargetDocument() !== null;
+        return !$customUrl->isRedirect() && null !== $customUrl->getTargetDocument();
     }
 
     /**

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/ExternalLinkEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/ExternalLinkEnhancer.php
@@ -27,7 +27,7 @@ class ExternalLinkEnhancer implements RouteEnhancerInterface
     public function enhance(array $defaults, Request $request)
     {
         if (!array_key_exists('_structure', $defaults)
-            || $defaults['_structure']->getNodeType() !== Structure::NODE_TYPE_EXTERNAL_LINK
+            || Structure::NODE_TYPE_EXTERNAL_LINK !== $defaults['_structure']->getNodeType()
         ) {
             return $defaults;
         }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/InternalLinkEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/InternalLinkEnhancer.php
@@ -27,7 +27,7 @@ class InternalLinkEnhancer implements RouteEnhancerInterface
     public function enhance(array $defaults, Request $request)
     {
         if (!array_key_exists('_structure', $defaults)
-            || $defaults['_structure']->getNodeType() !== Structure::NODE_TYPE_INTERNAL_LINK
+            || Structure::NODE_TYPE_INTERNAL_LINK !== $defaults['_structure']->getNodeType()
         ) {
             return $defaults;
         }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
@@ -41,7 +41,7 @@ class RedirectEnhancer extends AbstractEnhancer
         Request $request
     ) {
         $resourceSegment = '/';
-        if ($customUrl->getTargetDocument() !== null) {
+        if (null !== $customUrl->getTargetDocument()) {
             $resourceSegment = $customUrl->getTargetDocument()->getResourceSegment();
         }
 
@@ -63,6 +63,6 @@ class RedirectEnhancer extends AbstractEnhancer
      */
     protected function supports(CustomUrlBehavior $customUrl)
     {
-        return $customUrl->isRedirect() || $customUrl->getTargetDocument() === null;
+        return $customUrl->isRedirect() || null === $customUrl->getTargetDocument();
     }
 }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/SeoEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/SeoEnhancer.php
@@ -63,6 +63,6 @@ class SeoEnhancer extends AbstractEnhancer
      */
     protected function supports(CustomUrlBehavior $customUrl)
     {
-        return $customUrl->getTargetDocument() !== null;
+        return null !== $customUrl->getTargetDocument();
     }
 }

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingHTMLEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingHTMLEnhancer.php
@@ -29,7 +29,7 @@ class TrailingHTMLEnhancer extends AbstractEnhancer
         array $defaults,
         Request $request
     ) {
-        if (substr($request->getRequestUri(), -5, 5) !== '.html') {
+        if ('.html' !== substr($request->getRequestUri(), -5, 5)) {
             return [];
         }
 

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingSlashEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/TrailingSlashEnhancer.php
@@ -29,7 +29,7 @@ class TrailingSlashEnhancer extends AbstractEnhancer
         array $defaults,
         Request $request
     ) {
-        if ($request->getRequestUri() === '/' || substr($request->getRequestUri(), -1, 1) !== '/') {
+        if ('/' === $request->getRequestUri() || '/' !== substr($request->getRequestUri(), -1, 1)) {
             return [];
         }
 

--- a/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
@@ -146,7 +146,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = new Generator(new Replacer());
         $result = $generator->generate($baseDomain, $domainParts, $locales);
 
-        if ($expected === null) {
+        if (null === $expected) {
             return;
         }
 

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/RouteProviderTest.php
@@ -114,7 +114,7 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $collection = $provider->getRouteCollectionForRequest($request->reveal());
 
-        if (!$exists || !$published || $workflowStage === WorkflowStage::TEST) {
+        if (!$exists || !$published || WorkflowStage::TEST === $workflowStage) {
             $this->assertCount(0, $collection);
 
             return;

--- a/src/Sulu/Component/Hash/RequestHashChecker.php
+++ b/src/Sulu/Component/Hash/RequestHashChecker.php
@@ -47,7 +47,7 @@ class RequestHashChecker implements RequestHashCheckerInterface
     public function checkHash(Request $request, $object, $identifier)
     {
         if (!$request->request->has($this->hashParameter)
-            || $request->query->get('force', false) === 'true'
+            || 'true' === $request->query->get('force', false)
             || $request->request->get($this->hashParameter) == $this->hasher->hash($object)
         ) {
             return true;

--- a/src/Sulu/Component/HttpCache/EventSubscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Component/HttpCache/EventSubscriber/InvalidationSubscriber.php
@@ -239,6 +239,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
 
         // get current resource-locator and history resource-locators
         $resourceLocators = [];
+
         try {
             $resourceLocators[] = $resourceLocatorStrategy->loadByContentUuid($uuid, $webspace, $locale);
         } catch (ResourceLocatorNotFoundException $e) {

--- a/src/Sulu/Component/HttpCache/Handler/DebugHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/DebugHandler.php
@@ -24,9 +24,13 @@ use Symfony\Component\HttpFoundation\Response;
 class DebugHandler implements HandlerUpdateResponseInterface
 {
     const HEADER_HANDLERS = 'X-Sulu-Handlers';
+
     const HEADER_CLIENT_NAME = 'X-Sulu-Proxy-Client';
+
     const HEADER_STRUCTURE_TYPE = 'X-Sulu-Structure-Type';
+
     const HEADER_STRUCTURE_UUID = 'X-Sulu-Structure-UUID';
+
     const HEADER_STRUCTURE_TTL = 'X-Sulu-Page-TTL';
 
     /**

--- a/src/Sulu/Component/HttpCache/Tests/Unit/EventSubscriber/UpdateResponseSubscriberTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/EventSubscriber/UpdateResponseSubscriberTest.php
@@ -18,7 +18,6 @@ use Sulu\Component\HttpCache\HandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class UpdateResponseSubscriberTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Sulu/Component/HttpCache/Tests/Unit/Handler/AggregateHandlerTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/Handler/AggregateHandlerTest.php
@@ -22,6 +22,7 @@ class AggregateHandlerTest extends \PHPUnit_Framework_TestCase
      * @var HandlerInterface
      */
     private $handler;
+
     /**
      * @var HandlerInterface
      */

--- a/src/Sulu/Component/Import/Format/Xliff12.php
+++ b/src/Sulu/Component/Import/Format/Xliff12.php
@@ -155,13 +155,14 @@ class Xliff12 implements FormatImportInterface
             $name = (string) $attributes['resname'];
             $value = $this->utf8ToCharset((string) $translation->target, $encoding);
 
-            if (strpos($name, '#') === false) {
+            if (false === strpos($name, '#')) {
                 $property = [
                     'name' => $name,
                     'value' => $value,
                 ];
 
                 $data[$name] = $property;
+
                 continue;
             }
 

--- a/src/Sulu/Component/Import/Import.php
+++ b/src/Sulu/Component/Import/Import.php
@@ -15,7 +15,6 @@ use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Import\Exception\FormatImporterNotFoundException;
-use Sulu\Component\Import\Manager\ImportManager;
 use Sulu\Component\Import\Manager\ImportManagerInterface;
 
 /**
@@ -43,9 +42,6 @@ class Import
      */
     protected $exceptionStore = [];
 
-    /**
-     * {@inheritdoc}
-     */
     public function add($service, $format)
     {
         $this->formatFilePaths[$format] = $service;

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -20,8 +20,11 @@ use Sulu\Component\Util\ArrayableInterface;
 class Localization implements \JsonSerializable, ArrayableInterface
 {
     const UNDERSCORE = 'de_at';
+
     const DASH = 'de-at';
+
     const ISO6391 = 'de-AT';
+
     const LCID = 'de_AT';
 
     /**
@@ -171,7 +174,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @param Localization $child
      */
-    public function addChild(Localization $child)
+    public function addChild(self $child)
     {
         $this->children[] = $child;
     }
@@ -208,10 +211,10 @@ class Localization implements \JsonSerializable, ArrayableInterface
      */
     public function getLocalization($delimiter = '_')
     {
-        @trigger_error(__method__ . '() is deprecated since version 1.2 and will be removed in 2.0. Use getLocale() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated since version 1.2 and will be removed in 2.0. Use getLocale() instead.', E_USER_DEPRECATED);
 
         $localization = $this->getLanguage();
-        if ($this->getCountry() != null) {
+        if (null != $this->getCountry()) {
             $localization .= $delimiter . $this->getCountry();
         }
 
@@ -258,7 +261,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
      *
      * @param Localization $parent
      */
-    public function setParent(Localization $parent)
+    public function setParent(self $parent)
     {
         $this->parent = $parent;
     }
@@ -345,7 +348,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
     public function getAllLocalizations()
     {
         $localizations = [];
-        if ($this->getChildren() !== null && count($this->getChildren()) > 0) {
+        if (null !== $this->getChildren() && count($this->getChildren()) > 0) {
             foreach ($this->getChildren() as $child) {
                 $localizations[] = $child;
                 $localizations = array_merge($localizations, $child->getAllLocalizations());

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -86,7 +86,7 @@ class MediaDataProvider extends BaseDataProvider
             return;
         }
 
-        if ($datasource === 'root') {
+        if ('root' === $datasource) {
             $title = 'smart-content.media.all-collections';
 
             return new DatasourceItem('root', $title, $title);

--- a/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
+++ b/src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
@@ -134,7 +134,7 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
      */
     private function getUserId()
     {
-        if (!$this->tokenProvider || ($token = $this->tokenProvider->getToken()) === null) {
+        if (!$this->tokenProvider || null === ($token = $this->tokenProvider->getToken())) {
             return;
         }
 
@@ -177,7 +177,7 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
      */
     private function iterateOverCollections($children, $userId, $parent = null, $namespace = '')
     {
-        $format = ($namespace !== '' ? '%s.%s' : '%s%s');
+        $format = ('' !== $namespace ? '%s.%s' : '%s%s');
         $collections = [];
         foreach ($children as $collectionKey => $collectionItem) {
             $key = sprintf($format, $namespace, $collectionKey);
@@ -215,7 +215,7 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
      */
     private function getOrCreateRoot($namespace, $title, $locale, $userId, $parent = null)
     {
-        if (($collection = $this->collectionManager->getByKey($namespace, $locale)) !== null) {
+        if (null !== ($collection = $this->collectionManager->getByKey($namespace, $locale))) {
             $collection->setTitle($title);
 
             return $collection;
@@ -240,7 +240,7 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
         $firstLocale = array_shift($locales);
 
         $collection = $this->collectionManager->getByKey($key, $firstLocale);
-        if ($collection === null) {
+        if (null === $collection) {
             $collection = $this->createCollection($localizedTitles[$firstLocale], $key, $firstLocale, $userId, $parent);
         } else {
             $collection->setTitle($localizedTitles[$firstLocale]);
@@ -274,11 +274,11 @@ class SystemCollectionManager implements SystemCollectionManagerInterface
             'locale' => $locale,
         ];
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $data['parent'] = $parent;
         }
 
-        if ($id !== null) {
+        if (null !== $id) {
             $data['id'] = $id;
         }
 

--- a/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SystemCollections/SystemCollectionManagerTest.php
@@ -392,7 +392,7 @@ class SystemCollectionManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetSystemCollection($data, $key, $expected, $exception = null)
     {
-        if ($exception !== null) {
+        if (null !== $exception) {
             $this->setExpectedException($exception);
         }
 
@@ -414,7 +414,7 @@ class SystemCollectionManagerTest extends \PHPUnit_Framework_TestCase
         );
         $result = $manager->getSystemCollection($key);
 
-        if ($exception === null) {
+        if (null === $exception) {
             $this->assertEquals($expected, $result);
         }
     }
@@ -510,7 +510,7 @@ class SystemCollectionManagerTest extends \PHPUnit_Framework_TestCase
             'locale' => $locale,
         ];
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $data['parent'] = $parent;
         }
 
@@ -536,7 +536,7 @@ class SystemCollectionManagerTest extends \PHPUnit_Framework_TestCase
             'locale' => $locale,
         ];
 
-        if ($parent !== null) {
+        if (null !== $parent) {
             $data['parent'] = $parent;
         }
 

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -57,7 +57,7 @@ class PathCleanup implements PathCleanupInterface
     {
         $replacers = $this->replacers['default'];
 
-        if ($languageCode !== null) {
+        if (null !== $languageCode) {
             $replacers = array_merge(
                 $replacers,
                 (isset($this->replacers[$languageCode]) ? $this->replacers[$languageCode] : [])
@@ -101,6 +101,6 @@ class PathCleanup implements PathCleanupInterface
      */
     public function validate($path)
     {
-        return $path === '/' || preg_match($this->pattern, $path) === 1;
+        return '/' === $path || 1 === preg_match($this->pattern, $path);
     }
 }

--- a/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
+++ b/src/Sulu/Component/PHPCR/SessionManager/SessionManager.php
@@ -58,7 +58,7 @@ class SessionManager implements SessionManagerInterface
             $webspaceKey,
             $this->nodeNames['route'],
             $languageCode,
-            ($segment !== null ? '/' . $segment : '')
+            (null !== $segment ? '/' . $segment : '')
         );
 
         return $path;

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -24,6 +24,7 @@ use Sulu\Component\Persistence\Model\TimestampableInterface;
 class TimestampableSubscriber implements EventSubscriber
 {
     const CREATED_FIELD = 'created';
+
     const CHANGED_FIELD = 'changed';
 
     /**
@@ -49,7 +50,7 @@ class TimestampableSubscriber implements EventSubscriber
         $metadata = $event->getClassMetadata();
         $reflection = $metadata->getReflectionClass();
 
-        if ($reflection !== null && $reflection->implementsInterface('Sulu\Component\Persistence\Model\TimestampableInterface')) {
+        if (null !== $reflection && $reflection->implementsInterface('Sulu\Component\Persistence\Model\TimestampableInterface')) {
             if (!$metadata->hasField(self::CREATED_FIELD)) {
                 $metadata->mapField([
                     'fieldName' => self::CREATED_FIELD,

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -30,6 +30,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 class UserBlameSubscriber implements EventSubscriber
 {
     const CHANGER_FIELD = 'changer';
+
     const CREATOR_FIELD = 'creator';
 
     /**
@@ -75,7 +76,7 @@ class UserBlameSubscriber implements EventSubscriber
         $metadata = $event->getClassMetadata();
         $reflection = $metadata->getReflectionClass();
 
-        if ($reflection !== null && $reflection->implementsInterface('Sulu\Component\Persistence\Model\UserBlameInterface')) {
+        if (null !== $reflection && $reflection->implementsInterface('Sulu\Component\Persistence\Model\UserBlameInterface')) {
             if (!$metadata->hasAssociation(self::CREATOR_FIELD)) {
                 $metadata->mapManyToOne([
                     'fieldName' => self::CREATOR_FIELD,

--- a/src/Sulu/Component/Persistence/RelationTrait.php
+++ b/src/Sulu/Component/Persistence/RelationTrait.php
@@ -134,10 +134,10 @@ trait RelationTrait
                 // find match callback
                 $compare($entity, $requestEntities, $matchedEntry, $matchedKey);
 
-                if ($matchedEntry == null && $delete != null) {
+                if (null == $matchedEntry && null != $delete) {
                     // delete entity if it is not listed anymore
                     $delete($entity);
-                } elseif ($update != null) {
+                } elseif (null != $update) {
                     // update entity if it is matched
                     $success = $update($entity, $matchedEntry);
                     if (!$success) {
@@ -146,14 +146,14 @@ trait RelationTrait
                 }
 
                 // Remove done element from array
-                if ($matchedKey !== null) {
+                if (null !== $matchedKey) {
                     unset($requestEntities[$matchedKey]);
                 }
             }
         }
 
         // The entity which have not been delete or updated have to be added
-        if (!empty($requestEntities) && $add != null) {
+        if (!empty($requestEntities) && null != $add) {
             foreach ($requestEntities as $entity) {
                 if (!$success) {
                     break;

--- a/src/Sulu/Component/Persistence/Repository/ORM/OrderByTrait.php
+++ b/src/Sulu/Component/Persistence/Repository/ORM/OrderByTrait.php
@@ -28,7 +28,7 @@ trait OrderByTrait
     {
         foreach ($sortBy as $field => $order) {
             // if no relation is defined add alias by default
-            if (strpos($field, '.') === false) {
+            if (false === strpos($field, '.')) {
                 $field = $alias . '.' . $field;
             }
 

--- a/src/Sulu/Component/Rest/DQL/Cast.php
+++ b/src/Sulu/Component/Rest/DQL/Cast.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Query\Lexer;
 class Cast extends FunctionNode
 {
     public $firstDateExpression = null;
+
     public $unit = null;
 
     public function parse(\Doctrine\ORM\Query\Parser $parser)

--- a/src/Sulu/Component/Rest/Exception/InvalidArgumentException.php
+++ b/src/Sulu/Component/Rest/Exception/InvalidArgumentException.php
@@ -40,7 +40,7 @@ class InvalidArgumentException extends RestException
         $this->entity = $entity;
         $this->argument = $argument;
         $message = 'The "' . $entity . '"-entity requires a valid "' . $argument . '"-argument. ';
-        if ($customMessage != null) {
+        if (null != $customMessage) {
             $message .= $customMessage;
         }
         parent::__construct($message, 0);

--- a/src/Sulu/Component/Rest/Exception/MissingParameterChoiceException.php
+++ b/src/Sulu/Component/Rest/Exception/MissingParameterChoiceException.php
@@ -20,6 +20,7 @@ class MissingParameterChoiceException extends RestException
      * @var string
      */
     private $names;
+
     /**
      * @var string
      */

--- a/src/Sulu/Component/Rest/Exception/MissingParameterException.php
+++ b/src/Sulu/Component/Rest/Exception/MissingParameterException.php
@@ -20,6 +20,7 @@ class MissingParameterException extends RestException
      * @var string
      */
     private $name;
+
     /**
      * @var string
      */

--- a/src/Sulu/Component/Rest/Exception/ParameterDataTypeException.php
+++ b/src/Sulu/Component/Rest/Exception/ParameterDataTypeException.php
@@ -20,6 +20,7 @@ class ParameterDataTypeException extends RestException
      * @var string
      */
     private $name;
+
     /**
      * @var string
      */

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -112,7 +112,7 @@ abstract class AbstractListBuilder implements ListBuilderInterface
                 /** @var PropertyMetadata $propertyMetadata */
                 $propertyMetadata = $fieldDescriptor->getMetadata()->get(PropertyMetadata::class);
 
-                return $propertyMetadata->getDisplay() !== PropertyMetadata::DISPLAY_NEVER;
+                return PropertyMetadata::DISPLAY_NEVER !== $propertyMetadata->getDisplay();
             }
         );
     }
@@ -218,7 +218,7 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     {
         $existingIndex = $this->retrieveIndexOfFieldDescriptor($fieldDescriptor, $this->sortFields);
 
-        if ($existingIndex !== false) {
+        if (false !== $existingIndex) {
             $this->sortOrders[$existingIndex] = $order;
         } else {
             // Else add to list of sort-fields.

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -127,7 +127,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         $numResults = count($result);
         if ($numResults > 1) {
             return $numResults;
-        } elseif ($numResults == 1) {
+        } elseif (1 == $numResults) {
             $result = array_values($result[0]);
 
             return (int) $result[0];
@@ -190,7 +190,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         $select = $this->getSelectAs($this->idField);
 
         $subQueryBuilder = $this->createSubQueryBuilder($select);
-        if ($this->limit != null) {
+        if (null != $this->limit) {
             $subQueryBuilder->setMaxResults($this->limit)->setFirstResult($this->limit * ($this->page - 1));
         }
 
@@ -226,7 +226,7 @@ class DoctrineListBuilder extends AbstractListBuilder
     protected function assignSortFields($queryBuilder)
     {
         // if no sort has been assigned add order by id ASC as default
-        if (count($this->sortFields) === 0) {
+        if (0 === count($this->sortFields)) {
             $queryBuilder->addOrderBy($this->idField->getSelect(), 'ASC');
         }
 
@@ -299,7 +299,7 @@ class DoctrineListBuilder extends AbstractListBuilder
             $this->getUniqueExpressionFieldDescriptors($this->expressions)
         );
 
-        if ($onlyReturnFilterFields !== true) {
+        if (true !== $onlyReturnFilterFields) {
             $fields = array_merge($fields, $this->selectFields);
         }
 
@@ -359,15 +359,15 @@ class DoctrineListBuilder extends AbstractListBuilder
         foreach ($this->getAllFields() as $key => $field) {
             // if field is in any conditional clause -> add join
             if (($field instanceof DoctrineFieldDescriptor || $field instanceof DoctrineJoinDescriptor) &&
-                array_search($field->getEntityName(), $necessaryEntityNames) !== false
+                false !== array_search($field->getEntityName(), $necessaryEntityNames)
                 && $field->getEntityName() !== $this->entityName
             ) {
                 $addJoins = array_merge($addJoins, $field->getJoins());
             } else {
                 // include inner joins
                 foreach ($field->getJoins() as $entityName => $join) {
-                    if ($join->getJoinMethod() !== DoctrineJoinDescriptor::JOIN_METHOD_INNER &&
-                        array_search($entityName, $necessaryEntityNames) === false
+                    if (DoctrineJoinDescriptor::JOIN_METHOD_INNER !== $join->getJoinMethod() &&
+                        false === array_search($entityName, $necessaryEntityNames)
                     ) {
                         break;
                     }
@@ -438,7 +438,7 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         $this->assignGroupBy($this->queryBuilder);
 
-        if ($this->search !== null) {
+        if (null !== $this->search) {
             $searchParts = [];
             foreach ($this->searchFields as $searchField) {
                 $searchParts[] = $searchField->getSearch();
@@ -459,7 +459,7 @@ class DoctrineListBuilder extends AbstractListBuilder
      */
     protected function assignJoins(QueryBuilder $queryBuilder, array $joins = null)
     {
-        if ($joins === null) {
+        if (null === $joins) {
             $joins = $this->getJoins();
         }
 
@@ -550,7 +550,7 @@ class DoctrineListBuilder extends AbstractListBuilder
      */
     protected function getUniqueExpressionFieldDescriptors(array $expressions)
     {
-        if (count($this->expressionFields) === 0) {
+        if (0 === count($this->expressionFields)) {
             $descriptors = [];
             $uniqueNames = array_unique($this->getAllFieldNames($expressions));
             foreach ($uniqueNames as $uniqueName) {

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptor.php
@@ -24,6 +24,7 @@ class DoctrineCaseFieldDescriptor extends AbstractDoctrineFieldDescriptor
      * @var DoctrineDescriptor
      */
     private $case1;
+
     /**
      * @var DoctrineDescriptor
      */

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineConcatenationFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineConcatenationFieldDescriptor.php
@@ -58,7 +58,7 @@ class DoctrineConcatenationFieldDescriptor extends AbstractDoctrineFieldDescript
         $concat = null;
 
         foreach ($this->fieldDescriptors as $fieldDescriptor) {
-            if ($concat == null) {
+            if (null == $concat) {
                 $concat = $fieldDescriptor->getSelect();
             } else {
                 $concat = 'CONCAT(' . $concat . ', CONCAT(\'' . $this->glue . '\', ' . $fieldDescriptor->getSelect() . '))';

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
@@ -17,9 +17,11 @@ namespace Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor;
 class DoctrineJoinDescriptor
 {
     const JOIN_METHOD_LEFT = 'LEFT';
+
     const JOIN_METHOD_INNER = 'INNER';
 
     const JOIN_CONDITION_METHOD_ON = 'ON';
+
     const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineInExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineInExpression.php
@@ -81,7 +81,7 @@ class DoctrineInExpression extends AbstractDoctrineExpression implements InExpre
         $result = array_filter(
             $values,
             function ($val) {
-                return $val || $val === 0 || $val === false;
+                return $val || 0 === $val || false === $val;
             }
         );
 

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineWhereExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineWhereExpression.php
@@ -59,9 +59,9 @@ class DoctrineWhereExpression extends AbstractDoctrineExpression implements Wher
     {
         $paramName = $this->getFieldName() . $this->getUniqueId();
 
-        if ($this->getValue() === null) {
+        if (null === $this->getValue()) {
             return $this->field->getSelect() . ' ' . $this->convertNullComparator($this->getComparator());
-        } elseif ($this->getComparator() === 'LIKE') {
+        } elseif ('LIKE' === $this->getComparator()) {
             $queryBuilder->setParameter($paramName, '%' . $this->getValue() . '%');
         } elseif (in_array($this->getComparator(), ['and', 'or']) && is_array($this->getValue())) {
             $statement = [];

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Exception/InvalidExpressionArgumentException.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Exception/InvalidExpressionArgumentException.php
@@ -40,7 +40,7 @@ class InvalidExpressionArgumentException extends ExpressionException
         $this->expression = $expression;
         $this->argument = $argument;
         $message = 'The "' . $expression . '"-expression requires a valid "' . $argument . '"-argument';
-        if ($customMessage != null) {
+        if (null != $customMessage) {
             $message .= $customMessage;
         }
         parent::__construct($message, 0);

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptor.php
@@ -126,7 +126,7 @@ class FieldDescriptor implements FieldDescriptorInterface
         $this->width = $width;
         $this->minWidth = $minWidth;
         $this->editable = $editable;
-        $this->translation = $translation == null ? $name : $translation;
+        $this->translation = null == $translation ? $name : $translation;
         $this->class = $cssClass;
     }
 

--- a/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/FieldDescriptorInterface.php
@@ -90,5 +90,5 @@ interface FieldDescriptorInterface
      *
      * @return bool
      */
-    public function compare(FieldDescriptorInterface $other);
+    public function compare(self $other);
 }

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -78,7 +78,7 @@ class ListRestHelper implements ListRestHelperInterface
     public function getLimit()
     {
         $default = 10;
-        if ($this->getRequest()->getRequestFormat() === 'csv') {
+        if ('csv' === $this->getRequest()->getRequestFormat()) {
             $default = null;
         }
 
@@ -96,7 +96,7 @@ class ListRestHelper implements ListRestHelperInterface
         $page = $this->getRequest()->get('page', 1);
         $limit = $this->getLimit();
 
-        return ($limit != null) ? $limit * ($page - 1) : null;
+        return (null != $limit) ? $limit * ($page - 1) : null;
     }
 
     /**
@@ -119,7 +119,7 @@ class ListRestHelper implements ListRestHelperInterface
     {
         $fields = $this->getRequest()->get('fields');
 
-        return ($fields != null) ? explode(',', $fields) : null;
+        return (null != $fields) ? explode(',', $fields) : null;
     }
 
     /**
@@ -141,6 +141,6 @@ class ListRestHelper implements ListRestHelperInterface
     {
         $searchFields = $this->getRequest()->get('searchFields');
 
-        return ($searchFields != null) ? explode(',', $searchFields) : [];
+        return (null != $searchFields) ? explode(',', $searchFields) : [];
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/Driver/XmlDriver.php
@@ -246,7 +246,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
         if (null !== $reference = XmlUtil::getValueFromXPath('@property-ref', $xpath, $fieldNode)) {
             $nodeList = $xpath->query(sprintf('/x:class/x:properties/x:*[@name="%s"]', $reference));
 
-            if ($nodeList->length === 0) {
+            if (0 === $nodeList->length) {
                 throw new \Exception(sprintf('Rest metadata doctrine field reference "%s" was not found.', $reference));
             }
 
@@ -283,7 +283,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
         if (null !== $reference = XmlUtil::getValueFromXPath('@ref', $xpath, $joinsNode)) {
             $nodeList = $xpath->query(sprintf('/x:class/orm:joins[@name="%s"]', $reference));
 
-            if ($nodeList->length === 0) {
+            if (0 === $nodeList->length) {
                 throw new \Exception(sprintf('Rest metadata doctrine joins reference "%s" was not found.', $reference));
             }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/JoinMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Doctrine/JoinMetadata.php
@@ -17,9 +17,11 @@ namespace Sulu\Component\Rest\ListBuilder\Metadata\Doctrine;
 class JoinMetadata
 {
     const JOIN_METHOD_LEFT = 'LEFT';
+
     const JOIN_METHOD_INNER = 'INNER';
 
     const JOIN_CONDITION_METHOD_ON = 'ON';
+
     const JOIN_CONDITION_METHOD_WITH = 'WITH';
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/General/PropertyMetadata.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/General/PropertyMetadata.php
@@ -19,8 +19,11 @@ use Metadata\PropertyMetadata as BasePropertyMetadata;
 class PropertyMetadata extends BasePropertyMetadata
 {
     const DISPLAY_ALWAYS = 'always';
+
     const DISPLAY_NEVER = 'never';
+
     const DISPLAY_YES = 'yes';
+
     const DISPLAY_NO = 'no';
 
     /**

--- a/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
+++ b/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
@@ -176,7 +176,7 @@ class ListQueryBuilder
     {
         $selectFromDQL = $this->getSelectFrom($prefix);
         $whereDQL = $this->getWhere($prefix);
-        if ($this->countQuery != true) {
+        if (true != $this->countQuery) {
             $orderDQL = $this->getOrderBy($prefix);
         } else {
             $orderDQL = '';
@@ -209,21 +209,21 @@ class ListQueryBuilder
 
         // select and where fields
         $fieldsWhere = array_merge(
-            ($this->fields != null) ? $this->fields : [],
+            (null != $this->fields) ? $this->fields : [],
             array_keys($this->where)
         );
 
         $fieldsWhere = array_merge($fieldsWhere, $this->searchTextFields, $this->searchNumberFields);
 
-        if ($fieldsWhere != null && count($fieldsWhere) >= 0) {
+        if (null != $fieldsWhere && count($fieldsWhere) >= 0) {
             foreach ($fieldsWhere as $field) {
                 $this->performSelectFromField($field, $prefix);
             }
         }
         // if no field is selected take prefix
-        if ($this->countQuery === true) {
+        if (true === $this->countQuery) {
             $this->select = $this->replaceSelect;
-        } elseif (strlen($this->select) == 0) {
+        } elseif (0 == strlen($this->select)) {
             $this->select = $prefix;
         }
 
@@ -319,7 +319,7 @@ class ListQueryBuilder
         while ($i <= count($fieldParts) - 2) {
             if (!in_array($fieldParts[$i], $this->prefixes)) {
                 $result .= $this->generateJoin(
-                    ($i == 0) ? $prefix : $fieldParts[$i - 1],
+                    (0 == $i) ? $prefix : $fieldParts[$i - 1],
                     $fieldParts[$i],
                     $fieldParts[$i]
                 );
@@ -405,7 +405,7 @@ class ListQueryBuilder
             foreach ($fields as $key) {
                 $keys = explode('_', $key);
                 $prefixActual = $prefix;
-                if (count($keys) == 1) {
+                if (1 == count($keys)) {
                     $col = $keys[0];
                 } else {
                     $i = count($keys);
@@ -436,7 +436,7 @@ class ListQueryBuilder
             }
 
             if (!empty($searches)) {
-                if ($result != '') {
+                if ('' != $result) {
                     $result .= ' AND ';
                 }
                 $result .= '(' . implode(' OR ', $searches) . ')';
@@ -459,7 +459,7 @@ class ListQueryBuilder
     {
         $result = '';
         // If sorting is defined
-        if ($this->sorting != null && count($this->sorting) > 0) {
+        if (null != $this->sorting && count($this->sorting) > 0) {
             $orderBy = '';
             // TODO OrderBy relations translations_value
             foreach ($this->sorting as $col => $dir) {

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -54,7 +54,7 @@ class ListRepository extends EntityRepository
         $searchFields = $this->helper->getSearchFields();
 
         // if search string is set, but search fields are not, take all fields into account
-        if (!is_null($searchPattern) && $searchPattern != '' && (is_null($searchFields) || count($searchFields) == 0)) {
+        if (!is_null($searchPattern) && '' != $searchPattern && (is_null($searchFields) || 0 == count($searchFields))) {
             $searchFields = $this->getEntityManager()->getClassMetadata($this->getEntityName())->getFieldNames();
         }
 
@@ -90,7 +90,7 @@ class ListRepository extends EntityRepository
             $query->setFirstResult($this->helper->getOffset())
                 ->setMaxResults($this->helper->getLimit());
         }
-        if ($searchPattern != null && $searchPattern != '') {
+        if (null != $searchPattern && '' != $searchPattern) {
             if (count($searchFields) > 0) {
                 if (count($textFields) > 0) {
                     $query->setParameter('search', '%' . $searchPattern . '%');
@@ -113,7 +113,7 @@ class ListRepository extends EntityRepository
         if (count($filters = $queryBuilder->getRelationalFilters()) > 0) {
             $filteredResults = [];
             // check if fields do contain id, else skip
-            if (count($fields = $this->helper->getFields()) > 0 && array_search('id', $fields) !== false) {
+            if (count($fields = $this->helper->getFields()) > 0 && false !== array_search('id', $fields)) {
                 $ids = [];
                 foreach ($results as $result) {
                     $id = $result['id'];

--- a/src/Sulu/Component/Rest/Listing/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/Listing/ListRestHelper.php
@@ -128,7 +128,7 @@ class ListRestHelper
         $page = $this->getRequest()->get('page', 1);
         $limit = $this->getRequest()->get('limit');
 
-        return ($limit != null) ? $limit * ($page - 1) : null;
+        return (null != $limit) ? $limit * ($page - 1) : null;
     }
 
     /**
@@ -179,7 +179,7 @@ class ListRestHelper
     {
         $fields = $this->getRequest()->get('fields');
 
-        return ($fields != null) ? explode(',', $fields) : null;
+        return (null != $fields) ? explode(',', $fields) : null;
     }
 
     /**
@@ -201,7 +201,7 @@ class ListRestHelper
     {
         $searchFields = $this->getRequest()->get('searchFields');
 
-        return ($searchFields != null) ? explode(',', $searchFields) : [];
+        return (null != $searchFields) ? explode(',', $searchFields) : [];
     }
 
     /**

--- a/src/Sulu/Component/Rest/RequestParametersTrait.php
+++ b/src/Sulu/Component/Rest/RequestParametersTrait.php
@@ -35,7 +35,7 @@ trait RequestParametersTrait
     protected function getRequestParameter(Request $request, $name, $force = false, $default = null)
     {
         $value = $request->get($name, $default);
-        if ($force && $value === null) {
+        if ($force && null === $value) {
             throw new MissingParameterException(get_class($this), $name);
         }
 
@@ -58,11 +58,11 @@ trait RequestParametersTrait
     protected function getBooleanRequestParameter($request, $name, $force = false, $default = null)
     {
         $value = $this->getRequestParameter($request, $name, $force, $default);
-        if ($value === 'true' || $value === true) {
+        if ('true' === $value || true === $value) {
             $value = true;
-        } elseif ($value === 'false' || $value === false) {
+        } elseif ('false' === $value || false === $value) {
             $value = false;
-        } elseif ($force && $value !== true && $value !== false) {
+        } elseif ($force && true !== $value && false !== $value) {
             throw new ParameterDataTypeException(get_class($this), $name);
         } else {
             $value = $default;

--- a/src/Sulu/Component/Rest/RestController.php
+++ b/src/Sulu/Component/Rest/RestController.php
@@ -261,7 +261,7 @@ abstract class RestController extends FOSRestController
                 'disabled' => in_array($field, $fieldsHidden) ? true : false,
                 'default' => in_array($field, $this->fieldsDefault) ? true : null,
                 'editable' => in_array($field, $this->fieldsEditable) ? true : null,
-                'width' => ($fieldWidth != null) ? $fieldWidth : null,
+                'width' => (null != $fieldWidth) ? $fieldWidth : null,
                 'minWidth' => array_key_exists($field, $this->fieldsMinWidth) ? $this->fieldsMinWidth[$field] : null,
                 'type' => $type,
                 'validation' => array_key_exists($field, $this->fieldsValidation) ?
@@ -291,7 +291,7 @@ abstract class RestController extends FOSRestController
                 return preg_replace('/(.*' . $key . ')([\,|\w]*)(\&*.*)/', '${1}' . $value . '${3}', $url);
             } else {
                 if ($add) {
-                    $and = (strpos($url, '?') === false) ? '?' : '&';
+                    $and = (false === strpos($url, '?')) ? '?' : '&';
 
                     return $url . $and . $key . $value;
                 }
@@ -382,7 +382,7 @@ abstract class RestController extends FOSRestController
     {
         $success = true;
         // default for entityIdCallback
-        if ($entityIdCallback === null) {
+        if (null === $entityIdCallback) {
             $entityIdCallback = function ($entity) {
                 return $entity->getId();
             };
@@ -392,7 +392,7 @@ abstract class RestController extends FOSRestController
             foreach ($entities as $entity) {
                 $this->findMatch($requestEntities, $entityIdCallback($entity), $matchedEntry, $matchedKey);
 
-                if ($matchedEntry == null) {
+                if (null == $matchedEntry) {
                     // delete entity if it is not listed anymore
                     $deleteCallback($entity);
                 } else {
@@ -404,7 +404,7 @@ abstract class RestController extends FOSRestController
                 }
 
                 // Remove done element from array
-                if ($matchedKey !== null) {
+                if (null !== $matchedKey) {
                     unset($requestEntities[$matchedKey]);
                 }
             }

--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -42,7 +42,7 @@ class RestHelper implements RestHelperInterface
         $listBuilder->setFieldDescriptors($fieldDescriptors);
 
         $fields = $this->listRestHelper->getFields();
-        if ($fields != null) {
+        if (null != $fields) {
             foreach ($fields as $field) {
                 if (!array_key_exists($field, $fieldDescriptors)) {
                     continue;
@@ -55,7 +55,7 @@ class RestHelper implements RestHelperInterface
         }
 
         $searchFields = $this->listRestHelper->getSearchFields();
-        if ($searchFields != null) {
+        if (null != $searchFields) {
             foreach ($searchFields as $searchField) {
                 $listBuilder->addSearchField($fieldDescriptors[$searchField]);
             }
@@ -64,7 +64,7 @@ class RestHelper implements RestHelperInterface
         }
 
         $sortBy = $this->listRestHelper->getSortColumn();
-        if ($sortBy != null) {
+        if (null != $sortBy) {
             $listBuilder->sort($fieldDescriptors[$sortBy], $this->listRestHelper->getSortOrder());
         }
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -75,6 +75,7 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
     ];
 
     private static $entityName = 'SuluCoreBundle:Example';
+
     private static $translationEntityName = 'SuluCoreBundle:ExampleTranslation';
 
     public function setUp()

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -235,7 +235,7 @@ class AccessControlManager implements AccessControlManagerInterface
                 continue;
             }
 
-            $hasLocale = $locale == null || in_array($locale, $userRole->getLocales());
+            $hasLocale = null == $locale || in_array($locale, $userRole->getLocales());
 
             if (!$hasLocale) {
                 continue;

--- a/src/Sulu/Component/Security/Authorization/PermissionTypes.php
+++ b/src/Sulu/Component/Security/Authorization/PermissionTypes.php
@@ -17,10 +17,16 @@ namespace Sulu\Component\Security\Authorization;
 final class PermissionTypes
 {
     const VIEW = 'view';
+
     const ADD = 'add';
+
     const EDIT = 'edit';
+
     const DELETE = 'delete';
+
     const ARCHIVE = 'archive';
+
     const LIVE = 'live';
+
     const SECURITY = 'security';
 }

--- a/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
@@ -52,7 +52,7 @@ class SecurityContextVoter implements VoterInterface
      */
     public function supportsClass($class)
     {
-        return $class === SecurityCondition::class || is_subclass_of($class, SecurityCondition::class);
+        return SecurityCondition::class === $class || is_subclass_of($class, SecurityCondition::class);
     }
 
     /**

--- a/src/Sulu/Component/Security/Tests/Unit/Serializer/Subscriber/SecuredEntitySubscriberTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Serializer/Subscriber/SecuredEntitySubscriberTest.php
@@ -47,6 +47,7 @@ class SecuredEntitySubscriberTest extends \PHPUnit_Framework_TestCase
     /**
      * @var UserInterface
      */
+
     /**
      * @var ObjectEvent
      */

--- a/src/Sulu/Component/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Component/SmartContent/Configuration/ProviderConfiguration.php
@@ -63,7 +63,7 @@ class ProviderConfiguration implements ProviderConfigurationInterface
      */
     public function hasDatasource()
     {
-        return $this->datasource !== null && $this->datasource !== false;
+        return null !== $this->datasource && false !== $this->datasource;
     }
 
     /**

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -386,7 +386,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
      */
     private function getCurrentPage($pageParameter)
     {
-        if ($this->requestStack->getCurrentRequest() !== null) {
+        if (null !== $this->requestStack->getCurrentRequest()) {
             $page = $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
         } else {
             $page = 1;

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -143,7 +143,7 @@ abstract class BaseDataProvider implements DataProviderInterface
         $result = $this->repository->findByFilters($filters, $page, $pageSize, $limit, $locale, $options);
 
         $hasNextPage = false;
-        if ($pageSize !== null && count($result) > $pageSize) {
+        if (null !== $pageSize && count($result) > $pageSize) {
             $hasNextPage = true;
             $result = array_splice($result, 0, $pageSize);
         }

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -136,13 +136,13 @@ trait DataProviderRepositoryTrait
             $query->setParameter($name, $value);
         }
 
-        if ($page !== null && $pageSize > 0) {
+        if (null !== $page && $pageSize > 0) {
             $pageOffset = ($page - 1) * $pageSize;
             $restLimit = $limit - $pageOffset;
 
             // if limitation is smaller than the page size then use the rest limit else use page size plus 1 to
             // determine has next page
-            $maxResults = ($limit !== null && $pageSize > $restLimit ? $restLimit : ($pageSize + 1));
+            $maxResults = (null !== $limit && $pageSize > $restLimit ? $restLimit : ($pageSize + 1));
 
             if ($maxResults <= 0) {
                 return [];
@@ -150,7 +150,7 @@ trait DataProviderRepositoryTrait
 
             $query->setMaxResults($maxResults);
             $query->setFirstResult($pageOffset);
-        } elseif ($limit !== null) {
+        } elseif (null !== $limit) {
             $query->setMaxResults($limit);
         }
 
@@ -171,7 +171,7 @@ trait DataProviderRepositoryTrait
      */
     private function getBoolean($value)
     {
-        if ($value === true || $value === 'true') {
+        if (true === $value || 'true' === $value) {
             return true;
         } else {
             return false;

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\SmartContent\Tests\Unit;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
+use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Component\SmartContent\ContentType as SmartContent;
 use Sulu\Component\SmartContent\DataProviderInterface;
@@ -262,9 +263,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             true,
             ['getValue', 'getParams']
         );
-        $structure = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\StructureInterface'
-        );
+        $structure = $this->prophesize(StructureInterface::class);
 
         $config = ['dataSource' => 'some-uuid'];
         $parameter = ['max_per_page' => new PropertyParameter('max_per_page', '5')];
@@ -277,7 +276,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $property->expects($this->any())->method('getParams')
             ->will($this->returnValue($parameter));
         $property->expects($this->exactly(3))->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->will($this->returnValue($structure->reveal()));
 
         $this->contentDataProvider->resolveResourceItems(
             [
@@ -325,13 +324,15 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'max_per_page' => new PropertyParameter('max_per_page', '5'),
                 'deep_link' => new PropertyParameter('deep_link', ''),
             ],
-            ['webspaceKey' => null, 'locale' => null],
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de'],
             null,
             1,
             5
-        )->willReturn(new DataProviderResult([1, 2, 3, 4, 5, 6], true, [1, 2, 3, 4, 5, 6]));
+        )->willReturn(new DataProviderResult([1, 2, 3, 4, 5, 6], true));
 
-        $structure->expects($this->any())->method('getUuid')->will($this->returnValue('123-123-123'));
+        $structure->getUuid()->willReturn('123-123-123');
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
 
         $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'))
@@ -381,9 +382,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             true,
             ['getValue', 'getParams']
         );
-        $structure = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\StructureInterface'
-        );
+        $structure = $this->prophesize(StructureInterface::class);
 
         $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'))
@@ -395,7 +394,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $property->expects($this->any())->method('getParams')
             ->will($this->returnValue(['max_per_page' => new PropertyParameter('max_per_page', '5')]));
         $property->expects($this->exactly(3))->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->will($this->returnValue($structure->reveal()));
 
         $this->contentDataProvider->resolveResourceItems(
             [
@@ -441,13 +440,15 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'max_per_page' => new PropertyParameter('max_per_page', '5'),
                 'deep_link' => new PropertyParameter('deep_link', ''),
             ],
-            ['webspaceKey' => null, 'locale' => null],
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de'],
             null,
             1,
             5
-        )->willReturn(new DataProviderResult([1, 2, 3, 4, 5], true, [1, 2, 3, 4, 5]));
+        )->willReturn(new DataProviderResult([1, 2, 3, 4, 5], true));
 
-        $structure->expects($this->any())->method('getUuid')->will($this->returnValue('123-123-123'));
+        $structure->getUuid()->willReturn('123-123-123');
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
 
         $contentData = $this->smartContent->getContentData($property);
 
@@ -488,9 +489,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             true,
             ['getValue', 'getParams']
         );
-        $structure = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\StructureInterface'
-        );
+        $structure = $this->prophesize(StructureInterface::class);
 
         $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'))
@@ -543,20 +542,22 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'max_per_page' => new PropertyParameter('max_per_page', $pageSize),
                 'deep_link' => new PropertyParameter('deep_link', ''),
             ],
-            ['webspaceKey' => null, 'locale' => null],
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de'],
             $limitResult,
             $page,
             $pageSize
-        )->willReturn(new DataProviderResult($expectedData, $hasNextPage, $expectedData));
+        )->willReturn(new DataProviderResult($expectedData, $hasNextPage));
 
         $property->expects($this->exactly(1))->method('getValue')
             ->will($this->returnValue($config));
         $property->expects($this->any())->method('getParams')
             ->will($this->returnValue(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]));
         $property->expects($this->exactly(3))->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->will($this->returnValue($structure->reveal()));
 
-        $structure->expects($this->any())->method('getUuid')->will($this->returnValue($uuid));
+        $structure->getUuid()->willReturn($uuid);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
 
         $contentData = $this->smartContent->getContentData($property);
         $this->assertEquals($expectedData, $contentData);
@@ -582,9 +583,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             true,
             ['getValue', 'getParams']
         );
-        $structure = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\StructureInterface'
-        );
+        $structure = $this->prophesize(StructureInterface::class);
 
         $this->request->expects($this->at(0))->method('get')
             ->with($this->equalTo('p'))
@@ -639,11 +638,11 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'max_per_page' => new PropertyParameter('max_per_page', $pageSize),
                 'deep_link' => new PropertyParameter('deep_link', null),
             ],
-            ['webspaceKey' => null, 'locale' => null],
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de'],
             $limitResult,
             $page,
             $pageSize
-        )->willReturn(new DataProviderResult($expectedData, $hasNextPage, $expectedData));
+        )->willReturn(new DataProviderResult($expectedData, $hasNextPage));
 
         $property->expects($this->at(1))->method('getValue')
             ->willReturn($config);
@@ -653,9 +652,11 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $property->expects($this->any())->method('getParams')
             ->will($this->returnValue(['max_per_page' => new PropertyParameter('max_per_page', $pageSize)]));
         $property->expects($this->exactly(3))->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->will($this->returnValue($structure->reveal()));
 
-        $structure->expects($this->any())->method('getUuid')->will($this->returnValue($uuid));
+        $structure->getUuid()->willReturn($uuid);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
 
         $viewData = $this->smartContent->getViewData($property);
         $this->assertEquals(
@@ -695,9 +696,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             true,
             ['getValue', 'getParams']
         );
-        $structure = $this->getMockForAbstractClass(
-            'Sulu\Component\Content\Compat\StructureInterface'
-        );
+        $structure = $this->prophesize(StructureInterface::class);
 
         $property->expects($this->exactly(1))->method('getValue')
             ->will($this->returnValue($value));
@@ -706,7 +705,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue([]));
 
         $property->expects($this->any())->method('getStructure')
-            ->will($this->returnValue($structure));
+            ->will($this->returnValue($structure->reveal()));
 
         $this->contentDataProvider->resolveResourceItems(
             [
@@ -751,7 +750,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                 'datasource' => null,
                 'deep_link' => new PropertyParameter('deep_link', null),
             ],
-            ['webspaceKey' => null, 'locale' => null],
+            ['webspaceKey' => 'sulu_io', 'locale' => 'de'],
             null
         )->willReturn(
             new DataProviderResult(
@@ -763,12 +762,13 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
                     ['uuid' => 5],
                     ['uuid' => 6],
                 ],
-                true,
-                [1, 2, 3, 4, 5, 6]
+                true
             )
         );
 
-        $structure->expects($this->any())->method('getUuid')->will($this->returnValue('123-123-123'));
+        $structure->getUuid()->willReturn('123-123-123');
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
 
         return $property;
     }

--- a/src/Sulu/Component/Snippet/Import/SnippetImport.php
+++ b/src/Sulu/Component/Snippet/Import/SnippetImport.php
@@ -80,7 +80,7 @@ class SnippetImport extends Import
         $this->structureManager = $structureManager;
         $this->importManager = $importManager; // only import/import
         $this->legacyPropertyFactory = $legacyPropertyFactory;
-         // only import/import
+        // only import/import
         $this->logger = $logger;
         $this->add($xliff12, '1.2.xliff');
     }
@@ -226,7 +226,7 @@ class SnippetImport extends Import
         $node->setProperty(sprintf('i18n:%s-state', $locale), $state);
 
         // Check title is set in xliff-file.
-        if ($this->getParser($format)->getPropertyData('title', $data) === '') {
+        if ('' === $this->getParser($format)->getPropertyData('title', $data)) {
             $this->addException(sprintf('Snippet(%s) has not set any title', $document->getUuid()), 'ignore');
 
             return false;

--- a/src/Sulu/Component/Symfony/CompilerPass/TaggedServiceCollectorCompilerPass.php
+++ b/src/Sulu/Component/Symfony/CompilerPass/TaggedServiceCollectorCompilerPass.php
@@ -34,6 +34,7 @@ class TaggedServiceCollectorCompilerPass implements CompilerPassInterface
      * @var int
      */
     private $argumentNumber;
+
     /**
      * @var string
      */

--- a/src/Sulu/Component/Tag/Request/TagRequestHandler.php
+++ b/src/Sulu/Component/Tag/Request/TagRequestHandler.php
@@ -33,7 +33,7 @@ class TagRequestHandler implements TagRequestHandlerInterface
      */
     public function getTags($tagsParameter = 'tags')
     {
-        if ($this->requestStack->getCurrentRequest() !== null) {
+        if (null !== $this->requestStack->getCurrentRequest()) {
             $tags = $this->requestStack->getCurrentRequest()->get($tagsParameter, '');
         } else {
             $tags = '';

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -90,7 +90,7 @@ final class SortUtils
             }
         });
 
-        if (strtoupper($direction) == 'DESC') {
+        if ('DESC' == strtoupper($direction)) {
             $values = array_reverse($values);
         }
 

--- a/src/Sulu/Component/Util/SuluNodeHelper.php
+++ b/src/Sulu/Component/Util/SuluNodeHelper.php
@@ -184,7 +184,7 @@ class SuluNodeHelper
      */
     public function extractSnippetTypeFromPath($path)
     {
-        if (substr($path, 0, 1) !== '/') {
+        if ('/' !== substr($path, 0, 1)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     'Path must be absolute, got "%s"',

--- a/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
@@ -162,6 +162,7 @@ class SortUtilsTest extends \PHPUnit_Framework_TestCase
 class FoobarTestClass
 {
     public $field1;
+
     public $field2;
 
     public function __construct($value1, $value2)

--- a/src/Sulu/Component/Util/WildcardUrlUtil.php
+++ b/src/Sulu/Component/Util/WildcardUrlUtil.php
@@ -67,7 +67,7 @@ final class WildcardUrlUtil
         if (preg_match($regexp, $url, $matches)) {
             for ($i = 0, $countStar = substr_count($portalUrl, '*'); $i < $countStar; ++$i) {
                 $pos = strpos($portalUrl, '*');
-                if ($pos !== false) {
+                if (false !== $pos) {
                     $portalUrl = substr_replace($portalUrl, $matches[$i + 1], $pos, 1);
                 }
             }

--- a/src/Sulu/Component/Util/XmlUtil.php
+++ b/src/Sulu/Component/Util/XmlUtil.php
@@ -29,12 +29,12 @@ class XmlUtil
     public static function getValueFromXPath($path, \DOMXPath $xpath, \DomNode $context = null, $default = null)
     {
         $result = $xpath->query($path, $context);
-        if ($result->length === 0) {
+        if (0 === $result->length) {
             return $default;
         }
 
         $item = $result->item(0);
-        if ($item === null) {
+        if (null === $item) {
             return $default;
         }
 
@@ -55,7 +55,7 @@ class XmlUtil
     {
         $value = self::getValueFromXPath($path, $xpath, $context, $default);
 
-        if ($value === null) {
+        if (null === $value) {
             return;
         }
 

--- a/src/Sulu/Component/Websocket/ConnectionContext/AuthenticatedConnectionContext.php
+++ b/src/Sulu/Component/Websocket/ConnectionContext/AuthenticatedConnectionContext.php
@@ -43,6 +43,6 @@ class AuthenticatedConnectionContext extends ConnectionContext implements Authen
      */
     public function isValid()
     {
-        return $this->getUser($this->firewall) !== null;
+        return null !== $this->getUser($this->firewall);
     }
 }

--- a/src/Sulu/Component/Websocket/ConnectionContext/ConnectionContext.php
+++ b/src/Sulu/Component/Websocket/ConnectionContext/ConnectionContext.php
@@ -15,7 +15,6 @@ use Guzzle\Http\Message\RequestInterface;
 use Guzzle\Http\QueryString;
 use Ratchet\ConnectionInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -99,7 +98,7 @@ class ConnectionContext implements ConnectionContextInterface
      */
     public function getToken($firewall)
     {
-        if ($this->session !== null) {
+        if (null !== $this->session) {
             return unserialize($this->session->get('_security_' . $firewall));
         }
 

--- a/src/Sulu/Component/Websocket/MessageDispatcher/MessageDispatcher.php
+++ b/src/Sulu/Component/Websocket/MessageDispatcher/MessageDispatcher.php
@@ -59,6 +59,7 @@ class MessageDispatcher implements MessageDispatcherInterface
         }
 
         $error = false;
+
         try {
             $message = $this->handlers[$name]->handle($conn, $message, $context);
         } catch (MessageHandlerException $ex) {

--- a/src/Sulu/Component/Websocket/MessageDispatcher/MessageDispatcherApp.php
+++ b/src/Sulu/Component/Websocket/MessageDispatcher/MessageDispatcherApp.php
@@ -58,7 +58,7 @@ class MessageDispatcherApp extends AbstractWebsocketApp implements MessageCompon
         try {
             $result = $this->dispatch($from, $context, $msg);
 
-            if ($result !== null) {
+            if (null !== $result) {
                 $from->send($result);
             }
         } catch (\Exception $e) {

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -50,7 +50,7 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
         $attributes['webspace'] = $portalInformation->getWebspace();
         $attributes['portal'] = $portalInformation->getPortal();
 
-        if ($portalInformation->getType() === RequestAnalyzerInterface::MATCH_TYPE_REDIRECT) {
+        if (RequestAnalyzerInterface::MATCH_TYPE_REDIRECT === $portalInformation->getType()) {
             return new RequestAttributes($attributes);
         }
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/RequestAttributes.php
@@ -50,7 +50,7 @@ class RequestAttributes
      *
      * @return RequestAttributes
      */
-    public function merge(RequestAttributes $requestAttributes)
+    public function merge(self $requestAttributes)
     {
         return new self(array_merge($requestAttributes->attributes, $this->attributes));
     }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/WebsiteRequestProcessor.php
@@ -74,7 +74,7 @@ class WebsiteRequestProcessor implements RequestProcessorInterface
             $this->environment
         );
 
-        if (count($portalInformations) === 0) {
+        if (0 === count($portalInformations)) {
             return new RequestAttributes();
         }
 

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -101,6 +101,7 @@ class WebspaceInitializer implements InitializerInterface
         foreach ($webspaceLocales as $webspaceLocale) {
             if (in_array($webspaceLocale, $existingLocales)) {
                 $output->writeln(sprintf('  [ ] <info>homepage</info>: %s (%s)', $homePath, $webspaceLocale));
+
                 continue;
             }
 
@@ -124,6 +125,7 @@ class WebspaceInitializer implements InitializerInterface
             $this->documentManager->publish($homeDocument, $webspaceLocale);
 
             $routePath = $routesPath . '/' . $webspaceLocale;
+
             try {
                 $routeDocument = $this->documentManager->find($routePath);
             } catch (DocumentNotFoundException $e) {

--- a/src/Sulu/Component/Webspace/Environment.php
+++ b/src/Sulu/Component/Webspace/Environment.php
@@ -150,9 +150,6 @@ class Environment
         $this->customUrls[] = $customUrl;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray($depth = null)
     {
         $res = [];

--- a/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
+++ b/src/Sulu/Component/Webspace/Loader/BaseXmlFileLoader.php
@@ -41,7 +41,7 @@ abstract class BaseXmlFileLoader extends FileLoader
         $namespace = substr($namespaces, $start);
 
         $end = strpos($namespace, ' ');
-        if ($end !== false) {
+        if (false !== $end) {
             $namespace = substr($namespace, 0, $end);
         }
 

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -257,14 +257,14 @@ class XmlFileLoader10 extends BaseXmlFileLoader
 
         $defaultNode = $localizationNode->attributes->getNamedItem('default');
         if ($defaultNode) {
-            $localization->setDefault($defaultNode->nodeValue == 'true');
+            $localization->setDefault('true' == $defaultNode->nodeValue);
         } else {
             $localization->setDefault(false);
         }
 
         $xDefaultNode = $localizationNode->attributes->getNamedItem('x-default');
         if ($xDefaultNode) {
-            $localization->setXDefault($xDefaultNode->nodeValue == 'true');
+            $localization->setXDefault('true' == $xDefaultNode->nodeValue);
         } else {
             $localization->setXDefault(false);
         }
@@ -317,7 +317,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
 
             $defaultNode = $segmentNode->attributes->getNamedItem('default');
             if ($defaultNode) {
-                $segment->setDefault($defaultNode->nodeValue == 'true');
+                $segment->setDefault('true' == $defaultNode->nodeValue);
             } else {
                 $segment->setDefault(false);
             }
@@ -362,7 +362,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
         }
 
         $nodes = $this->xpath->query('/x:webspace/x:theme');
-        if ($nodes->length === 0) {
+        if (0 === $nodes->length) {
             return;
         }
 
@@ -387,10 +387,10 @@ class XmlFileLoader10 extends BaseXmlFileLoader
         foreach ($this->xpath->query('/x:webspace/x:theme/x:error-templates/x:error-template') as $errorTemplateNode) {
             /* @var \DOMNode $errorTemplateNode */
             $template = $errorTemplateNode->nodeValue;
-            if (($codeNode = $errorTemplateNode->attributes->getNamedItem('code')) !== null) {
+            if (null !== ($codeNode = $errorTemplateNode->attributes->getNamedItem('code'))) {
                 $webspace->addTemplate('error-' . $codeNode->nodeValue, $template);
-            } elseif (($defaultNode = $errorTemplateNode->attributes->getNamedItem('default')) !== null) {
-                $default = $defaultNode->nodeValue === 'true';
+            } elseif (null !== ($defaultNode = $errorTemplateNode->attributes->getNamedItem('default'))) {
+                $default = 'true' === $defaultNode->nodeValue;
                 if (!$default) {
                     throw new InvalidDefaultErrorTemplateException($template, $this->webspace->getKey());
                 }
@@ -428,7 +428,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
             $type = $node->attributes->getNamedItem('type')->nodeValue;
 
             $webspace->addDefaultTemplate($type, $template);
-            if ($type === 'homepage') {
+            if ('homepage' === $type) {
                 $webspace->addDefaultTemplate('home', $template);
             }
         }
@@ -596,18 +596,18 @@ class XmlFileLoader10 extends BaseXmlFileLoader
      */
     protected function checkUrlNode(\DOMNode $urlNode)
     {
-        $hasLocalization = ($urlNode->attributes->getNamedItem('localization') != null)
-            || (strpos($urlNode->nodeValue, '{localization}') !== false);
+        $hasLocalization = (null != $urlNode->attributes->getNamedItem('localization'))
+            || (false !== strpos($urlNode->nodeValue, '{localization}'));
 
-        $hasLanguage = ($urlNode->attributes->getNamedItem('language') != null)
-            || (strpos($urlNode->nodeValue, '{language}') !== false)
+        $hasLanguage = (null != $urlNode->attributes->getNamedItem('language'))
+            || (false !== strpos($urlNode->nodeValue, '{language}'))
             || $hasLocalization;
 
-        $hasSegment = (count($this->webspace->getSegments()) == 0)
-            || ($urlNode->attributes->getNamedItem('segment') != null)
-            || (strpos($urlNode->nodeValue, '{segment}') !== false);
+        $hasSegment = (0 == count($this->webspace->getSegments()))
+            || (null != $urlNode->attributes->getNamedItem('segment'))
+            || (false !== strpos($urlNode->nodeValue, '{segment}'));
 
-        $hasRedirect = ($urlNode->attributes->getNamedItem('redirect') != null);
+        $hasRedirect = (null != $urlNode->attributes->getNamedItem('redirect'));
 
         return ($hasLanguage && $hasSegment) || $hasRedirect;
     }

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -54,7 +54,7 @@ class XmlFileLoader11 extends XmlFileLoader10
             $type = $node->attributes->getNamedItem('type')->nodeValue;
 
             $webspace->addDefaultTemplate($type, $template);
-            if ($type === 'homepage') {
+            if ('homepage' === $type) {
                 $webspace->addDefaultTemplate('home', $template);
             }
         }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -98,7 +98,7 @@ class WebspaceCollection implements \IteratorAggregate
                 'Unknown portal environment "%s"', $environment
             ));
         }
-        if ($types === null) {
+        if (null === $types) {
             return $this->portalInformations[$environment];
         }
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -151,7 +151,7 @@ class WebspaceCollectionBuilder
             $urlAddress = $url->getUrl();
             $urlRedirect = $url->getRedirect();
             $urlAnalyticsKey = $url->getAnalyticsKey();
-            if ($urlRedirect == null) {
+            if (null == $urlRedirect) {
                 $this->buildUrls($portal, $environment, $url, $segments, $urlAddress, $urlAnalyticsKey);
             } else {
                 // create the redirect
@@ -401,7 +401,7 @@ class WebspaceCollectionBuilder
             // only valid if there is no full match already
             !array_key_exists($urlResult, $this->portalInformations[$environment->getType()])
             // check if last character is no dot
-            && substr($urlResult, -1) != '.';
+            && '.' != substr($urlResult, -1);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -155,7 +155,7 @@ class WebspaceManager implements WebspaceManagerInterface
         );
         foreach ($portals as $portalInformation) {
             $sameLocalization = $portalInformation->getLocalization()->getLocalization() === $languageCode;
-            $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
+            $sameWebspace = null === $webspaceKey || $portalInformation->getWebspace()->getKey() === $webspaceKey;
             $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
                 $urls[] = $url;
@@ -187,10 +187,10 @@ class WebspaceManager implements WebspaceManagerInterface
         );
         foreach ($portals as $portalInformation) {
             $sameLocalization = (
-                $portalInformation->getLocalization() === null
+                null === $portalInformation->getLocalization()
                 || $portalInformation->getLocalization()->getLocalization() === $languageCode
             );
-            $sameWebspace = $webspaceKey === null || $portalInformation->getWebspace()->getKey() === $webspaceKey;
+            $sameWebspace = null === $webspaceKey || $portalInformation->getWebspace()->getKey() === $webspaceKey;
             $url = rtrim(sprintf('%s://%s%s', $scheme, $portalInformation->getUrl(), $resourceLocator), '/');
             if ($sameLocalization && $sameWebspace && $this->isFromDomain($url, $domain)) {
                 if ($portalInformation->isMain()) {
@@ -293,7 +293,7 @@ class WebspaceManager implements WebspaceManagerInterface
      */
     public function getWebspaceCollection()
     {
-        if ($this->webspaceCollection === null) {
+        if (null === $this->webspaceCollection) {
             $class = $this->options['cache_class'];
             $cache = new ConfigCache(
                 $this->options['cache_dir'] . '/' . $class . '.php',

--- a/src/Sulu/Component/Webspace/Portal.php
+++ b/src/Sulu/Component/Webspace/Portal.php
@@ -254,9 +254,6 @@ class Portal
         return $this->webspace;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray($depth = null)
     {
         $res = [];

--- a/src/Sulu/Component/Webspace/PortalInformation.php
+++ b/src/Sulu/Component/Webspace/PortalInformation.php
@@ -380,7 +380,7 @@ class PortalInformation implements ArrayableInterface
     private function getHostLength()
     {
         $hostLength = strpos($this->url, '/');
-        $hostLength = ($hostLength === false) ? strlen($this->url) : $hostLength;
+        $hostLength = (false === $hostLength) ? strlen($this->url) : $hostLength;
 
         return $hostLength;
     }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
@@ -252,7 +252,7 @@ class WebsiteRequestProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidate($attributes, $exception = null, $message = '')
     {
-        if ($exception !== null) {
+        if (null !== $exception) {
             $this->setExpectedException($exception, $message);
         }
 

--- a/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
+++ b/src/Sulu/Component/Webspace/Url/ReplacerInterface.php
@@ -17,9 +17,13 @@ namespace Sulu\Component\Webspace\Url;
 interface ReplacerInterface
 {
     const REPLACER_LANGUAGE = '{language}';
+
     const REPLACER_COUNTRY = '{country}';
+
     const REPLACER_LOCALIZATION = '{localization}';
+
     const REPLACER_SEGMENT = '{segment}';
+
     const REPLACER_HOST = '{host}';
 
     /**

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -436,8 +436,8 @@ class Webspace implements ArrayableInterface
         foreach ($this->getPortals() as $portal) {
             foreach ($portal->getEnvironment($environment)->getUrls() as $url) {
                 $host = parse_url('//' . $url->getUrl())['host'];
-                if (($locale === null || $url->isValidLocale($language, $country))
-                    && ($host === $domain || $host === '{host}')
+                if ((null === $locale || $url->isValidLocale($language, $country))
+                    && ($host === $domain || '{host}' === $host)
                 ) {
                     return true;
                 }
@@ -559,7 +559,7 @@ class Webspace implements ArrayableInterface
         }
 
         $thisSecurity = $this->getSecurity();
-        if ($thisSecurity != null) {
+        if (null != $thisSecurity) {
             $res['security']['system'] = $thisSecurity->getSystem();
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3680
| Related issues/PRs | https://github.com/sulu/sulu-minimal/pull/78 https://github.com/sulu/sulu-standard/pull/836
| License | MIT

#### What's in this PR?

Set the framework session cookie path to `/admin` in admin session context.

#### Why?

Avoid conflict with the website session cookie.

See https://github.com/alexander-schranz/sulu/compare/hotfix/1.5-styleci...hotfix/admin-session-path-problem for file changes without styleci changes.

The changes in `ContentTypeTest.php` where ported from @wachterjohannes changes in https://github.com/sulu/sulu/pull/3601