### PR TITLE
Set proper default locale for document-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-release/1.5
     * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
+    * ENHANCEMENT #3735 [DocumentManager]       Set proper default locale for document-manager
     * HOTFIX      #3730 [ContactBundle]         Fixed class parameter to load field-descriptor
     * HOTFIX      #3720 [MediaBundle]           Added extension-guesser to fix wrong extensions on download
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -129,7 +129,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue('i18n')
                         ->end()
                         ->scalarNode('default')
-                            ->defaultValue('en')
+                            ->defaultValue('%kernel.default_locale%')
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3722
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR set a proper default-locale for document-manager.