### PR TITLE
Correct extension stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media
     * HOTFIX      #3750 [PreviewBundle]           Fixed refresh preview
     * HOTFIX      #3747 [RouteBundle]             Added empty array as default value to histories property.
+    * BUGFIX      #3755 [RouteBundle]             Fixed how the route provider strips format extensions from the path
 
 * 1.6.14 (2018-02-06)
     * ENHANCEMENT #3717 [ContentBundle]           ResourceLocator: Show whole url in history overlay

--- a/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Routing/RouteProvider.php
@@ -109,9 +109,7 @@ class RouteProvider implements RouteProviderInterface
             return $collection;
         }
 
-        if ('html' !== $format) {
-            $path = substr($path, 0, strpos($path, $format) - 1);
-        }
+        $path = $this->stripFormatExtension($path, $format);
 
         $route = $this->findRouteByPath($path, $request->getLocale());
         if ($route && array_key_exists($route->getId(), $this->symfonyRouteCache)) {
@@ -260,5 +258,23 @@ class RouteProvider implements RouteProviderInterface
         }
 
         return '/' . ltrim(rawurldecode($pathInfo), '/');
+    }
+
+    /**
+     * Return the given path without the format extension.
+     *
+     * @param string $path
+     * @param string $format
+     *
+     * @return string
+     */
+    private function stripFormatExtension($path, $format)
+    {
+        $extension = '.' . $format;
+        if (substr($path, -strlen($extension)) === $extension) {
+            $path = substr($path, 0, strlen($path) - strlen($extension));
+        }
+
+        return $path;
     }
 }


### PR DESCRIPTION
The removal of the extension of formats should only take place when
the format is present as extension in the url. (#3755)

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3755
| Related issues/PRs | #3755
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### Why?

When using json as request format by default, without using .json extensions, the RouteProvider cut off the last character of the url, resulting in a 404.
In this PR, the stripping of the extension is only attempted if the format extension is present.


