### PR TITLE
Bugfix: Moved StructureResourceMetadataProvider from Core to Content

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/ResourceMetadata/StructureResourceMetadataProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/ResourceMetadata/StructureResourceMetadataProvider.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CoreBundle\ResourceMetadata;
+namespace Sulu\Bundle\ContentBundle\ResourceMetadata;
 
 use Sulu\Bundle\AdminBundle\ResourceMetadata\ResourceMetadataInterface;
 use Sulu\Bundle\AdminBundle\ResourceMetadata\ResourceMetadataMapper;

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
@@ -28,5 +28,16 @@
             <argument>%kernel.cache_dir%/sulu/structures</argument>
             <argument>%kernel.debug%</argument>
         </service>
+
+        <!-- resource metadata provider -->
+        <service id="sulu_core.resource_metadata_provider.structure"
+                 class="Sulu\Bundle\ContentBundle\ResourceMetadata\StructureResourceMetadataProvider"
+        >
+            <argument type="service" id="sulu_content.structure.factory"/>
+            <argument type="service" id="sulu_admin.metadata.resource_metadata_mapper"/>
+            <argument type="string">%sulu.content.structure.resources%</argument>
+
+            <tag name="sulu.resource_metadata_provider"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/ResourceMetadata/StructureResourceMetadataProviderTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/ResourceMetadata/StructureResourceMetadataProviderTest.php
@@ -9,14 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CoreBundle\Tests\Unit\ResourceMetadata;
+namespace Sulu\Bundle\ContentBundle\Tests\Unit\ResourceMetadata;
 
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\ResourceMetadata\Datagrid\Datagrid;
 use Sulu\Bundle\AdminBundle\ResourceMetadata\Form\Form;
 use Sulu\Bundle\AdminBundle\ResourceMetadata\ResourceMetadataMapper;
 use Sulu\Bundle\AdminBundle\ResourceMetadata\Schema\Schema;
-use Sulu\Bundle\CoreBundle\ResourceMetadata\StructureResourceMetadataProvider;
+use Sulu\Bundle\ContentBundle\ResourceMetadata\StructureResourceMetadataProvider;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -186,16 +186,5 @@
         <service id="sulu.content.localization_finder" class="Sulu\Component\Content\Compat\LocalizationFinder">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
         </service>
-
-        <!-- resource metadata provider -->
-        <service id="sulu_core.resource_metadata_provider.structure"
-                 class="Sulu\Bundle\CoreBundle\ResourceMetadata\StructureResourceMetadataProvider"
-        >
-            <argument type="service" id="sulu_content.structure.factory"/>
-            <argument type="service" id="sulu_admin.metadata.resource_metadata_mapper"/>
-            <argument type="string">%sulu.content.structure.resources%</argument>
-
-            <tag name="sulu.resource_metadata_provider"/>
-        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -44,6 +44,7 @@ class SuluTestKernel extends SuluKernel
             // Sulu
             new \Sulu\Bundle\SearchBundle\SuluSearchBundle(),
             new \Sulu\Bundle\PersistenceBundle\SuluPersistenceBundle(),
+            new \Sulu\Bundle\AdminBundle\SuluAdminBundle(),
             new \Sulu\Bundle\ContentBundle\SuluContentBundle(),
             new \Sulu\Bundle\ContactBundle\SuluContactBundle(),
             new \Sulu\Bundle\SecurityBundle\SuluSecurityBundle(),
@@ -65,7 +66,6 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Bundle\RouteBundle\SuluRouteBundle(),
             new \Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
             new \Sulu\Bundle\AudienceTargetingBundle\SuluAudienceTargetingBundle(),
-            new \Sulu\Bundle\AdminBundle\SuluAdminBundle(),
         ];
 
         if (self::CONTEXT_WEBSITE === $this->getContext()) {

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -44,7 +44,6 @@ class SuluTestKernel extends SuluKernel
             // Sulu
             new \Sulu\Bundle\SearchBundle\SuluSearchBundle(),
             new \Sulu\Bundle\PersistenceBundle\SuluPersistenceBundle(),
-            new \Sulu\Bundle\AdminBundle\SuluAdminBundle(),
             new \Sulu\Bundle\ContentBundle\SuluContentBundle(),
             new \Sulu\Bundle\ContactBundle\SuluContactBundle(),
             new \Sulu\Bundle\SecurityBundle\SuluSecurityBundle(),
@@ -66,6 +65,7 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Bundle\RouteBundle\SuluRouteBundle(),
             new \Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
             new \Sulu\Bundle\AudienceTargetingBundle\SuluAudienceTargetingBundle(),
+            new \Sulu\Bundle\AdminBundle\SuluAdminBundle(),
         ];
 
         if (self::CONTEXT_WEBSITE === $this->getContext()) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Moved StructureResourceMetadataProvider from Core to Content Bundle.

#### Why?

CoreBundle shouldn't have a dependency to AdminBundle, because on the website the AdminBundle isn't loaded at all.
