### PR TITLE
rename info_text to infoText

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Option.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Option.php
@@ -36,7 +36,7 @@ class Option
     /**
      * @var ?string
      */
-    protected $infotext;
+    protected $infoText;
 
     public function getName(): ?string
     {
@@ -95,11 +95,11 @@ class Option
 
     public function getInfotext(): ?string
     {
-        return $this->infotext;
+        return $this->infoText;
     }
 
-    public function setInfotext(string $infotext = null): void
+    public function setInfotext(string $infoText = null): void
     {
-        $this->infotext = $infotext;
+        $this->infoText = $infoText;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -15,8 +15,20 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<stri
     }
 
     render() {
-        const {onChange, value, schemaOptions, onFinish} = this.props;
-        const mode = schemaOptions && schemaOptions.mode ? schemaOptions.mode : 'leaf';
+        const {
+            onChange,
+            value,
+            schemaOptions: {
+                mode: {
+                    value: mode,
+                } = {value: 'leaf'},
+            } = {},
+            onFinish,
+        } = this.props;
+
+        if (mode !== 'leaf' && mode !== 'full') {
+            throw new Error('The "mode" schema option must be either "leaf" or "full"!');
+        }
 
         if (!value) {
             return null;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -15,10 +15,22 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
             return;
         }
 
-        const {default_value: defaultValue} = schemaOptions;
+        const {
+            default_value: {
+                value: defaultValue,
+            } = {},
+        } = schemaOptions;
+
+        if (!defaultValue) {
+            return;
+        }
+
+        if (typeof defaultValue !== 'number' && typeof defaultValue !== 'string') {
+            throw new Error('The "default_value" schema option must be a string or a number!');
+        }
 
         if (value === undefined) {
-            onChange(defaultValue.value);
+            onChange(defaultValue);
         }
     }
 
@@ -40,17 +52,23 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
 
         const {values} = schemaOptions;
 
-        if (!values) {
+        if (!Array.isArray(values.value)) {
             throw new Error(MISSING_VALUES_OPTIONS);
         }
 
         return (
             <SingleSelectComponent onChange={this.handleChange} value={value}>
-                {values.value.map((value) => (
-                    <SingleSelectComponent.Option key={value.value} value={value.value}>
-                        {value.title}
-                    </SingleSelectComponent.Option>
-                ))}
+                {values.value.map(({value, title}) => {
+                    if (typeof value !== 'string' && typeof value !== 'number') {
+                        throw new Error('The children of "values" must only contain values of type string or number!');
+                    }
+
+                    return (
+                        <SingleSelectComponent.Option key={value} value={value}>
+                            {title}
+                        </SingleSelectComponent.Option>
+                    );
+                })}
             </SingleSelectComponent>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -6,7 +6,9 @@ import ResourceLocatorComponent from '../../../../components/ResourceLocator';
 
 test('Pass props correctly to ResourceLocator', () => {
     const schemaOptions = {
-        mode: 'full',
+        mode: {
+            value: 'full',
+        },
     };
 
     const resourceLocator = shallow(
@@ -19,7 +21,19 @@ test('Pass props correctly to ResourceLocator', () => {
     );
 
     expect(resourceLocator.find(ResourceLocatorComponent).prop('value')).toBe('/');
-    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe(schemaOptions.mode);
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
+});
+
+test('Throw an exception if a non-valid mode is passed', () => {
+    const schemaOptions = {
+        mode: {
+            value: 'test',
+        },
+    };
+
+    expect(
+        () => shallow(<ResourceLocator onChange={jest.fn()} schemaOptions={schemaOptions} value="/" />)
+    ).toThrow(/"leaf" or "full"/);
 });
 
 test('Set default value correctly with undefined value', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -38,6 +38,61 @@ test('Pass props correctly to SingleSelect', () => {
     }));
 });
 
+test('Should throw an exception if defaultValue is of wrong type', () => {
+    const schemaOptions = {
+        default_value: {
+            value: [],
+        },
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelect
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            schemaOptions={schemaOptions}
+            value="test"
+        />
+    )).toThrow(/"default_value"/);
+});
+
+test('Should throw an exception if value is of wrong type', () => {
+    const schemaOptions = {
+        values: {
+            value: [
+                {
+                    value: [],
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelect
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            schemaOptions={schemaOptions}
+            value="test"
+        />
+    )).toThrow(/"values"/);
+});
+
 test('Should call onFinish callback on every onChange', () => {
     const finishSpy = jest.fn();
     const schemaOptions = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -24,6 +24,15 @@ export type Error = BlockError | PropertyError;
 
 export type ErrorCollection = {[key: string]: Error};
 
+export type SchemaOption = {
+    name?: string,
+    infoText?: string,
+    title?: string,
+    value?: string | Array<SchemaOption>,
+};
+
+export type SchemaOptions = {[key: string]: SchemaOption};
+
 export type FieldTypeProps<T> = {|
     error?: Error | ErrorCollection,
     fieldTypeOptions?: Object,
@@ -32,7 +41,7 @@ export type FieldTypeProps<T> = {|
     minOccurs?: number,
     onChange: (value: T) => void,
     onFinish?: () => void,
-    schemaOptions?: Object,
+    schemaOptions?: SchemaOptions,
     showAllErrors?: boolean,
     types?: Types,
     value: ?T,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Rename this field on the server side to match xml.

Also introduced some flow typings to find the necessary changes, and found a few bugs because of that.

#### Why?

Because we want to be consistent.