### PR TITLE
Show custom url tab only when configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * ENHANCEMENT #3843 [CustomUrlBundle]         Show custom url tab only when configured
     * BUGFIX      #3828 [Husky]                   Avoid expand ids parameter to be added to datagrid request without content
     * BUGFIX      #3828 [Husky]                   Fixed paragraphs and breaks in paste from word plugin
     * BUGFIX      #3806 [All]                     Fix compatibility on lowest and fix appveyor

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/admin.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/admin.xml
@@ -15,6 +15,8 @@
         <service id="sulu_custom_urls.webspace_navigation_provider"
                  class="Sulu\Bundle\CustomUrlBundle\Admin\WebspaceContentNavigationProvider">
             <argument type="service" id="sulu_security.security_checker"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+            <argument type="string">%kernel.environment%</argument>
 
             <tag name="sulu_admin.content_navigation" alias="webspace"/>
             <tag name="sulu.context" context="admin"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3053
| License | MIT

#### What's in this PR?

Check if custom url are configured for the given webspace else avoid rendering of custom url tab.

#### Why?

The custom url tab will only make sense when configured for the webspace.

#### Example Usage

1. Create a webspace without custom url (e.g. sulu-minimal)

#### To Do

- [x] Create a documentation PR (is documented in: http://docs.sulu.io/en/latest/cookbook/custom-urls.html#configuration)
