### PR TITLE
Add ssl configuration parameter to support wss

### DIFF
--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('ip_address')->defaultValue('0.0.0.0')->end()
                         ->scalarNode('port')->defaultValue('9876')->end()
                         ->scalarNode('http_host')->defaultValue('localhost')->end()
+                        ->booleanNode('ssl')->defaultFalse()->end()
                     ->end()
                 ->end()
                 ->arrayNode('cache')

--- a/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/SuluWebsocketExtension.php
+++ b/src/Sulu/Bundle/WebsocketBundle/DependencyInjection/SuluWebsocketExtension.php
@@ -34,6 +34,7 @@ class SuluWebsocketExtension extends Extension implements PrependExtensionInterf
         $container->setParameter('sulu_websocket.server.ip_address', $config['server']['ip_address']);
         $container->setParameter('sulu_websocket.server.port', $config['server']['port']);
         $container->setParameter('sulu_websocket.server.http_host', $config['server']['http_host']);
+        $container->setParameter('sulu_websocket.server.ssl', $config['server']['ssl']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Sulu/Bundle/WebsocketBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsocketBundle/Resources/config/services.xml
@@ -31,6 +31,7 @@
                 <argument key="enabled" type="string">%sulu_websocket.enabled%</argument>
                 <argument key="port" type="string">%sulu_websocket.server.port%</argument>
                 <argument key="httpHost" type="string">%sulu_websocket.server.http_host%</argument>
+                <argument key="ssl">%sulu_websocket.server.ssl%</argument>
             </argument>
 
             <tag name="sulu.js_config"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | /
| Related issues/PRs | /
| License | MIT
| Documentation PR | /

#### What's in this PR?

Allows wss:// instead of ws:// if you enable ssl.


#### Why?

To use ssl

#### Example Usage

```yaml
sulu_websocket:
    enabled: true
    server:
        http_host: "foo"
        port: "bar"
        ssl: true
```
