### PR TITLE
Add branch alias for 2.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,6 +184,9 @@
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"
+        },
+        "branch-alias": {
+            "dev-develop": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add [branch alias](https://getcomposer.org/doc/articles/aliases.md#branch-alias) for 2.0-dev. Inspired by [symfony](https://github.com/symfony/symfony/blob/master/composer.json#L134-L136)

#### Why?

To allow bundles require sulu on 2.0 dev.

#### Example Usage

1. set stability on dev
2. require sulu 2.0

