### PR TITLE
Improved developer-experience when overriding content-teaser-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * ENHANCEMENT #3884 [ContentBundle]           Improved developer-experience when overriding content-teaser-provider
     * HOTFIX      #3870 [Husky]                   Updated husky to fix bug with thumbnails in datagrid
 
 * 1.6.16 (2018-03-19)

--- a/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Teaser/ContentTeaserProvider.php
@@ -67,9 +67,9 @@ class ContentTeaserProvider implements TeaserProviderInterface
         foreach ($searchResult as $item) {
             $document = $item->getDocument();
 
-            $title = $document->getField('title')->getValue();
-            $excerptTitle = $document->getField('excerptTitle')->getValue();
-            $excerptDescription = $document->getField('excerptDescription')->getValue();
+            $title = $this->getTitleFromDocument($document);
+            $excerptTitle = $this->getExcerptTitleFromDocument($document);
+            $excerptDescription = $this->getExcerptDescritionFromDocument($document);
             $excerptMedia = $this->getMedia($document, 'excerptImages');
 
             $teaserDescription = $document->hasField(StructureProvider::FIELD_TEASER_DESCRIPTION) ?
@@ -93,6 +93,21 @@ class ContentTeaserProvider implements TeaserProviderInterface
         }
 
         return $result;
+    }
+
+    protected function getTitleFromDocument(Document $document)
+    {
+        return $document->getField('title')->getValue();
+    }
+
+    protected function getExcerptTitleFromDocument(Document $document)
+    {
+        return $document->getField('excerptTitle')->getValue();
+    }
+
+    protected function getExcerptDescritionFromDocument(Document $document)
+    {
+        return $document->getField('excerptDescription')->getValue();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3803
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR extracts some functions to improve overriding `ContentTeaserProvider`.