### PR TITLE
Remove recreation of MediaStores in MediaOverview and MediaSelection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -472,7 +472,8 @@ EOL
             "label": "Description",
             "type": "text_area"
         }
-    }
+    },
+    "schema": {}
 }
 EOL
             );
@@ -507,7 +508,8 @@ EOL
                 }
             }
         }
-    }
+    },
+    "schema": {}
 }
 EOL
             );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -99,10 +99,9 @@ export default class DatagridStore {
         }
 
         const observableOptions = {};
-        observableOptions.page = this.observableOptions.page.get();
 
-        if (this.observableOptions.locale) {
-            observableOptions.locale = this.observableOptions.locale.get();
+        for (const key in this.observableOptions) {
+            observableOptions[key] = this.observableOptions[key].get();
         }
 
         this.setDataLoading(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -98,10 +98,8 @@ export default class DatagridStore {
             return;
         }
 
-        const page = this.getPage();
-
         const observableOptions = {};
-        observableOptions.page = page;
+        observableOptions.page = this.observableOptions.page.get();
 
         if (this.observableOptions.locale) {
             observableOptions.locale = this.observableOptions.locale.get();
@@ -138,13 +136,8 @@ export default class DatagridStore {
         this.dataLoading = dataLoading;
     }
 
-    getPage(): ?number {
-        const page = parseInt(this.observableOptions.page.get());
-        if (!page) {
-            return undefined;
-        }
-
-        return page;
+    getPage() {
+        return this.observableOptions.page.get();
     }
 
     @action setPage(page: number) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -180,6 +180,10 @@ export default class DatagridStore {
         this.selections = [];
     }
 
+    clearData() {
+        this.structureStrategy.clear();
+    }
+
     destroy() {
         this.disposer();
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
@@ -1,5 +1,5 @@
 // @flow
-import {observable} from 'mobx';
+import {action, observable} from 'mobx';
 import type {StructureStrategyInterface} from '../types';
 
 export default class FlatStructureStrategy implements StructureStrategyInterface {
@@ -13,7 +13,7 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         return this.data;
     }
 
-    clear() {
+    @action clear() {
         this.data.splice(0, this.data.length);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
@@ -35,7 +35,7 @@ export default class TreeStructureStrategy implements StructureStrategyInterface
         };
     }
 
-    clear() {
+    @action clear() {
         this.data.splice(0, this.data.length);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -382,6 +382,17 @@ test('Clear the selection', () => {
     expect(datagridStore.selections).toHaveLength(0);
 });
 
+test('Clear the data', () => {
+    const datagridStore = new DatagridStore('tests', {
+        page: observable(),
+    });
+    const structureStrategy = new StructureStrategy();
+    datagridStore.updateStrategies(new LoadingStrategy(), structureStrategy);
+
+    datagridStore.clearData();
+    expect(structureStrategy.clear).toBeCalled();
+});
+
 test('Nothing should happen when to the same loading strategy is changed', () => {
     const loadingStrategy = new LoadingStrategy();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -27,11 +27,13 @@ test('The loading strategy should be called when a request is sent', () => {
     const structureStrategy = new StructureStrategy();
     const page = observable(1);
     const locale = observable();
+    const additionalValue = observable(5);
     const datagridStore = new DatagridStore(
         'tests',
         {
             page,
             locale,
+            additionalValue,
         },
         {
             test: 'value',
@@ -45,6 +47,7 @@ test('The loading strategy should be called when a request is sent', () => {
         toJS(datagridStore.data),
         'tests',
         {
+            additionalValue: 5,
             locale: undefined,
             page: 1,
             test: 'value',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -41,7 +41,7 @@ class List extends React.Component<ViewProps> {
 
         const observableOptions = {};
 
-        router.bind('page', this.page, '1');
+        router.bind('page', this.page, 1);
         observableOptions.page = this.page;
 
         if (locales) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -159,7 +159,7 @@ test('Should unbind the binding and destroy the store on unmount', () => {
 
     expect(page.get()).toBe(undefined);
     expect(locale.get()).toBe(undefined);
-    expect(router.bind).toBeCalledWith('page', page, '1');
+    expect(router.bind).toBeCalledWith('page', page, 1);
     expect(router.bind).toBeCalledWith('locale', locale);
 
     list.unmount();
@@ -184,7 +184,7 @@ test('Should unbind the binding and destroy the store on unmount without locale'
     const page = router.bind.mock.calls[0][1];
 
     expect(page.get()).toBe(undefined);
-    expect(router.bind).toBeCalledWith('page', page, '1');
+    expect(router.bind).toBeCalledWith('page', page, 1);
     expect(router.bind).not.toBeCalledWith('locale');
 
     list.unmount();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
@@ -30,7 +30,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
 
     mediaPage: IObservableValue<number> = observable();
     collectionPage: IObservableValue<number> = observable();
-    @observable collectionId: ?string | number;
+    collectionId: IObservableValue<?string | number> = observable();
     @observable mediaDatagridStore: DatagridStore;
     @observable collectionDatagridStore: DatagridStore;
     collectionStore: CollectionStore;
@@ -84,7 +84,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
         }
 
         this.selectedMedia = [];
-        this.collectionId = undefined;
+        this.collectionId.set(undefined);
     }
 
     @action setMediaPage(page: number) {
@@ -95,17 +95,15 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
         this.collectionPage.set(page);
     }
 
-    @action setCollectionId(id: ?string | number) {
-        this.collectionId = id;
-    }
-
     createStores = () => {
         this.setMediaPage(1);
         this.setCollectionPage(1);
 
-        this.createCollectionStore(this.collectionId, this.locale);
-        this.createMediaDatagridStore(this.collectionId, this.mediaPage, this.locale);
-        this.createCollectionDatagridStore(this.collectionId, this.collectionPage, this.locale);
+        const collectionId = this.collectionId.get();
+
+        this.createCollectionStore(collectionId, this.locale);
+        this.createMediaDatagridStore(collectionId, this.mediaPage, this.locale);
+        this.createCollectionDatagridStore(collectionId, this.collectionPage, this.locale);
     };
 
     @action createCollectionDatagridStore(
@@ -202,7 +200,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
     };
 
     handleCollectionNavigate = (collectionId: ?string | number) => {
-        this.setCollectionId(collectionId);
+        this.collectionId.set(collectionId);
     };
 
     handleClose = () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -73,6 +73,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.destroy = jest.fn();
             this.sendRequest = jest.fn();
             this.clearSelection = jest.fn();
+            this.clearData = jest.fn();
             this.setAppendRequestData = jest.fn();
             this.deselectEntirePage = jest.fn();
             this.select = jest.fn();
@@ -178,10 +179,10 @@ test('Should instantiate the needed stores when the overlay opens', () => {
     expect(mediaSelectionOverlayInstance.mediaPage.get()).toBe(1);
     expect(mediaSelectionOverlayInstance.collectionPage.get()).toBe(1);
 
-    expect(DatagridStore.mock.calls[0][0]).toBe(mediaResourceKey);
-    expect(DatagridStore.mock.calls[0][1].locale).toBe(locale);
-    expect(DatagridStore.mock.calls[0][1].page.get()).toBe(1);
-    expect(DatagridStore.mock.calls[0][2].fields).toEqual([
+    expect(DatagridStore.mock.calls[1][0]).toBe(mediaResourceKey);
+    expect(DatagridStore.mock.calls[1][1].locale).toBe(locale);
+    expect(DatagridStore.mock.calls[1][1].page.get()).toBe(1);
+    expect(DatagridStore.mock.calls[1][2].fields).toEqual([
         'id',
         'type',
         'name',
@@ -192,9 +193,9 @@ test('Should instantiate the needed stores when the overlay opens', () => {
         'thumbnails',
     ].join(','));
 
-    expect(DatagridStore.mock.calls[1][0]).toBe(collectionResourceKey);
-    expect(DatagridStore.mock.calls[1][1].locale).toBe(locale);
-    expect(DatagridStore.mock.calls[1][1].page.get()).toBe(1);
+    expect(DatagridStore.mock.calls[0][0]).toBe(collectionResourceKey);
+    expect(DatagridStore.mock.calls[0][1].locale).toBe(locale);
+    expect(DatagridStore.mock.calls[0][1].page.get()).toBe(1);
 });
 
 test('Should add and remove media ids', () => {
@@ -358,4 +359,49 @@ test('Should destroy the stores and cleanup all states when the overlay is close
     expect(mediaSelectionOverlayInstance.collectionStore.resourceStore.destroy).toBeCalled();
     expect(mediaSelectionOverlayInstance.mediaDatagridStore.destroy).toBeCalled();
     expect(mediaSelectionOverlayInstance.collectionDatagridStore.destroy).toBeCalled();
+});
+
+test('Should change collection with selected media', () => {
+    const locale = observable();
+    const mediaSelectionOverlay = mount(
+        <MediaSelectionOverlay
+            open={true}
+            locale={locale}
+            excludedIds={[]}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+        />
+    );
+
+    mediaSelectionOverlay.instance().mediaPage.set(4);
+    mediaSelectionOverlay.instance().collectionPage.set(3);
+
+    mediaSelectionOverlay.find('Folder').at(0).simulate('click');
+
+    expect(mediaSelectionOverlay.instance().mediaPage.get()).toEqual(1);
+    expect(mediaSelectionOverlay.instance().collectionPage.get()).toEqual(1);
+    expect(mediaSelectionOverlay.instance().collectionId.get()).toEqual(1);
+    expect(mediaSelectionOverlay.instance().mediaDatagridStore.clearSelection).not.toBeCalled();
+});
+
+test('Should reset both datagrid to first page after reopening overlay', () => {
+    const locale = observable();
+    const mediaSelectionOverlay = mount(
+        <MediaSelectionOverlay
+            open={true}
+            locale={locale}
+            excludedIds={[]}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+        />
+    );
+
+    mediaSelectionOverlay.instance().mediaPage.set(3);
+    mediaSelectionOverlay.instance().collectionPage.set(2);
+
+    mediaSelectionOverlay.setProps({open: false});
+    mediaSelectionOverlay.setProps({open: true});
+
+    expect(mediaSelectionOverlay.instance().mediaPage.get()).toEqual(1);
+    expect(mediaSelectionOverlay.instance().collectionPage.get()).toEqual(1);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -330,9 +330,9 @@ test('Should destroy the stores and cleanup all states when the overlay is close
         added: [2],
         removed: [],
     }));
-    mediaSelectionOverlayInstance.setCollectionId(1);
+    mediaSelectionOverlayInstance.collectionId.set(1);
 
-    expect(mediaSelectionOverlayInstance.collectionId).toBe(1);
+    expect(mediaSelectionOverlayInstance.collectionId.get()).toBe(1);
     expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
         {
             id: 1,
@@ -353,7 +353,7 @@ test('Should destroy the stores and cleanup all states when the overlay is close
     ]);
 
     mediaSelectionOverlayInstance.handleClose();
-    expect(mediaSelectionOverlayInstance.collectionId).toBe(undefined);
+    expect(mediaSelectionOverlayInstance.collectionId.get()).toBe(undefined);
     expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([]);
     expect(mediaSelectionOverlayInstance.collectionStore.resourceStore.destroy).toBeCalled();
     expect(mediaSelectionOverlayInstance.mediaDatagridStore.destroy).toBeCalled();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -100,7 +100,7 @@ class MediaOverview extends React.Component<ViewProps> {
         );
     }
 
-    @action handleCollectionOpen = (collectionId) => {
+    @action handleCollectionNavigate = (collectionId) => {
         this.mediaDatagridStore.clearData();
         this.mediaDatagridStore.clearSelection();
         this.collectionDatagridStore.clearData();
@@ -130,7 +130,7 @@ class MediaOverview extends React.Component<ViewProps> {
                     mediaDatagridAdapters={['media_card_overview', 'table']}
                     mediaDatagridStore={this.mediaDatagridStore}
                     collectionDatagridStore={this.collectionDatagridStore}
-                    onCollectionNavigate={this.handleCollectionOpen}
+                    onCollectionNavigate={this.handleCollectionNavigate}
                     onMediaNavigate={this.handleMediaNavigate}
                 />
             </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -31,7 +31,7 @@ class MediaOverview extends React.Component<ViewProps> {
 
         this.mediaPage.set(1);
 
-        router.bind('collectionPage', this.collectionPage, '1');
+        router.bind('collectionPage', this.collectionPage, 1);
         router.bind('locale', this.locale);
         router.bind('id', this.collectionId);
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -20,7 +20,7 @@ class MediaOverview extends React.Component<ViewProps> {
     mediaPage: IObservableValue<number> = observable();
     collectionPage: IObservableValue<number> = observable();
     locale: IObservableValue<string> = observable();
-    @observable collectionId: ?number;
+    collectionId: IObservableValue<?number> = observable();
     @observable mediaDatagridStore: DatagridStore;
     @observable collectionDatagridStore: DatagridStore;
     collectionStore: CollectionStore;
@@ -33,6 +33,7 @@ class MediaOverview extends React.Component<ViewProps> {
 
         router.bind('collectionPage', this.collectionPage, '1');
         router.bind('locale', this.locale);
+        router.bind('id', this.collectionId);
 
         this.disposer = autorun(this.createStores);
     }
@@ -48,31 +49,13 @@ class MediaOverview extends React.Component<ViewProps> {
         this.disposer();
     }
 
-    getCollectionId() {
-        const {router} = this.props;
-        const {
-            attributes: {
-                id,
-            },
-        } = router;
-
-        return id;
-    }
-
     createStores = () => {
-        const collectionId = this.getCollectionId();
+        const collectionId = this.collectionId.get();
 
-        if (collectionId !== this.collectionId || !this.collectionDatagridStore) {
-            this.setCollectionId(collectionId);
-            this.createCollectionStore(collectionId, this.locale);
-            this.createMediaDatagridStore(collectionId, this.mediaPage, this.locale);
-            this.createCollectionDatagridStore(collectionId, this.collectionPage, this.locale);
-        }
+        this.createCollectionStore(collectionId, this.locale);
+        this.createMediaDatagridStore(collectionId, this.mediaPage, this.locale);
+        this.createCollectionDatagridStore(collectionId, this.collectionPage, this.locale);
     };
-
-    @action setCollectionId(id) {
-        this.collectionId = id;
-    }
 
     @action createCollectionDatagridStore(collectionId, page, locale) {
         if (this.collectionDatagridStore) {
@@ -200,7 +183,7 @@ export default withToolbar(MediaOverview, function() {
     return {
         locale,
         disableAll: loading,
-        backButton: (this.collectionId)
+        backButton: this.collectionId.get()
             ? {
                 onClick: () => {
                     router.restore(

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -66,6 +66,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.destroy = jest.fn();
             this.sendRequest = jest.fn();
             this.clearSelection = jest.fn();
+            this.clearData = jest.fn();
             this.updateStrategies = jest.fn();
         }),
         FlatStructureStrategy: require(
@@ -219,7 +220,7 @@ test('Should navigate to defined route on back button click', () => {
     });
 });
 
-test('Router navigate should be called when a collection or media was clicked', () => {
+test('Router navigate should be called when a media was clicked', () => {
     const MediaOverview = require('../MediaOverview').default;
     const locale = 'de';
     const router = {
@@ -236,18 +237,44 @@ test('Router navigate should be called when a collection or media was clicked', 
         navigate: jest.fn(),
     };
     const mediaOverview = mount(<MediaOverview router={router} />);
-    mediaOverview.instance().collectionId = 4;
     mediaOverview.instance().locale.set(locale);
-
-    mediaOverview.find('Folder').at(1).simulate('click');
-    expect(router.navigate).toBeCalledWith(
-        'sulu_media.overview',
-        {'collectionPage': '1', 'id': 2, 'locale': locale}
-    );
 
     mediaOverview.find('.media').at(0).simulate('click');
     expect(router.navigate).toBeCalledWith(
         'sulu_media.form.detail',
         {'id': 1, 'locale': locale}
     );
+});
+
+test('The collectionId should be update along with the content when a collection was clicked', () => {
+    const MediaOverview = require('../MediaOverview').default;
+    const locale = 'de';
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [locale],
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+        navigate: jest.fn(),
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />);
+    mediaOverview.instance().locale.set(locale);
+    mediaOverview.instance().mediaPage.set(3);
+    mediaOverview.instance().collectionPage.set(2);
+    mediaOverview.instance().collectionId.set(4);
+
+    mediaOverview.find('Folder').at(0).simulate('click');
+
+    expect(mediaOverview.instance().collectionId.get()).toEqual(1);
+    expect(mediaOverview.instance().collectionPage.get()).toEqual(1);
+    expect(mediaOverview.instance().mediaPage.get()).toEqual(1);
+    expect(mediaOverview.instance().mediaDatagridStore.clearSelection).toBeCalled();
+    expect(mediaOverview.instance().mediaDatagridStore.clearData).toBeCalled();
+    expect(mediaOverview.instance().collectionDatagridStore.clearSelection).toBeCalled();
+    expect(mediaOverview.instance().collectionDatagridStore.clearData).toBeCalled();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -179,7 +179,7 @@ test('Unbind all query params and destroy all stores on unmount', () => {
 
     expect(page.get()).toBe(undefined);
     expect(locale.get()).toBe(undefined);
-    expect(router.bind).toBeCalledWith('collectionPage', page, '1');
+    expect(router.bind).toBeCalledWith('collectionPage', page, 1);
     expect(router.bind).toBeCalledWith('locale', locale);
 
     mediaOverview.unmount();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -207,7 +207,7 @@ test('Should navigate to defined route on back button click', () => {
         },
     };
     const mediaOverview = mount(<MediaOverview router={router} />).at(0).instance();
-    mediaOverview.collectionId = 4;
+    mediaOverview.collectionId.set(4);
     mediaOverview.locale.set('de');
 
     const toolbarConfig = toolbarFunction.call(mediaOverview);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3743
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the permanent recreation of the stores in the `MediaOverview` and `MediaSelection` components.

#### Why?

Because we have fixed our routing issue in #3801, but the fix does break the weird behavior with the recreation of these components.

#### ToDo

- [ ] How to show loader for collection datagrid? It changed a bit.
- [x] Fix reset to first page for `MediaDatagridStore` when collection is changed