### PR TITLE
Improved cache-invalidation for categories/tags in excerpt tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * ENHANCEMENT #3777 [ContentBundle]           Added tag/category reference-store
     * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media
     * HOTFIX      #3750 [PreviewBundle]           Fixed refresh preview
     * HOTFIX      #3747 [RouteBundle]             Added empty array as default value to histories property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * ENHANCEMENT #3779 [ContentBundle]           Improved cache-invalidation for categories/tags in excerpt tab
     * ENHANCEMENT #3777 [ContentBundle]           Added tag/category reference-store
     * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media
     * HOTFIX      #3750 [PreviewBundle]           Fixed refresh preview

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -55,5 +55,10 @@
             <argument type="service" id="sulu.repository.category_translation"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
+
+        <service id="sulu_category.reference_store.category"
+                 class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
+            <tag name="sulu_website.reference_store" alias="category"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/smart_content.xml
@@ -51,6 +51,8 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu_tag.tag_request_handler"/>
             <argument type="service" id="sulu_category.category_request_handler"/>
+            <argument type="service" id="sulu_tag.reference_store.tag"/>
+            <argument type="service" id="sulu_category.reference_store.category"/>
             <argument>%sulu.content.type.smart_content.template%</argument>
             <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null"/>
 

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/event-subscribers.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/event-subscribers.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="sulu_tag.tag_manager"/>
             <argument>%kernel.environment%</argument>
 
             <tag name="sulu_document_manager.event_subscriber"/>

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -3,3 +3,4 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
+

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -3,4 +3,3 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
-

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -54,5 +54,8 @@
             <tag name="massive_search.converter" from="tags"/>
         </service>
 
+        <service id="sulu_tag.reference_store.tag" class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
+            <tag name="sulu_website.reference_store" alias="tag"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Component/HttpCache/Handler/AggregateHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/AggregateHandler.php
@@ -17,6 +17,7 @@ use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\HttpCache\HandlerFlushInterface;
 use Sulu\Component\HttpCache\HandlerInterface;
 use Sulu\Component\HttpCache\HandlerInvalidatePathInterface;
+use Sulu\Component\HttpCache\HandlerInvalidateReferenceInterface;
 use Sulu\Component\HttpCache\HandlerInvalidateStructureInterface;
 use Sulu\Component\HttpCache\HandlerUpdateResponseInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AggregateHandler implements
     HandlerFlushInterface,
     HandlerUpdateResponseInterface,
-    HandlerInvalidateStructureInterface,
+    HandlerInvalidateReferenceInterface,
     HandlerInvalidatePathInterface
 {
     /**
@@ -60,13 +61,37 @@ class AggregateHandler implements
                 continue;
             }
 
-            $this->logger->debug(sprintf(
-                '[CACHE] INVALIDATING [%s]: %s (%s)',
-                get_class($handler),
-                get_class($structure),
-                $structure->getUuid()
-            ));
+            $this->logger->debug(
+                sprintf(
+                    '[CACHE] INVALIDATING [%s]: %s (%s)',
+                    get_class($handler),
+                    get_class($structure),
+                    $structure->getUuid()
+                )
+            );
             $handler->invalidateStructure($structure);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invalidateReference($alias, $id)
+    {
+        foreach ($this->handlers as $handler) {
+            if (!$handler instanceof HandlerInvalidateStructureInterface) {
+                continue;
+            }
+
+            $this->logger->debug(
+                sprintf(
+                    '[CACHE] INVALIDATING [%s]: %s (%s)',
+                    get_class($handler),
+                    $alias,
+                    $id
+                )
+            );
+            $handler->invalidateReference($alias, $id);
         }
     }
 

--- a/src/Sulu/Component/HttpCache/Handler/AggregateHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/AggregateHandler.php
@@ -79,7 +79,7 @@ class AggregateHandler implements
     public function invalidateReference($alias, $id)
     {
         foreach ($this->handlers as $handler) {
-            if (!$handler instanceof HandlerInvalidateStructureInterface) {
+            if (!$handler instanceof HandlerInvalidateReferenceInterface) {
                 continue;
             }
 

--- a/src/Sulu/Component/HttpCache/HandlerInvalidateReferenceInterface.php
+++ b/src/Sulu/Component/HttpCache/HandlerInvalidateReferenceInterface.php
@@ -11,22 +11,21 @@
 
 namespace Sulu\Component\HttpCache;
 
-use Sulu\Component\Content\Compat\StructureInterface;
-
 /**
- * Handlers implementing will invalidate the given structure with the
+ * Handlers implementing will invalidate the given reference with the
  * caching proxy server.
  *
  * Note that this is called during the request therefore the task of this
  * interfaces method should normally be to record references to the structures
  * which should later be invalidated in the `flush` interface.
  */
-interface HandlerInvalidateStructureInterface extends HandlerInterface
+interface HandlerInvalidateReferenceInterface extends HandlerInvalidateStructureInterface
 {
     /**
-     * Invalidate the given structure.
+     * Invalidate the given reference.
      *
-     * @param StructureInterface $structure
+     * @param string $alias
+     * @param string $id
      */
-    public function invalidateStructure(StructureInterface $structure);
+    public function invalidateReference($alias, $id);
 }

--- a/src/Sulu/Component/HttpCache/Tests/Unit/Handler/TagsHandlerTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/Handler/TagsHandlerTest.php
@@ -85,6 +85,20 @@ class TagsHandlerTest extends \PHPUnit_Framework_TestCase
         $this->handler->flush();
     }
 
