### PR TITLE
Fix spacing between rows and section in content template generation for 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * BUGFIX      #3805 [ContentBundle]           Fix spacing between rows and section in content template generation
+
 * 1.6.15 (2018-02-27)
     * HOTFIX      #3802 [ContentBundle]           Fixed XmlLoader internal flag
     * HOTFIX      #3796 [HttpCache]               Increased priority of update-response-subscriber 

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
@@ -1,5 +1,8 @@
-<div class="grid-col-{{ property.colspan != "" ? property.colspan : '12' }} floating m-top-20">
-    <h2 class="light">{{ property.getTitle(userLocale) }}</h2>
+<div class="grid-col-{{ property.colspan != "" ? property.colspan : '12' }} floating">
+    {% set blockTitle = property.getTitle(userLocale) %}
+    {% if blockTitle %}
+        <h2 class="light">{{ blockTitle }}</h2>
+    {% endif %}
 
     <div class="grid">
         <div id="text-block-header-{{ id|raw }}" class="text-blocks-header">
@@ -11,7 +14,7 @@
             </div>
             <div class="clear"></div>
         </div>
-        <div class="grid-row small"
+        <div class="grid-row m-bottom-0"
              id="{{ id|raw }}"
              data-form="true"
              data-type="block"
@@ -65,7 +68,7 @@
             {% endfor %}
         </div>
 
-        <div class="text-block-footer" id="{{ id|raw }}-add" style="width: 200px">
+        <div class="text-block-footer m-bottom-0" id="{{ id|raw }}-add" style="width: 200px">
 
         </div>
     </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/properties.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/properties.html.twig
@@ -1,6 +1,7 @@
 <div class="grid-row">
 {# initialize columns #}
 {% set columns = 0 %}
+{% set lastProperty = null %}
 
 {% for property in properties %}
     {% if property.name not in excludedProperties %}
@@ -13,7 +14,12 @@
             {% set columns = columns + propertyColspan %}
         {% else %}
             </div>
-            <div class="grid-row">
+
+            {% set gridRowClass = '' %}
+            {% if property.contentTypeName == 'section' and lastProperty.contentTypeName|default != 'section' %}
+                {% set gridRowClass = ' m-top-40' %}
+            {% endif %}
+            <div class="grid-row{{ gridRowClass }}">
             {# set current amount of colspans #}
             {% set columns = propertyColspan %}
         {% endif %}
@@ -74,5 +80,7 @@
             {% endif %}
         {% endif %}
     {% endif %}
+
+    {% set lastProperty = property %}
 {% endfor %}
 </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/section.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/section.html.twig
@@ -3,15 +3,15 @@
         <h2 class="divider m-bottom-20"
             title="{{ property.getInfoText(userLocale) }}">{{ property.getTitle(userLocale) }}</h2>
 
-        <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+        {% if property.getInfoText(userLocale) %}
+            <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+        {% endif %}
     {% endif %}
 
     <div class="grid">
-        <div class="grid-row">
-            {% include 'SuluContentBundle:Template:macros/properties.html.twig' with {
-                'properties': property.childProperties,
-                'excludedProperties': excludedProperties
-            } %}
-        </div>
+        {% include 'SuluContentBundle:Template:macros/properties.html.twig' with {
+            'properties': property.childProperties,
+            'excludedProperties': excludedProperties
+        } %}
     </div>
 </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/single.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/single.html.twig
@@ -6,5 +6,7 @@
 
     {% include type.template %}
 
-    <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+    {% if property.getInfoText(userLocale) %}
+        <div class="input-description">{{ property.getInfoText(userLocale) }}</div>
+    {% endif %}
 </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/3351#event-1142007764
| License | MIT

#### What's in this PR?

Fix spacing between rows and section in content template generation

#### Why?

See https://github.com/sulu/sulu/pull/3351

#### ATTENTION should be merged without SQUASH MERGE as this fix conflicts between 1.6 and 1.5 branch!