### PR TITLE
fix superfluous updates on binded observable on the router

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -114,3 +114,6 @@ value.set('anything'); // will navigate to /page?value=anything
 
 router.unbind('value', value); // unbind to avoid leaking listeners
 ```
+
+Mind that the bindings will be cleared on every `navigate` call. This is necessary to avoid superfluous updates because
+of wrong update on observers.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -52,13 +52,9 @@ export default class Router {
         this.bindingDefaults.set(key, defaultValue);
     }
 
-    @action unbind(key: string, value: IObservableValue<*>) {
-        if (this.bindings.get(key) !== value) {
-            return;
-        }
-
-        this.bindings.delete(key);
-        this.bindingDefaults.delete(key);
+    @action clearBindings() {
+        this.bindings.clear();
+        this.bindingDefaults.clear();
     }
 
     match(path: string, queryString: string) {
@@ -81,19 +77,24 @@ export default class Router {
                 attributes[key] = Router.tryParseNumber(value);
             });
 
-            this.navigate(name, attributes);
+            this.handleNavigation(name, attributes);
 
             break;
         }
     }
 
-    navigate(name: string, attributes: Object = {}) {
+    handleNavigation(name: string, attributes: Object) {
         if (!this.isRouteChanging(name, attributes)) {
             return;
         }
 
         this.createAttributesHistory();
         this.update(name, attributes);
+    }
+
+    navigate(name: string, attributes: Object = {}) {
+        this.clearBindings();
+        this.handleNavigation(name, attributes);
     }
 
     restore(name: string, attributes: Object = {}) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -121,7 +121,7 @@ test('Navigate to route without default attribute when observable is changed', (
 
     router.bind('locale', locale);
 
-    router.navigate('list');
+    router.handleNavigation('list', {});
     expect(router.attributes.locale).toBe('en');
     expect(history.location.pathname).toBe('/list/en');
 
@@ -414,7 +414,7 @@ test('Binding should update passed observable', () => {
     const router = new Router(history);
 
     router.bind('page', value);
-    router.navigate('list', {page: 2});
+    router.handleNavigation('list', {page: 2});
 
     expect(value.get()).toBe(2);
 });
@@ -458,7 +458,7 @@ test('Binding should set default attribute', () => {
     const router = new Router(history);
 
     router.bind('locale', locale, 'en');
-    router.navigate('page');
+    router.handleNavigation('page', {});
     expect(router.attributes.locale).toBe('en');
     expect(router.url).toBe('/page/en');
 });
@@ -529,38 +529,11 @@ test('Binding should update state in router with other default bindings', () => 
 
     router.bind('page', page, '1');
     router.bind('locale', locale);
-    router.navigate('list');
+    router.handleNavigation('list', {});
 
     locale.set('de');
     expect(history.location.search).toBe('?locale=de');
     expect(router.attributes.locale).toBe('de');
-});
-
-test('Unbind should remove binding', () => {
-    const value = observable();
-
-    const history = createHistory();
-    const router = new Router(history);
-
-    router.bind('remove', value);
-    expect(router.bindings.has('remove')).toBe(true);
-
-    router.unbind('remove', value);
-    expect(router.bindings.has('remove')).toBe(false);
-});
-
-test('Unbind query should not remove binding if it is assigned to a new observable', () => {
-    const history = createHistory();
-    const router = new Router(history);
-
-    const value = observable();
-    router.bind('remove', value);
-    expect(router.bindings.get('remove')).toBe(value);
-
-    const newValue = observable();
-    router.bind('remove', newValue);
-    router.unbind('remove', value);
-    expect(router.bindings.get('remove')).toBe(newValue);
 });
 
 test('Do not add parameter to URL if undefined', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -26,11 +26,6 @@ class Form extends React.PureComponent<Props> {
 
     componentWillUnmount() {
         this.formStore.destroy();
-        const {resourceStore, router} = this.props;
-
-        if (resourceStore.locale) {
-            router.unbind('locale', resourceStore.locale);
-        }
     }
 
     handleSubmit = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -558,13 +558,12 @@ test('Should render save button loading only if form is saving', () => {
     expect(getSaveItem().loading).toBe(true);
 });
 
-test('Should unbind the binding and destroy the store on unmount', () => {
+test('Should destroy the store on unmount', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 12, {locale: observable()});
     const router = {
         bind: jest.fn(),
-        unbind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -579,8 +578,11 @@ test('Should unbind the binding and destroy the store on unmount', () => {
 
     expect(router.bind).toBeCalledWith('locale', locale);
 
+    const formStore = form.instance().formStore;
+    formStore.destroy = jest.fn();
+
     form.unmount();
-    expect(router.unbind).toBeCalledWith('locale', locale);
+    expect(formStore.destroy).toBeCalled();
 });
 
 test('Should not bind the locale if no locales have been passed via options', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -53,19 +53,7 @@ class List extends React.Component<ViewProps> {
     }
 
     componentWillUnmount() {
-        const {router} = this.props;
-        const {
-            route: {
-                options: {
-                    locales,
-                },
-            },
-        } = router;
         this.datagridStore.destroy();
-        router.unbind('page', this.page);
-        if (locales) {
-            router.unbind('locale', this.locale);
-        }
     }
 
     handleEditClick = (rowId) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -139,11 +139,10 @@ test('Should throw an error when no resourceKey is defined in the route options'
     expect(() => render(<List router={router} />)).toThrow(/mandatory resourceKey option/);
 });
 
-test('Should unbind the binding and destroy the store on unmount', () => {
+test('Should destroy the store on unmount', () => {
     const List = require('../List').default;
     const router = {
         bind: jest.fn(),
-        unbind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -162,34 +161,10 @@ test('Should unbind the binding and destroy the store on unmount', () => {
     expect(router.bind).toBeCalledWith('page', page, 1);
     expect(router.bind).toBeCalledWith('locale', locale);
 
+    const datagridStore = list.instance().datagridStore;
     list.unmount();
-    expect(router.unbind).toBeCalledWith('page', page);
-    expect(router.unbind).toBeCalledWith('locale', locale);
-});
 
-test('Should unbind the binding and destroy the store on unmount without locale', () => {
-    const List = require('../List').default;
-    const router = {
-        bind: jest.fn(),
-        unbind: jest.fn(),
-        route: {
-            options: {
-                resourceKey: 'snippets',
-                adapters: ['table'],
-            },
-        },
-    };
-
-    const list = mount(<List router={router} />);
-    const page = router.bind.mock.calls[0][1];
-
-    expect(page.get()).toBe(undefined);
-    expect(router.bind).toBeCalledWith('page', page, 1);
-    expect(router.bind).not.toBeCalledWith('locale');
-
-    list.unmount();
-    expect(router.unbind).toBeCalledWith('page', page);
-    expect(router.unbind).not.toBeCalledWith('locale');
+    expect(datagridStore.destroy).toBeCalled();
 });
 
 test('Should render the add button in the toolbar only if a addRoute has been passed in options', () => {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
@@ -36,11 +36,6 @@ class PageForm extends React.Component<Props> {
 
     componentWillUnmount() {
         this.formStore.destroy();
-        const {resourceStore, router} = this.props;
-
-        if (resourceStore.locale) {
-            router.unbind('locale', resourceStore.locale);
-        }
     }
 
     handleSubmit = (action) => {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -93,12 +93,6 @@ class WebspaceOverview extends React.Component<ViewProps> {
     }
 
     componentWillUnmount() {
-        const {router} = this.props;
-
-        router.unbind('page', this.page);
-        router.unbind('webspace', this.webspace);
-        router.unbind('locale', this.locale);
-
         this.datagridStore.destroy();
     }
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -129,11 +129,10 @@ test('Should change webspace when value of webspace select is changed', () => {
     });
 });
 
-test('Should bind/unbind router', () => {
+test('Should bind router', () => {
     const WebspaceOverview = require('../WebspaceOverview').default;
     const router = {
         bind: jest.fn(),
-        unbind: jest.fn(),
         attributes: {},
     };
 
@@ -146,9 +145,4 @@ test('Should bind/unbind router', () => {
     expect(router.bind).toBeCalledWith('page', page, '1');
     expect(router.bind).toBeCalledWith('locale', locale);
     expect(router.bind).toBeCalledWith('webspace', webspace);
-
-    webspaceOverview.unmount();
-    expect(router.unbind).toBeCalledWith('page', page);
-    expect(router.unbind).toBeCalledWith('locale', locale);
-    expect(router.unbind).toBeCalledWith('webspace', webspace);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -40,6 +40,10 @@ class MediaDetail extends React.Component<Props> {
         this.mediaUploadStore = new MediaUploadStore(locale);
     }
 
+    componentWillUnmount() {
+        this.formStore.destroy();
+    }
+
     @computed get thumbnail(): ?string {
         const {resourceStore} = this.props;
         const {
@@ -58,14 +62,6 @@ class MediaDetail extends React.Component<Props> {
     @computed get mimeType(): string {
         const {resourceStore} = this.props;
         return resourceStore.data.mimeType;
-    }
-
-    componentWillUnmount() {
-        const {resourceStore, router} = this.props;
-
-        if (resourceStore.locale) {
-            router.unbind('locale', resourceStore.locale);
-        }
     }
 
     setFormRef = (form) => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -156,7 +156,6 @@ test('Should call update method of MediaUploadStore if a file was dropped', (don
     const router = {
         navigate: jest.fn(),
         bind: jest.fn(),
-        unbind: jest.fn(),
         route: {
             options: {
                 locales: [],
@@ -265,7 +264,6 @@ test('Should save form when submitted', (done) => {
 
     const router = {
         bind: jest.fn(),
-        unbind: jest.fn(),
         navigate: jest.fn(),
         route: {
             options: {
@@ -289,13 +287,12 @@ test('Should save form when submitted', (done) => {
     jsonSchemaResolve({});
 });
 
-test('Should unbind the binding and destroy the store on unmount', () => {
+test('Should destroy the store on unmount', () => {
     const MediaDetail = require('../MediaDetail').default;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
     const resourceStore = new ResourceStore('media', 12, {locale: observable()});
     const router = {
         bind: jest.fn(),
-        unbind: jest.fn(),
         route: {
             options: {
                 resourceKey: 'snippets',
@@ -310,6 +307,9 @@ test('Should unbind the binding and destroy the store on unmount', () => {
 
     expect(router.bind).toBeCalledWith('locale', locale);
 
+    const formStore = mediaDetail.instance().formStore;
+    formStore.destroy = jest.fn();
+
     mediaDetail.unmount();
-    expect(router.unbind).toBeCalledWith('locale', locale);
+    expect(formStore.destroy).toBeCalled();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -41,10 +41,6 @@ class MediaOverview extends React.Component<ViewProps> {
     }
 
     componentWillUnmount() {
-        const {router} = this.props;
-
-        router.unbind('collectionPage', this.collectionPage);
-        router.unbind('locale', this.locale);
         this.mediaDatagridStore.destroy();
         this.collectionDatagridStore.destroy();
         this.collectionStore.destroy();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -164,11 +164,10 @@ test('Render a simple MediaOverview', () => {
     expect(mediaOverview).toMatchSnapshot();
 });
 
-test('Unbind all query params and destroy all stores on unmount', () => {
+test('Destroy all stores on unmount', () => {
     const MediaOverview = require('../MediaOverview').default;
     const router = {
         bind: jest.fn(),
-        unbind: jest.fn(),
         attributes: {},
     };
 
@@ -186,8 +185,6 @@ test('Unbind all query params and destroy all stores on unmount', () => {
     expect(mediaOverviewInstance.mediaDatagridStore.destroy).toBeCalled();
     expect(mediaOverviewInstance.collectionDatagridStore.destroy).toBeCalled();
     expect(mediaOverviewInstance.collectionStore.resourceStore.destroy).toBeCalled();
-    expect(router.unbind).toBeCalledWith('collectionPage', page);
-    expect(router.unbind).toBeCalledWith('locale', locale);
 });
 
 test('Should navigate to defined route on back button click', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes a bug, which caused some wrong update on render. The problem was that the `unbind` calls in `componentWillUnmount` were called after the `bind` calls of `componentWillMount`. That made the observables be updated on the `bind` calls and already called all reactions.

#### Why?

Because in quite a lot situation reactions were run, where they shouldn't. E.g. switching from the Snippet List to e.g. Contacts led to two requests, whereby one was sent to the "old" snippet endpoint with a locale of `undefined`. That should definitely not happen, and is fixed in this PR.

#### BC Breaks/Deprecations

The `unbind` method of the `Router` was removed, because all bindings are unbinded on the `navigate` call (which might be another BC break).