### PR TITLE
WebspaceImport: Bugfix when no url is given

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Command/WebspaceImportCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/WebspaceImportCommand.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\ContentBundle\Command;
 
-use Sulu\Component\Content\Import\WebspaceInterface;
+use Sulu\Component\Content\Import\WebspaceImportInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -71,12 +71,12 @@ class WebspaceImportCommand extends ContainerAwareCommand
         if (!$helper->ask($input, $output, $question)) {
             $output->writeln('<error>Abort!</error>');
 
-            return;
+            return -1;
         }
 
         $output->writeln('<info>Continue!</info>');
 
-        /** @var WebspaceInterface $webspaceImporter */
+        /** @var WebspaceImportInterface $webspaceImporter */
         $webspaceImporter = $this->getContainer()->get('sulu_content.import.webspace');
 
         $import = $webspaceImporter->import(

--- a/src/Sulu/Bundle/ContentBundle/Repository/ResourceLocatorRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/ResourceLocatorRepository.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContentBundle\Repository;
 
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Exception\ResourceLocatorGeneratorException;
 use Sulu\Component\Content\Types\ResourceLocator\ResourceLocatorInformation;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 
@@ -62,7 +63,18 @@ class ResourceLocatorRepository implements ResourceLocatorRepositoryInterface
         $title = $this->implodeRlpParts($structure, $parts);
 
         $resourceLocatorStrategy = $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey($webspaceKey);
-        $resourceLocator = $resourceLocatorStrategy->generate($title, $parentUuid, $webspaceKey, $languageCode, $segmentKey);
+
+        try {
+            $resourceLocator = $resourceLocatorStrategy->generate(
+                $title,
+                $parentUuid,
+                $webspaceKey,
+                $languageCode,
+                $segmentKey
+            );
+        } catch (ResourceLocatorGeneratorException $exception) {
+            $resourceLocator = $exception->getParentPath() . '/';
+        }
 
         return [
             'resourceLocator' => $resourceLocator,

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/export.xml
@@ -24,6 +24,7 @@
             <argument>%sulu_content.export.webspace.formats%</argument>
         </service>
 
+        <!-- Webspace import -->
         <service id="sulu_content.import.webspace" class="Sulu\Component\Content\Import\WebspaceImport">
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
@@ -11,8 +11,10 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Functional\Import;
 
+use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Bundle\ContentBundle\Document\PageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Content\Import\WebspaceImport;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -30,15 +32,20 @@ class WebspaceImportTest extends SuluTestCase
     /**
      * @var object
      */
-    private $parent;
+    private $homeDocument;
 
     private $pages = [];
 
+    /**
+     * @var WebspaceImport
+     */
     private $webspaceImporter;
 
     protected $distPath = '/../../app/Resources/import/export.xliff.dist';
+    protected $distPathRU = '/../../app/Resources/import/export_ru.xliff.dist';
 
     protected $path = '/../../app/Resources/import/export.xliff';
+    protected $pathRU = '/../../app/Resources/import/export_ru.xliff';
 
     /**
      * Setup data for import.
@@ -123,6 +130,84 @@ class WebspaceImportTest extends SuluTestCase
         $this->assertEquals($loadedDocuments[0]->getPath(), '/cmf/sulu_io/contents/test-0-imported');
         $this->assertEquals($loadedDocuments[1]->getPath(), '/cmf/sulu_io/contents/test-1-imported');
 
+        // resource segment
+        $this->assertEquals($loadedDocuments[0]->getResourceSegment(), '/parent');
+        $this->assertEquals($loadedDocuments[1]->getResourceSegment(), '/child');
+
+        // seo
+        $this->assertEquals($loadedDocuments[0]->getExtensionsData()->toArray()['seo']['title'], '');
+        $this->assertEquals($loadedDocuments[1]->getExtensionsData()->toArray()['seo']['title'], 'SEO Title');
+
+        // excerpt
+        $this->assertEquals($loadedDocuments[0]->getExtensionsData()->toArray()['excerpt']['title'], 'Excerpt title');
+        $this->assertEquals($loadedDocuments[1]->getExtensionsData()->toArray()['excerpt']['title'], '');
+    }
+
+    /**
+     * Run tests for language "ru" import:
+     * - import data
+     * - get documents
+     * - test document data.
+     */
+    public function testImport12XliffRU()
+    {
+        // run language import
+        // import it to FR (because RU isn't initialized)
+        $importData = [
+            'webspaceKey' => 'sulu_io',
+            'locale' => 'fr',
+            'format' => '1.2.xliff',
+            'filePath' => __DIR__ . $this->pathRU,
+        ];
+
+        $import = $this->webspaceImporter->import(
+            $importData['webspaceKey'],
+            $importData['locale'],
+            $importData['filePath'],
+            null,
+            $importData['format'],
+            '',
+            false
+        );
+
+        // testing imported data
+        $loadedDocuments = [];
+
+        /** @var BasePageDocument $document */
+        $loadedDocuments[0] = $this->documentManager->find(
+            $this->pages[0]->getUuid(),
+            'fr',
+            [
+                'type' => 'page',
+                'load_ghost_content' => false,
+            ]
+        );
+
+        /** @var BasePageDocument $document */
+        $loadedDocuments[1] = $this->documentManager->find(
+            $this->pages[1]->getUuid(),
+            'fr',
+            [
+                'type' => 'page',
+                'load_ghost_content' => false,
+            ]
+        );
+
+        // import
+        $this->assertEquals($import->successes, 2);
+
+        // structure
+        $this->assertEquals($loadedDocuments[0]->getTitle(), 'привет');
+        $this->assertEquals($loadedDocuments[1]->getTitle(), 'привет привет привет');
+
+        // path
+        $this->assertEquals($loadedDocuments[0]->getPath(), '/cmf/sulu_io/contents/parent');
+        $this->assertEquals($loadedDocuments[1]->getPath(), '/cmf/sulu_io/contents/child');
+
+        // resource segment
+        $this->assertEquals($loadedDocuments[0]->getResourceSegment(), '/parent-ru-new-shit');
+        $this->assertEquals($loadedDocuments[1]->getResourceSegment(), '/child-ru-new-shit');
+
         // seo
         $this->assertEquals($loadedDocuments[0]->getExtensionsData()->toArray()['seo']['title'], '');
         $this->assertEquals($loadedDocuments[1]->getExtensionsData()->toArray()['seo']['title'], 'SEO Title');
@@ -141,6 +226,7 @@ class WebspaceImportTest extends SuluTestCase
             $fs = new Filesystem();
 
             $fs->remove(__DIR__ . $this->path);
+            $fs->remove(__DIR__ . $this->pathRU);
         } catch (IOExceptionInterface $e) {
             echo 'An error occurred while creating your directory at ' . $e->getPath();
         }
@@ -166,6 +252,23 @@ class WebspaceImportTest extends SuluTestCase
             ], $distContent);
 
             file_put_contents(__DIR__ . $this->path, $newContent);
