### PR TITLE
Require symfony web-link component as needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "symfony/twig-bridge": "^3.0",
         "symfony/twig-bundle": "^3.0",
         "symfony/validator": "^3.0",
+        "symfony/web-link": "^3.0",
         "twig/twig": "^1.11 || ^2.0",
         "willdurand/hateoas-bundle": "^1.1",
         "sensio/distribution-bundle": "~5.0.6"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Require symfony/web-link component.

#### Why?

The symfony/web-link is used for the symfony.
