### PR TITLE
Make Sulu compatible with PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - php: 5.5
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
-    - php: 7.0
+    - php: 7.2
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction
         - SYMFONY__DATABASE__DRIVER=pdo_pgsql

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - php: 5.5
       env:
         - COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
-    - php: 7.2
+    - php: 7.1
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction
         - SYMFONY__DATABASE__DRIVER=pdo_pgsql

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/TemplateControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/TemplateControllerTest.php
@@ -39,7 +39,7 @@ class TemplateControllerTest extends SuluTestCase
     public function testGetActionSorting()
     {
         $client = $this->createAuthenticatedClient();
-        $client->request('GET', '/content/template');
+        $client->request('GET', '/content/template?webspace=sulu_io');
 
         $this->assertHttpStatusCode(200, $client->getResponse());
 

--- a/src/Sulu/Bundle/CoreBundle/Entity/ApiEntity.php
+++ b/src/Sulu/Bundle/CoreBundle/Entity/ApiEntity.php
@@ -51,7 +51,7 @@ abstract class ApiEntity
      *
      * @var string
      */
-    private $_links;
+    private $_links = [];
 
     /**
      * returns the id of an entity.

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
@@ -144,6 +144,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->collectionRepository->findTree(5, 'de')->willReturn($entities);
+	$this->mediaRepository->findMedia(Argument::cetera())->willReturn([]);
 
         $result = $this->collectionManager->getTreeById(5, 'de');
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Collection/CollectionManagerTest.php
@@ -144,7 +144,7 @@ class CollectionManagerTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->collectionRepository->findTree(5, 'de')->willReturn($entities);
-	$this->mediaRepository->findMedia(Argument::cetera())->willReturn([]);
+        $this->mediaRepository->findMedia(Argument::cetera())->willReturn([]);
 
         $result = $this->collectionManager->getTreeById(5, 'de');
 

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -286,7 +286,7 @@ class RequestAnalyzerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAnalyzeNotExisting()
     {
-        $this->webspaceManager->findPortalInformationsByUrl(Argument::any(), Argument::any())->willReturn(null);
+        $this->webspaceManager->findPortalInformationsByUrl(Argument::any(), Argument::any())->willReturn([]);
         $this->webspaceManager->getPortalInformations(Argument::any())->willReturn([]);
 
         $request = $this->getMock('\Symfony\Component\HttpFoundation\Request');

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -59,7 +59,7 @@ class Webspace implements ArrayableInterface
      *
      * @var Segment[]
      */
-    private $segments;
+    private $segments = [];
 
     /**
      * The default segment defined for this webspace.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure the `Webspace::segments`  variable is an array from the very beginning.

#### Why?

Because starting with PHP 7.2 the ` count`  method will fail on this variable.

See https://wiki.php.net/rfc/counting_non_countables