### PR TITLE
Added bundle name to config response

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -211,7 +211,9 @@ class AdminController
     public function configV2Action(): Response
     {
         $view = View::create([
-            'routes' => $this->adminPool->getRoutes(),
+            'sulu_admin' => [
+                'routes' => $this->adminPool->getRoutes(),
+            ],
         ]);
         $view->setFormat('json');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -12,11 +12,11 @@ import Application from './containers/Application';
 import {fieldRegistry, Input, ResourceLocator, SingleSelect} from './containers/Form';
 import FieldBlocks from './containers/FieldBlocks';
 import {viewRegistry} from './containers/ViewRenderer';
-import {datagridAdapterRegistry, ColumnListAdapter, FolderAdapter, TableAdapter} from './containers/Datagrid';
+import {ColumnListAdapter, datagridAdapterRegistry, FolderAdapter, TableAdapter} from './containers/Datagrid';
 import Form from './views/Form';
 import ResourceTabs from './views/ResourceTabs';
 import List from './views/List';
-import {bundlesReadyPromise, bundleReady} from './services/Bundles';
+import {bundleReady, bundlesReadyPromise} from './services/Bundles';
 import type {FieldTypeProps} from './types';
 
 export type {FieldTypeProps};
@@ -55,13 +55,18 @@ function startApplication() {
 const translationPromise = Requester.get('/admin/v2/translations?locale=en')
     .then((response) => setTranslations(response));
 
-const configPromise = Requester.get('/admin/v2/config')
-    .then((response) => routeRegistry.addCollection(response.routes));
+const configPromise = Requester.get('/admin/v2/config').then((response) => {
+    routeRegistry.addCollection(response['sulu_admin'].routes);
+
+    return response;
+});
 
 Promise.all([
     translationPromise,
     configPromise,
     bundlesReadyPromise,
 ]).then(startApplication);
+
+export {configPromise};
 
 bundleReady();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -166,7 +166,7 @@ class AdminControllerTest extends \PHPUnit_Framework_TestCase
         $this->adminPool->getRoutes()->willReturn($data);
 
         $this->viewHandler->handle(Argument::that(function(View $view) use ($data) {
-            return 'json' === $view->getFormat() && $view->getData() === ['routes' => $data];
+            return 'json' === $view->getFormat() && $view->getData() === ['sulu_admin' => ['routes' => $data]];
         }))->shouldBeCalled()->willReturn(new Response());
 
         $this->adminController->configV2Action();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the name of the bundle as sections to admin config.

#### Why?

This will be needed to add other bundle configuration.
