### PR TITLE
Support utf8mb4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - SYMFONY__PHPCR__TRANSPORT=doctrinedbal
     - TEST_FLAGS=""
     - SYMFONY__DATABASE__DRIVER=pdo_mysql
+    - SYMFONY__DATABASE__CHARSET=utf8mb4
+    - SYMFONY__DATABASE__COLLATE=utf8mb4_unicode_ci
 
 matrix:
   include:
@@ -31,6 +33,8 @@ matrix:
         - SYMFONY__DATABASE__USER=postgres
         - SYMFONY__DATABASE__PASSWORD=postgres
         - SYMFONY__PHPCR__TRANSPORT=jackrabbit
+        - SYMFONY__DATABASE__CHARSET=UTF8
+        - SYMFONY__DATABASE__COLLATE=
         # restart jackrabbit after each suite see: https://github.com/sulu-io/sulu/issues/2137
         - TEST_FLAGS="--jackrabbit-restart"
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,32 @@ Follow upgrade path of following libraries:
 
 The api endpoint for `/admin/api/nodes/filter` was removed and replaced by `/admin/api/items`.
 
+### Database changes
+
+To support utf8mb4 we needed to change some database entities which you also need to migrate when not using utf8mb4:
+Run the following SQL to migrate to the new schema:
+
+```sql
+ALTER TABLE me_format_options CHANGE format_key format_key VARCHAR(191) NOT NULL;
+ALTER TABLE me_collections CHANGE collection_key collection_key VARCHAR(191) DEFAULT NULL;
+ALTER TABLE me_collection_types CHANGE collection_type_key collection_type_key VARCHAR(191) DEFAULT NULL;
+ALTER TABLE me_media_types CHANGE name name VARCHAR(191) NOT NULL;
+ALTER TABLE me_file_versions CHANGE mimeType mimeType VARCHAR(191) DEFAULT NULL;
+ALTER TABLE se_users CHANGE email email VARCHAR(191) DEFAULT NULL;
+ALTER TABLE se_role_settings CHANGE settingKey settingKey VARCHAR(191) NOT NULL;
+ALTER TABLE se_permissions CHANGE context context VARCHAR(191) NOT NULL;
+ALTER TABLE se_access_controls CHANGE entityClass entityClass VARCHAR(191) NOT NULL;
+ALTER TABLE ca_categories CHANGE category_key category_key VARCHAR(191) DEFAULT NULL;
+ALTER TABLE ca_keywords CHANGE keyword keyword VARCHAR(191) NOT NULL;
+ALTER TABLE ta_tags CHANGE name name VARCHAR(191) NOT NULL;
+ALTER TABLE we_domains CHANGE url url VARCHAR(191) NOT NULL;
+ALTER TABLE we_analytics CHANGE webspace_key webspace_key VARCHAR(191) NOT NULL;
+ALTER TABLE ro_routes CHANGE path path VARCHAR(191) NOT NULL, CHANGE entity_class entity_class VARCHAR(191) NOT NULL, CHANGE entity_id entity_id VARCHAR(191) NOT NULL;
+ALTER TABLE me_collection_meta CHANGE title title VARCHAR(191) NOT NULL;
+ALTER TABLE me_file_version_meta CHANGE title title VARCHAR(191) NOT NULL;
+ALTER TABLE me_file_versions CHANGE name name VARCHAR(191) NOT NULL;
+```
+
 ## 1.6.11
 
 ### SEO Description

--- a/bin/runtests
+++ b/bin/runtests
@@ -334,7 +334,8 @@ function init_dbal()
     write_info('Creating database');
     exec_sf_cmd(
         'doctrine:database:create',
-        false, false
+        false,
+        false
     );
 
     write_info('Updating schema');

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Category.orm.xml
@@ -9,7 +9,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="key" column="category_key" type="string" length="255" nullable="true" unique="true"/>
+        <field name="key" column="category_key" type="string" length="191" nullable="true" unique="true"/>
         <field name="defaultLocale" column="default_locale" type="string" length="5" nullable="false"/>
         <field name="lft" type="integer" column="lft">
             <gedmo:tree-left/>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
