### PR TITLE
WebspaceOverview: Load webspaces from server

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/index.js
@@ -1,8 +1,10 @@
 // @flow
 import {bundleReady} from './Bundles';
 import ResourceRequester from './ResourceRequester';
+import Requester from './Requester';
 
 export {
     bundleReady,
     ResourceRequester,
+    Requester,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/index.js
@@ -5,6 +5,6 @@ import Requester from './Requester';
 
 export {
     bundleReady,
-    ResourceRequester,
     Requester,
+    ResourceRequester,
 };

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/WebspaceStore.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/WebspaceStore.js
@@ -1,0 +1,21 @@
+// @flow
+import {Requester} from 'sulu-admin-bundle/services';
+import type {Webspace} from './types';
+
+class WebspaceStore {
+    baseUrl: string = '/admin/api/webspaces';
+
+    webspacePromise: Promise<Object>;
+
+    loadWebspaces(): Promise<Array<Webspace>> {
+        if (!this.webspacePromise) {
+            this.webspacePromise = Requester.get(this.baseUrl);
+        }
+
+        return this.webspacePromise.then((response: Object) => {
+            return response._embedded.webspaces;
+        });
+    }
+}
+
+export default new WebspaceStore();

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/index.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/index.js
@@ -1,0 +1,4 @@
+// @flow
+import WebspaceStore from './WebspaceStore';
+
+export default WebspaceStore;

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/tests/WebspaceStore.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/tests/WebspaceStore.test.js
@@ -1,0 +1,38 @@
+// @flow
+import Requester from 'sulu-admin-bundle/services/Requester';
+import webspaceStore from '../WebspaceStore';
+
+jest.mock('sulu-admin-bundle/services/Requester', () => ({
+    get: jest.fn().mockReturnValue({
+        then: jest.fn(),
+    }),
+}));
+
+test('Load configuration for given key', () => {
+    const response = {
+        _embedded: {
+            webspaces: [
+                {
+                    name: 'sulu',
+                    key: 'sulu',
+                },
+                {
+                    name: 'Sulu Blog',
+                    key: 'sulu_blog',
+                },
+            ],
+        },
+    };
+
+    const promise = Promise.resolve(response);
+
+    Requester.get.mockReturnValue(promise);
+
+    const webspacePromise = webspaceStore.loadWebspaces();
+
+    return webspacePromise.then((webspaces) => {
+        // check if promise have been cached
+        expect(webspaceStore.webspacePromise).toEqual(promise);
+        expect(webspaces).toBe(response._embedded.webspaces);
+    });
+});

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/types.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/types.js
@@ -1,0 +1,44 @@
+// @flow
+export type Webspace = {
+    name: string,
+    key: string,
+    localizations: Array<Localization>,
+    urls: Array<Url>,
+    allLocalizations: Array<LocalizationItem>,
+    portalInformation: Array<PortalInformation>,
+    children: Array<Localization>,
+};
+
+export type Localization = {
+    locale: string,
+    language: string,
+    country: string,
+    shadow: string,
+    default: boolean,
+    xDefault: boolean,
+    children: Array<Localization>,
+};
+
+export type Url = {
+    url: string,
+    language: string,
+    country: string,
+    segment: string,
+    redirect: string,
+    main: boolean,
+    analyticsKey: string,
+    environment: string,
+};
+
+export type LocalizationItem = {
+    localization: string,
+    name: string,
+};
+
+export type PortalInformation = {
+    webspaceKey: string,
+    portalKey: string,
+    locale: string,
+    url: string,
+    main: boolean,
+};

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/types.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/types.js
@@ -6,7 +6,6 @@ export type Webspace = {
     urls: Array<Url>,
     allLocalizations: Array<LocalizationItem>,
     portalInformation: Array<PortalInformation>,
-    children: Array<Localization>,
 };
 
 export type Localization = {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -127,7 +127,7 @@ export default withToolbar(WebspaceOverview, function() {
         return {};
     }
 
-    const options = this.selectedWebspace.allLocalizations.map(function (localization) {
+    const options = this.selectedWebspace.allLocalizations.map((localization) => {
         return {
             value: localization.localization,
             label: localization.name,

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -25,14 +25,24 @@ class WebspaceOverview extends React.Component<ViewProps> {
     };
 
     @action setDefaultLocaleForWebspace = () => {
-        if (!this.selectedWebspace || !this.selectedWebspace.localizations) {
+        const selectedWebspace = this.selectedWebspace;
+
+        if (!selectedWebspace || !selectedWebspace.localizations) {
             return;
         }
 
-        this.locale.set(this.findDefaultLocale(this.selectedWebspace.localizations));
+        const locale = this.findDefaultLocale(selectedWebspace.localizations);
+
+        if (!locale) {
+            throw new Error(
+                'Default locale in webspace "' + selectedWebspace.key + '" not found'
+            );
+        }
+
+        this.locale.set(locale);
     };
 
-    findDefaultLocale = (localizations: Array<Localization>): string => {
+    findDefaultLocale = (localizations: Array<Localization>): ?string => {
         for (let localization of localizations) {
             if (localization.default) {
                 return localization.locale;
@@ -46,8 +56,6 @@ class WebspaceOverview extends React.Component<ViewProps> {
                 }
             }
         }
-
-        throw new Error('Default locale in webspace not found');
     };
 
     @computed get selectedWebspace(): ?Webspace {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -127,12 +127,10 @@ export default withToolbar(WebspaceOverview, function() {
         return {};
     }
 
-    const options = this.selectedWebspace.allLocalizations.map((localization) => {
-        return {
-            value: localization.localization,
-            label: localization.name,
-        };
-    });
+    const options = this.selectedWebspace.allLocalizations.map((localization) => ({
+        value: localization.localization,
+        label: localization.name,
+    }));
 
     const locale = {
         value: this.locale.get(),

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {mount, render} from 'enzyme';
+import {mount} from 'enzyme';
+import WebspaceStore from '../../../stores/WebspaceStore';
 
 jest.mock('sulu-admin-bundle/containers', () => {
     return {
@@ -26,18 +27,25 @@ jest.mock('sulu-admin-bundle/containers/Datagrid/registries/DatagridAdapterRegis
     has: jest.fn().mockReturnValue(true),
 }));
 
-test('Render WebspaceOverview', () => {
-    const WebspaceOverview = require('../WebspaceOverview').default;
-    const router = {
-        bind: jest.fn(),
-        attributes: {},
-    };
+jest.mock('../../../stores/WebspaceStore', () => ({
+    loadWebspaces: jest.fn(() => Promise.resolve()),
+}));
 
-    const webspaceOverview = render(<WebspaceOverview router={router} />);
-    expect(webspaceOverview).toMatchSnapshot();
+beforeEach(() => {
+    jest.resetModules();
 });
 
-test('Should change webspace when value of select is changed', () => {
+test('Render WebspaceOverview', () => {
+    // $FlowFixMe
+    const webspaceStore: typeof WebspaceStore = require('../../../stores/WebspaceStore');
+    const promise = Promise.resolve(
+        [
+            {key: 'sulu', localizations: [{locale: 'en', default: true}]},
+            {key: 'sulu_blog', localizations: [{locale: 'en', default: false}, {locale: 'de', default: true}]},
+        ]
+    );
+    webspaceStore.loadWebspaces.mockReturnValue(promise);
+
     const WebspaceOverview = require('../WebspaceOverview').default;
     const router = {
         bind: jest.fn(),
@@ -46,11 +54,79 @@ test('Should change webspace when value of select is changed', () => {
 
     const webspaceOverview = mount(<WebspaceOverview router={router} />);
 
-    webspaceOverview.instance().webspace.set('sulu');
-    expect(webspaceOverview.instance().webspace.get()).toBe('sulu');
+    return promise.then(() => {
+        webspaceOverview.update();
+        expect(webspaceOverview.render()).toMatchSnapshot();
+    });
+});
 
-    webspaceOverview.find('WebspaceSelect').prop('onChange')('sulu_blog');
-    expect(webspaceOverview.instance().webspace.get()).toBe('sulu_blog');
+test('Should change webspace when value of webspace select is changed', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const WebspaceOverview = require('../WebspaceOverview').default;
+    // $FlowFixMe
+    const toolbarFunction = withToolbar.mock.calls[0][1];
+    // $FlowFixMe
+    const webspaceStore: typeof WebspaceStore = require('../../../stores/WebspaceStore');
+
+    const promise = Promise.resolve(
+        [
+            {
+                key: 'sulu',
+                localizations: [{locale: 'en', default: true}],
+                allLocalizations: [{localization: 'en', name: 'en'}, {localization: 'de', name: 'de'}],
+            },
+            {
+                key: 'sulu_blog',
+                localizations: [{locale: 'en', default: false}, {locale: 'de', default: true}],
+                allLocalizations: [{localization: 'en', name: 'en'}, {localization: 'de', name: 'de'}],
+            },
+        ]
+    );
+
+    webspaceStore.loadWebspaces.mockReturnValue(promise);
+
+    const router = {
+        bind: jest.fn(),
+        attributes: {},
+    };
+
+    const webspaceOverview = mount(<WebspaceOverview router={router} />);
+
+    return promise.then(() => {
+        webspaceOverview.update();
+        webspaceOverview.instance().webspace.set('sulu');
+        webspaceOverview.instance().locale.set('en');
+        expect(webspaceOverview.instance().webspace.get()).toBe('sulu');
+        expect(webspaceOverview.instance().locale.get()).toBe('en');
+
+        const toolbarConfig = toolbarFunction.call(webspaceOverview.instance());
+        expect(toolbarConfig.locale.value).toBe('en');
+        expect(toolbarConfig.locale.options).toEqual(
+            expect.arrayContaining(
+                [
+                    expect.objectContaining({label: 'en', value: 'en'}),
+                    expect.objectContaining({label: 'de', value: 'de'}),
+                ]
+            )
+        );
+
+        webspaceOverview.update();
+        webspaceOverview.find('WebspaceSelect').prop('onChange')('sulu_blog');
+        // check if webspace is correctly set
+        expect(webspaceOverview.instance().webspace.get()).toBe('sulu_blog');
+        // check if default locale of selected webspace is set
+        expect(webspaceOverview.instance().locale.get()).toBe('de');
+
+        const toolbarConfigNew = toolbarFunction.call(webspaceOverview.instance());
+        expect(toolbarConfigNew.locale.value).toBe('de');
+        expect(toolbarConfigNew.locale.options).toEqual(
+            expect.arrayContaining(
+                [
+                    expect.objectContaining({label: 'de', value: 'de'}),
+                ]
+            )
+        );
+    });
 });
 
 test('Should bind/unbind router', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

`WebspaceOverview`: Load webspaces from server.
Used is the `WebspaceStore`.
