### PR TITLE
update rule for spaces in JSX tags

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -102,7 +102,12 @@
         ],
         "react/jsx-wrap-multilines": "error",
         "react/jsx-pascal-case": "error",
-        "react/jsx-tag-spacing": "error",
+        "react/jsx-tag-spacing": [
+            "error",
+            {
+                "beforeClosing": "never"
+            }
+        ],
         "react/jsx-key": "error",
         "react/jsx-indent": "error",
         "react/jsx-no-bind": "error",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "eslint-plugin-class-property": "^1.0.6",
         "eslint-plugin-flowtype": "^2.34.0",
         "eslint-plugin-import": "^2.7.0",
-        "eslint-plugin-react": "^7.0.1",
+        "eslint-plugin-react": "^7.6.1",
         "extract-text-webpack-plugin": "^3.0.1",
         "file-loader": "^0.11.2",
         "flow-bin": "^0.64.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | https://github.com/yannickcr/eslint-plugin-react/issues/1396
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR forbids to write whitespaces before the `>` character in opening tags.

#### Why?

Because we don't want that :see_no_evil: 

#### Example Usage

```javascript
// not allowed
<header >Header</header>

// write instead
<header>Header</header>
```