+        } catch (IOExceptionInterface $e) {
+            echo 'An error occurred while creating your directory at ' . $e->getPath();
+        }
+
+        try {
+            $fs->copy(__DIR__ . $this->distPathRU, __DIR__ . $this->pathRU);
+
+            $distContent = file_get_contents(__DIR__ . $this->pathRU, true);
+            $newContent = str_replace([
+                '%uuid_page_0%',
+                '%uuid_page_1%',
+            ], [
+                $this->pages[0]->getUuid(),
+                $this->pages[1]->getUuid(),
+            ], $distContent);
+
+            file_put_contents(__DIR__ . $this->pathRU, $newContent);
         } catch (IOExceptionInterface $e) {
             echo 'An error occurred while creating your directory at ' . $e->getPath();
         }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Import/WebspaceImportTest.php
@@ -42,9 +42,11 @@ class WebspaceImportTest extends SuluTestCase
     private $webspaceImporter;
 
     protected $distPath = '/../../app/Resources/import/export.xliff.dist';
+
     protected $distPathRU = '/../../app/Resources/import/export_ru.xliff.dist';
 
     protected $path = '/../../app/Resources/import/export.xliff';
+
     protected $pathRU = '/../../app/Resources/import/export_ru.xliff';
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/import/export_ru.xliff.dist
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/import/export_ru.xliff.dist
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <!-- WebspaceKey: sulu_lo -->
-    <file source-language="en" datatype="plaintext" original="%uuid_page_0%">
+    <file source-language="fr" datatype="plaintext" original="%uuid_page_0%">
         <body>
             <!-- title: text_line -->
             <trans-unit id="0" resname="title">
                 <source>Parent</source>
-                <target>test 0 imported</target>
+                <target>привет</target>
             </trans-unit>
 
             <!-- url: resource_locator -->
             <trans-unit id="1" resname="url" translate="no">
                 <source>/parent</source>
-                <target></target>
+                <target>/parent-ru-new-shit</target>
             </trans-unit>
 
             <!-- article: text_editor -->
@@ -214,18 +214,18 @@
             </trans-unit>
         </body>
     </file>
-    <file source-language="en" datatype="plaintext" original="%uuid_page_1%">
+    <file source-language="fr" datatype="plaintext" original="%uuid_page_1%">
         <body>
             <!-- title: text_line -->
             <trans-unit id="36" resname="title">
                 <source>Child</source>
-                <target>test 1 imported</target>
+                <target>привет привет привет</target>
             </trans-unit>
 
             <!-- url: resource_locator -->
             <trans-unit id="37" resname="url" translate="no">
                 <source>/child</source>
-                <target>/child</target>
+                <target>/child-ru-new-shit</target>
             </trans-unit>
 
             <!-- article: text_editor -->

