### PR TITLE
Enhanced the default title length for seo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
         java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
     fi
   # the content tests are intensive and there are memory leaks, this is more pronounced with the Jackalope DBAL PHPCR implementation.
-  - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - composer self-update
   - if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then composer require jackalope/jackalope-jackrabbit:~1.2  --no-update --no-interaction ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * ENHANCEMENT #3884 [ContentBundle]           Improved developer-experience when overriding content-teaser-provider
+    * ENHANCEMENT #3897 [ContentBundle]           SEO title length changed from 55 to 70
     * HOTFIX      #3870 [Husky]                   Updated husky to fix bug with thumbnails in datagrid
 
 * 1.6.16 (2018-03-19)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrade
 
+## dev-master
+
+### SEO Title
+
+The default length for the title field in the SEO tab has changed from 55 to 70, because Google has expanded
+the max length. If you want to have a different length for some reason you can change it in the configuration:
+
+```yaml
+sulu_content:
+    seo:
+        max_title_length: 55
+```
+
 ## 1.6.16
 
 ### Page index extension

--- a/src/Sulu/Bundle/ContentBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContentBundle/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('seo')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('max_title_length')->defaultValue(55)->end()
+                        ->scalarNode('max_title_length')->defaultValue(70)->end()
                         ->scalarNode('max_description_length')->defaultValue(320)->end()
                         ->scalarNode('max_keywords')->defaultValue(5)->end()
                         ->scalarNode('keywords_separator')->defaultValue(',')->end()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes see UPGRADE
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR enhances the default title length for seo.