### PR TITLE
Removed export-ignore attribute for package.json files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,6 @@ bower.json export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore
 Gruntfile.js export-ignore
-package.json export-ignore
 phpunit.xml.dist export-ignore
 README.md export-ignore
 UPGRADE.md export-ignore


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the export-ignore git attribute for package.json files

#### Why?

The build in sulu-minimal needs it.
