### PR TITLE
update eslint because of breaking bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "devDependencies": {
         "autoprefixer": "^7.1.5",
         "babel-core": "^6.25.0",
-        "babel-eslint": "^7.2.3",
+        "babel-eslint": "^8.1.2",
         "babel-loader": "^7.1.1",
         "babel-plugin-transform-class-properties": "^6.24.1",
         "babel-plugin-transform-decorators-legacy": "^1.3.4",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR updates the ` babel-eslint`  package

#### Why?

Because there was a bug with older versions, also see https://github.com/eslint/eslint/issues/9767