### PR TITLE
Fix kernel.project_dir parameter for PreviewKernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #3980 [PreviewBundle]           Fix kernel.project_dir parameter for PreviewKernel
     * BUGFIX      #3967 [AudienceTargetingBundle] Fixed loading of minified js files for production
     * HOTFIX      #3950 [ContactBundle]           Fixed empty latitude and longitude
     * HOTFIX      #3949 [ContentBundle]           Fixed security check for deleting draft

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -21,6 +21,11 @@ class PreviewKernel extends \WebsiteKernel
     const CONTEXT_PREVIEW = 'preview';
 
     /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
      * {@inheritdoc}
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -47,6 +52,26 @@ class PreviewKernel extends \WebsiteKernel
         }
 
         return $this->rootDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProjectDir()
+    {
+        if (null === $this->projectDir) {
+            $reflectionClass = new \ReflectionClass(\WebsiteKernel::class);
+            $dir = $rootDir = dirname($reflectionClass->getFileName());
+            while (!file_exists($dir . '/composer.json')) {
+                if ($dir === dirname($dir)) {
+                    return $this->projectDir = $rootDir;
+                }
+                $dir = dirname($dir);
+            }
+            $this->projectDir = $dir;
+        }
+
+        return $this->projectDir;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix kernel.project_dir parameter for PreviewKernel.

#### Why?

Currently the preview kernel use the false project_dir it should use the WebsiteKernel project_dir which is currently not being used.