### PR TITLE
Replaced links in preview with '#'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG for Sulu
 
 * dev-master
     * FEATURE     #3905 [MediaBundle]             Add canonical and robots noIndex headers to download of old versions 
+    * ENHANCEMENT #3899 [PreviewBundle]           Replaced links in preview with '#'
     * ENHANCEMENT #3884 [ContentBundle]           Improved developer-experience when overriding content-teaser-provider
     * ENHANCEMENT #3897 [ContentBundle]           SEO title length changed from 55 to 70
     * HOTFIX      #3870 [Husky]                   Updated husky to fix bug with thumbnails in datagrid

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -113,7 +113,7 @@ class Preview implements PreviewInterface
         $this->save($token, $object);
 
         $id = $provider->getId($object);
-        $html = $this->renderer->render($object, $id, $webspaceKey, $locale, true, $targetGroupId);
+        $html = $this->replaceLinks($this->renderer->render($object, $id, $webspaceKey, $locale, true, $targetGroupId));
 
         $extractor = new RdfaExtractor($html);
 
@@ -130,7 +130,9 @@ class Preview implements PreviewInterface
         if (0 === count($context)) {
             $id = $provider->getId($object);
 
-            return $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId);
+            return $this->replaceLinks(
+                $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId)
+            );
         }
 
         // context
@@ -144,7 +146,7 @@ class Preview implements PreviewInterface
 
         $this->save($token, $object);
 
