### PR TITLE
Added extension-guesser to fix wrong extensions on download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * HOTFIX      #3720 [MediaBundle]           Added extension-guesser to fix wrong extensions on download
+
 * 1.5.9 (2018-01-18)
     * HOTFIX      #3709 [CategoryBundle]        Category API: Fix bug when searching with rootKey parameter
     * BUGFIX      #3693 [MediaBundle]           Fix retina flag in XmlFormatLoader11 & add tests for retina flag

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -219,6 +219,14 @@ class Media extends ApiWrapper
     }
 
     /**
+     * @return string|null
+     */
+    public function getExtension()
+    {
+        return $this->getFileVersion()->getExtension();
+    }
+
+    /**
      * @param string $title
      *
      * @return $this

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -126,13 +126,11 @@ class MediaStreamController extends Controller
 
         $response = new BinaryFileResponse($path);
 
-        $pathInfo = pathinfo($fileName);
-
         // Prepare headers
         $disposition = $response->headers->makeDisposition(
             $dispositionType,
             $fileName,
-            $cleaner->cleanup($pathInfo['filename'], $locale) . '.' . $pathInfo['extension']
+            $this->cleanUpFileName($fileName, $locale, $fileVersion->getExtension())
         );
 
         // Set headers
@@ -181,6 +179,26 @@ class MediaStreamController extends Controller
         }
 
         return $currentFileVersion;
+    }
+
+    /**
+     * Cleaned up filename.
+     *
+     * @param string $fileName
+     * @param string $locale
+     * @param string $extension
+     *
+     * @return string
+     */
+    private function cleanUpFileName($fileName, $locale, $extension)
+    {
+        $pathInfo = pathinfo($fileName);
+        $cleanedFileName = $this->get('sulu.content.path_cleaner')->cleanup($pathInfo['filename'], $locale);
+        if ($extension) {
+            $cleanedFileName .= '.' . $extension;
+        }
+
+        return $cleanedFileName;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\MediaBundle\Entity;
 use JMS\Serializer\Annotation\Exclude;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 
 /**
  * FileVersion.
@@ -273,6 +274,24 @@ class FileVersion implements AuditableInterface
     public function getMimeType()
     {
         return $this->mimeType;
+    }
+
+    /**
+     * Get extension.
+     *
+     * @return null|string
+     */
+    public function getExtension()
+    {
+        $pathInfo = pathinfo($this->getName());
+        $extension = ExtensionGuesser::getInstance()->guess($this->getMimeType());
+        if ($extension) {
+            return $extension;
+        } elseif (isset($pathInfo['extension'])) {
+            return $pathInfo['extension'];
+        }
+
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -11,10 +11,60 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes;
+use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadMediaTypes;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class MediaStreamControllerTest extends SuluTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->purgeDatabase();
+
+        $collectionTypes = new LoadCollectionTypes();
+        $collectionTypes->load($this->getEntityManager());
+        $mediaTypes = new LoadMediaTypes();
+        $mediaTypes->load($this->getEntityManager());
+    }
+
+    public function testDownloadAction()
+    {
+        $filePath = $this->createMediaFile('test.jpg');
+        $media = $this->createMedia($filePath, 'file-without-extension');
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', $media->getUrl());
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    public function testDownloadWithoutExtensionAction()
+    {
+        $filePath = $this->createMediaFile('file-without-extension');
+        $media = $this->createMedia($filePath, 'File without Extension');
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', $media->getUrl());
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    public function testDownloadWithDotInName()
+    {
+        $filePath = $this->createMediaFile('fitness-seasons.agency--C-&-C--Rodach,-Johannes');
+        $media = $this->createMedia($filePath, 'fitness-seasons.agency--C-&-C--Rodach,-Johannes');
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', $media->getUrl());
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $this->assertEquals(
+            'attachment; filename="fitness-seasons.jpeg"; filename*=utf-8\'\'fitness-seasons.agency--C-%26-C--Rodach%2C-Johannes',
+            $response->headers->get('content-disposition')
+        );
+    }
+
     public function testGetImageActionForNonExistingMedia()
     {
         $client = $this->createAuthenticatedClient();
@@ -31,5 +81,55 @@ class MediaStreamControllerTest extends SuluTestCase
         $client->request('GET', '/media/999/download/test.jpg?v=1');
 
         $this->assertHttpStatusCode(404, $client->getResponse());
+    }
+
+    private function createUploadedFile($path)
+    {
+        return new UploadedFile($path, basename($path), mime_content_type($path), filesize($path));
+    }
+
+    private function createCollection($title = 'Test')
+    {
+        $collection = $this->getCollectionManager()->save(
+            [
+                'title' => $title,
+                'locale' => 'en',
+                'type' => ['id' => 1],
+            ],
+            null
+        );
+
+        return $collection->getId();
+    }
+
+    private function createMedia($path, $title)
+    {
+        return $this->getMediaManager()->save(
+            $this->createUploadedFile($path),
+            [
+                'title' => $title,
+                'collection' => $this->createCollection(),
+                'locale' => 'en',
+            ],
+            null
+        );
+    }
+
+    private function getMediaManager()
+    {
+        return $this->getContainer()->get('sulu_media.media_manager');
+    }
+
+    private function getCollectionManager()
+    {
+        return $this->getContainer()->get('sulu_media.collection_manager');
+    }
+
+    private function createMediaFile($name)
+    {
+        $filePath = sys_get_temp_dir() . '/' . $name;
+        copy(__DIR__ . '/../../app/Resources/images/photo.jpeg', $filePath);
+
+        return $filePath;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3719 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes an error in download when the filename contains a wrong extension.
