### PR TITLE
Disable items by ids in datagrid

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -7,19 +7,21 @@ import ItemButton from './ItemButton';
 import type {ItemButtonConfig} from './types';
 import itemStyles from './item.scss';
 
-type Props = {
+type Props = {|
     active: boolean,
     buttons?: Array<ItemButtonConfig>,
     children: string,
+    disabled: boolean,
     hasChildren: boolean,
     id: string | number,
     onClick?: (id: string | number) => void,
     selected: boolean,
-};
+|};
 
 export default class Item extends React.Component<Props> {
     static defaultProps = {
         active: false,
+        disabled: false,
         hasChildren: false,
         selected: false,
     };
@@ -30,7 +32,7 @@ export default class Item extends React.Component<Props> {
         }
     };
 
-    createButtons = () => {
+    renderButtons = () => {
         const {buttons, id} = this.props;
 
         if (!buttons) {
@@ -47,12 +49,13 @@ export default class Item extends React.Component<Props> {
     };
 
     render() {
-        const {children, active, hasChildren, selected} = this.props;
+        const {active, children, disabled, hasChildren, selected} = this.props;
 
         const itemClass = classNames(
             itemStyles.item,
             {
                 [itemStyles.active]: active,
+                [itemStyles.disabled]: disabled,
                 [itemStyles.selected]: selected,
             }
         );
@@ -60,7 +63,7 @@ export default class Item extends React.Component<Props> {
         return (
             <div onClick={this.handleClick} className={itemClass}>
                 <span className={itemStyles.buttons}>
-                    {this.createButtons()}
+                    {this.renderButtons()}
                 </span>
                 <span className={itemStyles.text}>
                     <CroppedText>{children}</CroppedText>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ItemButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ItemButton.js
@@ -4,10 +4,10 @@ import Icon from '../Icon';
 import type {ItemButtonConfig} from './types';
 import itemStyles from './item.scss';
 
-type Props = {
+type Props = {|
     id: string | number,
     config: ItemButtonConfig,
-};
+|};
 
 export default class ItemButton extends React.Component<Props> {
     handleClick = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/README.md
@@ -61,7 +61,7 @@ const toolbarItems = [
     <ColumnList buttons={buttons} onItemClick={handleItemClick} toolbarItems={toolbarItems}>
         <ColumnList.Column>
             <ColumnList.Item id="1" selected="true">Google 1</ColumnList.Item>
-            <ColumnList.Item id="2" hasChildren="true">Apple 1</ColumnList.Item>
+            <ColumnList.Item id="2" hasChildren="true" disabled={true}>Apple 1</ColumnList.Item>
             <ColumnList.Item id="3">Microsoft 1</ColumnList.Item>
         </ColumnList.Column>
         <ColumnList.Column>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
@@ -1,8 +1,8 @@
 @import '../../containers/Application/colors.scss';
 
 $itemBackgroundColorSelected: $alabaster;
-$itemBackgroundColorHover: $blueZodiac;
-$itemColorHover: $white;
+$itemBackgroundColorHover: $concrete;
+$itemColorDisabled: $dustyGray;
 
 .item {
     height: 40px;
@@ -23,9 +23,12 @@ $itemColorHover: $white;
         font-weight: bold;
     }
 
+    &.disabled {
+        color: $itemColorDisabled;
+    }
+
     &:hover {
         background: $itemBackgroundColorHover;
-        color: $itemColorHover;
     }
 
     .children {
@@ -38,16 +41,21 @@ $itemColorHover: $white;
     width: 20px;
     font-size: 20px;
     text-align: center;
-    visibility: hidden;
 
     &:last-child {
         margin-right: 5px;
     }
 }
 
-.item:hover,
-.item.selected {
-    .button {
-        visibility: visible;
+.buttons {
+    visibility: hidden;
+}
+
+.item:not(.disabled) {
+    &:hover,
+    &.selected {
+        .buttons {
+            visibility: visible;
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Item.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Item.test.js
@@ -10,3 +10,7 @@ test('Should render item as not selected by default', () => {
 test('Should render item as selected', () => {
     expect(render(<Item id={1} selected={true}>Test</Item>)).toMatchSnapshot();
 });
+
+test('Should render item as disabled', () => {
+    expect(render(<Item id={1} disabled={true}>Test</Item>)).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Item.test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Should render item as disabled 1`] = `
+<div
+  class="item disabled"
+>
+  <span
+    class="buttons"
+  />
+  <span
+    class="text"
+  >
+    <div
+      aria-label="Test"
+      class="croppedText"
+      title="Test"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Te
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          st
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Test
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
 exports[`Should render item as not selected by default 1`] = `
 <div
   class="item"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/Assignment.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/Assignment.js
@@ -10,6 +10,7 @@ import assignmentStyles from './assignment.scss';
 
 type Props = {|
     adapter: string,
+    disabledIds: Array<string | number>,
     displayProperties: Array<string>,
     onChange: (selectedIds: Array<string | number>) => void,
     label?: string,
@@ -23,6 +24,7 @@ type Props = {|
 @observer
 export default class Assignment extends React.Component<Props> {
     static defaultProps = {
+        disabledIds: [],
         displayProperties: [],
         icon: 'su-plus',
         value: [],
@@ -94,7 +96,7 @@ export default class Assignment extends React.Component<Props> {
     };
 
     render() {
-        const {adapter, displayProperties, icon, label, locale, resourceKey, overlayTitle} = this.props;
+        const {adapter, disabledIds, displayProperties, icon, label, locale, resourceKey, overlayTitle} = this.props;
         const {items, loading} = this.assignmentStore;
         const columns = displayProperties.length;
 
@@ -128,6 +130,7 @@ export default class Assignment extends React.Component<Props> {
                 </MultiItemSelection>
                 <DatagridOverlay
                     adapter={adapter}
+                    disabledIds={disabledIds}
                     locale={locale}
                     onClose={this.handleOverlayClose}
                     onConfirm={this.handleOverlayConfirm}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/DatagridOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/DatagridOverlay.js
@@ -11,6 +11,7 @@ import datagridOverlayStyles from './datagridOverlay.scss';
 
 type Props = {|
     adapter: string,
+    disabledIds: Array<string | number>,
     locale?: ?IObservableValue<string>,
     onClose: () => void,
     onConfirm: (selectedItems: Array<Object>) => void,
@@ -25,6 +26,7 @@ export default class DatagridOverlay extends React.Component<Props> {
     page: IObservableValue<number> = observable.box(1);
 
     static defaultProps = {
+        disabledIds: [],
         preSelectedItems: [],
     };
 
@@ -65,7 +67,7 @@ export default class DatagridOverlay extends React.Component<Props> {
     };
 
     render() {
-        const {adapter, onClose, open, title} = this.props;
+        const {adapter, disabledIds, onClose, open, title} = this.props;
 
         const datagridContainerClass = classNames(
             datagridOverlayStyles['adapter-container'],
@@ -89,7 +91,7 @@ export default class DatagridOverlay extends React.Component<Props> {
             >
                 <div className={datagridContainerClass}>
                     <div className={datagridClass}>
-                        <Datagrid adapters={[adapter]} store={this.datagridStore} />
+                        <Datagrid adapters={[adapter]} disabledIds={disabledIds} store={this.datagridStore} />
                     </div>
                 </div>
             </Overlay>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/tests/Assignment.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/tests/Assignment.test.js
@@ -81,6 +81,22 @@ test('Pass locale to DatagridOverlay', () => {
     expect(assignment.find('DatagridOverlay').prop('locale').get()).toEqual('de');
 });
 
+test('Pass disabledIds to DatagridOverlay', () => {
+    const disabledIds = [1, 2, 4];
+
+    const assignment = mount(
+        <Assignment
+            adapter="table"
+            disabledIds={disabledIds}
+            onChange={jest.fn()}
+            overlayTitle="Assignment"
+            resourceKey="snippets"
+        />
+    );
+
+    expect(assignment.find('DatagridOverlay').prop('disabledIds')).toEqual(disabledIds);
+});
+
 test('Show with passed values as items in right locale', () => {
     const locale = observable.box('en');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/tests/DatagridOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/tests/DatagridOverlay.test.js
@@ -52,6 +52,24 @@ test('Should instantiate the DatagridStore without locale', () => {
     expect(datagridOverlay.instance().datagridStore.observableOptions.locale).toEqual(undefined);
 });
 
+test('Should pass disabledIds to the Datagrid', () => {
+    const disabledIds = [1, 2, 5];
+
+    const datagridOverlay = shallow(
+        <DatagridOverlay
+            adapter="table"
+            disabledIds={disabledIds}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            resourceKey="snippets"
+            title="Assignment"
+        />
+    );
+
+    expect(datagridOverlay.find(Datagrid).prop('disabledIds')).toBe(disabledIds);
+});
+
 test('Should call onConfirm with the current selection', () => {
     const confirmSpy = jest.fn();
     const datagridOverlay = mount(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -10,16 +10,18 @@ import AdapterSwitch from './AdapterSwitch';
 import datagridStyles from './datagrid.scss';
 
 type Props = {|
+    adapters: Array<string>,
+    disabledIds: Array<string | number>,
     onItemClick?: (itemId: string | number) => void,
     onAddClick?: (id: string | number) => void,
     selectable: boolean,
     store: DatagridStore,
-    adapters: Array<string>,
 |};
 
 @observer
 export default class Datagrid extends React.Component<Props> {
     static defaultProps = {
+        disabledIds: [],
         selectable: true,
     };
 
@@ -103,6 +105,7 @@ export default class Datagrid extends React.Component<Props> {
     render() {
         const {
             adapters,
+            disabledIds,
             onItemClick,
             onAddClick,
             selectable,
@@ -120,6 +123,7 @@ export default class Datagrid extends React.Component<Props> {
                 <Adapter
                     active={store.active}
                     data={store.data}
+                    disabledIds={disabledIds}
                     loading={store.loading}
                     onAllSelectionChange={selectable ? this.handleAllSelectionChange : undefined}
                     onItemActivation={this.handleItemActivation}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
@@ -111,7 +111,7 @@ export default class ColumnListAdapter extends AbstractAdapter {
     }
 
     render() {
-        const {loading, onAddClick, onItemClick, onItemSelectionChange, selections} = this.props;
+        const {disabledIds, loading, onAddClick, onItemClick, onItemSelectionChange, selections} = this.props;
 
         const buttons = [];
 
@@ -151,6 +151,7 @@ export default class ColumnListAdapter extends AbstractAdapter {
                                 // TODO: Don't access properties like "hasChildren" or "title" directly
                                 <ColumnList.Item
                                     active={this.activeItemPath.includes(item.id)}
+                                    disabled={disabledIds.includes(item.id)}
                                     hasChildren={item.hasChildren}
                                     id={item.id}
                                     key={item.id}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -114,6 +114,14 @@ test('Render the adapter in non-selectable mode', () => {
     expect(datagrid.find('TestAdapter').prop('onAllSelectionChange')).toEqual(undefined);
 });
 
+test('Pass the ids to be disabled to the adapter', () => {
+    const disabledIds = [1, 3];
+    const datagridStore = new DatagridStore('test', {page: observable.box(1)});
+    const datagrid = shallow(<Datagrid adapters={['test']} disabledIds={disabledIds} store={datagridStore} />);
+
+    expect(datagrid.find('TestAdapter').prop('disabledIds')).toBe(disabledIds);
+});
+
 test('Selecting and deselecting items should update store', () => {
     datagridAdapterRegistry.get.mockReturnValue(TableAdapter);
     const datagridStore = new DatagridStore('test', {page: observable.box(1)});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
@@ -45,6 +45,7 @@ test('Render data with edit button', () => {
         <ColumnListAdapter
             active={4}
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemClick={jest.fn()}
             onPageChange={jest.fn()}
@@ -83,6 +84,7 @@ test('Render data without edit button', () => {
         <ColumnListAdapter
             active={4}
             data={data}
+            disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
             page={undefined}
@@ -120,6 +122,46 @@ test('Render data with selection', () => {
         <ColumnListAdapter
             active={4}
             data={data}
+            disabledIds={[]}
+            loading={false}
+            onItemSelectionChange={jest.fn()}
+            onPageChange={jest.fn()}
+            page={undefined}
+            pageCount={0}
+            schema={{}}
+            selections={[1]}
+        />
+    );
+
+    expect(columnListAdapter).toMatchSnapshot();
+});
+
+test('Render data with disabled items', () => {
+    const data = [
+        {
+            children: [
+                {
+                    children: [],
+                    data: {
+                        id: 3,
+                        title: 'Page 1.1',
+                        hasChildren: false,
+                    },
+                },
+            ],
+            data: {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+            },
+        },
+    ];
+
+    const columnListAdapter = render(
+        <ColumnListAdapter
+            active={3}
+            data={data}
+            disabledIds={[3]}
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
@@ -140,6 +182,7 @@ test('Render with add button in toolbar when onAddClick callback is given', () =
         <ColumnListAdapter
             active={4}
             data={data}
+            disabledIds={[]}
             loading={false}
             onAddClick={jest.fn()}
             onPageChange={jest.fn()}
@@ -177,6 +220,7 @@ test('Render data with loading column', () => {
         <ColumnListAdapter
             active={1}
             data={data}
+            disabledIds={[]}
             loading={true}
             onPageChange={jest.fn()}
             page={undefined}
@@ -233,6 +277,7 @@ test('Execute onItemActivation callback when an item is clicked with the correct
         <ColumnListAdapter
             active={3}
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemActivation={onItemActivationSpy}
             onPageChange={jest.fn()}
@@ -274,6 +319,7 @@ test('Execute onItemSelectionChange callback when an item is selected', () => {
         <ColumnListAdapter
             active={3}
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemSelectionChange={itemSelectionChangeSpy}
             onPageChange={jest.fn()}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
@@ -33,6 +33,7 @@ test('Render a basic Folder list with data', () => {
     const folderAdapter = render(
         <FolderAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
             page={1}
@@ -70,6 +71,7 @@ test('Click on a Folder should call the onItemEdit callback', () => {
     const folderAdapter = shallow(
         <FolderAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemClick={itemClickSpy}
             onPageChange={jest.fn()}
@@ -86,6 +88,7 @@ test('Pagination should be passed correct props', () => {
     const pageChangeSpy = jest.fn();
     const folderAdapter = shallow(
         <FolderAdapter
+            disabledIds={[]}
             loading={false}
             onPageChange={pageChangeSpy}
             page={2}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
@@ -34,6 +34,7 @@ test('Render data with schema', () => {
     const tableAdapter = render(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             page={2}
             pageCount={5}
@@ -71,6 +72,7 @@ test('Render data with schema and selections', () => {
     const tableAdapter = render(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
@@ -104,6 +106,7 @@ test('Render data with schema in different order', () => {
     const tableAdapter = render(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
             page={2}
@@ -135,6 +138,7 @@ test('Render data with schema not containing all fields', () => {
     const tableAdapter = render(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
             page={1}
@@ -167,6 +171,7 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
     const tableAdapter = render(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemClick={rowEditClickSpy}
             onPageChange={jest.fn()}
@@ -200,6 +205,7 @@ test('Click on pencil should execute onItemEdit callback', () => {
     const tableAdapter = shallow(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemClick={rowEditClickSpy}
             onPageChange={jest.fn()}
@@ -237,6 +243,7 @@ test('Click on checkbox should call onItemSelectionChange callback', () => {
     const tableAdapter = shallow(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onItemSelectionChange={rowSelectionChangeSpy}
             onPageChange={jest.fn()}
@@ -259,6 +266,7 @@ test('Click on checkbox in header should call onAllSelectionChange callback', ()
     const tableAdapter = shallow(
         <TableAdapter
             data={data}
+            disabledIds={[]}
             loading={false}
             onAllSelectionChange={allSelectionChangeSpy}
             onPageChange={jest.fn()}
@@ -275,7 +283,15 @@ test('Click on checkbox in header should call onAllSelectionChange callback', ()
 test('Pagination should be passed correct props', () => {
     const pageChangeSpy = jest.fn();
     const tableAdapter = shallow(
-        <TableAdapter loading={false} onPageChange={pageChangeSpy} page={2} pageCount={7} schema={{}} selections={[]} />
+        <TableAdapter
+            disabledIds={[]}
+            loading={false}
+            onPageChange={pageChangeSpy}
+            page={2}
+            pageCount={7}
+            schema={{}}
+            selections={[]}
+        />
     );
     expect(tableAdapter.find('Pagination').get(0).props).toEqual({
         total: 7,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render data with disabled items 1`] = `
+<div
+  class="columnListAdapter"
+>
+  <div
+    class="columnListToolbarContainer"
+  >
+    <div
+      class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
+    >
+      <div
+        class="columnList"
+      >
+        <div
+          class="column"
+        >
+          <div
+            class="item active selected"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-checkmark"
+                class="button su-checkmark clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 1"
+                class="croppedText"
+                title="Page 1"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Pag
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e 1
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 1
+                </div>
+              </div>
+            </span>
+            <span
+              aria-label="su-arrow-right"
+              class="children su-arrow-right"
+            />
+          </div>
+        </div>
+        <div
+          class="column"
+        >
+          <div
+            class="item active disabled"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-checkmark"
+                class="button su-checkmark clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 1.1"
+                class="croppedText"
+                title="Page 1.1"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Page
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                     1.1
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 1.1
+                </div>
+              </div>
+            </span>
+          </div>
+        </div>
+        <div
+          class="column"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render data with edit button 1`] = `
 <div
   class="columnListAdapter"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -13,6 +13,7 @@ export type Schema = {
 export type DatagridAdapterProps = {
     active?: ?string | number,
     data: Array<*>,
+    disabledIds: Array<string | number>,
     loading: boolean,
     onAllSelectionChange?: (selected?: boolean) => void,
     onItemClick?: (itemId: string | number) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Assignment.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Assignment.js
@@ -29,6 +29,7 @@ export default class Assignment extends React.Component<FieldTypeProps<Array<str
             <AssignmentComponent
                 adapter={adapter}
                 displayProperties={displayProperties}
+                disabledIds={resourceKey === formInspector.resourceKey && formInspector.id ? [formInspector.id] : []}
                 icon={icon}
                 label={label}
                 locale={formInspector.locale}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardAdapter.test.js
@@ -40,6 +40,7 @@ test('Render a basic Masonry view with MediaCards', () => {
     const mediaCardAdapter = render(
         <MediaCardAdapter
             data={data}
+            disabledIds={[]}
             icon="su-pen"
             loading={false}
             onItemSelectionChange={jest.fn()}
@@ -81,6 +82,7 @@ test('MediaCard should call the the appropriate handler', () => {
     const mediaCardAdapter = shallow(
         <MediaCardAdapter
             data={data}
+            disabledIds={[]}
             icon="su-pen"
             loading={false}
             onItemClick={mediaCardSelectionChangeSpy}
@@ -102,6 +104,7 @@ test('InfiniteScroller should be passed correct props', () => {
     const tableAdapter = shallow(
         <MediaCardAdapter
             data={[]}
+            disabledIds={[]}
             icon="su-pen"
             loading={false}
             onPageChange={pageChangeSpy}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
@@ -40,7 +40,7 @@ test('Render a basic Masonry view with the MediaCardOverviewAdapter', () => {
     const mediaCardAdapter = render(
         <MediaCardOverviewAdapter
             data={data}
-            icon="su-pen"
+            disabledIds={[]}
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #3855
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to disable certain items in the datagrid by passing the ids to disable in the `disabledIds` prop of the Datagrid.

#### Why?

Because in #3855 we introduced the internal links field type, but you can still select the page you are currently editing to itself, which the backend does not allow.

#### Example Usage

~~~jsx
<Datagrid disabledIds={[1, 4]} />
~~~

#### To Do

- [ ] Add disabledIds as property in the Assignment field type to avoid linking a page to itself