### PR TITLE
Replace is_array with is iterable in twig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.5
+    * ENHANCEMENT #3775 [Component]             Use is iterable instead of custom is_array twig function in webspace dumper
+
 * 1.5.10 (2018-02-06)
     * HOTFIX      #3739 [ContentBundle]         Added locale to content-teaser query
     * ENHANCEMENT #3735 [DocumentManager]       Set proper default locale for document-manager

--- a/src/Sulu/Component/Webspace/Manager/Dumper/WebspaceCollectionDumper.php
+++ b/src/Sulu/Component/Webspace/Manager/Dumper/WebspaceCollectionDumper.php
@@ -18,14 +18,6 @@ class WebspaceCollectionDumper
         //TODO set path in a more elegant way
         $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/../../Resources/skeleton/'));
 
-        $twig->addFunction(
-            new \Twig_SimpleFunction(
-                'is_array', function ($value) {
-                    return is_array($value);
-                }
-            )
-        );
-
         return $twig->render($template, $parameters);
     }
 }

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -185,7 +185,7 @@ class {{ cache_class }} extends {{ base_class }}
 {% macro renderArray(array) %}{% import _self as self %}
     array(
     {% for key, value in array %}
-        {% if is_array(value) %}
+        {% if value is iterable %}
             '{{ key }}' => {{ self.renderArray(value) }},
         {% else %}
             '{{ key }}' => '{{ value }}',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It uses the twig [is iterable](https://twig.symfony.com/doc/1.x/tests/iterable.html) instead of a custom is_array twig extension.

#### Why?

Better to use a twig core functionality instead of a custom function. Also did got on an older installation but can't reproduce it why this did happens once:

```
[Symfony\Component\Debug\Exception\ContextErrorException]
Catchable Fatal Error: Argument 1 passed to Twig_Function::__construct() must be an instance of string, string given, called in 
vendor/sulu/sulu/src/Sulu/Component/Webspace/Manager/Dumper/WebspaceCollectionDumper.php on line 26 and defined
```
