### PR TITLE
Added check for unknown-document for sulu_content_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3848 [ContentBundle]           Added check for unknown-document for "sulu_content_load"
     * BUGFIX      #3844 [Husky]                   Fix accidentally escaping of select value
     * ENHANCEMENT #3846 [ContentBundle]           Added authored field to base-page-document index
     * ENHANCEMENT #3843 [CustomUrlBundle]         Show custom url tab only when configured

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -48,8 +48,10 @@ use Sulu\Component\Content\Metadata\Factory\Exception\StructureTypeNotFoundExcep
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\Content\Types\ResourceLocatorInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Document\UnknownDocument;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -275,6 +277,10 @@ class ContentMapper implements ContentMapperInterface
                 'load_ghost_content' => $loadGhostContent,
             ]
         );
+
+        if ($document instanceof UnknownDocument) {
+            throw new DocumentNotFoundException();
+        }
 
         return $this->documentToStructure($document);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes `sulu_content_load` when an unpublished page should be loaded.

#### Why?

The document-manager returns a `UnknownDocument` which leads into an exception in the `StructureBridge`.