### PR TITLE
Fix test after npm update

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
@@ -19,7 +19,7 @@ export default class ToolbarDropdown extends React.Component<ToolbarDropdownProp
     @observable popoverOpen: boolean = false;
     @observable popoverAnchorElement: ?ElementRef<*>;
 
-    @action handleOptionClick = (event: SyntheticEvent<HTMLOptionElement>) => {
+    @action handleClick = (event: SyntheticEvent<HTMLOptionElement>) => {
         this.popoverAnchorElement = event.currentTarget;
         this.popoverOpen = true;
     };
@@ -28,7 +28,7 @@ export default class ToolbarDropdown extends React.Component<ToolbarDropdownProp
         this.popoverOpen = false;
     };
 
-    render = () => {
+    render() {
         const {icon, options, skin, columnIndex} = this.props;
 
         const className = classNames(
@@ -38,7 +38,7 @@ export default class ToolbarDropdown extends React.Component<ToolbarDropdownProp
 
         return (
             <Fragment>
-                <div onClick={this.handleOptionClick} className={className}>
+                <div onClick={this.handleClick} className={className}>
                     <Icon name={icon} />
                 </div>
                 <Popover
@@ -63,6 +63,6 @@ export default class ToolbarDropdown extends React.Component<ToolbarDropdownProp
                 </Popover>
             </Fragment>
         );
-    };
+    }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Toolbar.test.js
@@ -40,6 +40,5 @@ test('The Toolbar component should render with active', () => {
     // check for opened dropdown in body
     expect(body.innerHTML).toBe('');
     toolbar.find(ToolbarDropdown).simulate('click');
-    expect(body.innerHTML).not.toBe('');
     expect(pretty(body.innerHTML)).toMatchSnapshot();
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the `ToolbarDropdown` render method not an arrow function. In addition to that I renamed the `handleOptionClick` method to just `handleClick`, because (I think) it is not handling a click on the option but on the dropdown itself.
#### Why?

The `render` method made problems in combination with enzyme. The component was not updated in enzyme, since a babel update. Seems like arrow functions are transpiled differently now and in a way that enzyme can't handle them.