### PR TITLE
Set media old versioning canonical and noindex headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * FEATURE     #3905 [MediaBundle]             Add canonical and robots noIndex headers to download of old versions 
     * ENHANCEMENT #3884 [ContentBundle]           Improved developer-experience when overriding content-teaser-provider
     * ENHANCEMENT #3897 [ContentBundle]           SEO title length changed from 55 to 70
     * HOTFIX      #3870 [Husky]                   Updated husky to fix bug with thumbnails in datagrid

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -865,13 +865,11 @@ class Media extends ApiWrapper
             } else {
                 $version = $file->getVersion();
             }
-            /** @var FileVersion $fileVersion */
-            foreach ($file->getFileVersions() as $fileVersion) {
-                if ($fileVersion->getVersion() == $version) {
-                    $this->fileVersion = $fileVersion;
 
-                    return $fileVersion;
-                }
+            if ($fileVersion = $file->getFileVersion($version)) {
+                $this->fileVersion = $fileVersion;
+
+                return $fileVersion;
             }
             break; // currently only one file per media exists
         }
@@ -898,7 +896,7 @@ class Media extends ApiWrapper
             return $this->file;
         }
 
-        throw new FileNotFoundException($this->entity->getId(), $this->version);
+        throw new FileNotFoundException($this->entity->getId());
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Entity/File.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/File.php
@@ -164,11 +164,30 @@ class File implements AuditableInterface
     /**
      * Get fileVersions.
      *
-     * @return FileVersion[]
+     * @return DoctrineCollection|FileVersion[]
      */
     public function getFileVersions()
     {
         return $this->fileVersions;
+    }
+
+    /**
+     * Get file version.
+     *
+     * @param int $version
+     *
+     * @return FileVersion|null
+     */
+    public function getFileVersion($version)
+    {
+        /** @var FileVersion $fileVersion */
+        foreach ($this->fileVersions as $fileVersion) {
+            if ($fileVersion->getVersion() === $version) {
+                return $fileVersion;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -178,14 +197,7 @@ class File implements AuditableInterface
      */
     public function getLatestFileVersion()
     {
-        /** @var FileVersion $fileVersion */
-        foreach ($this->fileVersions as $fileVersion) {
-            if ($fileVersion->getVersion() === $this->getVersion()) {
-                return $fileVersion;
-            }
-        }
-
-        return;
+        return $this->getFileVersion($this->version);
     }
 
     /**
@@ -205,7 +217,7 @@ class File implements AuditableInterface
     /**
      * Get media.
      *
-     * @return Media
+     * @return MediaInterface
      */
     public function getMedia()
     {

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -349,15 +349,7 @@ class MediaManager implements MediaManagerInterface
 
         $version = $file->getVersion();
 
-        $currentFileVersion = null;
-
-        foreach ($file->getFileVersions() as $fileVersion) {
-            /** @var FileVersion $fileVersion */
-            if ($version == $fileVersion->getVersion()) {
-                $currentFileVersion = $fileVersion;
-                break;
-            }
-        }
+        $currentFileVersion = $file->getFileVersion($version);
 
         if (!$currentFileVersion) {
             throw new FileVersionNotFoundException($mediaEntity->getId(), $version);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -344,7 +344,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
 
         $fileVersion = $this->prophesize(FileVersion::class);
         $fileVersion->getVersion()->willReturn(1);
-        $file->getFileVersions()->willReturn([$fileVersion]);
+        $file->getFileVersion(1)->willReturn($fileVersion->reveal());
 
         $this->typeManager->getMediaType('img')->willReturn(2);
 
@@ -368,6 +368,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $fileVersion->getProperties()->willReturn([]);
         $fileVersion->getFocusPointX()->willReturn(null);
         $fileVersion->getFocusPointY()->willReturn(null);
+        $file->getFileVersion(1)->willReturn($fileVersion->reveal());
         $file->getFileVersions()->willReturn([$fileVersion->reveal()]);
         $file->getVersion()->willReturn(1);
         $media->getFiles()->willReturn([$file->reveal()]);
@@ -403,6 +404,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $fileVersion->getProperties()->willReturn([]);
         $fileVersion->getFocusPointX()->willReturn(1);
         $fileVersion->getFocusPointY()->willReturn(2);
+        $file->getFileVersion(1)->willReturn($fileVersion->reveal());
         $file->getFileVersions()->willReturn([$fileVersion->reveal()]);
         $file->getVersion()->willReturn(1);
         $media->getFiles()->willReturn([$file->reveal()]);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add a canonical tag to the media to link to the new version and set media to noindex.

#### Why?

That old media are not longer indexed by search engines.

#### TODO

 - [x] Changelog
 - [x] Tests