### PR TITLE
[WIP] Added FocusPointOverlay

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -1,10 +1,13 @@
 // @flow
 import React from 'react';
+import type {Node} from 'react';
+import Icon from '../Icon';
 import buttonStyles from './button.scss';
 
 type Props = {
-    children: string,
-    skin: 'primary' | 'secondary' | 'link',
+    children: Node,
+    icon?: string,
+    skin: 'primary' | 'secondary' | 'link' | 'underlined',
     onClick: () => void,
 };
 
@@ -17,11 +20,15 @@ export default class Button extends React.PureComponent<Props> {
         const {
             children,
             skin,
+            icon,
         } = this.props;
 
         return (
             <button className={buttonStyles[skin]} onClick={this.handleClick}>
-                {children}
+                {!!icon &&
+                    <Icon className={buttonStyles.icon} name={icon} />
+                }
+                <span className={buttonStyles.text}>{children}</span>
             </button>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -10,6 +10,9 @@ $secondaryBorder: $silver;
 $secondaryBackground: $wildSand;
 $secondaryColor: $black;
 
+$underlinedFontSize: 14px;
+$underlinedColor: $black;
+
 $linkFontSize: 14px;
 $linkColor: $black;
 
@@ -37,13 +40,37 @@ $linkColor: $black;
     color: $secondaryColor;
 }
 
-.link {
+.underlined {
     padding: 0;
     margin: 0 10px 0 0;
     border: 0;
     background: transparent;
     cursor: pointer;
     text-decoration: underline;
+    font-size: $underlinedFontSize;
+    color: $underlinedColor;
+}
+
+.link {
+    border: 0;
+    background: transparent;
+    cursor: pointer;
     font-size: $linkFontSize;
     color: $linkColor;
+
+    &:hover {
+        .text {
+            text-decoration: underline;
+        }
+    }
+
+    .icon {
+        font-size: 20px;
+    }
+}
+
+.icon {
+    position: relative;
+    top: 1px;
+    margin-right: 10px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -15,6 +15,14 @@ test('Button should render with skin link', () => {
     expect(render(<Button skin="link" />)).toMatchSnapshot();
 });
 
+test('Button should render with skin underlined', () => {
+    expect(render(<Button skin="underlined" />)).toMatchSnapshot();
+});
+
+test('Button should render with an icon', () => {
+    expect(render(<Button skin="link" icon="gear" />)).toMatchSnapshot();
+});
+
 test('Button should call the callback on click', () => {
     const onClick = jest.fn();
     const button = shallow(<Button skin="primary" onClick={onClick} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
@@ -1,19 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button should render with an icon 1`] = `
+<button
+  class="link"
+>
+  <span
+    aria-label="gear"
+    class="icon fa fa-gear"
+  />
+  <span
+    class="text"
+  />
+</button>
+`;
+
 exports[`Button should render with skin link 1`] = `
 <button
   class="link"
-/>
+>
+  <span
+    class="text"
+  />
+</button>
 `;
 
 exports[`Button should render with skin primary 1`] = `
 <button
   class="primary"
-/>
+>
+  <span
+    class="text"
+  />
+</button>
 `;
 
 exports[`Button should render with skin secondary 1`] = `
 <button
   class="secondary"
-/>
+>
+  <span
+    class="text"
+  />
+</button>
+`;
+
+exports[`Button should render with skin underlined 1`] = `
+<button
+  class="underlined"
+>
+  <span
+    class="text"
+  />
+</button>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -15,8 +15,8 @@ exports[`The component should render in body when open 2`] = `
         <header>My dialog title</header>
         <article>My dialog content</article>
         <footer>
-          <button class=\\"secondary\\">Cancel</button>
-          <button class=\\"primary\\">Confirm</button>
+          <button class=\\"secondary\\"><span class=\\"text\\">Cancel</span></button>
+          <button class=\\"primary\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Actions.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Actions.js
@@ -23,7 +23,7 @@ export default class Actions extends React.PureComponent<Props> {
                         <Button
                             key={index}
                             onClick={handleButtonClick}
-                            skin="link"
+                            skin="underlined"
                         >
                             {action.title}
                         </Button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Actions.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Actions.test.js.snap
@@ -5,14 +5,22 @@ exports[`The component should render 1`] = `
   class="actions"
 >
   <button
-    class="link"
+    class="underlined"
   >
-    Action 1
+    <span
+      class="text"
+    >
+      Action 1
+    </span>
   </button>
   <button
-    class="link"
+    class="underlined"
   >
-    Action 2
+    <span
+      class="text"
+    >
+      Action 2
+    </span>
   </button>
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -20,7 +20,7 @@ exports[`The component should render in body when open 2`] = `
         </article>
         <footer>
           <!-- react-empty: 10 -->
-          <button class=\\"primary\\">Apply</button>
+          <button class=\\"primary\\"><span class=\\"text\\">Apply</span></button>
         </footer>
       </section>
     </div>
@@ -46,10 +46,10 @@ exports[`The component should render in body with actions when open 2`] = `
         </article>
         <footer>
           <div class=\\"actions\\">
-            <button class=\\"link\\">Action 1</button>
-            <button class=\\"link\\">Action 2</button>
+            <button class=\\"underlined\\"><span class=\\"text\\">Action 1</span></button>
+            <button class=\\"underlined\\"><span class=\\"text\\">Action 2</span></button>
           </div>
-          <button class=\\"primary\\">Apply</button>
+          <button class=\\"primary\\"><span class=\\"text\\">Apply</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
@@ -1,6 +1,7 @@
 // @flow
 import {arrayMove} from 'react-sortable-hoc';
 import Breadcrumb from './Breadcrumb';
+import Button from './Button';
 import Checkbox from './Checkbox';
 import CircularProgressbar from './CircularProgressbar';
 import CroppedText from './CroppedText';
@@ -18,6 +19,7 @@ import withContainerSize from './withContainerSize';
 export {
     arrayMove,
     Breadcrumb,
+    Button,
     Checkbox,
     CircularProgressbar,
     CroppedText,

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Controller;
 
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\Get;
 use FOS\RestBundle\Controller\Annotations\Post;
 use FOS\RestBundle\Routing\ClassResourceInterface;
@@ -102,6 +103,10 @@ class MediaController extends AbstractMediaController implements
         } catch (MediaException $e) {
             $view = $this->view($e->toArray(), 400);
         }
+
+        $context = new Context();
+        $context->setSerializeNull(true);
+        $view->setContext($context);
 
         return $this->handleView($view);
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/imageFocusPoint.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/imageFocusPoint.scss
@@ -1,6 +1,7 @@
 .image-focus-point {
     position: relative;
     display: inline-block;
+    max-height: inherit;
 }
 
 .focus-points {
@@ -11,4 +12,8 @@
     height: 100%;
     display: flex;
     flex-flow: wrap;
+}
+
+.image {
+    max-height: inherit;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/index.js
@@ -1,4 +1,6 @@
 // @flow
 import ImageFocusPoint from './ImageFocusPoint';
+import type {Point} from './types';
 
 export default ImageFocusPoint;
+export type {Point};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
@@ -140,9 +140,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
         </article>
         <footer>
           <div class=\\"actions\\">
-            <button class=\\"link\\">Reset fields</button>
+            <button class=\\"underlined\\"><span class=\\"text\\">Reset fields</span></button>
           </div>
-          <button class=\\"primary\\">Confirm</button>
+          <button class=\\"primary\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -132,9 +132,9 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
         </article>
         <footer>
           <div class=\\"actions\\">
-            <button class=\\"link\\">Reset fields</button>
+            <button class=\\"underlined\\"><span class=\\"text\\">Reset fields</span></button>
           </div>
-          <button class=\\"primary\\">Confirm</button>
+          <button class=\\"primary\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/ImageFocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/ImageFocusPointOverlay.js
@@ -1,0 +1,89 @@
+// @flow
+import React from 'react';
+import {action, computed} from 'mobx';
+import {observer} from 'mobx-react';
+import {translate} from 'sulu-admin-bundle/utils';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {Overlay} from 'sulu-admin-bundle/components';
+import ImageFocusPoint from '../../components/ImageFocusPoint';
+import type {Point} from '../../components/ImageFocusPoint';
+import imageFocusPointOverlayStyles from './imageFocusPointOverlay.scss';
+
+type Props = {
+    open: boolean,
+    onClose: () => void,
+    resourceStore: ResourceStore,
+};
+
+@observer
+export default class ImageFocusPointOverlay extends React.PureComponent<Props> {
+    static defaultProps = {
+        open: false,
+    };
+
+    @computed get image(): string {
+        const {resourceStore} = this.props;
+
+        return resourceStore.data.url;
+    }
+
+    @computed get focusPoint(): Point {
+        const {
+            resourceStore: {
+                data: {
+                    focusPointX,
+                    focusPointY,
+                },
+            },
+        } = this.props;
+
+        return {
+            x: focusPointX,
+            y: focusPointY,
+        };
+    }
+
+    handleClose = () => {
+        this.props.onClose();
+    };
+
+    handleConfirm = () => {
+        this.props.onClose();
+    };
+
+    @action handleFocusPointChange = (value: Point) => {
+        const {resourceStore} = this.props;
+
+        resourceStore.set('focusPointX', value.x);
+        resourceStore.set('focusPointY', value.y);
+    };
+
+    render() {
+        const {open} = this.props;
+        const actions = [{
+            title: translate('sulu_admin.cancel'),
+            onClick: this.handleClose,
+        }];
+
+        return (
+            <Overlay
+                open={open}
+                title={translate('sulu_media.set_focus_point')}
+                onClose={this.handleClose}
+                onConfirm={this.handleConfirm}
+                confirmText={translate('sulu_media.save_and_crop')}
+                actions={actions}
+            >
+                <div className={imageFocusPointOverlayStyles.overlay}>
+                    <div className={imageFocusPointOverlayStyles.imageFocusPoint}>
+                        <ImageFocusPoint
+                            image={this.image}
+                            value={this.focusPoint}
+                            onChange={this.handleFocusPointChange}
+                        />
+                    </div>
+                </div>
+            </Overlay>
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -1,17 +1,20 @@
 // @flow
 import React from 'react';
 import {observer} from 'mobx-react';
-import {computed} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import {translate} from 'sulu-admin-bundle/utils';
+import {Button} from 'sulu-admin-bundle/components';
 import {Form, withToolbar} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import MediaUploadStore from '../../stores/MediaUploadStore';
 import SingleMediaDropzone from '../../components/SingleMediaDropzone';
+import ImageFocusPointOverlay from './ImageFocusPointOverlay';
 import mediaDetailStyles from './mediaDetail.scss';
 
 const COLLECTION_ROUTE = 'sulu_media.overview';
 const THUMBNAIL_SIZE = 'sulu-400x400-inset';
+const SET_FOCUS_POINT_ICON = 'crosshairs';
 
 type Props = ViewProps & {
     resourceStore: ResourceStore,
@@ -21,6 +24,7 @@ type Props = ViewProps & {
 class MediaDetail extends React.PureComponent<Props> {
     mediaUploadStore: MediaUploadStore;
     form: ?Form;
+    @observable imageFocusPointOverlayOpen: boolean = false;
 
     componentWillMount() {
         const {
@@ -70,6 +74,14 @@ class MediaDetail extends React.PureComponent<Props> {
         this.form = form;
     };
 
+    @action openImageFocusPointOverlay() {
+        this.imageFocusPointOverlayOpen = true;
+    }
+
+    @action closeImageFocusPointOverlay() {
+        this.imageFocusPointOverlayOpen = false;
+    }
+
     handleMediaDrop = (file: File) => {
         const {resourceStore} = this.props;
         const {
@@ -90,6 +102,14 @@ class MediaDetail extends React.PureComponent<Props> {
         this.props.resourceStore.save();
     };
 
+    handleOpenImageFocusPointOverlay = () => {
+        this.openImageFocusPointOverlay();
+    };
+
+    handleCloseImageFocusPointOverlay = () => {
+        this.closeImageFocusPointOverlay();
+    };
+
     render() {
         const {resourceStore} = this.props;
         const {
@@ -108,6 +128,13 @@ class MediaDetail extends React.PureComponent<Props> {
                         uploadText={translate('sulu_media.upload_or_replace')}
                         mimeType={this.mimeType}
                     />
+                    <Button
+                        skin="link"
+                        icon={SET_FOCUS_POINT_ICON}
+                        onClick={this.handleOpenImageFocusPointOverlay}
+                    >
+                        {translate('sulu_media.set_focus_point')}
+                    </Button>
                 </section>
                 <section className={mediaDetailStyles.formContainer}>
                     <Form
@@ -116,6 +143,11 @@ class MediaDetail extends React.PureComponent<Props> {
                         onSubmit={this.handleSubmit}
                     />
                 </section>
+                <ImageFocusPointOverlay
+                    resourceStore={resourceStore}
+                    open={this.imageFocusPointOverlayOpen}
+                    onClose={this.handleCloseImageFocusPointOverlay}
+                />
             </div>
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/imageFocusPointOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/imageFocusPointOverlay.scss
@@ -1,0 +1,19 @@
+@import 'sulu-admin-bundle/containers/Application/variables.scss';
+
+.overlay {
+    width: 1170px;
+    padding: 30px $viewPadding $viewPadding;
+
+    @media (max-width: 1200px) {
+        width: 900px;
+    }
+
+    @media (max-width: 900px) {
+        width: 600px;
+    }
+}
+
+.image-focus-point {
+    text-align: center;
+    max-height: 600px;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/__snapshots__/MediaDetail.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/__snapshots__/MediaDetail.test.js.snap
@@ -45,7 +45,19 @@ exports[`Render a MediaDetail view 1`] = `
         type="file"
       />
     </div>
+    <button
+      class="link"
+    >
+      <span
+        aria-label="crosshairs"
+        class="icon fa fa-crosshairs"
+      />
+      <span
+        class="text"
+      />
+    </button>
   </section>
+<<<<<<< HEAD
   <section
     class="formContainer"
   >
@@ -63,5 +75,8 @@ exports[`Render a MediaDetail view 1`] = `
       </button>
     </form>
   </section>
+=======
+  <div />
+>>>>>>> created ImageFocusPointverlay
 </div>
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/__snapshots__/MediaDetail.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/__snapshots__/MediaDetail.test.js.snap
@@ -57,7 +57,6 @@ exports[`Render a MediaDetail view 1`] = `
       />
     </button>
   </section>
-<<<<<<< HEAD
   <section
     class="formContainer"
   >
@@ -75,8 +74,6 @@ exports[`Render a MediaDetail view 1`] = `
       </button>
     </form>
   </section>
-=======
   <div />
->>>>>>> created ImageFocusPointverlay
 </div>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/sulu/sulu/pull/3679
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

The overlay for setting the `ImageFocusPoint`

#### To Do

- [ ] Use the new `clone` method in https://github.com/sulu/sulu/pull/3679 to create a new `ResourceStore` for the overlay
- [ ] Set the `confirmLoading` prop on the overlay after https://github.com/sulu/sulu/pull/3679 is merged
