### PR TITLE
adjust folder for admin build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ const entries = glob.sync(
     path.resolve(__dirname, 'src/Sulu/Bundle/*/Resources/js/index.js') // eslint-disable-line no-undef
 );
 const entriesCount = entries.length;
-const basePath = 'adminV2';
+const basePath = 'admin/build';
 
 entries.unshift('core-js/fn/array/includes');
 entries.unshift('core-js/fn/array/find-index');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #---
| Related issues/PRs | sulu/sulu-minimal#90
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The folder for the build is renamed.

#### Why?

To avoid that somebody accidentially puts some own files into the build folder and it gets deleted with the new script in sulu/sulu-minimal#90.