### PR TITLE
Fixed class parameter to load field-descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * HOTFIX      #3730 [ContactBundle]         Fixed class parameter to load field-descriptor
     * HOTFIX      #3720 [MediaBundle]           Added extension-guesser to fix wrong extensions on download
 
 * 1.5.9 (2018-01-18)

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -104,7 +104,7 @@ class ContactController extends RestController implements ClassResourceInterface
     {
         $this->fieldDescriptors = $this->get(
             'sulu_core.list_builder.field_descriptor_factory'
-        )->getFieldDescriptorForClass(Contact::class);
+        )->getFieldDescriptorForClass($this->getParameter('sulu.model.contact.class'));
 
         // field descriptors for the account contact list
         $this->accountContactFieldDescriptors = [];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the field-descriptor loading for extended contacts.

#### Why?

If you extend the contact and want to add field-descriptors.
