### PR TITLE
add icon prop to Button

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -5,7 +5,6 @@ import {observer} from 'mobx-react';
 import {arrayMove} from 'react-sortable-hoc';
 import {translate} from '../../utils/Translator';
 import Button from '../Button';
-import Icon from '../Icon';
 import SortableBlocks from './SortableBlocks';
 import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
@@ -159,8 +158,12 @@ export default class BlockCollection extends React.Component<Props> {
                     useDragHandle={true}
                     value={identifiedValues}
                 />
-                <Button skin="secondary" onClick={this.handleAddBlock} disabled={this.hasMaximumReached()}>
-                    <Icon name="su-plus" className={blockCollectionStyles.addButtonIcon} />
+                <Button
+                    skin="secondary"
+                    icon="su-plus"
+                    onClick={this.handleAddBlock}
+                    disabled={this.hasMaximumReached()}
+                >
                     {translate('sulu_admin.add_block')}
                 </Button>
             </section>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/blockCollection.scss
@@ -1,7 +1,3 @@
 .blockCollection {
     text-align: center;
 }
-
-.add-button-icon {
-    margin-right: 10px;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -47,12 +47,12 @@ exports[`Should render a block list 1`] = `
     type="button"
   >
     <span
+      aria-label="su-plus"
+      class="buttonIcon su-plus"
+    />
+    <span
       class="text"
     >
-      <span
-        aria-label="su-plus"
-        class="addButtonIcon su-plus"
-      />
       Add block
     </span>
   </button>
@@ -107,12 +107,12 @@ exports[`Should render a fully filled block list without add button if maxOccurs
     type="button"
   >
     <span
+      aria-label="su-plus"
+      class="buttonIcon su-plus"
+    />
+    <span
       class="text"
     >
-      <span
-        aria-label="su-plus"
-        class="addButtonIcon su-plus"
-      />
       Add block
     </span>
   </button>
@@ -131,12 +131,12 @@ exports[`Should render an empty block list 1`] = `
     type="button"
   >
     <span
+      aria-label="su-plus"
+      class="buttonIcon su-plus"
+    />
+    <span
       class="text"
     >
-      <span
-        aria-label="su-plus"
-        class="addButtonIcon su-plus"
-      />
       Add block
     </span>
   </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -2,22 +2,24 @@
 import React from 'react';
 import type {Node} from 'react';
 import classNames from 'classnames';
+import Icon from '../Icon';
 import Loader from '../Loader';
 import buttonStyles from './button.scss';
 
 const LOADER_SIZE = 25;
 
-type Props = {
+type Props = {|
     active: boolean,
     children: Node,
     className?: string,
     disabled: boolean,
+    icon?: string,
     loading: boolean,
     onClick: (value: *) => void,
     size: 'small' | 'large',
     skin: 'primary' | 'secondary' | 'link' | 'icon',
     value?: *,
-};
+|};
 
 export default class Button extends React.PureComponent<Props> {
     static defaultProps = {
@@ -39,6 +41,7 @@ export default class Button extends React.PureComponent<Props> {
             children,
             className,
             disabled,
+            icon,
             loading,
             skin,
         } = this.props;
@@ -54,6 +57,7 @@ export default class Button extends React.PureComponent<Props> {
 
         return (
             <button className={buttonClass} onClick={this.handleClick} disabled={loading || disabled} type="button">
+                {icon && <Icon name={icon} className={buttonStyles.buttonIcon} />}
                 <span className={buttonStyles.text}>{children}</span>
                 {loading &&
                     <div className={buttonStyles.loader}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/README.md
@@ -38,3 +38,23 @@ const onClick = () => {
     Click me dude
 </Button>
 ```
+
+The buttons can also be used in combination with an icon.
+
+```javascript
+<Button skin="primary" icon="su-plus">
+    Add something
+</Button>
+```
+
+```javascript
+<Button skin="secondary" icon="su-plus">
+    Add something
+</Button>
+```
+
+```javascript
+<Button skin="link" icon="su-plus">
+    Add something
+</Button>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -33,7 +33,7 @@ $iconColorActive: $white;
     font-size: $fontSize;
     border: 1px solid;
     border-radius: $borderRadius;
-    line-height: 30px;
+    line-height: 28px;
     cursor: pointer;
     text-align: center;
     min-width: 140px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -38,6 +38,15 @@ $iconColorActive: $white;
     text-align: center;
     min-width: 140px;
     padding: 0 40px;
+
+    .button-icon {
+        display: inline-flex;
+        align-items: center;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 10px;
+    }
 }
 
 .primary {
@@ -62,9 +71,16 @@ $iconColorActive: $white;
     border: 0;
     background: transparent;
     cursor: pointer;
-    text-decoration: underline;
     font-size: $linkFontSize;
     color: $linkColor;
+
+    .text {
+        text-decoration: underline;
+    }
+
+    .button-icon {
+        margin-right: 10px;
+    }
 }
 
 .icon {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -3,6 +3,10 @@ import React from 'react';
 import {render, shallow} from 'enzyme';
 import Button from '../Button';
 
+test('Should render the button with icon', () => {
+    expect(render(<Button icon="su-plus">Add something</Button>)).toMatchSnapshot();
+});
+
 test('Should render with skin primary', () => {
     expect(render(<Button skin="primary" />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/__snapshots__/Button.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Should render the button with icon 1`] = `
+<button
+  class="button secondary"
+  type="button"
+>
+  <span
+    aria-label="su-plus"
+    class="buttonIcon su-plus"
+  />
+  <span
+    class="text"
+  >
+    Add something
+  </span>
+</button>
+`;
+
 exports[`Should render with skin icon 1`] = `
 <button
   class="button icon"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/displayValue.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/displayValue.scss
@@ -1,6 +1,6 @@
 @import '../../containers/Application/colors.scss';
 
-$lineHeight: 24px;
+$lineHeight: 28px;
 $fontSize: 12px;
 $color: $blueZodiac;
 $backgroundColor: $white;
@@ -13,7 +13,7 @@ $hoverColor: $shakespeare;
     display: block;
     position: relative;
     width: 100%;
-    padding: 5px 30px 5px 10px;
+    padding: 7px 30px 7px 10px;
     border: $borderSize solid $borderColor;
     border-radius: 3px;
     text-align: left;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -56,8 +56,7 @@ exports[`Render block with schema 1`] = `
       </div>
     </section>
   </div>
-  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
-  </button>
+  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
 </section>"
 `;
 
@@ -122,8 +121,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
       </div>
     </section>
   </div>
-  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
-  </button>
+  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
 </section>"
 `;
 
@@ -188,7 +186,6 @@ exports[`Render block with schema and error on fields already being modified 2`]
       </div>
     </section>
   </div>
-  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"><span class=\\"addButtonIcon su-plus\\" aria-label=\\"su-plus\\"></span>sulu_admin.add_block</span>
-  </button>
+  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
 </section>"
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ...
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds an optional `icon` prop to the `Button` component.
#### Why?

Because until now buttons with icons have always been faked by inserting a button as child, but that means that the icon always has to be styled. This way this styling is done in a central place, and therefore is consistent.