### PR TITLE
Fix api ContactLocale constructor typehint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * 1.5.13 (2018-04-23)
+    * BUGFIX      #3915 [ContactBundle]         Fix typehint in api ContactLocale constructor
     * BUGFIX      #3918 [RestComponent]         CSV Export: Fixed serialization of boolean
     * ENHANCEMENT #3876 [ContentBundle]         Reload data when changing template  
 

--- a/src/Sulu/Bundle/ContactBundle/Api/ContactLocale.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/ContactLocale.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ContactBundle\Api;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
+use Sulu\Bundle\ContactBundle\Entity\ContactLocale as ContactLocaleEntity;
 use Sulu\Component\Rest\ApiWrapper;
 
 /**
@@ -24,9 +25,9 @@ use Sulu\Component\Rest\ApiWrapper;
 class ContactLocale extends ApiWrapper
 {
     /**
-     * @param ContactLocale $contactLocale
+     * @param ContactLocaleEntity $contactLocale
      */
-    public function __construct(self $contactLocale)
+    public function __construct(ContactLocaleEntity $contactLocale)
     {
         $this->entity = $contactLocale;
     }
@@ -48,7 +49,7 @@ class ContactLocale extends ApiWrapper
      *
      * @param string $locale
      *
-     * @return ContactLocale
+     * @return $this
      */
     public function setLocale($locale)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix api ContactLocale constructor typehint.

#### Why?

Currently the false class is set in the contactLocale constructor.
