### PR TITLE
Fix retina flag in XmlFormatLoader11 & add tests for retina flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * BUGFIX      #3693 [MediaBundle]           Fix retina flag in XmlFormatLoader11 & add tests for retina flag
+
 * 1.5.8 (2017-12-13)
     * HOTFIX      #3690 [ContentBundle]         Fix saving of not yet started text editor
     * HOTFIX      #3684 [SecurityBundle]        Fixed conflict between admin and website session cookie

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
@@ -85,7 +85,7 @@ class XmlFormatLoader11 extends BaseXmlFormatLoader
                 $forceRatio = false;
             }
             if (null !== $retinaNode && 'true' === $retinaNode->nodeValue) {
-                $retina = false;
+                $retina = true;
             }
 
             $scale = [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/image/formats/version10.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/image/formats/version10.xml
@@ -39,4 +39,18 @@
             </command>
         </commands>
     </format>
+
+    <format>
+        <name>3840x2160-retina</name>
+        <commands>
+            <command>
+                <action>resize</action>
+                <parameters>
+                    <parameter name="x">3840</parameter>
+                    <parameter name="y">2160</parameter>
+                    <parameter name="retina">true</parameter>
+                </parameters>
+            </command>
+        </commands>
+    </format>
 </formats>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/image/formats/version11.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/image/formats/version11.xml
@@ -34,4 +34,8 @@
     <format key="200x180-inset">
         <scale x="200" y="180"/>
     </format>
+
+    <format key="3840x2160-retina">
+        <scale x="3840" y="2160" retina="true"/>
+    </format>
 </formats>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader10Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader10Test.php
@@ -52,7 +52,7 @@ class XmlFormatLoader10Test extends WebspaceTestCase
     {
         $result = $this->loader->load(dirname(__DIR__) . '/../../Fixtures/image/formats/version10.xml');
 
-        $this->assertEquals(2, count($result));
+        $this->assertEquals(3, count($result));
 
         $this->assertArrayHasKey('640x480', $result);
         $this->assertEquals(
@@ -108,6 +108,28 @@ class XmlFormatLoader10Test extends WebspaceTestCase
             $result['300x']
         );
         $this->assertNotNull($result['300x']['internal']);
+
+        $this->assertArrayHasKey('3840x2160-retina', $result);
+        $this->assertEquals(
+            [
+                'key' => '3840x2160-retina',
+                'internal' => false,
+                'meta' => [
+                    'title' => [],
+                ],
+                'scale' => [
+                    'x' => '3840',
+                    'y' => '2160',
+                    'mode' => 'outbound',
+                    'forceRatio' => true,
+                    'retina' => true,
+                ],
+                'transformations' => [],
+                'options' => [],
+            ],
+            $result['3840x2160-retina']
+        );
+        $this->assertNotNull($result['3840x2160-retina']['internal']);
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader11Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader11Test.php
@@ -52,7 +52,7 @@ class XmlFormatLoader11Test extends WebspaceTestCase
     {
         $result = $this->loader->load(dirname(__DIR__) . '/../../Fixtures/image/formats/version11.xml');
 
-        $this->assertEquals(3, count($result));
+        $this->assertEquals(4, count($result));
 
         $this->assertArrayHasKey('400x400', $result);
         $this->assertEquals(
@@ -135,6 +135,28 @@ class XmlFormatLoader11Test extends WebspaceTestCase
             $result['200x180-inset']
         );
         $this->assertNotNull($result['200x180-inset']['internal']);
+
+        $this->assertArrayHasKey('3840x2160-retina', $result);
+        $this->assertEquals(
+            [
+                'key' => '3840x2160-retina',
+                'internal' => false,
+                'meta' => [
+                    'title' => [],
+                ],
+                'scale' => [
+                    'x' => '3840',
+                    'y' => '2160',
+                    'mode' => 'outbound',
+                    'forceRatio' => true,
+                    'retina' => true,
+                ],
+                'transformations' => [],
+                'options' => [],
+            ],
+            $result['3840x2160-retina']
+        );
+        $this->assertNotNull($result['3840x2160-retina']['internal']);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs |
| License | MIT

#### What's in this PR?

This PR fixes loading of XML file if you set the retina flag to true.

#### Why?

Because it always set the retina flag to false, instead of using the value from the XML.
