### PR TITLE
update to flow 0.71

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,8 +3,10 @@ esproposal.decorators=ignore
 module.name_mapper='.+\.s?css' -> 'empty/object'
 
 [ignore]
+.*/node_modules/bower-json/.*
 .*/node_modules/config-chain/.*
 .*/node_modules/findup/.*
 .*/node_modules/jss/.*
+.*/node_modules/npmconf/.*
 .*/node_modules/stylelint/.*
 .*/vendor/symfony/.*

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "eslint-plugin-react": "^7.6.1",
         "extract-text-webpack-plugin": "^3.0.1",
         "file-loader": "^0.11.2",
-        "flow-bin": "^0.67.1",
+        "flow-bin": "^0.71.0",
         "glob": "^7.1.2",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^22.4.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Toolbar.js
@@ -30,7 +30,7 @@ export default class Toolbar extends React.Component<Props> {
         }
     };
 
-    renderToolbarItems = (toolbarItems: Array<ToolbarItemConfig>) => {
+    renderToolbarItems = (toolbarItems: Array<ToolbarItemConfig>): Array<*> => {
         return toolbarItems.map((toolbarItemConfig: ToolbarItemConfig, index: number) => {
             switch (toolbarItemConfig.type) {
                 case 'dropdown':

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/types.js
@@ -1,0 +1,4 @@
+// @flow
+import type {Element} from 'react';
+
+export type WithContainerSizeElement = Element<*> & {containerDidMount?: () => {}};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/withContainerSize/withContainerSize.js
@@ -1,16 +1,17 @@
 // @flow
 import {action, observable} from 'mobx';
-import type {ComponentType, Element, ElementRef} from 'react';
+import type {ComponentType, ElementRef} from 'react';
 import React from 'react';
 import {observer} from 'mobx-react';
 import {buildHocDisplayName} from '../../services/react';
 import {afterElementsRendered} from '../../services/DOM';
 import styles from './withContainerSize.scss';
+import type {WithContainerSizeElement} from './types';
 
 export default function withContainerSize(Component: ComponentType<*>, containerClass: string = styles.container) {
     @observer
     class WithContainerSizeComponent extends React.Component<*> {
-        component: Element<*>;
+        component: WithContainerSizeElement;
 
         container: ElementRef<'div'>;
 
@@ -42,7 +43,7 @@ export default function withContainerSize(Component: ComponentType<*>, container
             }));
         };
 
-        setComponent = (component: Element<*>) => {
+        setComponent = (component: WithContainerSizeElement) => {
             this.component = component;
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/AbstractTableAdapter.js
@@ -1,7 +1,6 @@
 // @flow
 import {computed} from 'mobx';
 import React from 'react';
-import type {Element} from 'react';
 import Table from '../../../components/Table';
 import datagridFieldTransformerRegistry from '../registries/DatagridFieldTransformerRegistry';
 import type {Schema} from '../types';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/AbstractTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/AbstractTableAdapter.js
@@ -1,6 +1,7 @@
 // @flow
 import {computed} from 'mobx';
 import React from 'react';
+import type {Element} from 'react';
 import Table from '../../../components/Table';
 import datagridFieldTransformerRegistry from '../registries/DatagridFieldTransformerRegistry';
 import type {Schema} from '../types';
@@ -27,7 +28,7 @@ export default class AbstractTableAdapter extends AbstractAdapter {
         return newSchema;
     }
 
-    renderCells(item: Object) {
+    renderCells(item: Object): Array<*> {
         const schemaKeys = Object.keys(this.schema);
 
         return schemaKeys.map((schemaKey) => {
@@ -40,7 +41,7 @@ export default class AbstractTableAdapter extends AbstractAdapter {
         });
     }
 
-    renderHeaderCells(sortingEnabled: boolean) {
+    renderHeaderCells(sortingEnabled: boolean): Array<*> {
         const {sortColumn, sortOrder} = this.props;
         const schemaKeys = Object.keys(this.schema);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TreeListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TreeListAdapter.js
@@ -57,7 +57,7 @@ export default class TreeListAdapter extends AbstractTableAdapter {
         });
     }
 
-    renderRows() {
+    renderRows(): Array<*> {
         return this.data.map((item) => {
             const {
                 selections,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/FormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/FormStore.js
@@ -94,8 +94,7 @@ export default class FormStore {
         this.schema = schema;
         const schemaFields = Object.keys(schema)
             .reduce((data, key) => addSchemaProperties(data, key, schema), {});
-        const newData = {...schemaFields, ...this.resourceStore.data};
-        this.resourceStore.data = this.hasType ? {[TYPE]: this.defaultType, ...newData} : newData;
+        this.resourceStore.data = {...schemaFields, ...this.resourceStore.data};
         this.schemaLoading = false;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -32,6 +32,7 @@ export default class ViewRenderer extends React.Component<Props> {
         route = route ? route : this.props.router.route;
         const View = this.getView(route);
 
+        // $FlowFixMe
         if (View.hasSidebar) {
             return true;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
@@ -5,6 +5,7 @@ import viewRegistry from './registries/ViewRegistry';
 const updateRouterAttributesFromView: UpdateAttributesHook = function (route) {
     const View = viewRegistry.get(route.view);
 
+    // $FlowFixMe
     if (typeof View.getDerivedRouteAttributes === 'function') {
         const attributes = View.getDerivedRouteAttributes(route);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -49,8 +49,6 @@ import type {FieldTypeProps} from './types';
 
 export type {FieldTypeProps};
 
-// Bug in flow: https://github.com/facebook/flow/issues/6186
-// $FlowFixMe:
 configure({enforceActions: true});
 
 window.log = log;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -45,7 +45,7 @@ export default class MultiMediaDropzone extends React.Component<Props> {
         this.mediaUploadStores = [];
     }
 
-    createMediaItems() {
+    createMediaItems(): Array<*> {
         return this.mediaUploadStores.map((mediaUploadStore, index) => (
             <MediaItem key={index} store={mediaUploadStore} />
         ));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR updates to flow 0.71.

#### Why?

Because the `finally` method on promises are available there.

#### To Do

- [x] Fix the rest of the errors