### PR TITLE
Implement custom find method for structure strategy

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,4 +7,4 @@ module.name_mapper='.+\.s?css' -> 'empty/object'
 .*/node_modules/findup/.*
 .*/node_modules/jss/.*
 .*/node_modules/stylelint/.*
-.*/vendor/symfony/symfony/.*
+.*/vendor/symfony/.*

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -72,8 +72,7 @@ export default class Datagrid extends React.Component<Props> {
 
     handleItemSelectionChange = (id: string | number, selected?: boolean) => {
         const {store} = this.props;
-        // TODO do not hardcode id but use metdata instead
-        const row = store.data.find((item) => item.id === id);
+        const row = store.findById(id);
 
         if (!row) {
             return;
@@ -88,6 +87,7 @@ export default class Datagrid extends React.Component<Props> {
     };
 
     handleAdapterChange = (adapter: string) => {
+        this.props.store.setActive(undefined); // TODO keep active and expand correctly
         this.setCurrentAdapterKey(adapter);
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -93,6 +93,10 @@ export default class DatagridStore {
         }
     }
 
+    findById(identifier: string | number): ?Object {
+        return this.structureStrategy.findById(identifier);
+    }
+
     sendRequest = () => {
         if (!this.initialized) {
             return;
@@ -143,7 +147,7 @@ export default class DatagridStore {
         this.observableOptions.page.set(page);
     }
 
-    @action setActive(active: string | number) {
+    @action setActive(active?: string | number) {
         this.active = active;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
@@ -17,6 +17,11 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         this.data.splice(0, this.data.length);
     }
 
+    findById(identifier: string | number): ?Object {
+        // TODO do not hardcode id but use metdata instead
+        return this.data.find((item) => item.id === identifier);
+    }
+
     enhanceItem(item: Object): Object {
         return item;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
@@ -28,6 +28,25 @@ export default class TreeStructureStrategy implements StructureStrategyInterface
         return this.findChildrenForParentId(this.data, parent);
     }
 
+    findById(id: string | number): ?Object {
+        return this.findRecursive(this.data, id);
+    }
+
+    findRecursive(items: Array<Object>, identifier: string | number): ?Object {
+        for (const item of items) {
+            // TODO do not hardcode id but use metdata instead
+            if (item.data.id === identifier) {
+                return item.data;
+            }
+
+            const data = this.findRecursive(item.children, identifier);
+
+            if (data) {
+                return data;
+            }
+        }
+    }
+
     enhanceItem(item: Object): Object {
         return {
             data: item,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -64,6 +64,7 @@ class StructureStrategy {
 
     clear = jest.fn();
     getData = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 
@@ -196,6 +197,7 @@ test('DatagridStore should be updated with current active element', () => {
             data = [];
             clear = jest.fn();
             getData = jest.fn();
+            findById = jest.fn();
             enhanceItem = jest.fn();
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -19,6 +19,7 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.selectionIds = [];
     this.loading = false;
     this.schema = {test: {}};
+    this.findById = jest.fn();
     this.select = jest.fn();
     this.deselect = jest.fn();
     this.selectEntirePage = jest.fn();
@@ -112,6 +113,9 @@ test('Selecting and deselecting items should update store', () => {
         {id: 2},
         {id: 3}
     );
+
+    datagridStore.findById.mockReturnValueOnce({id: 1}).mockReturnValueOnce({id: 2}).mockReturnValueOnce({id: 1});
+
     const datagrid = mount(<Datagrid adapters={['table']} store={datagridStore} />);
 
     const checkboxes = datagrid.find('input[type="checkbox"]');
@@ -119,10 +123,13 @@ test('Selecting and deselecting items should update store', () => {
     checkboxes.at(1).getDOMNode().checked = true;
     checkboxes.at(2).getDOMNode().checked = true;
     checkboxes.at(1).simulate('change', {currentTarget: {checked: true}});
+    expect(datagridStore.findById).toBeCalledWith(1);
     expect(datagridStore.select).toBeCalledWith({id: 1});
     checkboxes.at(2).simulate('change', {currentTarget: {checked: true}});
+    expect(datagridStore.findById).toBeCalledWith(2);
     expect(datagridStore.select).toBeCalledWith({id: 2});
     checkboxes.at(1).simulate('change', {currentTarget: {checked: false}});
+    expect(datagridStore.findById).toBeCalledWith(1);
     expect(datagridStore.deselect).toBeCalledWith({id: 1});
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/FullLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/FullLoadingStrategy.test.js
@@ -21,6 +21,7 @@ class StructureStrategy {
     data = [];
     getData = jest.fn().mockReturnValue(this.data);
     clear = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
@@ -21,6 +21,7 @@ class StructureStrategy {
     data = [];
     getData = jest.fn().mockReturnValue(this.data);
     clear = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 
@@ -63,6 +64,7 @@ test('Should reset page count to 0 and page to 1 when locale is changed', () => 
         data = [];
         clear = jest.fn();
         getData = jest.fn().mockReturnValue([]);
+        findById = jest.fn();
         enhanceItem = jest.fn();
     }
     const structureStrategy = new StructureStrategy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
@@ -21,6 +21,7 @@ class StructureStrategy {
     data = [];
     getData = jest.fn().mockReturnValue(this.data);
     clear = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -51,6 +51,7 @@ export interface StructureStrategyInterface {
     data: Array<*>,
     getData(parent: ?string | number): ?Array<*>,
     enhanceItem(item: Object): Object,
+    findById(identifier: string | number): ?Object,
     clear(): void,
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Move find from store to the structure strategies to allow custom findById implementations.

#### Why?

Find need a custom implementation for tree strategy to recursive search the tree for the element. Needed for Internal Links and Tree Component (https://github.com/sulu/sulu/pull/3582)

#### Example Usage

~~~php
treeStrategy.findBy(identifier);
flatStrategy.findBy(identifier);
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

