### PR TITLE
Feature Sulu Snippet Load By Type

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -66,6 +66,13 @@
             <tag name="twig.extension"/>
         </service>
 
+        <service id="sulu_snippet.twig.type_snippet" class="Sulu\Bundle\SnippetBundle\Twig\SnippetTypeTwigExtension">
+            <argument type="service" id="sulu_snippet.repository"/>
+            <argument type="service" id="sulu_core.webspace.request_analyzer"/>
+
+            <tag name="twig.extension"/>
+        </service>
+
         <service id="sulu_snippet.form.snippet" class="%sulu_snippet.form.snippet.class%">
             <tag name="form.type"/>
         </service>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetTypeTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetTypeTwigExtensionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Twig;
+
+use Sulu\Bundle\SnippetBundle\Snippet\SnippetRepository;
+use Sulu\Bundle\SnippetBundle\Twig\SnippetTypeTwigExtension;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+class SnippetTypeTwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SnippetRepository
+     */
+    private $snippetRepository;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    public function testLoadByType()
+    {
+        $this->snippetRepository = $this->prophesize(SnippetRepository::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $twigExtension = new SnippetTypeTwigExtension(
+            $this->snippetRepository->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $snippets = $twigExtension->loadByType('car', 'de');
+
+//        $this->assertEquals(
+//            ['title' => 'test-title'],
+//            $snippets[0]['title']
+//        );
+    }
+
+    public function testLoadByTypeNotExist()
+    {
+        $this->snippetRepository = $this->prophesize(SnippetRepository::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $twigExtension = new SnippetTypeTwigExtension(
+            $this->snippetRepository->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $this->assertEquals([], $twigExtension->loadByType('test', 'de'));
+    }
+
+    public function testLoadByTypeOtherLocale()
+    {
+        $this->snippetRepository = $this->prophesize(SnippetRepository::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $twigExtension = new SnippetTypeTwigExtension(
+            $this->snippetRepository->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+
+        $snippets = $twigExtension->loadByType('car', 'en');
+
+//        $this->assertEquals(
+//            ['title' => 'Test Snippet EN'],
+//            $snippets[0]['title']
+//        );
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTypeTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTypeTwigExtension.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\Twig;
+
+use Sulu\Bundle\SnippetBundle\Snippet\SnippetRepository;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+
+/**
+ * Provides global snippets by type.
+ */
+class SnippetTypeTwigExtension extends \Twig_Extension
+{
+    /**
+     * @var SnippetRepository
+     */
+    private $snippetRepository;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @param SnippetRepository $snippetRepository
+     * @param RequestAnalyzerInterface $requestAnalyzer
+     */
+    public function __construct(SnippetRepository $snippetRepository, RequestAnalyzerInterface $requestAnalyzer)
+    {
+        $this->snippetRepository = $snippetRepository;
+        $this->requestAnalyzer = $requestAnalyzer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('sulu_snippet_load_by_type', [$this, 'loadByType']),
+        ];
+    }
+
+    /**
+     * Load global snippets by type.
+     *
+     * @param string type
+     * @param string $locale
+     *
+     * @return array
+     */
+    public function loadByType($type, $locale = null)
+    {
+        // ensure locale
+        if (null === $locale) {
+            $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        }
+
+        // practical helper
+        $helper = [];
+
+        // get all snippets by their type
+        if ($snippets = $this->snippetRepository->getSnippets($locale, $type)) {
+            // convert snippet documents to array
+            foreach ($snippets as $snippet) {
+                $helper[] = $snippet->getStructure()->toArray();
+            }
+        }
+
+        return $helper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sulu_snippet.type';
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#376

#### What's in this PR?

A twig extension to load all snippets of a given type.

#### Why?

We use this to let a content editor edit and translate our React app contents.

#### Example Usage

~~~twig
        {% set snippets = sulu_snippet_load_by_type('foo') %}
        <script>
            window.translations = {
            {% for snippet in snippets %}
                {{ snippet.key }}:'{{ snippet.title }}'{{ not loop.last ? ','}}
            {% endfor %}
            }
        </script>
~~~