### PR TITLE
Fixed missing metadata mapper service

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -187,6 +187,11 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
         </service>
 
+        <service id="sulu_admin.metadata.resource_metadata_mapper" class="Sulu\Bundle\AdminBundle\ResourceMetadata\ResourceMetadataMapper">
+            <argument type="service" id="sulu_core.list_builder.field_descriptor_factory"/>
+            <argument type="service" id="translator.default"/>
+        </service>
+
         <!-- resource metadata provider -->
         <service id="sulu_core.resource_metadata_provider.structure"
                  class="Sulu\Bundle\CoreBundle\ResourceMetadata\StructureResourceMetadataProvider"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Copied service definition "sulu_admin.metadata.resource_metadata_mapper" in CoreBundle/.../content.xml line 190ff.

#### Why?

Error thrown while running composer install:

`
[RuntimeException]
An error occurred when executing the "'cache:clear --no-warmup'" command:
The service "sulu_core.resource_metadata_provider.structure" has a dependency 
on a non-existent service "sulu_admin.metadata.resource_metadata_mapper"
`