### PR TITLE
Fix: the sitemap query builder only considers the "de" hiddenInSitemap flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * unrealeased
+    * HOTFIX      #3941 [WebsiteBundle]         Fix hideInSitemap flag for sitemap twig extension
     * BUGFIX      #3926 [WebsiteBundle]         Fix profiler for none sulu routes
 
 * 1.5.13 (2018-04-23)

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapContentQueryBuilder.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapContentQueryBuilder.php
@@ -29,10 +29,10 @@ class SitemapContentQueryBuilder extends ContentQueryBuilder
                 ISDESCENDANTNODE('/cmf/%s/contents')
                 OR ISSAMENODE('/cmf/%s/contents')
             ) AND (
-                page.[i18n:de-seo-hideInSitemap] IS NULL
-                OR page.[i18n:de-seo-hideInSitemap] = false
+                page.[i18n:%s-seo-hideInSitemap] IS NULL
+                OR page.[i18n:%s-seo-hideInSitemap] = false
             )
-        )", $webspaceKey, $webspaceKey, $locale);
+        )", $webspaceKey, $webspaceKey, $locale, $locale, $locale);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapContentQueryBuilder.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapContentQueryBuilder.php
@@ -32,7 +32,7 @@ class SitemapContentQueryBuilder extends ContentQueryBuilder
                 page.[i18n:%s-seo-hideInSitemap] IS NULL
                 OR page.[i18n:%s-seo-hideInSitemap] = false
             )
-        )", $webspaceKey, $webspaceKey, $locale, $locale, $locale);
+        )", $webspaceKey, $webspaceKey, $locale, $locale);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapGeneratorTest.php
@@ -264,6 +264,17 @@ class SitemapGeneratorTest extends SuluTestCase
         $this->documentManager->persist($document, $locale);
         $this->documentManager->publish($document, $locale);
         $this->documentManager->flush();
+
+        $document = $this->documentManager->create('page');
+        $document->setStructureType('overview');
+        $document->setTitle('SEO-NoSitemap ' . $locale);
+        $document->setResourceSegment('/seo-no-sitemap');
+        $document->setNavigationContexts(['footer']);
+        $document->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $document->setExtension('seo', ['hideInSitemap' => true]);
+        $this->documentManager->persist($document, $locale, ['parent_path' => '/cmf/test_io/contents']);
+        $this->documentManager->publish($document, $locale);
+        $this->documentManager->flush();
     }
 
     public function testGenerateAllFlat()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | (none found)
| Related issues/PRs | (none found)
| License | MIT
| Documentation PR | not applicable

#### What's in this PR?

This PR is a Bugfix in the WebsiteBundle

#### Why?

This PR fixes a small bug in the `SitemapContentQueryBuilder` when creating the sitemaps. When querying for the documents to load it does not filter out the documents with the `hideInSitemap`-flag unless the flag is added in the "de" locale.

This is my first contribution to Sulu, I hope I followed the contributing guidelines correctly - otherwise please tell me what I need to fix. I wasn't sure if I had to create an issue first.