### PR TITLE
Added authored field to base-page-document index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * BUGFIX      #3844 [Husky]                   Fix accidentally escaping of select value
+    * ENHANCEMENT #3846 [ContentBundle]           Added authored field to base-page-document index
     * ENHANCEMENT #3843 [CustomUrlBundle]         Show custom url tab only when configured
     * BUGFIX      #3828 [Husky]                   Avoid expand ids parameter to be added to datagrid request without content
     * BUGFIX      #3828 [Husky]                   Fixed paragraphs and breaks in paste from word plugin

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # Upgrade
 
+## dev-master
+
+### Page index extension
+
+The field `authored` are now added to massive_search index. Because of this the index has to be rebuild.
+
+```bash
+bin/adminconsole massive:search:reindex --provider structure
+bin/websiteconsole massive:search:reindex --provider structure
+```
+
 ## 1.6.15
 
 ### Priority of UpdateResponseSubscriber

--- a/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Search/Metadata/StructureProvider.php
@@ -20,6 +20,7 @@ use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadata;
 use Massive\Bundle\SearchBundle\Search\Metadata\IndexMetadataInterface;
 use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
+use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
 use Sulu\Component\Content\Document\Behavior\RedirectTypeBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
@@ -262,6 +263,18 @@ EOT;
                     'type' => 'date',
                     'field' => $this->factory->createMetadataExpression(
                         'object.getPublished()'
+                    ),
+                ]
+            );
+        }
+
+        if ($class->isSubclassOf(LocalizedAuthorBehavior::class)) {
+            $indexMeta->addFieldMapping(
+                'authored',
+                [
+                    'type' => 'date',
+                    'field' => $this->factory->createMetadataExpression(
+                        'object.getAuthored()'
                     ),
                 ]
             );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #3840 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds the mapping for `authored` to `BasePageDocument` metadata.

#### BC Breaks/Deprecations

The index has to be rebuild.