### PR TITLE
Overwrite 'doctrine:phpcr:workspace:import' set default to throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * HOTFIX      #3752 [ContentBundle]           Overwrite 'doctrine:phpcr:workspace:import' set default to throw
+
 * 1.5.10 (2018-02-06)
     * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
     * ENHANCEMENT #3735 [DocumentManager]       Set proper default locale for document-manager

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         "symfony/symfony": "2.8.10",
         "symfony/phpunit-bridge": "2.8.10",
         "symfony/monolog-bundle": "2.8.10",
-        "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1"
+        "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1",
+        "phpcr/phpcr-utils": "1.2.1 - 1.2.10 || 1.3.1 || 1.3.2"
     },
     "replace": {
         "sulu/media-bundle": "self.version",

--- a/src/Sulu/Bundle/ContentBundle/Command/WorkspaceImportCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/WorkspaceImportCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Command;
+
+use Doctrine\Bundle\PHPCRBundle\Command\WorkspaceImportCommand as BaseWorkspaceImportCommand;
+
+class WorkspaceImportCommand extends BaseWorkspaceImportCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->getDefinition()->getOption('uuid-behavior')->setDefault('throw');
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/phpcr/phpcr-utils
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR overwrites the command `doctrine:phpcr:workspace:import` and set the default of `uuid-behavior` to `throw`.

#### Why?

This disables the regeneration of `uuid` while import from xml.