### PR TITLE
Fix bug in resourcemetadatamapper when block is in section

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
@@ -95,10 +95,10 @@ class ResourceMetadataMapper
         $section->setSize($property->getSize());
 
         foreach ($property->getChildren() as $component) {
-            if ($component instanceof PropertyMetadata) {
-                $item = $this->mapProperty($component, $locale);
-            } elseif ($component instanceof BlockMetadata) {
+            if ($component instanceof BlockMetadata) {
                 $item = $this->mapBlock($component, $locale);
+            } elseif ($component instanceof PropertyMetadata) {
+                $item = $this->mapProperty($component, $locale);
             } else {
                 throw new \Exception('Unsupported property given "' . get_class($property) . '"');
             }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
@@ -203,7 +203,13 @@ class ResourceMetadataMapperTest extends \PHPUnit_Framework_TestCase
         $section = $form->getItems()['sectiontest'];
         $this->assertSame('sectiontest', $section->getName());
         $this->assertSame('Section Title', $section->getLabel());
-        $this->assertCount(3, $section->getItems());
+        $this->assertCount(4, $section->getItems());
+        $this->assertArrayHasKey('test1', $section->getItems());
+        $this->assertArrayHasKey('test2', $section->getItems());
+        $this->assertArrayHasKey('test3', $section->getItems());
+        $this->assertArrayHasKey('blocktest', $section->getItems());
+        $this->assertInstanceOf(Field::class, $section->getItems()['blocktest']);
+        $this->assertCount(2, $section->getItems()['blocktest']->getTypes());
     }
 
     private function getProperties(string $type): array
@@ -295,6 +301,7 @@ class ResourceMetadataMapperTest extends \PHPUnit_Framework_TestCase
         $section->addChild($property1);
         $section->addChild($property2);
         $section->addChild($property3);
+        $section->addChild($block);
 
         switch ($type) {
             case 'properties':


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Bugfix in `ResourceMetadataMapper` when block is in section.

#### Why?

Fronted crashes when it's not valid.
