### PR TITLE
Remove web-server-bundle from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,6 @@
         "symfony/twig-bridge": "^3.0",
         "symfony/twig-bundle": "^3.0",
         "symfony/validator": "^3.0",
-        "symfony/web-server-bundle": "^3.0",
         "twig/twig": "^1.11 || ^2.0",
         "willdurand/hateoas-bundle": "^1.1"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes unnecessary `symfony/web-server-bundle`.