### PR TITLE
add prefer-const rule to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,6 +82,7 @@
         "curly": "error",
         "no-case-declarations": "off",
         "no-multi-spaces": "error",
+        "prefer-const": "error",
         "space-infix-ops": "error",
         "import/order": "error",
         "import/no-dynamic-require": "error",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -23,7 +23,7 @@ export default class MultiSelect extends React.PureComponent<Props> {
     static Divider = Select.Divider;
 
     get displayValue(): string {
-        let selectedValues = [];
+        const selectedValues = [];
         let countOptions = 0;
 
         React.Children.forEach(this.props.children, (child: any) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/PopoverPositioner.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/PopoverPositioner.js
@@ -44,7 +44,7 @@ export default class PopoverPositioner {
         const windowWidth = window.innerWidth;
         const windowHeight = window.innerHeight;
         // First, the popover is positioned without taking the screen borders or the minimum height into account.
-        let dimensions = {
+        const dimensions = {
             top: anchorTop + verticalOffset - centerChildOffsetTop,
             left: anchorLeft + horizontalOffset,
             height: popoverHeight,
@@ -89,12 +89,12 @@ export default class PopoverPositioner {
     }
 
     static cropVerticalDimensions(dimensions: PopoverDimensions, windowHeight: number): VerticalCrop {
-        let newDimensions = {...dimensions};
+        const newDimensions = {...dimensions};
         let touchesTopBorder = false;
         let touchesBottomBorder = false;
 
         if (dimensions.top < PADDING_TO_WINDOW) {
-            let newHeight = dimensions.height + dimensions.top - PADDING_TO_WINDOW;
+            const newHeight = dimensions.height + dimensions.top - PADDING_TO_WINDOW;
             newDimensions.top = PADDING_TO_WINDOW;
             newDimensions.height = (newHeight < 0) ? dimensions.height : newHeight;
             newDimensions.scrollTop = -dimensions.top + PADDING_TO_WINDOW;
@@ -114,7 +114,7 @@ export default class PopoverPositioner {
         windowWidth: number,
         popoverWidth: number
     ): PopoverDimensions {
-        let newDimensions = {...dimensions};
+        const newDimensions = {...dimensions};
         newDimensions.left = Math.max(PADDING_TO_WINDOW, newDimensions.left);
         newDimensions.left = Math.min(windowWidth - popoverWidth - PADDING_TO_WINDOW, newDimensions.left);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RatioNormalizer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RatioNormalizer.js
@@ -17,7 +17,7 @@ export default class RatioNormalizer implements Normalizer {
     normalize(data: SelectionData): SelectionData {
         let height = data.height;
         let width = data.width;
-        let calculatedWidth = height * (this.minWidth / this.minHeight);
+        const calculatedWidth = height * (this.minWidth / this.minHeight);
 
         if (calculatedWidth > this.containerWidth) {
             width = this.containerWidth;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/RectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/RectangleSelection.test.js
@@ -24,13 +24,12 @@ test('The component should render with children', () => {
 });
 
 test('The component should render with initial selection', (done) => {
-    let view;
     const spy = jest.fn(() => {
         expect(view.render()).toMatchSnapshot();
         done();
     });
 
-    view = mount(
+    const view = mount(
         <MockedRectangleSelection
             containerWidth={2000}
             containerHeight={1000}
@@ -43,13 +42,12 @@ test('The component should render with initial selection', (done) => {
 });
 
 test('The component should maximize the selection when no initial values given', (done) => {
-    let view;
     const spy = jest.fn(() => {
         expect(view.render()).toMatchSnapshot();
         done();
     });
 
-    view = mount(
+    const view = mount(
         <MockedRectangleSelection mountSpy={spy} containerWidth={2000} containerHeight={1000}>
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
@@ -88,7 +86,6 @@ test('The component should center and maximize the selection when a minHeight an
 });
 
 test('The component should publish the new selection when the rectangle changes', (done) => {
-    let view;
     let selection = {};
     const setSelection = jest.fn((s) => selection = s);
     const spy = jest.fn(() => {
@@ -97,7 +94,7 @@ test('The component should publish the new selection when the rectangle changes'
         done();
     });
 
-    view = mount(
+    const view = mount(
         <MockedRectangleSelection
             mountSpy={spy}
             onChange={setSelection}
@@ -110,7 +107,6 @@ test('The component should publish the new selection when the rectangle changes'
 });
 
 test('The component should not allow the selection to move over the borders', (done) => {
-    let view;
     let selection = {};
     const setSelection = jest.fn((s) => selection = s);
     const spy = jest.fn(() => {
@@ -119,7 +115,7 @@ test('The component should not allow the selection to move over the borders', (d
         done();
     });
 
-    view = mount(
+    const view = mount(
         <MockedRectangleSelection mountSpy={spy} onChange={setSelection} containerWidth={2000} containerHeight={1000}>
             <p>Lorem ipsum</p>
         </MockedRectangleSelection>
@@ -127,7 +123,6 @@ test('The component should not allow the selection to move over the borders', (d
 });
 
 test('The component should not allow the selection to be bigger than the container', (done) => {
-    let view;
     let selection = {};
     const setSelection = jest.fn((s) => selection = s);
     const spy = jest.fn(() => {
@@ -136,7 +131,7 @@ test('The component should not allow the selection to be bigger than the contain
         done();
     });
 
-    view = mount(
+    const view = mount(
         <MockedRectangleSelection
             mountSpy={spy}
             onChange={setSelection}
@@ -149,7 +144,6 @@ test('The component should not allow the selection to be bigger than the contain
 });
 
 test('The component should enforce a ratio on the selection if minWidth and minHeight are given', (done) => {
-    let view;
     let selection = {};
     const setSelection = jest.fn((s) => selection = s);
     const spy = jest.fn(() => {
@@ -158,7 +152,7 @@ test('The component should enforce a ratio on the selection if minWidth and minH
         done();
     });
 
-    view = mount(
+    const view = mount(
         <MockedRectangleSelection
             containerWidth={2000}
             containerHeight={1000}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RoundingNormalizer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/normalizers/RoundingNormalizer.test.js
@@ -2,13 +2,13 @@
 import RoundingNormalizer from '../../normalizers/RoundingNormalizer';
 
 test('The RoundingNormalizer should round correctly', () => {
-    let size = new RoundingNormalizer();
-    let selection = size.normalize({width: 1.33, height: 2.55, left: 6, top: 7.1234});
+    const size = new RoundingNormalizer();
+    const selection = size.normalize({width: 1.33, height: 2.55, left: 6, top: 7.1234});
     expect(selection).toEqual({width: 1, height: 3, left: 6, top: 7});
 });
 
 test('The RoundingNormalizer should not alter already rounded selections', () => {
-    let size = new RoundingNormalizer();
-    let selection = size.normalize({width: 1, height: 2, left: 6, top: 7});
+    const size = new RoundingNormalizer();
+    const selection = size.normalize({width: 1, height: 2, left: 6, top: 7});
     expect(selection).toEqual({width: 1, height: 2, left: 6, top: 7});
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js
@@ -55,7 +55,7 @@ test('Call life-cycle events of rendered component', () => {
         return {};
     });
 
-    let component = mount(<ComponentWithSidebar />);
+    const component = mount(<ComponentWithSidebar />);
     expect(component.instance().componentWillMount).toBeCalled();
     expect(component.instance().render).toBeCalled();
 
@@ -77,7 +77,7 @@ test('Recall sidebar-function when changing observable', () => {
         return {view: this.sidebarView};
     });
 
-    let component = mount(<ComponentWithSidebar />);
+    const component = mount(<ComponentWithSidebar />);
 
     expect(sidebarStore.setConfig).toBeCalledWith({
         view: 'preview',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
@@ -65,7 +65,7 @@ test('Call life-cycle events of rendered component', () => {
 
     const ComponentWithToolbar = withToolbar(Component, () => {});
 
-    let component = mount(<ComponentWithToolbar />);
+    const component = mount(<ComponentWithToolbar />);
     expect(component.instance().componentWillMount).toBeCalled();
     expect(component.instance().render).toBeCalled();
 
@@ -87,7 +87,7 @@ test('Recall toolbar-function when changing observable', () => {
         return {disableAll: this.test};
     });
 
-    let component = mount(<ComponentWithToolbar />);
+    const component = mount(<ComponentWithToolbar />);
 
     expect(toolbarStorePool.setToolbarConfig).toBeCalledWith(DEFAULT_STORE_KEY, {
         disableAll: true,

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -53,7 +53,7 @@ class WebspaceOverview extends React.Component<ViewProps> {
     };
 
     findDefaultLocale = (localizations: Array<Localization>): ?string => {
-        for (let localization of localizations) {
+        for (const localization of localizations) {
             if (localization.default) {
                 return localization.locale;
             }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -81,7 +81,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Services',
             sections: (function() {
-                let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/services/*');
+                const folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/services/*');
 
                 return folders
                     .filter((folder) => path.basename(folder) !== 'index.js')
@@ -97,7 +97,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Views',
             sections: (function() {
-                let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/views/*');
+                const folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/views/*');
 
                 return folders
                     .map((folder) => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This eslint rule checks if it would be possible to use `const` instead of `let` or `var`.

#### Why?

Because I start sweating when I see `let` :wink: And it would be less work for the reviewer and reviewee when submitting PRs.