### PR TITLE
Increased priority of update-response-subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3796 [HttpCache]               Increased priority of update-response-subscriber 
     * HOTFIX      #3793 [PreviewBundle]           Set context data (token, locale) before render can fail
     * ENHANCEMENT #3779 [ContentBundle]           Improved cache-invalidation for categories/tags in excerpt tab
     * ENHANCEMENT #3777 [ContentBundle]           Added tag/category reference-store

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## dev-master
+
+### Priority of UpdateResponseSubscriber
+
+If you had hooked into response-event of symfony to change the cache behavior of Sulu, be aware of changed priority
+and update yours if required.
+
 ## 1.6.11
 
 ### SEO Description

--- a/src/Sulu/Component/HttpCache/EventSubscriber/UpdateResponseSubscriber.php
+++ b/src/Sulu/Component/HttpCache/EventSubscriber/UpdateResponseSubscriber.php
@@ -32,7 +32,7 @@ class UpdateResponseSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::RESPONSE => 'onResponse',
+            KernelEvents::RESPONSE => ['onResponse', 10],
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3792
| Related issues/PRs | #3792
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR increases the priority of `UpdateResponseSubscriber` to set the cache-headers before symfony does it.

#### Why?

See issue https://github.com/sulu/sulu/issues/3792