-        return $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId);
+        return $this->replaceLinks($this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId));
     }
 
     /**
@@ -155,7 +157,19 @@ class Preview implements PreviewInterface
         $object = $this->fetch($token);
         $id = $this->getProvider(get_class($object))->getId($object);
 
-        return $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId);
+        return $this->replaceLinks($this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId));
+    }
+
+    /**
+     * Replaces links with "#".
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    protected function replaceLinks($html)
+    {
+        return preg_replace('/(href|action)="[^"]*"/', '$1="#"', $html);
     }
 
     /**

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -154,6 +154,31 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['title' => [['property' => 'title', 'html' => 'SULU']]], $changes);
     }
 
+    public function testUpdateWithLink()
+    {
+        $object = $this->prophesize(\stdClass::class);
+
+        $token = '123-123-123';
+        $this->dataCache->contains($token)->willReturn(true);
+        $this->dataCache->fetch($token)->willReturn(get_class($object->reveal()) . "\n{\"title\": \"test\"}");
+        $this->dataCache->save($token, get_class($object->reveal()) . "\n{\"title\": \"SULU\"}", $this->cacheLifeTime)
+            ->shouldBeCalled();
+
+        $provider = $this->prophesize(PreviewObjectProviderInterface::class);
+        $provider->deserialize('{"title": "test"}', get_class($object->reveal()))->willReturn($object->reveal());
+        $provider->setValues($object->reveal(), 'de', ['title' => 'SULU'])->shouldBeCalled();
+        $provider->serialize($object->reveal())->willReturn('{"title": "SULU"}');
+        $provider->getId($object->reveal())->willReturn(1);
+
+        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', true, null)
+            ->willReturn('<a property="title" href="/test">SULU</a>');
+
+        $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
+        $changes = $preview->update($token, 'sulu_io', 'de', ['title' => 'SULU']);
+
+        $this->assertEquals(['title' => [['property' => 'title', 'href' => '#', 'html' => 'SULU']]], $changes);
+    }
+
     public function testUpdateNoData()
     {
         $preview = $this->getPreview();
@@ -244,6 +269,42 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<html><body><h1 property="title">SULU</h1></html></body>', $response);
     }
 
+    public function testUpdateContextWithLink()
+    {
+        $object = $this->prophesize(\stdClass::class);
+        $newObject = $this->prophesize(\stdClass::class);
+
+        $token = '123-123-123';
+        $this->dataCache->contains($token)->willReturn(true);
+        $this->dataCache->fetch($token)->willReturn(get_class($object->reveal()) . "\n{\"title\": \"test\"}");
+        $this->dataCache->save($token, get_class($newObject->reveal()) . "\n{\"title\": \"SULU\"}", $this->cacheLifeTime)
+            ->shouldBeCalled();
+
+        $provider = $this->prophesize(PreviewObjectProviderInterface::class);
+        $provider->deserialize('{"title": "test"}', get_class($object->reveal()))->willReturn($object->reveal());
+        $provider->setContext($object->reveal(), 'de', ['template' => 'test-template'])
+            ->shouldBeCalled()->willReturn($newObject->reveal());
+        $provider->setValues($newObject->reveal(), 'de', ['title' => 'SULU'])->shouldBeCalled();
+        $provider->serialize($newObject->reveal())->willReturn('{"title": "SULU"}');
+        $provider->getId($newObject->reveal())->willReturn(1);
+
+        $this->renderer->render($newObject->reveal(), 1, 'sulu_io', 'de', false, null)
+            ->willReturn('<html><body><a property="title" href="/test">SULU</a></html></body>');
+
+        $preview = $this->getPreview(
+            [get_class($object->reveal()) => $provider, get_class($newObject->reveal()) => $provider]
+        );
+        $response = $preview->updateContext(
+            $token,
+            'sulu_io',
+            'de',
+            ['template' => 'test-template'],
+            ['title' => 'SULU']
+        );
+
+        $this->assertEquals('<html><body><a property="title" href="#">SULU</a></html></body>', $response);
+    }
+
     public function testUpdateContextNoContext()
     {
         $object = $this->prophesize(\stdClass::class);
@@ -269,6 +330,33 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals('<html><body><h1 property="title">SULU</h1></html></body>', $response);
+    }
+
+    public function testUpdateContextNoContextWithLink()
+    {
+        $object = $this->prophesize(\stdClass::class);
+
+        $token = '123-123-123';
+        $this->dataCache->contains($token)->willReturn(true);
+        $this->dataCache->fetch($token)->willReturn(get_class($object->reveal()) . "\n{\"title\": \"test\"}");
+
+        $provider = $this->prophesize(PreviewObjectProviderInterface::class);
+        $provider->deserialize('{"title": "test"}', get_class($object->reveal()))->willReturn($object->reveal());
+        $provider->getId($object->reveal())->willReturn(1);
+
+        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', false, null)
+            ->willReturn('<html><body><a property="title" href="/test">SULU</a></html></body>');
+
+        $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
+        $response = $preview->updateContext(
+            $token,
+            'sulu_io',
+            'de',
+            [],
+            ['title' => 'SULU']
+        );
+
+        $this->assertEquals('<html><body><a property="title" href="#">SULU</a></html></body>', $response);
     }
 
     public function testUpdateContextNoData()
@@ -362,6 +450,27 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         $response = $preview->render($token, 'sulu_io', 'de');
 
         $this->assertEquals('<h1 property="title">test</h1>', $response);
+    }
+
+    public function testRenderWithLink()
+    {
+        $object = $this->prophesize(\stdClass::class);
+
+        $token = '123-123-123';
+        $this->dataCache->contains($token)->willReturn(true);
+        $this->dataCache->fetch($token)->willReturn(get_class($object->reveal()) . "\n{\"title\": \"test\"}");
+
+        $provider = $this->prophesize(PreviewObjectProviderInterface::class);
+        $provider->deserialize('{"title": "test"}', get_class($object->reveal()))->willReturn($object->reveal());
+        $provider->getId($object->reveal())->willReturn(1);
+
+        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', false, null)
+            ->willReturn('<a property="title" href="/test">test</a>');
+
+        $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
+        $response = $preview->render($token, 'sulu_io', 'de');
+
+        $this->assertEquals('<a property="title" href="#">test</a>', $response);
     }
 
     public function testRenderWithTargetGroup()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR replaces links with `#` in preview.