### PR TITLE
Improved cache-invalidation for media/contact/account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG for Sulu
     * HOTFIX      #3793 [PreviewBundle]           Set context data (token, locale) before render can fail
     * ENHANCEMENT #3779 [ContentBundle]           Improved cache-invalidation for categories/tags in excerpt tab
     * ENHANCEMENT #3777 [ContentBundle]           Added tag/category reference-store
-    * ENHANCEMENT #3778 [ContactBundle]            Improved cache-invalidation for media/contact/account
+    * ENHANCEMENT #3778 [ContactBundle]           Improved cache-invalidation for media/contact/account
     * ENHANCEMENT #3778 [ContactBundle]           Added reference-store to contact/account
     * ENHANCEMENT #3778 [MediaBundle]             Added reference-store to media
     * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG for Sulu
     * HOTFIX      #3793 [PreviewBundle]           Set context data (token, locale) before render can fail
     * ENHANCEMENT #3779 [ContentBundle]           Improved cache-invalidation for categories/tags in excerpt tab
     * ENHANCEMENT #3777 [ContentBundle]           Added tag/category reference-store
+    * ENHANCEMENT #3778 [ContactBundle]            Improved cache-invalidation for media/contact/account
+    * ENHANCEMENT #3778 [ContactBundle]           Added reference-store to contact/account
+    * ENHANCEMENT #3778 [MediaBundle]             Added reference-store to media
     * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media
     * HOTFIX      #3750 [PreviewBundle]           Fixed refresh preview
     * HOTFIX      #3747 [RouteBundle]             Added empty array as default value to histories property.

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactSelectionContentType.php
@@ -31,6 +31,10 @@ use Sulu\Component\Content\PreResolvableContentTypeInterface;
  */
 class ContactSelectionContentType extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface
 {
+    const PREFIX_CONTACT = 'c';
+
+    const PREFIX_ACCOUNT = 'a';
+
     /**
      * @var string
      */
@@ -152,17 +156,20 @@ class ContactSelectionContentType extends ComplexContentType implements ContentT
             return [];
         }
 
-        $ids = $this->converter->convertIdsToGroupedIds($value, ['a' => [], 'c' => []]);
+        $ids = $this->converter->convertIdsToGroupedIds(
+            $value,
+            [self::PREFIX_ACCOUNT => [], self::PREFIX_CONTACT => []]
+        );
 
-        $accounts = $this->accountManager->getByIds($ids['a'], $locale);
-        $contacts = $this->contactManager->getByIds($ids['c'], $locale);
+        $accounts = $this->accountManager->getByIds($ids[self::PREFIX_ACCOUNT], $locale);
+        $contacts = $this->contactManager->getByIds($ids[self::PREFIX_CONTACT], $locale);
 
         $result = array_merge($accounts, $contacts);
         @usort(
             $result,
             function ($a, $b) use ($value) {
-                $typeA = $a instanceof Contact ? 'c' : 'a';
-                $typeB = $b instanceof Contact ? 'c' : 'a';
+                $typeA = $a instanceof Contact ? self::PREFIX_CONTACT : self::PREFIX_ACCOUNT;
+                $typeB = $b instanceof Contact ? self::PREFIX_CONTACT : self::PREFIX_ACCOUNT;
 
                 return $this->comparator->compare($typeA . $a->getId(), $typeB . $b->getId(), $value);
             }
@@ -252,13 +259,16 @@ class ContactSelectionContentType extends ComplexContentType implements ContentT
             return [];
         }
 
-        $ids = $this->converter->convertIdsToGroupedIds($value, ['a' => [], 'c' => []]);
+        $ids = $this->converter->convertIdsToGroupedIds(
+            $value,
+            [self::PREFIX_ACCOUNT => [], self::PREFIX_CONTACT => []]
+        );
 
