### PR TITLE
Added exception when default_host is needed for sitemap generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-release/1.5
     * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
     * ENHANCEMENT #3735 [DocumentManager]       Set proper default locale for document-manager
+    * ENHANCEMENT #3736 [WebsiteBundle]         Added exception when default_host is needed for sitemap generation
     * HOTFIX      #3730 [ContactBundle]         Fixed class parameter to load field-descriptor
     * HOTFIX      #3720 [MediaBundle]           Added extension-guesser to fix wrong extensions on download
 

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -89,7 +89,7 @@ class DumpSitemapCommand extends ContainerAwareCommand
         }
 
         if ($input->getOption('clear')) {
-            $this->filesystem->remove(rtrim($this->baseDirectory, '/') . '/' . $this->scheme);
+            $this->clear();
         }
 
         $output->writeln('Start dumping "sitemap.xml" files:');
@@ -125,8 +125,22 @@ class DumpSitemapCommand extends ContainerAwareCommand
      */
     private function dumpPortalInformations(array $portalInformations)
     {
-        foreach ($portalInformations as $portalInformation) {
-            $this->sitemapDumper->dumpPortalInformation($portalInformation, $this->scheme);
+        try {
+            foreach ($portalInformations as $portalInformation) {
+                $this->sitemapDumper->dumpPortalInformation($portalInformation, $this->scheme);
+            }
+        } catch (\InvalidArgumentException $exception) {
+            $this->clear();
+
+            throw $exception;
         }
+    }
+
+    /**
+     * Clear the sitemap-cache.
+     */
+    private function clear()
+    {
+        $this->filesystem->remove(rtrim($this->baseDirectory, '/') . '/' . $this->scheme);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumper.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumper.php
@@ -104,7 +104,7 @@ class XmlSitemapDumper implements XmlSitemapDumperInterface
     {
         if (false !== strpos($portalInformation->getUrl(), '{host}')) {
             if (!$this->defaultHost) {
-                return;
+                throw new \InvalidArgumentException('When using host replacer a default_host has to be set.');
             }
 
             $portalInformation->setUrl(str_replace('{host}', $this->defaultHost, $portalInformation->getUrl()));

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumperInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapDumperInterface.php
@@ -49,6 +49,8 @@ interface XmlSitemapDumperInterface
      *
      * @param PortalInformation $portalInformation
      * @param string $scheme
+     *
+     * @throws \InvalidArgumentException
      */
     public function dumpPortalInformation(PortalInformation $portalInformation, $scheme);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3732, fixes #3382
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes silent fail for sitemap generation.
