### PR TITLE
Cleand-up xliff import/export component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
     * ENHANCEMENT #3735 [DocumentManager]       Set proper default locale for document-manager
     * ENHANCEMENT #3736 [WebsiteBundle]         Added exception when default_host is needed for sitemap generation
+    * HOTFIX      #3741 [ContentBundle]         Cleand-up xliff import/export component
     * HOTFIX      #3730 [ContactBundle]         Fixed class parameter to load field-descriptor
     * HOTFIX      #3720 [MediaBundle]           Added extension-guesser to fix wrong extensions on download
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
@@ -19,19 +19,20 @@ use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\WorkflowStage;
-use Sulu\Component\Content\Export\WebspaceInterface;
+use Sulu\Component\Content\Export\WebspaceExportInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
-use Symfony\Component\DependencyInjection\Extension\Extension;
+use Sulu\Component\DocumentManager\Exception\MetadataNotFoundException;
 
 /**
  * Tests for the Webspace Export class.
  */
-class WebspaceTest extends SuluTestCase
+class WebspaceExportTest extends SuluTestCase
 {
     /**
-     * @var WebspaceInterface
+     * @var WebspaceExportInterface
      */
     private $webspaceExporter;
 
@@ -86,21 +87,66 @@ class WebspaceTest extends SuluTestCase
 
     /**
      * @return StructureInterface[]
+     *
+     * @throws DocumentManagerException
+     * @throws MetadataNotFoundException
      */
     private function prepareData()
     {
         /** @var \Sulu\Component\Content\Compat\Structure\PageBridge[] $data */
-        $data = $this->getDataArray();
+        $data = $this->getRawData();
         $extensionDataList = $this->getExtensionDataArray();
         $data[0]['ext'] = $extensionDataList[0];
         $data[1]['ext'] = $extensionDataList[1];
 
         $documents = [];
 
-        $documents[0] = $this->save($data[0], 'overview', 'sulu_io', 'en', $this->creator);
-        $documents[1] = $this->save($data[1], 'overview', 'sulu_io', 'en', $this->creator);
+        $documents[0] = $this->save($data[0], 'overview', 'sulu_io', 'en');
+        $documents[1] = $this->save($data[1], 'overview', 'sulu_io', 'en');
 
         return $documents;
+    }
+
+    /**
+     * @return array
+     */
+    private function getRawData()
+    {
+        $data = $this->getDataArray();
+
+        return [
+            [
+                'title' => $data[0]['title'],
+                'subtitle' => $data[0]['subtitle'],
+                'url' => $data[0]['url'],
+                'article' => $data[0]['article'],
+                'block' => [
+                    [
+                        'type' => $data[0]['block'][0]['type']['value'],
+                        'title' => $data[0]['block'][0]['title']['value'],
+                        'article' => $data[0]['block'][0]['article']['value'],
+                    ],
+                    [
+                        'type' => $data[0]['block'][1]['type']['value'],
+                        'title' => $data[0]['block'][1]['title']['value'],
+                        'article' => $data[0]['block'][1]['article']['value'],
+                    ],
+                ],
+            ],
+            [
+                'title' => $data[1]['title'],
+                'subtitle' => $data[1]['subtitle'],
+                'url' => $data[1]['url'],
+                'article' => $data[1]['article'],
+                'block' => [
+                    [
+                        'type' => $data[1]['block'][0]['type']['value'],
+                        'title' => $data[1]['block'][0]['title']['value'],
+                        'article' => $data[1]['block'][0]['article']['value'],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -116,14 +162,56 @@ class WebspaceTest extends SuluTestCase
                 'article' => 'Lorem Ipsum dolorem apsum',
                 'block' => [
                     [
-                        'type' => 'type1',
-                        'title' => 'Block-Title-1',
-                        'article' => 'Block-Article-1-1',
+                        'type' => [
+                            'name' => 'type',
+                            'type' => 'block_type',
+                            'options' => [
+                                'translate' => false,
+                            ],
+                            'value' => 'type1',
+                        ],
+                        'title' => [
+                            'name' => 'title',
+                            'type' => 'text_line',
+                            'options' => [
+                                'translate' => true,
+                            ],
+                            'value' => 'Block-Title-1',
+                        ],
+                        'article' => [
+                            'name' => 'article',
+                            'type' => 'text_line',
+                            'options' => [
+                                'translate' => true,
+                            ],
+                            'value' => 'Block-Article-1-1',
+                        ],
                     ],
                     [
-                        'type' => 'type1',
-                        'title' => 'Block-Title-1',
-                        'article' => 'Block-Article-1-2',
+                        'type' => [
+                            'name' => 'type',
+                            'type' => 'block_type',
+                            'options' => [
+                                'translate' => false,
+                            ],
+                            'value' => 'type1',
+                        ],
+                        'title' => [
+                            'name' => 'title',
+                            'type' => 'text_line',
+                            'options' => [
+                                'translate' => true,
+                            ],
+                            'value' => 'Block-Title-1',
+                        ],
+                        'article' => [
+                            'name' => 'article',
+                            'type' => 'text_line',
+                            'options' => [
+                                'translate' => true,
+                            ],
+                            'value' => 'Block-Article-1-2',
+                        ],
                     ],
                 ],
             ],
@@ -134,9 +222,30 @@ class WebspaceTest extends SuluTestCase
                 'article' => 'asdfasdf',
                 'block' => [
                     [
-                        'type' => 'type1',
-                        'title' => 'Block-Title-2',
-                        'article' => 'Block-Article-2-1',
+                        'type' => [
+                            'name' => 'type',
+                            'type' => 'block_type',
+                            'options' => [
+                                'translate' => false,
+                            ],
+                            'value' => 'type1',
+                        ],
+                        'title' => [
+                            'name' => 'title',
+                            'type' => 'text_line',
+                            'options' => [
+                                'translate' => true,
+                            ],
+                            'value' => 'Block-Title-2',
+                        ],
+                        'article' => [
+                            'name' => 'article',
+                            'type' => 'text_line',
+                            'options' => [
+                                'translate' => true,
+                            ],
+                            'value' => 'Block-Article-2-1',
+                        ],
                     ],
                 ],
             ],
@@ -432,7 +541,7 @@ class WebspaceTest extends SuluTestCase
         }
 
         if (null !== $children) {
-            $data['value'] = $children;
+            $data['children'] = $children;
         }
 
         return $data;
@@ -443,8 +552,6 @@ class WebspaceTest extends SuluTestCase
      * @param string $structureType
      * @param string $webspaceKey
      * @param string $locale
-     * @param int $userId
-     * @param bool $partialUpdate
      * @param string $uuid
      * @param string $parentUuid
      * @param int $state
@@ -453,14 +560,15 @@ class WebspaceTest extends SuluTestCase
      * @param string $documentAlias
      *
      * @return object
+     *
+     * @throws DocumentManagerException
+     * @throws MetadataNotFoundException
      */
     private function save(
         $data,
         $structureType,
         $webspaceKey,
         $locale,
-        $userId,
-        $partialUpdate = true,
         $uuid = null,
         $parentUuid = null,
         $state = null,

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\SnippetBundle\Command;
 
-use Sulu\Component\Snippet\Import\SnippetImport;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,9 +65,7 @@ class SnippetImportCommand extends ContainerAwareCommand
 
         $output->writeln('<info>Continue!</info>');
 
-        /** @var SnippetImport $webspaceImporter */
         $webspaceImporter = $this->getContainer()->get('sulu_snippet.import.snippet');
-
         $import = $webspaceImporter->import(
             $locale,
             $filePath,

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Import/SnippetImportTest.php
@@ -11,8 +11,12 @@
 
 namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Import;
 
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
+use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\Snippet\Import\SnippetImportInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -27,16 +31,23 @@ class SnippetImportTest extends SuluTestCase
     private $documentManager;
 
     /**
-     * @var object
+     * @var SnippetImportInterface
      */
-    private $parent;
-
     private $snippetImporter;
 
+    /**
+     * @var SnippetDocument[]
+     */
     private $snippets = [];
 
+    /**
+     * @var string
+     */
     protected $distPath = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff.dist';
 
+    /**
+     * @var string
+     */
     protected $path = './src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/import/export.xliff';
 
     /**

--- a/src/Sulu/Component/Content/Import/WebspaceImportInterface.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImportInterface.php
@@ -17,14 +17,6 @@ namespace Sulu\Component\Content\Import;
 interface WebspaceImportInterface
 {
     /**
-     * Add import format like XLIFF1.2.
-     *
-     * @param WebspaceFormatImportInterface $service
-     * @param $format
-     */
-    public function add($service, $format);
-
-    /**
      * Starts language import for given webspace and locale.
      *
      * @param string $webspaceKey
@@ -33,6 +25,7 @@ interface WebspaceImportInterface
      * @param $output
      * @param string $format
      * @param string $uuid
+     * @param string $exportSuluVersion
      *
      * @return array
      */

--- a/src/Sulu/Component/Export/Export.php
+++ b/src/Sulu/Component/Export/Export.php
@@ -11,7 +11,15 @@
 
 namespace Sulu\Component\Export;
 
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
+use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
+use Sulu\Component\Content\Document\Structure\PropertyValue;
+use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\Export\Manager\ExportManagerInterface;
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * Base export for sulu documents.
@@ -24,7 +32,7 @@ class Export
     protected $templating;
 
     /**
-     * @var DocumentManager
+     * @var DocumentManagerInterface
      */
     protected $documentManager;
 
@@ -34,14 +42,38 @@ class Export
     protected $documentInspector;
 
     /**
-     * @var null
+     * @var ExportManagerInterface
+     */
+    protected $exportManager;
+
+    /**
+     * @var string[]
+     */
+    protected $formatFilePaths;
+
+    /**
+     * @var string
      */
     protected $exportLocale = 'en';
 
     /**
-     * @var null
+     * @var string
      */
     protected $format = '1.2.xliff';
+
+    public function __construct(
+        EngineInterface $templating,
+        DocumentManagerInterface $documentManager,
+        DocumentInspector $documentInspector,
+        ExportManagerInterface $exportManager,
+        array $formatFilePaths
+    ) {
+        $this->templating = $templating;
+        $this->documentManager = $documentManager;
+        $this->documentInspector = $documentInspector;
+        $this->exportManager = $exportManager;
+        $this->formatFilePaths = $formatFilePaths;
+    }
 
     /**
      * Creates and returns a property-array.
@@ -66,7 +98,6 @@ class Export
      *
      * @param BlockMetadata $property
      * @param PropertyValue $propertyValue
-     * @param $format
      *
      * @return array
      */
@@ -137,7 +168,6 @@ class Export
      *
      * @param PropertyMetadata[] $properties
      * @param $propertyValues
-     * @param $format
      *
      * @return array
      */
@@ -173,6 +203,8 @@ class Export
      * @param $locale
      *
      * @return array
+     *
+     * @throws DocumentManagerException
      */
     protected function getContentData($document, $locale)
     {

--- a/src/Sulu/Component/Import/Import.php
+++ b/src/Sulu/Component/Import/Import.php
@@ -13,8 +13,10 @@ namespace Sulu\Component\Import;
 
 use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Import\Exception\FormatImporterNotFoundException;
+use Sulu\Component\Import\Format\FormatImportInterface;
 use Sulu\Component\Import\Manager\ImportManagerInterface;
 
 /**
@@ -23,7 +25,7 @@ use Sulu\Component\Import\Manager\ImportManagerInterface;
 class Import
 {
     /**
-     * @var WebspaceFormatImportInterface[]
+     * @var FormatImportInterface[]
      */
     protected $formatFilePaths = [];
 
@@ -42,9 +44,14 @@ class Import
      */
     protected $exceptionStore = [];
 
-    public function add($service, $format)
-    {
-        $this->formatFilePaths[$format] = $service;
+    public function __construct(
+        ImportManagerInterface $importManager,
+        LegacyPropertyFactory $legacyPropertyFactory,
+        array $formatFilePaths
+    ) {
+        $this->formatFilePaths = $formatFilePaths;
+        $this->importManager = $importManager;
+        $this->legacyPropertyFactory = $legacyPropertyFactory;
     }
 
     /**
@@ -52,9 +59,9 @@ class Import
      *
      * @param $format
      *
-     * @return WebspaceFormatImportInterface
+     * @return FormatImportInterface
      *
-     * @throws WebspaceFormatImporterNotFoundException
+     * @throws FormatImporterNotFoundException
      */
     protected function getParser($format)
     {
@@ -70,6 +77,7 @@ class Import
      *
      * @param PropertyInterface $property
      * @param NodeInterface $node
+     * @param StructureInterface $structure
      * @param string $value
      * @param string $webspaceKey
      * @param string $locale

--- a/src/Sulu/Component/Snippet/Export/SnippetExport.php
+++ b/src/Sulu/Component/Snippet/Export/SnippetExport.php
@@ -15,10 +15,12 @@ use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetRepository;
 use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\Export\Export;
 use Sulu\Component\Export\Manager\ExportManagerInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Templating\EngineInterface;
 
 /**
@@ -32,29 +34,10 @@ class SnippetExport extends Export implements SnippetExportInterface
     private $snippetManager;
 
     /**
-     * @var ExportManagerInterface
-     */
-    protected $exportManager;
-
-    /**
-     * @var string[]
-     */
-    protected $formatFilePaths;
-
-    /**
-     * @var Output
+     * @var OutputInterface
      */
     protected $output;
 
-    /**
-     * Snippet constructor.
-     *
-     * @param EngineInterface $templating
-     * @param SnippetRepository $snippetManager
-     * @param DocumentManager $documentManager
-     * @param DocumentInspector $documentInspector
-     * @param array $formatFilePaths
-     */
     public function __construct(
         EngineInterface $templating,
         SnippetRepository $snippetManager,
@@ -63,23 +46,17 @@ class SnippetExport extends Export implements SnippetExportInterface
         ExportManagerInterface $exportManager,
         $formatFilePaths
     ) {
-        $this->templating = $templating;
+        parent::__construct($templating, $documentManager, $documentInspector, $exportManager, $formatFilePaths);
+
         $this->snippetManager = $snippetManager;
-        $this->documentManager = $documentManager;
-        $this->documentInspector = $documentInspector;
-        $this->exportManager = $exportManager;
-        $this->formatFilePaths = $formatFilePaths;
         $this->output = new NullOutput();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function export(
-        $locale,
-        $output = null,
-        $format = '1.2.xliff'
-    ) {
+    public function export($locale, $output = null, $format = '1.2.xliff')
+    {
         if (!$locale) {
             throw new \Exception(sprintf('Invalid parameters for export "%s"', $locale));
         }
@@ -102,6 +79,8 @@ class SnippetExport extends Export implements SnippetExportInterface
      * Returns all data that we need to create a xliff-File.
      *
      * @return array
+     *
+     * @throws DocumentManagerException
      */
     public function getExportData()
     {
@@ -138,7 +117,7 @@ class SnippetExport extends Export implements SnippetExportInterface
     /**
      * Returns all Snippets.
      *
-     * @return SnippetBridge[]
+     * @return SnippetDocument[]
      */
     protected function getSnippets()
     {

--- a/src/Sulu/Component/Snippet/Export/SnippetExportInterface.php
+++ b/src/Sulu/Component/Snippet/Export/SnippetExportInterface.php
@@ -25,9 +25,5 @@ interface SnippetExportInterface
      *
      * @return array
      */
-    public function export(
-        $locale,
-        $output,
-        $format = '1.2.xliff'
-    );
+    public function export($locale, $output, $format = '1.2.xliff');
 }

--- a/src/Sulu/Component/Snippet/Import/SnippetImportInterface.php
+++ b/src/Sulu/Component/Snippet/Import/SnippetImportInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Snippet\Import;
+
+use Sulu\Component\Import\Exception\FormatImporterNotFoundException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Import Snippets by given xliff-file.
+ */
+interface SnippetImportInterface
+{
+    /**
+     * Import Snippet by given XLIFF-File.
+     *
+     * @param string $locale
+     * @param string $filePath
+     * @param OutputInterface $output
+     * @param string $format
+     *
+     * @return \stdClass
+     *
+     * @throws FormatImporterNotFoundException
+     */
+    public function import($locale, $filePath, OutputInterface $output = null, $format = '1.2.xliff');
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3301 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR cleans-up the Import/Export component.

#### Why?

The missing uses/properties leads into an error when import/export blocks.
