### PR TITLE
apply colspan from sections to form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
@@ -47,7 +47,7 @@ abstract class Item
         return $this->name;
     }
 
-    public function getLabel(): string
+    public function getLabel(): ?string
     {
         return $this->label;
     }

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
@@ -96,7 +96,11 @@ class ResourceMetadataMapper
     {
         $section = new Section($property->getName());
 
-        $section->setLabel($property->getTitle($locale));
+        $title = $property->getTitle($locale);
+        if ($title) {
+            $section->setLabel($title);
+        }
+
         $section->setSize($property->getSize());
 
         foreach ($property->getChildren() as $component) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Header.js
@@ -71,7 +71,7 @@ export default class Header extends React.PureComponent<Props> {
             const {props} = headerCell;
             let {children} = props;
 
-            if (0 === index) {
+            if (index === 0) {
                 children = this.createFirstCell(children);
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -93,7 +93,7 @@ export default class Row extends React.PureComponent<Props> {
         return React.Children.map(originalCells, (cell: Element<typeof Cell>, index) => {
             const key = `cell-${index}`;
             const {props} = cell;
-            const firstCell = 0 === index;
+            const firstCell = index === 0;
             const {depth} = this.props;
             let {children} = props;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -45,11 +45,13 @@ export default class Renderer extends React.Component<Props> {
         const {items, size} = schemaField;
         return (
             <Grid.Section key={schemaKey} className={rendererStyles.gridSection} size={size}>
-                <Grid.Item size={12}>
-                    <Divider>
-                        {schemaField.label}
-                    </Divider>
-                </Grid.Item>
+                {schemaField.label &&
+                    <Grid.Item size={12}>
+                        <Divider>
+                            {schemaField.label}
+                        </Divider>
+                    </Grid.Item>
+                }
                 {items &&
                     Object.keys(items).map((key) => this.renderItem(items[key], key))
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -42,9 +42,9 @@ export default class Renderer extends React.Component<Props> {
     };
 
     renderGridSection(schemaField: SchemaEntry, schemaKey: string) {
-        const {items} = schemaField;
+        const {items, size} = schemaField;
         return (
-            <Grid.Section key={schemaKey} className={rendererStyles.gridSection}>
+            <Grid.Section key={schemaKey} className={rendererStyles.gridSection} size={size}>
                 <Grid.Item size={12}>
                     <Divider>
                         {schemaField.label}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -323,3 +323,43 @@ test('Should render sections with size', () => {
         />
     )).toMatchSnapshot();
 });
+
+test('Should render sections without label', () => {
+    const changeSpy = jest.fn();
+
+    const schema = {
+        section1: {
+            type: 'section',
+            size: 8,
+            items: {
+                item11: {
+                    label: 'Item 1.1',
+                    type: 'text_line',
+                },
+            },
+        },
+        section2: {
+            label: 'Section 2',
+            type: 'section',
+            size: 4,
+            items: {
+                item21: {
+                    label: 'Item 2.1',
+                    type: 'text_line',
+                },
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
+
+    expect(render(
+        <Renderer
+            data={{}}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFieldFinish={jest.fn()}
+            schema={schema}
+        />
+    )).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -282,3 +282,44 @@ test('Should render nested sections', () => {
         />
     )).toMatchSnapshot();
 });
+
+test('Should render sections with size', () => {
+    const changeSpy = jest.fn();
+
+    const schema = {
+        section1: {
+            label: 'Section 1',
+            type: 'section',
+            size: 8,
+            items: {
+                item11: {
+                    label: 'Item 1.1',
+                    type: 'text_line',
+                },
+            },
+        },
+        section2: {
+            label: 'Section 2',
+            type: 'section',
+            size: 4,
+            items: {
+                item21: {
+                    label: 'Item 2.1',
+                    type: 'text_line',
+                },
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
+
+    expect(render(
+        <Renderer
+            data={{}}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFieldFinish={jest.fn()}
+            schema={schema}
+        />
+    )).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -144,3 +144,80 @@ exports[`Should render nested sections 1`] = `
   </div>
 </div>
 `;
+
+exports[`Should render sections with size 1`] = `
+<div
+  class="grid"
+>
+  <div
+    class="section gridSection"
+    style="width:66.66666666666667%;margin-left:0%;margin-right:0%"
+  >
+    <div
+      class="item"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="divider"
+      >
+        Section 1
+      </div>
+    </div>
+    <div
+      class="item gridItem"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="field"
+      >
+        <label
+          class="label"
+        >
+          Item 1.1
+        </label>
+        <input
+          type="text"
+        />
+        <label
+          class="errorLabel"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="section gridSection"
+    style="width:33.333333333333336%;margin-left:0%;margin-right:0%"
+  >
+    <div
+      class="item"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="divider"
+      >
+        Section 2
+      </div>
+    </div>
+    <div
+      class="item gridItem"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="field"
+      >
+        <label
+          class="label"
+        >
+          Item 2.1
+        </label>
+        <input
+          type="text"
+        />
+        <label
+          class="errorLabel"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -221,3 +221,70 @@ exports[`Should render sections with size 1`] = `
   </div>
 </div>
 `;
+
+exports[`Should render sections without label 1`] = `
+<div
+  class="grid"
+>
+  <div
+    class="section gridSection"
+    style="width:66.66666666666667%;margin-left:0%;margin-right:0%"
+  >
+    <div
+      class="item gridItem"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="field"
+      >
+        <label
+          class="label"
+        >
+          Item 1.1
+        </label>
+        <input
+          type="text"
+        />
+        <label
+          class="errorLabel"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="section gridSection"
+    style="width:33.333333333333336%;margin-left:0%;margin-right:0%"
+  >
+    <div
+      class="item"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="divider"
+      >
+        Section 2
+      </div>
+    </div>
+    <div
+      class="item gridItem"
+      style="width:100%;margin-left:0%;margin-right:0%"
+    >
+      <div
+        class="field"
+      >
+        <label
+          class="label"
+        >
+          Item 2.1
+        </label>
+        <input
+          type="text"
+        />
+        <label
+          class="errorLabel"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -16,7 +16,7 @@ export type Types = {[key: string]: Type};
 
 export type SchemaEntry = {
     items?: Schema,
-    label: string,
+    label?: string,
     maxOccurs?: number,
     minOccurs?: number,
     options?: Object,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -51,6 +51,24 @@ class FormXmlLoaderTest extends TestCase
         $this->assertEquals('salutation', $formMetadata->getProperties()['salutation']->getName());
     }
 
+    public function testLoadFormWithSizedSections()
+    {
+        /** @var FormMetadata $formMetadata */
+        $formMetadata = $this->loader->load(
+            __DIR__ . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'form_with_sections.xml'
+        );
+
+        $this->assertInstanceOf(FormMetadata::class, $formMetadata);
+
+        $this->assertCount(2, $formMetadata->getChildren());
+        $this->assertEquals('logo', $formMetadata->getChildren()['logo']->getName());
+        $this->assertEquals(4, $formMetadata->getChildren()['logo']->getSize());
+        $this->assertCount(1, $formMetadata->getChildren()['logo']->getChildren());
+        $this->assertEquals('name', $formMetadata->getChildren()['name']->getName());
+        $this->assertEquals(8, $formMetadata->getChildren()['name']->getSize());
+        $this->assertCount(1, $formMetadata->getChildren()['name']->getChildren());
+    }
+
     public function testLoadFormInvalid()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_with_sections.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_with_sections.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/properties-1.0.xsd">
+    <section name="logo" colspan="4">
+        <properties>
+            <property name="upload" type="single_media_upload" />
+        </properties>
+    </section>
+
+    <section name="name" colspan="8">
+        <properties>
+            <property name="lastname" type="text_line" mandatory="true" colspan="12" />
+        </properties>
+    </section>
+</properties>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
@@ -213,6 +213,18 @@ class ResourceMetadataMapperTest extends TestCase
         $this->assertCount(2, $section->getItems()['blocktest']->getTypes());
     }
 
+    public function testMapFormSectionWithoutLabel()
+    {
+        $section = new SectionMetadata('sectiontest');
+
+        $form = $this->resourceMetadataMapper->mapForm([$section], 'de');
+
+        /** @var Section $section */
+        $section = $form->getItems()['sectiontest'];
+        $this->assertEquals('sectiontest', $section->getName());
+        $this->assertNull($section->getLabel());
+    }
+
     private function getProperties(string $type): array
     {
         $property1 = new PropertyMetadata('test1');

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -409,6 +409,7 @@ class PropertiesXmlParser
     {
         $section = new SectionMetadata();
         $section->setName($propertyName);
+        $section->setSize($data['colspan']);
         if (isset($data['meta']['title'])) {
             $section->setTitles($data['meta']['title']);
         }

--- a/src/Sulu/Component/Content/Metadata/SectionMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/SectionMetadata.php
@@ -31,11 +31,15 @@ class SectionMetadata extends ItemMetadata
      */
     protected $size = null;
 
-    /**
-     * Return the colspan.
-     *
-     * @return int
-     */
+    public function getTitle($locale)
+    {
+        if (!array_key_exists($locale, $this->titles)) {
+            return;
+        }
+
+        return $this->titles[$locale];
+    }
+
     public function getColSpan()
     {
         @trigger_error(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the missing colspans in form sections.

#### Why?

Because we would like to use sections with colspans in the account and contact form.

#### Example Usage

~~~xml
<section name="test" colspan="8">
</section>
~~~

#### To Do

- [x] return label from resource API only if a title has been set
