### PR TITLE
Set context data (token, locale) before render can fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3793 [PreviewBundle]           Set context data (token, locale) before render can fail
     * ENHANCEMENT #3779 [ContentBundle]           Improved cache-invalidation for categories/tags in excerpt tab
     * ENHANCEMENT #3777 [ContentBundle]           Added tag/category reference-store
     * FEATURE     #3028 [MediaBundle]             Added blur, grayscale, gamma, negative and sharpen transformation to media

--- a/src/Sulu/Bundle/PreviewBundle/Websocket/PreviewMessageHandler.php
+++ b/src/Sulu/Bundle/PreviewBundle/Websocket/PreviewMessageHandler.php
@@ -131,10 +131,11 @@ class PreviewMessageHandler implements MessageHandlerInterface
             $message['locale'],
             $message['data'] ?: []
         );
-        $response = $this->preview->render($token, $message['webspaceKey'], $message['locale']);
 
         $context->set('previewToken', $token);
         $context->set('locale', $message['locale']);
+
+        $response = $this->preview->render($token, $message['webspaceKey'], $message['locale']);
 
         return ['command' => 'start', 'token' => $token, 'response' => $response, 'msg' => 'OK'];
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the token not found exception if the start fails because of rendering error.

#### Why?

Rendering error can be:

* Twig-Exception
* Webspace not found for requested data (webspace_key, locale, ...)
