### PR TITLE
RouteRepository: Added method findAllByEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
-    * ENHANCEMENT #XXXX [RouteBundle]             RouteRepository: Added method 'findAllByEntity'
+    * ENHANCEMENT #3715 [RouteBundle]             RouteRepository: Added method 'findAllByEntity'
 
 * 1.6.12 (2017-12-21)
     * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * ENHANCEMENT #XXXX [RouteBundle]             RouteRepository: Added method 'findAllByEntity'
+
 * 1.6.12 (2017-12-21)
     * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320
     * HOTFIX      #3695 [RouteBundle]             Added check for empty request format

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -116,7 +116,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
         // new structures will container an instance of MediaSelectionContainer
         if ($data instanceof MediaSelectionContainer) {
             $medias = $data->getData('de');
-            // old ones an array ...
+        // old ones an array ...
         } else {
             if (!isset($data['ids'])) {
                 throw new \RuntimeException(

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -116,7 +116,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
         // new structures will container an instance of MediaSelectionContainer
         if ($data instanceof MediaSelectionContainer) {
             $medias = $data->getData('de');
-        // old ones an array ...
+            // old ones an array ...
         } else {
             if (!isset($data['ids'])) {
                 throw new \RuntimeException(

--- a/src/Sulu/Bundle/RouteBundle/Entity/RouteRepository.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/RouteRepository.php
@@ -74,4 +74,23 @@ class RouteRepository extends EntityRepository implements RouteRepositoryInterfa
 
         return $query->getResult();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findAllByEntity($entityClass, $entityId, $locale = null)
+    {
+        $queryBuilder = $this->createQueryBuilder('entity')
+            ->andWhere('entity.entityClass = :entityClass')
+            ->andWhere('entity.entityId = :entityId')
+            ->setParameters(['entityClass' => $entityClass, 'entityId' => $entityId]);
+
+        if ($locale) {
+            $queryBuilder
+                ->andWhere('entity.locale = :locale')
+                ->setParameter('locale', $locale);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
 }

--- a/src/Sulu/Bundle/RouteBundle/Entity/RouteRepositoryInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/RouteRepositoryInterface.php
@@ -65,4 +65,15 @@ interface RouteRepositoryInterface
      * @return RouteInterface[]
      */
     public function findHistoryByEntity($entityClass, $entityId, $locale);
+
+    /**
+     * Return all routes inclusive history for given entity information.
+     *
+     * @param string $entityClass
+     * @param string $entityId
+     * @param string $locale
+     *
+     * @return RouteInterface[]
+     */
+    public function findAllByEntity($entityClass, $entityId, $locale = null);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

RouteRepository: Added method `findAllByEntity`

#### Why?

Get all routes inclusive history.

#### Example Usage

~~~php
$routes = $this->routeRepository->findAllByEntity(get_class($object), $object->getRoute()->getEntityId());
~~~
