### PR TITLE
Add a firewall to disable security for the PreviewKernel

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: security.yml }
+
 framework:
     session:
         storage_id: session.storage.mock_file

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/security.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/security.yml
@@ -1,0 +1,5 @@
+security:
+    firewalls:
+        preview:
+            pattern:  ^/
+            security: false


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes*
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a firewall for the `PreviewKernel`, to make sure the preview in the CMS can always show the page you're trying to edit/create.

#### Why?

The preview uses no URI so the access control in `app/config/website/security.yml` wont work as expected. This could lead to access denied exceptions while the editor should be able to see the page.

#### BC Breaks
This change as is right now would require the `app/config/website/security.yml` to contain the firewall `preview` which seems a bit weird.
