### PR TITLE
Fix profiler for none sulu routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* unrealeased
+    * BUGFIX      #3926 [WebsiteBundle]         Fix profiler for none sulu routes
+
 * 1.5.13 (2018-04-23)
     * BUGFIX      #3915 [ContactBundle]         Fix typehint in api ContactLocale constructor
     * BUGFIX      #3918 [RestComponent]         CSV Export: Fixed serialization of boolean

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
@@ -79,6 +79,7 @@
         </tbody>
     </table>
     <h2>Structure</h2>
+    {% if collector.data('structure') %}
     <table>
         <tbody>
             {{ self.table_row('id', collector.data('structure').id) }}
@@ -101,6 +102,9 @@
             {{ self.table_row('changed', collector.data('structure').changed.format('Y-m-d H:i:s')) }}
         </tbody>
     </table>
+    {% else %}
+        No structure was found.
+    {% endif %}
 {% endblock %}
 
 {% macro table_row(field, value) %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix profiler for none sulu routes.

#### Why?

Currently the profiler fails with the following message on none sulu routes:

> Impossible to access an attribute ("id") on a null variable.

![bildschirmfoto 2018-04-25 um 09 32 14](https://user-images.githubusercontent.com/1698337/39231824-a98d79ca-486b-11e8-9dee-f890a92d97d4.png)

