### PR TITLE
Toolbar: Disable dropdown when all options are disabled

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -58,12 +58,14 @@ export default class Dropdown extends React.Component<DropdownProps> {
             }
         );
 
+        const allChildrenDisabled = options.every((option) => option.disabled);
+
         return (
             <div className={dropdownClass}>
                 <Button
                     icon={icon}
                     size={size}
-                    disabled={disabled}
+                    disabled={disabled || allChildrenDisabled}
                     value={label}
                     onClick={this.handleButtonClick}
                     active={this.open}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
@@ -96,8 +96,13 @@ test('Click on disabled option will not fire onClick', () => {
         options: [
             {
                 label: 'An option',
-                onClick: clickSpy,
+                onClick: jest.fn(),
                 disabled: true,
+            },
+            {
+                label: 'Another option',
+                onClick: clickSpy,
+                disabled: false,
             },
         ],
     };
@@ -105,7 +110,34 @@ test('Click on disabled option will not fire onClick', () => {
     const dropdown = mount(<Dropdown {...propsMock} />);
 
     dropdown.find('button').simulate('click');
-    dropdown.find('.option > button').first().simulate('click');
+    dropdown.find('.option').first('button').first().simulate('click');
 
     expect(clickSpy).toHaveBeenCalledTimes(0);
+});
+
+test('No active options should disable dropdown', () => {
+    const propsMock = {
+        label: 'Click to open',
+        options: [
+            {
+                label: 'An option',
+                onClick: jest.fn(),
+                disabled: true,
+            },
+            {
+                label: 'Another option',
+                onClick: jest.fn(),
+                disabled: true,
+            },
+        ],
+    };
+
+    const dropdown = mount(<Dropdown {...propsMock} />);
+
+    expect(dropdown.find('button').instance().disabled).toBe(true);
+    expect(dropdown.instance().open).toBe(false);
+
+    // click on button shouldn't open the options
+    dropdown.find('button').simulate('click');
+    expect(dropdown.instance().open).toBe(false);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
@@ -96,12 +96,12 @@ test('Click on disabled option will not fire onClick', () => {
         options: [
             {
                 label: 'An option',
-                onClick: jest.fn(),
+                onClick: clickSpy,
                 disabled: true,
             },
             {
                 label: 'Another option',
-                onClick: clickSpy,
+                onClick: jest.fn(),
                 disabled: false,
             },
         ],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
@@ -110,7 +110,7 @@ test('Click on disabled option will not fire onClick', () => {
     const dropdown = mount(<Dropdown {...propsMock} />);
 
     dropdown.find('button').simulate('click');
-    dropdown.find('.option').first('button').first().simulate('click');
+    dropdown.find('.option > button').first().simulate('click');
 
     expect(clickSpy).toHaveBeenCalledTimes(0);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Iterate over options to check if all options are disabled.
When yes, disable also the button itself.

#### Why?

When no active options is available, button is still clickable at the moment.
