### PR TITLE
Fixed: Fix PHP 7.2 issue prevents adding new contacts (#3925)

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1793,7 +1793,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      */
     private function resetIndexOfSubentites($entities)
     {
-        if (count($entities) > 0 && method_exists($entities, 'getValues')) {
+        if ($entities && count($entities) > 0 && method_exists($entities, 'getValues')) {
             $newEntities = $entities->getValues();
             $entities->clear();
             foreach ($newEntities as $value) {


### PR DESCRIPTION
Originated by http://php.net/manual/de/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3925
| License | MIT

#### What's in this PR?

Fix for php warning prevents users to add new contacts (without bankaccount) (see #3925)

