### PR TITLE
Added function to get value for property name

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
@@ -20,4 +20,12 @@ export default class FormInspector {
     get id(): ?string | number {
         return this.formStore.id;
     }
+
+    getValueByName(name: string): mixed {
+        if (!this.formStore.data[name]) {
+            throw new Error('Property with name "' + name + '" not found');
+        }
+
+        return this.formStore.data[name];
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/FormInspector.js
@@ -1,5 +1,6 @@
 // @flow
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import pointer from 'jsonpointer';
 import FormStore from './stores/FormStore';
 
 export default class FormInspector {
@@ -21,11 +22,7 @@ export default class FormInspector {
         return this.formStore.id;
     }
 
-    getValueByName(name: string): mixed {
-        if (!this.formStore.data[name]) {
-            throw new Error('Property with name "' + name + '" not found');
-        }
-
-        return this.formStore.data[name];
+    getValueByPath(path: string): mixed {
+        return pointer.get(this.formStore.data, path);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/FormInspector.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/FormInspector.test.js
@@ -7,6 +7,9 @@ import FormStore from '../stores/FormStore';
 jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, options) {
     this.resourceKey = resourceKey;
     this.id = id;
+    this.data = {
+        test: 'value',
+    };
 
     if (options) {
         this.locale = options.locale;
@@ -42,4 +45,18 @@ test('Should return the id from the FormStore', () => {
     const formInspector = new FormInspector(formStore);
 
     expect(formInspector.id).toEqual(3);
+});
+
+test('Should return value for property name', () => {
+    const formStore = new FormStore(new ResourceStore('test', 3));
+    const formInspector = new FormInspector(formStore);
+
+    expect(formInspector.getValueByName('test')).toEqual('value');
+});
+
+test('Should throw error for non existing property', () => {
+    const formStore = new FormStore(new ResourceStore('test', 3));
+    const formInspector = new FormInspector(formStore);
+
+    expect(() => formInspector.getValueByName('test')).toThrow(/test/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/FormInspector.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/FormInspector.test.js
@@ -7,9 +7,6 @@ import FormStore from '../stores/FormStore';
 jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, options) {
     this.resourceKey = resourceKey;
     this.id = id;
-    this.data = {
-        test: 'value',
-    };
 
     if (options) {
         this.locale = options.locale;
@@ -20,6 +17,7 @@ jest.mock('../stores/FormStore', () => jest.fn(function(resourceStore) {
     this.resourceKey = resourceStore.resourceKey;
     this.id = resourceStore.id;
     this.locale = resourceStore.locale;
+    this.data = resourceStore.data;
 }));
 
 test('Should return the resourceKey from the FormStore', () => {
@@ -47,16 +45,12 @@ test('Should return the id from the FormStore', () => {
     expect(formInspector.id).toEqual(3);
 });
 
-test('Should return value for property name', () => {
-    const formStore = new FormStore(new ResourceStore('test', 3));
+test('Should return value for property path', () => {
+    const resourceStore = new ResourceStore('test', 3);
+    resourceStore.data = {test: 'value'};
+
+    const formStore = new FormStore(resourceStore);
     const formInspector = new FormInspector(formStore);
 
-    expect(formInspector.getValueByName('test')).toEqual('value');
-});
-
-test('Should throw error for non existing property', () => {
-    const formStore = new FormStore(new ResourceStore('test', 3));
-    const formInspector = new FormInspector(formStore);
-
-    expect(() => formInspector.getValueByName('test')).toThrow(/test/);
+    expect(formInspector.getValueByPath('/test')).toEqual('value');
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds a function `getValueByName` to build dependent field-types.