+    public function testInvalidateReference()
+    {
+        $this->proxyCache->ban(
+            [
+                TagsHandler::TAGS_HEADER => '(' . preg_quote('test-1') . ')(,.+)?$',
+            ]
+        )->shouldBeCalled();
+        $this->proxyCache->flush()->shouldBeCalled();
+
+        $this->handler->invalidateReference('test', 1);
+
+        $this->handler->flush();
+    }
+
     public function testUpdateResponse()
     {
         $id = Uuid::uuid4()->toString();

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\SmartContent;
 use PHPCR\NodeInterface;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
@@ -72,6 +73,16 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
     private $targetGroupStore;
 
     /**
+     * @var ReferenceStoreInterface
+     */
+    private $tagReferenceStore;
+
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $categoryReferenceStore;
+
+    /**
      * SmartContentType constructor.
      *
      * @param DataProviderPoolInterface $dataProviderPool
@@ -79,6 +90,8 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
      * @param RequestStack $requestStack
      * @param TagRequestHandlerInterface $tagRequestHandler
      * @param CategoryRequestHandlerInterface $categoryRequestHandler
+     * @param ReferenceStoreInterface $tagReferenceStore
+     * @param ReferenceStoreInterface $categoryReferenceStore
      * @param string $template
      * @param TargetGroupStoreInterface $targetGroupStore
      */
@@ -88,6 +101,8 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         RequestStack $requestStack,
         TagRequestHandlerInterface $tagRequestHandler,
         CategoryRequestHandlerInterface $categoryRequestHandler,
+        ReferenceStoreInterface $tagReferenceStore,
+        ReferenceStoreInterface $categoryReferenceStore,
         $template,
         TargetGroupStoreInterface $targetGroupStore = null
     ) {
@@ -96,6 +111,8 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         $this->requestStack = $requestStack;
         $this->tagRequestHandler = $tagRequestHandler;
         $this->categoryRequestHandler = $categoryRequestHandler;
+        $this->tagReferenceStore = $tagReferenceStore;
+        $this->categoryReferenceStore = $categoryReferenceStore;
         $this->template = $template;
         $this->targetGroupStore = $targetGroupStore;
     }
@@ -270,6 +287,14 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
 
         // resolve website tags to id
         $this->resolveTags($filters, 'websiteTags');
+
+        foreach (array_merge($filters['tags'], $filters['websiteTags']) as $item) {
+            $this->tagReferenceStore->add($item);
+        }
+
+        foreach (array_merge($filters['categories'], $filters['websiteCategories']) as $item) {
+            $this->categoryReferenceStore->add($item);
+        }
 
         // get provider
         $provider = $this->getProvider($property);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR uses reference-store of categories and tags to invalidate pages where a smart-content uses tags/categories in the query.

#### To Do

- [x] Tests
