### PR TITLE
Add sorting functionality in Datagrid with remembering the state

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
@@ -5,7 +5,7 @@ import type {ButtonConfig, SelectMode} from './types';
 import Row from './Row';
 
 type Props = {
-    children: ChildrenArray<Element<typeof Row>>,
+    children?: ChildrenArray<Element<typeof Row>>,
     /** @ignore */
     buttons?: Array<ButtonConfig>,
     /** @ignore */
@@ -19,7 +19,11 @@ export default class Body extends React.PureComponent<Props> {
         selectMode: 'none',
     };
 
-    cloneRows = (originalRows: ChildrenArray<Element<typeof Row>>) => {
+    cloneRows = (originalRows: ?ChildrenArray<Element<typeof Row>>) => {
+        if (!originalRows) {
+            return undefined;
+        }
+
         const {buttons, selectMode} = this.props;
         return React.Children.map(originalRows, (row, index) => React.cloneElement(
             row,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/HeaderCell.js
@@ -4,31 +4,29 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import tableStyles from './table.scss';
+import type {SortOrder} from './types';
 
 const ASCENDING_ICON = 'su-angle-up';
 const DESCENDING_ICON = 'su-angle-down';
 
-type Props = {
+type Props = {|
     children?: Node,
     className?: string,
+    name?: string,
     /** Called when column was clicked */
-    onClick?: () => void,
+    onClick?: (sortColumn: string, sortOrder: SortOrder) => void, // TODO extract order to own type file
     /** If set, an indicator will show up */
-    sortMode: 'none' | 'ascending' | 'descending',
-};
+    sortOrder?: ?SortOrder,
+|};
 
 export default class HeaderCell extends React.PureComponent<Props> {
-    static defaultProps = {
-        sortMode: 'none',
-    };
+    getSortOrderIcon = () => {
+        const {sortOrder} = this.props;
 
-    getSortModeIcon = () => {
-        const {sortMode} = this.props;
-
-        switch (sortMode) {
-            case 'ascending':
+        switch (sortOrder) {
+            case 'asc':
                 return (<Icon name={ASCENDING_ICON} className={tableStyles.headerCellSortIcon} />);
-            case 'descending':
+            case 'desc':
                 return (<Icon name={DESCENDING_ICON} className={tableStyles.headerCellSortIcon} />);
             default:
                 return null;
@@ -36,8 +34,9 @@ export default class HeaderCell extends React.PureComponent<Props> {
     };
 
     handleOnClick = () => {
-        if (this.props.onClick) {
-            this.props.onClick();
+        const {name, onClick, sortOrder} = this.props;
+        if (onClick && name) {
+            onClick(name, sortOrder === 'asc' ? 'desc' : 'asc');
         }
     };
 
@@ -65,7 +64,7 @@ export default class HeaderCell extends React.PureComponent<Props> {
                         onClick={this.handleOnClick}
                     >
                         <span>{children}</span>
-                        {this.getSortModeIcon()}
+                        {this.getSortOrderIcon()}
                     </button>
                 }
             </th>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
@@ -79,6 +79,11 @@ export default class Table extends React.Component<Props> {
 
     checkAllRowsSelected = (body: Element<typeof Body>) => {
         const rows = body.props.children;
+
+        if (!rows) {
+            return false;
+        }
+
         const rowSelections = React.Children.map(rows, (row) => row.props.selected);
 
         return !rowSelections.includes(false);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {render, mount} from 'enzyme';
 import React from 'react';
 import Table from '../Table';
@@ -8,7 +8,11 @@ import Row from '../Row';
 import Cell from '../Cell';
 import HeaderCell from '../HeaderCell';
 
-afterEach(() => document.body.innerHTML = '');
+afterEach(() => {
+    if (document.body) {
+        document.body.innerHTML = '';
+    }
+});
 
 test('Render the Table component', () => {
     expect(render(
@@ -44,7 +48,7 @@ test('Render an empty table', () => {
                 <HeaderCell>Column Title</HeaderCell>
                 <HeaderCell>Column Title</HeaderCell>
             </Header>
-            <Body></Body>
+            <Body />
         </Table>
     )).toMatchSnapshot();
 });
@@ -74,10 +78,10 @@ test('Render a table with buttons', () => {
 });
 
 test('Table buttons should implement an onClick handler', () => {
-    const onClickSpy = jest.fn();
+    const clickSpy = jest.fn();
     const buttons = [{
         icon: 'fa-pencil',
-        onClick: onClickSpy,
+        onClick: clickSpy,
     }];
 
     const table = mount(
@@ -97,9 +101,9 @@ test('Table buttons should implement an onClick handler', () => {
         </Table>
     );
 
-    expect(onClickSpy).toHaveBeenCalledTimes(0);
+    expect(clickSpy).toHaveBeenCalledTimes(0);
     table.find('.buttonCell button').simulate('click');
-    expect(onClickSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
 });
 
 test('Render the Table component in single selection mode', () => {
@@ -238,15 +242,27 @@ test('Clicking the select-all checkbox should call the onAllSelectionChange call
     expect(onChangeSpy).toHaveBeenCalledWith(true);
 });
 
-test('Header cells with an attacked onClick handler should be clickable', () => {
-    const onClickSpy = jest.fn();
+test('Header cells with a defined sortOrder must show a sort indicator', () => {
+    const clickSpy = jest.fn();
+
+    expect(render(
+        <Table>
+            <Header>
+                <HeaderCell onClick={clickSpy} sortOrder="asc">ColumnTitle</HeaderCell>
+                <HeaderCell onClick={clickSpy} sortOrder="desc">ColumnTitle</HeaderCell>
+                <HeaderCell>ColumnTitle</HeaderCell>
+            </Header>
+        </Table>
+    )).toMatchSnapshot();
+});
+
+test('Header cells with an attached onClick handler should be clickable', () => {
+    const clickSpy = jest.fn();
 
     const table = mount(
         <Table>
             <Header>
-                <HeaderCell onClick={onClickSpy}>
-                    Column Title
-                </HeaderCell>
+                <HeaderCell onClick={clickSpy} name="column1">Column Title</HeaderCell>
                 <HeaderCell>Column Title</HeaderCell>
                 <HeaderCell>Column Title</HeaderCell>
             </Header>
@@ -261,5 +277,35 @@ test('Header cells with an attacked onClick handler should be clickable', () => 
     );
 
     table.find('HeaderCell').at(0).find('button').simulate('click');
-    expect(onClickSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+});
+
+test('Header cells with an attached name should call the onClick callback with the name and the new sortOrder', () => {
+    const clickSpy = jest.fn();
+
+    const table = mount(
+        <Table>
+            <Header>
+                <HeaderCell onClick={clickSpy} name="column1">Column Title</HeaderCell>
+                <HeaderCell onClick={clickSpy} name="column2" sortOrder="asc">Column Title</HeaderCell>
+                <HeaderCell onClick={clickSpy} name="column3" sortOrder="desc">Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    );
+
+    table.find('HeaderCell').at(0).find('button').simulate('click');
+    expect(clickSpy).lastCalledWith('column1', 'asc');
+
+    table.find('HeaderCell').at(1).find('button').simulate('click');
+    expect(clickSpy).lastCalledWith('column2', 'desc');
+
+    table.find('HeaderCell').at(2).find('button').simulate('click');
+    expect(clickSpy).lastCalledWith('column3', 'asc');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Header cells with a defined sortOrder must show a sort indicator 1`] = `
+<div
+  class="tableContainer"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell clickable"
+        >
+          <button>
+            <span>
+              ColumnTitle
+            </span>
+            <span
+              aria-label="su-angle-up"
+              class="headerCellSortIcon su-angle-up"
+            />
+          </button>
+        </th>
+        <th
+          class="headerCell clickable"
+        >
+          <button>
+            <span>
+              ColumnTitle
+            </span>
+            <span
+              aria-label="su-angle-down"
+              class="headerCellSortIcon su-angle-down"
+            />
+          </button>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            ColumnTitle
+          </span>
+        </th>
+      </tr>
+    </thead>
+  </table>
+</div>
+`;
+
 exports[`Render a table with buttons 1`] = `
 <div
   class="tableContainer"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
@@ -1,6 +1,8 @@
 // @flow
 export type SelectMode = 'none' | 'single' | 'multiple';
 
+export type SortOrder = 'asc' | 'desc';
+
 export type ButtonConfig = {
     icon: string,
     onClick: (string | number) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -143,8 +143,8 @@ export default class Datagrid extends React.Component<Props> {
                         page={store.getPage()}
                         pageCount={store.pageCount}
                         schema={store.schema}
-                        sortColumn={store.sortColumn}
-                        sortOrder={store.sortOrder}
+                        sortColumn={store.sortColumn.get()}
+                        sortOrder={store.sortOrder.get()}
                         selections={store.selectionIds}
                     />
                 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -3,6 +3,7 @@ import {observer} from 'mobx-react';
 import {observable, action, computed} from 'mobx';
 import React, {Fragment} from 'react';
 import equal from 'fast-deep-equal';
+import type {SortOrder} from './types';
 import DatagridStore from './stores/DatagridStore';
 import datagridAdapterRegistry from './registries/DatagridAdapterRegistry';
 import AbstractAdapter from './adapters/AbstractAdapter';
@@ -77,6 +78,10 @@ export default class Datagrid extends React.Component<Props> {
         this.props.store.setPage(page);
     };
 
+    handleSort = (column: string, order: SortOrder) => {
+        this.props.store.sort(column, order);
+    };
+
     handleItemSelectionChange = (id: string | number, selected?: boolean) => {
         const {store} = this.props;
         const row = store.findById(id);
@@ -128,15 +133,18 @@ export default class Datagrid extends React.Component<Props> {
                         data={store.data}
                         disabledIds={disabledIds}
                         loading={store.loading}
+                        onAddClick={onAddClick}
                         onAllSelectionChange={selectable ? this.handleAllSelectionChange : undefined}
                         onItemActivation={this.handleItemActivation}
                         onItemClick={onItemClick}
                         onItemSelectionChange={selectable ? this.handleItemSelectionChange : undefined}
-                        onAddClick={onAddClick}
                         onPageChange={this.handlePageChange}
+                        onSort={this.handleSort}
                         page={store.getPage()}
                         pageCount={store.pageCount}
                         schema={store.schema}
+                        sortColumn={store.sortColumn}
+                        sortOrder={store.sortOrder}
                         selections={store.selectionIds}
                     />
                 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TableAdapter.js
@@ -54,13 +54,19 @@ export default class TableAdapter extends AbstractAdapter {
     }
 
     renderHeaderCells() {
+        const {sortColumn, sortOrder} = this.props;
         const schemaKeys = Object.keys(this.schema);
 
         return schemaKeys.map((schemaKey) => {
             const label = this.schema[schemaKey].label ? this.schema[schemaKey].label : schemaKey;
 
             return(
-                <Table.HeaderCell key={schemaKey}>
+                <Table.HeaderCell
+                    key={schemaKey}
+                    onClick={this.props.onSort}
+                    name={schemaKey}
+                    sortOrder={sortColumn === schemaKey ? sortOrder : undefined}
+                >
                     {label}
                 </Table.HeaderCell>
             );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -11,7 +11,7 @@ import type {
 import userStore from '../../../stores/UserStore';
 import metadataStore from './MetadataStore';
 
-const USER_SETTING_PREFIX = 'datagrid';
+const USER_SETTING_PREFIX = 'sulu_admin.datagrid';
 const USER_SETTING_SORT_COLUMN = 'sort_column';
 const USER_SETTING_SORT_ORDER = 'sort_order';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -1,6 +1,12 @@
 // @flow
 import {action, autorun, observable, computed} from 'mobx';
-import type {LoadingStrategyInterface, ObservableOptions, Schema, StructureStrategyInterface} from '../types';
+import type {
+    LoadingStrategyInterface,
+    ObservableOptions,
+    Schema,
+    SortOrder,
+    StructureStrategyInterface,
+} from '../types';
 import metadataStore from './MetadataStore';
 
 export default class DatagridStore {
@@ -12,6 +18,8 @@ export default class DatagridStore {
     @observable loadingStrategy: LoadingStrategyInterface;
     @observable structureStrategy: StructureStrategyInterface;
     @observable options: Object;
+    @observable sortColumn: string;
+    @observable sortOrder: SortOrder;
     disposer: () => void;
     resourceKey: string;
     schema: Schema = {};
@@ -120,6 +128,14 @@ export default class DatagridStore {
             options.parent = this.active;
         }
 
+        if (this.sortColumn) {
+            options.sortBy = this.sortColumn;
+        }
+
+        if (this.sortOrder) {
+            options.sortOrder = this.sortOrder;
+        }
+
         this.loadingStrategy.load(
             data,
             this.resourceKey,
@@ -149,6 +165,11 @@ export default class DatagridStore {
 
     @action setActive(active: ?string | number) {
         this.active = active;
+    }
+
+    @action sort(column: string, order: SortOrder) {
+        this.sortColumn = column;
+        this.sortOrder = order;
     }
 
     @action select(row: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -8,12 +8,7 @@ import type {
     SortOrder,
     StructureStrategyInterface,
 } from '../types';
-import userStore from '../../../stores/UserStore';
 import metadataStore from './MetadataStore';
-
-const USER_SETTING_PREFIX = 'sulu_admin.datagrid';
-const USER_SETTING_SORT_COLUMN = 'sort_column';
-const USER_SETTING_SORT_ORDER = 'sort_order';
 
 export default class DatagridStore {
     @observable pageCount: number = 0;
@@ -30,8 +25,6 @@ export default class DatagridStore {
     schema: Schema = {};
     observableOptions: ObservableOptions;
     sendRequestDisposer: () => void;
-    sortColumnDisposer: () => void;
-    sortOrderDisposer: () => void;
 
     constructor(
         resourceKey: string,
@@ -42,32 +35,13 @@ export default class DatagridStore {
         this.observableOptions = observableOptions;
         this.options = options;
 
-        this.sort(
-            userStore.getPersistentSetting(this.sortColumnSettingKey),
-            userStore.getPersistentSetting(this.sortOrderSettingKey)
-        );
-
         this.sendRequestDisposer = autorun(this.sendRequest);
-        this.sortColumnDisposer = autorun(
-            () => userStore.setPersistentSetting(this.sortColumnSettingKey, this.sortColumn.get())
-        );
-        this.sortOrderDisposer = autorun(
-            () => userStore.setPersistentSetting(this.sortOrderSettingKey, this.sortOrder.get())
-        );
 
         metadataStore.getSchema(this.resourceKey)
             .then(action((schema) => {
                 this.schema = schema;
                 this.schemaLoading = false;
             }));
-    }
-
-    get sortColumnSettingKey(): string {
-        return [USER_SETTING_PREFIX, this.resourceKey, USER_SETTING_SORT_COLUMN].join('.');
-    }
-
-    get sortOrderSettingKey(): string {
-        return [USER_SETTING_PREFIX, this.resourceKey, USER_SETTING_SORT_ORDER].join('.');
     }
 
     @computed get initialized(): boolean {
@@ -241,7 +215,5 @@ export default class DatagridStore {
 
     destroy() {
         this.sendRequestDisposer();
-        this.sortColumnDisposer();
-        this.sortOrderDisposer();
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -1,5 +1,6 @@
 // @flow
 import {action, autorun, observable, computed} from 'mobx';
+import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import type {
     LoadingStrategyInterface,
     ObservableOptions,
@@ -18,8 +19,8 @@ export default class DatagridStore {
     @observable loadingStrategy: LoadingStrategyInterface;
     @observable structureStrategy: StructureStrategyInterface;
     @observable options: Object;
-    @observable sortColumn: string;
-    @observable sortOrder: SortOrder;
+    sortColumn: IObservableValue<string> = observable.box();
+    sortOrder: IObservableValue<SortOrder> = observable.box();
     disposer: () => void;
     resourceKey: string;
     schema: Schema = {};
@@ -128,13 +129,8 @@ export default class DatagridStore {
             options.parent = this.active;
         }
 
-        if (this.sortColumn) {
-            options.sortBy = this.sortColumn;
-        }
-
-        if (this.sortOrder) {
-            options.sortOrder = this.sortOrder;
-        }
+        options.sortBy = this.sortColumn.get();
+        options.sortOrder = this.sortOrder.get();
 
         this.loadingStrategy.load(
             data,
@@ -168,8 +164,8 @@ export default class DatagridStore {
     }
 
     @action sort(column: string, order: SortOrder) {
-        this.sortColumn = column;
-        this.sortOrder = order;
+        this.sortColumn.set(column);
+        this.sortOrder.set(order);
     }
 
     @action select(row: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -42,8 +42,10 @@ export default class DatagridStore {
         this.observableOptions = observableOptions;
         this.options = options;
 
-        this.sortColumn.set(userStore.getPersistentSetting(this.sortColumnSettingKey));
-        this.sortOrder.set(userStore.getPersistentSetting(this.sortOrderSettingKey));
+        this.sort(
+            userStore.getPersistentSetting(this.sortColumnSettingKey),
+            userStore.getPersistentSetting(this.sortOrderSettingKey)
+        );
 
         this.sendRequestDisposer = autorun(this.sendRequest);
         this.sortColumnDisposer = autorun(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -14,6 +14,7 @@ import StringFieldTransformer from '../fieldTransformers/StringFieldTransformer'
 jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.setPage = jest.fn();
     this.setActive = jest.fn();
+    this.sort = jest.fn();
     this.updateStrategies = jest.fn();
     this.getPage = jest.fn().mockReturnValue(4);
     this.pageCount = 7;
@@ -192,6 +193,21 @@ test('Selecting and unselecting all items on current page should update store', 
     expect(datagridStore.selectEntirePage).toBeCalledWith();
     headerCheckbox.simulate('change', {currentTarget: {checked: false}});
     expect(datagridStore.deselectEntirePage).toBeCalledWith();
+});
+
+test('Clicking a header cell should sort the table', () => {
+    datagridAdapterRegistry.get.mockReturnValue(TableAdapter);
+    const datagridStore = new DatagridStore('test', {page: observable.box(1)});
+    datagridStore.structureStrategy.data = [
+        {id: 1},
+        {id: 2},
+        {id: 3},
+    ];
+    const datagrid = mount(<Datagrid adapters={['table']} store={datagridStore} />);
+
+    const headerCell = datagrid.find('th button').at(0);
+    headerCell.simulate('click');
+    expect(datagridStore.sort).toBeCalledWith('title', 'asc');
 });
 
 test('Switching the adapter should render the correct adapter', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -15,6 +15,12 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.setPage = jest.fn();
     this.setActive = jest.fn();
     this.sort = jest.fn();
+    this.sortColumn = {
+        get: jest.fn(),
+    };
+    this.sortOrder = {
+        get: jest.fn(),
+    };
     this.updateStrategies = jest.fn();
     this.getPage = jest.fn().mockReturnValue(4);
     this.pageCount = 7;
@@ -145,6 +151,18 @@ test('Pass the ids to be disabled to the adapter', () => {
     const datagrid = shallow(<Datagrid adapters={['test']} disabledIds={disabledIds} store={datagridStore} />);
 
     expect(datagrid.find('TestAdapter').prop('disabledIds')).toBe(disabledIds);
+});
+
+test('Pass sortColumn and sortOrder to adapter', () => {
+    const datagridStore = new DatagridStore('test', {page: observable.box(1)});
+    datagridStore.sortColumn.get.mockReturnValue('title');
+    datagridStore.sortOrder.get.mockReturnValue('asc');
+    const datagrid = shallow(<Datagrid adapters={['test']} store={datagridStore} />);
+
+    expect(datagrid.find('TestAdapter').props()).toEqual(expect.objectContaining({
+        sortColumn: 'title',
+        sortOrder: 'asc',
+    }));
 });
 
 test('Selecting and deselecting items should update store', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
@@ -49,10 +49,13 @@ test('Render data with edit button', () => {
             loading={false}
             onItemClick={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -87,10 +90,13 @@ test('Render data without edit button', () => {
             disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -126,10 +132,13 @@ test('Render data with selection', () => {
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[1]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -165,10 +174,13 @@ test('Render data with disabled items', () => {
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[1]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -186,10 +198,13 @@ test('Render with add button in toolbar when onAddClick callback is given', () =
             loading={false}
             onAddClick={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -223,10 +238,13 @@ test('Render data with loading column', () => {
             disabledIds={[]}
             loading={true}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -281,10 +299,13 @@ test('Execute onItemActivation callback when an item is clicked with the correct
             loading={false}
             onItemActivation={onItemActivationSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -323,10 +344,13 @@ test('Execute onItemSelectionChange callback when an item is selected', () => {
             loading={false}
             onItemSelectionChange={itemSelectionChangeSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={undefined}
             pageCount={0}
             schema={{}}
             selections={[2]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
@@ -36,10 +36,13 @@ test('Render a basic Folder list with data', () => {
             disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={2}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -75,10 +78,13 @@ test('Click on a Folder should call the onItemEdit callback', () => {
             loading={false}
             onItemClick={itemClickSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
     expect(folderAdapter.find('FolderList').get(0).props.onFolderClick).toBe(itemClickSpy);
@@ -91,10 +97,13 @@ test('Pagination should be passed correct props', () => {
             disabledIds={[]}
             loading={false}
             onPageChange={pageChangeSpy}
+            onSort={jest.fn()}
             page={2}
             pageCount={7}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
     expect(folderAdapter.find('Pagination').get(0).props).toEqual({

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
@@ -59,8 +59,11 @@ test('Render data with schema', () => {
             page={2}
             pageCount={5}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -110,8 +113,11 @@ test('Render data with all different visibility types schema', () => {
             page={2}
             pageCount={5}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -155,10 +161,13 @@ test('Render data with schema and selections', () => {
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[1, 3]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -196,10 +205,13 @@ test('Render data with schema in different order', () => {
             disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={2}
             pageCount={3}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -237,10 +249,13 @@ test('Render data with schema not containing all fields', () => {
             disabledIds={[]}
             loading={false}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -280,10 +295,91 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
             loading={false}
             onItemClick={rowEditClickSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
+        />
+    );
+
+    expect(tableAdapter).toMatchSnapshot();
+});
+
+test('Render column with ascending sort icon', () => {
+    const data = [
+        {
+            id: 1,
+            title: 'Title 1',
+            description: 'Description 1',
+        },
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            type: 'string',
+            visibility: 'yes',
+        },
+        description: {
+            label: 'Description',
+            type: 'string',
+            visibility: 'yes',
+        },
+    };
+    const tableAdapter = render(
+        <TableAdapter
+            data={data}
+            disabledIds={[]}
+            loading={false}
+            onPageChange={jest.fn()}
+            onSort={jest.fn()}
+            page={1}
+            pageCount={3}
+            schema={schema}
+            selections={[]}
+            sortColumn="title"
+            sortOrder="asc"
+        />
+    );
+
+    expect(tableAdapter).toMatchSnapshot();
+});
+
+test('Render column with descending sort icon', () => {
+    const data = [
+        {
+            id: 1,
+            title: 'Title 1',
+            description: 'Description 1',
+        },
+    ];
+    const schema = {
+        title: {
+            label: 'Title',
+            type: 'string',
+            visibility: 'yes',
+        },
+        description: {
+            label: 'Description',
+            type: 'string',
+            visibility: 'yes',
+        },
+    };
+    const tableAdapter = render(
+        <TableAdapter
+            data={data}
+            disabledIds={[]}
+            loading={false}
+            onPageChange={jest.fn()}
+            onSort={jest.fn()}
+            page={1}
+            pageCount={3}
+            schema={schema}
+            selections={[]}
+            sortColumn="description"
+            sortOrder="desc"
         />
     );
 
@@ -323,10 +419,13 @@ test('Click on pencil should execute onItemEdit callback', () => {
             loading={false}
             onItemClick={rowEditClickSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
     const buttons = tableAdapter.find('Table').prop('buttons');
@@ -370,10 +469,13 @@ test('Click on checkbox should call onItemSelectionChange callback', () => {
             loading={false}
             onItemSelectionChange={rowSelectionChangeSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -397,10 +499,13 @@ test('Click on checkbox in header should call onAllSelectionChange callback', ()
             loading={false}
             onAllSelectionChange={allSelectionChangeSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -414,10 +519,13 @@ test('Pagination should be passed correct props', () => {
             disabledIds={[]}
             loading={false}
             onPageChange={pageChangeSpy}
+            onSort={jest.fn()}
             page={2}
             pageCount={7}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
     expect(tableAdapter.find('Pagination').get(0).props).toEqual({

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -1,5 +1,193 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render column with ascending sort icon 1`] = `
+<section>
+  <div
+    class="tableContainer"
+  >
+    <table
+      class="table"
+    >
+      <thead
+        class="header"
+      >
+        <tr>
+          <th
+            class="headerCell clickable"
+          >
+            <button>
+              <span>
+                Title
+              </span>
+              <span
+                aria-label="su-angle-up"
+                class="headerCellSortIcon su-angle-up"
+              />
+            </button>
+          </th>
+          <th
+            class="headerCell clickable"
+          >
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Title 1
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Description 1
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <nav
+    class="pagination"
+  >
+    <div
+      class="loader"
+    />
+    <span
+      class="display"
+    >
+      Page: 1 of 3
+    </span>
+    <button
+      class="previous"
+      disabled=""
+    >
+      <span
+        aria-label="su-angle-left"
+        class="su-angle-left"
+      />
+    </button>
+    <button
+      class="next"
+    >
+      <span
+        aria-label="su-angle-right"
+        class="su-angle-right"
+      />
+    </button>
+  </nav>
+</section>
+`;
+
+exports[`Render column with descending sort icon 1`] = `
+<section>
+  <div
+    class="tableContainer"
+  >
+    <table
+      class="table"
+    >
+      <thead
+        class="header"
+      >
+        <tr>
+          <th
+            class="headerCell clickable"
+          >
+            <button>
+              <span>
+                Title
+              </span>
+            </button>
+          </th>
+          <th
+            class="headerCell clickable"
+          >
+            <button>
+              <span>
+                Description
+              </span>
+              <span
+                aria-label="su-angle-down"
+                class="headerCellSortIcon su-angle-down"
+              />
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Title 1
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Description 1
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <nav
+    class="pagination"
+  >
+    <div
+      class="loader"
+    />
+    <span
+      class="display"
+    >
+      Page: 1 of 3
+    </span>
+    <button
+      class="previous"
+      disabled=""
+    >
+      <span
+        aria-label="su-angle-left"
+        class="su-angle-left"
+      />
+    </button>
+    <button
+      class="next"
+    >
+      <span
+        aria-label="su-angle-right"
+        class="su-angle-right"
+      />
+    </button>
+  </nav>
+</section>
+`;
+
 exports[`Render data with all different visibility types schema 1`] = `
 <section>
   <div
@@ -13,18 +201,22 @@ exports[`Render data with all different visibility types schema 1`] = `
       >
         <tr>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Description
-            </span>
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
           </th>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Test 1
-            </span>
+            <button>
+              <span>
+                Test 1
+              </span>
+            </button>
           </th>
         </tr>
       </thead>
@@ -126,11 +318,13 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
             </span>
           </th>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Description
-            </span>
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
           </th>
         </tr>
       </thead>
@@ -237,11 +431,13 @@ exports[`Render data with schema 1`] = `
       >
         <tr>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Description
-            </span>
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
           </th>
         </tr>
       </thead>
@@ -337,11 +533,13 @@ exports[`Render data with schema and selections 1`] = `
             </span>
           </th>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Description
-            </span>
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
           </th>
         </tr>
       </thead>
@@ -508,11 +706,13 @@ exports[`Render data with schema in different order 1`] = `
       >
         <tr>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Description
-            </span>
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
           </th>
         </tr>
       </thead>
@@ -590,11 +790,13 @@ exports[`Render data with schema not containing all fields 1`] = `
       >
         <tr>
           <th
-            class="headerCell"
+            class="headerCell clickable"
           >
-            <span>
-              Description
-            </span>
+            <button>
+              <span>
+                Description
+              </span>
+            </button>
           </th>
         </tr>
       </thead>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -226,9 +226,9 @@ test('The loading strategy should be called with the defined sortings', () => {
 test('Should update the persistent settings in the UserStore if the sorting changes', () => {
     userStore.getPersistentSetting.mockImplementation((key) => {
         switch (key) {
-            case 'datagrid.snippets.sort_column':
+            case 'sulu_admin.datagrid.snippets.sort_column':
                 return 'title';
-            case 'datagrid.snippets.sort_order':
+            case 'sulu_admin.datagrid.snippets.sort_order':
                 return 'asc';
         }
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -183,6 +183,36 @@ test('The loading strategy should be called with a different locale when a reque
     datagridStore.destroy();
 });
 
+test('The loading strategy should be called with the defined sortings', () => {
+    const loadingStrategy = new LoadingStrategy();
+    const structureStrategy = new StructureStrategy();
+    const page = observable.box(1);
+    const datagridStore = new DatagridStore(
+        'snippets',
+        {
+            page,
+        }
+    );
+
+    const data = [{id: 1}];
+    structureStrategy.getData.mockReturnValue(data);
+    datagridStore.sort('title', 'desc');
+    datagridStore.updateStrategies(loadingStrategy, structureStrategy);
+
+    expect(loadingStrategy.load).toBeCalledWith(
+        data,
+        'snippets',
+        {
+            page: 1,
+            sortBy: 'title',
+            sortOrder: 'desc',
+        },
+        structureStrategy.enhanceItem
+    );
+
+    datagridStore.destroy();
+});
+
 test('The loading strategy should be called with the active item as parent', () => {
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -1,17 +1,11 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import 'url-search-params-polyfill';
 import {observable, toJS, when} from 'mobx';
-import userStore from '../../../../stores/UserStore';
 import DatagridStore from '../../stores/DatagridStore';
 import metadataStore from '../../stores/MetadataStore';
 
 jest.mock('../../stores/MetadataStore', () => ({
     getSchema: jest.fn(() => Promise.resolve()),
-}));
-
-jest.mock('../../../../stores/UserStore', () => ({
-    getPersistentSetting: jest.fn(),
-    setPersistentSetting: jest.fn(),
 }));
 
 function LoadingStrategy() {
@@ -27,10 +21,6 @@ class StructureStrategy {
     getData = jest.fn().mockReturnValue(this.data);
     enhanceItem = jest.fn((item) => item);
 }
-
-beforeEach(() => {
-    userStore.getPersistentSetting.mockReset();
-});
 
 test('The loading strategy should be called when a request is sent', () => {
     const loadingStrategy = new LoadingStrategy();
@@ -221,29 +211,6 @@ test('The loading strategy should be called with the defined sortings', () => {
     );
 
     datagridStore.destroy();
-});
-
-test('Should update the persistent settings in the UserStore if the sorting changes', () => {
-    userStore.getPersistentSetting.mockImplementation((key) => {
-        switch (key) {
-            case 'sulu_admin.datagrid.snippets.sort_column':
-                return 'title';
-            case 'sulu_admin.datagrid.snippets.sort_order':
-                return 'asc';
-        }
-    });
-    const loadingStrategy = new LoadingStrategy();
-    const structureStrategy = new StructureStrategy();
-    const datagridStore = new DatagridStore('snippets', {page: observable.box(1)});
-    datagridStore.updateStrategies(loadingStrategy, structureStrategy);
-
-    expect(datagridStore.sortColumn.get()).toEqual('title');
-    expect(datagridStore.sortOrder.get()).toEqual('asc');
-
-    datagridStore.sort('description', 'desc');
-
-    expect(datagridStore.sortColumn.get()).toEqual('description');
-    expect(datagridStore.sortOrder.get()).toEqual('desc');
 });
 
 test('The loading strategy should be called with the active item as parent', () => {
@@ -554,12 +521,8 @@ test('Should reset the data array and set page to 1 when the reload method is ca
 test('Should call all disposers if destroy is called', () => {
     const datagridStore = new DatagridStore('snippets', {page: observable.box()});
     datagridStore.sendRequestDisposer = jest.fn();
-    datagridStore.sortColumnDisposer = jest.fn();
-    datagridStore.sortOrderDisposer = jest.fn();
 
     datagridStore.destroy();
 
     expect(datagridStore.sendRequestDisposer).toBeCalledWith();
-    expect(datagridStore.sortColumnDisposer).toBeCalledWith();
-    expect(datagridStore.sortOrderDisposer).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -45,8 +45,10 @@ export type ObservableOptions = {
 };
 
 export type LoadOptions = {
-    page?: number,
     locale?: ?string,
+    page?: number,
+    sortBy?: string,
+    sortOrder?: SortOrder,
 };
 
 export type ItemEnhancer = (item: Object) => Object;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -17,6 +17,8 @@ export type Schema = {
     [string]: SchemaEntry,
 };
 
+export type SortOrder = 'asc' | 'desc';
+
 export type DatagridAdapterProps = {
     active?: ?string | number,
     data: Array<*>,
@@ -28,10 +30,13 @@ export type DatagridAdapterProps = {
     onAddClick?: (id: string | number) => void,
     onItemSelectionChange?: (rowId: string | number, selected?: boolean) => void,
     onPageChange: (page: number) => void,
+    onSort: (column: string, order: SortOrder) => void,
     page: ?number,
     pageCount: number,
     schema: Schema,
     selections: Array<number | string>,
+    sortColumn: ?string,
+    sortOrder: ?SortOrder,
 };
 
 export type ObservableOptions = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/README.md
@@ -74,3 +74,10 @@ const router = {
 
 <ViewRenderer router={router} />
 ```
+
+In addition to all of that the View can also have an influence on the routing process. The optional static
+`getDerivedRouteAttributes` function of each view is called before the navigating to a certain route is executed. In
+there an object can be returned, which will be used to supplement the attributes of the routing. The [router](#router)
+will merge these returned attributes with the attributes that has been passed to its `navigate` call. The default
+attributes of the route will only be applied if neither the attributes are passed nor set in the
+`getDerivedRouteAttributes` call.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/index.js
@@ -1,8 +1,9 @@
 // @flow
+import updateRouterAttributesFromView from './updateRouterAttributesFromView';
 import ViewRenderer from './ViewRenderer';
 import viewRegistry from './registries/ViewRegistry';
 import type {ViewProps} from './types';
 
 export default ViewRenderer;
-export {viewRegistry};
+export {updateRouterAttributesFromView, viewRegistry};
 export type {ViewProps};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/updateRouterAttributesFromView.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/updateRouterAttributesFromView.test.js
@@ -1,0 +1,50 @@
+// @flow
+import updateRouterAttributesFromView from '../updateRouterAttributesFromView';
+import viewRegistry from '../registries/ViewRegistry';
+
+jest.mock('../registries/ViewRegistry', () => ({
+    get: jest.fn(),
+}));
+
+test('Return an empty object if the corresponding View has no getDerivedRouterAttributes function', () => {
+    viewRegistry.get.mockImplementation((key) => {
+        if (key === 'test') {
+            return {};
+        }
+    });
+
+    expect(updateRouterAttributesFromView({
+        attributeDefaults: {},
+        children: [],
+        name: 'test',
+        options: {},
+        path: '/test',
+        parent: undefined,
+        rerenderAttributes: [],
+        view: 'test',
+    })).toEqual({});
+});
+
+test('Return the attributes returned from the getDerivedRouterAttributes function', () => {
+    viewRegistry.get.mockImplementation((key) => {
+        if (key === 'test') {
+            return {
+                getDerivedRouteAttributes: jest.fn().mockReturnValue({
+                    value1: 'test1',
+                    value2: 'test2',
+                }),
+            };
+        }
+    });
+
+    expect(updateRouterAttributesFromView({
+        attributeDefaults: {},
+        children: [],
+        name: 'test',
+        options: {},
+        path: '/test',
+        parent: undefined,
+        rerenderAttributes: [],
+        view: 'test',
+    })).toEqual({value1: 'test1', value2: 'test2'});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/updateRouterAttributesFromView.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/updateRouterAttributesFromView.test.js
@@ -48,3 +48,24 @@ test('Return the attributes returned from the getDerivedRouterAttributes functio
         view: 'test',
     })).toEqual({value1: 'test1', value2: 'test2'});
 });
+
+test('Throw an error if attributes returned from the getDerivedRouterAttributes function are not an object', () => {
+    viewRegistry.get.mockImplementation((key) => {
+        if (key === 'test') {
+            return {
+                getDerivedRouteAttributes: jest.fn().mockReturnValue('test'),
+            };
+        }
+    });
+
+    expect(() => updateRouterAttributesFromView({
+        attributeDefaults: {},
+        children: [],
+        name: 'test',
+        options: {},
+        path: '/test',
+        parent: undefined,
+        rerenderAttributes: [],
+        view: 'test',
+    })).toThrow(/"getDerivedRouteAttributes".*"test" view/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
@@ -1,0 +1,15 @@
+// @flow
+import type {UpdateAttributesHook} from '../../services/Router/types';
+import viewRegistry from './registries/ViewRegistry';
+
+const updateRouterAttributesFromView: UpdateAttributesHook = function (route) {
+    const View = viewRegistry.get(route.view);
+
+    if (typeof(View.getDerivedRouteAttributes) === 'function') {
+        return View.getDerivedRouteAttributes(route);
+    }
+
+    return {};
+};
+
+export default updateRouterAttributesFromView;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
@@ -5,10 +5,10 @@ import viewRegistry from './registries/ViewRegistry';
 const updateRouterAttributesFromView: UpdateAttributesHook = function (route) {
     const View = viewRegistry.get(route.view);
 
-    if (typeof(View.getDerivedRouteAttributes) === 'function') {
+    if ('function' === typeof View.getDerivedRouteAttributes) {
         const attributes = View.getDerivedRouteAttributes(route);
 
-        if (typeof attributes !== 'object') {
+        if ('object' !== typeof attributes) {
             throw new Error(
                 'The "getDerivedRouteAttributes" function of the "' + route.view + '" view did not return an object.'
             );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
@@ -6,7 +6,15 @@ const updateRouterAttributesFromView: UpdateAttributesHook = function (route) {
     const View = viewRegistry.get(route.view);
 
     if (typeof(View.getDerivedRouteAttributes) === 'function') {
-        return View.getDerivedRouteAttributes(route);
+        const attributes = View.getDerivedRouteAttributes(route);
+
+        if (typeof attributes !== 'object') {
+            throw new Error(
+                'The "getDerivedRouteAttributes" function of the "' + route.view + '" view did not return an object.'
+            );
+        }
+
+        return attributes;
     }
 
     return {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -21,7 +21,7 @@ import {
     Time,
 } from './containers/Form';
 import FieldBlocks from './containers/FieldBlocks';
-import {viewRegistry} from './containers/ViewRenderer';
+import {updateRouterAttributesFromView, viewRegistry} from './containers/ViewRenderer';
 import {navigationRegistry} from './containers/Navigation';
 import resourceMetadataStore from './stores/ResourceMetadataStore';
 import {
@@ -93,6 +93,7 @@ function registerDatagridFieldTypes() {
 
 function startApplication() {
     const router = new Router(createHistory());
+    router.addUpdateAttributesHook(updateRouterAttributesFromView);
     const id = 'application';
     const applicationElement = document.getElementById(id);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -117,3 +117,42 @@ router.unbind('value', value); // unbind to avoid leaking listeners
 
 Mind that the bindings will be cleared on every `navigate` call. This is necessary to avoid superfluous updates because
 of wrong update on observers.
+
+In addition to the normal navigating there are the `updateAttributesHooks`. These hooks can be added using the
+`addUpdateAttributesHook` function. These hooks will get the route to which is currently navigated as its first
+argument, and the hook can decide using that argument what attributes it will return. These attributes will be merged
+with the attribute passed to the `navigate` or `restore` call, whereby the arguments from the function call take
+precedence. Finally the attribute defaults will only be applied if the given attribute has not been in either of the
+previous two described ways. So the priorities of the available attributes is as follows:
+
+- arguments from `navigate` or `restore` call
+- return value from `updateAttributesHooks`
+- attribute defaults
+
+If the attribute is mandatory (i.e. in the path and not a query parameter) and it is not passed in any of these ways,
+then an error will be thrown.
+
+See the following example for a better understanding.
+
+```javascript static
+routeRegistry.addCollection([
+    {
+        name: 'sulu_webspace.webspace_overview',
+        path: '/webspace/:webspace/:locale',
+        view: 'sulu_content.webspace_overview',
+        attributeDefaults: {
+            webspace: 'example',
+            locale: 'en',
+            utf: true,
+        },
+    },
+]);
+
+router.addUpdateAttributesHooks((route) => ({
+    route: route.name,
+    locale: 'de',
+}));
+
+// navigates to #/webspace/sulu_io/de?utf=true&test=true
+router.navigate('sulu_webspace.webspace_overview', {webspace: 'sulu_io', test: true})
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -130,6 +130,46 @@ test('Navigate to route without default attribute when observable is changed', (
     expect(history.location.pathname).toBe('/list/de');
 });
 
+test('Apply updateAttributesHooks before applying default attributes but after passed attributes', () => {
+    routeRegistry.getAll.mockReturnValue({
+        webspace_overview: {
+            name: 'webspace_overview',
+            view: 'webspace_overview',
+            path: '/webspace/:webspace/:locale',
+            attributeDefaults: {
+                webspace: 'webspace1',
+                sortOrder: 'desc',
+            },
+        },
+    });
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.addUpdateAttributesHook((route) => {
+        if (route.view !== 'webspace_overview') {
+            return {};
+        }
+
+        return {
+            webspace: 'webspace2',
+        };
+    });
+
+    router.addUpdateAttributesHook(() => {
+        return {
+            value: 'test',
+        };
+    });
+
+    router.handleNavigation('webspace_overview', {locale: 'en'});
+
+    expect(router.attributes.webspace).toEqual('webspace2');
+    expect(router.attributes.locale).toEqual('en');
+    expect(router.attributes.sortOrder).toEqual('desc');
+    expect(router.attributes.value).toEqual('test');
+});
+
 test('Update observable attribute on route change', () => {
     routeRegistry.getAll.mockReturnValue({
         list: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -170,6 +170,28 @@ test('Apply updateAttributesHooks before applying default attributes but after p
     expect(router.attributes.value).toEqual('test');
 });
 
+test('Apply attribute defaults if value of passed attribute is undefined', () => {
+    routeRegistry.getAll.mockReturnValue({
+        webspace_overview: {
+            name: 'webspace_overview',
+            view: 'webspace_overview',
+            path: '/webspace/:webspace/:locale',
+            attributeDefaults: {
+                webspace: 'webspace1',
+                sortOrder: 'desc',
+            },
+        },
+    });
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.handleNavigation('webspace_overview', {locale: 'en', webspace: undefined});
+
+    expect(router.attributes.webspace).toEqual('webspace1');
+    expect(router.attributes.locale).toEqual('en');
+});
+
 test('Update observable attribute on route change', () => {
     routeRegistry.getAll.mockReturnValue({
         list: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -23,3 +23,5 @@ export type Route = {|
 export type AttributeMap = {[string]: string};
 
 export type RouteMap = {[string]: Route};
+
+export type UpdateAttributesHook = (route: Route) => AttributeMap;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -1,0 +1,19 @@
+// @flow
+
+class UserStore {
+    persistentSettings: {[string]: *} = {};
+
+    clear() {
+        this.persistentSettings = {};
+    }
+
+    setPersistentSetting(key: string, value: *) {
+        this.persistentSettings[key] = value;
+    }
+
+    getPersistentSetting(key: string) {
+        return this.persistentSettings[key];
+    }
+}
+
+export default new UserStore();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/index.js
@@ -1,0 +1,4 @@
+// @flow
+import userStore from './UserStore';
+
+export default userStore;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -1,0 +1,14 @@
+// @flow
+import userStore from '../UserStore';
+
+test('Should clear the user store', () => {
+    userStore.setPersistentSetting('something', 'somevalue');
+    expect(Object.keys(userStore.persistentSettings)).toHaveLength(1);
+    userStore.clear();
+    expect(Object.keys(userStore.persistentSettings)).toHaveLength(0);
+});
+
+test('Should set persistent setting', () => {
+    userStore.setPersistentSetting('categories.sortColumn', 'name');
+    expect(userStore.getPersistentSetting('categories.sortColumn')).toEqual('name');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/index.js
@@ -1,8 +1,10 @@
 // @flow
 import ResourceStore from './ResourceStore';
 import ResourceMetadataStore from './ResourceMetadataStore';
+import userStore from './UserStore';
 
 export {
     ResourceStore,
     ResourceMetadataStore,
+    userStore,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -18,7 +18,7 @@ class Datagrid extends React.Component<ViewProps> {
     datagridStore: DatagridStore;
     @observable deleting = false;
 
-    componentWillMount() {
+    @action componentWillMount() {
         const router = this.props.router;
         const {
             route: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -50,6 +50,9 @@ class Datagrid extends React.Component<ViewProps> {
         }
 
         this.datagridStore = new DatagridStore(resourceKey, observableOptions, apiOptions);
+
+        router.bind('sortColumn', this.datagridStore.sortColumn);
+        router.bind('sortOrder', this.datagridStore.sortOrder);
     }
 
     componentWillUnmount() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -19,6 +19,12 @@ jest.mock(
         this.options = options;
         this.loading = false;
         this.pageCount = 3;
+        this.sortColumn = {
+            get: jest.fn(),
+        };
+        this.sortOrder = {
+            get: jest.fn(),
+        };
         this.updateStrategies = jest.fn();
         this.data = [
             {
@@ -175,12 +181,15 @@ test('Should destroy the store on unmount', () => {
     const page = router.bind.mock.calls[0][1];
     const locale = router.bind.mock.calls[1][1];
 
+    const datagridStore = datagrid.instance().datagridStore;
+
     expect(page.get()).toBe(undefined);
     expect(locale.get()).toBe(undefined);
     expect(router.bind).toBeCalledWith('page', page, 1);
     expect(router.bind).toBeCalledWith('locale', locale);
+    expect(router.bind).toBeCalledWith('sortColumn', datagridStore.sortColumn);
+    expect(router.bind).toBeCalledWith('sortOrder', datagridStore.sortOrder);
 
-    const datagridStore = datagrid.instance().datagridStore;
     datagrid.unmount();
 
     expect(datagridStore.destroy).toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -43,11 +43,13 @@ exports[`Should render the datagrid with a title 1`] = `
                 </span>
               </th>
               <th
-                class="headerCell"
+                class="headerCell clickable"
               >
-                <span>
-                  Description
-                </span>
+                <button>
+                  <span>
+                    Description
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -196,11 +198,13 @@ exports[`Should render the datagrid with the correct resourceKey 1`] = `
                 </span>
               </th>
               <th
-                class="headerCell"
+                class="headerCell clickable"
               >
-                <span>
-                  Description
-                </span>
+                <button>
+                  <span>
+                    Description
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>
@@ -359,11 +363,13 @@ exports[`Should render the datagrid with the pencil icon if a editRoute has been
                 </span>
               </th>
               <th
-                class="headerCell"
+                class="headerCell clickable"
               >
-                <span>
-                  Description
-                </span>
+                <button>
+                  <span>
+                    Description
+                  </span>
+                </button>
               </th>
             </tr>
           </thead>

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -8,6 +8,12 @@ jest.mock('sulu-admin-bundle/containers', () => {
         withToolbar: jest.fn((Component) => Component),
         Datagrid: require('sulu-admin-bundle/containers/Datagrid/Datagrid').default,
         DatagridStore: jest.fn(function() {
+            this.sortColumn = {
+                get: jest.fn(),
+            };
+            this.sortOrder = {
+                get: jest.fn(),
+            };
             this.selections = [];
             this.selectionIds = [];
             this.getPage = jest.fn().mockReturnValue(1);

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -3,36 +3,41 @@ import React from 'react';
 import {mount} from 'enzyme';
 import WebspaceStore from '../../../stores/WebspaceStore';
 
-jest.mock('sulu-admin-bundle/containers', () => {
-    return {
-        withToolbar: jest.fn((Component) => Component),
-        Datagrid: require('sulu-admin-bundle/containers/Datagrid/Datagrid').default,
-        DatagridStore: jest.fn(function() {
-            this.sortColumn = {
-                get: jest.fn(),
-            };
-            this.sortOrder = {
-                get: jest.fn(),
-            };
-            this.selections = [];
-            this.selectionIds = [];
-            this.getPage = jest.fn().mockReturnValue(1);
-            this.destroy = jest.fn();
-            this.sendRequest = jest.fn();
-            this.updateStrategies = jest.fn();
-        }),
-        FlatStructureStrategy: require(
-            'sulu-admin-bundle/containers/Datagrid/structureStrategies/FlatStructureStrategy'
-        ).default,
-        FullLoadingStrategy: require(
-            'sulu-admin-bundle/containers/Datagrid/loadingStrategies/FullLoadingStrategy'
-        ).default,
-    };
-});
+jest.mock('sulu-admin-bundle/containers', () => ({
+    withToolbar: jest.fn((Component) => Component),
+    Datagrid: require('sulu-admin-bundle/containers/Datagrid/Datagrid').default,
+    DatagridStore: jest.fn(function() {
+        this.sortColumn = {
+            get: jest.fn(),
+        };
+        this.sortOrder = {
+            get: jest.fn(),
+        };
+        this.selections = [];
+        this.selectionIds = [];
+        this.getPage = jest.fn().mockReturnValue(1);
+        this.destroy = jest.fn();
+        this.sendRequest = jest.fn();
+        this.updateStrategies = jest.fn();
+    }),
+    FlatStructureStrategy: require(
+        'sulu-admin-bundle/containers/Datagrid/structureStrategies/FlatStructureStrategy'
+    ).default,
+    FullLoadingStrategy: require(
+        'sulu-admin-bundle/containers/Datagrid/loadingStrategies/FullLoadingStrategy'
+    ).default,
+}));
 
 jest.mock('sulu-admin-bundle/containers/Datagrid/registries/DatagridAdapterRegistry', () => ({
     get: jest.fn().mockReturnValue(require('sulu-admin-bundle/containers/Datagrid/adapters/ColumnListAdapter').default),
     has: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('sulu-admin-bundle/stores', () => ({
+    userStore: {
+        setPersistentSetting: jest.fn(),
+        getPersistentSetting: jest.fn(),
+    },
 }));
 
 jest.mock('../../../stores/WebspaceStore', () => ({
@@ -84,6 +89,7 @@ test('Should change webspace when value of webspace select is changed', () => {
     const toolbarFunction = withToolbar.mock.calls[0][1];
     // $FlowFixMe
     const webspaceStore: typeof WebspaceStore = require('../../../stores/WebspaceStore');
+    const userStore = require('sulu-admin-bundle/stores').userStore;
 
     const promise = Promise.resolve(
         [
@@ -129,10 +135,9 @@ test('Should change webspace when value of webspace select is changed', () => {
 
         webspaceOverview.update();
         webspaceOverview.find('WebspaceSelect').prop('onChange')('sulu_blog');
-        // check if webspace is correctly set
         expect(webspaceOverview.instance().webspace.get()).toBe('sulu_blog');
-        // check if default locale of selected webspace is set
         expect(webspaceOverview.instance().locale.get()).toBe('de');
+        expect(userStore.setPersistentSetting).lastCalledWith('sulu_content.webspace_overview.webspace', 'sulu_blog');
 
         const toolbarConfigNew = toolbarFunction.call(webspaceOverview.instance());
         expect(toolbarConfigNew.locale.value).toBe('de');
@@ -143,6 +148,22 @@ test('Should change webspace when value of webspace select is changed', () => {
                 ]
             )
         );
+    });
+});
+
+test('Should load webspace route attribute from userStore', () => {
+    const WebspaceOverview = require('../WebspaceOverview').default;
+    const userStore = require('sulu-admin-bundle/stores').userStore;
+
+    userStore.getPersistentSetting.mockImplementation((key) => {
+        if (key === 'sulu_content.webspace_overview.webspace') {
+            return 'sulu';
+        }
+    });
+
+    // $FlowFixMe
+    expect(WebspaceOverview.getDerivedRouteAttributes()).toEqual({
+        webspace: 'sulu',
     });
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardAdapter.test.js
@@ -45,10 +45,13 @@ test('Render a basic Masonry view with MediaCards', () => {
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={1}
             pageCount={7}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -88,10 +91,13 @@ test('MediaCard should call the the appropriate handler', () => {
             onItemClick={mediaCardSelectionChangeSpy}
             onItemSelectionChange={mediaCardSelectionChangeSpy}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={3}
             pageCount={9}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 
@@ -108,10 +114,13 @@ test('InfiniteScroller should be passed correct props', () => {
             icon="su-pen"
             loading={false}
             onPageChange={pageChangeSpy}
+            onSort={jest.fn()}
             page={2}
             pageCount={7}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
     expect(tableAdapter.find('InfiniteScroller').get(0).props).toEqual({

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
@@ -44,10 +44,13 @@ test('Render a basic Masonry view with the MediaCardOverviewAdapter', () => {
             loading={false}
             onItemSelectionChange={jest.fn()}
             onPageChange={jest.fn()}
+            onSort={jest.fn()}
             page={2}
             pageCount={5}
             schema={{}}
             selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
         />
     );
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -76,6 +76,12 @@ jest.mock('sulu-admin-bundle/containers', () => {
 
             this.loading = false;
             this.pageCount = 3;
+            this.sortColumn = {
+                get: jest.fn(),
+            };
+            this.sortOrder = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -63,6 +63,12 @@ jest.mock('sulu-admin-bundle/containers', () => {
             });
             this.loading = false;
             this.pageCount = 3;
+            this.sortColumn = {
+                get: jest.fn(),
+            };
+            this.sortOrder = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -62,6 +62,12 @@ jest.mock('sulu-admin-bundle/containers', () => {
             });
             this.loading = false;
             this.pageCount = 3;
+            this.sortColumn = {
+                get: jest.fn(),
+            };
+            this.sortOrder = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -54,6 +54,12 @@ jest.mock('sulu-admin-bundle/containers', () => {
 
             this.loading = false;
             this.pageCount = 3;
+            this.sortColumn = {
+                get: jest.fn(),
+            };
+            this.sortOrder = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3799
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the sorting functionality in the datagrid and will remember the sorting in the new `UserStore`.

#### Why?

Because we want to sort stuff in the datagrid.

#### To Do

- [x] Show sorting indicator in table header
- [ ] Sorting should probably trigger a reload (not that the new result gets appended when using `InfiniteScrolling`
- [x] Implement `sortColumn` and `sortOrder` as `observable.box` and put them into the URL
- [x] Add correct typing for `getDeriveRouterAttributes` (currently it does detect if the static function in return types have the wrong return type)
- [ ] Move writing the user setting in the Datagrid to the container instead of the view (?)
- [x] Document `getDerivedRouterAttributes`
- [ ] Save persistent user settings (?)