### PR TITLE
Preview voter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ CHANGELOG for Sulu
     * FEATURE     #3816 [All]                     Validate if grunt build was run for all bundles with circleci
     * BUGFIX      #3806 [All]                     Fix compatibility on lowest and fix appveyor
     * BUGFIX      #3351 [ContentBundle]           Fix spacing between rows and section in content template generation
-
+    * BUGFIX      #3901 [PreviewBundle]           Add a voter to allow the PreviewKernel to access all uris.
+    
 * 1.6.15 (2018-02-27)
     * HOTFIX      #3802 [ContentBundle]           Fixed XmlLoader internal flag
     * HOTFIX      #3796 [HttpCache]               Increased priority of update-response-subscriber 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -6,7 +6,7 @@ framework:
 
 services:
     sulu.preview.voter:
-        class: 'Sulu\Bundle\PreviewBundle\Security\PreviewVoter'
+        class: "Sulu\Bundle\PreviewBundle\Security\PreviewVoter"
         public: false
         tags:
-            - { name: security.voter }
+            - { name: "security.voter" }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -1,5 +1,15 @@
+parameters:
+    sulu.preview.voter_class: 'Sulu\Bundle\PreviewBundle\Security\PreviewVoter'
+
 framework:
     session:
         storage_id: session.storage.mock_file
     profiler:
         enabled: false
+
+services:
+    sulu.preview.voter:
+        class: '%sulu.preview.voter_class%'
+        public: false
+        tags:
+            - { name: security.voter }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -1,6 +1,3 @@
-parameters:
-    sulu.preview.voter_class: 'Sulu\Bundle\PreviewBundle\Security\PreviewVoter'
-
 framework:
     session:
         storage_id: session.storage.mock_file
@@ -9,7 +6,7 @@ framework:
 
 services:
     sulu.preview.voter:
-        class: '%sulu.preview.voter_class%'
+        class: 'Sulu\Bundle\PreviewBundle\Security\PreviewVoter'
         public: false
         tags:
             - { name: security.voter }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/config_preview.yml
@@ -6,7 +6,7 @@ framework:
 
 services:
     sulu.preview.voter:
-        class: "Sulu\Bundle\PreviewBundle\Security\PreviewVoter"
+        class: Sulu\Bundle\PreviewBundle\Security\PreviewVoter
         public: false
         tags:
-            - { name: "security.voter" }
+            - { name: security.voter }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -60,10 +60,6 @@
 
             <tag name="sulu.websocket.message.handler" dispatcher="admin" alias="sulu_preview.preview"/>
         </service>
-
-        <service id="sulu_preview.preview.voter" class="Sulu\Bundle\PreviewBundle\Security\PreviewVoter" public="false">
-            <tag name="security.voter"/>
-        </service>
     </services>
 
 </container>

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -60,6 +60,10 @@
 
             <tag name="sulu.websocket.message.handler" dispatcher="admin" alias="sulu_preview.preview"/>
         </service>
+
+        <service id="sulu_preview.preview.voter" class="Sulu\Bundle\PreviewBundle\Security\PreviewVoter" public="false">
+            <tag name="security.voter"/>
+        </service>
     </services>
 
 </container>

--- a/src/Sulu/Bundle/PreviewBundle/Security/PreviewVoter.php
+++ b/src/Sulu/Bundle/PreviewBundle/Security/PreviewVoter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Security;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * A voter which disables security for the PreviewKernel.
+ */
+class PreviewVoter implements VoterInterface
+{
+    /**
+     * Checks if the voter supports the given attribute.
+     *
+     * @param string $attribute An attribute
+     *
+     * @return bool true if this Voter supports the attribute, false otherwise
+     */
+    public function supportsAttribute($attribute)
+    {
+        return true;
+    }
+
+    /**
+     * Checks if the voter supports the given class.
+     *
+     * @param string $class A class name
+     *
+     * @return bool true if this Voter can process the class
+     */
+    public function supportsClass($class)
+    {
+        return true;
+    }
+
+    /**
+     * Returns the vote for the given parameters.
+     *
+     * This method must return one of the following constants:
+     * ACCESS_GRANTED, ACCESS_DENIED, or ACCESS_ABSTAIN.
+     *
+     * @param TokenInterface $token      A TokenInterface instance
+     * @param object         $object     The object to secure
+     * @param array          $attributes An array of attributes associated with the method being invoked
+     *
+     * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     */
+    public function vote(TokenInterface $token, $object, array $attributes)
+    {
+        return VoterInterface::ACCESS_GRANTED;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no (?)
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a voter for the `PreviewKernel`, which allows all requests coming from the PreviewKernel

#### Why?

The preview uses no URI so the access control in `app/config/website/security.yml` wont work as expected. This could lead to access denied exceptions while the editor should be able to see the page he/she is trying to create / edit
