### PR TITLE
Avoid duplicated run of composer update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ before_script:
   - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - composer self-update
+  - if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then composer require jackalope/jackalope-jackrabbit:~1.2  --no-update --no-interaction ; fi
   - composer update $COMPOSER_FLAGS
-  - if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then composer require jackalope/jackalope-jackrabbit:~1.2 ; fi
 
 script: 
   - time ./bin/runtests -i -a $TEST_FLAGS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * ENHANCEMENT #3830 [All]                   Avoid duplicated run of composer update for travis
     * BUGFIX      #3826 [ContentBundle]         Fix enabling of save button when toggler is changed
     * HOTFIX      #3819 [MediaBundle]           Fix forgotten context binding for resetPreviewUrl method
     * FEATURE     #3816 [All]                   Validate if grunt build was run for all bundles with circleci


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add jackrabbit dependency in travis without updating dependencies.

#### Why?

To run composer with correct composer flags.
