### PR TITLE
Use correct imagine adapter for paste transformation

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/PasteTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/PasteTransformation.php
@@ -11,11 +11,10 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation;
 
-use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
 use Imagine\Image\Point;
-use Imagine\Imagick\Imagine as ImagickImagine;
 use Symfony\Component\Config\FileLocator;
 
 /**
@@ -24,6 +23,11 @@ use Symfony\Component\Config\FileLocator;
 class PasteTransformation implements TransformationInterface
 {
     /**
+     * @var ImagineInterface
+     */
+    private $imagine;
+
+    /**
      * @var FileLocator
      */
     private $fileLocator;
@@ -31,11 +35,14 @@ class PasteTransformation implements TransformationInterface
     /**
      * MaskTransformation constructor.
      *
+     * @param ImagineInterface $imagine
      * @param FileLocator $fileLocator
      */
     public function __construct(
+        ImagineInterface $imagine,
         FileLocator $fileLocator
     ) {
+        $this->imagine = $imagine;
         $this->fileLocator = $fileLocator;
     }
 
@@ -94,14 +101,7 @@ class PasteTransformation implements TransformationInterface
      */
     protected function createMask($maskPath, $width, $height)
     {
-        try {
-            // todo get this from a service
-            $imagine = new ImagickImagine();
-        } catch (\RuntimeException $ex) {
-            $imagine = new GdImagine();
-        }
-
-        $mask = $imagine->open($maskPath);
+        $mask = $this->imagine->open($maskPath);
         $mask->resize(
             new Box(
                 $width ?: 1,

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -103,6 +103,7 @@
         </service>
 
         <service id="sulu_media.image.transformation.paste" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\PasteTransformation">
+            <argument type="service" id="sulu_media.adapter"/>
             <argument type="service" id="file_locator"/>
 
             <tag name="sulu_media.image.transformation" alias="paste" />

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Transformations/PasteTransformationTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter\Transformations;
 
+use Imagine\Gd\Imagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
 use Prophecy\Argument;
@@ -41,7 +42,8 @@ class PasteTransformationTest extends SuluTestCase
             __DIR__ . '/../../../../app/Resources/images/photo.jpeg'
         );
 
-        $this->pasteTransformation = new pasteTransformation(
+        $this->pasteTransformation = new PasteTransformation(
+            new Imagine(),
             $this->fileLocator->reveal()
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use image adapter from the service definition.

#### Why?

Currently it don't use the defined service for the paste adapter.
