### PR TITLE
Throw a proper error if the route passed to the router does not exist

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/RouteRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/registries/RouteRegistry.js
@@ -39,6 +39,10 @@ class RouteRegistry {
     }
 
     get(name: string): Route {
+        if (!(name in this.routes)) {
+            throw new Error('The route with the name "' + name + '" does not exist');
+        }
+
         return this.routes[name];
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/registries/RouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/registries/RouteRegistry.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+//@flow
 import {toJS} from 'mobx';
 import routeRegistry from '../../registries/RouteRegistry';
 
@@ -12,6 +12,9 @@ test('Clear routes from RouteRegistry', () => {
             name:'route',
             view: 'view',
             path: '/route',
+            options: {},
+            attributeDefaults: {},
+            rerenderAttributes: [],
         },
     ]);
 
@@ -26,17 +29,21 @@ test('Get routes from RouteRegistry', () => {
         name: 'route1',
         view: 'view1',
         path: '/route/1',
-        parameters: {
+        options: {
             test: 'value',
         },
+        attributeDefaults: {},
+        rerenderAttributes: [],
     };
     const route2 = {
         name: 'route2',
         view: 'view2',
         path: '/route/2',
-        parameters: {
+        options: {
             test2: 'value2',
         },
+        attributeDefaults: {},
+        rerenderAttributes: [],
     };
 
     routeRegistry.addCollection([route1, route2]);
@@ -48,20 +55,24 @@ test('Get routes from RouteRegistry', () => {
         name: 'route1',
         view: 'view1',
         path: '/route/1',
-        parameters: {
+        options: {
             test: 'value',
         },
         children: [],
+        attributeDefaults: {},
+        rerenderAttributes: [],
         parent: undefined,
     });
     expect(toJS(routes.route2)).toEqual({
         name: 'route2',
         view: 'view2',
         path: '/route/2',
-        parameters: {
+        options: {
             test2: 'value2',
         },
         children: [],
+        attributeDefaults: {},
+        rerenderAttributes: [],
         parent: undefined,
     });
 });
@@ -71,18 +82,22 @@ test('Add a route collection to the RouteRegistry', () => {
         name: 'route1',
         view: 'view1',
         path: '/route/1',
-        parameters: {
+        options: {
             test: 'value',
         },
+        attributeDefaults: {},
+        rerenderAttributes: [],
     };
 
     const route2 = {
         name: 'route2',
         view: 'view2',
         path: '/route/2',
-        parameters: {
+        options: {
             test2: 'value2',
         },
+        attributeDefaults: {},
+        rerenderAttributes: [],
     };
 
     routeRegistry.addCollection([route1, route2]);
@@ -91,21 +106,25 @@ test('Add a route collection to the RouteRegistry', () => {
         name: 'route1',
         view: 'view1',
         path: '/route/1',
-        parameters: {
+        options: {
             test: 'value',
         },
         parent: undefined,
         children: [],
+        attributeDefaults: {},
+        rerenderAttributes: [],
     });
     expect(toJS(routeRegistry.get('route2'))).toEqual({
         name: 'route2',
         view: 'view2',
         path: '/route/2',
-        parameters: {
+        options: {
             test2: 'value2',
         },
         parent: undefined,
         children: [],
+        attributeDefaults: {},
+        rerenderAttributes: [],
     });
 });
 
@@ -114,6 +133,9 @@ test('Add route with existing key should throw', () => {
         name: 'test_route',
         view: 'view',
         path: '/route',
+        options: {},
+        attributeDefaults: {},
+        rerenderAttributes: [],
     };
 
     routeRegistry.addCollection([route]);
@@ -127,18 +149,27 @@ test('Set parent and children routes based on passed RouteConfig', () => {
             name: 'sulu_snippet.form',
             view: 'sulu_admin.tab',
             path: '/snippets/:uuid',
+            options: {},
+            attributeDefaults: {},
+            rerenderAttributes: [],
         },
         {
             name: 'sulu_snippet.form.detail',
             parent: 'sulu_snippet.form',
             view: 'sulu_admin.form',
             path: '/detail',
+            options: {},
+            attributeDefaults: {},
+            rerenderAttributes: [],
         },
         {
             name: 'sulu_snippet.form.taxonomy',
             parent: 'sulu_snippet.form',
             view: 'sulu_admin.form',
             path: '/taxonomy',
+            options: {},
+            attributeDefaults: {},
+            rerenderAttributes: [],
         },
     ]);
 
@@ -154,4 +185,8 @@ test('Set parent and children routes based on passed RouteConfig', () => {
     expect(detailRoute.parent).toBe(formRoute);
     expect(taxonomyRoute.name).toBe('sulu_snippet.form.taxonomy');
     expect(taxonomyRoute.parent).toBe(formRoute);
+});
+
+test('Get a non-existing route should throw an exception', () => {
+    expect(() => routeRegistry.get('test')).toThrow(/"test"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -1,5 +1,5 @@
 // @flow
-export type RouteConfig = {
+export type RouteConfig = {|
     name: string,
     parent?: string,
     view: string,
@@ -7,9 +7,9 @@ export type RouteConfig = {
     options: Object,
     attributeDefaults: AttributeMap,
     rerenderAttributes: Array<string>,
-};
+|};
 
-export type Route = {
+export type Route = {|
     name: string,
     parent: ?Route,
     children: Array<Route>,
@@ -18,7 +18,7 @@ export type Route = {
     options: Object,
     attributeDefaults: AttributeMap,
     rerenderAttributes: Array<string>,
-};
+|};
 
 export type AttributeMap = {[string]: string};
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR throws an error if the router is passed a route which does not exist. Before that something weird happened, and it is not directly obvious what the problem actually is.

#### Why?

This way we have a better DX.

#### BC Breaks/Deprecations

Instead of returning `undefined` when a non-existing route is passed it will throw an error. In most cases it does not work anyway afterwards, so this should not be a big deal.