### PR TITLE
Add debug 404 image for image converter errors

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -45,7 +45,7 @@ class MediaStreamController extends Controller
     /**
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function getImageAction(Request $request)
     {
@@ -57,11 +57,11 @@ class MediaStreamController extends Controller
             $url = $request->getPathInfo();
 
             list($id, $format) = $this->getCacheManager()->getMediaProperties($url);
-
-            return $this->getCacheManager()->returnImage($id, $format);
         } catch (ImageProxyException $e) {
             throw $this->createNotFoundException('Image create error. Code: ' . $e->getCode());
         }
+
+        return $this->getCacheManager()->returnImage($id, $format);
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -163,6 +163,7 @@
             <argument type="string">%sulu_media.format_manager.response_headers%</argument>
             <argument>%sulu_media.image.formats%</argument>
             <argument>%sulu_media.format_manager.mime_types%</argument>
+            <argument>%kernel.debug%</argument>
             <argument type="service" id="logger" on-invalid="null"/>
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Return a svg with `ERROR CODE` when image format could not be generated or original file not found. And also log an error into the log.

#### Why?

To show devs some feedback when an image could not been generated.

#### Example Usage

Open an image which format does not exist. Should return an image like this:

![bildschirmfoto 2018-02-16 um 12 45 58](https://user-images.githubusercontent.com/1698337/36306283-602ad7ca-1317-11e8-9672-b067b1c6d8be.png)

  