### PR TITLE
Fixed content-query when a child is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3912 [ContentBundle]           Fixed content-query when a child is broken
     * FEATURE     #3905 [MediaBundle]             Add canonical and robots noIndex headers to download of old versions 
     * ENHANCEMENT #3884 [ContentBundle]           Improved developer-experience when overriding content-teaser-provider
     * ENHANCEMENT #3897 [ContentBundle]           SEO title length changed from 55 to 70

--- a/src/Sulu/Component/Content/Repository/Content.php
+++ b/src/Sulu/Component/Content/Repository/Content.php
@@ -270,6 +270,14 @@ class Content implements \ArrayAccess
     }
 
     /**
+     * @return bool
+     */
+    public function isBrokenTemplate()
+    {
+        return $this->brokenTemplate;
+    }
+
+    /**
      * @return array
      */
     public function getPermissions()

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -126,13 +126,14 @@ class ContentRepository implements ContentRepositoryInterface
         );
         $this->appendMapping($queryBuilder, $mapping, $locale, $locales);
 
-        $rows = $queryBuilder->execute();
+        $queryResult = $queryBuilder->execute();
 
-        if (1 !== count(iterator_to_array($rows->getRows()))) {
+        $rows = iterator_to_array($queryResult->getRows());
+        if (1 !== count($rows)) {
             throw new ItemNotFoundException();
         }
 
-        return $this->resolveContent($rows->getRows()->current(), $locale, $locales, $mapping, $user);
+        return $this->resolveContent(current($rows), $locale, $locales, $mapping, $user);
     }
 
     /**
@@ -792,7 +793,7 @@ class ContentRepository implements ContentRepositoryInterface
         }
 
         $structure = $this->structureManager->getStructure($template);
-        if (!$structure->hasTag('sulu.rlp')) {
+        if (!$structure || !$structure->hasTag('sulu.rlp')) {
             return;
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Repository/ContentRepositoryTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Tests\Unit\Repository;
+
+use Jackalope\Query\Row;
+use PHPCR\Query\QOM\ChildNodeInterface;
+use PHPCR\Query\QOM\ColumnInterface;
+use PHPCR\Query\QOM\ComparisonInterface;
+use PHPCR\Query\QOM\OrderingInterface;
+use PHPCR\Query\QOM\PropertyValueInterface;
+use PHPCR\Query\QOM\QueryObjectModelFactoryInterface;
+use PHPCR\Query\QOM\SelectorInterface;
+use PHPCR\Query\QOM\StaticOperandInterface;
+use PHPCR\Query\QueryInterface;
+use PHPCR\Query\QueryManagerInterface;
+use PHPCR\Query\QueryResultInterface;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
+use Prophecy\Argument;
+use Sulu\Component\Content\Compat\LocalizationFinderInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
+use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Sulu\Component\Content\Document\RedirectType;
+use Sulu\Component\Content\Document\WorkflowStage;
+use Sulu\Component\Content\Repository\ContentRepository;
+use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
+use Sulu\Component\Util\SuluNodeHelper;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+
+class ContentRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var SessionManagerInterface
+     */
+    private $sessionManager;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    /**
+     * @var LocalizationFinderInterface
+     */
+    private $localizationFinder;
+
+    /**
+     * @var StructureManagerInterface
+     */
+    private $structureManager;
+
+    /**
+     * @var SuluNodeHelper
+     */
+    private $nodeHelper;
+
+    /**
+     * @var ContentRepository
+     */
+    private $contentRepository;
+
+    /**
+     * @var QueryInterface
+     */
+    private $query;
+
+    public function setUp()
+    {
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->sessionManager = $this->prophesize(SessionManagerInterface::class);
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->localizationFinder = $this->prophesize(LocalizationFinderInterface::class);
+        $this->structureManager = $this->prophesize(StructureManagerInterface::class);
+        $this->nodeHelper = $this->prophesize(SuluNodeHelper::class);
+
+        $webspace = $this->prophesize(Webspace::class);
+        $this->webspaceManager->findWebspaceByKey(Argument::any())->willReturn($webspace->reveal());
+        $webspace->getAllLocalizations()->willReturn(
+            [
+                new Localization('de', 'at'),
+            ]
+        );
+
+        $this->sessionManager->getSession()->willReturn($this->session->reveal());
+
+        $workspace = $this->prophesize(WorkspaceInterface::class);
+        $this->session->getWorkspace()->willReturn($workspace->reveal());
+
+        $queryManager = $this->prophesize(QueryManagerInterface::class);
+        $workspace->getQueryManager()->willReturn($queryManager);
+
+        $qomFactory = $this->prophesize(QueryObjectModelFactoryInterface::class);
+        $queryManager->getQOMFactory()->willReturn($qomFactory);
+
+        $this->contentRepository = new ContentRepository(
+            $this->sessionManager->reveal(),
+            $this->propertyEncoder->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->localizationFinder->reveal(),
+            $this->structureManager->reveal(),
+            $this->nodeHelper->reveal()
+        );
+
+        $qomFactory->selector(Argument::cetera())->willReturn($this->prophesize(SelectorInterface::class)->reveal());
+        $qomFactory->column(Argument::cetera())->willReturn($this->prophesize(ColumnInterface::class)->reveal());
+        $qomFactory->propertyValue(Argument::cetera())->willReturn(
+            $this->prophesize(PropertyValueInterface::class)->reveal()
+        );
+        $qomFactory->ascending(Argument::cetera())->willReturn($this->prophesize(OrderingInterface::class)->reveal());
+        $qomFactory->literal(Argument::cetera())->willReturn(
+            $this->prophesize(StaticOperandInterface::class)->reveal()
+        );
+        $qomFactory->comparison(Argument::cetera())->willReturn(
+            $this->prophesize(ComparisonInterface::class)->reveal()
+        );
+        $qomFactory->childNode(Argument::cetera())->willReturn($this->prophesize(ChildNodeInterface::class)->reveal());
+
+        $structure = $this->prophesize(StructureInterface::class);
+        $this->structureManager->getStructures('page')->willReturn([$structure->reveal()]);
+        $this->structureManager->getStructure('test')->willReturn($structure->reveal());
+
+        $this->query = $this->prophesize(QueryInterface::class);
+        $this->query->setLimit(Argument::any())->willReturn(null);
+        $qomFactory->createQuery(Argument::cetera())->willReturn($this->query->reveal());
+    }
+
+    public function testFindWithBrokenTemplate()
+    {
+        $mapping = MappingBuilder::create()->setResolveUrl(true)->getMapping();
+
+        $queryResult = $this->prophesize(QueryResultInterface::class);
+        $this->query->execute()->willReturn($queryResult->reveal());
+
+        $row = $this->prophesize(Row::class);
+        $rowIterator = new \ArrayIterator([$row->reveal()]);
+        $queryResult->getRows()->willReturn($rowIterator);
+
+        $row->getPath()->willReturn('/cmf/sulu_io/contents');
+        $this->nodeHelper->extractWebspaceFromPath('/cmf/sulu_io/contents')->willReturn('sulu_io');
+
+        $row->getValues()->willReturn(
+            [
+                'node.deTemplate' => 'default',
+                'shadowOn' => false,
+                'node.deShadow_on' => false,
+            ]
+        );
+        $row->getValue('node.deShadow_on')->willReturn(false);
+        $row->getValue('shadowOn')->willReturn(false);
+        $row->getValue('nodeType')->willReturn(RedirectType::NONE);
+        $row->getValue('uuid')->willReturn('123-123-123');
+        $row->getValue('state')->willReturn(WorkflowStage::PUBLISHED);
+        $row->getValue('nodeType')->willReturn(1);
+        $row->getValue('deTemplate')->willReturn('default');
+        $row->getValue('deDeState')->willReturn(WorkflowStage::PUBLISHED);
+        $row->getValue('de_atDe_atState')->willReturn(WorkflowStage::TEST);
+
+        $this->sessionManager->getContentPath('sulu_io')->willReturn('/cmf/sulu_io/contents');
+
+        $this->structureManager->getStructure('default')->willReturn(null);
+
+        $result = $this->contentRepository->find('123-123-123', 'de', 'sulu_io', $mapping);
+
+        $this->assertTrue($result->isBrokenTemplate());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes an issue for following scenario:

![image](https://user-images.githubusercontent.com/1464615/38861161-2a61479c-4232-11e8-9d26-13901fc14cfb.png)

When clicking on the parent-page the query fails because the child has no structure.