-        foreach ($ids['a'] as $account) {
+        foreach ($ids[self::PREFIX_ACCOUNT] as $account) {
             $this->accountReferenceStore->add($account);
         }
 
-        foreach ($ids['c'] as $contact) {
+        foreach ($ids[self::PREFIX_CONTACT] as $contact) {
             $this->contactReferenceStore->add($contact);
         }
     }

--- a/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\EventListener;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Component\Contact\Model\ContactInterface;
+use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
+
+/**
+ * Invalidate references when account/contact are persisted.
+ */
+class CacheInvalidationListener
+{
+    /**
+     * @var HandlerInvalidateReferenceInterface
+     */
+    private $invalidationHandler;
+
+    public function __construct(HandlerInvalidateReferenceInterface $invalidationHandler)
+    {
+        $this->invalidationHandler = $invalidationHandler;
+    }
+
+    public function postPersist(LifecycleEventArgs $eventArgs)
+    {
+        $object = $eventArgs->getObject();
+        if ($object instanceof ContactInterface) {
+            $this->invalidationHandler->invalidateReference('contact', $object->getId());
+        } elseif ($object instanceof AccountInterface) {
+            $this->invalidationHandler->invalidateReference('account', $object->getId());
+        }
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
@@ -35,7 +35,21 @@ class CacheInvalidationListener
 
     public function postPersist(LifecycleEventArgs $eventArgs)
     {
-        $object = $eventArgs->getObject();
+        $this->invalidateEntity($eventArgs->getObject());
+    }
+
+    public function postUpdate(LifecycleEventArgs $eventArgs)
+    {
+        $this->invalidateEntity($eventArgs->getObject());
+    }
+
+    public function preRemove(LifecycleEventArgs $eventArgs)
+    {
+        $this->invalidateEntity($eventArgs->getObject());
+    }
+
+    private function invalidateEntity($object)
+    {
         if ($object instanceof ContactInterface) {
             $this->invalidationHandler->invalidateReference('contact', $object->getId());
             $this->invalidateTags($object->getTags());

--- a/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/ContactBundle/EventListener/CacheInvalidationListener.php
@@ -12,7 +12,9 @@
 namespace Sulu\Bundle\ContactBundle\EventListener;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Component\Contact\Model\ContactInterface;
 use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
 
@@ -36,8 +38,32 @@ class CacheInvalidationListener
         $object = $eventArgs->getObject();
         if ($object instanceof ContactInterface) {
             $this->invalidationHandler->invalidateReference('contact', $object->getId());
+            $this->invalidateTags($object->getTags());
+            $this->invalidateCategories($object->getCategories());
         } elseif ($object instanceof AccountInterface) {
             $this->invalidationHandler->invalidateReference('account', $object->getId());
+            $this->invalidateTags($object->getTags());
+            $this->invalidateCategories($object->getCategories());
+        }
+    }
+
+    /**
+     * @param TagInterface[] $tags
+     */
+    private function invalidateTags($tags)
+    {
+        foreach ($tags as $tag) {
+            $this->invalidationHandler->invalidateReference('tag', $tag->getId());
+        }
+    }
+
+    /**
+     * @param CategoryInterface[] $categories
+     */
+    private function invalidateCategories($categories)
+    {
+        foreach ($categories as $category) {
+            $this->invalidationHandler->invalidateReference('category', $category->getId());
         }
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
@@ -15,6 +15,8 @@
             <argument type="service" id="serializer" />
             <argument type="service" id="sulu_contact.util.id_converter" />
             <argument type="service" id="sulu_contact.util.index_comparator" />
+            <argument type="service" id="sulu_contact.reference_store.account" />
+            <argument type="service" id="sulu_contact.reference_store.contact" />
 
             <tag name="sulu.content.type" alias="contact"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false"/>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -99,12 +99,14 @@
         <service id="sulu_contact.smart_content.data_provider.contact" class="%sulu_contact.smart_content.data_provider.contact.class%">
             <argument type="service" id="sulu_contact.contact_manager"/>
             <argument type="service" id="serializer"/>
+            <argument type="service" id="sulu_contact.reference_store.contact"/>
 
             <tag name="sulu.smart_content.data_provider" alias="contact"/>
         </service>
         <service id="sulu_contact.smart_content.data_provider.account" class="%sulu_contact.smart_content.data_provider.account.class%">
             <argument type="service" id="sulu_contact.account_manager"/>
             <argument type="service" id="serializer"/>
+            <argument type="service" id="sulu_contact.reference_store.account"/>
 
             <tag name="sulu.smart_content.data_provider" alias="account"/>
         </service>
@@ -118,5 +120,14 @@
             <tag name="sulu.js_config"/>
         </service>
 
+        <service id="sulu_contact.reference_store.contact"
+                 class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
+            <tag name="sulu_website.reference_store" alias="contact"/>
+        </service>
+
+        <service id="sulu_contact.reference_store.account"
+                 class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
+            <tag name="sulu_website.reference_store" alias="account"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -133,6 +133,8 @@
             <argument type="service" id="sulu_http_cache.handler.aggregate"/>
 
             <tag name="doctrine.event_listener" event="postPersist"/>
+            <tag name="doctrine.event_listener" event="postUpdate"/>
+            <tag name="doctrine.event_listener" event="preRemove"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -129,5 +129,10 @@
                  class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
             <tag name="sulu_website.reference_store" alias="account"/>
         </service>
+        <service id="sulu_contact.doctrine.invalidation_listener" class="Sulu\Bundle\ContactBundle\EventListener\CacheInvalidationListener">
+            <argument type="service" id="sulu_http_cache.handler.aggregate"/>
+
+            <tag name="doctrine.event_listener" event="postPersist"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\EventListener\CacheInvalidationListener;
+use Sulu\Component\Contact\Model\ContactInterface;
+use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
+
+class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HandlerInvalidateReferenceInterface
+     */
+    private $invalidationHandler;
+
+    /**
+     * @var CacheInvalidationListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->invalidationHandler = $this->prophesize(HandlerInvalidateReferenceInterface::class);
+
+        $this->listener = new CacheInvalidationListener($this->invalidationHandler->reveal());
+    }
+
+    public function provideDataPostPersist()
+    {
+        return [
+            [ContactInterface::class, 'contact'],
+            [AccountInterface::class, 'account'],
+            [\stdClass::class, null],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataPostPersist
+     */
+    public function testPostPersist($class, $alias)
+    {
+        $entity = $this->prophesize($class);
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        if ($alias) {
+            $entity->getId()->willReturn(1);
+            $this->invalidationHandler->invalidateReference($alias, 1)->shouldBeCalled();
+        }
+
+        $this->listener->postPersist($eventArgs->reveal());
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CacheInvalidationListenerTest.php
@@ -39,7 +39,7 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener = new CacheInvalidationListener($this->invalidationHandler->reveal());
     }
 
-    public function provideDataPostPersist()
+    public function provideData()
     {
         return [
             [ContactInterface::class, 'contact'],
@@ -49,7 +49,7 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideDataPostPersist
+     * @dataProvider provideData
      */
     public function testPostPersist($class, $alias)
     {
@@ -71,7 +71,53 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->postPersist($eventArgs->reveal());
     }
 
-    public function provideDataPostPersistWithTagsAndCategories()
+    /**
+     * @dataProvider provideData
+     */
+    public function testPostUpdate($class, $alias)
+    {
+        $entity = $this->prophesize($class);
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        if ($alias) {
+            $entity->getId()->willReturn(1);
+            $entity->getTags()->willReturn([]);
+            $entity->getCategories()->willReturn([]);
+
+            $this->invalidationHandler->invalidateReference($alias, 1)->shouldBeCalled();
+        } else {
+            $this->invalidationHandler->invalidateReference(Argument::cetera())->shouldNotBeCalled();
+        }
+
+        $this->listener->postUpdate($eventArgs->reveal());
+    }
+
+    /**
+     * @dataProvider provideData
+     */
+    public function testPreRemove($class, $alias)
+    {
+        $entity = $this->prophesize($class);
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        if ($alias) {
+            $entity->getId()->willReturn(1);
+            $entity->getTags()->willReturn([]);
+            $entity->getCategories()->willReturn([]);
+
+            $this->invalidationHandler->invalidateReference($alias, 1)->shouldBeCalled();
+        } else {
+            $this->invalidationHandler->invalidateReference(Argument::cetera())->shouldNotBeCalled();
+        }
+
+        $this->listener->preRemove($eventArgs->reveal());
+    }
+
+    public function provideDataWithTagsAndCategories()
     {
         return [
             [ContactInterface::class, 'contact'],
@@ -80,9 +126,9 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideDataPostPersistWithTagsAndCategories
+     * @dataProvider provideDataWithTagsAndCategories
      */
-    public function testPostPersistWithTagsAndCategories($class, $alias)
+    public function testPersistUpdateWithTagsAndCategories($class, $alias)
     {
         $entity = $this->prophesize($class);
         $entity->getId()->willReturn(1);
@@ -107,5 +153,65 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->invalidationHandler->invalidateReference($alias, 1)->shouldBeCalled();
 
         $this->listener->postPersist($eventArgs->reveal());
+    }
+
+    /**
+     * @dataProvider provideDataWithTagsAndCategories
+     */
+    public function testPostUpdateWithTagsAndCategories($class, $alias)
+    {
+        $entity = $this->prophesize($class);
+        $entity->getId()->willReturn(1);
+
+        $tags = [$this->prophesize(TagInterface::class), $this->prophesize(TagInterface::class)];
+        $tags[0]->getId()->willReturn(1);
+        $tags[1]->getId()->willReturn(2);
+        $entity->getTags()->willReturn($tags);
+        $this->invalidationHandler->invalidateReference('tag', 1)->shouldBeCalled();
+        $this->invalidationHandler->invalidateReference('tag', 2)->shouldBeCalled();
+
+        $categories = [$this->prophesize(CategoryInterface::class), $this->prophesize(CategoryInterface::class)];
+        $categories[0]->getId()->willReturn(1);
+        $categories[1]->getId()->willReturn(2);
+        $entity->getCategories()->willReturn($categories);
+        $this->invalidationHandler->invalidateReference('category', 1)->shouldBeCalled();
+        $this->invalidationHandler->invalidateReference('category', 2)->shouldBeCalled();
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $this->invalidationHandler->invalidateReference($alias, 1)->shouldBeCalled();
+
+        $this->listener->postUpdate($eventArgs->reveal());
+    }
+
+    /**
+     * @dataProvider provideDataWithTagsAndCategories
+     */
+    public function testPreRemoveUpdateWithTagsAndCategories($class, $alias)
+    {
+        $entity = $this->prophesize($class);
+        $entity->getId()->willReturn(1);
+
+        $tags = [$this->prophesize(TagInterface::class), $this->prophesize(TagInterface::class)];
+        $tags[0]->getId()->willReturn(1);
+        $tags[1]->getId()->willReturn(2);
+        $entity->getTags()->willReturn($tags);
+        $this->invalidationHandler->invalidateReference('tag', 1)->shouldBeCalled();
+        $this->invalidationHandler->invalidateReference('tag', 2)->shouldBeCalled();
+
+        $categories = [$this->prophesize(CategoryInterface::class), $this->prophesize(CategoryInterface::class)];
+        $categories[0]->getId()->willReturn(1);
+        $categories[1]->getId()->willReturn(2);
+        $entity->getCategories()->willReturn($categories);
+        $this->invalidationHandler->invalidateReference('category', 1)->shouldBeCalled();
+        $this->invalidationHandler->invalidateReference('category', 2)->shouldBeCalled();
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $this->invalidationHandler->invalidateReference($alias, 1)->shouldBeCalled();
+
+        $this->listener->preRemove($eventArgs->reveal());
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactSelectionContentTypeTest.php
@@ -22,6 +22,7 @@ use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\ContactBundle\Content\Types\ContactSelectionContentType;
 use Sulu\Bundle\ContactBundle\Util\CustomerIdConverter;
 use Sulu\Bundle\ContactBundle\Util\IndexComparator;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -83,6 +84,16 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
      */
     private $serializer;
 
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $accountReferenceStore;
+
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $contactReferenceStore;
+
     protected function setUp()
     {
         parent::setUp();
@@ -99,6 +110,8 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->property->getStructure()->willReturn($this->structure->reveal());
 
         $this->serializer = $this->prophesize(Serializer::class);
+        $this->accountReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $this->contactReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
     }
 
     public function testGetTemplate()
@@ -109,7 +122,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->assertEquals($this->template, $type->getTemplate());
@@ -123,7 +138,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getName()->willReturn('test');
@@ -148,7 +165,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getName()->willReturn('test');
@@ -173,7 +192,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getName()->willReturn('test');
@@ -198,7 +219,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getName()->willReturn('test');
@@ -223,7 +246,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getName()->willReturn('test');
@@ -249,7 +274,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $nodeProperty = $this->prophesize(\PHPCR\PropertyInterface::class);
@@ -280,7 +307,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $view = $type->getViewData($this->property->reveal());
@@ -296,7 +325,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $defaultValue = $type->getDefaultValue();
@@ -312,7 +343,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $defaultParams = $type->getDefaultParams();
@@ -334,7 +367,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getName()->willReturn('test');
@@ -359,7 +394,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $contact1 = $this->prophesize(Contact::class);
@@ -400,7 +437,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $entity1 = $this->prophesize(Account::class);
@@ -441,7 +480,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $contact1 = $this->prophesize(Contact::class);
@@ -483,7 +524,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getValue()->willReturn([]);
@@ -503,7 +546,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getValue()->willReturn(null);
@@ -523,7 +568,9 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
             new CustomerIdConverter(),
-            new IndexComparator()
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
         );
 
         $this->property->getValue()->willReturn('blabla');
@@ -533,5 +580,26 @@ class ContactSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
         $result = $type->getContentData($this->property->reveal());
 
         $this->assertCount(0, $result);
+    }
+
+    public function testPreResolve()
+    {
+        $type = new ContactSelectionContentType(
+            $this->template,
+            $this->contactManager->reveal(),
+            $this->accountManager->reveal(),
+            $this->serializer->reveal(),
+            new CustomerIdConverter(),
+            new IndexComparator(),
+            $this->accountReferenceStore->reveal(),
+            $this->contactReferenceStore->reveal()
+        );
+
+        $this->property->getValue()->willReturn(['a1', 'c1', 'a3']);
+        $type->preResolve($this->property->reveal());
+
+        $this->accountReferenceStore->add(1)->shouldBeCalled();
+        $this->accountReferenceStore->add(3)->shouldBeCalled();
+        $this->contactReferenceStore->add(1)->shouldBeCalled();
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
@@ -21,7 +21,7 @@ use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
 
 /**
- * Invalidate references when account/contact are persisted.
+ * Invalidate references when media is persisted.
  */
 class CacheInvalidationListener
 {
@@ -36,6 +36,16 @@ class CacheInvalidationListener
     }
 
     public function postPersist(LifecycleEventArgs $eventArgs)
+    {
+        $this->invalidateEntity($eventArgs->getObject());
+    }
+
+    public function postUpdate(LifecycleEventArgs $eventArgs)
+    {
+        $this->invalidateEntity($eventArgs->getObject());
+    }
+
+    public function preRemove(LifecycleEventArgs $eventArgs)
     {
         $this->invalidateEntity($eventArgs->getObject());
     }

--- a/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/CacheInvalidationListener.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\EventListener;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Sulu\Bundle\MediaBundle\Entity\File;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
+
+/**
+ * Invalidate references when account/contact are persisted.
+ */
+class CacheInvalidationListener
+{
+    /**
+     * @var HandlerInvalidateReferenceInterface
+     */
+    private $invalidationHandler;
+
+    public function __construct(HandlerInvalidateReferenceInterface $invalidationHandler)
+    {
+        $this->invalidationHandler = $invalidationHandler;
+    }
+
+    public function postPersist(LifecycleEventArgs $eventArgs)
+    {
+        $object = $eventArgs->getObject();
+        if ($object instanceof MediaInterface) {
+            $this->invalidate($object);
+        } elseif ($object instanceof File) {
+            $this->invalidate($object->getMedia());
+        } elseif ($object instanceof FileVersion) {
+            $this->invalidate($object->getFile()->getMedia());
+        } elseif ($object instanceof FileVersionMeta) {
+            $this->invalidate($object->getFileVersion()->getFile()->getMedia());
+        }
+    }
+
+    private function invalidate(MediaInterface $media)
+    {
+        $this->invalidationHandler->invalidateReference('media', $media->getId());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -291,5 +291,12 @@
         <service id="sulu_media.reference_store.media" class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
             <tag name="sulu_website.reference_store" alias="media"/>
         </service>
+
+        <service id="sulu_media.doctrine.invalidation_listener"
+                 class="Sulu\Bundle\MediaBundle\EventListener\CacheInvalidationListener">
+            <argument type="service" id="sulu_http_cache.handler.aggregate"/>
+
+            <tag name="doctrine.event_listener" event="postPersist"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -297,6 +297,8 @@
             <argument type="service" id="sulu_http_cache.handler.aggregate"/>
 
             <tag name="doctrine.event_listener" event="postPersist"/>
+            <tag name="doctrine.event_listener" event="postUpdate"/>
+            <tag name="doctrine.event_listener" event="preRemove"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -180,7 +180,9 @@
 
         <service id="sulu_media.type.media_selection" class="%sulu_media.media_selection.class%">
             <argument type="service" id="sulu_media.media_manager"/>
+            <argument type="service" id="sulu_media.reference_store.media"/>
             <argument type="string">%sulu_media.media_selection.template%</argument>
+
             <tag name="sulu.content.type" alias="media_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
@@ -250,6 +252,7 @@
             <argument type="service" id="sulu_media.collection_manager"/>
             <argument type="service" id="serializer"/>
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_media.reference_store.media"/>
 
             <tag name="sulu.smart_content.data_provider" alias="media"/>
         </service>
@@ -283,6 +286,10 @@
             <argument>%sulu_media.disposition_type.default%</argument>
             <argument>%sulu_media.disposition_type.mime_types_inline%</argument>
             <argument>%sulu_media.disposition_type.mime_types_attachment%</argument>
+        </service>
+
+        <service id="sulu_media.reference_store.media" class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
+            <tag name="sulu_website.reference_store" alias="media"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\EventListener;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Prophecy\Argument;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\MediaBundle\Entity\File;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\EventListener\CacheInvalidationListener;
+use Sulu\Bundle\TagBundle\Tag\TagInterface;
+use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
+
+class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HandlerInvalidateReferenceInterface
+     */
+    private $invalidationHandler;
+
+    /**
+     * @var CacheInvalidationListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->invalidationHandler = $this->prophesize(HandlerInvalidateReferenceInterface::class);
+
+        $this->listener = new CacheInvalidationListener($this->invalidationHandler->reveal());
+    }
+
+    public function provideDataPostPersist()
+    {
+        return [
+            [MediaInterface::class, 'media'],
+            [File::class, 'media'],
+            [FileVersion::class, 'media'],
+            [FileVersionMeta::class, 'media'],
+            [\stdClass::class, null],
+        ];
+    }
+
+    public function testPostPersist()
+    {
+        $entity = $this->prophesize(MediaInterface::class);
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $entity->getId()->willReturn(1);
+        $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
+
+        $this->listener->postPersist($eventArgs->reveal());
+    }
+
+    public function testPostPersistFile()
+    {
+        $media = $this->prophesize(MediaInterface::class);
+        $entity = $this->prophesize(File::class);
+        $entity->getMedia()->willReturn($media->reveal());
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $media->getId()->willReturn(1);
+        $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
+
+        $this->listener->postPersist($eventArgs->reveal());
+    }
+
+    public function testPostPersistFileVersion()
+    {
+        $media = $this->prophesize(MediaInterface::class);
+        $file = $this->prophesize(File::class);
+        $entity = $this->prophesize(FileVersion::class);
+        $entity->getFile()->willReturn($file->reveal());
+        $file->getMedia()->willReturn($media->reveal());
+
+        $tags = [$this->prophesize(TagInterface::class), $this->prophesize(TagInterface::class)];
+        $tags[0]->getId()->willReturn(1);
+        $tags[1]->getId()->willReturn(2);
+        $entity->getTags()->willReturn($tags);
+        $this->invalidationHandler->invalidateReference('tag', 1)->shouldBeCalled();
+        $this->invalidationHandler->invalidateReference('tag', 2)->shouldBeCalled();
+
+        $categories = [$this->prophesize(CategoryInterface::class), $this->prophesize(CategoryInterface::class)];
+        $categories[0]->getId()->willReturn(1);
+        $categories[1]->getId()->willReturn(2);
+        $entity->getCategories()->willReturn($categories);
+        $this->invalidationHandler->invalidateReference('category', 1)->shouldBeCalled();
+        $this->invalidationHandler->invalidateReference('category', 2)->shouldBeCalled();
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $media->getId()->willReturn(1);
+        $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
+
+        $this->listener->postPersist($eventArgs->reveal());
+    }
+
+    public function testPostPersistFileVersionMeta()
+    {
+        $media = $this->prophesize(MediaInterface::class);
+        $file = $this->prophesize(File::class);
+        $fileVersion = $this->prophesize(FileVersion::class);
+        $fileVersion->getTags()->willReturn([]);
+        $fileVersion->getCategories()->willReturn([]);
+        $entity = $this->prophesize(FileVersionMeta::class);
+        $entity->getFileVersion()->willReturn($fileVersion->reveal());
+        $fileVersion->getFile()->willReturn($file->reveal());
+        $file->getMedia()->willReturn($media->reveal());
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $media->getId()->willReturn(1);
+        $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
+
+        $this->listener->postPersist($eventArgs->reveal());
+    }
+
+    public function testPostPersistOther()
+    {
+        $entity = $this->prophesize(\stdClass::class);
+
+        $eventArgs = $this->prophesize(LifecycleEventArgs::class);
+        $eventArgs->getObject()->willReturn($entity->reveal());
+
+        $this->invalidationHandler->invalidateReference(Argument::cetera())->shouldNotBeCalled();
+
+        $this->listener->postPersist($eventArgs->reveal());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/CacheInvalidationListenerTest.php
@@ -41,18 +41,19 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener = new CacheInvalidationListener($this->invalidationHandler->reveal());
     }
 
-    public function provideDataPostPersist()
+    public function provideFunctionName()
     {
         return [
-            [MediaInterface::class, 'media'],
-            [File::class, 'media'],
-            [FileVersion::class, 'media'],
-            [FileVersionMeta::class, 'media'],
-            [\stdClass::class, null],
+            ['postPersist'],
+            ['postUpdate'],
+            ['preRemove'],
         ];
     }
 
-    public function testPostPersist()
+    /**
+     * @dataProvider provideFunctionName
+     */
+    public function testPostUpdate($functionName)
     {
         $entity = $this->prophesize(MediaInterface::class);
 
@@ -62,10 +63,13 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $entity->getId()->willReturn(1);
         $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
 
-        $this->listener->postPersist($eventArgs->reveal());
+        $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    public function testPostPersistFile()
+    /**
+     * @dataProvider provideFunctionName
+     */
+    public function testPostUpdateFile($functionName)
     {
         $media = $this->prophesize(MediaInterface::class);
         $entity = $this->prophesize(File::class);
@@ -77,10 +81,13 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $media->getId()->willReturn(1);
         $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
 
-        $this->listener->postPersist($eventArgs->reveal());
+        $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    public function testPostPersistFileVersion()
+    /**
+     * @dataProvider provideFunctionName
+     */
+    public function testPostUpdateFileVersion($functionName)
     {
         $media = $this->prophesize(MediaInterface::class);
         $file = $this->prophesize(File::class);
@@ -108,10 +115,13 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $media->getId()->willReturn(1);
         $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
 
-        $this->listener->postPersist($eventArgs->reveal());
+        $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    public function testPostPersistFileVersionMeta()
+    /**
+     * @dataProvider provideFunctionName
+     */
+    public function testPostUpdateFileVersionMeta($functionName)
     {
         $media = $this->prophesize(MediaInterface::class);
         $file = $this->prophesize(File::class);
@@ -129,10 +139,13 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $media->getId()->willReturn(1);
         $this->invalidationHandler->invalidateReference('media', 1)->shouldBeCalled();
 
-        $this->listener->postPersist($eventArgs->reveal());
+        $this->listener->{$functionName}($eventArgs->reveal());
     }
 
-    public function testPostPersistOther()
+    /**
+     * @dataProvider provideFunctionName
+     */
+    public function testPostUpdateOther($functionName)
     {
         $entity = $this->prophesize(\stdClass::class);
 
@@ -141,6 +154,6 @@ class CacheInvalidationListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->invalidationHandler->invalidateReference(Argument::cetera())->shouldNotBeCalled();
 
-        $this->listener->postPersist($eventArgs->reveal());
+        $this->listener->{$functionName}($eventArgs->reveal());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -14,26 +14,35 @@ namespace Sulu\Bundle\MediaBundle\Tests\Unit\Content\Types;
 use PHPCR\NodeInterface;
 use Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 
 class MediaSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType
+     * @var MediaSelectionContentType
      */
     private $mediaSelection;
 
     /**
-     * @var \Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface
+     * @var ReferenceStoreInterface
+     */
+    private $mediaReferenceStore;
+
+    /**
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
     protected function setUp()
     {
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $this->mediaReferenceStore = $this->prophesize(ReferenceStoreInterface::class);
 
         $this->mediaSelection = new MediaSelectionContentType(
-            $this->mediaManager->reveal(), 'SuluMediaBundle:Template:image-selection.html.twig'
+            $this->mediaManager->reveal(),
+            $this->mediaReferenceStore->reveal(),
+            'SuluMediaBundle:Template:image-selection.html.twig'
         );
     }
 
@@ -309,5 +318,17 @@ class MediaSelectionContentTypeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->mediaSelection->read($node, $property, 'test', 'en', 's');
+    }
+
+    public function testPreResolve()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $property->getValue()->willReturn(['ids' => [1, 2, 3]]);
+
+        $this->mediaSelection->preResolve($property->reveal());
+
+        $this->mediaReferenceStore->add(1)->shouldBeCalled();
+        $this->mediaReferenceStore->add(2)->shouldBeCalled();
+        $this->mediaReferenceStore->add(3)->shouldBeCalled();
     }
 }

--- a/src/Sulu/Component/Contact/SmartContent/AccountDataProvider.php
+++ b/src/Sulu/Component/Contact/SmartContent/AccountDataProvider.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Contact\SmartContent;
 
 use JMS\Serializer\SerializerInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 
@@ -20,9 +21,9 @@ use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
  */
 class AccountDataProvider extends BaseDataProvider
 {
-    public function __construct(DataProviderRepositoryInterface $repository, SerializerInterface $serializer)
+    public function __construct(DataProviderRepositoryInterface $repository, SerializerInterface $serializer, ReferenceStoreInterface $referenceStore)
     {
-        parent::__construct($repository, $serializer);
+        parent::__construct($repository, $serializer, $referenceStore);
 
         $this->configuration = self::createConfigurationBuilder()
             ->enableTags()

--- a/src/Sulu/Component/Contact/SmartContent/ContactDataProvider.php
+++ b/src/Sulu/Component/Contact/SmartContent/ContactDataProvider.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Contact\SmartContent;
 
 use JMS\Serializer\SerializerInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 
@@ -20,9 +21,12 @@ use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
  */
 class ContactDataProvider extends BaseDataProvider
 {
-    public function __construct(DataProviderRepositoryInterface $repository, SerializerInterface $serializer)
-    {
-        parent::__construct($repository, $serializer);
+    public function __construct(
+        DataProviderRepositoryInterface $repository,
+        SerializerInterface $serializer,
+        ReferenceStoreInterface $referenceStore
+    ) {
+        parent::__construct($repository, $serializer, $referenceStore);
 
         $this->configuration = self::createConfigurationBuilder()
             ->enableTags()

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/AccountDataProviderTest.php
@@ -15,6 +15,7 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Prophecy\Argument;
 use Sulu\Bundle\ContactBundle\Api\Account;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Contact\SmartContent\AccountDataItem;
 use Sulu\Component\Contact\SmartContent\AccountDataProvider;
 use Sulu\Component\SmartContent\ArrayAccessItem;
@@ -27,9 +28,11 @@ class AccountDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetConfiguration()
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new AccountDataProvider(
             $this->getRepository(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $configuration = $provider->getConfiguration();
@@ -40,9 +43,11 @@ class AccountDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetDefaultParameter()
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new AccountDataProvider(
             $this->getRepository(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $parameter = $provider->getDefaultPropertyParameter();
@@ -77,9 +82,11 @@ class AccountDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testResolveDataItems($filters, $limit, $page, $pageSize, $repositoryResult, $hasNextPage, $items)
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new AccountDataProvider(
             $this->getRepository($filters, $page, $pageSize, $limit, $repositoryResult),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveDataItems(
@@ -146,9 +153,11 @@ class AccountDataProviderTest extends \PHPUnit_Framework_TestCase
                 }
             );
 
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new AccountDataProvider(
             $this->getRepository($filters, $page, $pageSize, $limit, $repositoryResult),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveResourceItems(
@@ -169,9 +178,11 @@ class AccountDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testResolveDataSource()
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new AccountDataProvider(
             $this->getRepository(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $this->assertNull($provider->resolveDatasource('', [], []));

--- a/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
+++ b/src/Sulu/Component/Contact/Tests/Unit/SmartContent/ContactDataProviderTest.php
@@ -15,6 +15,7 @@ use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Prophecy\Argument;
 use Sulu\Bundle\ContactBundle\Api\Contact;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Contact\SmartContent\ContactDataItem;
 use Sulu\Component\Contact\SmartContent\ContactDataProvider;
 use Sulu\Component\SmartContent\ArrayAccessItem;
@@ -27,9 +28,11 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetConfiguration()
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new ContactDataProvider(
             $this->getRepository(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $configuration = $provider->getConfiguration();
@@ -40,9 +43,11 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetDefaultParameter()
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new ContactDataProvider(
             $this->getRepository(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $parameter = $provider->getDefaultPropertyParameter();
@@ -77,9 +82,11 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testResolveDataItems($filters, $limit, $page, $pageSize, $repositoryResult, $hasNextPage, $items)
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new ContactDataProvider(
             $this->getRepository($filters, $page, $pageSize, $limit, $repositoryResult),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveDataItems(
@@ -111,9 +118,11 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
         }
 
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new ContactDataProvider(
             $this->getRepository(['sortBy' => null], 1, null, null, $contacts),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveDataItems(['sortBy' => null], [], ['webspace' => 'sulu_io', 'locale' => 'en']);
@@ -169,9 +178,11 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
                 }
             );
 
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new ContactDataProvider(
             $this->getRepository($filters, $page, $pageSize, $limit, $repositoryResult),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveResourceItems(
@@ -192,9 +203,11 @@ class ContactDataProviderTest extends \PHPUnit_Framework_TestCase
     public function testResolveDataSource()
     {
         $serializer = $this->prophesize(SerializerInterface::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new ContactDataProvider(
             $this->getRepository(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $referenceStore->reveal()
         );
 
         $this->assertNull($provider->resolveDatasource('', [], []));

--- a/src/Sulu/Component/HttpCache/Handler/TagsHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/TagsHandler.php
@@ -42,7 +42,7 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
     /**
      * @var array
      */
-    private $referencesToInvalidate;
+    private $referencesToInvalidate = [];
 
     /**
      * @param ProxyClientInterface $proxyClient
@@ -67,13 +67,16 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
      */
     public function invalidateReference($alias, $id)
     {
-        if (Uuid::isValid($id)) {
-            $this->referencesToInvalidate[] = $id;
+        $reference = $id;
+        if (!Uuid::isValid($id)) {
+            $reference = sprintf('%s-%s', $alias, $id);
+        }
 
+        if (in_array($reference, $this->referencesToInvalidate)) {
             return;
         }
 
-        $this->referencesToInvalidate[] = sprintf('%s-%s', $alias, $id);
+        $this->referencesToInvalidate[] = $reference;
     }
 
     /**
@@ -91,7 +94,7 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
      */
     public function flush()
     {
-        if (!$this->referencesToInvalidate) {
+        if (0 === count($this->referencesToInvalidate)) {
             return false;
         }
 
@@ -104,6 +107,7 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
         }
 
         $this->proxyClient->flush();
+        $this->referencesToInvalidate = [];
 
         return true;
     }

--- a/src/Sulu/Component/HttpCache/Tests/Unit/Handler/TagsHandlerTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/Handler/TagsHandlerTest.php
@@ -99,6 +99,21 @@ class TagsHandlerTest extends \PHPUnit_Framework_TestCase
         $this->handler->flush();
     }
 
+    public function testInvalidateReferenceDuplicated()
+    {
+        $this->proxyCache->ban(
+            [
+                TagsHandler::TAGS_HEADER => '(' . preg_quote('test-1') . ')(,.+)?$',
+            ]
+        )->shouldBeCalledTimes(1);
+        $this->proxyCache->flush()->shouldBeCalled();
+
+        $this->handler->invalidateReference('test', 1);
+        $this->handler->invalidateReference('test', 1);
+
+        $this->handler->flush();
+    }
+
     public function testUpdateResponse()
     {
         $id = Uuid::uuid4()->toString();

--- a/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
+++ b/src/Sulu/Component/Media/SmartContent/MediaDataProvider.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Media\SmartContent;
 
 use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\SmartContent\DatasourceItem;
 use Sulu\Component\SmartContent\Orm\BaseDataProvider;
@@ -38,9 +39,10 @@ class MediaDataProvider extends BaseDataProvider
         DataProviderRepositoryInterface $repository,
         CollectionManagerInterface $collectionManager,
         SerializerInterface $serializer,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        ReferenceStoreInterface $referenceStore
     ) {
-        parent::__construct($repository, $serializer);
+        parent::__construct($repository, $serializer, $referenceStore);
 
         $this->configuration = self::createConfigurationBuilder()
             ->enableTags()

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -17,6 +17,7 @@ use Prophecy\Argument;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Media\SmartContent\MediaDataItem;
 use Sulu\Component\Media\SmartContent\MediaDataProvider;
@@ -34,11 +35,13 @@ class MediaDataProviderTest extends \PHPUnit_Framework_TestCase
         $serializer = $this->prophesize(SerializerInterface::class);
         $collectionManager = $this->prophesize(CollectionManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new MediaDataProvider(
             $this->getRepository(),
             $collectionManager->reveal(),
             $serializer->reveal(),
-            $requestStack->reveal()
+            $requestStack->reveal(),
+            $referenceStore->reveal()
         );
 
         $configuration = $provider->getConfiguration();
@@ -52,11 +55,13 @@ class MediaDataProviderTest extends \PHPUnit_Framework_TestCase
         $serializer = $this->prophesize(SerializerInterface::class);
         $collectionManager = $this->prophesize(CollectionManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new MediaDataProvider(
             $this->getRepository(),
             $collectionManager->reveal(),
             $serializer->reveal(),
-            $requestStack->reveal()
+            $requestStack->reveal(),
+            $referenceStore->reveal()
         );
 
         $parameter = $provider->getDefaultPropertyParameter();
@@ -99,11 +104,13 @@ class MediaDataProviderTest extends \PHPUnit_Framework_TestCase
         $serializer = $this->prophesize(SerializerInterface::class);
         $collectionManager = $this->prophesize(CollectionManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new MediaDataProvider(
             $this->getRepository($filters, $page, $pageSize, $limit, $repositoryResult),
             $collectionManager->reveal(),
             $serializer->reveal(),
-            $requestStack->reveal()
+            $requestStack->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveDataItems(
@@ -168,11 +175,13 @@ class MediaDataProviderTest extends \PHPUnit_Framework_TestCase
 
         $collectionManager = $this->prophesize(CollectionManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new MediaDataProvider(
             $this->getRepository($filters, $page, $pageSize, $limit, $repositoryResult),
             $collectionManager->reveal(),
             $serializer->reveal(),
-            $requestStack->reveal()
+            $requestStack->reveal(),
+            $referenceStore->reveal()
         );
 
         $result = $provider->resolveResourceItems(
@@ -195,11 +204,13 @@ class MediaDataProviderTest extends \PHPUnit_Framework_TestCase
         $serializer = $this->prophesize(SerializerInterface::class);
         $collectionManager = $this->prophesize(CollectionManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
+        $referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $provider = new MediaDataProvider(
             $this->getRepository(),
             $collectionManager->reveal(),
             $serializer->reveal(),
-            $requestStack->reveal()
+            $requestStack->reveal(),
+            $referenceStore->reveal()
         );
 
         $collection = $this->prophesize(Collection::class);

--- a/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
+++ b/src/Sulu/Component/SmartContent/Orm/BaseDataProvider.php
@@ -206,9 +206,16 @@ abstract class BaseDataProvider implements DataProviderInterface
         );
     }
 
-    protected function getIdForItem($item)
+    /**
+     * Returns id for given entity.
+     *
+     * @param object $entity
+     *
+     * @return int
+     */
+    protected function getIdForItem($entity)
     {
-        return $item->getId();
+        return $entity->getId();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the reference-store to media/contact/account content-types to improve cache-invalidation.

#### To Do

- [x] Invalidation
- [x] Tests
