### PR TITLE
Fix styling of resource locator field type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/resourceLocator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/resourceLocator.scss
@@ -12,4 +12,5 @@ $textColor: $black;
     line-height: 22px;
     color: $textColor;
     margin-right: 10px;
+    white-space: nowrap;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add white-space no wrap to the fixed part of the resource locator.

#### Why?

Fix that the resource locator fixed part is wrapped.

