### PR TITLE
Added check for empty request format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG for Sulu
 
 * dev-master
     * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320
-    * HOTFIX      #3695 [MediaBundle]             Keep doctrine 2.5
+    * HOTFIX      #3695 [RouteBundle]             Added check for empty request format
+    * HOTFIX      #3696 [MediaBundle]             Keep doctrine 2.5
 
 * 1.6.11 (2017-12-13)
     * HOTFIX      #3690 [ContentBundle]           Fix saving of not yet started text editor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320
     * HOTFIX      #3695 [RouteBundle]             Added check for empty request format
+    * HOTFIX      #3695 [WebsiteBundle]           Added check for empty request format
     * HOTFIX      #3696 [MediaBundle]             Keep doctrine 2.5
 
 * 1.6.11 (2017-12-13)

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -104,7 +104,12 @@ class RouteProvider implements RouteProviderInterface
             $path = PathHelper::relativizePath($path, $prefix);
         }
 
-        if ('html' !== $format = $request->getRequestFormat()) {
+        // when the URI ends with a dot - symfony returns empty request-format
+        if ('' === $format = $request->getRequestFormat()) {
+            return $collection;
+        }
+
+        if ('html' !== $format) {
             $path = substr($path, 0, strpos($path, $format) - 1);
         }
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Routing/RouteProviderTest.php
@@ -342,4 +342,16 @@ class RouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/test', $routes[0]->getPath());
         $this->assertEquals(['test' => 1], $routes[0]->getDefaults());
     }
+
+    public function testGetRouteCollectionForRequestEndingDot()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->getPathInfo()->willReturn('/test.');
+        $request->getLocale()->willReturn('de');
+        $request->getRequestFormat()->willReturn('');
+
+        $collection = $this->routeProvider->getRouteCollectionForRequest($request->reveal());
+
+        $this->assertCount(0, $collection);
+    }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -86,6 +86,10 @@ class ContentRouteProvider implements RouteProviderInterface
     {
         $collection = new RouteCollection();
 
+        if ('' === $request->getRequestFormat()) {
+            return $collection;
+        }
+
         /** @var RequestAttributes $attributes */
         $attributes = $request->attributes->get('_sulu');
         if (!$attributes) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds a check for empty request-format.

#### Why?

If you call a URI with dot ending `example.com/test.` symfony request returns empty request-format which lead into a `strpos` warning.