### PR TITLE
Fixed rename and publish exception if page has link to a child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * BUGFIX      #3806 [All]                     Fix compatibility on lowest and fix appveyor
+    * HOTFIX      #3810 [ContentBundle]           Fixed rename and publish exception if page has link to a child
     * BUGFIX      #3805 [ContentBundle]           Fix spacing between rows and section in content template generation
     * HOTFIX      #3797 [CategoryBundle]          Fixed category csv-export
     * HOTFIX      #3797 [Rest]                    Fixed issue with large amount of ids in doctrine list-builder query

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "imagine/imagine": "~0.6.1 || ~0.7.0",
         "massive/search-bundle": "0.16.*",
         "sensio/framework-extra-bundle": "^3.0",
-        "sulu/document-manager": "~0.10.0",
+        "sulu/document-manager": "dev-master as 0.10.1",
         "stof/doctrine-extensions-bundle": "^1.2.2",
         "gedmo/doctrine-extensions": "~2.4",
         "symfony-cmf/routing-bundle": "^1.2 || ^2.0",

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -49,6 +49,8 @@ class NodeControllerTest extends SuluTestCase
 
     public function setUp()
     {
+        parent::setUp();
+
         $this->em = $this->getEntityManager();
         $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
         $this->liveSession = $this->getContainer()->get('sulu_document_manager.live_session');
@@ -2064,6 +2066,52 @@ class NodeControllerTest extends SuluTestCase
 
         $this->assertEquals('/dornbirn', $result['path']);
         $this->assertEquals('Dornbirn', $result['title']);
+    }
+
+    public function testRenamePageWithLinkedChild()
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->importer->import(__DIR__ . '/../../app/Resources/exports/tree.xml');
+
+        $document = $this->documentManager->find('585ccd35-a98e-4e41-a62c-e502ca905496', 'en');
+        $document->setStructureType('internallinks');
+        $document->getStructure()->bind(
+            [
+                'internalLinks' => [
+                    '5778b19f-460a-47fc-93da-9a6126e5c384',
+                ],
+            ]
+        );
+        $this->documentManager->persist($document, 'en');
+        $this->documentManager->publish($document, 'en');
+        $this->documentManager->flush();
+        $this->documentManager->clear();
+
+        $client->request('GET', '/api/nodes/' . $document->getUuid() . '?webspace=sulu_io&language=en');
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $data['title'] = 'Sulu is awesome';
+
+        $client->request(
+            'PUT',
+            '/api/nodes/' . $document->getUuid() . '?webspace=sulu_io&language=en&action=publish',
+            $data
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $data = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertEquals('/sulu-is-awesome', $data['path']);
+
+        /** @var SessionInterface $liveSession */
+        $liveSession = $this->getContainer()->get('sulu_document_manager.live_session');
+        /** @var SessionInterface $session */
+        $session = $this->getContainer()->get('sulu_document_manager.default_session');
+
+        $node = $liveSession->getNode('/cmf/sulu_io/contents/sulu-is-awesome');
+        $this->assertEquals($data['id'], $node->getIdentifier());
+
+        $node = $session->getNode('/cmf/sulu_io/contents/sulu-is-awesome');
+        $this->assertEquals($data['id'], $node->getIdentifier());
     }
 
     private function setUpContent($data)

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.xml
@@ -18,6 +18,8 @@
             <argument type="service" id="sulu_document_manager.node_name_slugifier" />
             <argument type="service" id="sulu_document_manager.name_resolver" />
             <argument type="service" id="sulu_document_manager.node_manager" />
+            <argument type="service" id="sulu_document_manager.live_session"/>
+            <argument type="service" id="sulu_document_manager.default_session"/>
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu-document-manager/pull/117  https://github.com/sulu/sulu-document-manager/pull/118 https://github.com/sulu/sulu-document-manager/pull/119
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a flush to node-controller between `persist` and `publish` call.

#### Why?

This is needed because of following scenario:

1. Imagine following content tree:

* Page 1
  * Page 1.1

2. Page one has an internal link (content-type) to page 1.1
3. Rename page 1 and click save and publish

The publish fails because the renaming of the node won't be synced to the repository and the following exception will be thrown.

```
Path not found (parent node /cmf/example/contents/page-1 moved in current session): /cmf/example/contents/page-1/page-1-1
```
