### PR TITLE
Add FieldType for checkbox

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react';
+import CheckboxComponent from '../../../components/Checkbox';
+import type {FieldTypeProps} from '../../../types';
+
+export default class Checkbox extends React.Component<FieldTypeProps<boolean>> {
+    handleChange = (checked: boolean) => {
+        const {onChange, onFinish} = this.props;
+        onChange(checked);
+
+        if (onFinish) {
+            onFinish();
+        }
+    };
+
+    render() {
+        const {value} = this.props;
+
+        return <CheckboxComponent checked={!!value} onChange={this.handleChange} />;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Checkbox.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import CheckboxComponent from '../../../components/Checkbox';
+import Toggler from '../../../components/Toggler';
 import type {FieldTypeProps} from '../../../types';
 
 export default class Checkbox extends React.Component<FieldTypeProps<boolean>> {
@@ -14,7 +15,14 @@ export default class Checkbox extends React.Component<FieldTypeProps<boolean>> {
     };
 
     render() {
-        const {value} = this.props;
+        const {
+            schemaOptions,
+            value,
+        } = this.props;
+
+        if (schemaOptions && schemaOptions.type && schemaOptions.type.value === 'toggler') {
+            return <Toggler checked={!!value} onChange={this.handleChange} />;
+        }
 
         return <CheckboxComponent checked={!!value} onChange={this.handleChange} />;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -4,6 +4,7 @@ import FormInspector from './FormInspector';
 import fieldRegistry from './registries/FieldRegistry';
 import FormStore from './stores/FormStore';
 import Assignment from './fields/Assignment';
+import Checkbox from './fields/Checkbox';
 import DatePicker from './fields/DatePicker';
 import Email from './fields/Email';
 import Input from './fields/Input';
@@ -18,6 +19,7 @@ import type {Schema, Types} from './types';
 export {
     fieldRegistry,
     Assignment,
+    Checkbox,
     DatePicker,
     Email,
     Input,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import Checkbox from '../../fields/Checkbox';
 import CheckboxComponent from '../../../../components/Checkbox';
+import Toggler from '../../../../components/Toggler';
 
 test('Pass the value of true correctly to Checkbox component', () => {
     const checkbox = shallow(<Checkbox onChange={jest.fn()} value={true} />);
@@ -14,12 +15,37 @@ test('Pass the value of false correctly to Checkbox component', () => {
     expect(checkbox.find(CheckboxComponent).prop('checked')).toEqual(false);
 });
 
-test('Call onChange and onFinish on the changed callback', () => {
+test('Call onChange and onFinish on the changed callback of the Checkbox', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
 
     const checkbox = shallow(<Checkbox onChange={changeSpy} onFinish={finishSpy} value={false} />);
     checkbox.find(CheckboxComponent).simulate('change', true);
+
+    expect(changeSpy).toBeCalledWith(true);
+    expect(finishSpy).toBeCalledWith();
+});
+
+test('Pass the value of true correctly to Toggler component', () => {
+    const checkbox = shallow(<Checkbox onChange={jest.fn()} schemaOptions={{type: {value: 'toggler'}}} value={true} />);
+    expect(checkbox.find(Toggler).prop('checked')).toEqual(true);
+});
+
+test('Pass the value of false correctly to Toggler component', () => {
+    const checkbox = shallow(
+        <Checkbox onChange={jest.fn()} schemaOptions={{type: {value: 'toggler'}}} value={false} />
+    );
+    expect(checkbox.find(Toggler).prop('checked')).toEqual(false);
+});
+
+test('Call onChange and onFinish on the changed callback of the Toggler', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const checkbox = shallow(
+        <Checkbox onChange={changeSpy} onFinish={finishSpy} schemaOptions={{type: {value: 'toggler'}}} value={false} />
+    );
+    checkbox.find(Toggler).simulate('change', true);
 
     expect(changeSpy).toBeCalledWith(true);
     expect(finishSpy).toBeCalledWith();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import Checkbox from '../../fields/Checkbox';
+import CheckboxComponent from '../../../../components/Checkbox';
+
+test('Pass the value of true correctly to Checkbox component', () => {
+    const checkbox = shallow(<Checkbox onChange={jest.fn()} value={true} />);
+    expect(checkbox.find(CheckboxComponent).prop('checked')).toEqual(true);
+});
+
+test('Pass the value of false correctly to Checkbox component', () => {
+    const checkbox = shallow(<Checkbox onChange={jest.fn()} value={false} />);
+    expect(checkbox.find(CheckboxComponent).prop('checked')).toEqual(false);
+});
+
+test('Call onChange and onFinish on the changed callback', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const checkbox = shallow(<Checkbox onChange={changeSpy} onFinish={finishSpy} value={false} />);
+    checkbox.find(CheckboxComponent).simulate('change', true);
+
+    expect(changeSpy).toBeCalledWith(true);
+    expect(finishSpy).toBeCalledWith();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -10,6 +10,7 @@ import {setTranslations} from './utils/Translator';
 import Application from './containers/Application';
 import {
     Assignment,
+    Checkbox,
     DatePicker,
     Email,
     fieldRegistry,
@@ -62,6 +63,7 @@ datagridAdapterRegistry.add('table', TableAdapter);
 
 function registerFieldTypes(fieldTypesConfig) {
     fieldRegistry.add('block', FieldBlocks);
+    fieldRegistry.add('checkbox', Checkbox);
     fieldRegistry.add('date', DatePicker);
     fieldRegistry.add('email', Email);
     fieldRegistry.add('phone', Phone);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a new FieldType for the checkbox corresponding to the one in the Aura UI. It can show a checkbox or a toggler, based on the `schemaOptions` it gets passed.

#### Why?

Because we need checkboxes in forms.