### PR TITLE
fix strange behaviours on enter keypress in form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/__snapshots__/Block.test.js.snap
@@ -106,6 +106,7 @@ exports[`Render an expanded block with a multiple types 1`] = `
         >
           <button
             class="displayValue"
+            type="button"
           >
             <div
               aria-label="Type1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -44,6 +44,7 @@ exports[`Should render a block list 1`] = `
   </div>
   <button
     class="button secondary"
+    type="button"
   >
     <span
       class="text"
@@ -103,6 +104,7 @@ exports[`Should render a fully filled block list without add button if maxOccurs
   <button
     class="button secondary"
     disabled=""
+    type="button"
   >
     <span
       class="text"
@@ -126,6 +128,7 @@ exports[`Should render an empty block list 1`] = `
   />
   <button
     class="button secondary"
+    type="button"
   >
     <span
       class="text"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/SortableBlock.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/SortableBlock.test.js.snap
@@ -88,6 +88,7 @@ exports[`Render expanded sortable block with types 1`] = `
         >
           <button
             class="displayValue"
+            type="button"
           >
             <div
               aria-label="Type 2"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -42,7 +42,7 @@ export default class Button extends React.PureComponent<Props> {
         );
 
         return (
-            <button className={buttonClass} onClick={this.handleClick} disabled={loading || disabled}>
+            <button className={buttonClass} onClick={this.handleClick} disabled={loading || disabled} type="button">
                 <span className={buttonStyles.text}>{children}</span>
                 {loading &&
                     <div className={buttonStyles.loader}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Should render with skin link 1`] = `
 <button
   class="button link"
+  type="button"
 >
   <span
     class="text"
@@ -13,6 +14,7 @@ exports[`Should render with skin link 1`] = `
 exports[`Should render with skin primary 1`] = `
 <button
   class="button primary"
+  type="button"
 >
   <span
     class="text"
@@ -23,6 +25,7 @@ exports[`Should render with skin primary 1`] = `
 exports[`Should render with skin secondary 1`] = `
 <button
   class="button secondary"
+  type="button"
 >
   <span
     class="text"
@@ -34,6 +37,7 @@ exports[`should render disabled with skin secondary 1`] = `
 <button
   class="button secondary"
   disabled=""
+  type="button"
 >
   <span
     class="text"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -17,8 +17,8 @@ exports[`The component should render in body when open 2`] = `
           <div>My dialog content</div>
         </article>
         <footer>
-          <button class=\\"button secondary\\"><span class=\\"text\\">Cancel</span></button>
-          <button class=\\"button primary\\"><span class=\\"text\\">Confirm</span></button>
+          <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button>
+          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>
@@ -41,8 +41,8 @@ exports[`The component should render in body with loader instead of confirm butt
           <div>My dialog content</div>
         </article>
         <footer>
-          <button class=\\"button secondary\\"><span class=\\"text\\">Cancel</span></button>
-          <button class=\\"button primary loading\\" disabled=\\"\\"><span class=\\"text\\">Confirm</span>
+          <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button>
+          <button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span>
             <div class=\\"loader\\">
               <div style=\\"width: 25px; height: 25px;\\" class=\\"spinner\\">
                 <div class=\\"doubleBounce1\\"></div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Actions.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Actions.test.js.snap
@@ -6,6 +6,7 @@ exports[`The component should render 1`] = `
 >
   <button
     class="button link"
+    type="button"
   >
     <span
       class="text"
@@ -15,6 +16,7 @@ exports[`The component should render 1`] = `
   </button>
   <button
     class="button link"
+    type="button"
   >
     <span
       class="text"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -17,7 +17,7 @@ exports[`The component should render in body when open 2`] = `
           <p>My overlay content</p>
         </article>
         <footer>
-          <button class=\\"button primary\\"><span class=\\"text\\">Apply</span></button>
+          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Apply</span></button>
         </footer>
       </section>
     </div>
@@ -41,10 +41,10 @@ exports[`The component should render in body with actions when open 2`] = `
         </article>
         <footer>
           <div class=\\"actions\\">
-            <button class=\\"button link\\"><span class=\\"text\\">Action 1</span></button>
-            <button class=\\"button link\\"><span class=\\"text\\">Action 2</span></button>
+            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Action 1</span></button>
+            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Action 2</span></button>
           </div>
-          <button class=\\"button primary\\"><span class=\\"text\\">Apply</span></button>
+          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Apply</span></button>
         </footer>
       </section>
     </div>
@@ -67,7 +67,7 @@ exports[`The component should render in body with loader instead of confirm butt
           <p>My overlay content</p>
         </article>
         <footer>
-          <button class=\\"button primary loading\\" disabled=\\"\\"><span class=\\"text\\">Apply</span>
+          <button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Apply</span>
             <div class=\\"loader\\">
               <div style=\\"width: 25px; height: 25px;\\" class=\\"spinner\\">
                 <div class=\\"doubleBounce1\\"></div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/DisplayValue.js
@@ -46,6 +46,7 @@ export default class DisplayValue extends React.PureComponent<Props> {
                 ref={this.setButtonRef}
                 onClick={this.handleClick}
                 className={displayValueClass}
+                type="button"
             >
                 {!!icon &&
                     <Icon className={displayValueStyles.frontIcon} name={icon} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/DisplayValue.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/DisplayValue.test.js.snap
@@ -3,6 +3,7 @@
 exports[`The component should render 1`] = `
 <button
   class="displayValue"
+  type="button"
 >
   <div
     aria-label="My value"
@@ -39,6 +40,7 @@ exports[`The component should render 1`] = `
 exports[`The component should render with an icon 1`] = `
 <button
   class="displayValue hasIcon"
+  type="button"
 >
   <span
     aria-label="su-plus"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -6,6 +6,7 @@ exports[`The component should open the popover when the display value is clicked
 >
   <button
     class="displayValue"
+    type="button"
   >
     <div
       aria-label="My text"
@@ -68,6 +69,7 @@ exports[`The component should render with an icon 1`] = `
 >
   <button
     class="displayValue hasIcon"
+    type="button"
   >
     <span
       aria-label="su-plus"
@@ -112,6 +114,7 @@ exports[`The component should render with the popover closed 1`] = `
 >
   <button
     class="displayValue"
+    type="button"
   >
     <div
       aria-label="My text"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -56,7 +56,7 @@ exports[`Render block with schema 1`] = `
       </div>
     </section>
   </div>
-  <button class=\\"button secondary\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
+  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
   </button>
 </section>"
 `;
@@ -122,7 +122,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
       </div>
     </section>
   </div>
-  <button class=\\"button secondary\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
+  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
   </button>
 </section>"
 `;
@@ -188,7 +188,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
       </div>
     </section>
   </div>
-  <button class=\\"button secondary\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
+  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
   </button>
 </section>"
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
@@ -140,9 +140,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
         </article>
         <footer>
           <div class=\\"actions\\">
-            <button class=\\"button link\\"><span class=\\"text\\">Reset fields</span></button>
+            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Reset fields</span></button>
           </div>
-          <button class=\\"button primary\\"><span class=\\"text\\">Confirm</span></button>
+          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -134,9 +134,9 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
         </article>
         <footer>
           <div class=\\"actions\\">
-            <button class=\\"button link\\"><span class=\\"text\\">Reset fields</span></button>
+            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Reset fields</span></button>
           </div>
-          <button class=\\"button primary\\"><span class=\\"text\\">Confirm</span></button>
+          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds `type="button"` to buttons, in order to avoid strange behavior when hitting the enter key in a form.

#### Why?

This fixes the issue with added blocks and opened selects in a form, when the enter button is pressed.