### PR TITLE
Fixed redirect listener to allow trailing slashes for homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * ENHANCEMENT #3715 [RouteBundle]             RouteRepository: Added method 'findAllByEntity'
+    * HOTFIX      #3713 [WebsiteBundle]           Fixed redirect listener to allow trailing slashes for homepage
 
 * 1.6.12 (2017-12-21)
     * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
@@ -103,7 +103,7 @@ class RedirectExceptionSubscriber implements EventSubscriberInterface
         $prefix = $attributes->getAttribute('resourceLocatorPrefix');
         $resourceLocator = $attributes->getAttribute('resourceLocator');
 
-        $route = rtrim($prefix . $resourceLocator, '/');
+        $route = '/' . trim($prefix . $resourceLocator, '/');
         if (!in_array($request->getRequestFormat(), ['htm', 'html'])
             || $route === $request->getPathInfo()
             || !$this->matchRoute($request->getSchemeAndHttpHost() . $route)

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/RedirectExceptionSubscriberTest.php
@@ -119,6 +119,54 @@ class RedirectExceptionSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->exceptionListener->redirectTrailingSlashOrHtml($this->event->reveal());
     }
 
+    public function testRedirectSlashToHomepage()
+    {
+        $this->attributes->getAttribute('resourceLocator', null)->willReturn('/');
+        $this->attributes->getAttribute('resourceLocatorPrefix', null)->willReturn(null);
+
+        $this->request->getPathInfo()->willReturn('//');
+        $this->request->getRequestFormat()->willReturn('html');
+
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
+            $this->prophesize(Route::class)->reveal()
+        );
+
+        $this->event->setResponse(
+            Argument::that(
+                function (RedirectResponse $response) {
+                    return '/' === $response->getTargetUrl();
+                }
+            )
+        )->shouldBeCalled();
+
+        $this->exceptionListener->redirectTrailingSlashOrHtml($this->event->reveal());
+    }
+
+    public function testRedirectDoubleSlashToHomepage()
+    {
+        $this->attributes->getAttribute('resourceLocator', null)->willReturn('//');
+        $this->attributes->getAttribute('resourceLocatorPrefix', null)->willReturn(null);
+
+        $this->request->getPathInfo()->willReturn('///');
+        $this->request->getRequestFormat()->willReturn('html');
+
+        $this->router->matchRequest(Argument::type(Request::class))->willReturn(
+            $this->prophesize(Route::class)->reveal()
+        );
+
+        $this->event->setResponse(
+            Argument::that(
+                function (RedirectResponse $response) {
+                    echo '"' . $response->getTargetUrl() . '"';
+
+                    return '/' === $response->getTargetUrl();
+                }
+            )
+        )->shouldBeCalled();
+
+        $this->exceptionListener->redirectTrailingSlashOrHtml($this->event->reveal());
+    }
+
     public function testRedirectTrailingHtml()
     {
         $this->attributes->getAttribute('resourceLocator', null)->willReturn('/test');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR extends the trim for trailing slashes and to allow trailing slashes for homepage.