### PR TITLE
Allow dynamic order of elements in webspace xmls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * ENHANCEMENT #3764 [Component]             Allow dynamic order of elements in webspace xml
+
 * 1.5.10 (2018-02-06)
     * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
     * ENHANCEMENT #3735 [DocumentManager]       Set proper default locale for document-manager

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.0.xsd
@@ -3,7 +3,7 @@
            targetNamespace="http://schemas.sulu.io/webspace/webspace" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="http://schemas.sulu.io/webspace/webspace">
     <xs:complexType name="webspaceType">
-        <xs:sequence>
+        <xs:all>
             <xs:element type="xs:string" name="name"/>
             <xs:element name="key">
                 <xs:simpleType>
@@ -18,7 +18,7 @@
             <xs:element type="themeType" name="theme"/>
             <xs:element type="navigationType" name="navigation"/>
             <xs:element type="portalsType" name="portals"/>
-        </xs:sequence>
+        </xs:all>
     </xs:complexType>
 
     <xs:complexType name="security">

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -4,7 +4,7 @@
            xmlns:webspace="http://schemas.sulu.io/webspace/webspace"
            xmlns="http://schemas.sulu.io/webspace/webspace">
     <xs:complexType name="webspaceType">
-        <xs:sequence>
+        <xs:all>
             <xs:element type="xs:string" name="name"/>
             <xs:element name="key">
                 <xs:simpleType>
@@ -22,7 +22,7 @@
             <xs:element type="navigationType" name="navigation"/>
             <xs:element type="resource-locatorType" name="resource-locator" maxOccurs="1" minOccurs="0"/>
             <xs:element type="portalsType" name="portals"/>
-        </xs:sequence>
+        </xs:all>
     </xs:complexType>
 
     <xs:complexType name="security">

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader10Test.php
@@ -135,4 +135,11 @@ class XmlFileLoader10Test extends WebspaceTestCase
             $this->getResourceDirectory() . '/DataFixtures/Webspace/invalid/sulu.io_deprecated_invalid_webspace_key.xml'
         );
     }
+
+    public function testLoadDynamicOrder()
+    {
+        $this->loader->load(
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/valid/sulu.io_deprecatedDynamicOrder.xml'
+        );
+    }
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -495,4 +495,11 @@ class XmlFileLoader11Test extends WebspaceTestCase
             $this->getResourceDirectory() . '/DataFixtures/Webspace/invalid/massiveart_invalid_custom_url.xml'
         );
     }
+
+    public function testLoadDynamicOrder()
+    {
+        $this->loader->load(
+            $this->getResourceDirectory() . '/DataFixtures/Webspace/valid/sulu.io_dynamicOrder.xml'
+        );
+    }
 }

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_deprecatedDynamicOrder.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_deprecatedDynamicOrder.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.0.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu_io</key>
+
+    <theme>
+        <key>sulu</key>
+
+        <default-templates>
+            <default-template type="page">default</default-template>
+            <default-template type="homepage">overview</default-template>
+        </default-templates>
+
+        <error-templates>
+            <error-template code="404">test.html.twig</error-template>
+            <error-template default="true">test.html.twig</error-template>
+        </error-templates>
+    </theme>
+
+    <security>
+        <system>sulu_io</system>
+    </security>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="de">Hauptnavigation</title>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+            <context key="footer">
+                <meta>
+                    <title lang="de">Unten</title>
+                    <title lang="en">Footer</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <localizations>
+        <localization language="en" country="us" shadow="auto"/>
+        <localization language="de" country="at" default="true"/>
+    </localizations>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at</key>
+            <resource-locator>
+                <strategy>short</strategy>
+            </resource-locator>
+
+            <localizations>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
+            </localizations>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="de" country="at">sulu.at</url>
+                        <url redirect="sulu.at">www.sulu.at</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url language="de" country="at">sulu.lo</url>
+                    </urls>
+                </environment>
+                <environment type="main">
+                    <urls>
+                        <url language="de" country="at">sulu.lo</url>
+                        <url language="de" country="at" main="true">sulu.at</url>
+                        <url language="de" country="at">at.sulu.de</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io_dynamicOrder.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io_dynamicOrder.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu_io</key>
+    <theme>sulu</theme>
+
+    <security>
+        <system>sulu_io</system>
+    </security>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="de">Hauptnavigation</title>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+            <context key="footer">
+                <meta>
+                    <title lang="de">Unten</title>
+                    <title lang="en">Footer</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <default-templates>
+        <default-template type="page">default</default-template>
+        <default-template type="homepage">overview</default-template>
+    </default-templates>
+
+    <localizations>
+        <localization language="en" country="us" shadow="auto"/>
+        <localization language="de" country="at" default="true"/>
+    </localizations>
+
+    <resource-locator>
+        <strategy>short</strategy>
+    </resource-locator>
+    
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at</key>
+
+            <localizations>
+                <localization language="en" country="us"/>
+                <localization language="de" country="at" default="true"/>
+            </localizations>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="de" country="at">sulu.at</url>
+                        <url redirect="sulu.at">www.sulu.at</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url language="de" country="at">sulu.lo</url>
+                    </urls>
+                </environment>
+                <environment type="main">
+                    <urls>
+                        <url language="de" country="at">sulu.lo</url>
+                        <url language="de" country="at" main="true">sulu.at</url>
+                        <url language="de" country="at">at.sulu.de</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu-docs#360
| License | MIT

#### What's in this PR?

It allow dynamic order of items in the webspace, template and format xmls.

#### Why?

For beginners a fix order can be a pitfall. 

#### Example Usage

See sulu/sulu-docs#360 issue.

