### PR TITLE
Check if current user is sulu user for access control check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * HOTFIX      #3789 [MediaBundle]           Check if current user is sulu user to avoid errors
     * ENHANCEMENT #3764 [Component]             Allow dynamic order of elements in webspace xml
     * HOTFIX      #3752 [ContentBundle]         Overwrite 'doctrine:phpcr:workspace:import' set default to throw
     * ENHANCEMENT #3775 [Component]             Use is iterable instead of custom is_array twig function in webspace dumper

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -887,7 +887,13 @@ class MediaManager implements MediaManagerInterface
             return;
         }
 
-        return $this->tokenStorage->getToken()->getUser();
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if ($user instanceof UserInterface) {
+            return $user;
+        }
+
+        return;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/3404
| License | MIT

#### What's in this PR?

Check if current user is sulu user in media manager.

#### Why?

When using the form bundle on the website and submitting medias and the current user is a none sulu user it will fail.

