### PR TITLE
Add upgrade for HttpCache class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,6 +38,10 @@ Renamed following Methods:
 
 * Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface::count => Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface::countCollections
 
+Rename following classes:
+
+* Sulu\Component\HttpCache\HttpCache => Sulu\Bundle\HttpCacheBundle\Cache\AbstractHttpCache
+
 ### Contact temporarily position removed
 
 The `setCurrentPosition` function was removed from the contact entity as this position was only used temporarily and was not persisted to the database. Use the `setPosition` to set the contact main account position function instead.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add upgrade for httpcache class.

#### Why?

This class is common used for the `HEADER_REVERSE_PROXY_TTL` constant.

Before:

```php
HttpCache::HEADER_REVERSE_PROXY_TTL
```

after

```php
AbstractHttpCache::HEADER_REVERSE_PROXY_TTL
```

