### PR TITLE
remove react deprecations

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -40,7 +40,9 @@ export default class BlockCollection extends React.Component<Props> {
         return Object.keys(types)[0];
     }
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.fillArrays();
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -53,7 +53,9 @@ export default class DatePicker extends React.Component<Props> {
         this.inputRef = ref;
     };
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.setValue(this.props.value);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -31,7 +31,9 @@ export default class Dialog extends React.Component<Props> {
     @observable visible: boolean = false;
     @observable openHasChanged: boolean = false;
 
-    @action componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.openHasChanged = this.props.open;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -48,7 +48,9 @@ export class ImageRectangleSelection extends React.Component<Props> {
         };
     }
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.image = new Image();
         this.image.onload = action(() => this.imageLoaded = true);
         this.image.onerror = () => log.error('Failed to preload image "' + this.props.src + '"');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
@@ -12,7 +12,9 @@ class MockedImageSelection extends ImageRectangleSelection {
         Promise.resolve().then(this.props.mountSpy);
     }
 
-    componentWillMount() {
+    constructor(props) {
+        super(props);
+
         this.image = {naturalWidth: 1920, naturalHeight: 1080};
         this.imageLoaded = true;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -34,7 +34,9 @@ export default class Navigation extends React.Component<Props> {
         this.findDefaultExpandedChild(newProps.children);
     }
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.findDefaultExpandedChild(this.props.children);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -39,7 +39,9 @@ export default class Overlay extends React.Component<Props> {
     @observable visible: boolean = false;
     @observable openHasChanged: boolean = false;
 
-    @action componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         Mousetrap.bind('esc', this.close);
         this.openHasChanged = this.props.open;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -69,7 +69,9 @@ export class RectangleSelection extends React.Component<Props> {
         return normalizers;
     }
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.normalizers = RectangleSelection.createNormalizers(this.props);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -18,7 +18,9 @@ export default class ResourceLocator extends React.PureComponent<Props> {
     fixed: string = '';
     changeable: string = '';
 
-    componentWillMount = () => {
+    constructor(props: Props) {
+        super(props);
+
         const {value, mode} = this.props;
 
         switch (mode) {
@@ -34,7 +36,7 @@ export default class ResourceLocator extends React.PureComponent<Props> {
             default:
                 throw new Error('Unknown mode given: "' + mode + '"');
         }
-    };
+    }
 
     componentWillReceiveProps = (nextProps: Props) => {
         this.changeable = nextProps.value.substring(this.fixed.length);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/Assignment.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/Assignment.js
@@ -36,7 +36,9 @@ export default class Assignment extends React.Component<Props> {
 
     @observable overlayOpen: boolean = false;
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {onChange, locale, resourceKey, value} = this.props;
 
         this.assignmentStore = new AssignmentStore(resourceKey, value, locale);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/DatagridOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Assignment/DatagridOverlay.js
@@ -30,7 +30,9 @@ export default class DatagridOverlay extends React.Component<Props> {
         preSelectedItems: [],
     };
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {locale, preSelectedItems, resourceKey} = this.props;
         const observableOptions = {};
         observableOptions.page = this.page;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -32,7 +32,9 @@ export default class Datagrid extends React.Component<Props> {
         return datagridAdapterRegistry.get(this.currentAdapterKey);
     }
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         this.validateAdapters();
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -286,7 +286,9 @@ test('DatagridStore should be updated with current active element', () => {
 
         static icon = 'su-th-large';
 
-        componentWillMount() {
+        constructor(props: *) {
+            super(props);
+
             const {onItemActivation} = this.props;
             if (onItemActivation) {
                 onItemActivation('some-uuid');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -4,7 +4,9 @@ import ResourceLocatorComponent from '../../../components/ResourceLocator';
 import type {FieldTypeProps} from '../../../types';
 
 export default class ResourceLocator extends React.Component<FieldTypeProps<string>> {
-    componentWillMount() {
+    constructor(props: FieldTypeProps<string>) {
+        super(props);
+
         const {onChange, value} = this.props;
 
         if (value === undefined || value === '') {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -6,7 +6,9 @@ import type {FieldTypeProps} from '../../../types';
 const MISSING_VALUES_OPTIONS = 'The "values" option has to be set for the SingleSelect FieldType';
 
 export default class SingleSelect extends React.Component<FieldTypeProps<string | number>> {
-    componentWillMount() {
+    constructor(props: FieldTypeProps<string | number>) {
+        super(props);
+
         const {onChange, schemaOptions, value} = this.props;
 
         if (!schemaOptions) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js
@@ -46,7 +46,6 @@ test('Bind sidebar method to component instance', () => {
 
 test('Call life-cycle events of rendered component', () => {
     const Component = class Component extends React.Component<*> {
-        componentWillMount = jest.fn();
         componentWillUnmount = jest.fn();
         render = jest.fn();
     };
@@ -56,7 +55,6 @@ test('Call life-cycle events of rendered component', () => {
     });
 
     const component = mount(<ComponentWithSidebar />);
-    expect(component.instance().componentWillMount).toBeCalled();
     expect(component.instance().render).toBeCalled();
 
     const componentWillUnmount = component.instance().componentWillUnmount;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/withSidebar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/withSidebar.js
@@ -14,13 +14,11 @@ export default function withSidebar(
 
         sidebarDisposer: Function;
 
-        componentWillMount() {
+        constructor(props: *) {
+            super(props);
+
             if (super.hasOwnProperty('sidebarDisposer')) {
                 throw new Error('Component passed to withSidebar cannot declare a property called "sidebarDisposer".');
-            }
-
-            if (super.componentWillMount) {
-                super.componentWillMount();
             }
 
             this.sidebarDisposer = autorun(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -43,7 +43,9 @@ export default class Toolbar extends React.Component<*> {
 
     toolbarStore: ToolbarStore;
 
-    componentWillMount() {
+    constructor(props: *) {
+        super(props);
+
         this.setStore(this.props.storeKey);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
@@ -58,7 +58,6 @@ test('Bind toolbar method to component instance', () => {
 
 test('Call life-cycle events of rendered component', () => {
     const Component = class Component extends React.Component {
-        componentWillMount = jest.fn();
         componentWillUnmount = jest.fn();
         render = jest.fn();
     };
@@ -66,7 +65,6 @@ test('Call life-cycle events of rendered component', () => {
     const ComponentWithToolbar = withToolbar(Component, () => {});
 
     const component = mount(<ComponentWithToolbar />);
-    expect(component.instance().componentWillMount).toBeCalled();
     expect(component.instance().render).toBeCalled();
 
     const componentWillUnmount = component.instance().componentWillUnmount;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -13,13 +13,11 @@ export default function withToolbar(
     const WithToolbarComponent = class extends Component {
         toolbarDisposer: Function;
 
-        componentWillMount() {
+        constructor(props: *) {
+            super(props);
+
             if (super.hasOwnProperty('toolbarDisposer')) {
                 throw new Error('Component passed to withToolbar cannot declare a property called "toolbarDisposer".');
-            }
-
-            if (super.componentWillMount) {
-                super.componentWillMount();
             }
 
             this.toolbarDisposer = autorun(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -47,7 +47,9 @@ class Datagrid extends React.Component<ViewProps> {
         };
     }
 
-    @action componentWillMount() {
+    constructor(props: ViewProps) {
+        super(props);
+
         const router = this.props.router;
         const {
             route: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -30,7 +30,9 @@ class Form extends React.PureComponent<Props> {
         return resourceKey && resourceStore.resourceKey !== resourceKey;
     }
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {resourceStore, router} = this.props;
         const {
             attributes: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -13,7 +13,9 @@ import resourceTabsStyle from './resourceTabs.scss';
 export default class ResourceTabs extends React.Component<ViewProps> {
     resourceStore: ResourceStore;
 
-    componentWillMount() {
+    constructor(props: ViewProps) {
+        super(props);
+
         const {router, route} = this.props;
         const {
             attributes: {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
@@ -20,7 +20,9 @@ class PageForm extends React.Component<Props> {
     form: ?Form;
     @observable webspace: Webspace;
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {resourceStore, router} = this.props;
         this.formStore = new FormStore(resourceStore);
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
@@ -24,7 +24,9 @@ export default class CollectionFormOverlay extends React.Component<Props> {
     operationType: string;
     @observable formStore: FormStore;
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {resourceStore} = this.props;
         this.formStore = new FormStore(resourceStore);
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
@@ -15,7 +15,9 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
     mediaSelectionStore: MediaSelectionStore;
     @observable overlayOpen: boolean = false;
 
-    componentWillMount() {
+    constructor(props: FieldTypeProps<Value>) {
+        super(props);
+
         const {
             formInspector,
             value,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
@@ -36,7 +36,9 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
     @observable collectionStore: CollectionStore;
     overlayDisposer: () => void;
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {open} = this.props;
 
         if (open) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -23,7 +23,9 @@ class MediaDetail extends React.Component<Props> {
     form: ?Form;
     formStore: FormStore;
 
-    componentWillMount() {
+    constructor(props: Props) {
+        super(props);
+
         const {
             router,
             resourceStore,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -25,7 +25,9 @@ class MediaOverview extends React.Component<ViewProps> {
     @observable collectionStore: CollectionStore;
     disposer: () => void;
 
-    componentWillMount() {
+    constructor(props: ViewProps) {
+        super(props);
+
         const {router} = this.props;
 
         this.mediaPage.set(1);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR replaces all occurences from `componentWillMount` with `constructor`. I've tested the components I've touched, and they still seem to work as expected.

#### Why?

Because `componentWillMount` is deprecated, and we do not want to use deprecated code to avoid problems in the future.

There are a few more deprecated react methods, but they were not that easy to replace.