### PR TITLE
WIP: Fix cascading in media entities for removing multiple medias

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/BaseCollection.orm.xml
@@ -8,6 +8,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="style" type="string" column="style" length="255" nullable="true"/>
         <field name="lft" type="integer" column="lft">
             <gedmo:tree-left/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Collection.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Collection.orm.xml
@@ -12,23 +12,31 @@
 
             <join-column name="idCollectionsMetaDefault" referenced-column-name="id" nullable="true" on-delete="CASCADE" />
         </one-to-one>
+
         <one-to-many field="meta" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionMeta" mapped-by="collection">
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-many>
-        <one-to-many field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface" mapped-by="collection"/>
+
+        <one-to-many field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface" mapped-by="collection">
+            <cascade>
+                <cascade-remove />
+            </cascade>
+        </one-to-many>
+
         <one-to-many field="children" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface" mapped-by="parent">
             <order-by>
                 <order-by-field name="id" direction="ASC"/>
             </order-by>
         </one-to-many>
+
         <many-to-one field="parent" target-entity="Sulu\Bundle\MediaBundle\Entity\Collection" inversed-by="children">
             <join-columns>
                 <join-column name="idCollectionsParent" referenced-column-name="id" on-delete="SET NULL" />
             </join-columns>
+
             <gedmo:tree-parent/>
         </many-to-one>
-
     </entity>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionMeta.orm.xml
@@ -11,9 +11,11 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="title" type="string" column="title" length="255"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="locale" type="string" column="locale" length="5"/>
+
         <many-to-one field="collection" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface" inversed-by="meta">
             <join-columns>
                 <join-column name="idCollections" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionType.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/CollectionType.orm.xml
@@ -9,6 +9,7 @@
         <field name="name" type="string" column="name" length="255"/>
         <field name="key" type="string" column="collection_type_key" length="255" unique="true" nullable="true"/>
         <field name="description" type="text" column="description" nullable="true"/>
+
         <one-to-many field="collections" target-entity="Sulu\Bundle\MediaBundle\Entity\CollectionInterface"
                      mapped-by="type"/>
     </entity>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/File.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/File.orm.xml
@@ -11,17 +11,19 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="version" type="integer" column="version"/>
+
         <one-to-many field="fileVersions" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" mapped-by="file">
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-many>
+
         <many-to-one field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface" inversed-by="files">
             <join-columns>
                 <join-column name="idMedia" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
             </join-columns>
         </many-to-one>
-
     </entity>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersion.orm.xml
@@ -14,6 +14,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="name" type="string" column="name" length="255" />
         <field name="version" type="integer" column="version" />
         <field name="subVersion" type="integer" column="subVersion">
@@ -42,22 +43,22 @@
         </one-to-one>
         <one-to-many field="contentLanguages" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersionContentLanguage" mapped-by="fileVersion">
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-many>
         <one-to-many field="publishLanguages" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersionPublishLanguage" mapped-by="fileVersion">
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-many>
         <one-to-many field="meta" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersionMeta" mapped-by="fileVersion">
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-many>
         <one-to-many field="formatOptions" target-entity="Sulu\Bundle\MediaBundle\Entity\FormatOptions" index-by="formatKey" mapped-by="fileVersion">
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-many>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionContentLanguage.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionContentLanguage.orm.xml
@@ -8,12 +8,13 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="locale" type="string" column="locale" length="5" />
+
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="contentLanguages">
             <join-columns>
                 <join-column name="idFileVersions" referenced-column-name="id" on-delete="CASCADE" />
             </join-columns>
         </many-to-one>
-
     </entity>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
@@ -13,6 +13,7 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="title" type="string" column="title" length="255"/>
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="copyright" type="text" column="copyright" nullable="true"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionPublishLanguage.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionPublishLanguage.orm.xml
@@ -4,16 +4,16 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="Sulu\Bundle\MediaBundle\Entity\FileVersionPublishLanguage" table="me_file_version_publish_languages">
-
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="locale" type="string" column="locale" length="5" />
+
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="publishLanguages">
             <join-columns>
                 <join-column name="idFileVersions" referenced-column-name="id" on-delete="CASCADE" />
             </join-columns>
         </many-to-one>
-
     </entity>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/Media.orm.xml
@@ -14,9 +14,13 @@
             <generator strategy="AUTO"/>
         </id>
 
+        <one-to-one field="previewImage" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface">
+            <join-column name="idPreviewImage" referenced-column-name="id"/>
+        </one-to-one>
+
         <one-to-many field="files" target-entity="Sulu\Bundle\MediaBundle\Entity\File" mapped-by="media">
             <cascade>
-                <cascade-persist />
+                <cascade-all/>
             </cascade>
         </one-to-many>
 
@@ -30,9 +34,5 @@
                 <join-column name="idMediaTypes" referenced-column-name="id" nullable="false"/>
             </join-columns>
         </many-to-one>
-
-        <one-to-one field="previewImage" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface">
-            <join-column name="idPreviewImage" referenced-column-name="id"/>
-        </one-to-one>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/MediaType.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/MediaType.orm.xml
@@ -10,8 +10,10 @@
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="name" type="string" column="name" length="255"/>
         <field name="description" type="text" column="description" nullable="true"/>
+
         <one-to-many field="media" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface"
                      mapped-by="type"/>
     </entity>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/SuluFormBundle/pull/158
| License | MIT

#### What's in this PR?

It add the cascade all to the media entities correctly.

Cascade-all does:
  - cascade-persist
  - cascade-remove
  - cascade-merge
  - cascade-detach

and this is mostly needed for all child elements of the media entity.

#### Why?

For example:

```php
$mediaManager->delete(1);
$mediaManager->delete(2);
```

Throws an error as only the Media entity is removed from memory and not the File and the File has still a relation to the Media. Else it throws 

`A new entity was found through the relationship 'Sulu\Bundle\MediaBundle\Entity\File#media' that was not configured to cascade persist operations for entity: . To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"})`

#### Example Usage

```php
$mediaManager->delete(1);
$mediaManager->delete(2);
```

