### PR TITLE
Fix bug with label in Switch component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
@@ -10,6 +10,7 @@ $marginBottom: 10px;
         font-size: $fontSize;
         margin-left: 10px;
         overflow: hidden;
+        line-height: normal;
     }
 
     & + .label {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Add `line-height: normal` to label.

#### Why?

The used font leads to errors.
