### PR TITLE
Added locale to content-teaser query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
     * HOTFIX      #3730 [ContactBundle]         Fixed class parameter to load field-descriptor
     * HOTFIX      #3720 [MediaBundle]           Added extension-guesser to fix wrong extensions on download
 

--- a/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
@@ -60,6 +60,7 @@ class ContentTeaserProvider implements TeaserProviderInterface
         $searchResult = $this->searchManager
             ->createSearch(implode(' OR ', $statements))
             ->indexes($this->getPageIndexes())
+            ->locale($locale)
             ->execute();
 
         /** @var QueryHit $item */

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Teaser/ContentTeaserProviderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Teaser/ContentTeaserProviderTest.php
@@ -82,6 +82,7 @@ class ContentTeaserProviderTest extends \PHPUnit_Framework_TestCase
             )
         )->willReturn($this->search->reveal())->shouldBeCalled();
         $this->search->indexes(['page_sulu_io_published'])->willReturn($this->search->reveal())->shouldBeCalled();
+        $this->search->locale('de')->willReturn($this->search->reveal())->shouldBeCalled();
         $this->search->execute()->willReturn(
             [$this->createQueryHit($ids[0], $data[$ids[0]]), $this->createQueryHit($ids[1], $data[$ids[1]])]
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3434
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the locale to the content-teaser query.

