### PR TITLE
Enable save button when toggler is used in block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * BUGFIX      #3826 [ContentBundle]         Fix enabling of save button when toggler is changed
     * HOTFIX      #3819 [MediaBundle]           Fix forgotten context binding for resetPreviewUrl method
     * FEATURE     #3816 [All]                   Validate if grunt build was run for all bundles with circleci
     * BUGFIX      #3806 [All]                   Fix compatibility on lowest and fix appveyor

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/checkbox.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/checkbox.html.twig
@@ -4,9 +4,9 @@
          class="preview-update trigger-save-button"
          data-form="true"
          data-aura-component="toggler@husky"
-         data-aura-instance-name="{{ property.name }}"
+         data-aura-instance-name="{{ id|raw }}"
          data-type="toggler"
-         data-type-instance-name="{{ property.name }}"
+         data-type-instance-name="{{ id|raw }}"
          data-mapper-property="{{ property.name }}"></div>
 </div>
 {% else %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3172 
| License | MIT

#### What's in this PR?

Use id instead of property name for reference as instance name.

#### Why?

Avoid conflicts between toggler and enable the save button when a toggler is changed inside a block.

#### Example Usage

<details>
<summary>Example</summary>

```php

        <property name="test-toggler2" type="checkbox">
            <meta>
                <title lang="de">Test Toggler</title>
                <title lang="en">Test Toggler</title>
            </meta>

            <params>
                <param name="type" value="toggler"/>
            </params>
        </property>

        <block name="blockTest" default-type="test-type" minOccurs="1">
            <types>
                <type name="test-type">
                    <properties>

                        <property name="test-checkbox" type="checkbox">
                            <meta>
                                <title lang="de">Test Checkbox</title>
                                <title lang="en">Test Checkbox</title>
                            </meta>
                        </property>

                        <property name="test-toggler" type="checkbox">
                            <meta>
                                <title lang="de">Test Toggler</title>
                                <title lang="en">Test Toggler</title>
                            </meta>

                            <params>
                                <param name="type" value="toggler"/>
                            </params>
                        </property>
                    </properties>
                </type>
            </types>
        </block>
```
</details>

#### To Do

- [x] Add Changelog
