### PR TITLE
Fix sulu route options with dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* unreleased
+    * HOTFIX      #3953 [RouteBundle]           Fix route options with dash
+
 * 1.5.14 (2018-05-03)
     * HOTFIX      #3946 [ContentBundle]         Single internal link: Clear selection when target doesn't exists
     * HOTFIX      #3941 [WebsiteBundle]         Fix hideInSitemap flag for sitemap twig extension

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('generator')->isRequired()->end()
                             ->arrayNode('options')
                                 ->isRequired()
+                                ->normalizeKeys(false)
                                 ->useAttributeAsKey('name')
                                 ->prototype('scalar')->end()
                             ->end()

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Tests\Unit\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
+use Sulu\Bundle\RouteBundle\DependencyInjection\Configuration;
+use Sulu\Bundle\RouteBundle\DependencyInjection\SuluRouteExtension;
+
+class ConfigurationTest extends AbstractExtensionConfigurationTestCase
+{
+    protected function getContainerExtension()
+    {
+        return new SuluRouteExtension();
+    }
+
+    protected function getConfiguration()
+    {
+        return new Configuration();
+    }
+
+    public function testLoadMappingConfigWithDashUnderlines()
+    {
+        $config = [
+            __DIR__ . '/../../app/Resources/test_config.yml',
+        ];
+
+        $this->assertProcessedConfigurationEquals(
+            [
+                'mappings' => [
+                    'Sulu\Bundle\ArticleBundle\Document\ArticleDocument' => [
+                        'generator' => 'template',
+                        'options' => [
+                            'test' => '/{object.getTitle()}',
+                            'test-dash' => '/{object.getDashTitle()}',
+                            'test_underline' => '/{object.getUnderlineTitle()}',
+                        ],
+                    ],
+                ],
+                'content_types' => [
+                    'route' => [
+                        'template' => '@Test/route.html.twig',
+                    ],
+                ],
+                'objects' => [
+                    'route' => [
+                        'model' => 'TestRouteEntity',
+                        'repository' => 'TestRouteRepository',
+                    ],
+                ],
+            ],
+            $config
+        );
+    }
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/app/Resources/test_config.yml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/app/Resources/test_config.yml
@@ -1,0 +1,15 @@
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
+            generator: template
+            options:
+                test: "/{object.getTitle()}"
+                test-dash: "/{object.getDashTitle()}"
+                test_underline: "/{object.getUnderlineTitle()}"
+    content_types:
+        route:
+            template: "@Test/route.html.twig"
+    objects:
+        route:
+            model: TestRouteEntity
+            repository: TestRouteRepository


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

By default symfony converts dashes to underline.

#### Why?

Example:

```yaml
sulu_route:
    mappings:
        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
            generator: template
            options:
                recipe-gallery: "/galerie/{object.getTitle()}"
```

Currently `recipe-gallery` will be converted to `recipe_gallery` which does not match with the template key.

http://symfony.com/doc/current/components/config/definition.html#normalization
