### PR TITLE
Load page content in Single internal link content type

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/SingleInternalLink.php
@@ -116,7 +116,27 @@ class SingleInternalLink extends SimpleContentType implements PreResolvableConte
      */
     public function getContentData(PropertyInterface $property)
     {
-        return $this->loadStructure($property->getValue(), $property->getStructure()->getLanguageCode());
+        $data = $this->loadStructure($property->getValue(), $property->getStructure()->getLanguageCode());
+
+        if (isset($data['content'])) {
+            $content = $data['content'];
+            unset($data['view']);
+            unset($data['content']);
+
+            return array_merge($data, $content);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewData(PropertyInterface $property)
+    {
+        $data = $this->loadStructure($property->getValue(), $property->getStructure()->getLanguageCode());
+
+        if (isset($data['view'])) {
+            return $data['view'];
+        }
     }
 
     /**
@@ -153,12 +173,10 @@ class SingleInternalLink extends SimpleContentType implements PreResolvableConte
                 $webspaceKey,
                 $locale
             );
-
-            return $this->structureResolver->resolve($contentStructure);
         } catch (DocumentNotFoundException $e) {
-            $this->logger->error((string) $e);
+            return null;
         }
 
-        return null;
+        return $this->structureResolver->resolve($contentStructure);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/content_types.xml
@@ -27,6 +27,8 @@
         </service>
 
         <service id="sulu.content.type.single_internal_link" class="%sulu.content.type.single_internal_link.class%">
+            <argument type="service" id="sulu.content.mapper"/>
+            <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_content.reference_store.content"/>
             <argument>%sulu.content.type.single_internal_link.template%</argument>
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/SingleInternalLinkTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/SingleInternalLinkTest.php
@@ -13,7 +13,10 @@ namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content\Types;
 
 use Sulu\Bundle\ContentBundle\Content\Types\SingleInternalLink;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Mapper\ContentMapperInterface;
 
 class SingleInternalLinkTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,6 +24,11 @@ class SingleInternalLinkTest extends \PHPUnit_Framework_TestCase
      * @var PropertyInterface
      */
     private $property;
+
+    /**
+     * @var StructureInterface
+     */
+    private $structure;
 
     /**
      * @var ReferenceStoreInterface
@@ -32,20 +40,35 @@ class SingleInternalLinkTest extends \PHPUnit_Framework_TestCase
      */
     private $type;
 
+    /**
+     * @var ContentMapperInterface
+     */
+    private $contentMapper;
+
+    /**
+     * @var StructureResolverInterface
+     */
+    private $structureResolver;
+
     public function setUp()
     {
         parent::setUp();
 
         $this->property = $this->prophesize(PropertyInterface::class);
+        $this->structure = $this->prophesize(StructureInterface::class);
+        $this->contentMapper = $this->prophesize(ContentMapperInterface::class);
+        $this->structureResolver = $this->prophesize(StructureResolverInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
 
         $this->type = new SingleInternalLink(
+            $this->contentMapper->reveal(),
+            $this->structureResolver->reveal(),
             $this->referenceStore->reveal(),
             'some_template.html.twig'
         );
     }
 
-    public function providePreResolve()
+    public function singleInternalLinkData()
     {
         return [
             [
@@ -64,15 +87,23 @@ class SingleInternalLinkTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider providePreResolve
+     * @dataProvider singleInternalLinkData
      */
-    public function testPreResolve($propertyValue, $expected)
+    public function testSingleInternalLink($propertyValue, $expected)
     {
         $this->property->getValue()->willReturn($propertyValue);
-        $this->type->preResolve($this->property->reveal());
+        $this->structure->getLanguageCode()->willReturn('de');
+        $structure = $this->structure->reveal();
+        $this->property->getStructure()->willReturn($structure);
 
         foreach ($expected as $uuid) {
             $this->referenceStore->add($uuid)->shouldBeCalled();
+            $this->contentMapper->load($uuid, null, 'de')->willReturn($structure)->shouldBeCalled();
+            $this->structureResolver->resolve($structure)->willReturn([])->shouldBeCalled();
         }
+
+        $this->type->preResolve($this->property->reveal());
+        $this->type->getContentData($this->property->reveal());
+        $this->type->getViewData($this->property->reveal());
     }
 }

--- a/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapperInterface.php
@@ -16,6 +16,7 @@ use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
 use Sulu\Component\Content\BreadcrumbItemInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 
 /**
  * Interface of ContentMapper.
@@ -77,6 +78,8 @@ interface ContentMapperInterface
      * @param bool   $loadGhostContent True if also a ghost page should be returned, otherwise false
      *
      * @return StructureInterface
+     *
+     * @throws DocumentNotFoundException
      */
     public function load($uuid, $webspaceKey, $languageCode, $loadGhostContent = false);
 

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -16,12 +16,14 @@ use PHPCR\NodeInterface;
 use Prophecy\Argument;
 use Sulu\Bundle\ContentBundle\Content\Types\SingleInternalLink;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
+use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\Block\BlockProperty;
 use Sulu\Component\Content\Compat\Block\BlockPropertyType;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ContentTypeManager;
 use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Content\Mapper\Translation\TranslatedProperty;
 use Sulu\Component\Content\Types\BlockContentType;
 use Sulu\Component\Content\Types\TextArea;
@@ -59,23 +61,35 @@ class BlockContentTypeTest extends \PHPUnit_Framework_TestCase
      */
     private $contentTypeManager;
 
+    /**
+     * @var ContentMapperInterface
+     */
+    private $contentMapper;
+
+    /**
+     * @var StructureResolverInterface
+     */
+    private $structureResolver;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->contentTypeManager = $this->prophesize(ContentTypeManager::class);
+        $this->contentMapper = $this->prophesize(ContentMapperInterface::class);
+        $this->structureResolver = $this->prophesize(StructureResolverInterface::class);
         $this->blockContentType = new BlockContentType($this->contentTypeManager->reveal(), 'not in use', 'i18n:');
 
         $this->contentTypeValueMap = [
             ['text_line', new TextLine('not in use')],
             ['text_area', new TextArea('not in use')],
-            ['internal_link', new SingleInternalLink(new ReferenceStore(), 'not in use')],
+            ['internal_link', new SingleInternalLink($this->contentMapper->reveal(), $this->structureResolver->reveal(), new ReferenceStore(), 'not in use')],
             ['block', $this->blockContentType],
         ];
 
         $this->contentTypeManager->get('text_line')->willReturn(new TextLine('not in use'));
         $this->contentTypeManager->get('text_area')->willReturn(new TextArea('not in use'));
-        $this->contentTypeManager->get('internal_link')->willReturn(new SingleInternalLink(new ReferenceStore(), 'not in use'));
+        $this->contentTypeManager->get('internal_link')->willReturn(new SingleInternalLink($this->contentMapper->reveal(), $this->structureResolver->reveal(), new ReferenceStore(), 'not in use'));
         $this->contentTypeManager->get('block')->willReturn($this->blockContentType);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | yes
| Fixed tickets | fixes #545
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/363

#### What's in this PR?

The single internal link content type return the page content instead of a uuid.
Also the content mapper load function does not longer need the webspaceKey as document manager does not need a webspace key.

#### Why?

Currently it does just a uuid is returned instead of page content. The single internal link now will return the whole page so it avoid to call `sulu_content_load`. 

#### BC Breaks/Deprecations

Removed the webspaceKey from Contentmapper::load function as not longer needed to load a page.

#### To Do

- [x] Create a documentation PR
