### PR TITLE
Clear MediaOverview stores when using back button

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -95,11 +95,15 @@ class MediaOverview extends React.Component<ViewProps> {
         );
     }
 
-    @action handleCollectionNavigate = (collectionId) => {
+    clearDatagrids() {
         this.mediaDatagridStore.clearData();
         this.mediaDatagridStore.clearSelection();
         this.collectionDatagridStore.clearData();
         this.collectionDatagridStore.clearSelection();
+    }
+
+    @action handleCollectionNavigate = (collectionId) => {
+        this.clearDatagrids();
         this.mediaPage.set(1);
         this.collectionPage.set(1);
         this.collectionId.set(collectionId);
@@ -164,6 +168,7 @@ export default withToolbar(MediaOverview, function() {
         backButton: this.collectionId.get()
             ? {
                 onClick: () => {
+                    this.clearDatagrids();
                     router.restore(
                         COLLECTION_ROUTE,
                         {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -211,6 +211,10 @@ test('Should navigate to defined route on back button click', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaOverview);
     toolbarConfig.backButton.onClick();
+    expect(mediaOverview.mediaDatagridStore.clearData).toBeCalled();
+    expect(mediaOverview.mediaDatagridStore.clearSelection).toBeCalled();
+    expect(mediaOverview.collectionDatagridStore.clearData).toBeCalled();
+    expect(mediaOverview.collectionDatagridStore.clearSelection).toBeCalled();
     expect(router.restore).toBeCalledWith('sulu_media.overview', {
         'collectionPage': '1',
         'id': 1,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #---
| Related issues/PRs | #---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR clears both stores of the `MediaOverview` when using the back button.

#### Why?

This fixes the bug which duplicates media entries in the `MediaOverview` when using the back button.