### PR TITLE
read properties param value using expression language

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/ExpressionLanguage/ContainerExpressionLanguageProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/ExpressionLanguage/ContainerExpressionLanguageProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\ExpressionLanguage;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+class ContainerExpressionLanguageProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new ExpressionFunction(
+                'service',
+                function () {
+                },
+                function (array $variables, $value) {
+                    return $this->container->get($value);
+                }
+            ),
+
+            new ExpressionFunction(
+                'parameter',
+                function () {
+                },
+                function (array $variables, $value) {
+                    return $this->container->getParameter($value);
+                }
+            ),
+        ];
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -100,5 +100,19 @@
             id="sulu_admin.field_type_option_registry"
             class="Sulu\Bundle\AdminBundle\FieldType\FieldTypeOptionRegistry"
         />
+
+        <service id="sulu_admin.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage">
+            <argument>null</argument>
+            <argument type="collection">
+                <argument type="service" id="sulu_admin.symfony_expression_language_provider" />
+            </argument>
+        </service>
+
+        <service
+            id="sulu_admin.symfony_expression_language_provider"
+            class="Sulu\Bundle\AdminBundle\ExpressionLanguage\ContainerExpressionLanguageProvider"
+        >
+            <argument type="service" id="service_container" />
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/AdminBundle/Tests/ExpressionLanguage/ContainerExpressionLanguageProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/ExpressionLanguage/ContainerExpressionLanguageProviderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\ExpressionLanguage;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\ExpressionLanguage\ContainerExpressionLanguageProvider;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class ContainerExpressionLanguageProviderTest extends TestCase
+{
+    /**
+     * @var ExpressionLanguage
+     */
+    private $expressionLanguage;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $containerExpressionLanguageProvider = new ContainerExpressionLanguageProvider($this->container->reveal());
+        $this->expressionLanguage = new ExpressionLanguage(null, [$containerExpressionLanguageProvider]);
+    }
+
+    public function testEvaluateWithService()
+    {
+        $testService = new \stdClass();
+        $testService->variable = 'test';
+
+        $this->container->get('test_service')->willReturn($testService);
+        $this->assertEquals('test', $this->expressionLanguage->evaluate('service("test_service").variable'));
+    }
+
+    public function testEvaluateWithParameter()
+    {
+        $this->container->getParameter('test_variable')->willReturn('test');
+        $this->assertEquals('test', $this->expressionLanguage->evaluate('parameter("test_variable")'));
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_with_expression_param.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_with_expression_param.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<properties xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/properties-1.0.xsd">
+    <property name="name" type="text_line">
+        <params>
+            <param name="id" expression="service('test').getId()" />
+        </params>
+    </property>
+</properties>

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
@@ -19,6 +19,7 @@
         <service id="sulu_content.structure.properties_xml_parser"
                  class="Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser"
                  public="false">
+            <argument type="service" id="sulu_admin.expression_language" />
         </service>
 
         <service id="sulu_content.structure.factory" class="%sulu_content.structure.factory.class%">

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -173,6 +173,7 @@
         <xs:attribute name="type" type="paramTypeType" default="string"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="value" type="xs:string" use="optional"/>
+        <xs:attribute name="expression" type="xs:string" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -21,6 +21,7 @@ use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\Loader\StructureXmlLoader;
 use Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser;
 use Sulu\Component\Content\Metadata\StructureMetadata;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 
@@ -62,6 +63,11 @@ class StructureMetadataFactoryTest extends TestCase
     private $defaultStructure;
 
     /**
+     * @var ExpressionLanguage
+     */
+    private $expressionLanguage;
+
+    /**
      * @var StructureMetadata
      */
     private $apostropheStructure;
@@ -85,6 +91,7 @@ class StructureMetadataFactoryTest extends TestCase
         $this->defaultMappingFile = implode(DIRECTORY_SEPARATOR, [__DIR__, 'data', 'other', 'default.xml']);
         $this->overriddenDefaultMappingFile = implode(DIRECTORY_SEPARATOR, [__DIR__, 'data', 'page', 'default.xml']);
 
+        $this->expressionLanguage = $this->prophesize(ExpressionLanguage::class);
         $this->apostropheStructure = $this->prophesize('Sulu\Component\Content\Metadata\StructureMetadata');
         $this->somethingStructure = $this->prophesize('Sulu\Component\Content\Metadata\StructureMetadata');
         $this->defaultStructure = $this->prophesize('Sulu\Component\Content\Metadata\StructureMetadata');
@@ -179,7 +186,7 @@ class StructureMetadataFactoryTest extends TestCase
         $cacheLifeTimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
-        $propertiesXmlLoader = new PropertiesXmlParser();
+        $propertiesXmlLoader = new PropertiesXmlParser($this->expressionLanguage->reveal());
 
         $xmlLoader = new StructureXmlLoader(
             $cacheLifeTimeResolver->reveal(),

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Metadata\Loader\StructureXmlLoader;
 use Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class XmlLoaderTest extends TestCase
 {
@@ -24,6 +25,11 @@ class XmlLoaderTest extends TestCase
      * @var StructureXmlLoader
      */
     private $loader;
+
+    /**
+     * @var ExpressionLanguage
+     */
+    private $expressionLanguage;
 
     /**
      * @var ContentTypeManagerInterface
@@ -37,10 +43,11 @@ class XmlLoaderTest extends TestCase
 
     public function setUp()
     {
+        $this->expressionLanguage = $this->prophesize(ExpressionLanguage::class);
         $this->contentTypeManager = $this->prophesize(ContentTypeManagerInterface::class);
         $this->cacheLifetimeResolver = $this->prophesize(CacheLifetimeResolverInterface::class);
 
-        $propertiesXmlParser = new PropertiesXmlParser();
+        $propertiesXmlParser = new PropertiesXmlParser($this->expressionLanguage->reveal());
 
         $this->loader = new StructureXmlLoader(
             $this->cacheLifetimeResolver->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces the possibility to use the expression language in the template `param` xml tag using the `expr` attribute.

#### Why?

Because we need to find some params using services, e.g. when deciding to which collection images from the `SingleMediaUpload` should be uploaded.

#### Example Usage

see #3956 