### PR TITLE
remove jackrabbit build from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ environment:
     # see http://windows.php.net/downloads/releases/ for available versions
     - PHP_VERSION: 7.1.14
       SYMFONY__DATABASE__PASSWORD: Password12!
-    - PHP_VERSION: 7.1.14
-      JACKRABBIT_VERSION: 2.12.0
-      SYMFONY__PHPCR__TRANSPORT: jackrabbit
-      SYMFONY__DATABASE__PASSWORD: Password12!
 
 services:
   - mysql
@@ -33,14 +29,6 @@ cache:
 install:
   # disable wuauserv service
   - ps: Set-Service wuauserv -StartupType Manual
-
-  # install jackrabbit
-  - IF NOT EXIST jackrabbit-standalone-%JACKRABBIT_VERSION%.jar (
-        IF "%SYMFONY__PHPCR__TRANSPORT%" == "jackrabbit" (
-            cd %APPVEYOR_BUILD_FOLDER%
-            && appveyor DownloadFile http://archive.apache.org/dist/jackrabbit/%JACKRABBIT_VERSION%/jackrabbit-standalone-%JACKRABBIT_VERSION%.jar
-        )
-    )
 
   # install composer
   - IF NOT EXIST C:\tools\composer.phar (
@@ -69,10 +57,6 @@ install:
 
 before_test:
   - cd %APPVEYOR_BUILD_FOLDER%
-
-  # Start Jackrabbit
-  - java -version
-  - ps: if ($env:SYMFONY__PHPCR__TRANSPORT -MATCH "jackrabbit") { $argumentList='-jar jackrabbit-standalone-' + $env:JACKRABBIT_VERSION + '.jar'; Start-Process -FilePath java -ArgumentList $argumentList }
 
   # Composer install
   - IF "%SYMFONY__PHPCR__TRANSPORT%" == "jackrabbit" (


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #---
| Related issues/PRs | #---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the jackrabbit build from appveyor.

#### Why?

We only have one concurrent build on appveyor, and having multiple builds there slows us down. Also, jackrabbit is already tested on the linux build, and I think that is enough.