@@ -17,7 +17,7 @@
         </id>
 
         <field name="locale" column="locale" type="string" length="5" nullable="false"/>
-        <field name="keyword" column="keyword" type="string" length="255" nullable="false"/>
+        <field name="keyword" column="keyword" type="string" length="191" nullable="false"/>
 
         <many-to-many target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface" field="categoryTranslations"
                       inversed-by="keywords">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
@@ -19,7 +19,7 @@
             <gedmo:tree-level/>
         </field>
 
-        <field name="key" type="string" column="collection_key" length="255" unique="true" nullable="true"/>
+        <field name="key" type="string" column="collection_key" length="191" unique="true" nullable="true"/>
 
         <many-to-one field="type" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionType" inversed-by="collections">
             <join-columns>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
@@ -11,7 +11,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="title" type="string" column="title" length="255"/>
+        <field name="title" type="string" column="title" length="191"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="locale" type="string" column="locale" length="5"/>
         <many-to-one field="collection" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface" inversed-by="meta">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionType.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionType.orm.xml
@@ -7,7 +7,7 @@
             <generator strategy="AUTO"/>
         </id>
         <field name="name" type="string" column="name" length="255"/>
-        <field name="key" type="string" column="collection_type_key" length="255" unique="true" nullable="true"/>
+        <field name="key" type="string" column="collection_type_key" length="191" unique="true" nullable="true"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <one-to-many field="collections" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface"
                      mapped-by="type"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -14,7 +14,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="name" type="string" column="name" length="255" />
+        <field name="name" type="string" column="name" length="191" />
         <field name="version" type="integer" column="version" />
         <field name="subVersion" type="integer" column="subVersion">
             <options>
@@ -28,7 +28,7 @@
             </options>
         </field>
         <field name="storageOptions" type="text" column="storageOptions" nullable="true" />
-        <field name="mimeType" type="string" column="mimeType" length="255" nullable="true" />
+        <field name="mimeType" type="string" column="mimeType" length="191" nullable="true" />
         <field name="properties" type="string" column="properties" length="1000" nullable="true" />
         <field name="focusPointX" type="integer" column="focusPointX" nullable="true"/>
         <field name="focusPointY" type="integer" column="focusPointY" nullable="true"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
@@ -13,7 +13,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="title" type="string" column="title" length="255"/>
+        <field name="title" type="string" column="title" length="191"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="copyright" type="text" column="copyright" nullable="true"/>
         <field name="credits" type="text" column="credits" nullable="true"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FormatOptions.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FormatOptions.orm.xml
@@ -7,7 +7,7 @@
             table="me_format_options">
 
         <id name="fileVersion" association-key="true"/>
-        <id name="formatKey" type="string" length="255"/>
+        <id name="formatKey" type="string" length="191"/>
 
         <field name="cropX" type="integer"/>
         <field name="cropY" type="integer"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/MediaType.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/MediaType.orm.xml
@@ -10,7 +10,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="name" type="string" column="name" length="255"/>
+        <field name="name" type="string" column="name" length="191"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <one-to-many field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface"
                      mapped-by="type"/>

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/doctrine/BaseRoute.orm.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/doctrine/BaseRoute.orm.xml
@@ -8,10 +8,10 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="path" type="string" length="255"/>
+        <field name="path" type="string" length="191"/>
         <field name="locale" type="string" length="8"/>
-        <field name="entityClass" type="string" length="255"/>
-        <field name="entityId" type="string" length="255"/>
+        <field name="entityClass" type="string" length="191"/>
+        <field name="entityId" type="string" length="191"/>
         <field name="history" type="boolean"/>
 
         <one-to-many field="histories" target-entity="Sulu\Bundle\RouteBundle\Model\RouteInterface" mapped-by="target">

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/AccessControl.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/AccessControl.orm.xml
@@ -14,7 +14,7 @@
 
         <field name="permissions" type="smallint" column="permissions"/>
         <field name="entityId" type="integer" column="entityId"/>
-        <field name="entityClass" type="string" column="entityClass"/>
+        <field name="entityClass" type="string" column="entityClass" length="191"/>
 
         <many-to-one field="role" target-entity="Sulu\Component\Security\Authentication\RoleInterface">
             <join-column name="idRoles" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseUser.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseUser.orm.xml
