### PR TITLE
Added base-domains to query for custom-urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * BUGFIX      #3828 [Husky]                   Avoid expand ids parameter to be added to datagrid request without content
     * BUGFIX      #3828 [Husky]                   Fixed paragraphs and breaks in paste from word plugin
     * BUGFIX      #3806 [All]                     Fix compatibility on lowest and fix appveyor
+    * HOTFIX      #3820 [CustomUrlBundle]         Added base-domains to query for custom-urls
     * HOTFIX      #3810 [ContentBundle]           Fixed rename and publish exception if page has link to a child
     * BUGFIX      #3805 [ContentBundle]           Fix spacing between rows and section in content template generation
     * HOTFIX      #3797 [CategoryBundle]          Fixed category csv-export

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/document.xml
@@ -17,6 +17,8 @@
             <argument type="service" id="sulu_document_manager.metadata_factory"/>
             <argument type="service" id="sulu_document_manager.path_builder"/>
             <argument type="service" id="sulu_http_cache.handler"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="string">%kernel.environment%</argument>
         </service>
 
         <service id="sulu_custom_urls.initializer"

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -22,6 +22,8 @@ use Sulu\Component\DocumentManager\Exception\NodeNameAlreadyExistsException;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\PathBuilder;
 use Sulu\Component\HttpCache\HandlerInvalidatePathInterface;
+use Sulu\Component\Webspace\CustomUrl;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -54,18 +56,32 @@ class CustomUrlManager implements CustomUrlManagerInterface
      */
     private $cacheHandler;
 
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var string
+     */
+    private $environment;
+
     public function __construct(
         DocumentManagerInterface $documentManager,
         CustomUrlRepository $customUrlRepository,
         MetadataFactoryInterface $metadataFactory,
         PathBuilder $pathBuilder,
-        HandlerInvalidatePathInterface $cacheHandler
+        HandlerInvalidatePathInterface $cacheHandler,
+        WebspaceManagerInterface $webspaceManager,
+        $environment
     ) {
         $this->documentManager = $documentManager;
         $this->customUrlRepository = $customUrlRepository;
         $this->metadataFactory = $metadataFactory;
         $this->pathBuilder = $pathBuilder;
         $this->cacheHandler = $cacheHandler;
+        $this->webspaceManager = $webspaceManager;
+        $this->environment = $environment;
     }
 
     /**
@@ -101,7 +117,17 @@ class CustomUrlManager implements CustomUrlManagerInterface
     {
         // TODO pagination
 
-        return $this->customUrlRepository->findList($this->getItemsPath($webspaceKey), $locale);
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+        $customUrls = $webspace->getPortals()[0]->getEnvironment($this->environment)->getCustomUrls();
+
+        $baseDomains = array_map(
+            function (CustomUrl $customUrl) {
+                return $customUrl->getUrl();
+            },
+            $customUrls
+        );
+
+        return $this->customUrlRepository->findList($this->getItemsPath($webspaceKey), $locale, $baseDomains);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the base-domains to query.

#### Why?

Custom-URLs created for another environment can break the UI and will not work.

#### To Do

- [x] Tests
