### PR TITLE
remember selected objects instead of ids

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -72,7 +72,14 @@ export default class Datagrid extends React.Component<Props> {
 
     handleItemSelectionChange = (id: string | number, selected?: boolean) => {
         const {store} = this.props;
-        selected ? store.select(id) : store.deselect(id);
+        // TODO do not hardcode id but use metdata instead
+        const row = store.data.find((item) => item.id === id);
+
+        if (!row) {
+            return;
+        }
+
+        selected ? store.select(row) : store.deselect(row);
     };
 
     handleAllSelectionChange = (selected?: boolean) => {
@@ -117,7 +124,7 @@ export default class Datagrid extends React.Component<Props> {
                     page={store.getPage()}
                     pageCount={store.pageCount}
                     schema={store.schema}
-                    selections={store.selections}
+                    selections={store.selectionIds}
                 />
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/README.md
@@ -14,12 +14,14 @@ adapterStore.add('table', TableAdapter);
 
 <Datagrid store={store} views={['table']} />
 
-store.selections; // returns the IDs of the selected items
+store.selections; // returns the the selected items
+store.selectionIds; // returns the IDs of the selected items
 store.destroy();
 ```
 
-The `Datagrid` also takes control of the store, and handles loading other pages and selecting of items. The `selections`
-property can be used to retrieve the IDs of the currently selected items.
+The `Datagrid` also takes control of the store, and handles loading other pages and selecting of items. The
+`selectionIds` property can be used to retrieve the IDs of the currently selected items and the `selections` property
+will return the selected items themselves.
 
 After the store is not used anymore, its `destroy` method should be called, because there are some observations, which
 have to be cancelled.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -6,7 +6,7 @@ import metadataStore from './MetadataStore';
 export default class DatagridStore {
     @observable pageCount: number = 0;
     @observable active: ?string | number = undefined;
-    @observable selections: Array<string | number> = [];
+    @observable selections: Array<Object> = [];
     @observable dataLoading: boolean = true;
     @observable schemaLoading: boolean = true;
     @observable loadingStrategy: LoadingStrategyInterface;
@@ -147,22 +147,24 @@ export default class DatagridStore {
         this.active = active;
     }
 
-    @action select(id: string | number) {
-        if (this.selections.includes(id)) {
+    @action select(row: Object) {
+        // TODO do not hardcode id but use metdata instead
+        if (this.selections.findIndex((item) => item.id === row.id) !== -1) {
             return;
         }
 
-        this.selections.push(id);
+        this.selections.push(row);
     }
 
     @action selectEntirePage() {
         this.data.forEach((item) => {
-            this.select(item.id);
+            this.select(item);
         });
     }
 
-    @action deselect(id: string | number) {
-        const index = this.selections.indexOf(id);
+    @action deselect(row: Object) {
+        // TODO do not hardcode id but use metdata instead
+        const index = this.selections.findIndex((item) => item.id === row.id);
         if (index === -1) {
             return;
         }
@@ -172,8 +174,13 @@ export default class DatagridStore {
 
     @action deselectEntirePage() {
         this.data.forEach((item) => {
-            this.deselect(item.id);
+            this.deselect(item);
         });
+    }
+
+    @computed get selectionIds(): Array<string | number> {
+        // TODO do not hardcode id but use metdata instead
+        return this.selections.map((item) => item.id);
     }
 
     @action clearSelection() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -16,6 +16,7 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.getPage = jest.fn().mockReturnValue(4);
     this.pageCount = 7;
     this.selections = [];
+    this.selectionIds = [];
     this.loading = false;
     this.schema = {test: {}};
     this.select = jest.fn();
@@ -88,8 +89,7 @@ test('Render TableAdapter with correct values', () => {
 
     const datagridStore = new DatagridStore('test', {page: observable(1)});
     datagridStore.active = 3;
-    datagridStore.selections.push(1);
-    datagridStore.selections.push(3);
+    datagridStore.selectionIds.push(1, 3);
     const editClickSpy = jest.fn();
 
     const datagrid = shallow(<Datagrid adapters={['table']} store={datagridStore} onItemClick={editClickSpy} />);
@@ -118,11 +118,11 @@ test('Selecting and deselecting items should update store', () => {
     checkboxes.at(1).getDOMNode().checked = true;
     checkboxes.at(2).getDOMNode().checked = true;
     checkboxes.at(1).simulate('change', {currentTarget: {checked: true}});
-    expect(datagridStore.select).toBeCalledWith(1);
+    expect(datagridStore.select).toBeCalledWith({id: 1});
     checkboxes.at(2).simulate('change', {currentTarget: {checked: true}});
-    expect(datagridStore.select).toBeCalledWith(2);
+    expect(datagridStore.select).toBeCalledWith({id: 2});
     checkboxes.at(1).simulate('change', {currentTarget: {checked: false}});
-    expect(datagridStore.deselect).toBeCalledWith(1);
+    expect(datagridStore.deselect).toBeCalledWith({id: 1});
 });
 
 test('Selecting and unselecting all items on current page should update store', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -322,12 +322,12 @@ test('Select an item', () => {
         page,
     });
     datagridStore.updateStrategies(new LoadingStrategy(), new StructureStrategy());
-    datagridStore.select(1);
-    datagridStore.select(2);
-    expect(toJS(datagridStore.selections)).toEqual([1, 2]);
+    datagridStore.select({id: 1}) ;
+    datagridStore.select({id: 2}) ;
+    expect(toJS(datagridStore.selectionIds)).toEqual([1, 2]);
 
-    datagridStore.deselect(1);
-    expect(toJS(datagridStore.selections)).toEqual([2]);
+    datagridStore.deselect({id: 1});
+    expect(toJS(datagridStore.selectionIds)).toEqual([2]);
     datagridStore.destroy();
 });
 
@@ -337,10 +337,10 @@ test('Deselect an item that has not been selected yet', () => {
         page,
     });
     datagridStore.updateStrategies(new LoadingStrategy(), new StructureStrategy());
-    datagridStore.select(1);
-    datagridStore.deselect(2);
+    datagridStore.select({id: 1}) ;
+    datagridStore.deselect({id: 2});
 
-    expect(toJS(datagridStore.selections)).toEqual([1]);
+    expect(toJS(datagridStore.selectionIds)).toEqual([1]);
     datagridStore.destroy();
 });
 
@@ -349,9 +349,12 @@ test('Select the entire page', () => {
     const datagridStore = new DatagridStore('tests', {page});
     datagridStore.updateStrategies(new LoadingStrategy(), new StructureStrategy());
     datagridStore.structureStrategy.data = [{id: 1}, {id: 2}, {id: 3}];
-    datagridStore.selections = [1, 7];
+    datagridStore.selections = [
+        {id: 1},
+        {id: 7},
+    ];
     datagridStore.selectEntirePage();
-    expect(toJS(datagridStore.selections)).toEqual([1, 7, 2, 3]);
+    expect(toJS(datagridStore.selectionIds)).toEqual([1, 7, 2, 3]);
     datagridStore.destroy();
 });
 
@@ -362,9 +365,13 @@ test('Deselect the entire page', () => {
     });
     datagridStore.updateStrategies(new LoadingStrategy(), new StructureStrategy());
     datagridStore.structureStrategy.data = [{id: 1}, {id: 2}, {id: 3}];
-    datagridStore.selections = [1, 2, 7];
+    datagridStore.selections = [
+        {id: 1},
+        {id: 2},
+        {id: 7},
+    ];
     datagridStore.deselectEntirePage();
-    expect(toJS(datagridStore.selections)).toEqual([7]);
+    expect(toJS(datagridStore.selectionIds)).toEqual([7]);
     datagridStore.destroy();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -128,13 +128,13 @@ export default withToolbar(List, function() {
         type: 'button',
         value: translate('sulu_admin.delete'),
         icon: 'su-trash',
-        disabled: this.datagridStore.selections.length === 0,
+        disabled: this.datagridStore.selectionIds.length === 0,
         loading: this.deleting,
         onClick: action(() => {
             this.deleting = true;
 
             const deletePromises = [];
-            this.datagridStore.selections.forEach((id) => {
+            this.datagridStore.selectionIds.forEach((id) => {
                 deletePromises.push(ResourceRequester.delete(resourceKey, id));
             });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -31,6 +31,7 @@ jest.mock(
             },
         ];
         this.selections = [];
+        this.selectionIds = [];
         this.getPage = jest.fn().mockReturnValue(2);
         this.schema = {
             title: {},
@@ -167,7 +168,7 @@ test('Should destroy the store on unmount', () => {
     expect(datagridStore.destroy).toBeCalled();
 });
 
-test('Should render the add button in the toolbar only if a addRoute has been passed in options', () => {
+test('Should render the add button in the toolbar only if an addRoute has been passed in options', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const List = require('../List').default;
     const toolbarFunction = withToolbar.mock.calls[0][1];
@@ -314,7 +315,7 @@ test('Should render the delete item enabled only if something is selected', () =
     item = toolbarConfig.items.find((item) => item.value === 'Delete');
     expect(item.disabled).toBe(true);
 
-    datagridStore.selections.push(1);
+    datagridStore.selectionIds.push(1);
     toolbarConfig = toolbarFunction.call(list.instance());
     item = toolbarConfig.items.find((item) => item.value === 'Delete');
     expect(item.disabled).toBe(false);
@@ -432,7 +433,7 @@ test('Should delete selected items when click on delete button', () => {
 
     const list = mount(<List router={router} />);
     const datagridStore = list.instance().datagridStore;
-    datagridStore.selections = [1, 4, 6];
+    datagridStore.selectionIds.push(1, 4, 6);
 
     expect(getDeleteItem().loading).toBe(false);
     const clickPromise = getDeleteItem().onClick();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -80,6 +80,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                 ? collectionData
                 : mediaData;
             this.selections = [];
+            this.selectionIds = [];
             this.getPage = jest.fn().mockReturnValue(2);
             this.getSchema = jest.fn().mockReturnValue({
                 title: {},

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
@@ -165,17 +165,17 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
     }
 
     handleMediaSelectionChanges = (change: any) => {
-        const mediaId = (change.added.length) ? change.added[0] : change.removed[0];
+        const selectedMedia = (change.added.length) ? change.added[0] : change.removed[0];
         const selected = !!change.added.length;
 
         if (selected) {
-            const media = this.mediaDatagridStore.data.find((entry) => entry.id === mediaId);
+            const media = this.mediaDatagridStore.data.find((entry) => entry.id === selectedMedia.id);
 
             if (media) {
                 this.selectedMedia.push(media);
             }
         } else {
-            this.selectedMedia = this.selectedMedia.filter((media) => media.id !== mediaId);
+            this.selectedMedia = this.selectedMedia.filter((media) => media.id !== selectedMedia.id);
         }
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, autorun, computed, observable, observe} from 'mobx';
+import {action, autorun, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
 import {DatagridStore} from 'sulu-admin-bundle/containers';
@@ -34,9 +34,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
     @observable mediaDatagridStore: DatagridStore;
     @observable collectionDatagridStore: DatagridStore;
     @observable collectionStore: CollectionStore;
-    selectedMedia: Array<Object> = [];
     overlayDisposer: () => void;
-    mediaSelectionsObservationDisposer: () => void;
 
     componentWillMount() {
         const {open} = this.props;
@@ -87,11 +85,6 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
             this.overlayDisposer();
         }
 
-        if (this.mediaSelectionsObservationDisposer) {
-            this.mediaSelectionsObservationDisposer();
-        }
-
-        this.selectedMedia = [];
         this.collectionId.set(undefined);
     }
 
@@ -155,29 +148,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
             },
             options
         );
-
-        this.mediaSelectionsObservationDisposer = observe(
-            this.mediaDatagridStore.selections,
-            this.handleMediaSelectionChanges
-        );
-
-        this.selectedMedia.forEach((media) => this.mediaDatagridStore.select(media.id));
     }
-
-    handleMediaSelectionChanges = (change: any) => {
-        const selectedMedia = (change.added.length) ? change.added[0] : change.removed[0];
-        const selected = !!change.added.length;
-
-        if (selected) {
-            const media = this.mediaDatagridStore.data.find((entry) => entry.id === selectedMedia.id);
-
-            if (media) {
-                this.selectedMedia.push(media);
-            }
-        } else {
-            this.selectedMedia = this.selectedMedia.filter((media) => media.id !== selectedMedia.id);
-        }
-    };
 
     @action handleCollectionNavigate = (collectionId: ?string | number) => {
         this.mediaDatagridStore.clearData();
@@ -201,12 +172,11 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
     };
 
     handleSelectionReset = () => {
-        this.selectedMedia = [];
-        this.mediaDatagridStore.deselectEntirePage();
+        this.mediaDatagridStore.clearSelection();
     };
 
     handleConfirm = () => {
-        this.props.onConfirm(this.selectedMedia);
+        this.props.onConfirm(this.mediaDatagridStore.selections);
         this.destroy();
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -59,6 +59,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
             ];
             extendObservable(this, {
                 selections: [],
+                selectionIds: [],
             });
             this.loading = false;
             this.pageCount = 3;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -58,6 +58,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
             ];
             extendObservable(this, {
                 selections: [],
+                selectionIds: [],
             });
             this.loading = false;
             this.pageCount = 3;
@@ -217,11 +218,11 @@ test('Should add and remove media ids', () => {
     expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([]);
 
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [1],
+        added: [{id: 1}],
         removed: [],
     }));
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [2],
+        added: [{id: 2}],
         removed: [],
     }));
     expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
@@ -245,7 +246,7 @@ test('Should add and remove media ids', () => {
 
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
         added: [],
-        removed: [2],
+        removed: [{id: 2}],
     }));
     expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
         {
@@ -276,11 +277,11 @@ test('Should reset the selection array when the "Reset Selection" button was cli
     ).instance();
 
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [1],
+        added: [{id: 1}],
         removed: [],
     }));
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [2],
+        added: [{id: 2}],
         removed: [],
     }));
     expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
@@ -324,11 +325,11 @@ test('Should destroy the stores and cleanup all states when the overlay is close
     ).instance();
 
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [1],
+        added: [{id: 1}],
         removed: [],
     }));
     mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [2],
+        added: [{id: 2}],
         removed: [],
     }));
     mediaSelectionOverlayInstance.collectionId.set(1);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import {mount, shallow} from 'enzyme';
-import {observable} from 'mobx';
+import {observable, toJS} from 'mobx';
 import pretty from 'pretty';
 import React from 'react';
 import datagridAdapterRegistry from 'sulu-admin-bundle/containers/Datagrid/registries/DatagridAdapterRegistry';
@@ -199,72 +199,30 @@ test('Should instantiate the needed stores when the overlay opens', () => {
     expect(DatagridStore.mock.calls[0][1].page.get()).toBe(1);
 });
 
-test('Should add and remove media ids', () => {
-    const thumbnails = {
-        'sulu-240x': 'http://lorempixel.com/240/100',
-        'sulu-25x25': 'http://lorempixel.com/25/25',
-    };
+test('Should call onConfirm callback with selections from datagrid', () => {
+    const confirmSpy = jest.fn();
     const locale = observable();
-    const mediaSelectionOverlayInstance = shallow(
+    const mediaSelectionOverlay = shallow(
         <MediaSelectionOverlay
             open={true}
             locale={locale}
             excludedIds={[]}
             onClose={jest.fn()}
-            onConfirm={jest.fn()}
+            onConfirm={confirmSpy}
         />
-    ).instance();
+    );
 
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([]);
+    const selections = [
+        {id: 1},
+        {id: 3},
+    ];
+    mediaSelectionOverlay.instance().mediaDatagridStore.selections = selections;
+    mediaSelectionOverlay.find('Overlay').simulate('confirm');
 
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [{id: 1}],
-        removed: [],
-    }));
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [{id: 2}],
-        removed: [],
-    }));
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
-        {
-            id: 1,
-            title: 'Title 1',
-            mimeType: 'image/png',
-            size: 12345,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-        {
-            id: 2,
-            title: 'Title 2',
-            mimeType: 'image/jpeg',
-            size: 54321,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-    ]);
-
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [],
-        removed: [{id: 2}],
-    }));
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
-        {
-            id: 1,
-            title: 'Title 1',
-            mimeType: 'image/png',
-            size: 12345,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-    ]);
+    expect(toJS(confirmSpy.mock.calls[0][0])).toEqual(selections);
 });
 
 test('Should reset the selection array when the "Reset Selection" button was clicked', () => {
-    const thumbnails = {
-        'sulu-240x': 'http://lorempixel.com/240/100',
-        'sulu-25x25': 'http://lorempixel.com/25/25',
-    };
     const locale = observable();
     const mediaSelectionOverlayInstance = shallow(
         <MediaSelectionOverlay
@@ -276,43 +234,11 @@ test('Should reset the selection array when the "Reset Selection" button was cli
         />
     ).instance();
 
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [{id: 1}],
-        removed: [],
-    }));
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [{id: 2}],
-        removed: [],
-    }));
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
-        {
-            id: 1,
-            title: 'Title 1',
-            mimeType: 'image/png',
-            size: 12345,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-        {
-            id: 2,
-            title: 'Title 2',
-            mimeType: 'image/jpeg',
-            size: 54321,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-    ]);
-
     mediaSelectionOverlayInstance.handleSelectionReset();
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([]);
-    expect(mediaSelectionOverlayInstance.mediaDatagridStore.deselectEntirePage).toBeCalled();
+    expect(mediaSelectionOverlayInstance.mediaDatagridStore.clearSelection).toBeCalled();
 });
 
 test('Should destroy the stores and cleanup all states when the overlay is closed', () => {
-    const thumbnails = {
-        'sulu-240x': 'http://lorempixel.com/240/100',
-        'sulu-25x25': 'http://lorempixel.com/25/25',
-    };
     const locale = observable();
     const mediaSelectionOverlayInstance = shallow(
         <MediaSelectionOverlay
@@ -324,39 +250,12 @@ test('Should destroy the stores and cleanup all states when the overlay is close
         />
     ).instance();
 
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [{id: 1}],
-        removed: [],
-    }));
-    mediaSelectionOverlayInstance.handleMediaSelectionChanges(observable({
-        added: [{id: 2}],
-        removed: [],
-    }));
     mediaSelectionOverlayInstance.collectionId.set(1);
 
     expect(mediaSelectionOverlayInstance.collectionId.get()).toBe(1);
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([
-        {
-            id: 1,
-            title: 'Title 1',
-            mimeType: 'image/png',
-            size: 12345,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-        {
-            id: 2,
-            title: 'Title 2',
-            mimeType: 'image/jpeg',
-            size: 54321,
-            url: 'http://lorempixel.com/500/500',
-            thumbnails: thumbnails,
-        },
-    ]);
 
     mediaSelectionOverlayInstance.handleClose();
     expect(mediaSelectionOverlayInstance.collectionId.get()).toBe(undefined);
-    expect(mediaSelectionOverlayInstance.selectedMedia).toEqual([]);
     expect(mediaSelectionOverlayInstance.collectionStore.resourceStore.destroy).toBeCalled();
     expect(mediaSelectionOverlayInstance.mediaDatagridStore.destroy).toBeCalled();
     expect(mediaSelectionOverlayInstance.collectionDatagridStore.destroy).toBeCalled();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -3,7 +3,6 @@ import React from 'react';
 import {action, autorun, observable} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
-import {translate} from 'sulu-admin-bundle/utils';
 import {withToolbar, DatagridStore} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
 import MediaCollection from '../../containers/MediaCollection';
@@ -176,19 +175,6 @@ export default withToolbar(MediaOverview, function() {
                 },
             }
             : undefined,
-        items: [
-            {
-                type: 'button',
-                value: translate('sulu_admin.add'),
-                icon: 'su-save',
-                onClick: () => {},
-            },
-            {
-                type: 'button',
-                value: translate('sulu_admin.delete'),
-                icon: 'su-trash',
-                onClick: () => {},
-            },
-        ],
+        items: [],
     };
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -58,6 +58,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
                 ? collectionData
                 : mediaData;
             this.selections = [];
+            this.selectionIds = [];
             this.getPage = jest.fn().mockReturnValue(2);
             this.getSchema = jest.fn().mockReturnValue({
                 title: {},


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Explain the contents of the PR.

#### Why?

This PR makes the `DatagridStore` remember the exact objects instead of only the IDs. This is required for #3811, because it allows to use the `DatagridStore` to reuse this logic instead of implementing the same stuff as in the `MediaSelection` again.

#### BC Breaks/Deprecations

`DatagridStore.selections` contains objects instead of IDs now, and `DatagridStore.selectionIds` has been introduced to still get the IDs.

#### To Do

- [x] Document changes
