### PR TITLE
make ExpressionLanguage available in website context

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -100,19 +100,5 @@
             id="sulu_admin.field_type_option_registry"
             class="Sulu\Bundle\AdminBundle\FieldType\FieldTypeOptionRegistry"
         />
-
-        <service id="sulu_admin.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage">
-            <argument>null</argument>
-            <argument type="collection">
-                <argument type="service" id="sulu_admin.symfony_expression_language_provider" />
-            </argument>
-        </service>
-
-        <service
-            id="sulu_admin.symfony_expression_language_provider"
-            class="Sulu\Bundle\AdminBundle\ExpressionLanguage\ContainerExpressionLanguageProvider"
-        >
-            <argument type="service" id="service_container" />
-        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/structure.xml
@@ -19,7 +19,7 @@
         <service id="sulu_content.structure.properties_xml_parser"
                  class="Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser"
                  public="false">
-            <argument type="service" id="sulu_admin.expression_language" />
+            <argument type="service" id="sulu_core.expression_language" />
         </service>
 
         <service id="sulu_content.structure.factory" class="%sulu_content.structure.factory.class%">

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -249,6 +249,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
 
         $this->initListBuilder($container, $loader);
 
+        $loader->load('expression_language.xml');
         $loader->load('phpcr.xml');
         $loader->load('rest.xml');
         $loader->load('build.xml');

--- a/src/Sulu/Bundle/CoreBundle/ExpressionLanguage/ContainerExpressionLanguageProvider.php
+++ b/src/Sulu/Bundle/CoreBundle/ExpressionLanguage/ContainerExpressionLanguageProvider.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AdminBundle\ExpressionLanguage;
+namespace Sulu\Bundle\CoreBundle\ExpressionLanguage;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/expression_language.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/expression_language.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_core.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage">
+            <argument>null</argument>
+            <argument type="collection">
+                <argument type="service" id="sulu_core.symfony_expression_language_provider" />
+            </argument>
+        </service>
+
+        <service
+            id="sulu_core.symfony_expression_language_provider"
+            class="Sulu\Bundle\CoreBundle\ExpressionLanguage\ContainerExpressionLanguageProvider"
+        >
+            <argument type="service" id="service_container" />
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Bundle/CoreBundle/Tests/ExpressionLanguage/ContainerExpressionLanguageProviderTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/ExpressionLanguage/ContainerExpressionLanguageProviderTest.php
@@ -9,10 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AdminBundle\Tests\ExpressionLanguage;
+namespace Sulu\Bundle\CoreBundle\Tests\ExpressionLanguage;
 
 use PHPUnit\Framework\TestCase;
-use Sulu\Bundle\AdminBundle\ExpressionLanguage\ContainerExpressionLanguageProvider;
+use Sulu\Bundle\CoreBundle\ExpressionLanguage\ContainerExpressionLanguageProvider;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The ExpressionLanguage was not available in the website context. This PR fixes that by moving it from the `SuluAdminBundle` to the `SuluCoreBundle`.

#### Why?

Because whatever is generated in the template properties xml must also be available in the website, and the includes evaluation using the EvaluationLanguage.