### PR TITLE
Category API: Fix bug when searching with rootKey parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
-    * HOTFIX      #XXXX [CategoryBundle]        Category API: Fix bug when searching with rootKey parameter
+    * HOTFIX      #3709 [CategoryBundle]        Category API: Fix bug when searching with rootKey parameter
     * BUGFIX      #3693 [MediaBundle]           Fix retina flag in XmlFormatLoader11 & add tests for retina flag
 
 * 1.5.8 (2017-12-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * HOTFIX      #XXXX [CategoryBundle]        Category API: Fix bug when searching with rootKey parameter
     * BUGFIX      #3693 [MediaBundle]           Fix retina flag in XmlFormatLoader11 & add tests for retina flag
 
 * 1.5.8 (2017-12-13)

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -290,7 +290,7 @@ class CategoryController extends RestController implements ClassResourceInterfac
             } elseif (count($parentExpressions) >= 1) {
                 $listBuilder->addExpression($parentExpressions[0]);
             }
-        } else if ($request->get('search') && $parentId && !$expandIds) {
+        } elseif ($request->get('search') && $parentId && !$expandIds) {
             // filter for parentId when search is active and no expandedIds are set
             $listBuilder->addExpression($parentExpressions[0]);
         }

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -284,7 +284,7 @@ class CategoryController extends RestController implements ClassResourceInterfac
         }
 
         if (!$request->get('search')) {
-            // expand collected parents if search is not set or search
+            // expand collected parents if search is not set
             if (count($parentExpressions) >= 2) {
                 $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
             } elseif (count($parentExpressions) >= 1) {

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -284,9 +284,13 @@ class CategoryController extends RestController implements ClassResourceInterfac
         }
 
         // expand collected parents
-        if (count($parentExpressions) >= 2) {
-            $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
-        } elseif (count($parentExpressions) >= 1) {
+        if (!$request->get('search')) {
+            if (count($parentExpressions) >= 2) {
+                $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
+            } elseif (count($parentExpressions) >= 1) {
+                $listBuilder->addExpression($parentExpressions[0]);
+            }
+        } else if ($request->get('search') && $parentId) {
             $listBuilder->addExpression($parentExpressions[0]);
         }
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -283,14 +283,15 @@ class CategoryController extends RestController implements ClassResourceInterfac
             );
         }
 
-        // expand collected parents
         if (!$request->get('search')) {
+            // expand collected parents if search is not set or search
             if (count($parentExpressions) >= 2) {
                 $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
             } elseif (count($parentExpressions) >= 1) {
                 $listBuilder->addExpression($parentExpressions[0]);
             }
-        } else if ($request->get('search') && $parentId) {
+        } else if ($request->get('search') && $parentId && !$expandIds) {
+            // filter for parentId when search is active and no expandedIds are set
             $listBuilder->addExpression($parentExpressions[0]);
         }
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -283,13 +283,11 @@ class CategoryController extends RestController implements ClassResourceInterfac
             );
         }
 
-        // expand collected parents if search is not set, else search all categories
-        if (!$request->get('search')) {
-            if (count($parentExpressions) >= 2) {
-                $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
-            } elseif (count($parentExpressions) >= 1) {
-                $listBuilder->addExpression($parentExpressions[0]);
-            }
+        // expand collected parents
+        if (count($parentExpressions) >= 2) {
+            $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
+        } elseif (count($parentExpressions) >= 1) {
+            $listBuilder->addExpression($parentExpressions[0]);
         }
 
         $results = $listBuilder->execute();

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -556,12 +556,12 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals($this->category3->getId(), $categories[0]->id);
         $this->assertTrue($categories[0]->hasChildren);
 
-        // search for not root category => should be excluded also!
+        // search for the root category => should be excluded also!
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
-            '/api/categories?locale=en&flat=true&searchFields=name&search=' .
-            $this->category1->findTranslationByLocale('en')->getTranslation()
+            '/api/categories?locale=en&flat=true&rootKey=' . $this->category1->getKey() .
+            '&searchFields=name&search=' . $this->category1->findTranslationByLocale('en')->getTranslation()
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());
@@ -576,7 +576,8 @@ class CategoryControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
-            '/api/categories?locale=en&flat=true&searchFields=name&search=XXX'
+            '/api/categories?locale=en&flat=true&rootKey=' . $this->category1->getKey() .
+            '&searchFields=name&search=XXX'
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -556,6 +556,22 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals($this->category3->getId(), $categories[0]->id);
         $this->assertTrue($categories[0]->hasChildren);
 
+        // search for not root category => should be excluded also!
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/categories?locale=en&flat=true&searchFields=name&search=' .
+            $this->category1->findTranslationByLocale('en')->getTranslation()
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $categories = $response->_embedded->categories;
+
+        $this->assertEquals(0, count($categories));
+
         // search for not existing category
         $client = $this->createAuthenticatedClient();
         $client->request(

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -530,6 +530,48 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertTrue($categories[0]->hasChildren);
     }
 
+    public function testCGetFlatWithRootAndSearch()
+    {
+        // search for existing third category
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/categories?locale=en&flat=true&rootKey=' . $this->category1->getKey() .
+            '&searchFields=name&search=' . $this->category3->findTranslationByLocale('en')->getTranslation()
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $categories = $response->_embedded->categories;
+        usort(
+            $categories,
+            function ($cat1, $cat2) {
+                return $cat1->id > $cat2->id;
+            }
+        );
+
+        $this->assertEquals(1, $response->total);
+        $this->assertEquals($this->category3->getId(), $categories[0]->id);
+        $this->assertTrue($categories[0]->hasChildren);
+
+        // search for not existing category
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/categories?locale=en&flat=true&searchFields=name&search=XXX'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $categories = $response->_embedded->categories;
+
+        $this->assertEquals(0, count($categories));
+    }
+
     public function testCGetFlatWithRootAndExpandIds()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -116,7 +116,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
         // new structures will container an instance of MediaSelectionContainer
         if ($data instanceof MediaSelectionContainer) {
             $medias = $data->getData('de');
-            // old ones an array ...
+        // old ones an array ...
         } else {
             if (!isset($data['ids'])) {
                 throw new \RuntimeException(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Category API: Fix bug when search is not working when the rootKey parameter is provided.

#### Why?

Because the search is not working
