### PR TITLE
Fixed priority of request-context-listener

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -174,7 +174,7 @@
         <service id="sulu_website.routing.request_listener" class="Sulu\Bundle\WebsiteBundle\Routing\RequestListener">
             <argument type="service" id="router"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
-            <tag name="kernel.event_listener" event="kernel.request" method="onRequest" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onRequest" priority="31" />
         </service>
 
         <!-- exception controller -->


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the priority of `RouterListener` which set the context attributes `prefix` and `host` - they are used to generate routes on the website.

#### Why?

When an `AuthenticationException` is thrown on the website the login route cannot be generated because these attributes are not set. The `RouterListener` depends only on the `_sulu` request-attribute and this will be set with the priority of 32.