### PR TITLE
Throw a meaningful error when a form is not embedded in a ResourceTabs

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -17,6 +17,14 @@ class Form extends React.PureComponent<Props> {
 
     componentWillMount() {
         const {resourceStore, router} = this.props;
+
+        if (!resourceStore) {
+            throw new Error(
+                'The view "Form" needs a resourceStore to work properly.'
+                + 'Did you maybe forget to make this view a child of a "ResourceTabs" view?'
+            );
+        }
+
         this.formStore = new FormStore(resourceStore);
 
         if (resourceStore.locale) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -608,3 +608,8 @@ test('Should not bind the locale if no locales have been passed via options', ()
     form.unmount();
     expect(router.unbind).not.toBeCalled();
 });
+
+test('Should throw an error if the resourceStore is not passed for some reason', () => {
+    const Form = require('../Form').default;
+    expect(() => shallow(<Form />)).toThrow(/"ResourceTabs"/);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Throw an exception for the `Form` view if it is not embedded in a `ResourceTabs` component.

#### Why?

Because that makes it easier for the developer to find a misconfigured form.