### PR TITLE
keep doctrine 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - php: 5.5
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
+    - php: 7.1
+      env:
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction
     - php: 7.0
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3695 [MediaBundle]             Keep doctrine 2.5
+
 * 1.6.11 (2017-12-13)
-    * HOTFIX      #3690 [ContentBundle]         Fix saving of not yet started text editor
+    * HOTFIX      #3690 [ContentBundle]           Fix saving of not yet started text editor
     * HOTFIX      #3684 [SecurityBundle]          Fixed conflict between admin and website session cookie
     * HOTFIX      #3686 [ContentBundle]           Validate if ckeditor instances are not in source mode
     * HOTFIX      #3585 [PersistanceBundle]       Fixed exception of blame for none sulu users

--- a/bin/runtests
+++ b/bin/runtests
@@ -371,7 +371,9 @@ function run_bundle_tests(\SplFileInfo $phpunitFile)
         $filesystem->remove($cacheDir);
     }
 
-    putenv('KERNEL_DIR=' . $bundleDir . DIRECTORY_SEPARATOR . get_kernel_dir($phpunitFile->getPathname()));
+    $kernelDirectory = $bundleDir . DIRECTORY_SEPARATOR . get_kernel_dir($phpunitFile->getPathname());
+    putenv('KERNEL_DIR=' . $kernelDirectory);
+    $_SERVER['KERNEL_DIR'] = $kernelDirectory;
 
     // see if this bundle uses doctrine orm, and update the schema if so..
     // (we assume that the bundle will purge the fixtures etc.)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "cboden/ratchet": "0.3.*",
-        "doctrine/orm": "^2.5.3",
+        "doctrine/orm": "~2.5.3",
         "doctrine/annotations": "^1.2",
         "doctrine/phpcr-bundle": "^1.3.5",
         "doctrine/doctrine-bundle": "~1.6",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #3694
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR keeps version 2.5 of doctrine.

#### Why?

The fix in  #3694 is a BC break, and even with the fix there it is not working, because there seem to be some doctrine internal issues (the purger calls a `doctrine/common` method, which does not exist anymore).