### PR TITLE
Add minOccurs and maxOccurs to Blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -264,6 +264,8 @@ class AdminController
                 },
                 "blocks": {
                     "label": "Blocks",
+                    "maxOccurs": 5,
+                    "minOccurs": 2,
                     "type": "block",
                     "types": {
                         "default": {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -11,6 +11,8 @@ import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {
+    maxOccurs?: number,
+    minOccurs?: number,
     onChange: (value: Array<BlockEntry>) => void,
     renderBlockContent: RenderBlockContentCallback,
     types?: {[key: string]: string},
@@ -53,7 +55,11 @@ export default class BlockCollection extends React.Component<Props> {
     }
 
     @action handleAddBlock = () => {
-        const {onChange, value} = this.props;
+        const {maxOccurs, onChange, value} = this.props;
+
+        if (maxOccurs && value.length >= maxOccurs) {
+            throw new Error('The maximum amount of blocks has already been reached!');
+        }
 
         if (value) {
             this.expandedBlocks.push(true);
@@ -63,8 +69,12 @@ export default class BlockCollection extends React.Component<Props> {
         }
     };
 
-    @action handleRemove = (index: number) => {
-        const {onChange, value} = this.props;
+    @action handleRemoveBlock = (index: number) => {
+        const {minOccurs, onChange, value} = this.props;
+
+        if (minOccurs && value.length <= minOccurs) {
+            throw new Error('The minimum amount of blocks has already been reached!');
+        }
 
         if (value) {
             this.expandedBlocks.splice(index, 1);
@@ -112,7 +122,7 @@ export default class BlockCollection extends React.Component<Props> {
                     lockAxis="y"
                     onExpand={this.handleExpand}
                     onCollapse={this.handleCollapse}
-                    onRemove={this.handleRemove}
+                    onRemove={this.handleRemoveBlock}
                     onSortEnd={this.handleSortEnd}
                     onTypeChange={this.handleTypeChange}
                     renderBlockContent={renderBlockContent}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -142,10 +142,12 @@ export default class BlockCollection extends React.Component<Props> {
                     useDragHandle={true}
                     value={identifiedValues}
                 />
-                <Button skin="secondary" onClick={this.handleAddBlock}>
-                    <Icon name="su-plus" className={blockCollectionStyles.addButtonIcon} />
-                    {translate('sulu_admin.add_block')}
-                </Button>
+                {!this.hasMaximumReached() &&
+                    <Button skin="secondary" onClick={this.handleAddBlock}>
+                        <Icon name="su-plus" className={blockCollectionStyles.addButtonIcon} />
+                        {translate('sulu_admin.add_block')}
+                    </Button>
+                }
             </section>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -114,13 +114,13 @@ export default class BlockCollection extends React.Component<Props> {
     hasMaximumReached() {
         const {maxOccurs, value} = this.props;
 
-        return maxOccurs && value.length >= maxOccurs;
+        return !!maxOccurs && value.length >= maxOccurs;
     }
 
     hasMinimumReached() {
         const {minOccurs, value} = this.props;
 
-        return minOccurs && value.length <= minOccurs;
+        return !!minOccurs && value.length <= minOccurs;
     }
 
     render() {
@@ -149,12 +149,10 @@ export default class BlockCollection extends React.Component<Props> {
                     useDragHandle={true}
                     value={identifiedValues}
                 />
-                {!this.hasMaximumReached() &&
-                    <Button skin="secondary" onClick={this.handleAddBlock}>
-                        <Icon name="su-plus" className={blockCollectionStyles.addButtonIcon} />
-                        {translate('sulu_admin.add_block')}
-                    </Button>
-                }
+                <Button skin="secondary" onClick={this.handleAddBlock} disabled={this.hasMaximumReached()}>
+                    <Icon name="su-plus" className={blockCollectionStyles.addButtonIcon} />
+                    {translate('sulu_admin.add_block')}
+                </Button>
             </section>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -44,7 +44,7 @@ export default class BlockCollection extends React.Component<Props> {
     }
 
     fillArrays() {
-        const {value} = this.props;
+        const {onChange, minOccurs, value} = this.props;
         const {expandedBlocks} = this;
 
         if (!value) {
@@ -52,6 +52,13 @@ export default class BlockCollection extends React.Component<Props> {
         }
 
         expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(false));
+        if (minOccurs && value.length < minOccurs) {
+            expandedBlocks.push(...new Array(minOccurs - value.length).fill(true));
+            onChange([
+                ...value,
+                ...new Array(minOccurs - value.length).fill(this.defaultType ? {type: this.defaultType} : {}),
+            ]);
+        }
     }
 
     @action handleAddBlock = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -55,9 +55,9 @@ export default class BlockCollection extends React.Component<Props> {
     }
 
     @action handleAddBlock = () => {
-        const {maxOccurs, onChange, value} = this.props;
+        const {onChange, value} = this.props;
 
-        if (maxOccurs && value.length >= maxOccurs) {
+        if (this.hasMaximumReached()) {
             throw new Error('The maximum amount of blocks has already been reached!');
         }
 
@@ -70,9 +70,9 @@ export default class BlockCollection extends React.Component<Props> {
     };
 
     @action handleRemoveBlock = (index: number) => {
-        const {minOccurs, onChange, value} = this.props;
+        const {onChange, value} = this.props;
 
-        if (minOccurs && value.length <= minOccurs) {
+        if (this.hasMinimumReached()) {
             throw new Error('The minimum amount of blocks has already been reached!');
         }
 
@@ -104,6 +104,18 @@ export default class BlockCollection extends React.Component<Props> {
         onChange(newValue);
     };
 
+    hasMaximumReached() {
+        const {maxOccurs, value} = this.props;
+
+        return maxOccurs && value.length >= maxOccurs;
+    }
+
+    hasMinimumReached() {
+        const {minOccurs, value} = this.props;
+
+        return minOccurs && value.length <= minOccurs;
+    }
+
     render() {
         const {renderBlockContent, types, value} = this.props;
 
@@ -122,7 +134,7 @@ export default class BlockCollection extends React.Component<Props> {
                     lockAxis="y"
                     onExpand={this.handleExpand}
                     onCollapse={this.handleCollapse}
-                    onRemove={this.handleRemoveBlock}
+                    onRemove={this.hasMinimumReached() ? undefined : this.handleRemoveBlock}
                     onSortEnd={this.handleSortEnd}
                     onTypeChange={this.handleTypeChange}
                     renderBlockContent={renderBlockContent}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
@@ -42,3 +42,24 @@ const renderBlockContent = (value, type) => 'This block does not really care abo
     value={state.value}
 />
 ```
+
+It is also possible to set the minimum and maximum amount of blocks on the `BlockCollection`, so it does not allow to
+have more or less blocks.
+
+```javascript
+initialState = {value: []};
+
+const onChange = (value) => {
+    setState({value});
+};
+
+const renderBlockContent = (value) => 'A not so unique block';
+
+<BlockCollection
+    maxOccurs={5}
+    minOccurs={2}
+    onChange={onChange}
+    renderBlockContent={renderBlockContent}
+    value={state.value}
+/>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
@@ -11,7 +11,7 @@ type Props = {
     expanded: boolean,
     onCollapse: (index: number) => void,
     onExpand: (index: number) => void,
-    onRemove: (index: number) => void,
+    onRemove?: (index: number) => void,
     onTypeChange?: (type: string | number, index: number) => void,
     renderBlockContent: RenderBlockContentCallback,
     sortIndex: number,
@@ -35,7 +35,9 @@ class SortableBlock extends React.Component<Props> {
     handleRemove = () => {
         const {sortIndex, onRemove} = this.props;
 
-        onRemove(sortIndex);
+        if (onRemove) {
+            onRemove(sortIndex);
+        }
     };
 
     handleTypeChange = (type) => {
@@ -47,7 +49,7 @@ class SortableBlock extends React.Component<Props> {
     };
 
     render() {
-        const {activeType, expanded, renderBlockContent, sortIndex, types, value} = this.props;
+        const {activeType, expanded, onRemove, renderBlockContent, sortIndex, types, value} = this.props;
 
         return (
             <Block
@@ -56,7 +58,7 @@ class SortableBlock extends React.Component<Props> {
                 expanded={expanded}
                 onCollapse={this.handleCollapse}
                 onExpand={this.handleExpand}
-                onRemove={this.handleRemove}
+                onRemove={onRemove ? this.handleRemove : undefined}
                 onTypeChange={this.handleTypeChange}
                 types={types}
             >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlocks.js
@@ -44,7 +44,7 @@ class SortableBlocks extends React.Component<Props> {
     };
 
     render() {
-        const {expandedBlocks, renderBlockContent, types, value} = this.props;
+        const {expandedBlocks, onRemove, renderBlockContent, types, value} = this.props;
 
         return (
             <div className={sortableBlockListStyles.sortableBlockList}>
@@ -56,7 +56,7 @@ class SortableBlocks extends React.Component<Props> {
                         key={block.__id}
                         onExpand={this.handleExpand}
                         onCollapse={this.handleCollapse}
-                        onRemove={this.handleRemove}
+                        onRemove={onRemove ? this.handleRemove : undefined}
                         onTypeChange={this.handleTypeChange}
                         renderBlockContent={renderBlockContent}
                         sortIndex={index}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -23,12 +23,10 @@ test('Should render an empty block list', () => {
 });
 
 test('Should render a filled block list', () => {
-    const renderBlockContent = jest.fn();
-
     expect(render(
         <BlockCollection
             onChange={jest.fn()}
-            renderBlockContent={renderBlockContent}
+            renderBlockContent={jest.fn()}
             value={[{content: 'Test 1'}, {content: 'Test 2'}]}
         />
     )).toMatchSnapshot();
@@ -169,6 +167,18 @@ test('Should allow to remove an existing block', () => {
     blockCollection.find('Block').at(0).find('Icon[name="su-trash"]').simulate('click');
 
     expect(changeSpy).toBeCalledWith([expect.objectContaining({content: 'Test 2'})]);
+});
+
+test('Should not render the remove icon if less or the exact amount of items are passed', () => {
+    const value = [{content: 'Value 1'}, {content: 'Value 2'}];
+
+    const blockCollection = mount(
+        <BlockCollection onChange={jest.fn()} minOccurs={2} renderBlockContent={jest.fn()} value={value} />
+    );
+
+    blockCollection.find('Block').at(0).simulate('click');
+
+    expect(blockCollection.find('Block Icon[name="su-trash"]')).toHaveLength(0);
 });
 
 test('Should throw an exception if a block is removed and the minimum has already been reached', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -22,9 +22,20 @@ test('Should render an empty block list', () => {
     expect(render(<BlockCollection onChange={jest.fn()} renderBlockContent={jest.fn()} />)).toMatchSnapshot();
 });
 
-test('Should render a filled block list', () => {
+test('Should render a block list', () => {
     expect(render(
         <BlockCollection
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+        />
+    )).toMatchSnapshot();
+});
+
+test('Should render a fully filled block list without add button', () => {
+    expect(render(
+        <BlockCollection
+            maxOccurs={2}
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
             value={[{content: 'Test 1'}, {content: 'Test 2'}]}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -142,6 +142,17 @@ test('Should allow to add a new block', () => {
     expect(changeSpy).toBeCalledWith([...value, {}]);
 });
 
+test('Should throw an exception if a new block is added and the maximum has already been reached', () => {
+    const changeSpy = jest.fn();
+    const value = [{content: 'Test 1'}, {content: 'Test 2'}];
+
+    const blockCollection = shallow(
+        <BlockCollection maxOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />
+    );
+
+    expect(() => blockCollection.instance().handleAddBlock()).toThrow(/maximum amount of blocks/);
+});
+
 test('Should allow to remove an existing block', () => {
     // observable makes calling onChange with deleting an entry from expandedBlocks
     // otherwise the value and BlockCollection.expandedBlocks variable get out of sync and emit a warning
@@ -158,6 +169,17 @@ test('Should allow to remove an existing block', () => {
     blockCollection.find('Block').at(0).find('Icon[name="su-trash"]').simulate('click');
 
     expect(changeSpy).toBeCalledWith([expect.objectContaining({content: 'Test 2'})]);
+});
+
+test('Should throw an exception if a block is removed and the minimum has already been reached', () => {
+    const changeSpy = jest.fn();
+    const value = [{content: 'Test 1'}, {content: 'Test 2'}];
+
+    const blockCollection = shallow(
+        <BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />
+    );
+
+    expect(() => blockCollection.instance().handleRemoveBlock()).toThrow(/minimum amount of blocks/);
 });
 
 test('Should apply renderBlockContent before rendering the block content', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -32,7 +32,7 @@ test('Should render a block list', () => {
     )).toMatchSnapshot();
 });
 
-test('Should render a fully filled block list without add button', () => {
+test('Should render a fully filled block list without add button if maxOccurs is reached', () => {
     expect(render(
         <BlockCollection
             maxOccurs={2}
@@ -41,6 +41,50 @@ test('Should render a fully filled block list without add button', () => {
             value={[{content: 'Test 1'}, {content: 'Test 2'}]}
         />
     )).toMatchSnapshot();
+});
+
+test('Should add at least the minOccurs amount of blocks', () => {
+    const changeSpy = jest.fn();
+    const value = [{}];
+
+    shallow(<BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />);
+
+    expect(changeSpy).toBeCalledWith([
+        expect.objectContaining({}),
+        expect.objectContaining({}),
+    ]);
+});
+
+test('Should add at least the minOccurs amount of blocks with empty starting value', () => {
+    const changeSpy = jest.fn();
+    const value = [];
+
+    shallow(<BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />);
+
+    expect(changeSpy).toBeCalledWith([
+        expect.objectContaining({}),
+        expect.objectContaining({}),
+    ]);
+});
+
+test('Should add at least the minOccurs amount of blocks with types', () => {
+    const changeSpy = jest.fn();
+    const value = [{type: 'default'}];
+
+    shallow(
+        <BlockCollection
+            minOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            types={{default: 'Default'}}
+            value={value}
+        />
+    );
+
+    expect(changeSpy).toBeCalledWith([
+        expect.objectContaining({type: 'default'}),
+        expect.objectContaining({type: 'default'}),
+    ]);
 });
 
 test('Choosing a different type should call the onChange callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
@@ -38,6 +38,21 @@ test('Render expanded sortable block', () => {
     )).toMatchSnapshot();
 });
 
+test('Render expanded sortable block without remove icon', () => {
+    const renderBlockContent = jest.fn().mockImplementation((value) => 'Test for ' + value.content);
+
+    expect(render(
+        <SortableBlock
+            expanded={true}
+            onCollapse={jest.fn()}
+            onExpand={jest.fn()}
+            renderBlockContent={renderBlockContent}
+            sortIndex={1}
+            value={{content: 'Test Content'}}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render expanded sortable block with types', () => {
     const renderBlockContent = jest.fn().mockImplementation(
         (value, type) => 'Test for ' + value.content + (type ? ' and type ' + type : '')

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -58,7 +58,7 @@ exports[`Should render a block list 1`] = `
 </section>
 `;
 
-exports[`Should render a fully filled block list without add button 1`] = `
+exports[`Should render a fully filled block list without add button if maxOccurs is reached 1`] = `
 <section
   class="blockCollection"
 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -100,6 +100,20 @@ exports[`Should render a fully filled block list without add button if maxOccurs
       </div>
     </section>
   </div>
+  <button
+    class="button secondary"
+    disabled=""
+  >
+    <span
+      class="text"
+    >
+      <span
+        aria-label="su-plus"
+        class="addButtonIcon su-plus"
+      />
+      Add block
+    </span>
+  </button>
 </section>
 `;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should render a filled block list 1`] = `
+exports[`Should render a block list 1`] = `
 <section
   class="blockCollection"
 >
@@ -55,6 +55,51 @@ exports[`Should render a filled block list 1`] = `
       Add block
     </span>
   </button>
+</section>
+`;
+
+exports[`Should render a fully filled block list without add button 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-shift"
+          class="sortableHandle su-shift"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article />
+      </div>
+    </section>
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-shift"
+          class="sortableHandle su-shift"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article />
+      </div>
+    </section>
+  </div>
 </section>
 `;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/SortableBlock.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/SortableBlock.test.js.snap
@@ -144,3 +144,39 @@ exports[`Render expanded sortable block with types 1`] = `
   </div>
 </section>
 `;
+
+exports[`Render expanded sortable block without remove icon 1`] = `
+<section
+  class="block expanded"
+>
+  <div
+    class="handle"
+  >
+    <span
+      aria-label="su-shift"
+      class="sortableHandle su-shift"
+    />
+  </div>
+  <div
+    class="content"
+  >
+    <header
+      class="header"
+    >
+      <div
+        class="icons"
+      >
+        <span
+          aria-label="su-x"
+          class="su-x clickable"
+          role="button"
+          tabindex="0"
+        />
+      </div>
+    </header>
+    <article>
+      Test for Test Content
+    </article>
+  </div>
+</section>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -9,6 +9,7 @@ const LOADER_SIZE = 25;
 
 type Props = {
     children: Node,
+    disabled: boolean,
     skin: 'primary' | 'secondary' | 'link',
     onClick: () => void,
     loading: boolean,
@@ -16,6 +17,7 @@ type Props = {
 
 export default class Button extends React.PureComponent<Props> {
     static defaultProps = {
+        disabled: false,
         loading: false,
     };
 
@@ -27,6 +29,7 @@ export default class Button extends React.PureComponent<Props> {
     render() {
         const {
             children,
+            disabled,
             loading,
             skin,
         } = this.props;
@@ -39,7 +42,7 @@ export default class Button extends React.PureComponent<Props> {
         );
 
         return (
-            <button className={buttonClass} onClick={this.handleClick} disabled={loading}>
+            <button className={buttonClass} onClick={this.handleClick} disabled={loading || disabled}>
                 <span className={buttonStyles.text}>{children}</span>
                 {loading &&
                     <div className={buttonStyles.loader}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -9,12 +9,17 @@ $primaryColor: $white;
 $secondaryBorder: $silver;
 $secondaryBackground: $wildSand;
 $secondaryColor: $black;
+$secondaryDisabledColor: $silver;
 
 $linkFontSize: 14px;
 $linkColor: $black;
 
 .button {
     position: relative;
+
+    &:disabled {
+        cursor: default;
+    }
 }
 
 .primary,
@@ -39,6 +44,10 @@ $linkColor: $black;
     border-color: $secondaryBorder;
     background: $secondaryBackground;
     color: $secondaryColor;
+
+    &:disabled {
+        color: $secondaryDisabledColor;
+    }
 }
 
 .link {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -3,19 +3,23 @@ import React from 'react';
 import {render, shallow} from 'enzyme';
 import Button from '../Button';
 
-test('Button should render with skin primary', () => {
+test('Should render with skin primary', () => {
     expect(render(<Button skin="primary" />)).toMatchSnapshot();
 });
 
-test('Button should render with skin secondary', () => {
+test('Should render with skin secondary', () => {
     expect(render(<Button skin="secondary" />)).toMatchSnapshot();
 });
 
-test('Button should render with skin link', () => {
+test('should render disabled with skin secondary', () => {
+    expect(render(<Button disabled={true} skin="secondary" />)).toMatchSnapshot();
+});
+
+test('Should render with skin link', () => {
     expect(render(<Button skin="link" />)).toMatchSnapshot();
 });
 
-test('Button should call the callback on click', () => {
+test('Should call the callback on click', () => {
     const preventDefaultSpy = jest.fn();
     const onClick = jest.fn();
     const button = shallow(<Button skin="primary" onClick={onClick} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button should render with skin link 1`] = `
+exports[`Should render with skin link 1`] = `
 <button
   class="button link"
 >
@@ -10,7 +10,7 @@ exports[`Button should render with skin link 1`] = `
 </button>
 `;
 
-exports[`Button should render with skin primary 1`] = `
+exports[`Should render with skin primary 1`] = `
 <button
   class="button primary"
 >
@@ -20,9 +20,20 @@ exports[`Button should render with skin primary 1`] = `
 </button>
 `;
 
-exports[`Button should render with skin secondary 1`] = `
+exports[`Should render with skin secondary 1`] = `
 <button
   class="button secondary"
+>
+  <span
+    class="text"
+  />
+</button>
+`;
+
+exports[`should render disabled with skin secondary 1`] = `
+<button
+  class="button secondary"
+  disabled=""
 >
   <span
     class="text"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -39,7 +39,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
     };
 
     render() {
-        const {onChange, types, value} = this.props;
+        const {maxOccurs, minOccurs, onChange, types, value} = this.props;
 
         if (!types) {
             throw new Error(MISSING_BLOCK_ERROR_MESSAGE);
@@ -52,6 +52,8 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
 
         return (
             <BlockCollection
+                maxOccurs={maxOccurs}
+                minOccurs={minOccurs}
                 onChange={onChange}
                 renderBlockContent={this.renderBlockContent}
                 types={blockTypes}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -60,6 +60,36 @@ test('Render block with schema', () => {
     expect(pretty(fieldBlocks.html())).toMatchSnapshot();
 });
 
+test('Should correctly pass props to the BlockCollection', () => {
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text: {
+                    label: 'Text',
+                    type: 'text_line',
+                },
+            },
+        },
+    };
+    const value = [];
+    const changeSpy = jest.fn();
+
+    const fieldBlocks = shallow(
+        <FieldBlocks maxOccurs={2} minOccurs={1} onChange={changeSpy} types={types} value={value} />
+    );
+
+    expect(fieldBlocks.find('BlockCollection').props()).toEqual(expect.objectContaining({
+        maxOccurs: 2,
+        minOccurs: 1,
+        onChange: changeSpy,
+        types: {
+            default: 'Default',
+        },
+        value,
+    }));
+});
+
 test('Throw error if no types are passed', () => {
     expect(() => shallow(<FieldBlocks onChange={jest.fn()} value={undefined} />))
         .toThrow('The "block" field type needs at least one type to be configured!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -26,13 +26,15 @@ export default class Field extends React.PureComponent<Props> {
             locale,
             schema,
         } = this.props;
-        const {label, options, type, types} = schema;
+        const {label, maxOccurs, minOccurs, options, type, types} = schema;
         const FieldType = fieldRegistry.get(type);
 
         return (
             <div>
                 <label className={fieldStyles.label}>{label}</label>
                 <FieldType
+                    maxOccurs={maxOccurs}
+                    minOccurs={minOccurs}
                     locale={locale}
                     onChange={this.handleChange}
                     options={options}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -29,18 +29,27 @@ test('Pass correct props to FieldType', () => {
     });
 
     const locale = observable('de');
+    const schema = {
+        label: 'Text',
+        maxOccurs: 4,
+        minOccurs: 2,
+        type: 'text_line',
+        types: {},
+    };
     const field = shallow(
         <Field
             locale={locale}
             name="text"
             onChange={jest.fn()}
-            schema={{label: 'Text', type: 'text_line', types: {}}}
+            schema={schema}
             value="test"
         />
     );
 
     expect(field.find('Text').props()).toEqual(expect.objectContaining({
         locale: locale,
+        maxOccurs: 4,
+        minOccurs: 2,
         types: {},
         value: 'test',
     }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -15,12 +15,14 @@ export type Type = {
 export type Types = {[key: string]: Type};
 
 export type SchemaEntry = {
+    items?: Schema,
     label: string,
-    type: string,
+    maxOccurs?: number,
+    minOccurs?: number,
+    options?: Object,
     size?: Size,
     spaceAfter?: Size,
-    items?: Schema,
-    options?: Object,
+    type: string,
     types?: Types,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -16,6 +16,8 @@ export type PaginationAdapter = ComponentType<PaginationProps>;
 export type FieldTypeProps<T> = {
     onChange: (value: T) => void,
     locale?: ?IObservableValue<string>,
+    maxOccurs?: number,
+    minOccurs?: number,
     options?: Object,
     types?: Types,
     value: ?T,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to have a min and max restriction on the blocks. It will also not be possible anymore to click add or remove if the max resp. min restriction is already met.

#### Why?

Because we want to be able to restrict the content manager in that regard.

#### To Do

- [x] Already show `minOccurs` items in the beginning