### PR TITLE
WIP: Add validation for form blocks

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/block.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/validation/types/block.js
@@ -358,8 +358,17 @@ define([
                 },
 
                 validate: function() {
-                    // TODO validate
-                    return true;
+                    var valid = true;
+
+                    this.getChildren().each(function(i, block) {
+                        if ($(block).length) {
+                            if (!Husky.form.validate($(block))) {
+                                valid = false;
+                            }
+                        }
+                    }.bind(this));
+
+                    return valid;
                 },
 
                 //TODO: make cleaner


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Fixed tickets | fixes #3161 fixes #3727
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add validation for form blocks

#### Why?

That form blocks are also validated.

#### Example Usage

<details>
    <summar>Example</summary>

```xml
        <block name="blockTest" default-type="test-type" minOccurs="1">
            <types>
                <type name="test-type">
                    <properties>

                        <property name="title-required" type="text_line" mandatory="true">
                            <meta>
                                <title lang="de">Title</title>
                                <title lang="en">Title</title>
                            </meta>
                        </property>

                        <property name="test-checkbox" type="checkbox">
                            <meta>
                                <title lang="de">Test Checkbox</title>
                                <title lang="en">Test Checkbox</title>
                            </meta>
                        </property>

                        <property name="test-toggler" type="checkbox">
                            <meta>
                                <title lang="de">Test Toggler</title>
                                <title lang="en">Test Toggler</title>
                            </meta>

                            <params>
                                <param name="type" value="toggler"/>
                            </params>
                        </property>
                    </properties>
                </type>
            </types>
        </block>
```

</details>


#### To Do

- [ ] Add changelog
- [ ] Add styling for errored block
   - [ ] Fix current styling by using `>` CSS Selector only based on the error class
     - [ ] https://github.com/massiveart/husky/blob/a2d909f144906ca1bb412b387135bc7d87c36b32/scss/modules/input.scss#L99
     - [ ] https://github.com/massiveart/husky/blob/a2d909f144906ca1bb412b387135bc7d87c36b32/scss/abstract/abstract-validation.scss#L2
   - [ ] Add styling for errored block (own error class `form-error`) so the validate form get this class 
