### PR TITLE
Implement custom find method for structure strategy

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,4 +7,4 @@ module.name_mapper='.+\.s?css' -> 'empty/object'
 .*/node_modules/findup/.*
 .*/node_modules/jss/.*
 .*/node_modules/stylelint/.*
-.*/vendor/symfony/symfony/.*
+.*/vendor/symfony/.*

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -72,8 +72,7 @@ export default class Datagrid extends React.Component<Props> {
 
     handleItemSelectionChange = (id: string | number, selected?: boolean) => {
         const {store} = this.props;
-        // TODO do not hardcode id but use metdata instead
-        const row = store.data.find((item) => item.id === id);
+        const row = store.findById(id);
 
         if (!row) {
             return;
@@ -88,6 +87,7 @@ export default class Datagrid extends React.Component<Props> {
     };
 
     handleAdapterChange = (adapter: string) => {
+        this.props.store.setActive(undefined); // TODO keep active and expand correctly
         this.setCurrentAdapterKey(adapter);
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -147,7 +147,7 @@ export default class DatagridStore {
         this.observableOptions.page.set(page);
     }
 
-    @action setActive(active?: string | number) {
+    @action setActive(active: ?string | number) {
         this.active = active;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -93,6 +93,10 @@ export default class DatagridStore {
         }
     }
 
+    findById(identifier: string | number): ?Object {
+        return this.structureStrategy.findById(identifier);
+    }
+
     sendRequest = () => {
         if (!this.initialized) {
             return;
@@ -143,7 +147,7 @@ export default class DatagridStore {
         this.observableOptions.page.set(page);
     }
 
-    @action setActive(active: string | number) {
+    @action setActive(active?: string | number) {
         this.active = active;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
@@ -17,6 +17,11 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         this.data.splice(0, this.data.length);
     }
 
+    findById(identifier: string | number): ?Object {
+        // TODO do not hardcode id but use metdata instead
+        return this.data.find((item) => item.id === identifier);
+    }
+
     enhanceItem(item: Object): Object {
         return item;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
@@ -28,6 +28,25 @@ export default class TreeStructureStrategy implements StructureStrategyInterface
         return this.findChildrenForParentId(this.data, parent);
     }
 
+    findById(id: string | number): ?Object {
+        return this.findRecursive(this.data, id);
+    }
+
+    findRecursive(items: Array<Object>, identifier: string | number): ?Object {
+        for (const item of items) {
+            // TODO do not hardcode id but use metdata instead
+            if (item.data.id === identifier) {
+                return item.data;
+            }
+
+            const data = this.findRecursive(item.children, identifier);
+
+            if (data) {
+                return data;
+            }
+        }
+    }
+
     enhanceItem(item: Object): Object {
         return {
             data: item,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -64,6 +64,7 @@ class StructureStrategy {
 
     clear = jest.fn();
     getData = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 
@@ -196,6 +197,7 @@ test('DatagridStore should be updated with current active element', () => {
             data = [];
             clear = jest.fn();
             getData = jest.fn();
+            findById = jest.fn();
             enhanceItem = jest.fn();
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -19,6 +19,7 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.selectionIds = [];
     this.loading = false;
     this.schema = {test: {}};
+    this.findById = jest.fn();
     this.select = jest.fn();
     this.deselect = jest.fn();
     this.selectEntirePage = jest.fn();
@@ -112,6 +113,9 @@ test('Selecting and deselecting items should update store', () => {
         {id: 2},
         {id: 3}
     );
+
+    datagridStore.findById.mockReturnValueOnce({id: 1}).mockReturnValueOnce({id: 2}).mockReturnValueOnce({id: 1});
+
     const datagrid = mount(<Datagrid adapters={['table']} store={datagridStore} />);
 
     const checkboxes = datagrid.find('input[type="checkbox"]');
@@ -119,10 +123,13 @@ test('Selecting and deselecting items should update store', () => {
     checkboxes.at(1).getDOMNode().checked = true;
     checkboxes.at(2).getDOMNode().checked = true;
     checkboxes.at(1).simulate('change', {currentTarget: {checked: true}});
+    expect(datagridStore.findById).toBeCalledWith(1);
     expect(datagridStore.select).toBeCalledWith({id: 1});
     checkboxes.at(2).simulate('change', {currentTarget: {checked: true}});
+    expect(datagridStore.findById).toBeCalledWith(2);
     expect(datagridStore.select).toBeCalledWith({id: 2});
     checkboxes.at(1).simulate('change', {currentTarget: {checked: false}});
+    expect(datagridStore.findById).toBeCalledWith(1);
     expect(datagridStore.deselect).toBeCalledWith({id: 1});
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/FullLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/FullLoadingStrategy.test.js
@@ -21,6 +21,7 @@ class StructureStrategy {
     data = [];
     getData = jest.fn().mockReturnValue(this.data);
     clear = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
@@ -21,6 +21,7 @@ class StructureStrategy {
     data = [];
     getData = jest.fn().mockReturnValue(this.data);
     clear = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 
@@ -63,6 +64,7 @@ test('Should reset page count to 0 and page to 1 when locale is changed', () => 
         data = [];
         clear = jest.fn();
         getData = jest.fn().mockReturnValue([]);
+        findById = jest.fn();
         enhanceItem = jest.fn();
     }
     const structureStrategy = new StructureStrategy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
@@ -21,6 +21,7 @@ class StructureStrategy {
     data = [];
     getData = jest.fn().mockReturnValue(this.data);
     clear = jest.fn();
+    findById = jest.fn();
     enhanceItem = jest.fn();
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/FlatStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/FlatStructureStrategy.test.js
@@ -25,3 +25,33 @@ test('Should not enhance the items', () => {
     const flatStructureStrategy = new FlatStructureStrategy();
     expect(flatStructureStrategy.enhanceItem({id: 1})).toEqual({id: 1});
 });
+
+test('Should find items by id or return undefined', () => {
+    const flatStructureStrategy = new FlatStructureStrategy();
+
+    const item1 = {
+        id: 1,
+        title: 'Homepage',
+    };
+
+    const item2 = {
+        id: 2,
+        title: 'Item 2',
+    };
+
+    const item3 = {
+        id: 'string',
+        title: 'Item 3',
+    };
+
+    flatStructureStrategy.data = [
+        item1,
+        item2,
+        item3,
+    ];
+
+    expect(flatStructureStrategy.findById(1)).toEqual(item1);
+    expect(flatStructureStrategy.findById(2)).toEqual(item2);
+    expect(flatStructureStrategy.findById('string')).toEqual(item3);
+    expect(flatStructureStrategy.findById(4)).toEqual(undefined);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/TreeStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/TreeStructureStrategy.test.js
@@ -121,3 +121,77 @@ test('Should enhance the items with data and children', () => {
         children: [],
     });
 });
+
+test('Should find nested items by id or return undefined', () => {
+    const treeStructureStrategy = new TreeStructureStrategy();
+
+    const homeData = {
+        id: 0,
+        title: 'Homepage',
+        hasChildren: true,
+    };
+
+    const child1 = {
+        data: {
+            id: 1,
+            title: 'Child1',
+            hasChildren: false,
+        },
+        children: [],
+    };
+
+    const child2 = {
+        data: {
+            id: 2,
+            title: 'Child2',
+            hasChildren: false,
+        },
+        children: [],
+    };
+
+    const child3a = {
+        data: {
+            id: '3a',
+            title: 'Child3a',
+            hasChildren: false,
+        },
+        children: [],
+    };
+
+    const child3b = {
+        data: {
+            id: '3b',
+            title: 'Child3b',
+            hasChildren: false,
+        },
+        children: [],
+    };
+
+    const child3 = {
+        data: {
+            id: 3,
+            title: 'Child3',
+            hasChildren: true,
+        },
+        children: [
+            child3a,
+            child3b,
+        ],
+    };
+
+    treeStructureStrategy.data = [
+        {
+            data: homeData,
+            children: [
+                child1,
+                child2,
+                child3,
+            ],
+        },
+    ];
+
+    expect(treeStructureStrategy.findById(0)).toEqual(homeData);
+    expect(treeStructureStrategy.findById(2)).toEqual(child2.data);
+    expect(treeStructureStrategy.findById('3a')).toEqual(child3a.data);
+    expect(treeStructureStrategy.findById(4)).toEqual(undefined);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -51,6 +51,7 @@ export interface StructureStrategyInterface {
     data: Array<*>,
     getData(parent: ?string | number): ?Array<*>,
     enhanceItem(item: Object): Object,
+    findById(identifier: string | number): ?Object,
     clear(): void,
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | #3860 
| License | MIT

#### What's in this PR?

Move find from store to the structure strategies to allow custom findById implementations.

#### Why?

Find need a custom implementation for tree strategy to recursive search the tree for the element. Needed for Internal Links and Tree Component (https://github.com/sulu/sulu/pull/3582)

#### Example Usage

~~~php
treeStrategy.findBy(identifier);
flatStrategy.findBy(identifier);
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

