### PR TITLE
SEO description length changed from 155 to 320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * ENHANCEMENT #XXXX [ContentBundle]           SEO description length changed from 155 to 320
     * HOTFIX      #3695 [MediaBundle]             Keep doctrine 2.5
 
 * 1.6.11 (2017-12-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * ENHANCEMENT #XXXX [ContentBundle]           SEO description length changed from 155 to 320
+    * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320
     * HOTFIX      #3695 [MediaBundle]             Keep doctrine 2.5
 
 * 1.6.11 (2017-12-13)

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Configuration.php
@@ -33,7 +33,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('max_title_length')->defaultValue(55)->end()
-                        ->scalarNode('max_description_length')->defaultValue(155)->end()
+                        ->scalarNode('max_description_length')->defaultValue(320)->end()
                         ->scalarNode('max_keywords')->defaultValue(5)->end()
                         ->scalarNode('keywords_separator')->defaultValue(',')->end()
                         ->scalarNode('url_prefix')->defaultValue('www.yoursite.com/{locale}')->end()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

SEO description length changed from 155 to 320

#### Why?

Google changed the max length.
