### PR TITLE
Fixed preview style-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * ENHANCEMENT #3930 [PreviewBundle]           Fixed preview style-link
+
 * 1.6.17 (2018-04-23)
     * FEATURE     #3906 [MediaBundle]             Add file version delete to media overlay
     * HOTFIX      #3912 [ContentBundle]           Fixed content-query when a child is broken

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -169,7 +169,7 @@ class Preview implements PreviewInterface
      */
     protected function replaceLinks($html)
     {
-        return preg_replace('/(href|action)="[^"]*"/', '$1="#"', $html);
+        return preg_replace('/((?:a|form)(?:[^>]*)(?:href|action))="[^"]*"/', '$1="#"', $html);
     }
 
     /**

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -473,6 +473,61 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<a property="title" href="#">test</a>', $response);
     }
 
+    public function testRenderWithStyle()
+    {
+        $object = $this->prophesize(\stdClass::class);
+
+        $token = '123-123-123';
+        $this->dataCache->contains($token)->willReturn(true);
+        $this->dataCache->fetch($token)->willReturn(get_class($object->reveal()) . "\n{\"title\": \"test\"}");
+
+        $provider = $this->prophesize(PreviewObjectProviderInterface::class);
+        $provider->deserialize('{"title": "test"}', get_class($object->reveal()))->willReturn($object->reveal());
+        $provider->getId($object->reveal())->willReturn(1);
+
+        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', false, null)
+            ->willReturn('<link rel="stylesheet" type="text/css" href="theme.css">');
+
+        $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
+        $response = $preview->render($token, 'sulu_io', 'de');
+
+        $this->assertEquals('<link rel="stylesheet" type="text/css" href="theme.css">', $response);
+    }
+
+    public function testRenderWithMultipleTags()
+    {
+        $object = $this->prophesize(\stdClass::class);
+
+        $token = '123-123-123';
+        $this->dataCache->contains($token)->willReturn(true);
+        $this->dataCache->fetch($token)->willReturn(get_class($object->reveal()) . "\n{\"title\": \"test\"}");
+
+        $provider = $this->prophesize(PreviewObjectProviderInterface::class);
+        $provider->deserialize('{"title": "test"}', get_class($object->reveal()))->willReturn($object->reveal());
+        $provider->getId($object->reveal())->willReturn(1);
+
+        $this->renderer->render($object->reveal(), 1, 'sulu_io', 'de', false, null)
+            ->willReturn(
+                '<link rel="stylesheet" type="text/css" href="theme.css">' .
+                '<a property="title" href="/test">test</a>' .
+                '<a href="/test">test</a>' .
+                '<form action="/test"></form>' .
+                '<form class="form" action="/test"></form>'
+            );
+
+        $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
+        $response = $preview->render($token, 'sulu_io', 'de');
+
+        $this->assertEquals(
+            '<link rel="stylesheet" type="text/css" href="theme.css">' .
+            '<a property="title" href="#">test</a>' .
+            '<a href="#">test</a>' .
+            '<form action="#"></form>' .
+            '<form class="form" action="#"></form>',
+            $response
+        );
+    }
+
     public function testRenderWithTargetGroup()
     {
         $object = $this->prophesize(\stdClass::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a problem which was introduced by #3899. It replaces the `href` of style tags and destroys website styling in preview.