@@ -33,7 +33,7 @@
         </field>
         <field name="privateKey" type="string" column="privateKey" length="2000" nullable="true"/>
         <field name="apiKey" type="guid" column="apiKey" length="128" nullable="true"/>
-        <field name="email" column="email" type="string" length="255" unique="true" nullable="true"/>
+        <field name="email" column="email" type="string" length="191" unique="true" nullable="true"/>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Permission.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Permission.orm.xml
@@ -11,7 +11,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="context" type="string" column="context" length="255"/>
+        <field name="context" type="string" column="context" length="191"/>
         <field name="module" type="string" column="module" nullable="true" length="60"/>
         <field name="permissions" type="smallint" column="permissions"/>
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/RoleSetting.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/RoleSetting.orm.xml
@@ -16,7 +16,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="key" type="string" column="settingKey" length="255"/>
+        <field name="key" type="string" column="settingKey" length="191"/>
         <field name="value" type="json_array" column="value"/>
 
         <many-to-one field="role" target-entity="Sulu\Component\Security\Authentication\RoleInterface"

--- a/src/Sulu/Bundle/TagBundle/Resources/config/doctrine/Tag.orm.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/doctrine/Tag.orm.xml
@@ -7,6 +7,6 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="name" type="string" column="name" unique="true" />
+        <field name="name" type="string" column="name" length="191" unique="true" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml.dist
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/parameters.yml.dist
@@ -7,6 +7,8 @@ parameters:
     database.port:     ~
     database.password: ~
     database.version:  5.6
+    database.charset:  utf8mb4
+    database.collate:  utf8mb4_unicode_ci
 
     phpcr.transport:   doctrinedbal
     phpcr.backend_url: http://localhost:8080/server/

--- a/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/dist/sulu.yml
@@ -76,7 +76,10 @@ doctrine:
         password: "%database.password%"
         path: "%database.path%"
         server_version: "%database.version%"
-        charset:  UTF8
+        charset: "%database.charset%"
+        default_table_options:
+            charset: "%database.charset%"
+            collate: "%database.collate%"
 
 stof_doctrine_extensions:
     orm:

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Analytics.orm.xml
@@ -14,7 +14,7 @@
             <generator strategy="AUTO"/>
         </id>
         <field name="title" type="string" column="title" length="255"/>
-        <field name="webspaceKey" type="string" column="webspace_key" length="255"/>
+        <field name="webspaceKey" type="string" column="webspace_key" length="191"/>
         <field name="allDomains" type="boolean" column="all_domains"/>
         <field name="content" type="json_array" column="content"/>
         <field name="type" type="string" column="type" length="60"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Domain.orm.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/doctrine/Domain.orm.xml
@@ -12,7 +12,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
-        <field name="url" type="string" column="url" length="255"/>
+        <field name="url" type="string" column="url" length="191"/>
         <field name="environment" type="string" column="environment" length="10"/>
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/jackalope/jackalope-doctrine-dbal/pull/353
| License | MIT

#### What's in this PR?

Decrease all indexed fields length to 191.

#### Why?

To support utf8mb4 the max index length on default innodb is 191. https://dev.mysql.com/doc/refman/5.6/en/charset-unicode-conversion.html

Testing this issue on different version of mysql different changes need to be done:
For example travis uses 5.6.33 there you only need to decrease indexes which are unique.
On my local installation 5.6.21 there you also need to decrease all indexed fields e.g. `FileVersion:mimeType`. So I did go the way to support also the older version of mysql with utf8mb4.

#### Example Usage

~~~php
doctrine:
    dbal:
        charset: utf8mb4
        default_table_options:
            charset: utf8mb4
            collate: utf8mb4_unicode_ci
~~~

#### BC Breaks/Deprecations

Some field length decreased.

#### To Do

- [x] Write UPGRADE file.
- [x] Needs https://github.com/jackalope/jackalope-doctrine-dbal/pull/353 (released in 1.3.2)
- [x] Should this be a ~1.6 hotfix~ or 2.0? 