### PR TITLE
Allow user to be null for security expressions for debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * ENHANCEMENT #3850 [SecurityBundle]        Allow user to be null for security config
+    * ENHANCEMENT #3850 [MediaBundle]           Allow user to be null for security expression in service build
     * BUGFIX      #4018 [SnippetBundle]         Fix conflict when saving snippet in new language
     * BUGFiX      #3995 [TestBundle]            Fix tests for latest Symfony version
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -204,10 +204,10 @@
             <argument>sulu-media</argument>
             <argument type="collection">
                 <argument key="permissions" type="expression">
-                    service('sulu_security.access_control_manager').getUserPermissions(
+                    service('security.token_storage').getToken() ? service('sulu_security.access_control_manager').getUserPermissions(
                         service('sulu_media.security_context'),
                         service('security.token_storage').getToken().getUser()
-                    )
+                    ) : null
                 </argument>
                 <argument key="maxFilesize" type="string">%sulu_media.upload.max_filesize%</argument>
                 <argument key="adobeCreativeKey" type="string">%sulu_media.adobe_creative_key%</argument>

--- a/src/Sulu/Bundle/SecurityBundle/Security/SecurityConfig.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/SecurityConfig.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\SecurityBundle\Security;
 
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
 use Sulu\Bundle\AdminBundle\Admin\JsConfigInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -57,12 +58,19 @@ class SecurityConfig implements JsConfigInterface
     public function getParameters()
     {
         $parameters = [];
+
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token || !$token->getUser() instanceof UserInterface) {
+            return [];
+        }
+
         foreach ($this->adminPool->getSecurityContexts() as $system => $sections) {
             foreach ($sections as $section => $contexts) {
                 foreach ($contexts as $context => $permissionTypes) {
                     $parameters[$context] = $this->accessControlManager->getUserPermissions(
                         new SecurityCondition($context),
-                        $this->tokenStorage->getToken()->getUser()
+                        $token->getUser()
                     );
                 }
             }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/SecurityConfigTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/SecurityConfigTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Security;
+
+use Prophecy\Argument;
+use Sulu\Bundle\AdminBundle\Admin\AdminPool;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCondition;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
+
+class SecurityConfigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SecurityConfig
+     */
+    private $securityConfig;
+
+    /**
+     * @var AccessControlManagerInterface
+     */
+    private $accessControlManager;
+
+    /**
+     * @var AdminPool
+     */
+    private $adminPool;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var TokenInterface
+     */
+    private $token;
+
+    /**
+     * @var UserInterface
+     */
+    private $user;
+
+    public function setUp()
+    {
+        $this->accessControlManager = $this->prophesize(AccessControlManagerInterface::class);
+        $this->adminPool = $this->prophesize(AdminPool::class);
+        $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
+        $this->token = $this->prophesize(TokenInterface::class);
+        $this->user = $this->prophesize(UserInterface::class);
+        $this->token->getUser()->willReturn($this->user->reveal());
+        $this->tokenStorage->getToken()->willReturn($this->token->reveal());
+        $this->securityConfig = new SecurityConfig(
+            'sulu_security.contexts',
+            $this->accessControlManager->reveal(),
+            $this->adminPool->reveal(),
+            $this->tokenStorage->reveal()
+        );
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('sulu_security.contexts', $this->securityConfig->getName());
+    }
+
+    public function testNoToken()
+    {
+        $this->tokenStorage->getToken()->willReturn(null)->shouldBeCalled();
+        $this->adminPool->getSecurityContexts()->shouldNotBeCalled();
+        $this->securityConfig->getParameters();
+    }
+
+    public function testNoSuluUser()
+    {
+        $user = $this->prophesize(SymfonyUserInterface::class);
+        $this->token->getUser()->willReturn($user)->shouldBeCalled();
+        $this->adminPool->getSecurityContexts()->shouldNotBeCalled();
+        $this->securityConfig->getParameters();
+    }
+
+    public function testGetParametersEmpty()
+    {
+        $this->adminPool->getSecurityContexts()->willReturn([])->shouldBeCalled();
+        $this->assertEquals([], $this->securityConfig->getParameters());
+    }
+
+    public function testGetParameters()
+    {
+        $this->adminPool->getSecurityContexts()->willReturn([
+            'Sulu' => [
+                'Security' => [
+                    'sulu.security.groups' => [
+                        PermissionTypes::VIEW,
+                        PermissionTypes::ADD,
+                        PermissionTypes::EDIT,
+                        PermissionTypes::DELETE,
+                    ],
+                    'sulu.security.roles' => [
+                        PermissionTypes::VIEW,
+                        PermissionTypes::ADD,
+                        PermissionTypes::EDIT,
+                        PermissionTypes::DELETE,
+                    ],
+                    'sulu.security.users' => [
+                        PermissionTypes::VIEW,
+                        PermissionTypes::ADD,
+                        PermissionTypes::EDIT,
+                        PermissionTypes::DELETE,
+                    ],
+                ],
+            ],
+        ])->shouldBeCalled();
+
+        $this->accessControlManager->getUserPermissions(Argument::type(SecurityCondition::class), $this->user->reveal())
+            ->willReturn(
+                [PermissionTypes::VIEW],
+                [PermissionTypes::ADD, PermissionTypes::EDIT],
+                [PermissionTypes::DELETE]
+            )->shouldBeCalled();
+
+        $this->assertEquals([
+            'sulu.security.groups' => [PermissionTypes::VIEW],
+            'sulu.security.roles' => [PermissionTypes::ADD, PermissionTypes::EDIT],
+            'sulu.security.users' => [PermissionTypes::DELETE],
+        ], $this->securityConfig->getParameters());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

It check if the tokenstorage can provide a user and don't throw an error then.

#### Why?

Some commands like debug:container, debug:router didn't work on specific routes or services.

Example:

```
bin/adminconsole debug:router sulu_admin_v2.resources
```