### PR TITLE
Fixed empty latitude and longitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #3950 [ContactBundle]           Fixed empty latitude and longitude
+    * HOTFIX      #3949 [ContentBundle]           Fixed security check for deleting draft
+
 * 1.6.18 (2018-05-03)
-    * HOTFIX      #3949 [ContentBundle]           Fix security check for deleting draft
     * ENHANCEMENT #3930 [PreviewBundle]           Fixed preview style-link
     * HOTFIX      #3946 [ContentBundle]           Single internal link: Clear selection when target doesn't exists
     * HOTFIX      #3941 [WebsiteBundle]           Fix hideInSitemap flag for sitemap twig extension

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1312,10 +1312,10 @@ abstract class AbstractContactManager implements ContactManagerInterface
             $address->setState($addressData['state']);
 
             if (isset($addressData['latitude'])) {
-                $address->setLatitude($addressData['latitude']);
+                $address->setLatitude('' !== $addressData['latitude'] ? $addressData['latitude'] : null);
             }
             if (isset($addressData['longitude'])) {
-                $address->setLongitude($addressData['longitude']);
+                $address->setLongitude('' !== $addressData['longitude'] ? $addressData['longitude'] : null);
             }
             if (isset($addressData['note'])) {
                 $address->setNote($addressData['note']);
@@ -1396,10 +1396,10 @@ abstract class AbstractContactManager implements ContactManagerInterface
                 $address->setAddressType($addressType);
 
                 if (isset($entry['latitude'])) {
-                    $address->setLatitude($entry['latitude']);
+                    $address->setLatitude($entry['latitude'] ?: null);
                 }
                 if (isset($entry['longitude'])) {
-                    $address->setLongitude($entry['longitude']);
+                    $address->setLongitude($entry['longitude'] ?: null);
                 }
                 if (isset($entry['note'])) {
                     $address->setNote($entry['note']);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -723,6 +723,8 @@ class ContactControllerTest extends SuluTestCase
                         'postboxPostcode' => '6850',
                         'postboxNumber' => '4711',
                         'note' => 'note',
+                        'latitude' => 47.4049309,
+                        'longitude' => 9.7593077,
                     ],
                 ],
                 'notes' => [
@@ -773,6 +775,8 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('Dornbirn', $response->addresses[0]->postboxCity);
         $this->assertEquals('6850', $response->addresses[0]->postboxPostcode);
         $this->assertEquals('4711', $response->addresses[0]->postboxNumber);
+        $this->assertEquals(47.4049309, $response->addresses[0]->latitude);
+        $this->assertEquals(9.7593077, $response->addresses[0]->longitude);
 
         $this->assertEquals(0, $response->formOfAddress);
         $this->assertEquals('Sehr geehrte Frau Dr Mustermann', $response->salutation);
@@ -824,6 +828,61 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('Sehr geehrte Frau Dr Mustermann', $response->salutation);
 
         $this->assertEquals(2, count($response->categories));
+    }
+
+    public function testPostEmptyLatitude()
+    {
+        $client = $this->createTestClient();
+
+        $client->request(
+            'POST',
+            '/api/contacts',
+            [
+                'firstName' => 'Erika',
+                'lastName' => 'Mustermann',
+                'title' => $this->contactTitle->getId(),
+                'addresses' => [
+                    [
+                        'title' => 'Home',
+                        'street' => 'Musterstraße',
+                        'number' => '1',
+                        'zip' => '0000',
+                        'city' => 'Musterstadt',
+                        'state' => 'Musterstate',
+                        'country' => [
+                            'id' => $this->country->getId(),
+                            'name' => 'Musterland',
+                            'code' => 'ML',
+                        ],
+                        'addressType' => [
+                            'id' => $this->addressType->getId(),
+                            'name' => 'Private',
+                        ],
+                        'billingAddress' => true,
+                        'primaryAddress' => true,
+                        'deliveryAddress' => false,
+                        'postboxCity' => 'Dornbirn',
+                        'postboxPostcode' => '6850',
+                        'postboxNumber' => '4711',
+                        'note' => 'note',
+                        'latitude' => 47.4049309,
+                        'longitude' => '',
+                    ],
+                ],
+                'formOfAddress' => [
+                    'id' => 0,
+                ],
+            ]
+        );
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertEquals('Erika', $response['firstName']);
+        $this->assertEquals('Mustermann', $response['lastName']);
+
+        $this->assertEquals('Home', $response['addresses'][0]['title']);
+        $this->assertEquals(47.4049309, $response['addresses'][0]['latitude']);
+        $this->assertArrayNotHasKey('longitude', $response['addresses'][0]);
     }
 
     public function testPostWithoutAdditionalData()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the lat/long contact-form with empty lat/long.

#### Why?

Newer MySQL versions dont allow empty strings as null value.