--- a/src/Sulu/Component/Content/Exception/ResourceLocatorGeneratorException.php
+++ b/src/Sulu/Component/Content/Exception/ResourceLocatorGeneratorException.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Exception;
+
+use Exception;
+
+class ResourceLocatorGeneratorException extends Exception
+{
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var string
+     */
+    private $parentPath;
+
+    public function __construct($title, $parentPath)
+    {
+        parent::__construct(sprintf("Could not generate ResourceLocator for given title '%s'", $title));
+
+        $this->title = $title;
+        $this->parentPath = $parentPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParentPath()
+    {
+        return $this->parentPath;
+    }
+}

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -317,6 +317,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
 
                     if ($parent instanceof BasePageDocument) {
                         $parentUuid = $parent->getUuid();
+
                         try {
                             $resourceSegment = $this->generateUrl(
                                 $structure->getPropertiesByTagName('sulu.rlp.part'),
@@ -330,7 +331,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
                             $resourceSegment = null;
                         }
 
-                        if (!$resourceSegment || $resourceSegment === '/') {
+                        if (!$resourceSegment || '/' === $resourceSegment) {
                             if (!$value) {
                                 $this->addException(
                                     sprintf('Document(%s) needs an resource locator (%s) because no url could be generated', $document->getUuid(), $property->getName()),

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -19,6 +19,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Exception\ResourceLocatorGeneratorException;
 use Sulu\Component\Content\Extension\ExportExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyInterface;
@@ -316,16 +317,33 @@ class WebspaceImport extends Import implements WebspaceImportInterface
 
                     if ($parent instanceof BasePageDocument) {
                         $parentUuid = $parent->getUuid();
-                        $value = $this->generateUrl(
-                            $structure->getPropertiesByTagName('sulu.rlp.part'),
-                            $parentUuid,
-                            $webspaceKey,
-                            $locale,
-                            $format,
-                            $data
-                        );
+                        try {
+                            $resourceSegment = $this->generateUrl(
+                                $structure->getPropertiesByTagName('sulu.rlp.part'),
+                                $parentUuid,
+                                $webspaceKey,
+                                $locale,
+                                $format,
+                                $data
+                            );
+                        } catch (ResourceLocatorGeneratorException $exception) {
+                            $resourceSegment = null;
+                        }
 
-                        $document->setResourceSegment($value);
+                        if (!$resourceSegment || $resourceSegment === '/') {
+                            if (!$value) {
+                                $this->addException(
+                                    sprintf('Document(%s) needs an resource locator (%s) because no url could be generated', $document->getUuid(), $property->getName()),
+                                    'ignore'
+                                );
+
+                                return false;
+                            }
+
+                            $document->setResourceSegment($value);
+                        } else {
+                            $document->setResourceSegment($resourceSegment);
+                        }
                     }
                 }
             }

--- a/src/Sulu/Component/Content/Import/WebspaceImportInterface.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImportInterface.php
@@ -25,6 +25,7 @@ interface WebspaceImportInterface
      * @param $output
      * @param string $format
      * @param string $uuid
+     * @param bool $overrideSettings
      * @param string $exportSuluVersion
      *
      * @return array
@@ -36,6 +37,7 @@ interface WebspaceImportInterface
         $output = null,
         $format = '1.2.xliff',
         $uuid = null,
+        $overrideSettings = false,
         $exportSuluVersion = '1.3'
     );
 }

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
@@ -117,7 +117,7 @@ abstract class ResourceLocatorStrategy implements ResourceLocatorStrategyInterfa
         $path = $this->cleaner->cleanup($path, $languageCode);
 
         // if no path was added throw an except that no url could be generated for the given title
-        if (substr($path,0, -1) === $parentPath) {
+        if (substr($path, 0, -1) === $parentPath) {
             throw new ResourceLocatorGeneratorException($title, $parentPath);
         }
 

--- a/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
+++ b/src/Sulu/Component/Content/Types/ResourceLocator/Strategy/ResourceLocatorStrategy.php
@@ -16,6 +16,7 @@ use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
+use Sulu\Component\Content\Exception\ResourceLocatorGeneratorException;
 use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
 use Sulu\Component\Content\Exception\ResourceLocatorNotValidException;
 use Sulu\Component\Content\Types\ResourceLocator\Mapper\ResourceLocatorMapperInterface;
@@ -114,6 +115,11 @@ abstract class ResourceLocatorStrategy implements ResourceLocatorStrategyInterfa
 
         // cleanup path
         $path = $this->cleaner->cleanup($path, $languageCode);
+
+        // if no path was added throw an except that no url could be generated for the given title
+        if (substr($path,0, -1) === $parentPath) {
+            throw new ResourceLocatorGeneratorException($title, $parentPath);
+        }
 
         // get unique path
         $path = $this->mapper->getUniquePath($path, $webspaceKey, $languageCode, $segmentKey);

--- a/src/Sulu/Component/Import/Manager/ImportManager.php
+++ b/src/Sulu/Component/Import/Manager/ImportManager.php
@@ -15,7 +15,7 @@ use PHPCR\NodeInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ContentTypeExportInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
-use Sulu\Component\Content\Import\Exception\ContentTypeImportMissingException;
+use Sulu\Component\Import\Exception\ContentTypeImportMissingException;
 
 /**
  * Import content by given xliff file.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

When no URL can be generated use the one from the import file.

#### Why?

Our URL generator has problems with utf8 signs.
In this case when no url is generated, us the one from the import file.
