### PR TITLE
Move document manager components to this repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 
 # Text editors backup files
 *~
+*.swp
 
 # Meld
 *.orig

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,7 @@ install:
   - echo extension=php_gd2.dll >> php.ini
   - echo extension=php_intl.dll >> php.ini
   - echo extension=php_pdo_mysql.dll >> php.ini
+  - echo extension=php_pdo_sqlite.dll >> php.ini
   - echo extension=php_fileinfo.dll >> php.ini
   - php -i
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "aferrandini/urlizer": "~1.0.0",
         "cboden/ratchet": "0.3.*",
         "dantleech/phpcr-migrations-bundle": "~1.0",
         "doctrine/annotations": "^1.2",
@@ -41,14 +42,15 @@
         "massive/build-bundle": "^0.3.0",
         "massive/search-bundle": "0.16.*",
         "mtdowling/cron-expression": "^1.1",
+        "ocramius/proxy-manager": "~1.0 | ~2.0",
         "oro/doctrine-extensions": "^1.0",
         "pagerfanta/pagerfanta": "^1.0.4",
         "piwik/device-detector": "^3.7",
         "ramsey/uuid": "^3.1",
         "sensio/framework-extra-bundle": "^5.0",
         "stof/doctrine-extensions-bundle": "^1.2.2",
-        "sulu/document-manager": "~0.10.1",
         "symfony-cmf/routing-bundle": "^2.0",
+        "symfony-cmf/slugifier-api": "~1.0",
         "symfony/asset": "^3.4",
         "symfony/cache": "^3.4",
         "symfony/config": "^3.4",
@@ -119,6 +121,7 @@
         "symfony/web-profiler-bundle": "3.4.7"
     },
     "replace": {
+        "sulu/document-manager": "self.version",
         "sulu/media-bundle": "self.version",
         "sulu/tag-bundle": "self.version",
         "sulu/category-bundle": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "sensio/framework-extra-bundle": "^5.0",
         "stof/doctrine-extensions-bundle": "^1.2.2",
         "symfony-cmf/routing-bundle": "^2.0",
-        "symfony-cmf/slugifier-api": "~1.0",
+        "symfony-cmf/slugifier-api": "^1.0 || ^2.0",
         "symfony/asset": "^3.4",
         "symfony/cache": "^3.4",
         "symfony/config": "^3.4",

--- a/src/Sulu/Bundle/RouteBundle/Generator/RouteGenerator.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/RouteGenerator.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\RouteBundle\Generator;
 
-use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/RouteGeneratorTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/RouteGeneratorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\RouteBundle\Generator\RouteGenerator;
 use Sulu\Bundle\RouteBundle\Generator\TokenProviderInterface;
 use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
-use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 
 class RouteGeneratorTest extends TestCase
 {

--- a/src/Sulu/Component/DocumentManager/Behavior/Audit/LocalizedTimestampBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Audit/LocalizedTimestampBehavior.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Audit;
+
+/**
+ * Adds the date when created and lastly changed the document.
+ */
+interface LocalizedTimestampBehavior
+{
+    /**
+     * @return \DateTime
+     */
+    public function getCreated();
+
+    /**
+     * @return \DateTime
+     */
+    public function getChanged();
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Audit/TimestampBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Audit/TimestampBehavior.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Audit;
+
+/**
+ * Adds the date when created and lastly changed the document (without locale).
+ */
+interface TimestampBehavior extends LocalizedTimestampBehavior
+{
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/ChildrenBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/ChildrenBehavior.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
+
+interface ChildrenBehavior
+{
+    /**
+     * Return the children for this document.
+     *
+     * @return ChildrenCollection
+     */
+    public function getChildren();
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/LocaleBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/LocaleBehavior.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+/**
+ * Populate the locale.
+ */
+interface LocaleBehavior
+{
+    /**
+     * Return the documents locale.
+     *
+     * @return string
+     */
+    public function getLocale();
+
+    /**
+     * Sets the document locale.
+     *
+     * @param string $locale
+     */
+    public function setLocale($locale);
+
+    /**
+     * Return the documents original locale.
+     *
+     * @return string
+     */
+    public function getOriginalLocale();
+
+    /**
+     * Sets the document original locale.
+     *
+     * @param string $locale
+     */
+    public function setOriginalLocale($locale);
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/LocalizedTitleBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/LocalizedTitleBehavior.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+/**
+ * Allows the title of a document to be localized.
+ */
+interface LocalizedTitleBehavior extends TitleBehavior
+{
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/NodeNameBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/NodeNameBehavior.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+/**
+ * Populate the node name.
+ */
+interface NodeNameBehavior
+{
+    /**
+     * Return the node name.
+     *
+     * NOTE: You must add a $nodeName property to your class
+     *
+     * @return string
+     */
+    public function getNodeName();
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/ParentBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/ParentBehavior.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+/**
+ * The document has a parent document.
+ */
+interface ParentBehavior
+{
+    /**
+     * Return the parent document for this document.
+     *
+     * @return object
+     */
+    public function getParent();
+
+    /**
+     * Set the parent document for this document.
+     *
+     * @param object $document
+     */
+    public function setParent($document);
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/PathBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/PathBehavior.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+interface PathBehavior
+{
+    /**
+     * @return string
+     */
+    public function getPath();
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/TitleBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/TitleBehavior.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+/**
+ * Document can have a human-friendly title.
+ */
+interface TitleBehavior
+{
+    /**
+     * Return a title.
+     *
+     * @return string
+     */
+    public function getTitle();
+
+    /**
+     * Set the title.
+     *
+     * @param string $title
+     */
+    public function setTitle($title);
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Mapping/UuidBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Mapping/UuidBehavior.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Mapping;
+
+/**
+ * Populate the UUID.
+ */
+interface UuidBehavior
+{
+    /**
+     * Return the documents UUID.
+     *
+     * @return string
+     */
+    public function getUuid();
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Path/AliasFilingBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Path/AliasFilingBehavior.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Path;
+
+/**
+ * Automatically positions the document at a configured location as a child of a node
+ * named after the documents alias.
+ *
+ * For example, if you specify the base path to be "/cmf/example" and the document has
+ * the alias "foobar" then the parent will be set to "/cmf/example/foobar".
+ *
+ * If the parent document does not exist, it will be created.
+ */
+interface AliasFilingBehavior extends BasePathBehavior
+{
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Path/AutoNameBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Path/AutoNameBehavior.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Path;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
+
+/**
+ * The PHPCR nodes of objects implementing this behavior will have
+ * names automatically assigned based on their title.
+ */
+interface AutoNameBehavior extends TitleBehavior, ParentBehavior
+{
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/Path/BasePathBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/Path/BasePathBehavior.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior\Path;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+
+/**
+ * This behavior adds an initial base path to the node.
+ */
+interface BasePathBehavior extends ParentBehavior
+{
+}

--- a/src/Sulu/Component/DocumentManager/Behavior/VersionBehavior.php
+++ b/src/Sulu/Component/DocumentManager/Behavior/VersionBehavior.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Behavior;
+
+use Sulu\Component\DocumentManager\Version;
+
+/**
+ * This behavior has to be attached to documents which should be versionable.
+ */
+interface VersionBehavior
+{
+    /**
+     * Returns all the versions of this document.
+     *
+     * @return Version[]
+     */
+    public function getVersions();
+
+    /**
+     * Sets the versions for this document.
+     *
+     * @param Version[] $versions
+     */
+    public function setVersions($versions);
+}

--- a/src/Sulu/Component/DocumentManager/ClassNameInflector.php
+++ b/src/Sulu/Component/DocumentManager/ClassNameInflector.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use ProxyManager\Inflector\ClassNameInflector as ProxyManagerClassNameInflector;
+
+/**
+ * This is a hack to statically use the ClassNameInflector to
+ * retrieve the "real" class names for proxy objects.
+ *
+ * TODO: This should be a service dependency not a static class
+ */
+class ClassNameInflector
+{
+    /**
+     * @var ProxyManagerClassNameInflector
+     */
+    public static $inflector;
+
+    /**
+     * Return the "real" class name if the given class name is a proxy
+     * class name.
+     *
+     * @param string $className
+     *
+     * @return string
+     */
+    public static function getUserClassName($className)
+    {
+        if (null === self::$inflector) {
+            static::$inflector = new ProxyManagerClassNameInflector('');
+        }
+
+        return static::$inflector->getUserClassName($className);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Collection/AbstractLazyCollection.php
+++ b/src/Sulu/Component/DocumentManager/Collection/AbstractLazyCollection.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Collection;
+
+/**
+ * Lazily hydrate query results.
+ */
+abstract class AbstractLazyCollection implements \Iterator, \Countable
+{
+    /**
+     * @var \Iterator
+     */
+    protected $documents;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        $this->initialize();
+
+        return $this->documents->count();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function current();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        $this->initialize();
+
+        return $this->documents->key();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        $this->initialize();
+
+        $this->documents->next();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->initialize();
+
+        $this->documents->rewind();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        $this->initialize();
+
+        return $this->documents->valid();
+    }
+
+    /**
+     * Returns a array of all documents in the collection.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $copy = [];
+        foreach ($this as $document) {
+            $copy[] = $document;
+        }
+
+        return $copy;
+    }
+
+    /**
+     * Initialize the collection documents.
+     */
+    abstract protected function initialize();
+}

--- a/src/Sulu/Component/DocumentManager/Collection/ChildrenCollection.php
+++ b/src/Sulu/Component/DocumentManager/Collection/ChildrenCollection.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Collection;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Lazily hydrate query results.
+ *
+ * TODO: Performance -- try fetch depth like in teh PHPCR-ODM ChildrenCollection
+ */
+class ChildrenCollection extends AbstractLazyCollection
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    /**
+     * @param NodeInterface $parentNode
+     * @param EventDispatcherInterface $dispatcher
+     * @param string $locale
+     * @param array $options
+     */
+    public function __construct(
+        NodeInterface $parentNode,
+        EventDispatcherInterface $dispatcher,
+        $locale,
+        $options = []
+    ) {
+        $this->parentNode = $parentNode;
+        $this->dispatcher = $dispatcher;
+        $this->locale = $locale;
+        $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $this->initialize();
+        $childNode = $this->documents->current();
+
+        $hydrateEvent = new HydrateEvent($childNode, $this->locale, $this->options);
+        $this->dispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+
+        return $hydrateEvent->getDocument();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        if (true === $this->initialized) {
+            return;
+        }
+
+        $this->documents = $this->parentNode->getNodes();
+        $this->initialized = true;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Collection/QueryResultCollection.php
+++ b/src/Sulu/Component/DocumentManager/Collection/QueryResultCollection.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Collection;
+
+use PHPCR\Query\QueryResultInterface;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Lazily hydrate query results.
+ */
+class QueryResultCollection extends AbstractLazyCollection
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var QueryResultInterface
+     */
+    private $result;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    /**
+     * @var null|string
+     */
+    private $primarySelector = null;
+
+    /**
+     * @param QueryResultInterface $result
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param string $locale
+     * @param array $options
+     * @param null|string $primarySelector
+     */
+    public function __construct(
+        QueryResultInterface $result,
+        EventDispatcherInterface $eventDispatcher,
+        $locale,
+        $options = [],
+        $primarySelector = null
+    ) {
+        $this->result = $result;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->locale = $locale;
+        $this->options = $options;
+        $this->primarySelector = $primarySelector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $this->initialize();
+        $row = $this->documents->current();
+        $node = $row->getNode($this->primarySelector);
+
+        $hydrateEvent = new HydrateEvent($node, $this->locale, $this->options);
+        $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+
+        return $hydrateEvent->getDocument();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        if (true === $this->initialized) {
+            return;
+        }
+
+        $this->documents = $this->result->getRows();
+        $this->initialized = true;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Collection/ReferrerCollection.php
+++ b/src/Sulu/Component/DocumentManager/Collection/ReferrerCollection.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Collection;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Lazily load documents referring to the given node.
+ */
+class ReferrerCollection extends AbstractLazyCollection
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    public function __construct(NodeInterface $node, EventDispatcherInterface $dispatcher, $locale)
+    {
+        $this->node = $node;
+        $this->dispatcher = $dispatcher;
+        $this->locale = $locale;
+        $this->documents = new \ArrayIterator();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $this->initialize();
+        $referrerNode = $this->documents->current();
+
+        $hydrateEvent = new HydrateEvent($referrerNode, $this->locale);
+        $this->dispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+
+        return $hydrateEvent->getDocument();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        if (true === $this->initialized) {
+            return;
+        }
+
+        $references = $this->node->getReferences();
+
+        // TODO: Performance: calling getParent adds overhead when the collection is
+        //       initialized, but if we don't do this, we won't know how many items are in the
+        //       collection, as one node could have many referring properties.
+        foreach ($references as $reference) {
+            /* @var PropertyInterface $reference */
+            $referrerNode = $reference->getParent();
+            $this->documents[$referrerNode->getIdentifier()] = $referrerNode;
+        }
+
+        $this->initialized = true;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Document/UnknownDocument.php
+++ b/src/Sulu/Component/DocumentManager/Document/UnknownDocument.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Document;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+
+/**
+ * This document class is used when an unmapped node is loaded.
+ */
+class UnknownDocument implements NodeNameBehavior, UuidBehavior
+{
+    /**
+     * @var string
+     */
+    private $nodeName;
+
+    /**
+     * @var string
+     */
+    private $uuid;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeName()
+    {
+        return $this->nodeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/DocumentAccessor.php
+++ b/src/Sulu/Component/DocumentManager/DocumentAccessor.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+class DocumentAccessor
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var \ReflectionClass
+     */
+    private $reflection;
+
+    /**
+     * @param $document
+     */
+    public function __construct($document)
+    {
+        $this->document = $document;
+        $documentClass = get_class($document);
+
+        if ($document instanceof LazyLoadingInterface) {
+            $documentClass = ClassNameInflector::getUserClassName($documentClass);
+        }
+
+        $this->reflection = new \ReflectionClass($documentClass);
+    }
+
+    /**
+     * @param string $field
+     * @param mixed $value
+     *
+     * @throws DocumentManagerException
+     */
+    public function set($field, $value)
+    {
+        if (!$this->has($field)) {
+            throw new DocumentManagerException(sprintf(
+                'Document "%s" must have property "%s" (it is probably required by a behavior)',
+                get_class($this->document), $field
+            ));
+        }
+
+        $property = $this->reflection->getProperty($field);
+        $property->setAccessible(true);
+        $property->setValue($this->document, $value);
+    }
+
+    public function get($field)
+    {
+        $property = $this->reflection->getProperty($field);
+        // TODO: Can be cached? Makes a performance diff?
+        $property->setAccessible(true);
+
+        return $property->getValue($this->document);
+    }
+
+    /**
+     * @param $field
+     *
+     * @return bool
+     */
+    public function has($field)
+    {
+        return $this->reflection->hasProperty($field);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/DocumentHelper.php
+++ b/src/Sulu/Component/DocumentManager/DocumentHelper.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
+
+class DocumentHelper
+{
+    /**
+     * Return a debug title for the document for use in exception messages.
+     *
+     * @param $document
+     *
+     * @return string
+     */
+    public static function getDebugTitle($document)
+    {
+        $title = spl_object_hash($document);
+
+        if ($document instanceof PathBehavior && $document->getPath()) {
+            $title .= ' (' . $document->getPath() . ')';
+        } elseif ($document instanceof TitleBehavior && $document->getTitle()) {
+            $title .= ' (' . $document->getTitle() . ')';
+        }
+
+        return $title;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/DocumentInspector.php
+++ b/src/Sulu/Component/DocumentManager/DocumentInspector.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+
+/**
+ * This class infers information about documents, for example
+ * the documents locale, webspace, path, etc.
+ */
+class DocumentInspector
+{
+    /**
+     * @var DocumentRegistry
+     */
+    protected $documentRegistry;
+
+    /**
+     * @var PathSegmentRegistry
+     */
+    protected $pathSegmentRegistry;
+
+    /**
+     * @var ProxyFactory
+     */
+    protected $proxyFactory;
+
+    /**
+     * @param DocumentRegistry $documentRegistry
+     * @param PathSegmentRegistry $pathSegmentRegistry
+     * @param ProxyFactory $proxyFactory
+     */
+    public function __construct(
+        DocumentRegistry $documentRegistry,
+        PathSegmentRegistry $pathSegmentRegistry,
+        ProxyFactory $proxyFactory
+    ) {
+        $this->documentRegistry = $documentRegistry;
+        $this->pathSegmentRegistry = $pathSegmentRegistry;
+        $this->proxyFactory = $proxyFactory;
+    }
+
+    /**
+     * Return the parent document for the given document.
+     *
+     * @param object $document
+     *
+     * @return object|null
+     */
+    public function getParent($document)
+    {
+        $parentNode = $this->getNode($document)->getParent();
+
+        if (!$parentNode) {
+            return;
+        }
+
+        return $this->proxyFactory->createProxyForNode($document, $parentNode);
+    }
+
+    /**
+     * Get referrers for the document.
+     *
+     * @param object $document
+     *
+     * @return Collection\ReferrerCollection
+     */
+    public function getReferrers($document)
+    {
+        return $this->proxyFactory->createReferrerCollection($document);
+    }
+
+    /**
+     * Return the PHPCR node for the given document.
+     *
+     * @param object $document
+     *
+     * @return NodeInterface
+     */
+    public function getNode($document)
+    {
+        return $this->documentRegistry->getNodeForDocument($document);
+    }
+
+    /**
+     * Returns lazy-loading children collection for given document.
+     *
+     * @param object $document
+     * @param array $options
+     *
+     * @return Collection\ChildrenCollection
+     */
+    public function getChildren($document, array $options = [])
+    {
+        return $this->proxyFactory->createChildrenCollection($document, $options);
+    }
+
+    /**
+     * Return true if the document has children.
+     *
+     * @param object $document
+     *
+     * @return bool
+     */
+    public function hasChildren($document)
+    {
+        return $this->getNode($document)->hasNodes();
+    }
+
+    /**
+     * Return the locale for the given document.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    public function getLocale($document)
+    {
+        return $this->documentRegistry->getLocaleForDocument($document);
+    }
+
+    /**
+     * Return the original (requested) locale for the given document.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    public function getOriginalLocale($document)
+    {
+        return $this->documentRegistry->getOriginalLocaleForDocument($document);
+    }
+
+    /**
+     * Return the depth of the given document within the content repository.
+     *
+     * @param $document
+     *
+     * @return int
+     */
+    public function getDepth($document)
+    {
+        return $this->getNode($document)->getDepth();
+    }
+
+    /**
+     * Return the name of the document.
+     *
+     * @param $document
+     *
+     * @return string
+     */
+    public function getName($document)
+    {
+        return $this->getNode($document)->getName();
+    }
+
+    /**
+     * Return the path for the given document.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    public function getPath($document)
+    {
+        return $this->documentRegistry
+            ->getNodeForDocument($document)
+            ->getPath();
+    }
+
+    /**
+     * Return the UUID of the given document.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    public function getUuid($document)
+    {
+        return $this->documentRegistry
+            ->getNodeForDocument($document)
+            ->getIdentifier();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/DocumentManager.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManager.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DocumentManager implements DocumentManagerInterface
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var array Cached options resolver instances
+     */
+    private $optionsResolvers = [];
+
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($identifier, $locale = null, array $options = [])
+    {
+        $options = $this->getOptionsResolver(Events::FIND)->resolve($options);
+
+        $event = new Event\FindEvent($identifier, $locale, $options);
+        $this->eventDispatcher->dispatch(Events::FIND, $event);
+
+        return $event->getDocument();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($alias)
+    {
+        $event = new Event\CreateEvent($alias);
+        $this->eventDispatcher->dispatch(Events::CREATE, $event);
+
+        return $event->getDocument();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persist($document, $locale = null, array $options = [])
+    {
+        $options = $this->getOptionsResolver(Events::PERSIST)->resolve($options);
+
+        $event = new Event\PersistEvent($document, $locale, $options);
+        $this->eventDispatcher->dispatch(Events::PERSIST, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($document)
+    {
+        $event = new Event\RemoveEvent($document);
+        $this->eventDispatcher->dispatch(Events::REMOVE, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function move($document, $destId)
+    {
+        $event = new Event\MoveEvent($document, $destId);
+        $this->eventDispatcher->dispatch(Events::MOVE, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copy($document, $destPath)
+    {
+        $event = new Event\CopyEvent($document, $destPath);
+        $this->eventDispatcher->dispatch(Events::COPY, $event);
+
+        return $event->getCopiedPath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reorder($document, $destId)
+    {
+        $event = new Event\ReorderEvent($document, $destId);
+        $this->eventDispatcher->dispatch(Events::REORDER, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function publish($document, $locale, array $options = [])
+    {
+        $options = $this->getOptionsResolver(Events::PUBLISH)->resolve($options);
+
+        $event = new Event\PublishEvent($document, $locale, $options);
+        $this->eventDispatcher->dispatch(Events::PUBLISH, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unpublish($document, $locale)
+    {
+        $event = new Event\UnpublishEvent($document, $locale);
+        $this->eventDispatcher->dispatch(Events::UNPUBLISH, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeDraft($document, $locale)
+    {
+        $event = new Event\RemoveDraftEvent($document, $locale);
+        $this->eventDispatcher->dispatch(Events::REMOVE_DRAFT, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function restore($document, $locale, $version, array $options = [])
+    {
+        $options = $this->getOptionsResolver(Events::RESTORE)->resolve($options);
+
+        $event = new Event\RestoreEvent($document, $locale, $version, $options);
+        $this->eventDispatcher->dispatch(Events::RESTORE, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refresh($document)
+    {
+        $event = new Event\RefreshEvent($document);
+        $this->eventDispatcher->dispatch(Events::REFRESH, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        $event = new Event\FlushEvent();
+        $this->eventDispatcher->dispatch(Events::FLUSH, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        $event = new Event\ClearEvent();
+        $this->eventDispatcher->dispatch(Events::CLEAR, $event);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQuery($query, $locale = null, array $options = [])
+    {
+        $event = new Event\QueryCreateEvent($query, $locale, $options);
+        $this->eventDispatcher->dispatch(Events::QUERY_CREATE, $event);
+
+        return $event->getQuery();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQueryBuilder()
+    {
+        $event = new Event\QueryCreateBuilderEvent();
+        $this->eventDispatcher->dispatch(Events::QUERY_CREATE_BUILDER, $event);
+
+        return $event->getQueryBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function getOptionsResolver($eventName)
+    {
+        if (isset($this->optionsResolvers[$eventName])) {
+            return $this->optionsResolvers[$eventName];
+        }
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefault('locale', null);
+
+        $event = new Event\ConfigureOptionsEvent($resolver);
+        $this->eventDispatcher->dispatch(Events::CONFIGURE_OPTIONS, $event);
+
+        $this->optionsResolvers[$eventName] = $resolver;
+
+        return $resolver;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
+++ b/src/Sulu/Component/DocumentManager/DocumentManagerInterface.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use Sulu\Component\DocumentManager\Query\Query;
+
+interface DocumentManagerInterface
+{
+    /**
+     * Find a document by path or UUID in the given locale, optionally enforcing the given type.
+     *
+     * @param string $identifier Path or UUID
+     * @param string $locale Locale
+     * @param array $options
+     *
+     * @throws Exception\DocumentManagerException
+     *
+     * @return object
+     */
+    public function find($identifier, $locale = null, array $options = []);
+
+    /**
+     * Create a new document instance for the given alias.
+     *
+     * @param string
+     *
+     * @throws Exception\MetadataNotFoundException
+     *
+     * @return object
+     */
+    public function create($alias);
+
+    /**
+     * Persist a document to a PHPCR node.
+     *
+     * @param object $document
+     * @param string $locale
+     * @param array $options
+     */
+    public function persist($document, $locale = null, array $options = []);
+
+    /**
+     * Remove the document. The document should be unregistered and the related PHPCR node should be removed from the
+     * session.
+     *
+     * @param object $document
+     */
+    public function remove($document);
+
+    /**
+     * Move the PHPCR node to which the document is mapped to be a child of the node at the given path or UUID.
+     *
+     * @param object $document
+     * @param string $destId The path of the new parent
+     */
+    public function move($document, $destId);
+
+    /**
+     * Create a copy of the node representing the given document at the given path.
+     *
+     * @param object $document
+     * @param string $destPath
+     *
+     * @return string
+     */
+    public function copy($document, $destPath);
+
+    /**
+     * Re-Order node before or after a specific node.
+     *
+     * @param object $document
+     * @param string $destId
+     */
+    public function reorder($document, $destId);
+
+    /**
+     * Publishes a document to the public workspace.
+     *
+     * @param object $document
+     * @param string $locale
+     * @param array $options
+     */
+    public function publish($document, $locale, array $options = []);
+
+    /**
+     * Unpublishes a document from the public workspace.
+     *
+     * @param object $document
+     * @param string $locale
+     */
+    public function unpublish($document, $locale);
+
+    /**
+     * Removes the draft for the given document and reverts it to the values from the public workspace.
+     *
+     * @param $document
+     * @param $locale
+     */
+    public function removeDraft($document, $locale);
+
+    /**
+     * Restores the given version of the document and makes it a new version keeping the linear approach.
+     *
+     * @param object $document
+     * @param string $locale
+     * @param string $version The UUID of the version to restore
+     * @param array $options
+     *
+     * @throws Exception\VersionNotFoundException
+     *
+     * @return mixed
+     */
+    public function restore($document, $locale, $version, array $options = []);
+
+    /**
+     * Refresh the given document with the persisted state of the node.
+     *
+     * @param object $document
+     */
+    public function refresh($document);
+
+    /**
+     * Persist changes to the persistent storage.
+     */
+    public function flush();
+
+    /**
+     * Clear the document manager, should reset the underlying PHPCR session and deregister all documents.
+     */
+    public function clear();
+
+    /**
+     * Create a new query from a JCR-SQL2 query string.
+     *
+     * NOTE: This should not be used generally as it exposes the database structure and breaks abstraction. Use the
+     *       domain-aware query builder instead.
+     *
+     * @param mixed $query Either a JCR-SQL2 string, or a PHPCR query object
+     * @param string $locale
+     * @param array $options
+     *
+     * @return Query
+     */
+    public function createQuery($query, $locale = null, array $options = []);
+
+    /**
+     * Create a new query builder.
+     *
+     * By default this will return the PHPCR-ODM query builder.
+     *
+     * http://doctrine-phpcr-odm.readthedocs.org/en/latest/reference/query-builder.html
+     */
+    public function createQueryBuilder();
+}

--- a/src/Sulu/Component/DocumentManager/DocumentRegistry.php
+++ b/src/Sulu/Component/DocumentManager/DocumentRegistry.php
@@ -1,0 +1,359 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+/**
+ * Handles the mapping between managed documents and nodes.
+ */
+class DocumentRegistry
+{
+    /**
+     * @var array
+     */
+    private $documentMap = [];
+
+    /**
+     * @var array
+     */
+    private $documentNodeMap = [];
+
+    /**
+     * @var array
+     */
+    private $nodeMap = [];
+
+    /**
+     * @var array
+     */
+    private $nodeDocumentMap = [];
+
+    /**
+     * @var array
+     */
+    private $documentLocaleMap = [];
+
+    /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
+     * @var array
+     */
+    private $hydrationState = [];
+
+    /**
+     * @param $defaultLocale
+     */
+    public function __construct($defaultLocale)
+    {
+        $this->defaultLocale = $defaultLocale;
+    }
+
+    /**
+     * Register a document.
+     *
+     * @param mixed $document
+     * @param NodeInterface $node
+     * @param NodeInterface $node
+     * @param string $locale
+     *
+     * @throws DocumentManagerException
+     */
+    public function registerDocument($document, NodeInterface $node, $locale)
+    {
+        $oid = $this->getObjectIdentifier($document);
+        $uuid = $node->getIdentifier();
+
+        // do not allow nodes without UUIDs or reregistration of documents
+        $this->validateDocumentRegistration($document, $locale, $node, $oid, $uuid);
+
+        $this->documentMap[$oid] = $document;
+        $this->documentNodeMap[$oid] = $uuid;
+        $this->nodeMap[$node->getIdentifier()] = $node;
+        $this->nodeDocumentMap[$this->getNodeLocaleKey($node->getIdentifier(), $locale)] = $document;
+        $this->documentLocaleMap[$oid] = $locale;
+    }
+
+    /**
+     * Return true if the document is managed.
+     *
+     * @param object $document
+     *
+     * @return bool
+     */
+    public function hasDocument($document)
+    {
+        $oid = $this->getObjectIdentifier($document);
+
+        return isset($this->documentMap[$oid]);
+    }
+
+    /**
+     * Return true if the node is managed.
+     *
+     * @param NodeInterface $node
+     * @param string $locale
+     *
+     * @return bool
+     */
+    public function hasNode(NodeInterface $node, $locale)
+    {
+        return array_key_exists($this->getNodeLocaleKey($node->getIdentifier(), $locale), $this->nodeDocumentMap);
+    }
+
+    /**
+     * Clear the registry (detach all documents).
+     */
+    public function clear()
+    {
+        $this->documentMap = [];
+        $this->documentNodeMap = [];
+        $this->nodeMap = [];
+        $this->nodeDocumentMap = [];
+        $this->documentLocaleMap = [];
+        $this->hydrationState = [];
+    }
+
+    /**
+     * Remove all references to the given document and its
+     * associated node.
+     *
+     * @param object $document
+     */
+    public function deregisterDocument($document)
+    {
+        $oid = $this->getObjectIdentifier($document);
+        $this->assertDocumentExists($document);
+        $nodeIdentifier = $this->documentNodeMap[$oid];
+        $locale = $this->documentLocaleMap[$oid];
+
+        unset($this->nodeMap[$nodeIdentifier]);
+        unset($this->nodeDocumentMap[$this->getNodeLocaleKey($nodeIdentifier, $locale)]);
+        unset($this->documentMap[$oid]);
+        unset($this->documentNodeMap[$oid]);
+        unset($this->documentLocaleMap[$oid]);
+        unset($this->hydrationState[$oid]);
+    }
+
+    /**
+     * Return the node for the given managed document.
+     *
+     * @param object $document
+     *
+     * @throws \RuntimeException If the node is not managed
+     *
+     * @return NodeInterface
+     */
+    public function getNodeForDocument($document)
+    {
+        $oid = $this->getObjectIdentifier($document);
+        $this->assertDocumentExists($document);
+
+        return $this->nodeMap[$this->documentNodeMap[$oid]];
+    }
+
+    /**
+     * Return the current locale for the given document.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    public function getLocaleForDocument($document)
+    {
+        $oid = $this->getObjectIdentifier($document);
+        $this->assertDocumentExists($document);
+
+        return $this->documentLocaleMap[$oid];
+    }
+
+    /**
+     * Return the original locale for the document.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    public function getOriginalLocaleForDocument($document)
+    {
+        $this->assertDocumentExists($document);
+
+        if ($document instanceof LocaleBehavior) {
+            return $document->getOriginalLocale() ?: $document->getLocale();
+        }
+
+        return $this->getLocaleForDocument($document);
+    }
+
+    /**
+     * Return the document for the given managed node.
+     *
+     * @param NodeInterface $node
+     * @param string $locale
+     *
+     * @return mixed If the node is not managed
+     */
+    public function getDocumentForNode(NodeInterface $node, $locale)
+    {
+        $identifier = $node->getIdentifier();
+        $this->assertNodeExists($identifier);
+
+        return $this->nodeDocumentMap[$this->getNodeLocaleKey($node->getIdentifier(), $locale)];
+    }
+
+    /**
+     * Return the default locale.
+     *
+     * @return string
+     */
+    public function getDefaultLocale()
+    {
+        return $this->defaultLocale;
+    }
+
+    /**
+     * @param object $document
+     */
+    private function assertDocumentExists($document)
+    {
+        $oid = spl_object_hash($document);
+
+        if (!isset($this->documentMap[$oid])) {
+            throw new \RuntimeException(sprintf(
+                'Document "%s" with OID "%s" is not managed, there are "%s" managed objects,',
+                get_class($document), $oid, count($this->documentMap)
+            ));
+        }
+    }
+
+    /**
+     * @param mixed $identifier
+     */
+    private function assertNodeExists($identifier)
+    {
+        if (!isset($this->nodeMap[$identifier])) {
+            throw new \RuntimeException(sprintf(
+                'Node with identifier "%s" is not managed, there are "%s" managed objects,',
+                $identifier, count($this->documentMap)
+            ));
+        }
+    }
+
+    /**
+     * Get the spl object hash for the given object.
+     *
+     * @param object $document
+     *
+     * @return string
+     */
+    private function getObjectIdentifier($document)
+    {
+        return spl_object_hash($document);
+    }
+
+    /**
+     * Ensure that the document is not already registered and that the node
+     * has a UUID.
+     *
+     * @param object $document
+     * @param NodeInterface $node
+     * @param string $oid
+     * @param string $uuid
+     *
+     * @throws DocumentManagerException
+     */
+    private function validateDocumentRegistration($document, $locale, NodeInterface $node, $oid, $uuid)
+    {
+        if (null === $uuid) {
+            throw new DocumentManagerException(sprintf(
+                'Node "%s" of type "%s" has no UUID. Only referencable nodes can be registered by the document manager',
+                $node->getPath(), $node->getPrimaryNodeType()->getName()
+            ));
+        }
+
+        $documentNodeKey = $this->getNodeLocaleKey($node->getIdentifier(), $locale);
+        if (array_key_exists($uuid, $this->nodeMap) && array_key_exists($documentNodeKey, $this->nodeDocumentMap)) {
+            $registeredDocument = $this->nodeDocumentMap[$documentNodeKey];
+
+            throw new \RuntimeException(sprintf(
+                'Document "%s" (%s) is already registered for node "%s" (%s) when trying to register document "%s" (%s)',
+                spl_object_hash($registeredDocument),
+                get_class($registeredDocument),
+                $uuid,
+                $node->getPath(),
+                $oid,
+                get_class($document)
+            ));
+        }
+    }
+
+    /**
+     * Register that the document has been hydrated and that it should
+     * not be hydrated again.
+     *
+     * @param object $document
+     */
+    public function markDocumentAsHydrated($document)
+    {
+        $oid = spl_object_hash($document);
+        $this->hydrationState[$oid] = true;
+    }
+
+    /**
+     * Unmark the document as being hydrated. It will then be
+     * rehydrated the next time a HYDRATE event is fired for ot.
+     *
+     * @param object $document
+     */
+    public function unmarkDocumentAsHydrated($document)
+    {
+        $oid = spl_object_hash($document);
+
+        unset($this->hydrationState[$oid]);
+    }
+
+    /**
+     * Return true if the document is a candidate for hydration/re-hydration.
+     *
+     * @param object $document
+     *
+     * @return bool
+     */
+    public function isHydrated($document)
+    {
+        $oid = spl_object_hash($document);
+
+        if (isset($this->hydrationState[$oid])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns array key for given uuid and locale.
+     *
+     * @param string $uuid
+     * @param string $locale
+     *
+     * @return string
+     */
+    private function getNodeLocaleKey($uuid, $locale)
+    {
+        return sprintf('%s_%s', $uuid, $locale);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/AbstractDocumentEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/AbstractDocumentEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+abstract class AbstractDocumentEvent extends AbstractEvent
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @param object $document
+     */
+    public function __construct($document)
+    {
+        $this->document = $document;
+    }
+
+    /**
+     * @return object
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugMessage()
+    {
+        return sprintf(
+            'd:%s',
+            $this->document ? spl_object_hash($this->document) : '<no document>'
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/AbstractEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/AbstractEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+abstract class AbstractEvent extends Event
+{
+    /**
+     * @return string
+     */
+    public function getDebugMessage()
+    {
+        return '';
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/AbstractMappingEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/AbstractMappingEvent.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+
+abstract class AbstractMappingEvent extends AbstractEvent
+{
+    use EventOptionsTrait;
+
+    /**
+     * @var object
+     */
+    protected $document;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
+
+    /**
+     * @var DocumentAccessor
+     */
+    protected $accessor;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugMessage()
+    {
+        return sprintf(
+            'n:%s d:%s l:%s',
+            $this->node ? $this->node->getPath() : '<no node>',
+            $this->document ? spl_object_hash($this->document) : '<no document>',
+            $this->locale ?: '<no locale>'
+        );
+    }
+
+    /**
+     * @return NodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * @return object
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * TODO: Refactor this away.
+     *
+     * @return DocumentAccessor
+     */
+    public function getAccessor()
+    {
+        if ($this->accessor) {
+            return $this->accessor;
+        }
+
+        $this->accessor = new DocumentAccessor($this->getDocument());
+
+        return $this->accessor;
+    }
+
+    /**
+     * Return true if the document has been set.
+     */
+    public function hasDocument()
+    {
+        return null !== $this->document;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasNode()
+    {
+        return null !== $this->node;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/ClearEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/ClearEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class ClearEvent extends AbstractEvent
+{
+}

--- a/src/Sulu/Component/DocumentManager/Event/ConfigureOptionsEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/ConfigureOptionsEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ConfigureOptionsEvent extends AbstractEvent
+{
+    use EventOptionsTrait;
+
+    /**
+     * @param OptionsResolver $options
+     */
+    public function __construct(OptionsResolver $options)
+    {
+        $this->options = $options;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/CopyEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/CopyEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class CopyEvent extends MoveEvent
+{
+    /**
+     * @var NodeInterface
+     */
+    private $copiedNode;
+
+    /**
+     * @return string|null
+     */
+    public function getCopiedPath()
+    {
+        if (!$this->copiedNode) {
+            return;
+        }
+
+        return $this->copiedNode->getPath();
+    }
+
+    /**
+     * @return NodeInterface
+     */
+    public function getCopiedNode()
+    {
+        return $this->copiedNode;
+    }
+
+    /**
+     * @param NodeInterface $copiedNode
+     */
+    public function setCopiedNode($copiedNode)
+    {
+        $this->copiedNode = $copiedNode;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/CreateEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/CreateEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class CreateEvent extends AbstractEvent
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @param string $alias
+     */
+    public function __construct($alias)
+    {
+        $this->alias = $alias;
+    }
+
+    /**
+     * @return object
+     *
+     * @throws \RuntimeException
+     */
+    public function getDocument()
+    {
+        if (!$this->document) {
+            throw new \RuntimeException(
+                'No document has been set, an event listener should have created a document before ' .
+                'this method was called.'
+            );
+        }
+
+        return $this->document;
+    }
+
+    /**
+     * @param object $document
+     */
+    public function setDocument($document)
+    {
+        $this->document = $document;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/EventOptionsTrait.php
+++ b/src/Sulu/Component/DocumentManager/Event/EventOptionsTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * This trait adds options to an event.
+ */
+trait EventOptionsTrait
+{
+    /**
+     * This array is used as key value storage for the options.
+     *
+     * @var OptionsResolver
+     */
+    protected $options;
+
+    /**
+     * Returns all the options for the event.
+     *
+     * @return OptionsResolver
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Returns the option with the given name.
+     *
+     * @param string $name The name of the option
+     * @param mixed $default The return value in case the option is not set
+     *
+     * @return mixed The value of the option
+     */
+    public function getOption($name, $default = null)
+    {
+        if (isset($this->options[$name])) {
+            return $this->options[$name];
+        }
+
+        return $default;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/FindEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/FindEvent.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+class FindEvent extends AbstractEvent
+{
+    use EventOptionsTrait;
+
+    /**
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @param string $identifier
+     * @param string $locale
+     * @param array $options
+     */
+    public function __construct($identifier, $locale, array $options = [])
+    {
+        $this->identifier = $identifier;
+        $this->locale = $locale;
+        $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugMessage()
+    {
+        return sprintf(
+            'i:%s d:%s l:%s',
+            $this->identifier,
+            $this->document ? spl_object_hash($this->document) : '<no document>',
+            $this->locale ?: '<no locale>'
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return object
+     *
+     * @throws DocumentManagerException
+     */
+    public function getDocument()
+    {
+        if (!$this->document) {
+            throw new DocumentManagerException(sprintf(
+                'No document has been set for the findEvent for "%s". An event listener should have done this.',
+                $this->identifier
+            ));
+        }
+
+        return $this->document;
+    }
+
+    /**
+     * @param object $document
+     */
+    public function setDocument($document)
+    {
+        $this->document = $document;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/FlushEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/FlushEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class FlushEvent extends AbstractEvent
+{
+}

--- a/src/Sulu/Component/DocumentManager/Event/HydrateEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/HydrateEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class HydrateEvent extends AbstractMappingEvent
+{
+    /**
+     * @param NodeInterface $node
+     * @param string $locale
+     * @param array $options
+     */
+    public function __construct(NodeInterface $node, $locale, array $options = [])
+    {
+        $this->locale = $locale;
+        $this->node = $node;
+        $this->options = $options;
+    }
+
+    /**
+     * @return object
+     *
+     * @throws \RuntimeException
+     */
+    public function getDocument()
+    {
+        if (null === $this->document) {
+            throw new \RuntimeException(
+                'Trying to retrieve document when no document has been set. An event ' .
+                'listener should have set the document.'
+            );
+        }
+
+        return $this->document;
+    }
+
+    /**
+     * @param object $document
+     */
+    public function setDocument($document)
+    {
+        $this->document = $document;
+        $this->accessor = null;
+    }
+
+    /**
+     * @param string $locale
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/MetadataLoadEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/MetadataLoadEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Sulu\Component\DocumentManager\Metadata;
+
+class MetadataLoadEvent extends AbstractEvent
+{
+    /**
+     * @param NodeInterface $node
+     * @param string $locale
+     * @param array $options
+     */
+    public function __construct(Metadata $metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * @return Metadata
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/MoveEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/MoveEvent.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class MoveEvent extends AbstractEvent
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var string
+     */
+    private $destId;
+
+    /**
+     * @var string
+     */
+    private $destName;
+
+    /**
+     * @param object $document
+     * @param string $destId
+     */
+    public function __construct($document, $destId)
+    {
+        $this->document = $document;
+        $this->destId = $destId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugMessage()
+    {
+        return sprintf(
+            'd:%s did:%s, dnam:%s',
+            $this->document ? spl_object_hash($this->document) : '<no document>',
+            $this->destId ?: '<no dest>',
+            $this->destName ?: '<no dest name>'
+        );
+    }
+
+    /**
+     * @return object
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDestId()
+    {
+        return $this->destId;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setDestName($name)
+    {
+        $this->destName = $name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasDestName()
+    {
+        return null !== $this->destName;
+    }
+
+    /**
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function getDestName()
+    {
+        if (!$this->destName) {
+            throw new \RuntimeException(sprintf(
+                'No destName set in copy/move event when copying/moving document "%s" to "%s". ' .
+                'This should have been set by a listener',
+                spl_object_hash($this->document),
+                $this->destId
+            ));
+        }
+
+        return $this->destName;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/PersistEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/PersistEvent.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentHelper;
+
+class PersistEvent extends AbstractMappingEvent
+{
+    /**
+     * @param NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @param object $document
+     * @param string $locale
+     * @param array $options
+     */
+    public function __construct($document, $locale, array $options = [])
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+        $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugMessage()
+    {
+        return sprintf(
+            '%s p:%s',
+            parent::getDebugMessage(),
+            $this->parentNode ? $this->parentNode->getPath() : '<no parent node>'
+        );
+    }
+
+    /**
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * @param NodeInterface $parentNode
+     */
+    public function setParentNode(NodeInterface $parentNode)
+    {
+        $this->parentNode = $parentNode;
+    }
+
+    /**
+     * @return NodeInterface
+     *
+     * @throws \RuntimeException
+     */
+    public function getNode()
+    {
+        if (!$this->node) {
+            throw new \RuntimeException(sprintf(
+                'Trying to retrieve node when no node has been set. An event ' .
+                'listener should have set the node when persisting document "%s"',
+                DocumentHelper::getDebugTitle($this->document)
+            ));
+        }
+
+        return $this->node;
+    }
+
+    /**
+     * @return NodeInterface
+     *
+     * @throws \RuntimeException
+     */
+    public function getParentNode()
+    {
+        if (!$this->parentNode) {
+            throw new \RuntimeException(sprintf(
+                'Trying to retrieve parent node when no parent node has been set. An event ' .
+                'listener should have set the node when persisting document "%s"',
+                DocumentHelper::getDebugTitle($this->document)
+            ));
+        }
+
+        return $this->parentNode;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasParentNode()
+    {
+        return null !== $this->parentNode;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/PublishEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/PublishEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class PublishEvent extends AbstractMappingEvent
+{
+    /**
+     * @param object $document
+     * @param string $locale
+     * @param array $options
+     */
+    public function __construct($document, $locale, array $options = [])
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+        $this->options = $options;
+    }
+
+    /**
+     * Sets the node this event should operate on.
+     *
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/QueryCreateBuilderEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/QueryCreateBuilderEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\Query\QueryBuilder;
+
+class QueryCreateBuilderEvent extends AbstractEvent
+{
+    /**
+     * @var
+     */
+    private $queryBuilder;
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function setQueryBuilder(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    /**
+     * @return mixed
+     *
+     * @throws DocumentManagerException
+     */
+    public function getQueryBuilder()
+    {
+        if (!$this->queryBuilder) {
+            throw new DocumentManagerException(
+                'No query builder has been set in listener. A listener should have set the query'
+            );
+        }
+
+        return $this->queryBuilder;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/QueryCreateEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/QueryCreateEvent.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\Query\Query;
+
+class QueryCreateEvent extends AbstractEvent
+{
+    use EventOptionsTrait;
+
+    /**
+     * @var string
+     */
+    private $innerQuery;
+
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var null|string
+     */
+    private $primarySelector;
+
+    /**
+     * @param string $innerQuery
+     * @param string $locale
+     * @param array $options
+     * @param null|string $primarySelector
+     */
+    public function __construct($innerQuery, $locale, array $options = [], $primarySelector = null)
+    {
+        $this->innerQuery = $innerQuery;
+        $this->locale = $locale;
+        $this->options = $options;
+        $this->primarySelector = $primarySelector;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInnerQuery()
+    {
+        return $this->innerQuery;
+    }
+
+    /**
+     * @param Query $query
+     */
+    public function setQuery(Query $query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPrimarySelector()
+    {
+        return $this->primarySelector;
+    }
+
+    /**
+     * @return mixed
+     *
+     * @throws DocumentManagerException
+     */
+    public function getQuery()
+    {
+        if (!$this->query) {
+            throw new DocumentManagerException(
+                'No query has been set in listener. A listener should have set the query'
+            );
+        }
+
+        return $this->query;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/QueryExecuteEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/QueryExecuteEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\Query\Query;
+
+class QueryExecuteEvent extends AbstractEvent
+{
+    use EventOptionsTrait;
+
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var QueryResultCollection
+     */
+    private $result;
+
+    /**
+     * @param Query $query
+     * @param array $options
+     */
+    public function __construct(Query $query, array $options = [])
+    {
+        $this->query = $query;
+        $this->options = $options;
+    }
+
+    /**
+     * @return Query
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * @param QueryResultCollection $collection
+     */
+    public function setResult(QueryResultCollection $collection)
+    {
+        $this->result = $collection;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/RefreshEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/RefreshEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class RefreshEvent extends AbstractDocumentEvent
+{
+}

--- a/src/Sulu/Component/DocumentManager/Event/RemoveDraftEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/RemoveDraftEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class RemoveDraftEvent extends AbstractMappingEvent
+{
+    /**
+     * @param object $document
+     * @param string $locale
+     */
+    public function __construct($document, $locale)
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+    }
+
+    /**
+     * Sets the node this event should operate on.
+     *
+     * TODO Check if should be move to DocumentManager itself
+     *
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/RemoveEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/RemoveEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+class RemoveEvent extends AbstractDocumentEvent
+{
+}

--- a/src/Sulu/Component/DocumentManager/Event/ReorderEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/ReorderEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class ReorderEvent extends AbstractMappingEvent
+{
+    /**
+     * @var string
+     */
+    private $destId;
+
+    /**
+     * @param object $document
+     * @param string $destId
+     */
+    public function __construct($document, $destId)
+    {
+        $this->document = $document;
+        $this->destId = $destId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugMessage()
+    {
+        return sprintf(
+            '%s did:%s',
+            parent::getDebugMessage(),
+            $this->destId ?: '<no dest>'
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getDestId()
+    {
+        return $this->destId;
+    }
+
+    /**
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/RestoreEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/RestoreEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class RestoreEvent extends AbstractMappingEvent
+{
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @param object $document
+     * @param string $locale
+     * @param string $version
+     * @param array $options
+     */
+    public function __construct($document, $locale, $version, array $options = [])
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+        $this->version = $version;
+        $this->options = $options;
+    }
+
+    /**
+     * Sets the node this event should operate on.
+     *
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * Returns the version, which should be restored.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Event/UnpublishEvent.php
+++ b/src/Sulu/Component/DocumentManager/Event/UnpublishEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Event;
+
+use PHPCR\NodeInterface;
+
+class UnpublishEvent extends AbstractMappingEvent
+{
+    /**
+     * @param object $document
+     * @param string $locale
+     */
+    public function __construct($document, $locale)
+    {
+        $this->document = $document;
+        $this->locale = $locale;
+    }
+
+    /**
+     * Sets the node this event should operate on.
+     *
+     * TODO Check if should be move to DocumentManager itself
+     *
+     * @param NodeInterface $node
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\EventDispatcher;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+/**
+ * Logging and profiling event dispatcher for the document manager.
+ */
+class DebugEventDispatcher extends ContainerAwareEventDispatcher
+{
+    /**
+     * @var Stopwatch
+     */
+    private $stopwatch;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param ContainerInterface $container
+     * @param Stopwatch $stopwatch
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        ContainerInterface $container,
+        Stopwatch $stopwatch,
+        LoggerInterface $logger
+    ) {
+        parent::__construct($container);
+        $this->stopwatch = $stopwatch;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDispatch($listeners, $eventName, Event $event)
+    {
+        $eventStopwatch = $this->stopwatch->start($eventName, 'section');
+
+        foreach ($listeners as $listener) {
+            list($listenerInstance, $methodName) = $listener;
+            $className = get_class($listenerInstance);
+            $name = $this->getDebugClassName($className);
+
+            $listenerStopwatch = $this->stopwatch->start($className . '->' . $methodName, 'document_manager_listener');
+
+            call_user_func($listener, $event, $eventName, $this);
+
+            $this->logger->debug(sprintf(
+                '%-40s%-20s %s', $name, $methodName, $event->getDebugMessage()
+            ));
+
+            if ($listenerStopwatch->isStarted()) {
+                $listenerStopwatch->stop();
+            }
+
+            if ($event->isPropagationStopped()) {
+                break;
+            }
+        }
+
+        if ($eventStopwatch->isStarted()) {
+            $eventStopwatch->stop();
+        }
+    }
+
+    private function getDebugClassName($className)
+    {
+        $parts = explode('\\', $className);
+        $last = array_pop($parts);
+        $parts = array_map(function ($part) {
+            return substr($part, 0, 1);
+        }, $parts);
+
+        return implode('\\', $parts) . '\\' . $last;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Events.php
+++ b/src/Sulu/Component/DocumentManager/Events.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+class Events
+{
+    /**
+     * Fired when a document is persisted (mapped to a PHPCR node).
+     *
+     * Fired both when a document is updated and when it is persisted
+     * for the first time.
+     */
+    const PERSIST = 'sulu_document_manager.persist';
+
+    /**
+     * Fired when a node is hydrated (a PHPCR node is mapped to a document).
+     */
+    const HYDRATE = 'sulu_document_manager.hydrate';
+
+    /**
+     * Fired when a document is removed via. the document manager.
+     */
+    const REMOVE = 'sulu_document_manager.remove';
+
+    /**
+     * Fired when a document should be refreshed.
+     */
+    const REFRESH = 'sulu_document_manager.refresh';
+
+    /**
+     * Fired when a document is copied via. the document manager.
+     */
+    const COPY = 'sulu_document_manager.copy';
+
+    /**
+     * Fired when a document is moved via. the document manager.
+     */
+    const MOVE = 'sulu_document_manager.move';
+
+    /**
+     * Fired when a document is created via. the document manager.
+     *
+     * NOTE: This event is NOT fired when a node is persisted for the first time,
+     *       it is fired when a NEW INSTANCE of a document is created from the document
+     *       manager, look at the PERSIST event instead.
+     */
+    const CREATE = 'sulu_document_manager.create';
+
+    /**
+     * Fired when the document manager should be cleared (i.e. detach all documents).
+     */
+    const CLEAR = 'sulu_document_manager.clear';
+
+    /**
+     * Fired when the document manager find method is called.
+     */
+    const FIND = 'sulu_document_manager.find';
+
+    /**
+     * Fired when the document manager reorder method is called.
+     */
+    const REORDER = 'sulu_document_manager.reorder';
+
+    /**
+     * Fired when the document manager publish method is called.
+     */
+    const PUBLISH = 'sulu_document_manager.publish';
+
+    /**
+     * Fired when the document manager unpublish method is called.
+     */
+    const UNPUBLISH = 'sulu_document_manager.unpublish';
+
+    /**
+     * Fired when the document discardDraft method is called.
+     */
+    const REMOVE_DRAFT = 'sulu_document_manager.remove_draft';
+
+    /**
+     * Fired when the document manager requests that are flush to persistent storage happen.
+     */
+    const FLUSH = 'sulu_document_manager.flush';
+
+    /**
+     * Fired when a query should be created from a query string.
+     */
+    const QUERY_CREATE = 'sulu_document_manager.query.create';
+
+    /**
+     * Fired when a new query builder should be created.
+     */
+    const QUERY_CREATE_BUILDER = 'sulu_document_manager.query.create_builder';
+
+    /**
+     * Fired when a PHPCR query should be executed.
+     */
+    const QUERY_EXECUTE = 'sulu_document_manager.query.execute';
+
+    /**
+     * Enables subscribers to define options.
+     */
+    const CONFIGURE_OPTIONS = 'sulu_document_manager.configure_options';
+
+    /**
+     * Enables fields to be added to the mapping.
+     */
+    const METADATA_LOAD = 'sulu_document_manager.metadata_load';
+
+    /**
+     * Fired when an old version of the document should be restored.
+     */
+    const RESTORE = 'sulu_document_manager.restore';
+}

--- a/src/Sulu/Component/DocumentManager/Exception/DocumentManagerException.php
+++ b/src/Sulu/Component/DocumentManager/Exception/DocumentManagerException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+class DocumentManagerException extends \Exception
+{
+}

--- a/src/Sulu/Component/DocumentManager/Exception/DocumentNotFoundException.php
+++ b/src/Sulu/Component/DocumentManager/Exception/DocumentNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+class DocumentNotFoundException extends DocumentManagerException
+{
+}

--- a/src/Sulu/Component/DocumentManager/Exception/InvalidLocaleException.php
+++ b/src/Sulu/Component/DocumentManager/Exception/InvalidLocaleException.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+/**
+ * Indicates invalid locale argument.
+ */
+class InvalidLocaleException extends \InvalidArgumentException
+{
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @param string $locale
+     */
+    public function __construct($locale)
+    {
+        parent::__construct(sprintf('Invalid locale "%s"', $locale));
+
+        $this->locale = $locale;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Exception/MetadataNotFoundException.php
+++ b/src/Sulu/Component/DocumentManager/Exception/MetadataNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+class MetadataNotFoundException extends DocumentManagerException
+{
+}

--- a/src/Sulu/Component/DocumentManager/Exception/NodeNameAlreadyExistsException.php
+++ b/src/Sulu/Component/DocumentManager/Exception/NodeNameAlreadyExistsException.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+/**
+ * This exception is thrown when the node name for the node does already exist.
+ */
+class NodeNameAlreadyExistsException extends DocumentManagerException
+{
+    /**
+     * @var string
+     */
+    private $nodeName;
+
+    /**
+     * @param string $nodeName
+     */
+    public function __construct($nodeName)
+    {
+        parent::__construct(
+            sprintf('The node name "%s" already exists, and therefore cannot be used to create a new node', $nodeName)
+        );
+        $this->nodeName = $nodeName;
+    }
+
+    /**
+     * The name of the node, which was tried to save.
+     *
+     * @return string
+     */
+    public function getNodeName()
+    {
+        return $this->nodeName;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Exception/VersionNotFoundException.php
+++ b/src/Sulu/Component/DocumentManager/Exception/VersionNotFoundException.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Exception;
+
+class VersionNotFoundException extends DocumentManagerException
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @var int
+     */
+    private $version;
+
+    /**
+     * @param object $document
+     * @param string $version
+     */
+    public function __construct($document, $version)
+    {
+        parent::__construct(
+            sprintf('Version "%s" for document "%s" not found', $version, $document->getUuid())
+        );
+        $this->document = $document;
+        $this->version = $version;
+    }
+
+    /**
+     * The document, which was tried to restore.
+     *
+     * @return object
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+
+    /**
+     * The version, which was tried to restore.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Metadata.php
+++ b/src/Sulu/Component/DocumentManager/Metadata.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+class Metadata
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @var string
+     */
+    private $phpcrType;
+
+    /**
+     * @var string
+     */
+    private $formType;
+
+    /**
+     * @var \ReflectionClass
+     */
+    private $reflection;
+
+    /**
+     * @var array
+     */
+    private $fieldMappings = [];
+
+    /**
+     * @var bool
+     */
+    private $syncRemoveLive = true;
+
+    /**
+     * @var bool
+     */
+    private $setDefaultAuthor = true;
+
+    /**
+     * Add a field mapping for field with given name, for example.
+     *
+     * ````
+     * $metadata->addFieldMapping(array(
+     *     'encoding' => 'content',
+     *     'property' => 'phpcr_property_name',
+     * ));
+     * ````
+     *
+     * @param string $name Name of field/property in the mapped class
+     * @param array $mapping {
+     *
+     *   @var string Encoding type to use, @see \Sulu\Component\DocumentManager\PropertyEncoder::encode()
+     *   @var string PHPCR property name (excluding the prefix)
+     *   @var string Type of field (leave blank to determine automatically)
+     *   @var bool If the field should be mapped. Set to false to manually persist and hydrate the data.
+     * }
+     */
+    public function addFieldMapping($name, $mapping)
+    {
+        $mapping = array_merge([
+            'encoding' => 'content',
+            'property' => $name,
+            'type' => null,
+            'mapped' => true,
+            'multiple' => false,
+            'default' => null,
+        ], $mapping);
+
+        $this->fieldMappings[$name] = $mapping;
+    }
+
+    /**
+     * Return all field mappings.
+     *
+     * @return array
+     */
+    public function getFieldMappings()
+    {
+        return $this->fieldMappings;
+    }
+
+    /**
+     * Returns class.
+     *
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * Set class.
+     *
+     * @param string $class
+     */
+    public function setClass($class)
+    {
+        $this->class = $class;
+        $this->reflection = null;
+    }
+
+    /**
+     * Returns reflection-class.
+     *
+     * @return \ReflectionClass
+     */
+    public function getReflectionClass()
+    {
+        if ($this->reflection) {
+            return $this->reflection;
+        }
+
+        if (!$this->class) {
+            throw new \InvalidArgumentException(
+                'Cannot retrieve ReflectionClass on metadata which has no class attribute'
+            );
+        }
+
+        $this->reflection = new \ReflectionClass($this->class);
+
+        return $this->reflection;
+    }
+
+    /**
+     * Returns alias.
+     *
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    /**
+     * Set alias.
+     *
+     * @param string $alias
+     */
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
+    }
+
+    /**
+     * Returns phpcr-type.
+     *
+     * @return string
+     */
+    public function getPhpcrType()
+    {
+        return $this->phpcrType;
+    }
+
+    /**
+     * Set phpcr-type.
+     *
+     * @param string $phpcrType
+     */
+    public function setPhpcrType($phpcrType)
+    {
+        $this->phpcrType = $phpcrType;
+    }
+
+    /**
+     * Returns form-type.
+     *
+     * @return string
+     */
+    public function getFormType()
+    {
+        return $this->formType;
+    }
+
+    /**
+     * Set form-type.
+     *
+     * @param string $formType
+     */
+    public function setFormType($formType)
+    {
+        $this->formType = $formType;
+    }
+
+    /**
+     * Returns removeLive.
+     *
+     * @return bool
+     */
+    public function getSyncRemoveLive()
+    {
+        return $this->syncRemoveLive;
+    }
+
+    /**
+     * Set removeLive.
+     *
+     * @param bool $syncRemoveLive
+     */
+    public function setSyncRemoveLive($syncRemoveLive)
+    {
+        $this->syncRemoveLive = $syncRemoveLive;
+    }
+
+    /**
+     * Returns set-default-author.
+     *
+     * @return bool
+     */
+    public function getSetDefaultAuthor()
+    {
+        return $this->setDefaultAuthor;
+    }
+
+    /**
+     * Set setDefaultAuthor.
+     *
+     * @param bool $setDefaultAuthor
+     */
+    public function setDefaultAuthor($setDefaultAuthor)
+    {
+        $this->setDefaultAuthor = $setDefaultAuthor;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Metadata/BaseMetadataFactory.php
+++ b/src/Sulu/Component/DocumentManager/Metadata/BaseMetadataFactory.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Metadata;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\ClassNameInflector;
+use Sulu\Component\DocumentManager\Event\MetadataLoadEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\MetadataNotFoundException;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Simple metadata factory which uses an array map.
+ *
+ * Note that this class does not  implement the getMetadataForPhpcrNode method
+ * as that would require a circular dependency.
+ */
+class BaseMetadataFactory implements MetadataFactoryInterface
+{
+    /**
+     * @var array
+     */
+    private $aliasMap = [];
+
+    /**
+     * @var array
+     */
+    private $classMap = [];
+
+    /**
+     * @var array
+     */
+    private $phpcrTypeMap = [];
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var Metadata[]
+     */
+    private $metadata = [];
+
+    /**
+     * @param array $mapping
+     */
+    public function __construct(EventDispatcherInterface $dispatcher, array $mapping)
+    {
+        $this->dispatcher = $dispatcher;
+
+        foreach ($mapping as $map) {
+            $this->aliasMap[$map['alias']] = $map;
+            $this->classMap[$map['class']] = $map;
+            $this->phpcrTypeMap[$map['phpcr_type']] = $map;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForAlias($alias)
+    {
+        if (!isset($this->aliasMap[$alias])) {
+            throw new MetadataNotFoundException(sprintf(
+                'Metadata with alias "%s" not found, known aliases: "%s"',
+                $alias, implode('", "', array_keys($this->aliasMap))
+            ));
+        }
+
+        $map = $this->aliasMap[$alias];
+
+        return $this->loadMetadata($map);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForPhpcrType($phpcrType)
+    {
+        if (!isset($this->phpcrTypeMap[$phpcrType])) {
+            throw new MetadataNotFoundException(sprintf(
+                'Metadata with phpcrType "%s" not found, known phpcrTypes: "%s"',
+                $phpcrType, implode('", "', array_keys($this->phpcrTypeMap))
+            ));
+        }
+
+        $map = $this->phpcrTypeMap[$phpcrType];
+
+        return $this->loadMetadata($map);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataForPhpcrType($phpcrType)
+    {
+        return isset($this->phpcrTypeMap[$phpcrType]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataForClass($class)
+    {
+        $class = ClassNameInflector::getUserClassName($class);
+
+        return isset($this->classMap[$class]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForClass($class)
+    {
+        $class = ClassNameInflector::getUserClassName($class);
+
+        if (!isset($this->classMap[$class])) {
+            throw new MetadataNotFoundException(sprintf(
+                'Metadata with class "%s" not found, known classes: "%s"',
+                $class, implode('", "', array_keys($this->classMap))
+            ));
+        }
+
+        $map = $this->classMap[$class];
+
+        return $this->loadMetadata($map);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAlias($alias)
+    {
+        return isset($this->aliasMap[$alias]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return array_keys($this->aliasMap);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForPhpcrNode(NodeInterface $node)
+    {
+        throw new \BadMethodCallException(
+            'The BaseMetadataFactory does not implement this method'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getPhpcrTypeMap()
+    {
+        return $this->phpcrTypeMap;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllMetadata()
+    {
+        $metadatas = [];
+        foreach (array_keys($this->aliasMap) as $alias) {
+            $metadatas[] = $this->getMetadataForAlias($alias);
+        }
+
+        return $metadatas;
+    }
+
+    /**
+     * @param array $mapping
+     *
+     * @return Metadata
+     */
+    private function loadMetadata($mapping)
+    {
+        $mapping = array_merge([
+            'alias' => null,
+            'phpcr_type' => null,
+            'form_type' => null,
+            'class' => null,
+            'mapping' => [],
+            'sync_remove_live' => true,
+            'set_default_author' => true,
+        ], $mapping);
+
+        if (isset($this->metadata[$mapping['alias']])) {
+            return $this->metadata[$mapping['alias']];
+        }
+
+        $metadata = new Metadata();
+        $metadata->setAlias($mapping['alias']);
+        $metadata->setPhpcrType($mapping['phpcr_type']);
+        $metadata->setFormType($mapping['form_type']);
+        $metadata->setClass($mapping['class']);
+        $metadata->setSyncRemoveLive($mapping['sync_remove_live']);
+        $metadata->setDefaultAuthor($mapping['set_default_author']);
+
+        foreach ($mapping['mapping'] as $fieldName => $fieldMapping) {
+            $fieldMapping = array_merge([
+                'encoding' => 'content',
+                'property' => $fieldName,
+            ], $fieldMapping);
+            $metadata->addFieldMapping($fieldName, $fieldMapping);
+        }
+
+        $event = new MetadataLoadEvent($metadata);
+        $this->dispatcher->dispatch(Events::METADATA_LOAD, $event);
+
+        $this->metadata[$mapping['alias']] = $metadata;
+
+        return $metadata;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Metadata/MetadataFactory.php
+++ b/src/Sulu/Component/DocumentManager/Metadata/MetadataFactory.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Metadata;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Document\UnknownDocument;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+
+/**
+ * This class fully implements the MetadataFactoryInterface by composing
+ * the "base" metadata factory and the node mxins.
+ */
+class MetadataFactory implements MetadataFactoryInterface
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @param MetadataFactoryInterface $metadataFactory
+     */
+    public function __construct(MetadataFactoryInterface $metadataFactory)
+    {
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForAlias($alias)
+    {
+        return $this->metadataFactory->getMetadataForAlias($alias);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForPhpcrType($phpcrType)
+    {
+        return $this->metadataFactory->getMetadataForPhpcrType($phpcrType);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataForPhpcrType($phpcrType)
+    {
+        return $this->metadataFactory->hasMetadataForPhpcrType($phpcrType);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForClass($class)
+    {
+        return $this->metadataFactory->getMetadataForClass($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasMetadataForClass($class)
+    {
+        return $this->metadataFactory->hasMetadataForClass($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAlias($alias)
+    {
+        return $this->metadataFactory->hasAlias($alias);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases()
+    {
+        return $this->metadataFactory->getAliases();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadataForPhpcrNode(NodeInterface $node)
+    {
+        if (false === $node->hasProperty('jcr:mixinTypes')) {
+            return $this->getUnknownMetadata();
+        }
+
+        $mixinTypes = (array) $node->getPropertyValue('jcr:mixinTypes');
+
+        foreach ($mixinTypes as $mixinType) {
+            if (true == $this->metadataFactory->hasMetadataForPhpcrType($mixinType)) {
+                return $this->metadataFactory->getMetadataForPhpcrType($mixinType);
+            }
+        }
+
+        return $this->getUnknownMetadata();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllMetadata()
+    {
+        return $this->metadataFactory->getAllMetadata();
+    }
+
+    /**
+     * @return Metadata
+     */
+    private function getUnknownMetadata()
+    {
+        $metadata = new Metadata();
+        $metadata->setAlias(null);
+        $metadata->setPhpcrType(null);
+        $metadata->setClass(UnknownDocument::class);
+
+        return $metadata;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/MetadataFactoryInterface.php
+++ b/src/Sulu/Component/DocumentManager/MetadataFactoryInterface.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+
+interface MetadataFactoryInterface
+{
+    /**
+     * Return metadata for the given alias.
+     *
+     * @param string $alias
+     *
+     * @return Metadata
+     */
+    public function getMetadataForAlias($alias);
+
+    /**
+     * Return metadata for the given PHPCR type (e.g. sulu:page).
+     *
+     * @param string $phpcrType
+     *
+     * @return Metadata
+     */
+    public function getMetadataForPhpcrType($phpcrType);
+
+    /**
+     * Return true if there is metadata for the given PHPCR type.
+     *
+     * @param string $phpcrType
+     *
+     * @return bool
+     */
+    public function hasMetadataForPhpcrType($phpcrType);
+
+    /**
+     * Return the metadata for the PHPCR node. If the PHPCR node is not managed
+     * then the Metadata should be that of the Sulu\Component\DocumentManager\Document\UnknownDocument.
+     *
+     * @param NodeInterface $phpcrNode
+     */
+    public function getMetadataForPhpcrNode(NodeInterface $phpcrNode);
+
+    /**
+     * Return metadata for the given class.
+     *
+     * @param mixed $class
+     *
+     * @return Metadata
+     */
+    public function getMetadataForClass($class);
+
+    /**
+     * Return true if the document has metadata for the given fully qualified
+     * class name.
+     *
+     * @param string
+     *
+     * @return bool
+     */
+    public function hasMetadataForClass($class);
+
+    /**
+     * Return the metadata for all managed document classes.
+     *
+     * @return Metadata[]
+     */
+    public function getAllMetadata();
+
+    /**
+     * Return true if the given alias exists.
+     *
+     * @param string $alias
+     *
+     * @return bool
+     */
+    public function hasAlias($alias);
+
+    /**
+     * Return all registered aliases.
+     *
+     * @return array
+     */
+    public function getAliases();
+}

--- a/src/Sulu/Component/DocumentManager/NameResolver.php
+++ b/src/Sulu/Component/DocumentManager/NameResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Exception\NodeNameAlreadyExistsException;
+
+/**
+ * Ensures that node names are unique.
+ */
+class NameResolver
+{
+    /**
+     * @param NodeInterface $parentNode
+     * @param string $name
+     * @param null|NodeInterface $forNode
+     * @param bool $autoRename When set to false an exception is thrown, in case the passed name already exists
+     *
+     * @return string
+     *
+     * @throws NodeNameAlreadyExistsException
+     */
+    public function resolveName(NodeInterface $parentNode, $name, NodeInterface $forNode = null, $autoRename = true)
+    {
+        $index = 0;
+        $baseName = $name;
+
+        if ($this->hasNameConflict($parentNode, $name, $forNode) && !$autoRename) {
+            throw new NodeNameAlreadyExistsException($name);
+        }
+
+        while ($this->hasNameConflict($parentNode, $name, $forNode)) {
+            $name = $baseName . '-' . ++$index;
+        }
+
+        return $name;
+    }
+
+    /**
+     * @param NodeInterface $parentNode
+     * @param string $name
+     * @param NodeInterface $forNode
+     *
+     * @return bool
+     */
+    private function hasNameConflict(NodeInterface $parentNode, $name, NodeInterface $forNode = null)
+    {
+        return $parentNode->hasNode($name) && (!$forNode || $parentNode->getNode($name) !== $forNode);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/NamespaceRegistry.php
+++ b/src/Sulu/Component/DocumentManager/NamespaceRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+/**
+ * Central registry of roles to namespaces.
+ */
+class NamespaceRegistry
+{
+    private $roleMap = [];
+
+    /**
+     * @param array $roleMap
+     */
+    public function __construct(array $roleMap)
+    {
+        $this->roleMap = $roleMap;
+    }
+
+    /**
+     * Return the namespace alias for the given role, e.g. "localized_content" => "lcont".
+     *
+     * @param $role
+     *
+     * @throws DocumentManagerException
+     *
+     * @return string
+     */
+    public function getPrefix($role)
+    {
+        if (!array_key_exists($role, $this->roleMap)) {
+            throw new DocumentManagerException(sprintf(
+                'Trying to get non-existant namespace alias role "%s", known roles: "%s"',
+                $role, implode('", "', array_keys($this->roleMap))
+            ));
+        }
+
+        return $this->roleMap[$role];
+    }
+}

--- a/src/Sulu/Component/DocumentManager/NodeHelper.php
+++ b/src/Sulu/Component/DocumentManager/NodeHelper.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use PHPCR\Util\PathHelper;
+use PHPCR\Util\UUIDHelper;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+/**
+ * The NodeHelper takes a node and some additional arguments to execute certain actions based on the passed node,
+ * especially on the session of the passed Node.
+ */
+class NodeHelper implements NodeHelperInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function move(NodeInterface $node, $parentUuid, $destinationName = null)
+    {
+        if (!$destinationName) {
+            $destinationName = $node->getName();
+        }
+
+        $session = $node->getSession();
+        $parentPath = $this->normalizePath($session, $parentUuid);
+        $session->move($node->getPath(), $parentPath . '/' . $destinationName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copy(NodeInterface $node, $parentUuid, $destinationName = null)
+    {
+        if (!$destinationName) {
+            $destinationName = $node->getName();
+        }
+
+        $session = $node->getSession();
+        $parentPath = $this->normalizePath($session, $parentUuid);
+        $destinationPath = $parentPath . '/' . $destinationName;
+        $session->getWorkspace()->copy($node->getPath(), $destinationPath);
+
+        return $destinationPath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reorder(NodeInterface $node, $destinationUuid)
+    {
+        $session = $node->getSession();
+        $parentNode = $node->getParent();
+
+        if (!$destinationUuid) {
+            $parentNode->orderBefore($node->getName(), null);
+
+            return;
+        }
+
+        $siblingPath = $session->getNodeByIdentifier($destinationUuid)->getPath();
+
+        if (PathHelper::getParentPath($siblingPath) !== $parentNode->getPath()) {
+            throw new DocumentManagerException(
+                sprintf(
+                    'Cannot reorder documents which are not sibilings. Trying to reorder "%s" to "%s".',
+                    $node->getPath(),
+                    $siblingPath
+                )
+            );
+        }
+
+        $parentNode->orderBefore($node->getName(), PathHelper::getNodeName($siblingPath));
+    }
+
+    /**
+     * Returns the path based on the given UUID.
+     *
+     * @param SessionInterface $session
+     * @param string $identifier
+     *
+     * @return string
+     */
+    private function normalizePath(SessionInterface $session, $identifier)
+    {
+        if (!UUIDHelper::isUUID($identifier)) {
+            return $identifier;
+        }
+
+        return $session->getNodeByIdentifier($identifier)->getPath();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/NodeHelperInterface.php
+++ b/src/Sulu/Component/DocumentManager/NodeHelperInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+
+/**
+ * The NodeHelperInterface describes action being executable on a node.
+ */
+interface NodeHelperInterface
+{
+    /**
+     * Move the given node to the given parent node. Additionally a new name can also be passed.
+     *
+     * @param NodeInterface $node
+     * @param string $parentUuid
+     * @param null $destinationName
+     */
+    public function move(NodeInterface $node, $parentUuid, $destinationName = null);
+
+    /**
+     * Copies the given node to the given parent node. Additionally a new name can also be passed.
+     *
+     * @param NodeInterface $node
+     * @param string $parentUuid
+     * @param null $destinationName
+     *
+     * @return string The path of the new node
+     */
+    public function copy(NodeInterface $node, $parentUuid, $destinationName = null);
+
+    /**
+     * Reorders the given node before the given UUID. Throws an exception if the given node and the node identified by
+     * the passed UUID are not siblings, since the operation would not be a simple reordering anymore.
+     *
+     * If the node should be passed to the last position null should be passed as destinationUuid.
+     *
+     * @param NodeInterface $node
+     * @param string|null $destinationUuid
+     *
+     * @throws DocumentManagerException
+     */
+    public function reorder(NodeInterface $node, $destinationUuid);
+}

--- a/src/Sulu/Component/DocumentManager/NodeManager.php
+++ b/src/Sulu/Component/DocumentManager/NodeManager.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+use PHPCR\RepositoryException;
+use PHPCR\SessionInterface;
+use PHPCR\Util\NodeHelper;
+use PHPCR\Util\UUIDHelper;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
+
+/**
+ * The node manager is responsible for talking to the PHPCR implementation.
+ */
+class NodeManager
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @param SessionInterface $session
+     */
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Find a document with the given path or UUID.
+     *
+     * @param string $identifier UUID or path
+     *
+     * @return NodeInterface
+     *
+     * @throws DocumentNotFoundException
+     */
+    public function find($identifier)
+    {
+        try {
+            if (UUIDHelper::isUUID($identifier)) {
+                return $this->session->getNodeByIdentifier($identifier);
+            }
+
+            return $this->session->getNode($identifier);
+        } catch (RepositoryException $e) {
+            throw new DocumentNotFoundException(sprintf(
+                'Could not find document with ID or path "%s"', $identifier
+            ), null, $e);
+        }
+    }
+
+    /**
+     * Determine if a node exists at the specified path or if a UUID is given,
+     * then if a node with the UUID exists.
+     *
+     * @param string $identifier
+     *
+     * @return bool
+     */
+    public function has($identifier)
+    {
+        $this->normalizeToPath($identifier);
+
+        try {
+            $this->find($identifier);
+
+            return true;
+        } catch (DocumentNotFoundException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Remove the document with the given path or UUID.
+     *
+     * @param string $identifier ID or path
+     */
+    public function remove($identifier)
+    {
+        $identifier = $this->normalizeToPath($identifier);
+        $this->session->removeItem($identifier);
+    }
+
+    /**
+     * Move the document with the given path or ID to the path
+     * of the destination document (as a child).
+     *
+     * @param string $srcId
+     * @param string $destId
+     * @param string $name
+     *
+     * @deprecated Use NodeHelper::move instead
+     */
+    public function move($srcId, $destId, $name)
+    {
+        $srcPath = $this->normalizeToPath($srcId);
+        $parentDestPath = $this->normalizeToPath($destId);
+        $destPath = $parentDestPath . '/' . $name;
+
+        $this->session->move($srcPath, $destPath);
+    }
+
+    /**
+     * Copy the document with the given path or ID to the path
+     * of the destination document (as a child).
+     *
+     * @param string $srcId
+     * @param string $destId
+     * @param string $name
+     *
+     * @return string
+     *
+     * @deprecated Use NodeHelper::copy instead
+     */
+    public function copy($srcId, $destId, $name)
+    {
+        $workspace = $this->session->getWorkspace();
+        $srcPath = $this->normalizeToPath($srcId);
+        $parentDestPath = $this->normalizeToPath($destId);
+        $destPath = $parentDestPath . '/' . $name;
+
+        $workspace->copy($srcPath, $destPath);
+
+        return $destPath;
+    }
+
+    /**
+     * Save all pending changes currently recorded in this Session.
+     */
+    public function save()
+    {
+        $this->session->save();
+    }
+
+    /**
+     * Clear the current session.
+     */
+    public function clear()
+    {
+        $this->session->refresh(false);
+    }
+
+    /**
+     * Create a path.
+     *
+     * @param string $path
+     *
+     * @return NodeInterface
+     */
+    public function createPath($path)
+    {
+        $current = $this->session->getRootNode();
+
+        $segments = preg_split('#/#', $path, null, PREG_SPLIT_NO_EMPTY);
+        foreach ($segments as $segment) {
+            if ($current->hasNode($segment)) {
+                $current = $current->getNode($segment);
+            } else {
+                $current = $current->addNode($segment);
+                $current->addMixin('mix:referenceable');
+                $current->setProperty('jcr:uuid', UUIDHelper::generateUUID());
+            }
+        }
+
+        return $current;
+    }
+
+    /**
+     * Purge the workspace.
+     */
+    public function purgeWorkspace()
+    {
+        NodeHelper::purgeWorkspace($this->session);
+    }
+
+    /**
+     * Normalize the given path or ID to a path.
+     *
+     * @param string $identifier
+     *
+     * @return string
+     */
+    private function normalizeToPath($identifier)
+    {
+        if (UUIDHelper::isUUID($identifier)) {
+            $identifier = $this->session->getNodeByIdentifier($identifier)->getPath();
+        }
+
+        return $identifier;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/PathBuilder.php
+++ b/src/Sulu/Component/DocumentManager/PathBuilder.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+/**
+ * The path builder provides a way to create paths from templates.
+ */
+class PathBuilder
+{
+    /**
+     * @var PathSegmentRegistry
+     */
+    private $registry;
+
+    /**
+     * @param PathSegmentRegistry $registry
+     */
+    public function __construct(PathSegmentRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Build a path from an array of path segments.
+     *
+     * Segments demarcated by "%" characters will be interpreted as path
+     * segment *names* and their value will be resolved from the PathSegmentRegistry.
+     *
+     * Other segments will be interpreted literally.
+     *
+     * The following:
+     *
+     * ````
+     * $path = $pathBuilder->build(array('%base%', 'hello', '%articles%'));
+     * ````
+     *
+     * Will yield `/cms/hello/articleDirectory` where `%base%` is "cms" and
+     * `%articles` is "articleDirectory"
+     *
+     * @see Sulu\Component\DocumentManager\PathSegmentRegistry
+     *
+     * @param array $segments
+     *
+     * @return string
+     */
+    public function build(array $segments)
+    {
+        $results = [];
+        foreach ($segments as $segment) {
+            $result = $this->buildSegment($segment);
+
+            if (null === $result) {
+                continue;
+            }
+
+            $results[] = $result;
+        }
+
+        return '/' . implode('/', $results);
+    }
+
+    /**
+     * @param string $segment
+     */
+    private function buildSegment($segment)
+    {
+        if (empty($segment) || '/' == $segment) {
+            return;
+        }
+
+        if ('%' == substr($segment, 0, 1)) {
+            if ('%' == substr($segment, -1)) {
+                return $this->registry->getPathSegment(substr($segment, 1, -1));
+            }
+        }
+
+        return $segment;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/PathSegmentRegistry.php
+++ b/src/Sulu/Component/DocumentManager/PathSegmentRegistry.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+/**
+ * Provides a centralized repository of path components.
+ *
+ * Note that this is not used by the document manager itself, but
+ * is a useful utility for implementors.
+ *
+ * TODO: Move this class to somewhere more appropriate
+ */
+class PathSegmentRegistry
+{
+    /**
+     * @var array
+     */
+    private $pathSegments;
+
+    /**
+     * @param array Array of roles to pathSegments
+     */
+    public function __construct(array $pathSegments = [])
+    {
+        $this->pathSegments = $pathSegments;
+    }
+
+    /**
+     * Return the configured named path segment.
+     *
+     * @param string $name Name of path segment
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return string The path segment
+     */
+    public function getPathSegment($name)
+    {
+        if (!isset($this->pathSegments[$name])) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown path segment "%s". Known path segments: "%s"',
+                    $name,
+                    implode('", "', array_keys($this->pathSegments))
+                )
+            );
+        }
+
+        return $this->pathSegments[$name];
+    }
+}

--- a/src/Sulu/Component/DocumentManager/PropertyEncoder.php
+++ b/src/Sulu/Component/DocumentManager/PropertyEncoder.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use Sulu\Component\DocumentManager\Exception\InvalidLocaleException;
+
+/**
+ * Class responsible for encoding properties to PHPCR nodes.
+ */
+class PropertyEncoder
+{
+    /**
+     * @var NamespaceRegistry
+     */
+    private $namespaceRegistry;
+
+    /**
+     * @param NamespaceRegistry $namespaceRegistry
+     */
+    public function __construct(NamespaceRegistry $namespaceRegistry)
+    {
+        $this->namespaceRegistry = $namespaceRegistry;
+    }
+
+    public function encode($encoding, $name, $locale)
+    {
+        switch ($encoding) {
+            case 'system_localized':
+                return $this->localizedSystemName($name, $locale);
+            case 'system':
+                return $this->systemName($name);
+            case 'content_localized':
+                return $this->localizedContentName($name, $locale);
+            case 'content':
+                return $this->contentName($name);
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    'Invalid encoding "%s"', $encoding
+                ));
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function localizedSystemName($name, $locale)
+    {
+        if (null === $locale) {
+            throw new InvalidLocaleException($locale);
+        }
+
+        return $this->formatLocalizedName('system_localized', $name, $locale);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function systemName($name)
+    {
+        return $this->formatName('system', $name);
+    }
+
+    /**
+     * @param string $name
+     * @param string $locale
+     *
+     * @return string
+     */
+    public function localizedContentName($name, $locale)
+    {
+        if (null === $locale) {
+            throw new InvalidLocaleException($locale);
+        }
+
+        return $this->formatLocalizedName('content_localized', $name, $locale);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    public function contentName($name)
+    {
+        return $this->formatName('content', $name);
+    }
+
+    private function formatName($role, $name)
+    {
+        $prefix = $this->namespaceRegistry->getPrefix($role);
+
+        if (!$prefix) {
+            return $name;
+        }
+
+        return sprintf(
+            '%s:%s',
+            $prefix,
+            $name
+        );
+    }
+
+    private function formatLocalizedName($role, $name, $locale)
+    {
+        $prefix = $this->namespaceRegistry->getPrefix($role);
+
+        if (!$prefix) {
+            return sprintf('%s-%s', $locale, $name);
+        }
+
+        return sprintf(
+            '%s:%s-%s',
+            $prefix,
+            $locale,
+            $name
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/ProxyFactory.php
+++ b/src/Sulu/Component/DocumentManager/ProxyFactory.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+use PHPCR\NodeInterface;
+use ProxyManager\Factory\LazyLoadingGhostFactory;
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
+use Sulu\Component\DocumentManager\Collection\ReferrerCollection;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Handle creation of proxies.
+ */
+class ProxyFactory
+{
+    /**
+     * @var LazyLoadingGhostFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $registry;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @param LazyLoadingGhostFactory $proxyFactory
+     * @param EventDispatcherInterface $dispatcher
+     * @param DocumentRegistry $registry
+     * @param MetadataFactoryInterface $metadataFactory
+     */
+    public function __construct(
+        LazyLoadingGhostFactory $proxyFactory,
+        EventDispatcherInterface $dispatcher,
+        DocumentRegistry $registry,
+        MetadataFactoryInterface $metadataFactory
+    ) {
+        $this->proxyFactory = $proxyFactory;
+        $this->dispatcher = $dispatcher;
+        $this->registry = $registry;
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * Create a new proxy object from the given document for
+     * the given target node.
+     *
+     * TODO: We only pass the document here in order to correctly evaluate its locale
+     *       later. I wonder if it necessary.
+     *
+     * @param object $fromDocument
+     * @param NodeInterface $targetNode
+     * @param array $options
+     *
+     * @return \ProxyManager\Proxy\GhostObjectInterface
+     */
+    public function createProxyForNode($fromDocument, NodeInterface $targetNode, $options = [])
+    {
+        // if node is already registered then just return the registered document
+        $locale = $this->registry->getOriginalLocaleForDocument($fromDocument);
+        if ($this->registry->hasNode($targetNode, $locale)) {
+            $document = $this->registry->getDocumentForNode($targetNode, $locale);
+
+            // If the parent is not loaded in the correct locale, reload it in the correct locale.
+            if ($this->registry->getOriginalLocaleForDocument($document) !== $locale) {
+                $hydrateEvent = new HydrateEvent($targetNode, $locale);
+                $hydrateEvent->setDocument($document);
+                $this->dispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+            }
+
+            return $document;
+        }
+
+        $initializer = function (LazyLoadingInterface $document, $method, array $parameters, &$initializer) use (
+            $fromDocument,
+            $targetNode,
+            $options,
+            $locale
+        ) {
+            $hydrateEvent = new HydrateEvent($targetNode, $locale, $options);
+            $hydrateEvent->setDocument($document);
+            $this->dispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+
+            $initializer = null;
+        };
+
+        $targetMetadata = $this->metadataFactory->getMetadataForPhpcrNode($targetNode);
+        $proxy = $this->proxyFactory->createProxy($targetMetadata->getClass(), $initializer);
+        $locale = $this->registry->getOriginalLocaleForDocument($fromDocument);
+        $this->registry->registerDocument($proxy, $targetNode, $locale);
+
+        return $proxy;
+    }
+
+    /**
+     * Create a new children collection for the given document.
+     *
+     * @param object $document
+     *
+     * @return ChildrenCollection
+     */
+    public function createChildrenCollection($document, array $options = [])
+    {
+        $node = $this->registry->getNodeForDocument($document);
+        $locale = $this->registry->getOriginalLocaleForDocument($document);
+
+        return new ChildrenCollection(
+            $node,
+            $this->dispatcher,
+            $locale,
+            $options
+        );
+    }
+
+    /**
+     * Create a new collection of referrers from a list of referencing items.
+     *
+     * @param $document
+     *
+     * @return ReferrerCollection
+     */
+    public function createReferrerCollection($document)
+    {
+        $node = $this->registry->getNodeForDocument($document);
+        $locale = $this->registry->getOriginalLocaleForDocument($document);
+
+        return new ReferrerCollection(
+            $node,
+            $this->dispatcher,
+            $locale
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Query/Query.php
+++ b/src/Sulu/Component/DocumentManager/Query/Query.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Query;
+
+use PHPCR\Query\QueryInterface;
+use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Based heavily on the PHPCR-ODM Query object.
+ *
+ * If we can break the phpcrQuery builder from the PHPCR-ODM we should
+ * also be able to break-out the PhpcrQuery object too:
+ *
+ * https://github.com/doctrine/phpcr-odm/issues/627
+ */
+class Query
+{
+    const HYDRATE_DOCUMENT = 'document';
+
+    const HYDRATE_PHPCR = 'phpcr_node';
+
+    /**
+     * @var QueryInterface
+     */
+    private $phpcrQuery;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var null|string
+     */
+    private $primarySelector;
+
+    /**
+     * @var null|string
+     */
+    private $locale;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var int
+     */
+    private $maxResults;
+
+    /**
+     * @var int
+     */
+    private $firstResult;
+
+    /**
+     * @param QueryInterface $phpcrQuery
+     * @param EventDispatcherInterface $dispatcher
+     * @param null|string $locale
+     * @param array $options
+     * @param null|string $primarySelector
+     */
+    public function __construct(
+        QueryInterface $phpcrQuery,
+        EventDispatcherInterface $dispatcher,
+        $locale = null,
+        array $options = [],
+        $primarySelector = null
+    ) {
+        $this->phpcrQuery = $phpcrQuery;
+        $this->dispatcher = $dispatcher;
+        $this->locale = $locale;
+        $this->options = $options;
+        $this->primarySelector = $primarySelector;
+    }
+
+    /**
+     * @param array $parameters
+     * @param string $hydrationMode
+     *
+     * @return mixed|\PHPCR\Query\QueryResultInterface
+     *
+     * @throws DocumentManagerException
+     */
+    public function execute(array $parameters = [], $hydrationMode = self::HYDRATE_DOCUMENT)
+    {
+        if (null !== $this->maxResults) {
+            $this->phpcrQuery->setLimit($this->maxResults);
+        }
+
+        if (null !== $this->firstResult) {
+            $this->phpcrQuery->setOffset($this->firstResult);
+        }
+
+        foreach ($parameters as $key => $value) {
+            $this->phpcrQuery->bindValue($key, $value);
+        }
+
+        if (self::HYDRATE_PHPCR === $hydrationMode) {
+            return $this->phpcrQuery->execute();
+        }
+
+        if (self::HYDRATE_DOCUMENT !== $hydrationMode) {
+            throw new DocumentManagerException(sprintf(
+                'Unknown hydration mode "%s", should be either "document" or "phpcr_node"',
+                $hydrationMode
+            ));
+        }
+
+        $event = new QueryExecuteEvent($this, $this->options);
+        $this->dispatcher->dispatch(Events::QUERY_EXECUTE, $event);
+
+        return $event->getResult();
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
+    }
+
+    /**
+     * @param int $maxResults
+     */
+    public function setMaxResults($maxResults)
+    {
+        $this->maxResults = $maxResults;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFirstResult()
+    {
+        return $this->firstResult;
+    }
+
+    /**
+     * @param int $firstResult
+     */
+    public function setFirstResult($firstResult)
+    {
+        $this->firstResult = $firstResult;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @param string $locale
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getPrimarySelector()
+    {
+        return $this->primarySelector;
+    }
+
+    /**
+     * @param string $primarySelector
+     */
+    public function setPrimarySelector($primarySelector)
+    {
+        $this->primarySelector = $primarySelector;
+    }
+
+    /**
+     * @return QueryInterface
+     */
+    public function getPhpcrQuery()
+    {
+        return $this->phpcrQuery;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Slugifier/NodeNameSlugifier.php
+++ b/src/Sulu/Component/DocumentManager/Slugifier/NodeNameSlugifier.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Slugifier;
+
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
+
+/**
+ * Wraps default slugifier and add some additional node-name stuff.
+ */
+class NodeNameSlugifier implements SlugifierInterface
+{
+    /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
+     * @param SlugifierInterface $slugifier
+     */
+    public function __construct(SlugifierInterface $slugifier)
+    {
+        $this->slugifier = $slugifier;
+    }
+
+    /**
+     * Slugifies given string to a valid node-name.
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    public function slugify($text)
+    {
+        $text = $this->slugifier->slugify($text);
+
+        // jackrabbit can not handle node-names which contains a number followed by "e" e.g. 10e
+        $text = preg_replace('((\d+)([eE]))', '$1-$2', $text);
+
+        return $text;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Audit/TimestampSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Audit/TimestampSubscriber.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Audit;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Audit\LocalizedTimestampBehavior;
+use Sulu\Component\DocumentManager\Behavior\Audit\TimestampBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
+use Sulu\Component\DocumentManager\Event\RestoreEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Manage the timestamp (created, changed) fields on documents before they are persisted.
+ */
+class TimestampSubscriber implements EventSubscriberInterface
+{
+    const CREATED = 'created';
+
+    const CHANGED = 'changed';
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    public function __construct(PropertyEncoder $propertyEncoder)
+    {
+        $this->propertyEncoder = $propertyEncoder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => 'setTimestampsOnNodeForPersist',
+            Events::PUBLISH => 'setTimestampsOnNodeForPublish',
+            Events::RESTORE => ['setChangedForRestore', -32],
+            Events::HYDRATE => 'setTimestampsOnDocument',
+        ];
+    }
+
+    /**
+     * Sets the timestamps from the node to the document.
+     *
+     * @param HydrateEvent $event
+     */
+    public function setTimestampsOnDocument(HydrateEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$this->supports($document)) {
+            return;
+        }
+
+        $accessor = $event->getAccessor();
+        $node = $event->getNode();
+        $locale = $event->getLocale();
+
+        $encoding = $this->getPropertyEncoding($document);
+
+        $accessor->set(
+            static::CHANGED,
+            $node->getPropertyValueWithDefault(
+                $this->propertyEncoder->encode($encoding, static::CHANGED, $locale),
+                null
+            )
+        );
+        $accessor->set(
+            static::CREATED,
+            $node->getPropertyValueWithDefault(
+                $this->propertyEncoder->encode($encoding, static::CREATED, $locale),
+                null
+            )
+        );
+    }
+
+    /**
+     * Sets the timestamps on the nodes for the persist operation.
+     *
+     * @param PersistEvent $event
+     */
+    public function setTimestampsOnNodeForPersist(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$this->supports($document)) {
+            return;
+        }
+
+        $this->setTimestampsOnNode(
+            $document,
+            $event->getNode(),
+            $event->getAccessor(),
+            $event->getLocale(),
+            new \DateTime()
+        );
+    }
+
+    public function setTimestampsOnNodeForPublish(PublishEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$this->supports($document)) {
+            return;
+        }
+
+        $this->setTimestampsOnNode(
+            $document,
+            $event->getNode(),
+            $event->getAccessor(),
+            $event->getLocale()
+        );
+    }
+
+    /**
+     * Set the timestamps on the node.
+     *
+     * @param LocalizedTimestampBehavior $document
+     * @param NodeInterface $node
+     * @param DocumentAccessor $accessor
+     * @param string $locale
+     * @param \DateTime|null $timestamp The timestamp to set, will use the documents timestamps if null is provided
+     */
+    public function setTimestampsOnNode(
+        LocalizedTimestampBehavior $document,
+        NodeInterface $node,
+        DocumentAccessor $accessor,
+        $locale,
+        $timestamp = null
+    ) {
+        if (!$document instanceof TimestampBehavior && !$locale) {
+            return;
+        }
+
+        $encoding = $this->getPropertyEncoding($document);
+
+        $createdPropertyName = $this->propertyEncoder->encode($encoding, static::CREATED, $locale);
+        if (!$node->hasProperty($createdPropertyName)) {
+            $createdTimestamp = $document->getCreated() ?: $timestamp;
+            $accessor->set(static::CREATED, $createdTimestamp);
+            $node->setProperty($createdPropertyName, $createdTimestamp);
+        }
+
+        $changedTimestamp = $timestamp ?: $document->getChanged();
+        $accessor->set(static::CHANGED, $changedTimestamp);
+        $node->setProperty($this->propertyEncoder->encode($encoding, static::CHANGED, $locale), $changedTimestamp);
+    }
+
+    /**
+     * Sets the changed timestamp when restoring a document.
+     *
+     * @param RestoreEvent $event
+     */
+    public function setChangedForRestore(RestoreEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$this->supports($document)) {
+            return;
+        }
+
+        $encoding = $this->getPropertyEncoding($document);
+
+        $event->getNode()->setProperty(
+            $this->propertyEncoder->encode($encoding, static::CHANGED, $event->getLocale()),
+            new \DateTime()
+        );
+    }
+
+    /**
+     * Returns the encoding for the given document.
+     *
+     * @param $document
+     *
+     * @return string
+     */
+    private function getPropertyEncoding($document)
+    {
+        $encoding = 'system_localized';
+        if ($document instanceof TimestampBehavior) {
+            $encoding = 'system';
+        }
+
+        return $encoding;
+    }
+
+    /**
+     * Return true if document is supported by this subscriber.
+     *
+     * @param $document
+     *
+     * @return bool
+     */
+    private function supports($document)
+    {
+        return $document instanceof LocalizedTimestampBehavior;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ChildrenSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ChildrenSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\ChildrenBehavior;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Set the children on the document.
+ */
+class ChildrenSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @param ProxyFactory $proxyFactory
+     */
+    public function __construct(ProxyFactory $proxyFactory)
+    {
+        $this->proxyFactory = $proxyFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => 'handleHydrate',
+        ];
+    }
+
+    /**
+     * @param HydrateEvent $event
+     */
+    public function handleHydrate(HydrateEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof ChildrenBehavior) {
+            return;
+        }
+
+        $accessor = $event->getAccessor();
+        $accessor->set('children', $this->proxyFactory->createChildrenCollection($document, $event->getOptions()));
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/LocaleSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/LocaleSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Maps the locale.
+ */
+class LocaleSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $registry;
+
+    public function __construct(DocumentRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => ['handleLocale', 410],
+            Events::PERSIST => ['handleLocale', 410],
+        ];
+    }
+
+    /**
+     * @param AbstractMappingEvent $event
+     *
+     * @throws DocumentManagerException
+     */
+    public function handleLocale(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof LocaleBehavior) {
+            return;
+        }
+
+        $locale = $this->registry->getLocaleForDocument($document);
+        $document->setLocale($locale);
+        $document->setOriginalLocale($locale);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/MixinSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/MixinSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use PHPCR\Util\UUIDHelper;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class MixinSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    public function __construct(MetadataFactoryInterface $metadataFactory)
+    {
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => ['setDocumentMixinsOnNode', 468],
+            Events::PUBLISH => ['setDocumentMixinsOnNode', 468],
+        ];
+    }
+
+    public function setDocumentMixinsOnNode(AbstractMappingEvent $event)
+    {
+        $node = $event->getNode();
+        $document = $event->getDocument();
+
+        $metadata = $this->metadataFactory->getMetadataForClass(get_class($document));
+
+        $node->addMixin($metadata->getPhpcrType());
+
+        if (!$node->hasProperty('jcr:uuid')) {
+            $node->setProperty('jcr:uuid', UUIDHelper::generateUUID());
+        }
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/NodeNameSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/NodeNameSubscriber.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Maps the node name.
+ */
+class NodeNameSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => 'setFinalNodeName',
+            Events::PERSIST => [
+                ['setInitialNodeName', 0],
+                ['setFinalNodeName', -480],
+            ],
+        ];
+    }
+
+    /**
+     * Sets the initial node name.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function setInitialNodeName(AbstractMappingEvent $event)
+    {
+        $this->setNodeName($event);
+    }
+
+    /**
+     * Sets the final node name at the end, in case it was changed.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function setFinalNodeName(AbstractMappingEvent $event)
+    {
+        $this->setNodeName($event);
+    }
+
+    /**
+     * Sets the node name.
+     *
+     * @param AbstractMappingEvent $event
+     *
+     * @throws DocumentManagerException
+     */
+    private function setNodeName(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof NodeNameBehavior) {
+            return;
+        }
+
+        $node = $event->getNode();
+        $accessor = $event->getAccessor();
+        $accessor->set(
+            'nodeName',
+            $node->getName()
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ParentSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ParentSubscriber.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\DocumentInspector;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Set the parent and children on the document.
+ */
+class ParentSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $inspector;
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @param ProxyFactory $proxyFactory
+     * @param DocumentInspector $inspector
+     * @param DocumentManagerInterface $documentManager
+     */
+    public function __construct(
+        ProxyFactory $proxyFactory,
+        DocumentInspector $inspector,
+        DocumentManagerInterface $documentManager
+    ) {
+        $this->proxyFactory = $proxyFactory;
+        $this->inspector = $inspector;
+        $this->documentManager = $documentManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => 'handleHydrate',
+            Events::PERSIST => [
+                ['handleChangeParent', 0],
+                ['handleSetParentNodeFromDocument', 490],
+            ],
+            Events::MOVE => 'handleMove',
+        ];
+    }
+
+    /**
+     * @param MoveEvent $event
+     */
+    public function handleMove(MoveEvent $event)
+    {
+        $document = $event->getDocument();
+        $node = $this->inspector->getNode($event->getDocument());
+        $this->mapParent($document, $node);
+    }
+
+    /**
+     * @param PersistEvent $event
+     */
+    public function handleSetParentNodeFromDocument(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof ParentBehavior) {
+            return;
+        }
+
+        if ($event->hasParentNode()) {
+            return;
+        }
+
+        $parentDocument = $document->getParent();
+
+        if (!$parentDocument) {
+            return;
+        }
+
+        $parentNode = $this->inspector->getNode($parentDocument);
+        $event->setParentNode($parentNode);
+    }
+
+    /**
+     * @param HydrateEvent $event
+     */
+    public function handleHydrate(HydrateEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof ParentBehavior) {
+            return;
+        }
+
+        $node = $event->getNode();
+
+        if (0 == $node->getDepth()) {
+            throw new \RuntimeException(sprintf(
+                'Cannot apply parent behavior to root node "%s" with type "%s" for document of class "%s"',
+                $node->getPath(),
+                $node->getPrimaryNodeType()->getName(),
+                get_class($document)
+            ));
+        }
+
+        $this->mapParent($document, $node, $event->getOptions());
+    }
+
+    /**
+     * @param PersistEvent $event
+     */
+    public function handleChangeParent(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof ParentBehavior) {
+            return;
+        }
+
+        $node = $this->inspector->getNode($document);
+        $parentNode = $event->getParentNode();
+
+        if ($parentNode->getPath() === $node->getParent()->getPath()) {
+            return;
+        }
+
+        $this->documentManager->move($document, $parentNode->getPath());
+    }
+
+    /**
+     * Map parent document to given document.
+     *
+     * @param object $document child-document
+     * @param NodeInterface $node to determine parent
+     * @param array $options options to load parent
+     */
+    private function mapParent($document, NodeInterface $node, $options = [])
+    {
+        // TODO: performance warning: We are eagerly fetching the parent node
+        $targetNode = $node->getParent();
+
+        // Do not map non-referenceable parent nodes
+        if (!$targetNode->hasProperty('jcr:uuid')) {
+            return;
+        }
+
+        $document->setParent($this->proxyFactory->createProxyForNode($document, $targetNode, $options));
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/PathSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/PathSubscriber.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
+use Sulu\Component\DocumentManager\DocumentInspector;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Set the path on the document.
+ */
+class PathSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentInspector
+     */
+    private $documentInspector;
+
+    /**
+     * @param DocumentInspector $documentInspector
+     */
+    public function __construct(DocumentInspector $documentInspector)
+    {
+        $this->documentInspector = $documentInspector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => [
+                ['setInitialPath', 0],
+                ['setFinalPath', -495],
+            ],
+            Events::HYDRATE => 'setFinalPath',
+        ];
+    }
+
+    /**
+     * Sets the path at the beginning of persisting.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function setInitialPath(AbstractMappingEvent $event)
+    {
+        $this->setPath($event);
+    }
+
+    /**
+     * Sets the path at the very end, in case the path has been changed in the persisting process.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function setFinalPath(AbstractMappingEvent $event)
+    {
+        $this->setPath($event);
+    }
+
+    /**
+     * @param AbstractMappingEvent $event
+     */
+    private function setPath(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof PathBehavior) {
+            return;
+        }
+
+        $event->getAccessor()->set('path', $this->documentInspector->getPath($document));
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/UuidSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/UuidSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Maps the UUID.
+ */
+class UuidSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => 'handleUuid',
+            Events::PERSIST => ['handleUuid', 0],
+        ];
+    }
+
+    /**
+     * @param AbstractMappingEvent $event
+     *
+     * @throws DocumentManagerException
+     */
+    public function handleUuid(AbstractMappingEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof UuidBehavior) {
+            return;
+        }
+
+        $node = $event->getNode();
+
+        $accessor = $event->getAccessor();
+        $accessor->set(
+            'uuid',
+            $node->getIdentifier()
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AbstractFilingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AbstractFilingSubscriber.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Path;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use PHPCR\Util\UUIDHelper;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Automatically set the parent at a pre-determined location.
+ */
+abstract class AbstractFilingSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var SessionInterface
+     */
+    private $defaultSession;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    /**
+     * @param SessionInterface $defaultSession
+     * @param SessionInterface $liveSession
+     */
+    public function __construct(
+        SessionInterface $defaultSession,
+        SessionInterface $liveSession
+    ) {
+        $this->defaultSession = $defaultSession;
+        $this->liveSession = $liveSession;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => ['handlePersist', 490],
+        ];
+    }
+
+    public function handlePersist(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$this->supports($document)) {
+            return;
+        }
+
+        $path = $this->generatePath($event);
+
+        $currentDefaultNode = $this->defaultSession->getRootNode();
+        $currentLiveNode = $this->liveSession->getRootNode();
+
+        $pathSegments = explode('/', ltrim($path, '/'));
+        foreach ($pathSegments as $pathSegment) {
+            $uuid = UUIDHelper::generateUUID();
+            $currentDefaultNode = $this->createNode($currentDefaultNode, $pathSegment, $uuid);
+            $currentLiveNode = $this->createNode($currentLiveNode, $pathSegment, $uuid);
+        }
+
+        $event->setParentNode($currentDefaultNode);
+    }
+
+    /**
+     * Generates the path for the given event.
+     *
+     * @return string
+     */
+    abstract protected function generatePath(PersistEvent $event);
+
+    /**
+     * Return true if this subscriber should be applied to the document.
+     *
+     * @param object $document
+     */
+    abstract protected function supports($document);
+
+    /**
+     * Return the name of the parent document.
+     *
+     * @param $document
+     *
+     * @return string
+     */
+    abstract protected function getParentName($document);
+
+    /**
+     * Adds a node with the given path segment as a node name to the given node.
+     *
+     * @param NodeInterface $node
+     * @param string $pathSegment
+     * @param string $uuid
+     *
+     * @return mixed
+     */
+    private function createNode(NodeInterface $node, $pathSegment, $uuid)
+    {
+        if ($node->hasNode($pathSegment)) {
+            return $node->getNode($pathSegment);
+        }
+
+        $node = $node->addNode($pathSegment);
+        $node->addMixin('mix:referenceable');
+        $node->setProperty('jcr:uuid', $uuid);
+
+        return $node;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AliasFilingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AliasFilingSubscriber.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Path;
+
+use Doctrine\Common\Inflector\Inflector;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\Behavior\Path\AliasFilingBehavior;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+
+/**
+ * Automatically set the parent at a pre-determined location.
+ */
+class AliasFilingSubscriber extends AbstractFilingSubscriber
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @param NodeManager $nodeManager
+     * @param MetadataFactoryInterface $metadataFactory
+     */
+    public function __construct(
+        SessionInterface $defaultSession,
+        SessionInterface $liveSession,
+        MetadataFactoryInterface $metadataFactory
+    ) {
+        parent::__construct($defaultSession, $liveSession);
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => ['handlePersist', 490],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function generatePath(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        $currentPath = '';
+        if ($event->hasParentNode()) {
+            $currentPath = $event->getParentNode()->getPath();
+        }
+        $parentName = $this->getParentName($document);
+
+        return sprintf('%s/%s', $currentPath, Inflector::pluralize($parentName));
+    }
+
+    /**
+     * @param object $document
+     *
+     * @return bool
+     */
+    protected function supports($document)
+    {
+        return $document instanceof AliasFilingBehavior;
+    }
+
+    /**
+     * @param $document
+     *
+     * @return string
+     */
+    protected function getParentName($document)
+    {
+        return $this->metadataFactory->getMetadataForClass(get_class($document))->getAlias();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -1,0 +1,282 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Path;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
+use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentHelper;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\CopyEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\NameResolver;
+use Sulu\Component\DocumentManager\NodeManager;
+use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Automatically assign a name to the document based on its title.
+ *
+ * TODO: Refactor MOVE auto-name handling somehow.
+ */
+class AutoNameSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $registry;
+
+    /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
+     * @var NameResolver
+     */
+    private $resolver;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    /**
+     * @var array
+     */
+    private $scheduledRename = [];
+
+    public function __construct(
+        DocumentRegistry $registry,
+        SlugifierInterface $slugifier,
+        NameResolver $resolver,
+        NodeManager $nodeManager,
+        SessionInterface $session,
+        SessionInterface $liveSession
+    ) {
+        $this->registry = $registry;
+        $this->slugifier = $slugifier;
+        $this->resolver = $resolver;
+        $this->nodeManager = $nodeManager;
+        $this->session = $session;
+        $this->liveSession = $liveSession;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::CONFIGURE_OPTIONS => 'configureOptions',
+            Events::PERSIST => [
+                ['handleScheduleRename'],
+                ['handlePersist', 480],
+            ],
+            Events::MOVE => ['handleMove', 480],
+            Events::COPY => ['handleCopy', 480],
+            Events::FLUSH => ['handleRename', 510],
+        ];
+    }
+
+    public function configureOptions(ConfigureOptionsEvent $event)
+    {
+        $options = $event->getOptions();
+
+        $options->setDefaults(
+            [
+                'auto_name' => true,
+                'auto_rename' => true,
+                'auto_name_locale' => $this->registry->getDefaultLocale(),
+            ]
+        );
+
+        $options->setAllowedTypes('auto_name', 'bool');
+        $options->setAllowedTypes('auto_rename', 'bool');
+        $options->setAllowedTypes('auto_name_locale', 'string');
+    }
+
+    /**
+     * @param MoveEvent $event
+     */
+    public function handleMove(MoveEvent $event)
+    {
+        $this->handleMoveCopy($event);
+    }
+
+    /**
+     * @param CopyEvent $event
+     */
+    public function handleCopy(CopyEvent $event)
+    {
+        $this->handleMoveCopy($event);
+    }
+
+    /**
+     * @param PersistEvent $event
+     *
+     * @throws DocumentManagerException
+     */
+    public function handlePersist(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$event->getOption('auto_name') || !$document instanceof AutoNameBehavior || $event->hasNode()) {
+            return;
+        }
+
+        $parentNode = $event->getParentNode();
+        $name = $this->getName($document, $parentNode, $event->getOption('auto_rename'));
+        $node = $parentNode->addNode($name);
+        $event->setNode($node);
+    }
+
+    /**
+     * Renames node if necessary.
+     *
+     * @param PersistEvent $event
+     */
+    public function handleScheduleRename(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$event->getOption('auto_name')
+            || !$document instanceof AutoNameBehavior
+            || $event->getOption('auto_name_locale') !== $event->getLocale()
+            || !$event->hasNode()
+            || $event->getNode()->isNew()
+        ) {
+            return;
+        }
+
+        $node = $event->getNode();
+        $name = $this->getName($document, $event->getParentNode(), $event->getOption('auto_rename'), $node);
+
+        if ($name === $node->getName()) {
+            return;
+        }
+
+        $uuid = $event->getNode()->getIdentifier();
+        $this->scheduledRename[] = ['uuid' => $uuid, 'name' => $name, 'locale' => $event->getLocale()];
+    }
+
+    public function handleRename()
+    {
+        foreach ($this->scheduledRename as $item) {
+            $defaultNode = $this->session->getNodeByIdentifier($item['uuid']);
+            $liveNode = $this->liveSession->getNodeByIdentifier($item['uuid']);
+            $this->rename($defaultNode, $item['name']);
+            $this->rename($liveNode, $item['name']);
+
+            $document = $this->registry->getDocumentForNode($defaultNode, $item['locale']);
+
+            $accessor = new DocumentAccessor($document);
+            if ($document instanceof NodeNameBehavior) {
+                $accessor->set('nodeName', $defaultNode->getName());
+            }
+
+            if ($document instanceof PathBehavior) {
+                $accessor->set('path', $defaultNode->getPath());
+            }
+        }
+
+        $this->scheduledRename = [];
+    }
+
+    /**
+     * Returns unique name for given document and nodes.
+     *
+     * @param AutoNameBehavior $document
+     * @param NodeInterface $parentNode
+     * @param NodeInterface|null $node
+     * @param bool $autoRename
+     *
+     * @return string
+     *
+     * @throws DocumentManagerException
+     */
+    private function getName(
+        AutoNameBehavior $document,
+        NodeInterface $parentNode,
+        $autoRename = true,
+        NodeInterface $node = null
+    ) {
+        $title = $document->getTitle();
+
+        if (!$title) {
+            throw new DocumentManagerException(
+                sprintf(
+                    'Document has no title (title is required for auto name behavior): %s)',
+                    DocumentHelper::getDebugTitle($document)
+                )
+            );
+        }
+
+        $name = $this->slugifier->slugify($title);
+
+        return $this->resolver->resolveName($parentNode, $name, $node, $autoRename);
+    }
+
+    /**
+     * TODO: This is a workaround for a bug in Jackalope which will be fixed in the next
+     *       release 1.2: https://github.com/jackalope/jackalope/pull/262.
+     */
+    private function rename(NodeInterface $node, $name)
+    {
+        $names = (array) $node->getParent()->getNodeNames();
+        $pos = array_search($node->getName(), $names);
+        $next = isset($names[$pos + 1]) ? $names[$pos + 1] : null;
+
+        $node->rename($name);
+
+        if ($next) {
+            $node->getParent()->orderBefore($name, $next);
+        }
+    }
+
+    /**
+     * Resolve the destination name on move and copy events.
+     *
+     * @param MoveEvent $event
+     */
+    private function handleMoveCopy(MoveEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof AutoNameBehavior) {
+            return;
+        }
+
+        $destId = $event->getDestId();
+        $node = $this->registry->getNodeForDocument($document);
+        $destNode = $this->nodeManager->find($destId);
+        $nodeName = $this->resolver->resolveName($destNode, $node->getName());
+
+        $event->setDestName($nodeName);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -27,7 +27,7 @@ use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\NameResolver;
 use Sulu\Component\DocumentManager\NodeManager;
-use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/BasePathSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/BasePathSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Path;
+
+use Sulu\Component\DocumentManager\Behavior\Path\BasePathBehavior;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NodeManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Sets the base path for the node.
+ */
+class BasePathSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var string
+     */
+    private $basePath;
+
+    /**
+     * @param NodeManager $nodeManager
+     * @param string $basePath
+     */
+    public function __construct(
+        NodeManager $nodeManager,
+        $basePath
+    ) {
+        $this->nodeManager = $nodeManager;
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => ['handlePersist', 500],
+        ];
+    }
+
+    public function handlePersist(PersistEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$document instanceof BasePathBehavior) {
+            return;
+        }
+
+        $parentNode = $this->nodeManager->createPath($this->basePath);
+        $event->setParentNode($parentNode);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/ExplicitSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/ExplicitSubscriber.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior\Path;
+
+use PHPCR\ItemExistsException;
+use PHPCR\NodeInterface;
+use PHPCR\Util\PathHelper;
+use Sulu\Component\DocumentManager\DocumentHelper;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\NodeManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+
+/**
+ * Populates or creates the node and/or parent node based on explicit
+ * options.
+ */
+class ExplicitSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @param NodeManager $nodeManager
+     */
+    public function __construct(NodeManager $nodeManager)
+    {
+        $this->nodeManager = $nodeManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => ['handlePersist', 485],
+            Events::CONFIGURE_OPTIONS => 'configureOptions',
+        ];
+    }
+
+    /**
+     * @param ConfigureOptionsEvent $event
+     */
+    public function configureOptions(ConfigureOptionsEvent $event)
+    {
+        $options = $event->getOptions();
+        $options->setDefaults([
+            'path' => null,
+            'node_name' => null,
+            'parent_path' => null,
+            'auto_create' => false,
+            'override' => false,
+        ]);
+
+        $options->setAllowedTypes('path', ['null', 'string']);
+        $options->setAllowedTypes('node_name', ['null', 'string']);
+        $options->setAllowedTypes('parent_path', ['null', 'string']);
+        $options->setAllowedTypes('auto_create', 'bool');
+        $options->setAllowedTypes('override', 'bool');
+    }
+
+    /**
+     * @param PersistEvent $event
+     *
+     * @throws DocumentManagerException
+     */
+    public function handlePersist(PersistEvent $event)
+    {
+        $options = $event->getOptions();
+        $this->validateOptions($options);
+        $document = $event->getDocument();
+        $parentPath = null;
+        $nodeName = null;
+
+        if ($options['path']) {
+            $parentPath = PathHelper::getParentPath($options['path']);
+            $nodeName = PathHelper::getNodeName($options['path']);
+        }
+
+        if ($options['parent_path']) {
+            $parentPath = $options['parent_path'];
+        }
+
+        if ($parentPath) {
+            $event->setParentNode(
+                $this->resolveParent($parentPath, $options)
+            );
+        }
+
+        if ($options['node_name']) {
+            if (!$event->hasParentNode()) {
+                throw new DocumentManagerException(sprintf(
+                    'The "node_name" option can only be used either with the "parent_path" option ' .
+                    'or when a parent node has been established by a previous subscriber. ' .
+                    'When persisting document: %s',
+                    DocumentHelper::getDebugTitle($document)
+                ));
+            }
+
+            $nodeName = $options['node_name'];
+        }
+
+        if (!$nodeName) {
+            return;
+        }
+
+        if ($event->hasNode()) {
+            $this->renameNode($event->getNode(), $nodeName);
+
+            return;
+        }
+
+        if (!$event->getParentNode()->hasNode($nodeName)) {
+            $node = $event->getParentNode()->addNode($nodeName);
+        } elseif ($options['override']) {
+            $node = $event->getParentNode()->getNode($nodeName);
+        } else {
+            throw new ItemExistsException(
+                sprintf(
+                    'The node \'%s\' already has a child named \'%s\'.',
+                    $event->getParentNode()->getPath(),
+                    $nodeName
+                )
+            );
+        }
+
+        $event->setNode($node);
+    }
+
+    private function renameNode(NodeInterface $node, $nodeName)
+    {
+        if ($node->getName() == $nodeName) {
+            return;
+        }
+
+        $node->rename($nodeName);
+    }
+
+    private function resolveParent($parentPath, array $options)
+    {
+        $autoCreate = $options['auto_create'];
+
+        if ($autoCreate) {
+            return $this->nodeManager->createPath($parentPath);
+        }
+
+        return $this->nodeManager->find($parentPath);
+    }
+
+    private function validateOptions(array $options)
+    {
+        if ($options['path'] && $options['node_name']) {
+            throw new InvalidOptionsException(
+                'Options "path" and "name" are mutually exclusive'
+            );
+        }
+
+        if ($options['path'] && $options['parent_path']) {
+            throw new InvalidOptionsException(
+                'Options "path" and "parent_path" are mutually exclusive'
+            );
+        }
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/VersionSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/VersionSubscriber.php
@@ -1,0 +1,338 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Behavior;
+
+use Jackalope\Version\VersionManager;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use PHPCR\Version\OnParentVersionAction;
+use PHPCR\Version\VersionException;
+use Sulu\Component\DocumentManager\Behavior\VersionBehavior;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
+use Sulu\Component\DocumentManager\Event\RestoreEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\VersionNotFoundException;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\Version;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This subscriber is responsible for creating versions of a document.
+ */
+class VersionSubscriber implements EventSubscriberInterface
+{
+    const VERSION_PROPERTY = 'sulu:versions';
+
+    /**
+     * @var SessionInterface
+     */
+    private $defaultSession;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var VersionManager
+     */
+    private $versionManager;
+
+    /**
+     * @var string[]
+     */
+    private $checkoutUuids = [];
+
+    /**
+     * @var string[]
+     */
+    private $checkpointUuids = [];
+
+    public function __construct(SessionInterface $defaultSession, PropertyEncoder $propertyEncoder)
+    {
+        $this->defaultSession = $defaultSession;
+        $this->propertyEncoder = $propertyEncoder;
+        $this->versionManager = $defaultSession->getWorkspace()->getVersionManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => [
+                ['setVersionMixin', 468],
+                ['rememberCheckoutUuids', -512],
+            ],
+            Events::PUBLISH => [
+                ['setVersionMixin', 468],
+                ['rememberCreateVersion'],
+            ],
+            Events::HYDRATE => 'setVersionsOnDocument',
+            Events::FLUSH => 'applyVersionOperations',
+            Events::RESTORE => 'restoreProperties',
+        ];
+    }
+
+    /**
+     * Sets the versionable mixin on the node if it is a versionable document.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    public function setVersionMixin(AbstractMappingEvent $event)
+    {
+        if (!$this->support($event->getDocument())) {
+            return;
+        }
+
+        $event->getNode()->addMixin('mix:versionable');
+    }
+
+    /**
+     * Sets the version information set on the node to the document.
+     *
+     * @param HydrateEvent $event
+     */
+    public function setVersionsOnDocument(HydrateEvent $event)
+    {
+        $document = $event->getDocument();
+
+        if (!$this->support($document)) {
+            return;
+        }
+
+        $node = $event->getNode();
+
+        $versions = [];
+        $versionProperty = $node->getPropertyValueWithDefault(static::VERSION_PROPERTY, []);
+        foreach ($versionProperty as $version) {
+            $versionInformation = json_decode($version);
+            $versions[] = new Version(
+                $versionInformation->version,
+                $versionInformation->locale,
+                $versionInformation->author,
+                new \DateTime($versionInformation->authored)
+            );
+        }
+
+        $document->setVersions($versions);
+    }
+
+    /**
+     * Remember which uuids need to be checked out after everything has been saved.
+     *
+     * @param PersistEvent $event
+     */
+    public function rememberCheckoutUuids(PersistEvent $event)
+    {
+        if (!$this->support($event->getDocument())) {
+            return;
+        }
+
+        $this->checkoutUuids[] = $event->getNode()->getIdentifier();
+    }
+
+    /**
+     * Remember for which uuids a new version has to be created.
+     *
+     * @param PublishEvent $event
+     */
+    public function rememberCreateVersion(PublishEvent $event)
+    {
+        $document = $event->getDocument();
+        if (!$this->support($document)) {
+            return;
+        }
+
+        $this->checkpointUuids[] = [
+            'uuid' => $event->getNode()->getIdentifier(),
+            'locale' => $document->getLocale(),
+            'author' => $event->getOption('user'),
+        ];
+    }
+
+    /**
+     * Apply all the operations which have been remembered after the flush.
+     */
+    public function applyVersionOperations()
+    {
+        foreach ($this->checkoutUuids as $uuid) {
+            $node = $this->defaultSession->getNodeByIdentifier($uuid);
+            $path = $node->getPath();
+
+            if (!$this->versionManager->isCheckedOut($path)) {
+                $this->versionManager->checkout($path);
+            }
+        }
+
+        $this->checkoutUuids = [];
+
+        /** @var NodeInterface[] $nodes */
+        $nodes = [];
+        $nodeVersions = [];
+        foreach ($this->checkpointUuids as $versionInformation) {
+            $node = $this->defaultSession->getNodeByIdentifier($versionInformation['uuid']);
+            $path = $node->getPath();
+
+            $version = $this->versionManager->checkpoint($path);
+
+            if (!array_key_exists($path, $nodes)) {
+                $nodes[$path] = $this->defaultSession->getNode($path);
+            }
+            $versions = $nodes[$path]->getPropertyValueWithDefault(static::VERSION_PROPERTY, []);
+
+            if (!array_key_exists($path, $nodeVersions)) {
+                $nodeVersions[$path] = $versions;
+            }
+            $nodeVersions[$path][] = json_encode(
+                [
+                    'locale' => $versionInformation['locale'],
+                    'version' => $version->getName(),
+                    'author' => $versionInformation['author'],
+                    'authored' => date('c'),
+                ]
+            );
+        }
+
+        foreach ($nodes as $uuid => $node) {
+            $node->setProperty(static::VERSION_PROPERTY, $nodeVersions[$uuid]);
+        }
+
+        $this->defaultSession->save();
+        $this->checkpointUuids = [];
+    }
+
+    /**
+     * Restore the properties of the old version.
+     *
+     * @param RestoreEvent $event
+     *
+     * @throws VersionNotFoundException
+     */
+    public function restoreProperties(RestoreEvent $event)
+    {
+        if (!$this->support($event->getDocument())) {
+            $event->stopPropagation();
+
+            return;
+        }
+
+        $contentPropertyPrefix = $this->propertyEncoder->localizedContentName('', $event->getLocale());
+        $systemPropertyPrefix = $this->propertyEncoder->localizedSystemName('', $event->getLocale());
+
+        $node = $event->getNode();
+
+        try {
+            $version = $this->versionManager->getVersionHistory($node->getPath())->getVersion($event->getVersion());
+
+            $frozenNode = $version->getFrozenNode();
+
+            $this->restoreNode($node, $frozenNode, $contentPropertyPrefix, $systemPropertyPrefix);
+        } catch (VersionException $exception) {
+            throw new VersionNotFoundException($event->getDocument(), $event->getVersion());
+        }
+    }
+
+    /**
+     * Restore given node with properties given from frozen-node.
+     * Will be called recursive.
+     *
+     * @param NodeInterface $node
+     * @param NodeInterface $frozenNode
+     * @param string $contentPropertyPrefix
+     * @param string $systemPropertyPrefix
+     */
+    private function restoreNode(
+        NodeInterface $node,
+        NodeInterface $frozenNode,
+        $contentPropertyPrefix,
+        $systemPropertyPrefix
+    ) {
+        // remove the properties for the given language, so that values being added since the last version are removed
+        foreach ($node->getProperties() as $property) {
+            if ($this->isRestoreProperty($property->getName(), $contentPropertyPrefix, $systemPropertyPrefix)) {
+                $property->remove();
+            }
+        }
+
+        // set all the properties from the saved version to the node
+        foreach ($frozenNode->getPropertiesValues() as $name => $value) {
+            if ($this->isRestoreProperty($name, $contentPropertyPrefix, $systemPropertyPrefix)) {
+                $node->setProperty($name, $value);
+            }
+        }
+
+        /** @var NodeInterface $childNode */
+        foreach ($frozenNode->getNodes() as $childNode) {
+            // create new node if it not exists
+            if (!$node->hasNode($childNode->getName())) {
+                $newNode = $node->addNode($childNode->getName());
+                $newNode->setMixins($childNode->getPropertyValueWithDefault('jcr:frozenMixinTypes', []));
+            }
+
+            $this->restoreNode(
+                $node->getNode($childNode->getName()),
+                $childNode,
+                $contentPropertyPrefix,
+                $systemPropertyPrefix
+            );
+        }
+
+        // remove child-nodes which do not exists in frozen-node
+        foreach ($node->getNodes() as $childNode) {
+            if (OnParentVersionAction::COPY !== $childNode->getDefinition()->getOnParentVersion()
+                || $frozenNode->hasNode($childNode->getName())
+            ) {
+                continue;
+            }
+
+            $childNode->remove();
+        }
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $contentPrefix
+     * @param string $systemPrefix
+     *
+     * @return bool
+     */
+    private function isRestoreProperty($propertyName, $contentPrefix, $systemPrefix)
+    {
+        // return all localized and non-translatable properties
+        // non-translatable properties can be recognized by their missing namespace, therfore the check for the colon
+        if (0 === strpos($propertyName, $contentPrefix)
+            || 0 === strpos($propertyName, $systemPrefix)
+            || false === strpos($propertyName, ':')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if the given document supports versioning.
+     *
+     * @param $document
+     *
+     * @return bool
+     */
+    private function support($document)
+    {
+        return $document instanceof VersionBehavior;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/InstantiatorSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/InstantiatorSubscriber.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Core;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Event\CreateEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Responsible for instantiating documents from PHPCR nodes and
+ * setting the document in the event so that other listeners can
+ * take further actions (such as hydrating it for example).
+ *
+ * NOTE: This should always be the first thing to be called
+ */
+class InstantiatorSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @param MetadataFactoryInterface $metadataFactory
+     */
+    public function __construct(
+        MetadataFactoryInterface $metadataFactory
+    ) {
+        $this->metadataFactory = $metadataFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => ['handleHydrate', 500],
+            Events::CREATE => ['handleCreate', 500],
+        ];
+    }
+
+    /**
+     * @param HydrateEvent $event
+     */
+    public function handleHydrate(HydrateEvent $event)
+    {
+        // don't need to instantiate the document if it is already existing.
+        if ($event->hasDocument()) {
+            return;
+        }
+
+        $node = $event->getNode();
+
+        $document = $this->getDocumentFromNode($node);
+        $event->setDocument($document);
+    }
+
+    /**
+     * @param mixed $event
+     */
+    public function handleCreate(CreateEvent $event)
+    {
+        $metadata = $this->metadataFactory->getMetadataForAlias($event->getAlias());
+        $document = $this->instantiateFromMetadata($metadata);
+        $event->setDocument($document);
+    }
+
+    /**
+     * Instantiate a new document. The class is determined from
+     * the mixins present in the PHPCR node for legacy reasons.
+     *
+     * @param NodeInterface $node
+     *
+     * @return object
+     */
+    private function getDocumentFromNode(NodeInterface $node)
+    {
+        $metadata = $this->metadataFactory->getMetadataForPhpcrNode($node);
+
+        return $this->instantiateFromMetadata($metadata);
+    }
+
+    /**
+     * @param Metadata $metadata
+     *
+     * @return object
+     */
+    private function instantiateFromMetadata(Metadata $metadata)
+    {
+        $class = $metadata->getClass();
+
+        if (!class_exists($class)) {
+            throw new \RuntimeException(sprintf(
+                'Document class "%s" does not exist', $class
+            ));
+        }
+
+        $document = new $class();
+
+        return $document;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/MappingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/MappingSubscriber.php
@@ -1,0 +1,372 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Core;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\InvalidLocaleException;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This subscriber uses the field map in the metadata to map fields from
+ * the PHPCR nodes to the document and vice-versa.
+ */
+class MappingSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @param MetadataFactoryInterface $factory
+     * @param PropertyEncoder $encoder
+     * @param ProxyFactory $proxyFactory
+     * @param DocumentRegistry $documentRegistry
+     */
+    public function __construct(
+        MetadataFactoryInterface $factory,
+        PropertyEncoder $encoder,
+        ProxyFactory $proxyFactory,
+        DocumentRegistry $documentRegistry
+    ) {
+        $this->factory = $factory;
+        $this->encoder = $encoder;
+        $this->proxyFactory = $proxyFactory;
+        $this->documentRegistry = $documentRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => ['handleHydrate', -100],
+            Events::PERSIST => ['handleMapping', -100],
+            Events::PUBLISH => ['handleMapping', -128],
+        ];
+    }
+
+    /**
+     * @param AbstractMappingEvent $event
+     */
+    public function handleMapping(AbstractMappingEvent $event)
+    {
+        $metadata = $this->factory->getMetadataForClass(get_class($event->getDocument()));
+        $locale = $event->getLocale();
+        $node = $event->getNode();
+        $accessor = $event->getAccessor();
+
+        foreach ($metadata->getFieldMappings() as $fieldName => $fieldMapping) {
+            if (false === $fieldMapping['mapped']) {
+                continue;
+            }
+
+            switch ($fieldMapping['type']) {
+                case 'reference':
+                    $this->persistReference($node, $accessor, $fieldName, $locale, $fieldMapping);
+
+                    break;
+                case 'json_array':
+                    $this->persistJsonArray($node, $accessor, $fieldName, $locale, $fieldMapping);
+
+                    break;
+                default:
+                    $this->persistGeneric($node, $accessor, $fieldName, $locale, $fieldMapping);
+            }
+        }
+    }
+
+    /**
+     * Persist a reference field type.
+     *
+     * @param NodeInterface $node
+     * @param DocumentAccessor $accessor
+     * @param mixed $fieldName
+     * @param mixed $locale
+     * @param mixed $fieldMapping
+     */
+    private function persistReference(
+        NodeInterface $node,
+        DocumentAccessor $accessor,
+        $fieldName,
+        $locale,
+        $fieldMapping
+    ) {
+        $referenceDocument = $accessor->get($fieldName);
+
+        if (!$referenceDocument) {
+            return;
+        }
+
+        if ($fieldMapping['multiple']) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Mapping references as multiple not currently supported (when mapping "%s")',
+                    $fieldName
+                )
+            );
+        }
+
+        try {
+            $referenceNode = $this->documentRegistry->getNodeForDocument($referenceDocument);
+            $phpcrName = $this->encoder->encode($fieldMapping['encoding'], $fieldMapping['property'], $locale);
+            $node->setProperty($phpcrName, $referenceNode);
+        } catch (InvalidLocaleException $ex) {
+            // arguments invalid, no valid propertyname could be generated (e.g. no locale given for localized encoding)
+            return;
+        }
+    }
+
+    /**
+     * Persist "scalar" field types.
+     *
+     * @param NodeInterface $node
+     * @param DocumentAccessor $accessor
+     * @param mixed $fieldName
+     * @param mixed $locale
+     * @param array $fieldMapping
+     */
+    private function persistGeneric(
+        NodeInterface $node,
+        DocumentAccessor $accessor,
+        $fieldName,
+        $locale,
+        array $fieldMapping
+    ) {
+        try {
+            $phpcrName = $this->encoder->encode($fieldMapping['encoding'], $fieldMapping['property'], $locale);
+            $value = $accessor->get($fieldName);
+            $this->validateFieldValue($value, $fieldName, $fieldMapping);
+            $node->setProperty($phpcrName, $value);
+        } catch (InvalidLocaleException $ex) {
+            // arguments invalid, no valid propertyname could be generated (e.g. no locale given for localized encoding)
+            return;
+        }
+    }
+
+    /**
+     * Persist "json_array" field types.
+     *
+     * @param NodeInterface $node
+     * @param DocumentAccessor $accessor
+     * @param mixed $fieldName
+     * @param mixed $locale
+     * @param array $fieldMapping
+     */
+    private function persistJsonArray(
+        NodeInterface $node,
+        DocumentAccessor $accessor,
+        $fieldName,
+        $locale,
+        array $fieldMapping
+    ) {
+        try {
+            $phpcrName = $this->encoder->encode($fieldMapping['encoding'], $fieldMapping['property'], $locale);
+            $value = $accessor->get($fieldName);
+            $this->validateFieldValue($value, $fieldName, $fieldMapping);
+            $node->setProperty($phpcrName, json_encode($value));
+        } catch (InvalidLocaleException $ex) {
+            // arguments invalid, no valid propertyname could be generated (e.g. no locale given for localized encoding)
+            return;
+        }
+    }
+
+    /**
+     * @param AbstractMappingEvent $event
+     */
+    public function handleHydrate(AbstractMappingEvent $event)
+    {
+        $class = get_class($event->getDocument());
+
+        // TODO: Return false here in case this is for instance an UnknownDocument.
+        //       But we should probably map the UnknownDocument and let an Exception be
+        //       thrown in other cases.
+        if (false === $this->factory->hasMetadataForClass($class)) {
+            return;
+        }
+
+        $metadata = $this->factory->getMetadataForClass($class);
+        $locale = $event->getLocale();
+        $node = $event->getNode();
+        $accessor = $event->getAccessor();
+        $document = $event->getDocument();
+
+        foreach ($metadata->getFieldMappings() as $fieldName => $fieldMapping) {
+            if (false === $fieldMapping['mapped']) {
+                continue;
+            }
+
+            switch ($fieldMapping['type']) {
+                case 'reference':
+                    $this->hydrateReferenceField(
+                        $node,
+                        $document,
+                        $accessor,
+                        $fieldName,
+                        $locale,
+                        $fieldMapping,
+                        $event->getOptions()
+                    );
+
+                    break;
+                case 'json_array':
+                    $this->hydrateJsonArrayField($node, $accessor, $fieldName, $locale, $fieldMapping);
+
+                    break;
+                default:
+                    $this->hydrateGenericField($node, $accessor, $fieldName, $locale, $fieldMapping);
+            }
+        }
+    }
+
+    /**
+     * Hydrate reference field types.
+     *
+     * @param NodeInterface $node
+     * @param mixed $document
+     * @param DocumentAccessor $accessor
+     * @param mixed $fieldName
+     * @param mixed $locale
+     * @param array $fieldMapping
+     * @param array $options
+     */
+    private function hydrateReferenceField(
+        NodeInterface $node,
+        $document,
+        DocumentAccessor $accessor,
+        $fieldName,
+        $locale,
+        array $fieldMapping,
+        array $options
+    ) {
+        try {
+            $phpcrName = $this->encoder->encode($fieldMapping['encoding'], $fieldMapping['property'], $locale);
+            $referencedNode = $node->getPropertyValueWithDefault(
+                $phpcrName,
+                $this->getDefaultValue($fieldMapping)
+            );
+
+            if ($referencedNode) {
+                $accessor->set(
+                    $fieldName,
+                    $this->proxyFactory->createProxyForNode($document, $referencedNode, $options)
+                );
+            }
+        } catch (InvalidLocaleException $ex) {
+            // arguments invalid, no valid propertyname could be generated (e.g. no locale given for localized encoding)
+            return;
+        }
+    }
+
+    /**
+     * Hydrate "scalar" field types.
+     *
+     * @param NodeInterface $node
+     * @param DocumentAccessor $accessor
+     * @param mixed $fieldName
+     * @param mixed $locale
+     * @param array $fieldMapping
+     */
+    private function hydrateGenericField(
+        NodeInterface $node,
+        DocumentAccessor $accessor,
+        $fieldName,
+        $locale,
+        array $fieldMapping
+    ) {
+        try {
+            $phpcrName = $this->encoder->encode($fieldMapping['encoding'], $fieldMapping['property'], $locale);
+            $value = $node->getPropertyValueWithDefault(
+                $phpcrName,
+                $this->getDefaultValue($fieldMapping)
+            );
+            $accessor->set($fieldName, $value);
+        } catch (InvalidLocaleException $ex) {
+            // arguments invalid, no valid propertyname could be generated (e.g. no locale given for localized encoding)
+            return;
+        }
+    }
+
+    /**
+     * Hydrate "json_array" field types.
+     *
+     * @param NodeInterface $node
+     * @param DocumentAccessor $accessor
+     * @param mixed $fieldName
+     * @param mixed $locale
+     * @param array $fieldMapping
+     */
+    private function hydrateJsonArrayField(
+        NodeInterface $node,
+        DocumentAccessor $accessor,
+        $fieldName,
+        $locale,
+        array $fieldMapping
+    ) {
+        try {
+            $phpcrName = $this->encoder->encode($fieldMapping['encoding'], $fieldMapping['property'], $locale);
+            $value = $node->getPropertyValueWithDefault(
+                $phpcrName,
+                $this->getDefaultValue($fieldMapping)
+            );
+            $accessor->set($fieldName, json_decode($value, true));
+        } catch (InvalidLocaleException $ex) {
+            // arguments invalid, no valid propertyname could be generated (e.g. no locale given for localized encoding)
+            return;
+        }
+    }
+
+    private function getDefaultValue(array $fieldMapping)
+    {
+        if ($fieldMapping['default']) {
+            return $fieldMapping['default'];
+        }
+
+        return $fieldMapping['multiple'] ? [] : null;
+    }
+
+    private function validateFieldValue($value, $fieldName, $fieldMapping)
+    {
+        if ($fieldMapping['multiple'] && !is_array($value)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Field "%s" is mapped as multiple, and therefore must be an array, got "%s"',
+                    $fieldName,
+                    is_object($value) ? get_class($value) : gettype($value)
+                )
+            );
+        }
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/RegistratorSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/RegistratorSubscriber.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Core;
+
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Event\ClearEvent;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Responsible for registering and deregistering documents and PHPCR nodes
+ * with the Document Registry.
+ */
+class RegistratorSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @param DocumentRegistry $documentRegistry
+     */
+    public function __construct(
+        DocumentRegistry $documentRegistry
+    ) {
+        $this->documentRegistry = $documentRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::HYDRATE => [
+                ['handleDefaultLocale', 520],
+                ['handleDocumentFromRegistry', 510],
+                ['handleStopPropagationAndResetLocale', 509],
+                ['handleHydrate', 490],
+                ['handleEndHydrate', -500],
+            ],
+            Events::PERSIST => [
+                ['handlePersist', 450],
+                ['handleNodeFromRegistry', 510],
+                ['handleEndPersist', -500],
+            ],
+            Events::REMOVE => ['handleRemove', 490],
+            Events::CLEAR => ['handleClear', 500],
+            Events::REORDER => ['handleNodeFromRegistry', 510],
+            Events::CONFIGURE_OPTIONS => 'configureOptions',
+            Events::REMOVE_DRAFT => ['handleNodeFromRegistry', 512],
+            Events::RESTORE => ['handleNodeFromRegistry', 512],
+        ];
+    }
+
+    /**
+     * @param ConfigureOptionsEvent $event
+     */
+    public function configureOptions(ConfigureOptionsEvent $event)
+    {
+        $options = $event->getOptions();
+        $options->setDefaults([
+            'rehydrate' => true,
+        ]);
+    }
+
+    /**
+     * Set the default locale for the hydration request.
+     *
+     * @param HydrateEvent $event
+     */
+    public function handleDefaultLocale(HydrateEvent $event)
+    {
+        // set the default locale
+        if (null === $event->getLocale()) {
+            $event->setLocale($this->documentRegistry->getDefaultLocale());
+        }
+    }
+
+    /**
+     * If there is already a document for the node registered, use that.
+     *
+     * @param HydrateEvent $event
+     */
+    public function handleDocumentFromRegistry(HydrateEvent $event)
+    {
+        if ($event->hasDocument()) {
+            return;
+        }
+
+        $node = $event->getNode();
+        if (!$this->documentRegistry->hasNode($node, $event->getLocale())) {
+            return;
+        }
+
+        $document = $this->documentRegistry->getDocumentForNode($node, $event->getLocale());
+
+        $event->setDocument($document);
+
+        $options = $event->getOptions();
+
+        // if reydration is not required (f.e. we just want to retrieve the
+        // current state of the document, no matter it's current state) stop
+        // further event propagation - we have the document now.
+        if (isset($options['rehydrate']) && false === $options['rehydrate']) {
+            $event->stopPropagation();
+        }
+    }
+
+    /**
+     * Stop propagation if the document is already loaded in the requested locale.
+     *
+     * @param HydrateEvent $event
+     */
+    public function handleStopPropagationAndResetLocale(HydrateEvent $event)
+    {
+        if (!$event->hasDocument()) {
+            return;
+        }
+
+        $locale = $event->getLocale();
+        $document = $event->getDocument();
+        $options = $event->getOptions();
+        $originalLocale = $this->documentRegistry->getOriginalLocaleForDocument($document);
+
+        if (
+            (!isset($options['rehydrate']) || false === $options['rehydrate']) &&
+            (true === $this->documentRegistry->isHydrated($document) && $originalLocale === $locale)
+        ) {
+            $event->stopPropagation();
+        }
+    }
+
+    /**
+     * When the hydrate request has finished, mark the document has hydrated.
+     * This should be the last event listener called.
+     *
+     * @param HydrateEvent $event
+     */
+    public function handleEndHydrate(HydrateEvent $event)
+    {
+        $this->documentRegistry->markDocumentAsHydrated($event->getDocument());
+    }
+
+    /**
+     * After the persist event has ended, unmark the document from being hydrated so that
+     * it will be re-hydrated on the next request.
+     *
+     * TODO: There might be better ways to ensure that the document state is updated.
+     *
+     * @param PersistEvent $event
+     */
+    public function handleEndPersist(PersistEvent $event)
+    {
+        $this->documentRegistry->unmarkDocumentAsHydrated($event->getDocument());
+    }
+
+    /**
+     * If the node for the persisted document is in the registry.
+     *
+     * @param PersistEvent|ReorderEvent $event
+     */
+    public function handleNodeFromRegistry($event)
+    {
+        if ($event->hasNode()) {
+            return;
+        }
+
+        $document = $event->getDocument();
+
+        if (!$this->documentRegistry->hasDocument($document)) {
+            return;
+        }
+
+        $node = $this->documentRegistry->getNodeForDocument($document);
+        $event->setNode($node);
+    }
+
+    /**
+     * Register any document that has been created in the hydrate event.
+     *
+     * @param HydrateEvent $event
+     */
+    public function handleHydrate(HydrateEvent $event)
+    {
+        $this->handleRegister($event);
+    }
+
+    /**
+     * Register any document that has been created in the persist event.
+     *
+     * @param PersistEvent $event
+     */
+    public function handlePersist(PersistEvent $event)
+    {
+        $this->handleRegister($event);
+    }
+
+    /**
+     * Deregister removed documents.
+     *
+     * @param RemoveEvent $event
+     */
+    public function handleRemove(RemoveEvent $event)
+    {
+        $document = $event->getDocument();
+        $this->documentRegistry->deregisterDocument($document);
+    }
+
+    /**
+     * Clear the register on the "clear" event.
+     *
+     * @param ClearEvent $event
+     */
+    public function handleClear(ClearEvent $event)
+    {
+        $this->documentRegistry->clear();
+    }
+
+    /**
+     * Register the document.
+     *
+     * @param AbstractMappingEvent $event
+     */
+    private function handleRegister(AbstractMappingEvent $event)
+    {
+        $node = $event->getNode();
+        $locale = $event->getLocale();
+
+        if (!$this->documentRegistry->hasNode($node, $locale)) {
+            $this->documentRegistry->registerDocument($event->getDocument(), $node, $locale);
+        }
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/FindSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/FindSubscriber.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\FindEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This class is responsible for finding documents.
+ */
+class FindSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param MetadataFactoryInterface $metadataFactory
+     * @param NodeManager $nodeManager
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(
+        MetadataFactoryInterface $metadataFactory,
+        NodeManager $nodeManager,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->metadataFactory = $metadataFactory;
+        $this->nodeManager = $nodeManager;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::FIND => ['handleFind', 500],
+            Events::CONFIGURE_OPTIONS => 'configureOptions',
+        ];
+    }
+
+    /**
+     * @param ConfigureOptionsEvent $event
+     */
+    public function configureOptions(ConfigureOptionsEvent $event)
+    {
+        $options = $event->getOptions();
+        $options->setDefaults([
+            'type' => null,
+        ]);
+    }
+
+    /**
+     * @param FindEvent $event
+     *
+     * @throws DocumentManagerException
+     * @throws DocumentNotFoundException
+     */
+    public function handleFind(FindEvent $event)
+    {
+        $options = $event->getOptions();
+        $aliasOrClass = $options['type'];
+        $node = $this->nodeManager->find($event->getId());
+
+        $hydrateEvent = new HydrateEvent($node, $event->getLocale(), $options);
+        $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+        $document = $hydrateEvent->getDocument();
+
+        if ($aliasOrClass) {
+            $this->checkAliasOrClass($aliasOrClass, $document);
+        }
+
+        $event->setDocument($hydrateEvent->getDocument());
+    }
+
+    private function checkAliasOrClass($aliasOrClass, $document)
+    {
+        if ($this->metadataFactory->hasAlias($aliasOrClass)) {
+            $class = $this->metadataFactory->getMetadataForAlias($aliasOrClass)->getClass();
+        } elseif (!class_exists($aliasOrClass)) {
+            throw new DocumentManagerException(sprintf(
+                'Unknown class specified and no alias exists for "%s", known aliases: "%s"',
+                $aliasOrClass, implode('", "', $this->metadataFactory->getAliases())
+            ));
+        } else {
+            $class = $aliasOrClass;
+        }
+
+        if (get_class($document) !== $class) {
+            throw new DocumentNotFoundException(sprintf(
+                'Requested document of type "%s" but got document of type "%s"',
+                $aliasOrClass,
+                get_class($document)
+            ));
+        }
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/GeneralSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/GeneralSubscriber.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\ClearEvent;
+use Sulu\Component\DocumentManager\Event\CopyEvent;
+use Sulu\Component\DocumentManager\Event\FlushEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NodeHelperInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This class aggregates some basic repository operations.
+ *
+ * NOTE: If any of these methods need to become more complicated, and
+ *       the changes cannot be done by implementing ANOTHER subscriber, then
+ *       the individual operations should be broken out into individual subscribers.
+ */
+class GeneralSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var NodeHelperInterface
+     */
+    private $nodeHelper;
+
+    public function __construct(
+        DocumentRegistry $documentRegistry,
+        NodeManager $nodeManager,
+        NodeHelperInterface $nodeHelper
+    ) {
+        $this->documentRegistry = $documentRegistry;
+        $this->nodeManager = $nodeManager;
+        $this->nodeHelper = $nodeHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::MOVE => ['handleMove', 400],
+            Events::COPY => ['handleCopy', 400],
+            Events::CLEAR => ['handleClear', 500],
+            Events::FLUSH => ['handleFlush', 500],
+        ];
+    }
+
+    /**
+     * @param MoveEvent $event
+     */
+    public function handleMove(MoveEvent $event)
+    {
+        $document = $event->getDocument();
+        $node = $this->documentRegistry->getNodeForDocument($document);
+        $this->nodeHelper->move($node, $event->getDestId(), $event->getDestName());
+    }
+
+    /**
+     * @param CopyEvent $event
+     */
+    public function handleCopy(CopyEvent $event)
+    {
+        $document = $event->getDocument();
+        $node = $this->documentRegistry->getNodeForDocument($document);
+        $newPath = $this->nodeHelper->copy($node, $event->getDestId(), $event->getDestName());
+        $event->setCopiedNode($this->nodeManager->find($newPath));
+    }
+
+    /**
+     * @param ClearEvent $event
+     */
+    public function handleClear(ClearEvent $event)
+    {
+        $this->nodeManager->clear();
+    }
+
+    /**
+     * @param FlushEvent $event
+     */
+    public function handleFlush(FlushEvent $event)
+    {
+        $this->nodeManager->save();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/QuerySubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/QuerySubscriber.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use PHPCR\Query\QueryInterface;
+use PHPCR\Query\QueryManagerInterface;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\Event\QueryCreateBuilderEvent;
+use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
+use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Query\Query;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Handles creation of query and query builder objects.
+ */
+class QuerySubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param SessionInterface $session
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(SessionInterface $session, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->session = $session;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::QUERY_CREATE => ['handleCreate', 500],
+            Events::QUERY_CREATE_BUILDER => ['handleCreateBuilder', 500],
+            Events::QUERY_EXECUTE => ['handleQueryExecute', 500],
+        ];
+    }
+
+    /**
+     * Create a new Sulu Query object.
+     *
+     * @param QueryCreateEvent $event
+     */
+    public function handleCreate(QueryCreateEvent $event)
+    {
+        $innerQuery = $event->getInnerQuery();
+
+        if (is_string($innerQuery)) {
+            $phpcrQuery = $this->getQueryManager()->createQuery($innerQuery, QueryInterface::JCR_SQL2);
+        } elseif ($innerQuery instanceof QueryInterface) {
+            $phpcrQuery = $innerQuery;
+        } else {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected inner query to be either a string or a PHPCR query object, got: "%s"',
+                is_object($innerQuery) ? get_class($innerQuery) : gettype($innerQuery)
+            ));
+        }
+
+        $event->setQuery(
+            new Query(
+                $phpcrQuery,
+                $this->eventDispatcher,
+                $event->getLocale(),
+                $event->getOptions(),
+                $event->getPrimarySelector()
+            )
+        );
+    }
+
+    /**
+     * TODO: We should reuse the PHPCR-ODM query builder here, see:
+     *       https://github.com/doctrine/phpcr-odm/issues/627.
+     *
+     * @param QueryCreateBuilderEvent $event
+     *
+     * @throws \Exception
+     */
+    public function handleCreateBuilder(QueryCreateBuilderEvent $event)
+    {
+        throw new \Exception('Not implemented');
+    }
+
+    /**
+     * Handle query execution.
+     *
+     * @param QueryExecuteEvent $event
+     */
+    public function handleQueryExecute(QueryExecuteEvent $event)
+    {
+        $query = $event->getQuery();
+        $locale = $query->getLocale();
+        $phpcrResult = $query->getPhpcrQuery()->execute();
+
+        $event->setResult(
+            new QueryResultCollection($phpcrResult, $this->eventDispatcher, $locale, $event->getOptions())
+        );
+    }
+
+    /**
+     * @return QueryManagerInterface
+     */
+    private function getQueryManager()
+    {
+        return $this->session->getWorkspace()->getQueryManager();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RefreshSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RefreshSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class RefreshSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, DocumentRegistry $documentRegistry)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->documentRegistry = $documentRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::REFRESH => 'refreshDocument',
+            Events::REMOVE_DRAFT => ['refreshDocumentForDeleteDraft', -512],
+        ];
+    }
+
+    /**
+     * Refreshes the document when the DocumentManager method for it is called.
+     *
+     * @param RefreshEvent $event
+     */
+    public function refreshDocument(RefreshEvent $event)
+    {
+        $document = $event->getDocument();
+        $node = $this->documentRegistry->getNodeForDocument($document);
+        $locale = $this->documentRegistry->getLocaleForDocument($document);
+
+        // revert/reload the node to the persisted state
+        $node->revert();
+
+        $this->rehydrateDocument($document, $node, $locale);
+    }
+
+    /**
+     * Refreshes the document after a draft have been removed.
+     *
+     * @param RemoveDraftEvent $event
+     */
+    public function refreshDocumentForDeleteDraft(RemoveDraftEvent $event)
+    {
+        $this->rehydrateDocument($event->getDocument(), $event->getNode(), $event->getLocale());
+    }
+
+    /**
+     * Rehydrates the given document from the given node for the given locale.
+     *
+     * @param object $document
+     * @param NodeInterface $node
+     * @param string $locale
+     */
+    private function rehydrateDocument($document, NodeInterface $node, $locale)
+    {
+        $hydrateEvent = new HydrateEvent($node, $locale, ['rehydrate' => true]);
+        $hydrateEvent->setDocument($document);
+        $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RemoveSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RemoveSubscriber.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NodeManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Remove subscriber.
+ */
+class RemoveSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    public function __construct(
+        DocumentRegistry $documentRegistry,
+        NodeManager $nodeManager
+    ) {
+        $this->documentRegistry = $documentRegistry;
+        $this->nodeManager = $nodeManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::REMOVE => ['handleRemove', 500],
+        ];
+    }
+
+    /**
+     * Remove the given documents node from PHPCR session and optionally
+     * remove any references to the node.
+     *
+     * @param RemoveEvent $event
+     */
+    public function handleRemove(RemoveEvent $event)
+    {
+        $document = $event->getDocument();
+        $node = $this->documentRegistry->getNodeForDocument($document);
+
+        $node->remove();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/ReorderSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/ReorderSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Subscriber\Phpcr;
+
+use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\NodeHelperInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Handles the document reorder operation.
+ */
+class ReorderSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var NodeHelperInterface
+     */
+    private $nodeHelper;
+
+    public function __construct(NodeHelperInterface $nodeHelper)
+    {
+        $this->nodeHelper = $nodeHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::REORDER => ['handleReorder', 500],
+        ];
+    }
+
+    /**
+     * Handle the reorder operation.
+     *
+     * @param ReorderEvent $event
+     *
+     * @throws DocumentManagerException
+     */
+    public function handleReorder(ReorderEvent $event)
+    {
+        $this->nodeHelper->reorder($event->getNode(), $event->getDestId());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Bootstrap.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Bootstrap.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests;
+
+use Jackalope\RepositoryFactoryDoctrineDBAL;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use PHPCR\SessionInterface;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
+
+class Bootstrap
+{
+    public static function createContainer()
+    {
+        $logDir = __DIR__ . '/../data/logs';
+
+        if (!file_exists($logDir)) {
+            mkdir($logDir);
+        }
+
+        $container = new ContainerBuilder();
+        $container->set('doctrine_phpcr.session', self::createSession());
+        $logger = new Logger('test');
+        $logger->pushHandler(new StreamHandler($logDir . '/test.log'));
+
+        $dispatcher = new ContainerAwareEventDispatcher($container);
+        $container->set('sulu_document_manager.event_dispatcher', $dispatcher);
+
+        $config = [
+            'sulu_document_manager.default_locale' => 'en',
+            'sulu_document_manager.mapping' => [
+                'full' => [
+                    'alias' => 'full',
+                    'phpcr_type' => 'mix:test',
+                    'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\FullDocument',
+                    'mapping' => [
+                        'title' => [
+                            'encoding' => 'content_localized',
+                        ],
+                        'body' => [
+                            'encoding' => 'content_localized',
+                        ],
+                        'status' => [
+                            'encoding' => 'system',
+                            'property' => 'my_status',
+                        ],
+                        'reference' => [
+                            'encoding' => 'content',
+                            'type' => 'reference',
+                        ],
+                    ],
+                ],
+                'mapping_5' => [
+                    'alias' => 'mapping_5',
+                    'phpcr_type' => 'mix:mapping5',
+                    'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\Mapping5Document',
+                    'mapping' => [
+                        'one' => [],
+                        'two' => [],
+                        'three' => [],
+                        'four' => [],
+                        'five' => [],
+                    ],
+                ],
+                'mapping_10' => [
+                    'alias' => 'mapping_10',
+                    'phpcr_type' => 'mix:mapping10',
+                    'class' => 'Sulu\Component\DocumentManager\Tests\Functional\Model\Mapping10Document',
+                    'mapping' => [
+                        'one' => [],
+                        'two' => [],
+                        'three' => [],
+                        'four' => [],
+                        'five' => [],
+                        'six' => [],
+                        'seven' => [],
+                        'eight' => [],
+                        'nine' => [],
+                        'ten' => [],
+                    ],
+                ],
+            ],
+            'sulu_document_manager.namespace_mapping' => [
+                'system' => 'nsys',
+                'system_localized' => 'lsys',
+                'content' => 'ncon',
+                'content_localized' => 'lcon',
+            ],
+        ];
+
+        foreach ($config as $parameterName => $parameterValue) {
+            $container->setParameter($parameterName, $parameterValue);
+        }
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../symfony-di'));
+        $loader->load('core.xml');
+        $loader->load('subscribers.xml');
+
+        foreach (array_keys($container->findTaggedServiceIds('sulu_document_manager.event_subscriber')) as $subscriberId) {
+            $def = $container->get($subscriberId);
+            $dispatcher->addSubscriberService($subscriberId, get_class($def));
+        }
+
+        return $container;
+    }
+
+    /**
+     * Create a new PHPCR session.
+     *
+     * @return SessionInterface
+     */
+    public static function createSession()
+    {
+        $transportName = getenv('SULU_DM_TRANSPORT') ?: 'jackalope-doctrine-dbal';
+
+        switch ($transportName) {
+            case 'jackalope-doctrine-dbal':
+                return static::createJackalopeDoctrineDbal();
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Unknown transport "%s"', $transportName
+        ));
+    }
+
+    public static function createDbalConnection()
+    {
+        $driver = 'pdo_sqlite'; // pdo_pgsql | pdo_sqlite
+
+        $connection = \Doctrine\DBAL\DriverManager::getConnection([
+            'driver' => $driver,
+            'host' => 'localhost',
+            'user' => 'admin',
+            'password' => 'admin',
+            'path' => __DIR__ . '/../data/test.sqlite',
+        ]);
+
+        return $connection;
+    }
+
+    private static function createJackalopeDoctrineDbal()
+    {
+        $connection = self::createDbalConnection();
+
+        $factory = new RepositoryFactoryDoctrineDBAL();
+        $repository = $factory->getRepository(
+            ['jackalope.doctrine_dbal_connection' => $connection]
+        );
+
+        $credentials = new \PHPCR\SimpleCredentials(null, null);
+
+        $session = $repository->login($credentials, 'default');
+
+        $nodeTypeManager = $session->getWorkspace()->getNodeTypeManager();
+        if (!$nodeTypeManager->hasNodeType('mix:test')) {
+            $nodeTypeManager->registerNodeTypesCnd(<<<'EOT'
+[mix:test] > mix:referenceable mix
+[mix:mapping5] > mix:referenceable mix
+[mix:mapping10] > mix:referenceable mix
+EOT
+            , true);
+        }
+
+        $namespaceRegistry = $session->getWorkspace()->getNamespaceRegistry();
+        $namespaceRegistry->registerNamespace('lsys', 'http://example.com/lsys');
+        $namespaceRegistry->registerNamespace('nsys', 'http://example.com/nsys');
+        $namespaceRegistry->registerNamespace('lcon', 'http://example.com/lcon');
+        $namespaceRegistry->registerNamespace('ncon', 'http://example.com/ncon');
+
+        return $session;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/BaseTestCase.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/BaseTestCase.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Component\DocumentManager\tests\Functional;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Tests\Bootstrap;
 
-abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCase extends TestCase
 {
     const BASE_NAME = 'test';
 

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/BaseTestCase.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/BaseTestCase.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Functional;
+
+use Sulu\Component\DocumentManager\Tests\Bootstrap;
+
+abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+{
+    const BASE_NAME = 'test';
+
+    const BASE_PATH = '/test';
+
+    private $container;
+
+    protected function initPhpcr()
+    {
+        $session = $this->getSession();
+
+        if ($session->getRootNode()->hasNode(self::BASE_NAME)) {
+            $session->removeItem(self::BASE_PATH);
+            $session->save();
+        }
+    }
+
+    protected function getSession()
+    {
+        return $this->getContainer()->get('doctrine_phpcr.session');
+    }
+
+    protected function getContainer()
+    {
+        if ($this->container) {
+            return $this->container;
+        }
+
+        $this->container = Bootstrap::createContainer();
+
+        return $this->container;
+    }
+
+    protected function getDocumentManager()
+    {
+        return $this->getContainer()->get('sulu_document_manager.document_manager');
+    }
+
+    protected function generateDataSet(array $options)
+    {
+        $options = array_merge([
+            'locales' => ['en'],
+        ], $options);
+
+        $manager = $this->getDocumentManager();
+        $document = $manager->create('full');
+
+        foreach ($options['locales'] as $locale) {
+            $manager->persist($document, $locale, [
+                'path' => self::BASE_PATH,
+            ]);
+        }
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/DocumentManager/FindTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/DocumentManager/FindTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Functional\DocumentManager;
+
+use Sulu\Component\DocumentManager\Tests\Functional\BaseTestCase;
+
+class FindTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->initPhpcr();
+    }
+
+    /**
+     * Persist a document in a single locale.
+     */
+    public function testPersist()
+    {
+        $this->generateDataSet([
+            'locales' => ['en'],
+        ]);
+
+        $manager = $this->getDocumentManager();
+        $manager->flush();
+
+        $document = $manager->find(self::BASE_PATH);
+        $this->assertNotNull($document);
+    }
+
+    /**
+     * Persist a document in a many locales.
+     */
+    public function testPersistManyLocales()
+    {
+        $this->generateDataSet([
+            'locales' => ['en', 'de'],
+        ]);
+
+        $manager = $this->getDocumentManager();
+        $manager->flush();
+
+        $document = $manager->find(self::BASE_PATH);
+        $this->assertNotNull($document);
+    }
+
+    /**
+     * It can persist and find without any locales.
+     */
+    public function testPersistFindNoLocales()
+    {
+        $manager = $this->getDocumentManager();
+        $document = $manager->create('full');
+        $document->setTitle('Hello');
+        $document->setBody('This is Hello');
+        $document->setStatus('open');
+        $manager->persist($document, null, [
+            'path' => '/test/foo',
+            'auto_create' => true,
+        ]);
+        $manager->flush();
+
+        $manager->clear();
+        $persistedDocument = $manager->find($document->getUuid());
+        $this->assertNotSame($document, $persistedDocument);
+        $document = $persistedDocument;
+        $this->assertEquals('en', $document->getLocale());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/DocumentManager/MappingTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/DocumentManager/MappingTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Functional\DocumentManager;
+
+use Sulu\Component\DocumentManager\Tests\Functional\BaseTestCase;
+
+class MappingTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        $this->initPhpcr();
+    }
+
+    /**
+     * It should map mapped fields.
+     */
+    public function testMapping()
+    {
+        $document = $this->getDocumentManager()->create('full');
+        $document->setTitle('Hallo');
+        $document->setBody('body');
+        $document->setStatus('published');
+
+        $this->getDocumentManager()->persist($document, 'de', [
+            'path' => '/test/foo',
+            'auto_create' => true,
+        ]);
+        $this->getDocumentManager()->flush();
+
+        $node = $this->getSession()->getNode('/test/foo');
+
+        foreach ([
+            'lcon:de-title' => 'Hallo',
+            'lcon:de-body' => 'body',
+            'nsys:my_status' => 'published',
+        ] as $phpcrName => $expectedValue) {
+            $this->assertEquals($expectedValue, $node->getPropertyValue($phpcrName));
+        }
+    }
+
+    /**
+     * It should map reference fields.
+     */
+    public function testMappingReference()
+    {
+        $manager = $this->getDocumentManager();
+
+        $reference = $manager->create('full');
+        $manager->persist($reference, 'de', [
+            'path' => '/test/foo',
+            'auto_create' => true,
+        ]);
+        $manager->flush();
+
+        $document = $manager->create('full');
+        $document->setReference($reference);
+        $manager->persist($document, 'de', [
+            'path' => '/test/boo',
+            'auto_create' => true,
+        ]);
+        $manager->flush();
+        $manager->clear();
+
+        $document = $manager->find('/test/boo');
+        $this->assertNotNull($document->getReference());
+        $this->assertEquals(
+            $reference->getUuid(),
+            $document->getReference()->getUuid()
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/Model/FullDocument.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/Model/FullDocument.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Functional\Model;
+
+use Sulu\Component\DocumentManager\Behavior\Audit\TimestampBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ChildrenBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+
+/**
+ * This functional test document should implement as many behaviors as possible.
+ */
+class FullDocument implements
+    NodeNameBehavior,
+    TimestampBehavior,
+    ParentBehavior,
+    UuidBehavior,
+    ChildrenBehavior,
+    PathBehavior,
+    LocaleBehavior
+{
+    protected $nodeName;
+
+    protected $created;
+
+    protected $changed;
+
+    protected $creator;
+
+    protected $changer;
+
+    protected $parent;
+
+    protected $uuid;
+
+    protected $children;
+
+    protected $path;
+
+    protected $title;
+
+    protected $body;
+
+    protected $status;
+
+    protected $reference;
+
+    protected $locale;
+
+    protected $originalLocale;
+
+    public function __construct()
+    {
+        $this->children = new \ArrayIterator();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeName()
+    {
+        return $this->nodeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChanged()
+    {
+        return $this->changed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreator()
+    {
+        return $this->creator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChanger()
+    {
+        return $this->changer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChildren()
+    {
+        return $this->children;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    public function getReference()
+    {
+        return $this->reference;
+    }
+
+    public function setReference($reference)
+    {
+        $this->reference = $reference;
+    }
+
+    public function getOriginalLocale()
+    {
+        return $this->originalLocale;
+    }
+
+    public function setOriginalLocale($originalLocale)
+    {
+        $this->originalLocale = $originalLocale;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/Model/Mapping10Document.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/Model/Mapping10Document.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Functional\Model;
+
+class Mapping10Document extends Mapping5Document
+{
+    public $six;
+
+    public $seven;
+
+    public $eight;
+
+    public $nine;
+
+    public $ten;
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Functional/Model/Mapping5Document.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Functional/Model/Mapping5Document.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Functional\Model;
+
+class Mapping5Document
+{
+    public $one;
+
+    public $two;
+
+    public $three;
+
+    public $four;
+
+    public $five;
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ClassNameInflectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ClassNameInflectorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use Sulu\Component\DocumentManager\ClassNameInflector;
+
+class ClassNameInflectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInflector()
+    {
+        $this->assertEquals(
+            'Hello',
+            ClassNameInflector::getUserClassName('Hello')
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ClassNameInflectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ClassNameInflectorTest.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\ClassNameInflector;
 
-class ClassNameInflectorTest extends \PHPUnit_Framework_TestCase
+class ClassNameInflectorTest extends TestCase
 {
     public function testInflector()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ChildrenCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->childNode = $this->prophesize(NodeInterface::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->collection = new ChildrenCollection(
+            $this->parentNode->reveal(),
+            $this->dispatcher->reveal(),
+            'fr'
+        );
+    }
+
+    /**
+     * It should be iterable.
+     */
+    public function testIterable()
+    {
+        $children = new \ArrayIterator([
+            $this->childNode->reveal(),
+        ]);
+        $this->parentNode->getNodes()->willReturn($children);
+
+        $this->dispatcher->dispatch(Events::HYDRATE, Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'))->will(function ($args) {
+            $args[1]->setDocument(new \stdClass());
+        });
+
+        $results = [];
+
+        foreach ($this->collection as $document) {
+            $results[] = $document;
+        }
+
+        $this->assertCount(1, $results);
+        $this->assertContainsOnlyInstancesOf('stdClass', $results);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
@@ -12,12 +12,13 @@
 namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ChildrenCollectionTest extends \PHPUnit_Framework_TestCase
+class ChildrenCollectionTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
+
+use PHPCR\NodeInterface;
+use PHPCR\Query\QueryResultInterface;
+use PHPCR\Query\RowInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class QueryResultCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->queryResult = $this->prophesize(QueryResultInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->collection = new QueryResultCollection(
+            $this->queryResult->reveal(),
+            $this->dispatcher->reveal(),
+            'fr',
+            [],
+            's'
+        );
+
+        $this->row1 = $this->prophesize(RowInterface::class);
+        $this->row2 = $this->prophesize(RowInterface::class);
+        $this->node1 = $this->prophesize(NodeInterface::class);
+        $this->node2 = $this->prophesize(NodeInterface::class);
+    }
+
+    /**
+     * It should be iterable.
+     */
+    public function testIterable()
+    {
+        $results = new \ArrayIterator([
+            $this->row1->reveal(),
+            $this->row2->reveal(),
+        ]);
+
+        $this->row1->getNode('s')->willReturn($this->node1->reveal());
+        $this->row2->getNode('s')->willReturn($this->node2->reveal());
+
+        $this->queryResult->getRows()->willReturn($results);
+
+        $this->dispatcher->dispatch(Events::HYDRATE, Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'))->will(function ($args) {
+            $args[1]->setDocument(new \stdClass());
+        });
+
+        $results = [];
+
+        foreach ($this->collection as $document) {
+            $results[] = $document;
+        }
+
+        $this->assertCount(2, $results);
+        $this->assertContainsOnlyInstancesOf('stdClass', $results);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
@@ -14,12 +14,13 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
 use PHPCR\NodeInterface;
 use PHPCR\Query\QueryResultInterface;
 use PHPCR\Query\RowInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class QueryResultCollectionTest extends \PHPUnit_Framework_TestCase
+class QueryResultCollectionTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Collection\ReferrerCollection;
+use Sulu\Component\DocumentManager\Events;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ReferrerCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->reference = $this->prophesize(PropertyInterface::class);
+        $this->referrerNode = $this->prophesize(NodeInterface::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->collection = new ReferrerCollection(
+            $this->node->reveal(),
+            $this->dispatcher->reveal(),
+            'fr'
+        );
+    }
+
+    /**
+     * It should be iterable.
+     */
+    public function testIterable()
+    {
+        $references = new \ArrayIterator([
+            $this->reference->reveal(),
+        ]);
+        $this->node->getReferences()->willReturn($references);
+        $this->reference->getParent()->willReturn($this->referrerNode->reveal());
+        $this->referrerNode->getIdentifier()->willReturn('1234');
+
+        $this->dispatcher->dispatch(Events::HYDRATE, Argument::type('Sulu\Component\DocumentManager\Event\HydrateEvent'))->will(function ($args) {
+            $args[1]->setDocument(new \stdClass());
+        });
+
+        $results = [];
+
+        foreach ($this->collection as $document) {
+            $results[] = $document;
+        }
+
+        $this->assertCount(1, $results);
+        $this->assertContainsOnlyInstancesOf('stdClass', $results);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
@@ -13,12 +13,13 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Collection\ReferrerCollection;
 use Sulu\Component\DocumentManager\Events;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ReferrerCollectionTest extends \PHPUnit_Framework_TestCase
+class ReferrerCollectionTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Component\DocumentManager\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 
-class DocumentAccessorTest extends \PHPUnit_Framework_TestCase
+class DocumentAccessorTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentAccessorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit;
+
+use Sulu\Component\DocumentManager\DocumentAccessor;
+
+class DocumentAccessorTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->object = new TestAccessObject();
+        $this->accessor = new DocumentAccessor($this->object);
+    }
+
+    /**
+     * It should be able to set private properties.
+     */
+    public function testAccessObject()
+    {
+        $this->accessor->set('privateProperty', 'Hai');
+        $this->assertEquals('Hai', $this->object->getPrivateProperty());
+    }
+
+    /**
+     * It should throw an exception if the property does not exist.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     */
+    public function testAccessObjectNotExist()
+    {
+        $this->accessor->set('asdf', 'asd');
+    }
+}
+
+class TestAccessObject
+{
+    private $privateProperty;
+
+    public function getPrivateProperty()
+    {
+        return $this->privateProperty;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
+use Sulu\Component\DocumentManager\DocumentHelper;
+
+class DocumentHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->document = new \stdClass();
+        $this->titleDocument = $this->prophesize(TitleBehavior::class);
+    }
+
+    /**
+     * It should return a debug title for a document.
+     */
+    public function testDebugTitle()
+    {
+        $title = DocumentHelper::getDebugTitle($this->document);
+        $this->assertEquals(32, strlen($title));
+    }
+
+    /**
+     * It should show the title for a document which implements the TitleBehavior.
+     */
+    public function testDebugTitleWithTitle()
+    {
+        $this->titleDocument->getTitle()->willReturn('Hello');
+        $title = DocumentHelper::getDebugTitle($this->titleDocument->reveal());
+        $this->assertContains('Hello', $title);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
@@ -11,10 +11,11 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\DocumentHelper;
 
-class DocumentHelperTest extends \PHPUnit_Framework_TestCase
+class DocumentHelperTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentInspector;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+use Sulu\Component\DocumentManager\ProxyFactory;
+
+class DocumentInspectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->pathRegistry = $this->prophesize(PathSegmentRegistry::class);
+        $this->document = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->proxyFactory = $this->prophesize(ProxyFactory::class);
+        $this->documentInspector = new DocumentInspector(
+            $this->documentRegistry->reveal(),
+            $this->pathRegistry->reveal(),
+            $this->proxyFactory->reveal()
+        );
+    }
+
+    /**
+     * It should return the current locale for the given document.
+     */
+    public function testGetLocale()
+    {
+        $this->documentRegistry->getLocaleForDocument($this->document)->willReturn('de');
+
+        $result = $this->documentInspector->getLocale($this->document);
+        $this->assertEquals('de', $result);
+    }
+
+    /**
+     * It should return the document path.
+     */
+    public function testGetPath()
+    {
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->node->getPath()->willReturn('/path/to');
+
+        $path = $this->documentInspector->getPath($this->document);
+        $this->assertEquals('/path/to', $path);
+    }
+
+    /**
+     * It should return a PHPCR node.
+     */
+    public function testGetPhpcrNode()
+    {
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+
+        $result = $this->documentInspector->getNode($this->document);
+        $this->assertEquals($this->node->reveal(), $result);
+    }
+
+    /**
+     * It should return the depth of the document in the repository.
+     */
+    public function testGetDepth()
+    {
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->node->getDepth()->willReturn(6);
+        $result = $this->documentInspector->getDepth($this->document);
+        $this->assertEquals(6, $result);
+    }
+
+    /**
+     * It should return the name of the document.
+     */
+    public function testGetName()
+    {
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->node->getName()->willReturn('hello');
+        $result = $this->documentInspector->getName($this->document);
+        $this->assertEquals('hello', $result);
+    }
+
+    /**
+     * It should return a children.
+     */
+    public function testGetChildren()
+    {
+        $childrenCollection = new \stdClass();
+        $this->proxyFactory->createChildrenCollection($this->document, [])->willReturn($childrenCollection);
+        $this->assertEquals(
+            $childrenCollection,
+            $this->documentInspector->getChildren($this->document)
+        );
+    }
+
+    /**
+     * It should return true if it has children.
+     */
+    public function testHasChildren()
+    {
+        $this->node->hasNodes()->willReturn(true);
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->assertTrue(
+            $this->documentInspector->hasChildren($this->document)
+        );
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
@@ -12,12 +12,13 @@
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
 use Sulu\Component\DocumentManager\ProxyFactory;
 
-class DocumentInspectorTest extends \PHPUnit_Framework_TestCase
+class DocumentInspectorTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\Event\ClearEvent;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\CopyEvent;
+use Sulu\Component\DocumentManager\Event\CreateEvent;
+use Sulu\Component\DocumentManager\Event\FindEvent;
+use Sulu\Component\DocumentManager\Event\FlushEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
+use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
+use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\Event\RestoreEvent;
+use Sulu\Component\DocumentManager\Event\UnpublishEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Query\Query;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class DocumentManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var \stdClass
+     */
+    private $document;
+
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var QueryResultCollection
+     */
+    private $queryResultCollection;
+
+    public function setUp()
+    {
+        $this->eventDispatcher = new EventDispatcher();
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->documentManager = new DocumentManager(
+            $this->eventDispatcher,
+            $this->nodeManager->reveal()
+        );
+
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->document = new \stdClass();
+
+        $this->query = $this->prophesize(Query::class);
+        $this->queryResultCollection = $this->prophesize(QueryResultCollection::class);
+    }
+
+    /**
+     * It should issue a persist event for the passed document.
+     */
+    public function testPersist()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->persist(new \stdClass(), 'fr');
+        $this->assertTrue($subscriber->persist);
+    }
+
+    /**
+     * It should issue a remove event.
+     */
+    public function testRemove()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->remove(new \stdClass());
+        $this->assertTrue($subscriber->remove);
+    }
+
+    /**
+     * It should issue a move event.
+     */
+    public function testMove()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->move(new \stdClass(), '/path/to');
+        $this->assertTrue($subscriber->move);
+    }
+
+    /**
+     * It should issue a copy event.
+     */
+    public function testCopy()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->copy(new \stdClass(), '/path/to');
+        $this->assertTrue($subscriber->copy);
+    }
+
+    /**
+     * It should issue a create event.
+     */
+    public function testCreate()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->create('foo');
+        $this->assertTrue($subscriber->create);
+    }
+
+    public function testPublish()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->publish(new \stdClass(), 'de');
+        $this->assertTrue($subscriber->publish);
+    }
+
+    public function testUnpublish()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->unpublish(new \stdClass(), 'de');
+        $this->assertTrue($subscriber->unpublish);
+    }
+
+    public function testRemoveDraft()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->removeDraft(new \stdClass(), 'de');
+        $this->assertTrue($subscriber->removeDraft);
+    }
+
+    public function testRestore()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->restore(new \stdClass(), 'de', '123-456-789');
+        $this->assertTrue($subscriber->restore);
+    }
+
+    /**
+     * It should issue a refresh event.
+     */
+    public function testRefresh()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->refresh($this->document);
+        $this->assertTrue($subscriber->refresh);
+    }
+
+    /**
+     * It should issue a clear event.
+     */
+    public function testClear()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->clear();
+        $this->assertTrue($subscriber->clear);
+    }
+
+    /**
+     * It should issue a flush event.
+     */
+    public function testFlush()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->flush();
+        $this->assertTrue($subscriber->flush);
+    }
+
+    /**
+     * It should issue a find event.
+     */
+    public function testFind()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->find('foo', 'fr');
+        $this->assertTrue($subscriber->find);
+    }
+
+    /**
+     * It should throw an exception with invalid options.
+     *
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
+     */
+    public function testFindWithInvalidOptions()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->find('foo', 'bar', ['foo123' => 'bar']);
+    }
+
+    /**
+     * It should pass options.
+     */
+    public function testFindWithOptions()
+    {
+        $subscriber = $this->addSubscriber();
+        $this->documentManager->find('foo', 'bar', ['test.foo' => 'bar']);
+    }
+
+    /**
+     * It should issue a query create event.
+     */
+    public function testQueryCreate()
+    {
+        $subscriber = $this->addSubscriber();
+        $query = $this->documentManager->createQuery('SELECT foo FROM [foo:bar]', 'fr');
+        $this->assertTrue($subscriber->queryCreate);
+        $this->assertInstanceOf(Query::class, $query);
+    }
+
+    /**
+     * It should issue a query builder create event.
+     *
+     * NOT SUPPORTED
+     */
+    public function testQueryCreateBuilder()
+    {
+        $this->markTestSkipped('Not supported yet');
+    }
+
+    private function addSubscriber()
+    {
+        $subscriber = new TestDocumentManagerSubscriber($this->query->reveal(), $this->queryResultCollection->reveal());
+        $this->eventDispatcher->addSubscriber($subscriber);
+
+        return $subscriber;
+    }
+}
+
+class TestDocumentManagerSubscriber implements EventSubscriberInterface
+{
+    public $persist = false;
+
+    public $hydrate = false;
+
+    public $remove = false;
+
+    public $copy = false;
+
+    public $move = false;
+
+    public $create = false;
+
+    public $clear = false;
+
+    public $flush = false;
+
+    public $find = false;
+
+    public $queryCreate = false;
+
+    public $queryCreateBuilder = false;
+
+    public $queryExecute = false;
+
+    public $publish = false;
+
+    public $unpublish = false;
+
+    public $removeDraft = false;
+
+    public $restore = false;
+
+    public $refresh = false;
+
+    public $reorder = false;
+
+    private $query;
+
+    private $resultCollection;
+
+    public function __construct(Query $query, QueryResultCollection $resultCollection)
+    {
+        $this->query = $query;
+        $this->resultCollection = $resultCollection;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::PERSIST => 'handlePersist',
+            Events::REMOVE => 'handleRemove',
+            Events::MOVE => 'handleMove',
+            Events::COPY => 'handleCopy',
+            Events::CREATE => 'handleCreate',
+            Events::CLEAR => 'handleClear',
+            Events::FLUSH => 'handleFlush',
+            Events::FIND => 'handleFind',
+            Events::QUERY_CREATE => 'handleQueryCreate',
+            Events::QUERY_CREATE_BUILDER => 'handleQueryBuilderCreate',
+            Events::QUERY_EXECUTE => 'handleQueryExecute',
+            Events::REFRESH => 'handleRefresh',
+            Events::REORDER => 'handleReorder',
+            Events::CONFIGURE_OPTIONS => 'handleConfigureOptions',
+            Events::PUBLISH => 'handlePublish',
+            Events::UNPUBLISH => 'handleUnpublish',
+            Events::REMOVE_DRAFT => 'handleRemoveDraft',
+            Events::RESTORE => 'handleRestore',
+        ];
+    }
+
+    public function handleConfigureOptions(ConfigureOptionsEvent $event)
+    {
+        $options = $event->getOptions();
+        $options->setDefaults([
+            'test.foo' => 'bar',
+        ]);
+    }
+
+    public function handlePersist(PersistEvent $event)
+    {
+        $this->persist = true;
+    }
+
+    public function handleRemove(RemoveEvent $event)
+    {
+        $this->remove = true;
+    }
+
+    public function handleCopy(CopyEvent $event)
+    {
+        $this->copy = true;
+    }
+
+    public function handleMove(MoveEvent $event)
+    {
+        $this->move = true;
+    }
+
+    public function handleCreate(CreateEvent $event)
+    {
+        $this->create = true;
+        $event->setDocument(new \stdClass());
+    }
+
+    public function handleClear(ClearEvent $event)
+    {
+        $this->clear = true;
+    }
+
+    public function handleFlush(FlushEvent $event)
+    {
+        $this->flush = true;
+    }
+
+    public function handleFind(FindEvent $event)
+    {
+        $this->find = true;
+        $event->setDocument(new \stdClass());
+    }
+
+    public function handleQueryCreate(QueryCreateEvent $event)
+    {
+        $this->queryCreate = true;
+        $event->setQuery($this->query);
+    }
+
+    public function handleQueryExecute(QueryExecuteEvent $event)
+    {
+        $this->queryExecute = true;
+        $event->setResult($this->resultCollection);
+    }
+
+    public function handlePublish(PublishEvent $event)
+    {
+        $this->publish = true;
+    }
+
+    public function handleUnpublish(UnpublishEvent $event)
+    {
+        $this->unpublish = true;
+    }
+
+    public function handleRemoveDraft(RemoveDraftEvent $event)
+    {
+        $this->removeDraft = true;
+    }
+
+    public function handleRefresh(RefreshEvent $event)
+    {
+        $this->refresh = true;
+    }
+
+    public function handleReorder(ReorderEvent $event)
+    {
+        $this->reorder = true;
+    }
+
+    public function handleRestore(RestoreEvent $event)
+    {
+        $this->restore = true;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Event\ClearEvent;
@@ -37,7 +38,7 @@ use Sulu\Component\DocumentManager\Query\Query;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class DocumentManagerTest extends \PHPUnit_Framework_TestCase
+class DocumentManagerTest extends TestCase
 {
     /**
      * @var EventDispatcher
@@ -225,7 +226,7 @@ class DocumentManagerTest extends \PHPUnit_Framework_TestCase
     public function testFindWithOptions()
     {
         $subscriber = $this->addSubscriber();
-        $this->documentManager->find('foo', 'bar', ['test.foo' => 'bar']);
+        $this->assertNotNull($this->documentManager->find('foo', 'bar', ['test.foo' => 'bar']));
     }
 
     /**

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
@@ -12,9 +12,10 @@
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 
-class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
+class DocumentRegistryTest extends TestCase
 {
     /**
      * @var DocumentRegistry

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+
+class DocumentRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $registry;
+
+    public function setUp()
+    {
+        $this->registry = new DocumentRegistry('de');
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->node->getIdentifier()->willReturn('1234');
+        $this->document = new \stdClass();
+    }
+
+    /**
+     * It should register a document and its associated PHPCR node.
+     */
+    public function testRegisterDocument()
+    {
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
+        $this->assertTrue($this->registry->hasDocument($this->document));
+        $this->assertTrue($this->registry->hasNode($this->node->reveal(), 'fr'));
+    }
+
+    /**
+     * It should deregister a given document.
+     *
+     * @depends testRegisterDocument
+     */
+    public function testDeregisterDocument()
+    {
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
+        $this->registry->deregisterDocument($this->document);
+        $this->assertFalse($this->registry->hasDocument($this->document));
+        $this->assertFalse($this->registry->hasNode($this->node->reveal(), 'fr'));
+    }
+
+    /**
+     * It should throw an exception when an unregistered document is deregistered.
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testDeregisterDocumentUnknown()
+    {
+        $this->registry->deregisterDocument($this->document);
+    }
+
+    /**
+     * It should return the PHPCR node for a registered document.
+     *
+     * @depends testRegisterDocument
+     */
+    public function testGetNodeForDocument()
+    {
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
+        $this->assertSame(
+            $this->node->reveal(),
+            $this->registry->getNodeForDocument($this->document)
+        );
+    }
+
+    /**
+     * Throw an exception if an attempt is made to re-register a document.
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage is already registered
+     */
+    public function testDifferentInstanceSameNode()
+    {
+        $this->node->getPath()->willReturn('/path/to');
+        $this->registry->registerDocument(new \stdClass(), $this->node->reveal(), 'fr');
+        $this->registry->registerDocument(new \stdClass(), $this->node->reveal(), 'fr');
+    }
+
+    /**
+     * It should throw an exception if an unregistered document is passed to get node for document.
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testGetNodeForDocumentUnknown()
+    {
+        $this->registry->getNodeForDocument($this->document);
+    }
+
+    /**
+     * It should return a document for a mangaed node.
+     *
+     * @depends testRegisterDocument
+     */
+    public function testGetDocumentForNode()
+    {
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
+        $document = $this->registry->getDocumentForNode($this->node->reveal(), 'fr');
+        $this->assertSame($this->document, $document);
+    }
+
+    /**
+     * It should provide a method to clear the registry.
+     */
+    public function testClear()
+    {
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
+        $this->assertTrue($this->registry->hasDocument($this->document));
+        $this->registry->clear();
+        $this->assertFalse($this->registry->hasDocument($this->document));
+    }
+
+    /**
+     * It should be able to determine the locale of a document.
+     */
+    public function testGetLocaleForDocument()
+    {
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr');
+        $this->assertEquals('fr', $this->registry->getLocaleForDocument($this->document));
+    }
+
+    /**
+     * It should return the default locale.
+     */
+    public function testGetDefaultLocale()
+    {
+        $this->assertEquals('de', $this->registry->getDefaultLocale());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
+
+use Sulu\Component\DocumentManager\DocumentStrategyInterface;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class BaseMetadataFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->strategy = $this->prophesize(DocumentStrategyInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->factory = new BaseMetadataFactory(
+            $this->dispatcher->reveal(),
+            [
+                [
+                    'alias' => 'page',
+                    'class' => 'Class\Page',
+                    'phpcr_type' => 'sulu:page',
+                ],
+                [
+                    'alias' => 'snippet',
+                    'class' => 'Class\Snippet',
+                    'phpcr_type' => 'sulu:snippet',
+                ],
+            ],
+            $this->strategy->reveal()
+        );
+    }
+
+    /**
+     * It should retrieve metadata for a fully qualified class name.
+     */
+    public function testGetForClass()
+    {
+        $metadata = $this->factory->getMetadataForClass('Class\Page');
+        $this->assertInstanceOf(Metadata::class, $metadata);
+        $this->assertEquals('page', $metadata->getAlias());
+        $this->assertEquals('Class\Page', $metadata->getClass());
+        $this->assertEquals('sulu:page', $metadata->getPhpcrType());
+    }
+
+    /**
+     * It should throw an exception if there is no mapping for the class name.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\MetadataNotFoundException
+     */
+    public function testGetForClassNotFound()
+    {
+        $this->factory->getMetadataForClass('Class\Page\NotFound');
+    }
+
+    /**
+     * It should retrieve metadata for a given alias.
+     */
+    public function testGetForAlias()
+    {
+        $metadata = $this->factory->getMetadataForAlias('snippet');
+        $this->assertInstanceOf(Metadata::class, $metadata);
+        $this->assertEquals('snippet', $metadata->getAlias());
+        $this->assertEquals('Class\Snippet', $metadata->getClass());
+        $this->assertEquals('sulu:snippet', $metadata->getPhpcrType());
+    }
+
+    /**
+     * It should throw an exception if there is no mapping for given alias.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\MetadataNotFoundException
+     */
+    public function testGetForAliasNotFound()
+    {
+        $this->factory->getMetadataForAlias('yak');
+    }
+
+    /**
+     * It should retrieve metadata for a given phpcrType.
+     */
+    public function testGetForPhpcrType()
+    {
+        $metadata = $this->factory->getMetadataForPhpcrType('sulu:snippet');
+        $this->assertInstanceOf(Metadata::class, $metadata);
+        $this->assertEquals('snippet', $metadata->getAlias());
+        $this->assertEquals('Class\Snippet', $metadata->getClass());
+        $this->assertEquals('sulu:snippet', $metadata->getPhpcrType());
+    }
+
+    public function testHasPhpcrType()
+    {
+        $res = $this->factory->hasMetadataForPhpcrType('sulu:snippet');
+        $this->assertTrue($res);
+
+        $res = $this->factory->hasMetadataForPhpcrType('foobar');
+        $this->assertFalse($res);
+    }
+
+    /**
+     * It should say if it has metadata for a class.
+     */
+    public function testHasMetadataForClass()
+    {
+        $this->assertTrue($this->factory->hasMetadataForClass('Class\Snippet'));
+    }
+
+    /**
+     * It should say if it has metadata for a class.
+     */
+    public function testHasMetadataForProxyClass()
+    {
+        $this->assertTrue($this->factory->hasMetadataForClass('ProxyManagerGeneratedProxy\__PM__\Class\Snippet\Generateda84aebfffbf882fd8bddc950faa89e05'));
+    }
+
+    /**
+     * It should throw an exception if there is no mapping for given phpcrType.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\MetadataNotFoundException
+     */
+    public function testGetForPhpcrTypeNotFound()
+    {
+        $this->factory->getMetadataForPhpcrType('yak');
+    }
+
+    /**
+     * It has a method to determine if an alias exists.
+     */
+    public function testHasAlias()
+    {
+        $this->assertTrue($this->factory->hasAlias('page'));
+        $this->assertFalse($this->factory->hasAlias('fooabarbardg'));
+    }
+
+    /**
+     * It should return metadata for all mapped documents.
+     */
+    public function testAllMetadata()
+    {
+        $metadatas = $this->factory->getAllMetadata();
+        $this->assertCount(2, $metadatas);
+        $this->assertContainsOnlyInstancesOf('Sulu\Component\DocumentManager\Metadata', $metadatas);
+        $metadata = reset($metadatas);
+        $this->assertEquals('Class\Page', $metadata->getClass());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -11,12 +11,13 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentStrategyInterface;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class BaseMetadataFactoryTest extends \PHPUnit_Framework_TestCase
+class BaseMetadataFactoryTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/MetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/MetadataFactoryTest.php
@@ -12,12 +12,13 @@
 namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Document\UnknownDocument;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 
-class MetadataFactoryTest extends \PHPUnit_Framework_TestCase
+class MetadataFactoryTest extends TestCase
 {
     /**
      * @var MetadataFactoryInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/MetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/MetadataFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Document\UnknownDocument;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+
+class MetadataFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $baseMetadataFactory;
+
+    /**
+     * @var MetadataFactory
+     */
+    private $metadataFactory;
+
+    public function setUp()
+    {
+        $this->baseMetadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->metadataFactory = new MetadataFactory($this->baseMetadataFactory->reveal());
+    }
+
+    public function testGetForPhpcrNodeWithoutMixins()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('jcr:mixinTypes')->willReturn(false);
+
+        $metadata = $this->metadataFactory->getMetadataForPhpcrNode($node->reveal());
+        $this->assertEquals(UnknownDocument::class, $metadata->getClass());
+    }
+
+    public function testGetForPhpcrNode()
+    {
+        $metadata = $this->prophesize(Metadata::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('jcr:mixinTypes')->willReturn(true);
+        $node->getPropertyValue('jcr:mixinTypes')->willReturn(['mix:referenceable', 'sulu:page']);
+
+        $this->baseMetadataFactory->hasMetadataForPhpcrType('mix:referenceable')->willReturn(false);
+        $this->baseMetadataFactory->hasMetadataForPhpcrType('sulu:page')->willReturn(true);
+        $this->baseMetadataFactory->getMetadataForPhpcrType('sulu:page')->willReturn($metadata->reveal());
+
+        $this->assertSame($metadata->reveal(), $this->metadataFactory->getMetadataForPhpcrNode($node->reveal()));
+    }
+
+    public function testGetForPhpcrNodeNoManaged()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('jcr:mixinTypes')->willReturn(true);
+        $node->getPropertyValue('jcr:mixinTypes')->willReturn([
+        ]);
+
+        $metadata = $this->metadataFactory->getMetadataForPhpcrNode($node->reveal());
+        $this->assertNull($metadata->getAlias());
+        $this->assertEquals(UnknownDocument::class, $metadata->getClass());
+        $this->assertNull($metadata->getPhpcrType());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/MetadataTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/MetadataTest.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Component\DocumentManager\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Metadata;
 
-class MetadataTest extends \PHPUnit_Framework_TestCase
+class MetadataTest extends TestCase
 {
     /**
      * @var Metadata

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/MetadataTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/MetadataTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit;
+
+use Sulu\Component\DocumentManager\Metadata;
+
+class MetadataTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Metadata
+     */
+    private $metadata;
+
+    public function setUp()
+    {
+        $this->metadata = new Metadata();
+    }
+
+    /**
+     * It should throw an exception if no class is set and the ReflectionClass
+     * is requested.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testNoClassGetReflection()
+    {
+        $this->metadata->getReflectionClass();
+    }
+
+    /**
+     * It should return the reflection class.
+     */
+    public function testReflectionClass()
+    {
+        $this->metadata->setClass('\stdClass');
+        $reflection = $this->metadata->getReflectionClass();
+
+        $this->assertInstanceOf('ReflectionClass', $reflection);
+        $this->assertEquals('stdClass', $reflection->name);
+
+        $this->assertSame($reflection, $this->metadata->getReflectionClass());
+
+        $this->metadata->setClass('\stdClass');
+        $this->assertNotSame($reflection, $this->metadata->getReflectionClass());
+    }
+
+    public function testGetFieldMappingsEmpty()
+    {
+        $this->assertInternalType('array', $this->metadata->getFieldMappings());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\NameResolver;
+
+class NameResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NameResolver
+     */
+    private $nameResolver;
+
+    public function setUp()
+    {
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->nameResolver = new NameResolver();
+    }
+
+    public function testResolveWithNotExistingName()
+    {
+        $this->parentNode->hasNode('foo')->willReturn(false);
+        $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo');
+
+        $this->assertEquals('foo', $name);
+    }
+
+    public function testResolveIncrementWithExistingName()
+    {
+        $this->parentNode->hasNode('foo')->willReturn(true);
+        $this->parentNode->hasNode('foo-1')->willReturn(true);
+        $this->parentNode->hasNode('foo-2')->willReturn(false);
+
+        $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo');
+        $this->assertEquals('foo-2', $name);
+    }
+
+    public function testResolveForNode()
+    {
+        $this->parentNode->hasNode('foo')->willReturn(true);
+        $this->parentNode->getNode('foo')->willReturn($this->node->reveal());
+
+        $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo', $this->node->reveal());
+        $this->assertEquals('foo', $name);
+    }
+
+    public function testResolveForNodeWithIncrement()
+    {
+        $this->parentNode->hasNode('foo')->willReturn(true);
+        $this->parentNode->getNode('foo')->willReturn($this->node->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+
+        $this->parentNode->hasNode('foo-1')->willReturn(true);
+        $this->parentNode->getNode('foo-1')->willReturn($node->reveal());
+
+        $name = $this->nameResolver->resolveName($this->parentNode->reveal(), 'foo', $node->reveal());
+        $this->assertEquals('foo-1', $name);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
@@ -12,9 +12,10 @@
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\NameResolver;
 
-class NameResolverTest extends \PHPUnit_Framework_TestCase
+class NameResolverTest extends TestCase
 {
     /**
      * @var NodeInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+
+class NamespaceRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->registry = new NamespaceRegistry([
+            'system' => 'asys',
+            'foobar' => 'lsys',
+        ]);
+    }
+
+    /**
+     * It should return an alias for a given role.
+     */
+    public function testGetPrefix()
+    {
+        $alias = $this->registry->getPrefix('system');
+        $this->assertEquals('asys', $alias);
+    }
+
+    /**
+     * It should thow an exception if the alias is not known.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     */
+    public function testGetUnknownPrefix()
+    {
+        $this->registry->getPrefix('foobarbar');
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 
-class NamespaceRegistryTest extends \PHPUnit_Framework_TestCase
+class NamespaceRegistryTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NodeHelperTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NodeHelperTest.php
@@ -14,11 +14,12 @@ namespace Sulu\Component\DocumentManager\Tests\Unit;
 use Jackalope\Workspace;
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\NodeHelper;
 use Sulu\Component\DocumentManager\NodeHelperInterface;
 
-class NodeHelperTest extends \PHPUnit_Framework_TestCase
+class NodeHelperTest extends TestCase
 {
     /**
      * @var NodeHelperInterface
@@ -86,7 +87,7 @@ class NodeHelperTest extends \PHPUnit_Framework_TestCase
         $this->node->getPath()->willReturn('/path/to/node');
 
         $workspace->copy('/path/to/node', '/path/to/some/other/node/node');
-        $this->nodeHelper->copy($this->node->reveal(), 'uuid');
+        $this->assertEquals('uuid/node', $this->nodeHelper->copy($this->node->reveal(), 'uuid'));
     }
 
     public function testCopyWithDestinationName()
@@ -102,7 +103,7 @@ class NodeHelperTest extends \PHPUnit_Framework_TestCase
         $this->node->getPath()->willReturn('/path/to/node');
 
         $workspace->copy('/path/to/node', '/path/to/some/other/node/new-node');
-        $this->nodeHelper->copy($this->node->reveal(), 'uuid', 'new-node');
+        $this->assertEquals('uuid/new-node', $this->nodeHelper->copy($this->node->reveal(), 'uuid', 'new-node'));
     }
 
     public function testReorderUuidTarget()
@@ -123,7 +124,7 @@ class NodeHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionTargetNotSibling()
     {
-        $this->setExpectedException(
+        $this->expectException(
             DocumentManagerException::class,
             'Cannot reorder documents which are not sibilings. Trying to reorder "/path/to/node" to "/path/to/deep/node".'
         );

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NodeHelperTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NodeHelperTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit;
+
+use Jackalope\Workspace;
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\NodeHelper;
+use Sulu\Component\DocumentManager\NodeHelperInterface;
+
+class NodeHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NodeHelperInterface
+     */
+    private $nodeHelper;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    public function setUp()
+    {
+        $this->nodeHelper = new NodeHelper();
+
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->session = $this->prophesize(SessionInterface::class);
+
+        $this->node->getSession()->willReturn($this->session->reveal());
+    }
+
+    public function testMove()
+    {
+        $destinationNode = $this->prophesize(NodeInterface::class);
+        $destinationNode->getPath()->willReturn('/path/to/some/other/node');
+        $this->session->getNodeByIdentifier('5f2a72d1-e384-4571-9663-51902d62ac86')
+            ->willReturn($destinationNode->reveal());
+
+        $this->node->getName()->willReturn('node');
+        $this->node->getPath()->willReturn('/path/to/node');
+
+        $this->session->move('/path/to/node', '/path/to/some/other/node/node')->shouldBeCalled();
+        $this->nodeHelper->move($this->node->reveal(), '5f2a72d1-e384-4571-9663-51902d62ac86');
+    }
+
+    public function testMoveWithDestinationName()
+    {
+        $destinationNode = $this->prophesize(NodeInterface::class);
+        $destinationNode->getPath()->willReturn('/path/to/some/other/node');
+        $this->session->getNodeByIdentifier('5f2a72d1-e384-4571-9663-51902d62ac86')
+            ->willReturn($destinationNode->reveal());
+
+        $this->node->getPath()->willReturn('/path/to/node');
+
+        $this->session->move('/path/to/node', '/path/to/some/other/node/new-node')->shouldBeCalled();
+        $this->nodeHelper->move($this->node->reveal(), '5f2a72d1-e384-4571-9663-51902d62ac86', 'new-node');
+    }
+
+    public function testCopy()
+    {
+        /** @var Workspace $workspace */
+        $workspace = $this->prophesize(Workspace::class);
+        $this->session->getWorkspace()->willReturn($workspace->reveal());
+
+        $destinationNode = $this->prophesize(NodeInterface::class);
+        $destinationNode->getPath()->willReturn('/path/to/some/other/node');
+        $this->session->getNodeByIdentifier('uuid')->willReturn($destinationNode->reveal());
+
+        $this->node->getName()->willReturn('node');
+        $this->node->getPath()->willReturn('/path/to/node');
+
+        $workspace->copy('/path/to/node', '/path/to/some/other/node/node');
+        $this->nodeHelper->copy($this->node->reveal(), 'uuid');
+    }
+
+    public function testCopyWithDestinationName()
+    {
+        /** @var Workspace $workspace */
+        $workspace = $this->prophesize(Workspace::class);
+        $this->session->getWorkspace()->willReturn($workspace->reveal());
+
+        $destinationNode = $this->prophesize(NodeInterface::class);
+        $destinationNode->getPath()->willReturn('/path/to/some/other/node');
+        $this->session->getNodeByIdentifier('uuid')->willReturn($destinationNode->reveal());
+
+        $this->node->getPath()->willReturn('/path/to/node');
+
+        $workspace->copy('/path/to/node', '/path/to/some/other/node/new-node');
+        $this->nodeHelper->copy($this->node->reveal(), 'uuid', 'new-node');
+    }
+
+    public function testReorderUuidTarget()
+    {
+        $parentNode = $this->prophesize(NodeInterface::class);
+        $parentNode->getPath()->willReturn('/path/to');
+        $this->node->getParent()->willReturn($parentNode->reveal());
+        $this->node->getName()->willReturn('node');
+
+        $siblingNode = $this->prophesize(NodeInterface::class);
+        $siblingNode->getPath()->willReturn('/path/to/sibling');
+        $this->session->getNodeByIdentifier('uuid')->willReturn($siblingNode->reveal());
+
+        $parentNode->orderBefore('node', 'sibling')->shouldBeCalled();
+
+        $this->nodeHelper->reorder($this->node->reveal(), 'uuid');
+    }
+
+    public function testExceptionTargetNotSibling()
+    {
+        $this->setExpectedException(
+            DocumentManagerException::class,
+            'Cannot reorder documents which are not sibilings. Trying to reorder "/path/to/node" to "/path/to/deep/node".'
+        );
+        $parentNode = $this->prophesize(NodeInterface::class);
+        $parentNode->getPath()->willReturn('/path/to');
+        $this->node->getParent()->willReturn($parentNode->reveal());
+        $this->node->getPath()->willReturn('/path/to/node');
+
+        $nonSiblingNode = $this->prophesize(NodeInterface::class);
+        $nonSiblingNode->getPath()->willReturn('/path/to/deep/node');
+        $this->session->getNodeByIdentifier('uuid')->willReturn($nonSiblingNode->reveal());
+
+        $this->nodeHelper->reorder($this->node->reveal(), 'uuid');
+    }
+
+    public function testOrderAfterLast()
+    {
+        $parentNode = $this->prophesize(NodeInterface::class);
+        $parentNode->getPath()->willReturn('/path/to');
+        $this->node->getParent()->willReturn($parentNode->reveal());
+        $this->node->getName()->willReturn('node');
+
+        $parentNode->orderBefore('node', null)->shouldBeCalled();
+
+        $this->nodeHelper->reorder($this->node->reveal(), null);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use PHPCR\NodeInterface;
+use PHPCR\PathNotFoundException;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+
+class NodeManagerTest extends \PHPUnit_Framework_TestCase
+{
+    const UUID1 = '0dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
+
+    const PATH1 = '/path/to';
+
+    const UUID2 = '1dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
+
+    const PATH2 = '/path/to/this';
+
+    /**
+     * @var NodeManager
+     */
+    private $manager;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var WorkspaceInterface
+     */
+    private $workspace;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node1;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node2;
+
+    public function setUp()
+    {
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->workspace = $this->prophesize(WorkspaceInterface::class);
+        $this->manager = new NodeManager(
+            $this->session->reveal()
+        );
+
+        $this->node1 = $this->prophesize(NodeInterface::class);
+        $this->node2 = $this->prophesize(NodeInterface::class);
+
+        $this->session->getWorkspace()->willReturn($this->workspace->reveal());
+    }
+
+    /**
+     * It should be able to find a node1 by UUID1.
+     */
+    public function testFindByUuid()
+    {
+        $this->session->getNodeByIdentifier(self::UUID1)->willReturn($this->node1->reveal());
+        $node1 = $this->manager->find(self::UUID1);
+        $this->assertSame($this->node1->reveal(), $node1);
+    }
+
+    /**
+     * It should be able to find a node1 by path.
+     */
+    public function testFindByPath()
+    {
+        $this->session->getNode(self::PATH1)->willReturn($this->node1->reveal());
+        $node1 = $this->manager->find(self::PATH1);
+        $this->assertSame($this->node1->reveal(), $node1);
+    }
+
+    /**
+     * It should throw an exception if the node1 was not found.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\DocumentNotFoundException
+     */
+    public function testFindNotFound()
+    {
+        $this->session->getNode(self::PATH1)->willThrow(new PathNotFoundException('Not found'));
+        $this->manager->find(self::PATH1);
+    }
+
+    /**
+     * It should be able to remove a document by UUID1.
+     */
+    public function testRemoveByUUid()
+    {
+        $this->session->getNodeByIdentifier(self::UUID1)->willReturn($this->node1->reveal());
+        $this->node1->getPath()->willReturn(self::PATH1);
+        $this->session->removeItem(self::PATH1)->shouldBeCalled();
+        $this->manager->remove(self::UUID1);
+    }
+
+    /**
+     * It should be able to remove by path.
+     */
+    public function testRemoveByPath()
+    {
+        $this->session->removeItem(self::PATH1)->shouldBeCalled();
+        $this->manager->remove(self::PATH1);
+    }
+
+    /**
+     * It should be able to copy a node1.
+     */
+    public function testCopy()
+    {
+        $this->session->getNodeByIdentifier(self::UUID1)->willReturn($this->node1->reveal());
+        $this->node1->getPath()->willReturn(self::PATH1);
+
+        $this->session->getNodeByIdentifier(self::UUID2)->willReturn($this->node2->reveal());
+        $this->node2->getPath()->willReturn(self::PATH2);
+
+        $this->workspace->copy(self::PATH1, self::PATH2 . '/foo')->shouldBeCalled();
+        $this->manager->copy(self::UUID1, self::UUID2, 'foo');
+    }
+
+    /**
+     * It should be able to save the session.
+     */
+    public function testSave()
+    {
+        $this->session->save()->shouldBeCalled();
+        $this->manager->save();
+    }
+
+    /**
+     * It should clear/reset the PHPCR session.
+     */
+    public function testClear()
+    {
+        $this->session->refresh(false)->shouldBeCalled();
+        $this->manager->clear();
+    }
+
+    /**
+     * It should purge the workspace.
+     */
+    public function testPurgeWorkspace()
+    {
+        $this->session->getRootNode()->willReturn($this->node1->reveal());
+        $this->node1->getProperties()->willReturn([]);
+        $this->node1->getNodes()->willReturn([]);
+
+        $this->manager->purgeWorkspace();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
@@ -15,9 +15,10 @@ use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;
 use PHPCR\SessionInterface;
 use PHPCR\WorkspaceInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\NodeManager;
 
-class NodeManagerTest extends \PHPUnit_Framework_TestCase
+class NodeManagerTest extends TestCase
 {
     const UUID1 = '0dd2270d-c1e1-4d4e-9b7c-6da0efb6e91d';
 
@@ -155,9 +156,9 @@ class NodeManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testPurgeWorkspace()
     {
-        $this->session->getRootNode()->willReturn($this->node1->reveal());
-        $this->node1->getProperties()->willReturn([]);
-        $this->node1->getNodes()->willReturn([]);
+        $this->session->getRootNode()->willReturn($this->node1->reveal())->shouldBeCalled();
+        $this->node1->getProperties()->willReturn([])->shouldBeCalled();
+        $this->node1->getNodes()->willReturn([])->shouldBeCalled();
 
         $this->manager->purgeWorkspace();
     }

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use Sulu\Component\DocumentManager\PathBuilder;
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+
+class PathBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    private $pathBuilder;
+
+    public function setUp()
+    {
+        $pathRegistry = new PathSegmentRegistry([
+            'one' => 'one',
+            'two' => 'two',
+        ]);
+        $this->pathBuilder = new PathBuilder($pathRegistry);
+    }
+
+    /**
+     * It should build a path
+     * Using a combination of tokens and literal values.
+     */
+    public function testBuild()
+    {
+        $result = $this->pathBuilder->build(['%one%', '%two%', 'four']);
+        $this->assertEquals('/one/two/four', $result);
+    }
+
+    /**
+     * It should build "/" for an empty array.
+     */
+    public function testBuildEmpty()
+    {
+        $this->assertEquals('/', $this->pathBuilder->build([]));
+    }
+
+    /**
+     * It should build "/" for an array with "/".
+     */
+    public function testBuildSingleSlash()
+    {
+        $this->assertEquals('/', $this->pathBuilder->build(['/']));
+    }
+
+    /**
+     * It should replace "//" with "/".
+     */
+    public function testBuildNoDoubleSlash()
+    {
+        $this->assertEquals('/hello/world', $this->pathBuilder->build(['hello', '', '', 'world']));
+    }
+
+    /**
+     * It should allow sub paths.
+     */
+    public function testBuildSubPath()
+    {
+        $this->assertEquals('/hello/world/goodbye/world/k', $this->pathBuilder->build(['hello', 'world/goodbye/world', 'k']));
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
@@ -11,10 +11,11 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\PathBuilder;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
 
-class PathBuilderTest extends \PHPUnit_Framework_TestCase
+class PathBuilderTest extends TestCase
 {
     private $pathBuilder;
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PathSegmentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PathSegmentRegistryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use Sulu\Component\DocumentManager\PathSegmentRegistry;
+
+class PathSegmentRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PathSegmentRegistry
+     */
+    private $pathRegistry;
+
+    public function setUp()
+    {
+        $this->pathRegistry = new PathSegmentRegistry(
+            [
+                'base' => 'cmf',
+                'foobar' => 'barfoo',
+            ]
+        );
+    }
+
+    /**
+     * It should retrieve a path segment.
+     */
+    public function testGetPathSegment()
+    {
+        $segment = $this->pathRegistry->getPathSegment('base');
+        $this->assertEquals('cmf', $segment);
+    }
+
+    /**
+     * It should throw an exception when the given path segment role does not exist.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown path segment "not exist". Known path segments: "base", "foobar"
+     */
+    public function testThrowException()
+    {
+        $this->pathRegistry->getPathSegment('not exist');
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PathSegmentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PathSegmentRegistryTest.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;
 
-class PathSegmentRegistryTest extends \PHPUnit_Framework_TestCase
+class PathSegmentRegistryTest extends TestCase
 {
     /**
      * @var PathSegmentRegistry

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PropertyEncoderTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PropertyEncoderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit;
+
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+
+class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var NamespaceRegistry
+     */
+    private $namespaceRegistry;
+
+    public function setUp()
+    {
+        $map = [
+            'system' => 'nsys',
+            'system_localized' => 'lsys',
+        ];
+
+        $this->namespaceRegistry = $this->prophesize(NamespaceRegistry::class);
+        $this->namespaceRegistry->getPrefix(Argument::type('string'))->will(function ($args) use ($map) {
+            return $map[$args[0]];
+        });
+        $this->encoder = new PropertyEncoder($this->namespaceRegistry->reveal());
+    }
+
+    /**
+     * It should encode localized system properties.
+     */
+    public function testEncodeLocalizedSystem()
+    {
+        $name = $this->encoder->localizedSystemName('created', 'fr');
+        $this->assertEquals('lsys:fr-created', $name);
+    }
+
+    /**
+     * It should encode system properties.
+     */
+    public function testEncodeSystem()
+    {
+        $name = $this->encoder->systemName('created');
+        $this->assertEquals('nsys:created', $name);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testEncodeLocalizedSystemEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('system_localized', 'test', null);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testEncodeLocalizedContentEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('content_localized', 'test', null);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testLocalizedContentEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('content_localized', 'test', null);
+    }
+
+    /**
+     * It should throw exception.
+     */
+    public function testLocalizedSystemEmptyLocale()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->encoder->encode('system_localized', 'test', null);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PropertyEncoderTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PropertyEncoderTest.php
@@ -11,11 +11,12 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 
-class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
+class PropertyEncoderTest extends TestCase
 {
     /**
      * @var PropertyEncoder
@@ -64,7 +65,7 @@ class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testEncodeLocalizedSystemEmptyLocale()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->encoder->encode('system_localized', 'test', null);
     }
@@ -74,7 +75,7 @@ class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testEncodeLocalizedContentEmptyLocale()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->encoder->encode('content_localized', 'test', null);
     }
@@ -84,7 +85,7 @@ class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLocalizedContentEmptyLocale()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->encoder->encode('content_localized', 'test', null);
     }
@@ -94,7 +95,7 @@ class PropertyEncoderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLocalizedSystemEmptyLocale()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->encoder->encode('system_localized', 'test', null);
     }

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
 use ProxyManager\Proxy\LazyLoadingInterface;
@@ -25,7 +26,7 @@ use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
+class ProxyFactoryTest extends TestCase
 {
     /**
      * @var NodeInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ProxyFactoryTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use ProxyManager\Factory\LazyLoadingGhostFactory;
+use ProxyManager\Proxy\LazyLoadingInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ProxyFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var Metadata\
+     */
+    private $metadata;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var LazyLoadingGhostFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var TestProxyDocument
+     */
+    private $document;
+
+    /**
+     * @var ProxyFactory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->proxyFactory = new LazyLoadingGhostFactory();
+        $this->document = new TestProxyDocument();
+
+        $this->factory = new ProxyFactory(
+            $this->proxyFactory,
+            $this->dispatcher->reveal(),
+            $this->documentRegistry->reveal(),
+            $this->metadataFactory->reveal()
+        );
+    }
+
+    /**
+     * It should populate the documents parent property with a proxy.
+     */
+    public function testCreateProxy()
+    {
+        $this->documentRegistry->hasNode(Argument::type(NodeInterface::class), 'de')->willReturn(false);
+        $this->documentRegistry->getDocumentForNode(Argument::any())->willReturn(new \stdClass());
+        $this->documentRegistry->getOriginalLocaleForDocument(Argument::any())->willReturn('de');
+        $this->documentRegistry->registerDocument(Argument::cetera())->willReturn(null);
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->metadataFactory->getMetadataForPhpcrNode($this->parentNode->reveal())->willReturn($this->metadata->reveal());
+        $this->metadata->getClass()->willReturn(TestProxyDocumentProxy::class);
+
+        $proxy = $this->factory->createProxyForNode($this->document, $this->parentNode->reveal());
+
+        $this->assertInstanceOf(LazyLoadingInterface::class, $proxy);
+
+        return [$this->dispatcher, $proxy];
+    }
+
+    /**
+     * It should populate the documents parent property (with custom options) with a proxy.
+     */
+    public function testCreateProxyOptions()
+    {
+        $options = ['test_option' => 'test'];
+
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->metadataFactory->getMetadataForPhpcrNode($this->parentNode->reveal())->willReturn(
+            $this->metadata->reveal()
+        );
+        $this->metadata->getClass()->willReturn(TestProxyDocumentProxy::class);
+
+        $proxy = $this->factory->createProxyForNode($this->document, $this->parentNode->reveal(), $options);
+
+        $this->assertInstanceOf(LazyLoadingInterface::class, $proxy);
+
+        $this->dispatcher->dispatch(
+            'sulu_document_manager.hydrate',
+            Argument::that(
+                function ($event) use ($options) {
+                    return $event->getOptions() === $options;
+                }
+            )
+        )->shouldBeCalled();
+
+        // hydrate
+        $proxy->getTitle();
+    }
+
+    /**
+     * It should lazy load the proxy.
+     *
+     * @depends testCreateProxy
+     */
+    public function testHydrateLazyProxy($result)
+    {
+        list($dispatcher, $proxy) = $result;
+
+        $dispatcher->dispatch(
+            Events::HYDRATE,
+            Argument::that(
+                function (HydrateEvent $arg) {
+                    return 'de' === $arg->getLocale();
+                }
+            )
+        )->shouldBeCalled();
+
+        $this->assertEquals('Hello', $proxy->getTitle());
+    }
+
+    /**
+     * It should create a children node collection.
+     */
+    public function testCreateChildrenCollection()
+    {
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->documentRegistry->getOriginalLocaleForDocument($this->document)->willReturn('de');
+        $childrenCollection = $this->factory->createChildrenCollection($this->document);
+
+        $this->assertInstanceOf(ChildrenCollection::class, $childrenCollection);
+    }
+}
+
+class TestProxyDocument implements ParentBehavior
+{
+    private $parent;
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+}
+
+class TestProxyDocumentProxy
+{
+    private $title = 'Hello';
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Query;
+
+use PHPCR\Query\QueryInterface;
+use PHPCR\Query\QueryResultInterface;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Query\Query;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class QueryTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->phpcrQuery = $this->prophesize(QueryInterface::class);
+        $this->phpcrResult = $this->prophesize(QueryResultInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        $this->query = new Query(
+            $this->phpcrQuery->reveal(),
+            $this->dispatcher->reveal(),
+            'fr',
+            [],
+            'p'
+        );
+    }
+
+    /**
+     * It should be able to return PHPCR results.
+     */
+    public function testExecutePhpcr()
+    {
+        $parameters = [
+            'one' => 'two',
+            'three' => 'four',
+        ];
+        $limit = 10;
+        $firstResult = 5;
+
+        $this->phpcrQuery->setLimit($limit)->shouldBeCalled();
+        $this->phpcrQuery->setOffset($firstResult)->shouldBeCalled();
+
+        foreach ($parameters as $key => $value) {
+            $this->phpcrQuery->bindValue($key, $value)->shouldBeCalled();
+        }
+
+        $this->phpcrQuery->execute()->willReturn($this->phpcrResult->reveal());
+
+        $this->query->setMaxResults($limit);
+        $this->query->setFirstResult($firstResult);
+
+        $result = $this->query->execute($parameters, Query::HYDRATE_PHPCR);
+
+        $this->assertSame($this->phpcrResult->reveal(), $result);
+    }
+
+    /**
+     * It should return documents by default.
+     */
+    public function testExecuteDocument()
+    {
+        $resultCollection = $this->prophesize(QueryResultCollection::class);
+        $this->dispatcher->dispatch(Events::QUERY_EXECUTE, new QueryExecuteEvent($this->query))->will(function ($args) use ($resultCollection) {
+            $args[1]->setResult($resultCollection->reveal());
+        });
+
+        $result = $this->query->execute();
+        $this->assertSame($resultCollection->reveal(), $result);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
@@ -13,13 +13,14 @@ namespace Sulu\Comonent\DocumentManager\tests\Unit\Query;
 
 use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Query\Query;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class QueryTest extends \PHPUnit_Framework_TestCase
+class QueryTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Slugifier;
+
+use Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
+
+class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
+     * @var NodeNameSlugifier
+     */
+    private $nodeNameSlugifier;
+
+    protected function setUp()
+    {
+        $this->slugifier = $this->prophesize(SlugifierInterface::class);
+        $this->nodeNameSlugifier = new NodeNameSlugifier($this->slugifier->reveal());
+    }
+
+    public function testSlugify()
+    {
+        $this->slugifier->slugify('Test article')->willReturn('test-article');
+
+        $this->assertEquals('test-article', $this->nodeNameSlugifier->slugify('Test article'));
+    }
+
+    public function provide10eData()
+    {
+        return [
+            ['10e', '10-e'],
+            ['.10e', '.10-e'],
+            ['-10e', '-10-e'],
+            ['%10e', '%10-e'],
+            ['test-10e-name', 'test-10-e-name'],
+            ['test.10e-name', 'test.10-e-name'],
+            ['test%10e-name', 'test%10-e-name'],
+            ['test-10E-name', 'test-10-E-name'],
+            ['test.10E-name', 'test.10-E-name'],
+            ['test%10E-name', 'test%10-E-name'],
+            ['test10E-name', 'test10-E-name'],
+            ['test-9e-name', 'test-9-e-name'],
+            ['test-500e-name', 'test-500-e-name'],
+        ];
+    }
+
+    /**
+     * @dataProvider provide10eData
+     */
+    public function testSlugify10e($actual, $expected)
+    {
+        $this->slugifier->slugify($actual)->willReturn($actual);
+
+        $this->assertEquals($expected, $this->nodeNameSlugifier->slugify($actual));
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -11,10 +11,11 @@
 
 namespace Sulu\Component\DocumentManager\tests\Unit\Slugifier;
 
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier;
 use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 
-class NodeNameSlugifierTest extends \PHPUnit_Framework_TestCase
+class NodeNameSlugifierTest extends TestCase
 {
     /**
      * @var SlugifierInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Behavior\Audit\LocalizedTimestampBehavior;
 use Sulu\Component\DocumentManager\Behavior\Audit\TimestampBehavior;
@@ -23,7 +24,7 @@ use Sulu\Component\DocumentManager\Event\RestoreEvent;
 use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Audit\TimestampSubscriber;
 
-class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
+class TimestampSubscriberTest extends TestCase
 {
     /**
      * @var PropertyEncoder
@@ -44,7 +45,7 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testSetTimestampsOnNodeForPersistNotImplementing()
     {
         $event = $this->prophesize(PersistEvent::class);
-        $event->getDocument()->willReturn(new \stdClass());
+        $event->getDocument()->willReturn(new \stdClass())->shouldBeCalled();
         $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
     }
 
@@ -170,7 +171,7 @@ class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testSetTimestampsOnNodeForPublishNotImplementing()
     {
         $event = $this->prophesize(PublishEvent::class);
-        $event->getDocument()->willReturn(new \stdClass());
+        $event->getDocument()->willReturn(new \stdClass())->shouldBeCalled();
         $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Audit/TimestampSubscriberTest.php
@@ -1,0 +1,366 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Behavior\Audit\LocalizedTimestampBehavior;
+use Sulu\Component\DocumentManager\Behavior\Audit\TimestampBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
+use Sulu\Component\DocumentManager\Event\RestoreEvent;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Audit\TimestampSubscriber;
+
+class TimestampSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var TimestampSubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
+        $this->subscriber = new TimestampSubscriber($this->propertyEncoder->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPersistNotImplementing()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $event->getDocument()->willReturn(new \stdClass());
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPersistCreatedWhenNull()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+
+        $node->hasProperty('i18n:de-created')->willReturn(false);
+        $accessor->set('created', Argument::type(\DateTime::class))->shouldBeCalled();
+        $node->setProperty('i18n:de-created', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPersistCreatedWhenSet()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+
+        $createdDate = new \DateTime('2013-01-12');
+        $document->getCreated()->willReturn($createdDate);
+        $node->hasProperty('i18n:de-created')->willReturn();
+        $accessor->set('created', $createdDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-created', $createdDate)->shouldBeCalled();
+
+        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPersistChanged()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $node->hasProperty('i18n:de-created')->willReturn(true);
+        $accessor->set('created', Argument::type(\DateTime::class))->shouldNotBeCalled();
+        $node->setProperty('i18n:de-created', Argument::type(\DateTime::class))->shouldNotBeCalled();
+
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+        $accessor->set('changed', Argument::type('DateTime'))->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPersistNonLocalized()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(TimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $this->propertyEncoder->encode('system', 'created', 'de')->willReturn('created');
+        $this->propertyEncoder->encode('system', 'changed', 'de')->willReturn('changed');
+
+        $node->hasProperty('created')->willReturn(false);
+        $accessor->set('created', Argument::type(\DateTime::class))->shouldBeCalled();
+        $node->setProperty('created', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+        $node->setProperty('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
+    public function testSetTimestampOnNodeForPersistLocalizedWithoutLocale()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+
+        $event->getNode()->willReturn($node->reveal());
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getLocale()->willReturn(null);
+
+        $this->propertyEncoder->encode(Argument::cetera())->shouldNotBeCalled();
+        $node->setProperty(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPersist($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPublishNotImplementing()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $event->getDocument()->willReturn(new \stdClass());
+        $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPublishCreatedWhenNull()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $createdDate = new \DateTime('2017-01-25');
+        $changedDate = new \DateTime('2017-01-18');
+
+        $document->getCreated()->willReturn($createdDate);
+        $document->getChanged()->willReturn($changedDate);
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+
+        $node->hasProperty('i18n:de-created')->willReturn(false);
+        $accessor->set('created', $createdDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-created', $createdDate)->shouldBeCalled();
+
+        $accessor->set('changed', $changedDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', $changedDate)->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPublishChanged()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $createdDate = new \DateTime('2017-01-25');
+        $changedDate = new \DateTime('2017-01-18');
+
+        $document->getCreated()->willReturn($createdDate);
+        $document->getChanged()->willReturn($changedDate);
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $node->hasProperty('i18n:de-created')->willReturn(true);
+        $accessor->set('created', $createdDate)->shouldNotBeCalled();
+        $node->setProperty('i18n:de-created', $createdDate)->shouldNotBeCalled();
+
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+        $accessor->set('changed', $changedDate)->shouldBeCalled();
+        $node->setProperty('i18n:de-changed', $changedDate)->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
+    }
+
+    public function testSetTimestampsOnNodeForPublishNonLocalized()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $document = $this->prophesize(TimestampBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getLocale()->willReturn('de');
+
+        $createdDate = new \DateTime('2017-01-25');
+        $changedDate = new \DateTime('2017-01-18');
+
+        $document->getCreated()->willReturn($createdDate);
+        $document->getChanged()->willReturn($changedDate);
+
+        $this->propertyEncoder->encode('system', 'created', 'de')->willReturn('created');
+        $this->propertyEncoder->encode('system', 'changed', 'de')->willReturn('changed');
+
+        $node->hasProperty('created')->willReturn(false);
+        $accessor->set('created', $createdDate)->shouldBeCalled();
+        $node->setProperty('created', $createdDate)->shouldBeCalled();
+
+        $accessor->set('changed', $changedDate)->shouldBeCalled();
+        $node->setProperty('changed', $changedDate)->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnNodeForPublish($event->reveal());
+    }
+
+    public function testHydrate()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $event->getLocale()->willReturn('de');
+
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $event->getAccessor()->willReturn($accessor->reveal());
+
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->propertyEncoder->encode('system_localized', 'created', 'de')->willReturn('i18n:de-created');
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('i18n:de-created', null)->willReturn(new \DateTime());
+        $node->getPropertyValueWithDefault('i18n:de-changed', null)->willReturn(new \DateTime());
+        $event->getNode()->willReturn($node->reveal());
+
+        $accessor->set('created', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnDocument($event->reveal());
+    }
+
+    public function testHydrateWithoutLocalization()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $event->getLocale()->willReturn('de');
+
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $event->getAccessor()->willReturn($accessor->reveal());
+
+        $document = $this->prophesize(TimestampBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->propertyEncoder->encode('system', 'created', 'de')->willReturn('created');
+        $this->propertyEncoder->encode('system', 'changed', 'de')->willReturn('changed');
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('created', null)->willReturn(new \DateTime());
+        $node->getPropertyValueWithDefault('changed', null)->willReturn(new \DateTime());
+        $event->getNode()->willReturn($node->reveal());
+
+        $accessor->set('created', Argument::type(\DateTime::class))->shouldBeCalled();
+        $accessor->set('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setTimestampsOnDocument($event->reveal());
+    }
+
+    public function testHydrateWithoutTimestampBehavior()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $accessor = $this->prophesize(DocumentAccessor::class);
+        $event->getAccessor()->willReturn($accessor->reveal());
+        $event->getDocument()->willReturn(new \stdClass());
+
+        $accessor->set(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->setTimestampsOnDocument($event->reveal());
+    }
+
+    public function testSetChangedForRestore()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $event->getLocale()->willReturn('de');
+
+        $node = $this->prophesize(NodeInterface::class);
+        $event->getNode()->willReturn($node->reveal());
+
+        $document = $this->prophesize(LocalizedTimestampBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->propertyEncoder->encode('system_localized', 'changed', 'de')->willReturn('i18n:de-changed');
+
+        $node->setProperty('i18n:de-changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setChangedForRestore($event->reveal());
+    }
+
+    public function testSetChangedForRestoreNonLocalized()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $event->getLocale()->willReturn('de');
+
+        $node = $this->prophesize(NodeInterface::class);
+        $event->getNode()->willReturn($node->reveal());
+
+        $document = $this->prophesize(TimestampBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $this->propertyEncoder->encode('system', 'changed', 'de')->willReturn('changed');
+
+        $node->setProperty('changed', Argument::type(\DateTime::class))->shouldBeCalled();
+
+        $this->subscriber->setChangedForRestore($event->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
@@ -12,13 +12,14 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\LocaleSubscriber;
 
-class LocaleSubscriberTest extends \PHPUnit_Framework_TestCase
+class LocaleSubscriberTest extends TestCase
 {
     public function setUp()
     {
@@ -39,7 +40,7 @@ class LocaleSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydrateNotImplementing()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing)->shouldBeCalled();
         $this->subscriber->handleLocale($this->hydrateEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\LocaleSubscriber;
+
+class LocaleSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->notImplementing = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->document = new TestLocaleDocument();
+        $this->accessor = new DocumentAccessor($this->document);
+        $this->registry = $this->prophesize(DocumentRegistry::class);
+
+        $this->subscriber = new LocaleSubscriber(
+            $this->registry->reveal()
+        );
+    }
+
+    /**
+     * It should return early when not implementing.
+     */
+    public function testHydrateNotImplementing()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->subscriber->handleLocale($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should set the node name on the document.
+     */
+    public function testHydrate()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getAccessor()->willReturn($this->accessor);
+        $this->registry->getLocaleForDocument($this->document)->willReturn('fr');
+
+        $this->subscriber->handleLocale($this->hydrateEvent->reveal());
+
+        $this->assertEquals('fr', $this->document->getLocale());
+    }
+}
+
+class TestLocaleDocument implements LocaleBehavior
+{
+    private $locale;
+
+    private $originalLocale;
+
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    public function getOriginalLocale()
+    {
+        return $this->originalLocale;
+    }
+
+    public function setOriginalLocale($originalLocale)
+    {
+        $this->originalLocale = $originalLocale;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/MixinSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/MixinSubscriberTest.php
@@ -12,13 +12,14 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\MixinSubscriber;
 
-class MixinSubscriberTest extends \PHPUnit_Framework_TestCase
+class MixinSubscriberTest extends TestCase
 {
     /**
      * @var MetadataFactoryInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/MixinSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/MixinSubscriberTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\MixinSubscriber;
+
+class MixinSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var MixinSubscriber
+     */
+    private $mixinSubscriber;
+
+    public function setUp()
+    {
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->mixinSubscriber = new MixinSubscriber($this->metadataFactory->reveal());
+    }
+
+    public function testSetDocumentMixinsOnNode()
+    {
+        $event = $this->prophesize(AbstractMappingEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('jcr:uuid')->willReturn(false);
+        $metadata = $this->prophesize(Metadata::class);
+        $metadata->getPhpcrType()->willReturn('phpcr:type');
+        $document = new \stdClass();
+
+        $this->metadataFactory->getMetadataForClass(get_class($document))->willReturn($metadata->reveal());
+
+        $event->getNode()->willReturn($node->reveal());
+        $event->getDocument()->willReturn($document);
+
+        $node->addMixin('phpcr:type')->shouldBeCalled();
+        $node->setProperty('jcr:uuid', Argument::type('string'))->shouldBeCalled();
+
+        $this->mixinSubscriber->setDocumentMixinsOnNode($event->reveal());
+    }
+
+    public function testSetDocumentMixinsOnNodeWithUuid()
+    {
+        $event = $this->prophesize(AbstractMappingEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $node->hasProperty('jcr:uuid')->willReturn(true);
+        $node->getMixinNodeTypes()->willReturn([]);
+        $metadata = $this->prophesize(Metadata::class);
+        $metadata->getPhpcrType()->willReturn('phpcr:type');
+        $document = new \stdClass();
+
+        $this->metadataFactory->getMetadataForClass(get_class($document))->willReturn($metadata->reveal());
+
+        $event->getNode()->willReturn($node->reveal());
+        $event->getDocument()->willReturn($document);
+
+        $node->removeMixin(Argument::cetera())->shouldNotBeCalled();
+        $node->addMixin('phpcr:type')->shouldBeCalled();
+        $node->setProperty('jcr:uuid', Argument::type('string'))->shouldNotBeCalled();
+
+        $this->mixinSubscriber->setDocumentMixinsOnNode($event->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
@@ -12,12 +12,13 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping\Mapping;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\NodeNameSubscriber;
 
-class NodeNameSubscriberTest extends \PHPUnit_Framework_TestCase
+class NodeNameSubscriberTest extends TestCase
 {
     /**
      * @var HydrateEvent
@@ -65,7 +66,7 @@ class NodeNameSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydrateNotImplementing()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing)->shouldBeCalled();
         $this->subscriber->setFinalNodeName($this->hydrateEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping\Mapping;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\NodeNameBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\NodeNameSubscriber;
+
+class NodeNameSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var \stdClass
+     */
+    private $notImplementing;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var TestNodeNameDocument
+     */
+    private $document;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var NodeNameSubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->notImplementing = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->document = new TestNodeNameDocument();
+        $this->accessor = new DocumentAccessor($this->document);
+
+        $this->subscriber = new NodeNameSubscriber();
+    }
+
+    /**
+     * It should return early when not implementing.
+     */
+    public function testHydrateNotImplementing()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->subscriber->setFinalNodeName($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should set the node name on the document.
+     */
+    public function testHydrate()
+    {
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getAccessor()->willReturn($this->accessor);
+        $this->node->getName()->willReturn('hello');
+
+        $this->subscriber->setFinalNodeName($this->hydrateEvent->reveal());
+
+        $this->assertEquals('hello', $this->document->getNodeName());
+    }
+}
+
+class TestNodeNameDocument implements NodeNameBehavior
+{
+    private $nodeName;
+
+    public function getNodeName()
+    {
+        return $this->nodeName;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
 use Sulu\Component\DocumentManager\DocumentInspector;
@@ -22,7 +23,7 @@ use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ParentSubscriber;
 
-class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
+class ParentSubscriberTest extends TestCase
 {
     /**
      * @var HydrateEvent
@@ -103,7 +104,7 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testHydrateNotImplementing()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing)->shouldBeCalled();
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
     }
 
@@ -126,12 +127,12 @@ class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
 
     public function testHydrateParentNoUuid()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
-        $this->hydrateEvent->getOptions()->willReturn(['test' => true]);
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal())->shouldBeCalled();
+        $this->hydrateEvent->getOptions()->willReturn(['test' => true])->shouldBeCalled();
 
-        $this->node->getParent()->willReturn($this->parentNode->reveal());
-        $this->node->getDepth()->willReturn(2);
-        $this->parentNode->hasProperty('jcr:uuid')->willReturn(false);
+        $this->node->getParent()->willReturn($this->parentNode->reveal())->shouldBeCalled();
+        $this->node->getDepth()->willReturn(2)->shouldBeCalled();
+        $this->parentNode->hasProperty('jcr:uuid')->willReturn(false)->shouldBeCalled();
 
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
     }

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/ParentSubscriberTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
+use Sulu\Component\DocumentManager\DocumentInspector;
+use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ParentSubscriber;
+
+class ParentSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var MoveEvent
+     */
+    private $moveEvent;
+
+    /**
+     * @var ParentBehavior
+     */
+    private $document;
+
+    /**
+     * @var \stdClass
+     */
+    private $notImplementing;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var \stdClass
+     */
+    private $parentDocument;
+
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $inspector;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @var ParentSubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->moveEvent = $this->prophesize(MoveEvent::class);
+        $this->document = $this->prophesize(ParentBehavior::class);
+        $this->notImplementing = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->parentDocument = new \stdClass();
+        $this->proxyFactory = $this->prophesize(ProxyFactory::class);
+        $this->inspector = $this->prophesize(DocumentInspector::class);
+        $this->documentManager = $this->prophesize(DocumentManager::class);
+
+        $this->subscriber = new ParentSubscriber(
+            $this->proxyFactory->reveal(),
+            $this->inspector->reveal(),
+            $this->documentManager->reveal()
+        );
+
+        $this->hydrateEvent->getNode()->willReturn($this->node);
+    }
+
+    public function testHydrateNotImplementing()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    public function testHydrateParent()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
+        $this->hydrateEvent->getOptions()->willReturn(['test' => true]);
+
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->node->getDepth()->willReturn(2);
+
+        $this->proxyFactory->createProxyForNode($this->document->reveal(), $this->parentNode->reveal(), ['test' => true])
+            ->willReturn($this->parentDocument);
+        $this->parentNode->hasProperty('jcr:uuid')->willReturn(true);
+
+        $this->document->setParent($this->parentDocument)->shouldBeCalled();
+
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    public function testHydrateParentNoUuid()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
+        $this->hydrateEvent->getOptions()->willReturn(['test' => true]);
+
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->node->getDepth()->willReturn(2);
+        $this->parentNode->hasProperty('jcr:uuid')->willReturn(false);
+
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testThrowExceptionRootNode()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->document->reveal());
+
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->node->getDepth()->willReturn(0);
+
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    public function testMove()
+    {
+        $this->moveEvent->getDocument()->willReturn($this->document);
+        $this->inspector->getNode($this->document)->willReturn($this->node);
+
+        $this->node->getParent()->willReturn($this->parentNode);
+        $this->parentNode->hasProperty('jcr:uuid')->willReturn(true);
+        $this->document->setParent(Argument::any())->shouldBeCalled();
+
+        $this->subscriber->handleMove($this->moveEvent->reveal());
+    }
+
+    public function testHandleChangeParent()
+    {
+        $persistEvent = $this->prophesize(PersistEvent::class);
+        $persistEvent->getDocument()->willReturn($this->document->reveal());
+        $persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->inspector->getNode($this->document->reveal())->willReturn($this->node->reveal());
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+
+        $newParentNode = $this->prophesize(NodeInterface::class);
+        $newParentNode->getPath()->willReturn('/path/to/new/parent');
+        $persistEvent->getParentNode()->willReturn($newParentNode->reveal());
+
+        $this->documentManager->move($this->document->reveal(), '/path/to/new/parent')->shouldBeCalled();
+
+        $this->subscriber->handleChangeParent($persistEvent->reveal());
+    }
+
+    public function testHandleChangeParentWithSameParent()
+    {
+        $persistEvent = $this->prophesize(PersistEvent::class);
+        $persistEvent->getDocument()->willReturn($this->document->reveal());
+        $persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->inspector->getNode($this->document->reveal())->willReturn($this->node->reveal());
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+
+        $this->documentManager->move(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleChangeParent($persistEvent->reveal());
+    }
+
+    public function testHandleChangeParentWithWrongDocument()
+    {
+        $persistEvent = $this->prophesize(PersistEvent::class);
+        $persistEvent->getDocument(new \stdClass());
+
+        $this->documentManager->move(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleChangeParent($persistEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/PathSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/PathSubscriberTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentInspector;
+use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\PathSubscriber;
+
+class PathSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractMappingEvent
+     */
+    private $abstractMappingEvent;
+
+    /**
+     * @var PathBehavior
+     */
+    private $document;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $pathNode;
+
+    /**
+     * @var \stdClass
+     */
+    private $pathDocument;
+
+    /**
+     * @var DocumentInspector
+     */
+    private $inspector;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var PathSubscriber
+     */
+    private $pathSubscriber;
+
+    public function setUp()
+    {
+        $this->abstractMappingEvent = $this->prophesize(AbstractMappingEvent::class);
+        $this->document = $this->prophesize(PathBehavior::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->pathNode = $this->prophesize(NodeInterface::class);
+        $this->pathDocument = new \stdClass();
+        $this->inspector = $this->prophesize(DocumentInspector::class);
+        $this->accessor = $this->prophesize(DocumentAccessor::class);
+        $this->abstractMappingEvent->getAccessor()->willReturn($this->accessor);
+
+        $this->pathSubscriber = new PathSubscriber(
+            $this->inspector->reveal()
+        );
+    }
+
+    public function testSetInitialPathNotImplementing()
+    {
+        $this->abstractMappingEvent->getDocument()->willReturn(\stdClass::class);
+        $this->accessor->set(Argument::cetera())->shouldNotBeCalled();
+        $this->pathSubscriber->setInitialPath($this->abstractMappingEvent->reveal());
+    }
+
+    public function testSetInitialPath()
+    {
+        $this->abstractMappingEvent->getDocument()->willReturn($this->document->reveal());
+
+        $this->inspector->getPath($this->document->reveal())->willReturn('/path/to');
+        $this->accessor->set('path', '/path/to')->shouldBeCalled();
+
+        $this->pathSubscriber->setInitialPath($this->abstractMappingEvent->reveal());
+    }
+
+    public function testSetFinalPathNotImplementing()
+    {
+        $this->abstractMappingEvent->getDocument()->willReturn(\stdClass::class);
+        $this->accessor->set(Argument::cetera())->shouldNotBeCalled();
+        $this->pathSubscriber->setFinalPath($this->abstractMappingEvent->reveal());
+    }
+
+    public function testSetFinalPath()
+    {
+        $this->abstractMappingEvent->getDocument()->willReturn($this->document->reveal());
+
+        $this->inspector->getPath($this->document->reveal())->willReturn('/path/to');
+        $this->accessor->set('path', '/path/to')->shouldBeCalled();
+
+        $this->pathSubscriber->setFinalPath($this->abstractMappingEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/PathSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/PathSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Behavior\Mapping\PathBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
@@ -19,7 +20,7 @@ use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\Event\AbstractMappingEvent;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\PathSubscriber;
 
-class PathSubscriberTest extends \PHPUnit_Framework_TestCase
+class PathSubscriberTest extends TestCase
 {
     /**
      * @var AbstractMappingEvent

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\UuidSubscriber;
+
+class UuidSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->notImplementing = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->document = new TestUuidDocument();
+        $this->accessor = new DocumentAccessor($this->document);
+
+        $this->subscriber = new UuidSubscriber();
+    }
+
+    /**
+     * It should return early when not implementing.
+     */
+    public function testHydrateNotImplementing()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->subscriber->handleUuid($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should set the node name on the document.
+     */
+    public function testUuid()
+    {
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getAccessor()->willReturn($this->accessor);
+        $this->node->getIdentifier()->willReturn('hello');
+
+        $this->subscriber->handleUuid($this->hydrateEvent->reveal());
+
+        $this->assertEquals('hello', $this->document->getUuid());
+    }
+}
+
+class TestUuidDocument implements UuidBehavior
+{
+    private $uuid;
+
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
@@ -12,12 +12,13 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\UuidSubscriber;
 
-class UuidSubscriberTest extends \PHPUnit_Framework_TestCase
+class UuidSubscriberTest extends TestCase
 {
     public function setUp()
     {
@@ -35,7 +36,7 @@ class UuidSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testHydrateNotImplementing()
     {
-        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing);
+        $this->hydrateEvent->getDocument()->willReturn($this->notImplementing)->shouldBeCalled();
         $this->subscriber->handleUuid($this->hydrateEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Sulu\Component\DocumentManager\Behavior\Path\AliasFilingBehavior;
+use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber;
+
+class AliasFilingSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var AliasFilingBehavior
+     */
+    private $document;
+
+    /**
+     * @var \stdClass
+     */
+    private $parentDocument;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var MetaData
+     */
+    private $metadata;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var SessionInterface
+     */
+    private $defaultSession;
+
+    /**
+     * @var NodeInterface
+     */
+    private $defaultNode;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    /**
+     * @var NodeInterface
+     */
+    private $liveNode;
+
+    /**
+     * @var AliasFilingSubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->persistEvent = $this->prophesize(PersistEvent::class);
+        $this->document = $this->prophesize(AliasFilingBehavior::class);
+        $this->parentDocument = new \stdClass();
+        $this->documentManager = $this->prophesize(DocumentManager::class);
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->defaultSession = $this->prophesize(SessionInterface::class);
+        $this->defaultNode = $this->prophesize(NodeInterface::class);
+        $this->liveSession = $this->prophesize(SessionInterface::class);
+        $this->liveNode = $this->prophesize(NodeInterface::class);
+
+        $this->metadataFactory->getMetadataForClass(get_class($this->document->reveal()))
+            ->willReturn($this->metadata->reveal());
+        $this->defaultSession->getRootNode()->willReturn($this->defaultNode->reveal());
+        $this->liveSession->getRootNode()->willReturn($this->liveNode->reveal());
+
+        $this->subscriber = new AliasFilingSubscriber(
+            $this->defaultSession->reveal(),
+            $this->liveSession->reveal(),
+            $this->metadataFactory->reveal()
+        );
+    }
+
+    /**
+     * It should return early if the document is not implementing the behavior.
+     */
+    public function testPersistNotImplementing()
+    {
+        $this->persistEvent->getDocument()->willReturn(new \stdClass());
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should set the parent document.
+     */
+    public function testSetParentDocument()
+    {
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->persistEvent->hasParentNode()->willReturn(true);
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+        $this->parentNode->getPath()->willReturn('/cmf');
+        $this->metadata->getAlias()->willReturn('banner');
+
+        $defaultCmfNode = $this->prophesize(NodeInterface::class);
+        $this->defaultNode->hasNode('cmf')->willReturn(true);
+        $this->defaultNode->getNode('cmf')->willReturn($defaultCmfNode->reveal());
+
+        $defaultBannerNode = $this->prophesize(NodeInterface::class);
+        $defaultCmfNode->hasNode('banners')->willReturn(false);
+        $defaultCmfNode->addNode('banners')->willReturn($defaultBannerNode->reveal());
+
+        $liveCmfNode = $this->prophesize(NodeInterface::class);
+        $this->liveNode->hasNode('cmf')->willReturn(true);
+        $this->liveNode->getNode('cmf')->willReturn($liveCmfNode->reveal());
+
+        $liveBannerNode = $this->prophesize(NodeInterface::class);
+        $liveCmfNode->hasNode('banners')->willReturn(false);
+        $liveCmfNode->addNode('banners')->willReturn($liveBannerNode->reveal());
+
+        $this->persistEvent->setParentNode($defaultBannerNode->reveal())->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Pa
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Behavior\Path\AliasFilingBehavior;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
@@ -20,7 +21,7 @@ use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber;
 
-class AliasFilingSubscriberTest extends \PHPUnit_Framework_TestCase
+class AliasFilingSubscriberTest extends TestCase
 {
     /**
      * @var PersistEvent
@@ -113,7 +114,7 @@ class AliasFilingSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testPersistNotImplementing()
     {
-        $this->persistEvent->getDocument()->willReturn(new \stdClass());
+        $this->persistEvent->getDocument()->willReturn(new \stdClass())->shouldBeCalled();
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Behavior\Path;
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
 use Sulu\Component\DocumentManager\DocumentRegistry;
@@ -25,7 +26,7 @@ use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber;
 use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
 
-class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
+class AutoNameSubscriberTest extends TestCase
 {
     const DEFAULT_LOCALE = 'en';
 
@@ -144,9 +145,9 @@ class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
     public function testNotInstanceOfAutoName()
     {
         $document = new \stdClass();
-        $this->persistEvent->getOption('auto_name')->willReturn(true);
-        $this->persistEvent->hasNode()->willReturn(false);
-        $this->persistEvent->getDocument()->willReturn($document);
+        $this->persistEvent->getOption('auto_name')->willReturn(true)->shouldBeCalled();
+        $this->persistEvent->hasNode()->shouldNotBeCalled();
+        $this->persistEvent->getDocument()->willReturn($document)->shouldBeCalled();
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 
@@ -155,7 +156,7 @@ class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoTitle()
     {
-        $this->setExpectedException(DocumentManagerException::class);
+        $this->expectException(DocumentManagerException::class);
 
         $this->persistEvent->hasNode()->willReturn(false);
         $this->document->getTitle()->willReturn(null);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -24,7 +24,7 @@ use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\NameResolver;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber;
-use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+use Symfony\Cmf\Api\Slugifier\SlugifierInterface;
 
 class AutoNameSubscriberTest extends TestCase
 {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -203,22 +203,6 @@ class AutoNameSubscriberTest extends TestCase
     }
 
     /**
-     * It should rename the node if the document is being saved in the default locale.
-     */
-    public function testAlreadyHasNode()
-    {
-        $this->persistEvent->getNode()->willReturn($this->node->reveal());
-        $this->persistEvent->getLocale()->willReturn(self::DEFAULT_LOCALE);
-        $this->doTestAutoName('hai-bye', 'hai-2', false, true);
-        $this->node->getParent()->willReturn($this->parentNode->reveal());
-        $this->parentNode->getNodeNames()->willReturn(['hai-bye']);
-        $this->node->hasNode()->willReturn(true);
-        $this->node->getName()->willReturn('foo');
-
-        $this->subscriber->handlePersist($this->persistEvent->reveal());
-    }
-
-    /**
      * It should not rename the node if the document is being saved a non-default locale.
      */
     public function testAlreadyHasNodeNonDefaultLocale()

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -1,0 +1,390 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Behavior\Path;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Behavior\Path\AutoNameBehavior;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\NameResolver;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber;
+use Symfony\Cmf\Bundle\CoreBundle\Slugifier\SlugifierInterface;
+
+class AutoNameSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    const DEFAULT_LOCALE = 'en';
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var SlugifierInterface
+     */
+    private $slugifier;
+
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var MoveEvent
+     */
+    private $moveEvent;
+
+    /**
+     * @var AutoNameBehavior
+     */
+    private $document;
+
+    /**
+     * @var \stdClass
+     */
+    private $parentDocument;
+
+    /**
+     * @var NodeInterface
+     */
+    private $newNode;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var Metadata
+     */
+    private $metadata;
+
+    /**
+     * @var \stdClass
+     */
+    private $parent;
+
+    /**
+     * @var NameResolver
+     */
+    private $resolver;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var AutoNameSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var SessionInterface
+     */
+    private $liveSession;
+
+    public function setUp()
+    {
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->slugifier = $this->prophesize(SlugifierInterface::class);
+        $this->persistEvent = $this->prophesize(PersistEvent::class);
+        $this->moveEvent = $this->prophesize(MoveEvent::class);
+        $this->document = $this->prophesize(AutoNameBehavior::class);
+        $this->parentDocument = new \stdClass();
+        $this->newNode = $this->prophesize(NodeInterface::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->parent = new \stdClass();
+        $this->documentRegistry->getDefaultLocale()->willReturn(self::DEFAULT_LOCALE);
+        $this->resolver = $this->prophesize(NameResolver::class);
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->liveSession = $this->prophesize(SessionInterface::class);
+
+        $this->subscriber = new AutoNameSubscriber(
+            $this->documentRegistry->reveal(),
+            $this->slugifier->reveal(),
+            $this->resolver->reveal(),
+            $this->nodeManager->reveal(),
+            $this->session->reveal(),
+            $this->liveSession->reveal()
+        );
+    }
+
+    /**
+     * It should return early if the document is not an instance of AutoName behavior.
+     */
+    public function testNotInstanceOfAutoName()
+    {
+        $document = new \stdClass();
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->hasNode()->willReturn(false);
+        $this->persistEvent->getDocument()->willReturn($document);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should throw an exception if the document has no title.
+     */
+    public function testNoTitle()
+    {
+        $this->setExpectedException(DocumentManagerException::class);
+
+        $this->persistEvent->hasNode()->willReturn(false);
+        $this->document->getTitle()->willReturn(null);
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getOption('auto_rename')->willReturn(true);
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should assign a name based on the documents title.
+     */
+    public function testAutoName()
+    {
+        $this->doTestAutoName('hai', 'hai', true, false);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not assign a new name, if the option says it is disabled.
+     */
+    public function testAutoNameWithDisabledOption()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(false);
+        $this->persistEvent->getDocument()->willReturn($this->prophesize(AutoNameBehavior::class)->reveal());
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->node->rename(Argument::any())->shouldNotBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not assign a new name, if a not supported document is passed.
+     */
+    public function testAutoNameWithNotSupportedDocument()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(false);
+        $this->persistEvent->getDocument()->willReturn(new \stdClass());
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->node->rename(Argument::any())->shouldNotBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should rename the node if the document is being saved in the default locale.
+     */
+    public function testAlreadyHasNode()
+    {
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->getLocale()->willReturn(self::DEFAULT_LOCALE);
+        $this->doTestAutoName('hai-bye', 'hai-2', false, true);
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+        $this->parentNode->getNodeNames()->willReturn(['hai-bye']);
+        $this->node->hasNode()->willReturn(true);
+        $this->node->getName()->willReturn('foo');
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not rename the node if the document is being saved a non-default locale.
+     */
+    public function testAlreadyHasNodeNonDefaultLocale()
+    {
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->getLocale()->willReturn('ay');
+        $this->doTestAutoName('hai-bye', 'hai-2', false, true);
+        $this->node->rename('hai-bye')->shouldNotBeCalled();
+        $this->node->hasNode()->willReturn(true);
+        $this->node->getName()->willReturn('foo');
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should ensure there is no confict when moving a node.
+     */
+    public function testMoveConflict()
+    {
+        $this->moveEvent->getDocument()->willReturn($this->document);
+        $this->moveEvent->getDestId()->willReturn(1234);
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->nodeManager->find(1234)->willReturn($this->node->reveal());
+        $this->node->getName()->willReturn('foo');
+        $this->resolver->resolveName($this->node->reveal(), 'foo')->willReturn('foobar');
+        $this->moveEvent->setDestName('foobar')->shouldBeCalled();
+
+        $this->subscriber->handleMove($this->moveEvent->reveal());
+    }
+
+    /**
+     * It should rename the node.
+     */
+    public function testRename()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getOption('auto_rename')->willReturn(true);
+        $this->persistEvent->getOption('auto_name_locale')->willReturn('en');
+        $this->persistEvent->hasNode()->willReturn(true);
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+        $this->persistEvent->getLocale()->willReturn('en');
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+
+        $this->node->isNew()->willReturn(false);
+        $this->node->getIdentifier()->willReturn('123-123-123');
+        $this->node->getName()->willReturn('foobar');
+        $this->node->getParent()->willReturn($this->parentNode->reveal());
+
+        $this->document->getTitle()->willReturn('Test');
+        $this->slugifier->slugify('Test')->willReturn('test');
+        $this->resolver->resolveName($this->parentNode->reveal(), 'test', $this->node->reveal(), true)->willReturn('test');
+
+        $liveNode = $this->prophesize(NodeInterface::class);
+        $liveNode->getName()->willReturn('foobar');
+        $liveNode->getParent()->willReturn($this->parentNode->reveal());
+        $this->session->getNodeByIdentifier('123-123-123')->willReturn($this->node->reveal());
+        $this->liveSession->getNodeByIdentifier('123-123-123')->willReturn($liveNode->reveal());
+
+        $liveNode->rename('test')->shouldNotBeCalled();
+        $this->node->rename('test')->shouldNotBeCalled();
+        $this->subscriber->handleScheduleRename($this->persistEvent->reveal());
+
+        $this->documentRegistry->getDocumentForNode($this->node->reveal(), 'en')->willReturn($this->document->reveal());
+
+        $liveNode->rename('test')->shouldBeCalled();
+        $this->node->rename('test')->shouldBeCalled();
+        $this->subscriber->handleRename();
+    }
+
+    /**
+     * It should not rename the node for auto_name false.
+     */
+    public function testRenameAutoNameFalse()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(false);
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+
+        $this->node->rename(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleRename($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not rename the node for a document which does not implement AutoNameBehavior.
+     */
+    public function testRenameWrongDocument()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getDocument()->willReturn(new \stdClass());
+
+        $this->node->rename(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleRename($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not rename the node for not for a locale which is not default.
+     */
+    public function testRenameNotDefaultLocale()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getOption('auto_name_locale')->willReturn('en');
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->persistEvent->getLocale()->willReturn('de');
+
+        $this->node->rename(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleRename($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not rename the node if no node isset.
+     */
+    public function testRenameForNoNode()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getOption('auto_name_locale')->willReturn('en');
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->persistEvent->getLocale()->willReturn('en');
+        $this->persistEvent->hasNode()->willReturn(false);
+
+        $this->node->rename(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleRename($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not rename the node if node is new.
+     */
+    public function testRenameForNewNode()
+    {
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getOption('auto_name_locale')->willReturn('en');
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->persistEvent->getLocale()->willReturn('en');
+        $this->persistEvent->hasNode()->willReturn(true);
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->node->isNew()->willReturn(true);
+
+        $this->node->rename(Argument::cetera())->shouldNotBeCalled();
+
+        $this->subscriber->handleRename($this->persistEvent->reveal());
+    }
+
+    private function doTestAutoName($title, $expectedName, $create = false, $hasNode = false, $slugifiedName = null)
+    {
+        $slugifiedName = $slugifiedName ?: $title;
+
+        $this->persistEvent->getOption('auto_name')->willReturn(true);
+        $this->persistEvent->getOption('auto_rename')->willReturn(true);
+        $this->persistEvent->hasNode()->willReturn($hasNode);
+        $node = $hasNode ? $this->node->reveal() : null;
+
+        $this->document->getTitle()->willReturn($title);
+        $this->document->getParent()->willReturn($this->parent);
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->slugifier->slugify($title)->willReturn($title);
+
+        $this->resolver->resolveName($this->parentNode->reveal(), $slugifiedName, $node, true)->willReturn($slugifiedName);
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+
+        if (!$create) {
+            return;
+        }
+
+        $this->parentNode->addNode($expectedName)->shouldBeCalled()->willReturn($this->newNode->reveal());
+        $this->persistEvent->setNode($this->newNode->reveal())->shouldBeCalled();
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Behavior\Path\BasePathBehavior;
+use Sulu\Component\DocumentManager\DocumentManager;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\BasePathSubscriber;
+
+class BasePathSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var \stdClass
+     */
+    private $notImplementing;
+
+    /**
+     * @var BasePathBehavior
+     */
+    private $document;
+
+    /**
+     * @var \stdClass
+     */
+    private $parentDocument;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var MetaData
+     */
+    private $metadata;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var AliasFilingSubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->persistEvent = $this->prophesize(PersistEvent::class);
+        $this->notImplementing = new \stdClass();
+        $this->document = $this->prophesize(BasePathBehavior::class);
+        $this->parentDocument = new \stdClass();
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->documentManager = $this->prophesize(DocumentManager::class);
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+
+        $this->subscriber = new BasePathSubscriber(
+            $this->nodeManager->reveal(),
+            '/base/path'
+        );
+    }
+
+    /**
+     * It should return early if the document is not implementing the behavior.
+     */
+    public function testPersistNotImplementing()
+    {
+        $this->persistEvent->getDocument()->willReturn($this->notImplementing);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should set the parent document.
+     */
+    public function testSetParentDocument()
+    {
+        $this->persistEvent->getDocument()->willReturn($this->document->reveal());
+        $this->persistEvent->getLocale()->willReturn('fr');
+        $this->metadataFactory->getMetadataForClass(get_class($this->document->reveal()))->willReturn(
+            $this->metadata->reveal()
+        );
+        $this->metadata->getAlias()->willReturn('test');
+        $this->nodeManager->createPath('/base/path')->willReturn($this->parentNode->reveal());
+
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->documentManager->find('/base/path/tests', 'fr')->willReturn($this->parentDocument);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Behavior\Path\BasePathBehavior;
 use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
@@ -21,7 +22,7 @@ use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AliasFilingSubscriber;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\BasePathSubscriber;
 
-class BasePathSubscriberTest extends \PHPUnit_Framework_TestCase
+class BasePathSubscriberTest extends TestCase
 {
     /**
      * @var PersistEvent
@@ -96,7 +97,7 @@ class BasePathSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testPersistNotImplementing()
     {
-        $this->persistEvent->getDocument()->willReturn($this->notImplementing);
+        $this->persistEvent->getDocument()->willReturn($this->notImplementing)->shouldBeCalled();
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
@@ -1,0 +1,276 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
+
+use PHPCR\ItemExistsException;
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\ExplicitSubscriber;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var \stdClass
+     */
+    private $document;
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var ConfigureOptionsEvent
+     */
+    private $configureEvent;
+
+    /**
+     * @var NodeInterface
+     */
+    private $parentNode;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var ExplicitSubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->persistEvent = $this->prophesize(PersistEvent::class);
+        $this->document = new \stdClass();
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->configureEvent = $this->prophesize(ConfigureOptionsEvent::class);
+        $this->parentNode = $this->prophesize(NodeInterface::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+
+        $this->subscriber = new ExplicitSubscriber(
+            $this->nodeManager->reveal()
+        );
+    }
+
+    /**
+     * It should throw an exception if both path name and node_name options are given.
+     *
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testExceptionNodeNameAndPath()
+    {
+        $options = $this->resolveOptions([
+            'path' => '/path/to/nodename',
+            'node_name' => '/foo',
+        ]);
+        $this->persistEvent->getOptions()->willReturn($options);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should throw an exception if both path name and parent_path options are given.
+     *
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testExceptionParentPathAndPath()
+    {
+        $options = $this->resolveOptions([
+            'path' => '/path/to/nodename',
+            'parent_path' => '/foo',
+        ]);
+        $this->persistEvent->getOptions()->willReturn($options);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should set the parent node and create a new node when given a full path.
+     */
+    public function testNewNodeFromPath()
+    {
+        $options = $this->resolveOptions(['path' => '/path/to/nodename']);
+        $this->nodeManager->find('/path/to')->willReturn($this->parentNode->reveal());
+        $this->parentNode->hasNode('nodename')->shouldBeCalled()->willReturn(false);
+        $this->parentNode->addNode('nodename')->shouldBeCalled()->willReturn($this->node->reveal());
+
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+        $this->persistEvent->hasParentNode()->willReturn(true);
+        $this->persistEvent->getOptions()->willReturn($options);
+        $this->persistEvent->hasNode()->willReturn(false);
+        $this->persistEvent->setNode($this->node->reveal())->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should use a new node when override flag is true.
+     */
+    public function testNewNodeFromPathOverwrite()
+    {
+        $options = $this->resolveOptions(['path' => '/path/to/nodename', 'override' => true]);
+        $this->nodeManager->find('/path/to')->willReturn($this->parentNode->reveal());
+        $this->parentNode->hasNode('nodename')->shouldBeCalled()->willReturn(true);
+        $this->parentNode->addNode('nodename')->shouldNotBeCalled();
+        $this->parentNode->getNode('nodename')->shouldBeCalled()->willReturn($this->node->reveal());
+
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+        $this->persistEvent->hasParentNode()->willReturn(true);
+        $this->persistEvent->getOptions()->willReturn($options);
+        $this->persistEvent->hasNode()->willReturn(false);
+        $this->persistEvent->setNode($this->node->reveal())->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should throw exception when override flag is false.
+     */
+    public function testNewNodeFromPathNoOverwrite()
+    {
+        $this->setExpectedException(
+            ItemExistsException::class,
+            'The node \'/path/to\' already has a child named \'nodename\'.'
+        );
+
+        // override default false
+        $options = $this->resolveOptions(['path' => '/path/to/nodename']);
+        $this->nodeManager->find('/path/to')->willReturn($this->parentNode->reveal());
+        $this->parentNode->hasNode('nodename')->shouldBeCalled()->willReturn(true);
+        $this->parentNode->addNode('nodename')->shouldNotBeCalled();
+        $this->parentNode->getNode('nodename')->shouldNotBeCalled();
+        $this->parentNode->getPath()->willReturn('/path/to');
+
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->persistEvent->getParentNode()->willReturn($this->parentNode->reveal());
+        $this->persistEvent->hasParentNode()->willReturn(true);
+        $this->persistEvent->hasNode()->willReturn(false);
+        $this->persistEvent->getOptions()->willReturn($options);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should just set the parent if only the "parent_path" is specified.
+     */
+    public function testSetParentNode()
+    {
+        $options = $this->resolveOptions([
+            'parent_path' => '/path/to',
+        ]);
+
+        $this->nodeManager->find('/path/to')->willReturn($this->parentNode->reveal());
+
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->persistEvent->getOptions()->willReturn($options);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should automatically create the parent path if auto_create is specified.
+     */
+    public function testAutoCreateParent()
+    {
+        $options = $this->resolveOptions([
+            'parent_path' => '/path/to',
+            'auto_create' => true,
+        ]);
+
+        $this->nodeManager->createPath('/path/to')->willReturn($this->parentNode->reveal());
+
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->persistEvent->getOptions()->willReturn($options);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should throw an exception if node_name is specified but no parent node is available.
+     *
+     * @expectedException \Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     */
+    public function testNodeNameButNotParentNode()
+    {
+        $options = $this->resolveOptions([
+            'node_name' => 'foobar',
+        ]);
+
+        $this->nodeManager->createPath('/path/to')->willReturn($this->parentNode->reveal());
+
+        $this->persistEvent->hasParentNode()->willReturn(false);
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->getOptions()->willReturn($options);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should rename the node if the node is already set in the Persist event and
+     * the node name is different.
+     */
+    public function testRename()
+    {
+        $options = $this->resolveOptions([
+            'parent_path' => '/path/to',
+            'node_name' => 'booboo',
+        ]);
+
+        $this->nodeManager->find('/path/to')->willReturn($this->parentNode->reveal());
+
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->setParentNode($this->parentNode->reveal())->shouldBeCalled();
+        $this->persistEvent->getOptions()->willReturn($options);
+        $this->persistEvent->hasNode()->willReturn(true);
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->hasParentNode()->willReturn(true);
+        $this->node->getName()->willReturn('barbar');
+        $this->node->rename('booboo')->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should do nothing if none of the options are specified.
+     */
+    public function testDoNothing()
+    {
+        $options = $this->resolveOptions([]);
+
+        $this->persistEvent->getOptions()->willReturn($options);
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    private function resolveOptions($options)
+    {
+        $resolver = new OptionsResolver();
+        $this->configureEvent->getOptions()->willReturn($resolver);
+        $this->subscriber->configureOptions($this->configureEvent->reveal());
+
+        return $resolver->resolve($options);
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
@@ -13,13 +13,14 @@ namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Pa
 
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\ExplicitSubscriber;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
+class ExplicitSubscriberTest extends TestCase
 {
     /**
      * @var PersistEvent
@@ -148,7 +149,7 @@ class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testNewNodeFromPathNoOverwrite()
     {
-        $this->setExpectedException(
+        $this->expectException(
             ItemExistsException::class,
             'The node \'/path/to\' already has a child named \'nodename\'.'
         );
@@ -260,8 +261,8 @@ class ExplicitSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $options = $this->resolveOptions([]);
 
-        $this->persistEvent->getOptions()->willReturn($options);
-        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->getOptions()->willReturn($options)->shouldBeCalled();
+        $this->persistEvent->getDocument()->willReturn($this->document)->shouldBeCalled();
         $this->subscriber->handlePersist($this->persistEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
@@ -1,0 +1,528 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior;
+
+use Jackalope\Version\Version as JackalopeVersion;
+use Jackalope\Workspace;
+use PHPCR\NodeInterface;
+use PHPCR\NodeType\NodeDefinitionInterface;
+use PHPCR\PropertyInterface;
+use PHPCR\SessionInterface;
+use PHPCR\Version\OnParentVersionAction;
+use PHPCR\Version\VersionHistoryInterface;
+use PHPCR\Version\VersionInterface;
+use PHPCR\Version\VersionManagerInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
+use Sulu\Component\DocumentManager\Behavior\VersionBehavior;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\PublishEvent;
+use Sulu\Component\DocumentManager\Event\RestoreEvent;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\Subscriber\Behavior\VersionSubscriber;
+use Sulu\Component\DocumentManager\Version;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var Workspace
+     */
+    private $workspace;
+
+    /**
+     * @var VersionManagerInterface
+     */
+    private $versionManager;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $propertyEncoder;
+
+    /**
+     * @var \ReflectionProperty
+     */
+    private $checkoutPathsReflection;
+
+    /**
+     * @var \ReflectionProperty
+     */
+    private $checkpointPathsReflection;
+
+    /**
+     * @var VersionSubscriber
+     */
+    private $versionSubscriber;
+
+    public function setUp()
+    {
+        $this->versionManager = $this->prophesize(VersionManagerInterface::class);
+        $this->propertyEncoder = $this->prophesize(PropertyEncoder::class);
+        $this->workspace = $this->prophesize(Workspace::class);
+        $this->workspace->getVersionManager()->willReturn($this->versionManager->reveal());
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->session->getWorkspace()->willReturn($this->workspace->reveal());
+
+        $this->versionSubscriber = new VersionSubscriber($this->session->reveal(), $this->propertyEncoder->reveal());
+
+        $this->checkoutPathsReflection = new \ReflectionProperty(VersionSubscriber::class, 'checkoutUuids');
+        $this->checkoutPathsReflection->setAccessible(true);
+
+        $this->checkpointPathsReflection = new \ReflectionProperty(VersionSubscriber::class, 'checkpointUuids');
+        $this->checkpointPathsReflection->setAccessible(true);
+    }
+
+    public function testSetVersionMixinOnPersist()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+
+        $document = $this->prophesize(VersionBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addMixin('mix:versionable')->shouldBeCalled();
+        $event->getNode()->willReturn($node->reveal());
+
+        $this->versionSubscriber->setVersionMixin($event->reveal());
+    }
+
+    public function testSetVersionMixinOnPersistWithoutVersionBehavior()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+
+        $event->getDocument()->willReturn(new \stdClass());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addMixin(Argument::any())->shouldNotBeCalled();
+        $event->getNode()->willReturn($node->reveal());
+
+        $this->versionSubscriber->setVersionMixin($event->reveal());
+    }
+
+    public function testSetVersionMixinOnPublish()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+
+        $document = $this->prophesize(VersionBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addMixin('mix:versionable')->shouldBeCalled();
+        $event->getNode()->willReturn($node->reveal());
+
+        $this->versionSubscriber->setVersionMixin($event->reveal());
+    }
+
+    public function testSetVersionMixinOnPublishWithoutVersionBehavior()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+
+        $event->getDocument()->willReturn(new \stdClass());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->addMixin(Argument::any())->shouldNotBeCalled();
+        $event->getNode()->willReturn($node->reveal());
+
+        $this->versionSubscriber->setVersionMixin($event->reveal());
+    }
+
+    public function testSetVersionsOnDocument()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+
+        $document = $this->prophesize(VersionBehavior::class);
+        $event->getDocument()->willReturn($document->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPropertyValueWithDefault('sulu:versions', [])
+            ->willReturn([
+                '{"version":"1.0","locale":"de","author":null,"authored":"2016-12-06T09:37:21+01:00"}',
+                '{"version":"1.1","locale":"en","author":1,"authored":"2016-12-05T19:47:22+01:00"}',
+            ]);
+        $event->getNode()->willReturn($node->reveal());
+
+        $document->setVersions(
+            [
+                new Version('1.0', 'de', null, new \DateTime('2016-12-06T09:37:21+01:00')),
+                new Version('1.1', 'en', 1, new \DateTime('2016-12-05T19:47:22+01:00')),
+            ]
+        );
+
+        $this->versionSubscriber->setVersionsOnDocument($event->reveal());
+    }
+
+    public function testSetVersionsOnDocumentWithoutVersionBehavior()
+    {
+        $event = $this->prophesize(HydrateEvent::class);
+        $event->getDocument()->willReturn(new \stdClass());
+        $event->getNode()->shouldNotBeCalled();
+
+        $this->versionSubscriber->setVersionsOnDocument($event->reveal());
+    }
+
+    public function testRememberCheckoutNodes()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $document = $this->prophesize(VersionBehavior::class);
+
+        $event->getNode()->willReturn($node->reveal());
+        $event->getDocument()->willReturn($document->reveal());
+
+        $node->getIdentifier()->willReturn('123-123-13');
+
+        $this->versionSubscriber->rememberCheckoutUuids($event->reveal());
+
+        $this->assertEquals(['123-123-13'], $this->checkoutPathsReflection->getValue($this->versionSubscriber));
+    }
+
+    public function testRememberCheckoutNodesWithoutVersionBehavior()
+    {
+        $event = $this->prophesize(PersistEvent::class);
+        $document = new \stdClass();
+
+        $event->getDocument()->willReturn($document);
+
+        $this->versionSubscriber->rememberCheckoutUuids($event->reveal());
+
+        $this->assertEmpty($this->checkoutPathsReflection->getValue($this->versionSubscriber));
+    }
+
+    public function testRememberCreateVersionNodes()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $document = $this->prophesize(VersionBehavior::class)
+            ->willImplement(LocaleBehavior::class);
+        $document->getLocale()->willReturn('de');
+
+        $event->getNode()->willReturn($node->reveal());
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getOption('user')->willReturn(2);
+
+        $node->getIdentifier()->willReturn('123-123-123');
+
+        $this->versionSubscriber->rememberCreateVersion($event->reveal());
+
+        $this->assertEquals(
+            [['uuid' => '123-123-123', 'locale' => 'de', 'author' => 2]],
+            $this->checkpointPathsReflection->getValue($this->versionSubscriber)
+        );
+    }
+
+    public function testRememberCreateVersionNodesWithoutVersionBehavior()
+    {
+        $event = $this->prophesize(PublishEvent::class);
+        $document = new \stdClass();
+
+        $event->getDocument()->willReturn($document);
+
+        $this->versionSubscriber->rememberCreateVersion($event->reveal());
+    }
+
+    public function testApplyVersionOperations()
+    {
+        ClockMock::register(VersionSubscriber::class);
+        ClockMock::withClockMock(true);
+
+        $this->checkoutPathsReflection->setValue($this->versionSubscriber, ['1-1-1-1', '2-2-2-2']);
+        $this->checkpointPathsReflection->setValue($this->versionSubscriber, [
+            ['uuid' => '3-3-3-3', 'locale' => 'de', 'author' => 1],
+        ]);
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/node1');
+        $this->session->getNodeByIdentifier('1-1-1-1')->willReturn($node->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/node2');
+        $this->session->getNodeByIdentifier('2-2-2-2')->willReturn($node->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/node3');
+        $this->session->getNodeByIdentifier('3-3-3-3')->willReturn($node->reveal());
+
+        $this->versionManager->isCheckedOut('/node1')->willReturn(false);
+        $this->versionManager->isCheckedOut('/node2')->willReturn(true);
+
+        $this->versionManager->checkout('/node1')->shouldBeCalled();
+        $this->versionManager->checkout('/node2')->shouldNotBeCalled();
+
+        $node = $this->prophesize(NodeInterface::class);
+        $this->session->getNode('/node3')->willReturn($node->reveal());
+
+        $version = $this->prophesize(VersionInterface::class);
+        $version->getName()->willReturn('a');
+        $this->versionManager->checkpoint('/node3')->willReturn($version->reveal());
+        $node->getPropertyValueWithDefault('sulu:versions', [])->willReturn([
+            '{"locale":"en","version":"0","author":null,"authored":"2016-12-05T19:47:22+01:00"}',
+        ]);
+        $node->setProperty(
+            'sulu:versions',
+            [
+                '{"locale":"en","version":"0","author":null,"authored":"2016-12-05T19:47:22+01:00"}',
+                '{"locale":"de","version":"a","author":1,"authored":"' . date('c', ClockMock::time()) . '"}',
+            ]
+        )->shouldBeCalled();
+        $this->session->save()->shouldBeCalled();
+
+        $this->versionSubscriber->applyVersionOperations();
+
+        $this->assertEquals([], $this->checkpointPathsReflection->getValue($this->versionSubscriber));
+        $this->assertEquals([], $this->checkoutPathsReflection->getValue($this->versionSubscriber));
+
+        ClockMock::withClockMock(false);
+    }
+
+    public function testApplyVersionOperationsWithMultipleCheckpoints()
+    {
+        $this->checkpointPathsReflection->setValue(
+            $this->versionSubscriber,
+            [
+                ['uuid' => '1-1-1-1', 'locale' => 'de', 'author' => 2],
+                ['uuid' => '1-1-1-1', 'locale' => 'en', 'author' => 3],
+                ['uuid' => '2-2-2-2', 'locale' => 'en', 'author' => 1],
+            ]
+        );
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/node1');
+        $this->session->getNodeByIdentifier('1-1-1-1')->willReturn($node->reveal());
+
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/node2');
+        $this->session->getNodeByIdentifier('2-2-2-2')->willReturn($node->reveal());
+
+        $node1 = $this->prophesize(NodeInterface::class);
+        $node1->getPropertyValueWithDefault('sulu:versions', [])->willReturn(['{"locale":"fr","version":"0","author":1,"authored":"2016-12-05T19:47:22+01:00"}']);
+        $this->session->getNode('/node1')->willReturn($node1->reveal());
+
+        $node2 = $this->prophesize(NodeInterface::class);
+        $node2->getPropertyValueWithDefault('sulu:versions', [])->willReturn(['{"locale":"en","version":"0","author":2,"authored":"2016-12-05T19:47:22+01:00"}']);
+        $this->session->getNode('/node2')->willReturn($node2->reveal());
+
+        $version1 = $this->prophesize(VersionInterface::class);
+        $version2 = $this->prophesize(VersionInterface::class);
+        $version3 = $this->prophesize(VersionInterface::class);
+        $this->versionManager->checkpoint('/node1')->willReturn($version1->reveal());
+        $this->versionManager->checkpoint('/node1')->willReturn($version2->reveal());
+        $this->versionManager->checkpoint('/node2')->willReturn($version3->reveal());
+
+        $version1->getName()->willReturn('a');
+        $version2->getName()->willReturn('b');
+        $version3->getName()->willReturn('c');
+
+        $this->session->save()->shouldBeCalledTimes(1);
+        $node1->setProperty(
+            'sulu:versions',
+            [
+                '{"locale":"fr","version":"0","author":1,"authored":"2016-12-05T19:47:22+01:00"}',
+                '{"locale":"de","version":"b","author":2,"authored":"' . date('c', ClockMock::time()) . '"}',
+                '{"locale":"en","version":"b","author":3,"authored":"' . date('c', ClockMock::time()) . '"}',
+            ]
+        )->shouldBeCalled();
+        $node2->setProperty(
+            'sulu:versions',
+            [
+                '{"locale":"en","version":"0","author":2,"authored":"2016-12-05T19:47:22+01:00"}',
+                '{"locale":"en","version":"c","author":1,"authored":"' . date('c', ClockMock::time()) . '"}',
+            ]
+        )->shouldBeCalled();
+
+        $this->versionSubscriber->applyVersionOperations();
+    }
+
+    public function testRestoreLocalizedProperties()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $document = $this->prophesize(VersionBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $versionHistory = $this->prophesize(VersionHistoryInterface::class);
+        $version = $this->prophesize(JackalopeVersion::class);
+        $frozenNode = $this->prophesize(NodeInterface::class);
+
+        $node->getPath()->willReturn('/node');
+        $property1 = $this->prophesize(PropertyInterface::class);
+        $property1->getName()->willReturn('i18n:de-test');
+        $property2 = $this->prophesize(PropertyInterface::class);
+        $property2->getName()->willReturn('non-translatable-test');
+        $property3 = $this->prophesize(PropertyInterface::class);
+        $property3->getName()->willReturn('jcr:uuid');
+        $node->getProperties()->willReturn([$property1->reveal(), $property2->reveal(), $property3->reveal()]);
+        $node->getNodes()->willReturn([]);
+
+        $property1->remove()->shouldBeCalled();
+        $property2->remove()->shouldBeCalled();
+        $property3->remove()->shouldNotBeCalled();
+
+        $this->propertyEncoder->localizedContentName('', 'de')->willReturn('i18n:de-');
+        $this->propertyEncoder->localizedSystemName('', 'de')->willReturn('i18n:de-');
+
+        $frozenNode->getNodes()->willReturn([]);
+        $frozenNode->getPropertiesValues()->willReturn([
+            'i18n:de-test' => 'Title',
+            'non-translatable-test' => 'Article',
+            'jcr:uuid' => 'asdf',
+        ]);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getVersion()->willReturn('1.0');
+        $event->getLocale()->willReturn('de');
+
+        $this->versionManager->getVersionHistory('/node')->willReturn($versionHistory->reveal());
+        $versionHistory->getVersion('1.0')->willReturn($version->reveal());
+        $version->getFrozenNode()->willReturn($frozenNode->reveal());
+
+        $node->setProperty('i18n:de-test', 'Title')->shouldBeCalled();
+        $node->setProperty('non-translatable-test', 'Article')->shouldBeCalled();
+        $node->setProperty('jcr:uuid', 'asdf')->shouldNotBeCalled();
+
+        $this->versionSubscriber->restoreProperties($event->reveal());
+    }
+
+    public function testRestoreChildren()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $document = $this->prophesize(VersionBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $versionHistory = $this->prophesize(VersionHistoryInterface::class);
+        $version = $this->prophesize(JackalopeVersion::class);
+        $frozenNode = $this->prophesize(NodeInterface::class);
+
+        $node->getPath()->willReturn('/node');
+        $node->getProperties()->willReturn([]);
+        $node->hasNode('child1')->willReturn(false);
+        $node->hasNode('child2')->willReturn(true);
+        $node->hasNode('child3')->willReturn(true);
+
+        $definition = $this->prophesize(NodeDefinitionInterface::class);
+        $definition->getOnParentVersion()->willReturn(OnParentVersionAction::COPY);
+
+        $newChild2Node = $this->prophesize(NodeInterface::class);
+        $newChild2Node->getName()->willReturn('child2');
+        $newChild2Node->getProperties()->willReturn([]);
+        $newChild2Node->getNodes()->willReturn([]);
+        $newChild2Node->getDefinition()->willReturn($definition->reveal());
+
+        $newChild3Node = $this->prophesize(NodeInterface::class);
+        $newChild3Node->getName()->willReturn('child3');
+        $newChild3Node->getDefinition()->willReturn($definition->reveal());
+        $newChild3Node->remove()->shouldBeCalled();
+
+        $newChild1Node = $this->prophesize(NodeInterface::class);
+        $newChild1Node->getName()->willReturn('child1');
+        $newChild1Node->setMixins(['jcr:referencable'])->shouldBeCalled();
+        $newChild1Node->getProperties()->willReturn([]);
+        $newChild1Node->getNodes()->willReturn([]);
+        $newChild1Node->getDefinition()->willReturn($definition->reveal());
+        $node->addNode('child1')->will(
+            function () use ($node, $newChild1Node, $newChild2Node, $newChild3Node) {
+                $node->getNode('child1')->willReturn($newChild1Node->reveal());
+                $node->getNodes()->willReturn(
+                    [$newChild1Node->reveal(), $newChild2Node->reveal(), $newChild3Node->reveal()]
+                );
+
+                return $newChild1Node->reveal();
+            }
+        );
+
+        $node->getNode('child2')->willReturn($newChild2Node->reveal());
+        $node->getNode('child3')->willReturn($newChild3Node->reveal());
+        $node->getNodes()->willReturn([$newChild2Node->reveal(), $newChild3Node->reveal()]);
+
+        $this->propertyEncoder->localizedContentName('', 'de')->willReturn('i18n:de-');
+        $this->propertyEncoder->localizedSystemName('', 'de')->willReturn('i18n:de-');
+
+        $child1 = $this->prophesize(NodeInterface::class);
+        $child1->getName()->willReturn('child1');
+        $child1->getPropertyValueWithDefault('jcr:frozenMixinTypes', [])->willReturn(['jcr:referencable']);
+        $child1->getPropertiesValues()->willReturn([]);
+        $child1->getNodes()->willReturn([]);
+        $child2 = $this->prophesize(NodeInterface::class);
+        $child2->getName()->willReturn('child2');
+        $child2->getPropertiesValues()->willReturn([]);
+        $child2->getNodes()->willReturn([]);
+
+        $frozenNode->getNodes()->willReturn([$child1->reveal(), $child2->reveal()]);
+        $frozenNode->getPropertiesValues()->willReturn([]);
+        $frozenNode->hasNode('child1')->willReturn(true);
+        $frozenNode->hasNode('child2')->willReturn(true);
+        $frozenNode->hasNode('child3')->willReturn(false);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getVersion()->willReturn('1.0');
+        $event->getLocale()->willReturn('de');
+
+        $this->versionManager->getVersionHistory('/node')->willReturn($versionHistory->reveal());
+        $versionHistory->getVersion('1.0')->willReturn($version->reveal());
+        $version->getFrozenNode()->willReturn($frozenNode->reveal());
+
+        $this->versionSubscriber->restoreProperties($event->reveal());
+    }
+
+    public function testRestoreIgnoreChildren()
+    {
+        $event = $this->prophesize(RestoreEvent::class);
+        $document = $this->prophesize(VersionBehavior::class);
+        $node = $this->prophesize(NodeInterface::class);
+        $versionHistory = $this->prophesize(VersionHistoryInterface::class);
+        $version = $this->prophesize(JackalopeVersion::class);
+        $frozenNode = $this->prophesize(NodeInterface::class);
+
+        $node->getPath()->willReturn('/node');
+        $node->getProperties()->willReturn([]);
+        $node->hasNode('child')->willReturn(true);
+
+        $definition = $this->prophesize(NodeDefinitionInterface::class);
+        $definition->getOnParentVersion()->willReturn(OnParentVersionAction::IGNORE);
+
+        $childNode = $this->prophesize(NodeInterface::class);
+        $childNode->getName()->willReturn('child');
+        $childNode->getProperties()->willReturn([]);
+        $childNode->getNodes()->willReturn([]);
+        $childNode->getDefinition()->willReturn($definition->reveal());
+
+        $node->getNode('child')->willReturn($childNode->reveal());
+        $node->getNodes()->willReturn([$childNode->reveal()]);
+
+        $this->propertyEncoder->localizedContentName('', 'de')->willReturn('i18n:de-');
+        $this->propertyEncoder->localizedSystemName('', 'de')->willReturn('i18n:de-');
+
+        $frozenNode->getNodes()->willReturn([]);
+        $frozenNode->getPropertiesValues()->willReturn([]);
+        $frozenNode->hasNode(Argument::type('string'))->willReturn(false);
+
+        $event->getDocument()->willReturn($document->reveal());
+        $event->getNode()->willReturn($node->reveal());
+        $event->getVersion()->willReturn('1.0');
+        $event->getLocale()->willReturn('de');
+
+        $this->versionManager->getVersionHistory('/node')->willReturn($versionHistory->reveal());
+        $versionHistory->getVersion('1.0')->willReturn($version->reveal());
+        $version->getFrozenNode()->willReturn($frozenNode->reveal());
+
+        // the child-node should not be touched
+        $childNode->remove()->shouldNotBeCalled();
+        $childNode->setProperty(Argument::cetera())->shouldNotBeCalled();
+
+        $this->versionSubscriber->restoreProperties($event->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/VersionSubscriberTest.php
@@ -21,6 +21,7 @@ use PHPCR\Version\OnParentVersionAction;
 use PHPCR\Version\VersionHistoryInterface;
 use PHPCR\Version\VersionInterface;
 use PHPCR\Version\VersionManagerInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\DocumentManager\Behavior\VersionBehavior;
@@ -33,7 +34,7 @@ use Sulu\Component\DocumentManager\Subscriber\Behavior\VersionSubscriber;
 use Sulu\Component\DocumentManager\Version;
 use Symfony\Bridge\PhpUnit\ClockMock;
 
-class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
+class VersionSubscriberTest extends TestCase
 {
     /**
      * @var SessionInterface
@@ -147,15 +148,15 @@ class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
         $event = $this->prophesize(HydrateEvent::class);
 
         $document = $this->prophesize(VersionBehavior::class);
-        $event->getDocument()->willReturn($document->reveal());
+        $event->getDocument()->willReturn($document->reveal())->shouldBeCalled();
 
         $node = $this->prophesize(NodeInterface::class);
         $node->getPropertyValueWithDefault('sulu:versions', [])
             ->willReturn([
                 '{"version":"1.0","locale":"de","author":null,"authored":"2016-12-06T09:37:21+01:00"}',
                 '{"version":"1.1","locale":"en","author":1,"authored":"2016-12-05T19:47:22+01:00"}',
-            ]);
-        $event->getNode()->willReturn($node->reveal());
+            ])->shouldBeCalled();
+        $event->getNode()->willReturn($node->reveal())->shouldBeCalled();
 
         $document->setVersions(
             [
@@ -231,7 +232,7 @@ class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
         $event = $this->prophesize(PublishEvent::class);
         $document = new \stdClass();
 
-        $event->getDocument()->willReturn($document);
+        $event->getDocument()->willReturn($document)->shouldBeCalled();
 
         $this->versionSubscriber->rememberCreateVersion($event->reveal());
     }
@@ -248,31 +249,31 @@ class VersionSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $node = $this->prophesize(NodeInterface::class);
         $node->getPath()->willReturn('/node1');
-        $this->session->getNodeByIdentifier('1-1-1-1')->willReturn($node->reveal());
+        $this->session->getNodeByIdentifier('1-1-1-1')->willReturn($node->reveal())->shouldBeCalled();
 
         $node = $this->prophesize(NodeInterface::class);
         $node->getPath()->willReturn('/node2');
-        $this->session->getNodeByIdentifier('2-2-2-2')->willReturn($node->reveal());
+        $this->session->getNodeByIdentifier('2-2-2-2')->willReturn($node->reveal())->shouldBeCalled();
 
         $node = $this->prophesize(NodeInterface::class);
         $node->getPath()->willReturn('/node3');
-        $this->session->getNodeByIdentifier('3-3-3-3')->willReturn($node->reveal());
+        $this->session->getNodeByIdentifier('3-3-3-3')->willReturn($node->reveal())->shouldBeCalled();
 
-        $this->versionManager->isCheckedOut('/node1')->willReturn(false);
-        $this->versionManager->isCheckedOut('/node2')->willReturn(true);
+        $this->versionManager->isCheckedOut('/node1')->willReturn(false)->shouldBeCalled();
+        $this->versionManager->isCheckedOut('/node2')->willReturn(true)->shouldBeCalled();
 
         $this->versionManager->checkout('/node1')->shouldBeCalled();
         $this->versionManager->checkout('/node2')->shouldNotBeCalled();
 
         $node = $this->prophesize(NodeInterface::class);
-        $this->session->getNode('/node3')->willReturn($node->reveal());
+        $this->session->getNode('/node3')->willReturn($node->reveal())->shouldBeCalled();
 
         $version = $this->prophesize(VersionInterface::class);
-        $version->getName()->willReturn('a');
+        $version->getName()->willReturn('a')->shouldBeCalled();
         $this->versionManager->checkpoint('/node3')->willReturn($version->reveal());
         $node->getPropertyValueWithDefault('sulu:versions', [])->willReturn([
             '{"locale":"en","version":"0","author":null,"authored":"2016-12-05T19:47:22+01:00"}',
-        ]);
+        ])->shouldBeCalled();
         $node->setProperty(
             'sulu:versions',
             [

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Event\CreateEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
@@ -19,7 +20,7 @@ use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\DocumentManager\MetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber;
 
-class InstantiatorSubscriberTest extends \PHPUnit_Framework_TestCase
+class InstantiatorSubscriberTest extends TestCase
 {
     const ALIAS = 'alias';
 
@@ -59,7 +60,7 @@ class InstantiatorSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testHandleHydrateDocumentAlreadySet()
     {
-        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->hydrateEvent->hasDocument()->willReturn(true)->shouldBeCalled();
         $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
     }
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Event\CreateEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber;
+
+class InstantiatorSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    const ALIAS = 'alias';
+
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->subscriber = new InstantiatorSubscriber(
+            $this->metadataFactory->reveal()
+        );
+
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->createEvent = $this->prophesize(CreateEvent::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+    }
+
+    /**
+     * It should create a document for a managed PHPCR node.
+     */
+    public function testHandleHydrate()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(false);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->metadataFactory->getMetadataForPhpcrNode($this->node->reveal())->willReturn(
+            $this->metadata->reveal()
+        );
+        $this->metadata->getClass()->willReturn('\stdClass');
+        $this->hydrateEvent->setDocument(Argument::type('stdClass'))->shouldBeCalled();
+
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * If the document has already been set, do nothing.
+     */
+    public function testHandleHydrateDocumentAlreadySet()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should create a new document.
+     */
+    public function testHandleCreate()
+    {
+        $this->createEvent->getAlias()->willReturn(self::ALIAS);
+        $this->metadataFactory->getMetadataForAlias(self::ALIAS)->willReturn(
+            $this->metadata->reveal()
+        );
+        $this->metadata->getClass()->willReturn('\stdClass');
+        $this->createEvent->setDocument(Argument::type('stdClass'))->shouldBeCalled();
+
+        $this->subscriber->handleCreate($this->createEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/MappingSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/MappingSubscriberTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Core;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentAccessor;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\PropertyEncoder;
+use Sulu\Component\DocumentManager\ProxyFactory;
+use Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber;
+
+class MappingSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MetadataFactoryInterface
+     */
+    private $metadataFactory;
+
+    /**
+     * @var PropertyEncoder
+     */
+    private $encoder;
+
+    /**
+     * @var Metadata\
+     */
+    private $metadata;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var \stdClass
+     */
+    private $document;
+
+    /**
+     * @var DocumentAccessor
+     */
+    private $accessor;
+
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var ProxyFactory
+     */
+    private $proxyFactory;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var MappingSubscriber
+     */
+    private $mappingSubscriber;
+
+    public function setUp()
+    {
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->encoder = $this->prophesize(PropertyEncoder::class);
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->document = new \stdClass();
+        $this->accessor = $this->prophesize(DocumentAccessor::class);
+        $this->persistEvent = $this->prophesize(PersistEvent::class);
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->proxyFactory = $this->prophesize(ProxyFactory::class);
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->hydrateEvent->getLocale()->willReturn('de');
+        $this->hydrateEvent->getAccessor()->willReturn($this->accessor);
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->getLocale()->willReturn('de');
+        $this->persistEvent->getAccessor()->willReturn($this->accessor);
+
+        $this->mappingSubscriber = new MappingSubscriber(
+            $this->metadataFactory->reveal(),
+            $this->encoder->reveal(),
+            $this->proxyFactory->reveal(),
+            $this->documentRegistry->reveal()
+        );
+
+        $this->metadataFactory->getMetadataForClass('stdClass')->willReturn($this->metadata->reveal());
+    }
+
+    /**
+     * It should map fields to the PHPCR node.
+     */
+    public function testPersist()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'localized_system',
+                    'property' => 'hello',
+                    'type' => null,
+                    'mapped' => true,
+                    'multiple' => false,
+                    'default' => null,
+                ],
+            ]
+        );
+
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('localized_system', 'hello', 'de')->willReturn('sys:hello');
+        $this->accessor->get('test')->willReturn('goodbye');
+        $this->node->setProperty('sys:hello', 'goodbye')->shouldBeCalled();
+        $this->mappingSubscriber->handleMapping($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not map non-mapped fields to the PHPCR node.
+     */
+    public function testPersistNonMapped()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'localized_system',
+                    'property' => 'hello',
+                    'type' => null,
+                    'multiple' => false,
+                    'default' => null,
+                    'mapped' => false,
+                ],
+            ]
+        );
+
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('localized_system', 'hello', 'de')->willReturn('sys:hello');
+        $this->node->setProperty('sys:hello', 'goodbye')->shouldNotBeCalled();
+        $this->mappingSubscriber->handleMapping($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should throw an exception when mapped non-array values to non-multiple fields.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPersistNonArray()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'localized_system',
+                    'property' => 'hello',
+                    'type' => null,
+                    'multiple' => true,
+                    'default' => null,
+                    'mapped' => true,
+                ],
+            ]
+        );
+
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('localized_system', 'hello', 'de')->willReturn('sys:hello');
+        $this->accessor->get('test')->willReturn('goodbye');
+        $this->mappingSubscriber->handleMapping($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should map fields from the PHPCR node.
+     */
+    public function testHydrate()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'localized_system',
+                    'property' => 'hello',
+                    'mapped' => true,
+                    'type' => null,
+                    'multiple' => false,
+                    'default' => null,
+                ],
+            ]
+        );
+
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('localized_system', 'hello', 'de')->willReturn('sys:hello');
+        $this->metadataFactory->hasMetadataForClass('stdClass')->willReturn(true);
+        $this->node->getPropertyValueWithDefault('sys:hello', null)->willReturn('goodbye');
+        $this->accessor->set('test', 'goodbye')->shouldBeCalled();
+
+        $this->mappingSubscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should not map non-mapped fields.
+     */
+    public function testHydrateNonMapped()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'localized_system',
+                    'property' => 'hello',
+                    'mapped' => false,
+                    'type' => null,
+                    'multiple' => false,
+                    'default' => null,
+                ],
+            ]
+        );
+
+        $this->metadataFactory->hasMetadataForClass('stdClass')->willReturn(true);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->accessor->set('test', 'goodbye')->shouldNotBeCalled();
+
+        $this->mappingSubscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should use a default value.
+     */
+    public function testHydrateDefault()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'localized_system',
+                    'property' => 'hello',
+                    'mapped' => false,
+                    'type' => null,
+                    'multiple' => false,
+                    'default' => 'HAI',
+                ],
+            ]
+        );
+
+        $this->metadataFactory->hasMetadataForClass('stdClass')->willReturn(true);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('localized_system', 'hello', 'de')->willReturn('sys:hello');
+        $this->node->getPropertyValueWithDefault('sys:hello', null)->willReturn(null);
+        $this->accessor->set('test', 'HAI')->shouldNotBeCalled();
+
+        $this->mappingSubscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should json_encode the data.
+     */
+    public function testPersistJsonArray()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'system',
+                    'property' => 'hello',
+                    'type' => 'json_array',
+                    'mapped' => true,
+                    'multiple' => false,
+                    'default' => null,
+                ],
+            ]
+        );
+
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('system', 'hello', 'de')->willReturn('sys:hello');
+        $this->accessor->get('test')->willReturn(['key' => 'value']);
+        $this->node->setProperty('sys:hello', json_encode(['key' => 'value']))->shouldBeCalled();
+        $this->mappingSubscriber->handleMapping($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should json_decode the data.
+     */
+    public function testHydrateJsonArray()
+    {
+        $this->metadata->getFieldMappings()->willReturn(
+            [
+                'test' => [
+                    'encoding' => 'system',
+                    'property' => 'hello',
+                    'mapped' => true,
+                    'type' => 'json_array',
+                    'multiple' => false,
+                    'default' => null,
+                ],
+            ]
+        );
+
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->encoder->encode('system', 'hello', 'de')->willReturn('sys:hello');
+        $this->metadataFactory->hasMetadataForClass('stdClass')->willReturn(true);
+        $this->node->getPropertyValueWithDefault('sys:hello', null)->willReturn(json_encode(['key' => 'value']));
+        $this->accessor->set('test', ['key' => 'value'])->shouldBeCalled();
+
+        $this->mappingSubscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/MappingSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/MappingSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Core;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentAccessor;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
@@ -22,7 +23,7 @@ use Sulu\Component\DocumentManager\PropertyEncoder;
 use Sulu\Component\DocumentManager\ProxyFactory;
 use Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber;
 
-class MappingSubscriberTest extends \PHPUnit_Framework_TestCase
+class MappingSubscriberTest extends TestCase
 {
     /**
      * @var MetadataFactoryInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\PersistEvent;
@@ -19,7 +20,7 @@ use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 use Sulu\Component\DocumentManager\Subscriber\Core\RegistratorSubscriber;
 
-class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
+class RegistratorSubscriberTest extends TestCase
 {
     /**
      * @var DocumentRegistry
@@ -190,7 +191,7 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testDocumentFromRegistryAlreadySet()
     {
-        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->hydrateEvent->hasDocument()->willReturn(true)->shouldBeCalled();
         $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
     }
 
@@ -199,9 +200,7 @@ class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testDocumentFromRegistryNoNode()
     {
-        $this->hydrateEvent->hasDocument()->willReturn(true);
-        $this->hydrateEvent->getLocale()->willReturn('fr');
-        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->hasDocument()->willReturn(true)->shouldBeCalled();
         $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
         $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
     }

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
@@ -1,0 +1,276 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\PersistEvent;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\Subscriber\Core\RegistratorSubscriber;
+
+class RegistratorSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DocumentRegistry
+     */
+    private $registry;
+
+    /**
+     * @var RegistratorSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var \stdClass
+     */
+    private $document;
+
+    /**
+     * @var HydrateEvent
+     */
+    private $hydrateEvent;
+
+    /**
+     * @var PersistEvent
+     */
+    private $persistEvent;
+
+    /**
+     * @var RemoveEvent
+     */
+    private $removeEvent;
+
+    public function setUp()
+    {
+        $this->registry = $this->prophesize(DocumentRegistry::class);
+        $this->subscriber = new RegistratorSubscriber(
+            $this->registry->reveal()
+        );
+
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->document = new \stdClass();
+        $this->hydrateEvent = $this->prophesize(HydrateEvent::class);
+        $this->persistEvent = $this->prophesize(PersistEvent::class);
+        $this->removeEvent = $this->prophesize(RemoveEvent::class);
+    }
+
+    /**
+     * It should set the document on hydrate if the document for the node to
+     * be hydrated is already in the registry.
+     */
+    public function testDocumentFromRegistry()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(false);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getLocale()->willReturn('fr');
+        $this->hydrateEvent->getOptions()->willReturn([]);
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
+        $this->registry->getDocumentForNode($this->node->reveal(), 'fr')->willReturn($this->document);
+        $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();
+
+        $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should halt propagation if the document is already in the registry and the "rehydrate" option is false.
+     */
+    public function testDocumentFromRegistryNoRehydration()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(false);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getLocale()->willReturn('fr');
+        $this->hydrateEvent->getOptions()->willReturn(
+            [
+                'rehydrate' => false,
+            ]
+        );
+        $this->hydrateEvent->stopPropagation()->shouldBeCalled();
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
+        $this->registry->getDocumentForNode($this->node->reveal(), 'fr')->willReturn($this->document);
+        $this->hydrateEvent->setDocument($this->document)->shouldBeCalled();
+        $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should set the default locale.
+     */
+    public function testDefaultLocale()
+    {
+        $this->hydrateEvent->getLocale()->willReturn(null);
+        $this->registry->getDefaultLocale()->willReturn('de');
+        $this->hydrateEvent->setLocale('de')->shouldBeCalled();
+
+        $this->subscriber->handleDefaultLocale($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should stop propagation if the document is already loaded in the requested locale.
+     */
+    public function testStopPropagation()
+    {
+        $locale = 'de';
+        $originalLocale = 'de';
+
+        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->hydrateEvent->getLocale()->willReturn($locale);
+        $this->hydrateEvent->getOptions()->willReturn([]);
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->registry->isHydrated($this->document)->willReturn(true);
+        $this->registry->getOriginalLocaleForDocument($this->document)->willReturn($originalLocale);
+        $this->hydrateEvent->stopPropagation()->shouldBeCalled();
+
+        $this->subscriber->handleStopPropagationAndResetLocale($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should not stop propagation if the document is loaded with rehydrate option.
+     */
+    public function testStopPropagationRehydrate()
+    {
+        $locale = 'de';
+        $originalLocale = 'de';
+
+        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->hydrateEvent->getLocale()->willReturn($locale);
+        $this->hydrateEvent->getOptions()->willReturn(['rehydrate' => true]);
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->registry->isHydrated($this->document)->willReturn(true);
+        $this->registry->getOriginalLocaleForDocument($this->document)->willReturn($originalLocale);
+        $this->hydrateEvent->stopPropagation()->shouldNotBeCalled();
+
+        $this->subscriber->handleStopPropagationAndResetLocale($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should set the node to the event on persist if the node for the document
+     * being persisted is already in the registry.
+     */
+    public function testPersistNodeFromRegistry()
+    {
+        $this->persistEvent->hasNode()->willReturn(false);
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->registry->hasDocument($this->document)->willReturn(true);
+        $this->registry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->persistEvent->setNode($this->node->reveal())->shouldBeCalled();
+        $this->subscriber->handleNodeFromRegistry($this->persistEvent->reveal());
+    }
+
+    /**
+     * The node should be available from the event.
+     */
+    public function testReorderNodeFomRegistry()
+    {
+        $reorderEvent = $this->prophesize(ReorderEvent::class);
+        $reorderEvent->hasNode()->willReturn(false);
+        $reorderEvent->getDocument()->willReturn($this->document);
+        $this->registry->hasDocument($this->document)->willReturn(true);
+        $this->registry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $reorderEvent->setNode($this->node->reveal())->shouldBeCalled();
+        $this->subscriber->handleNodeFromRegistry($reorderEvent->reveal());
+    }
+
+    /**
+     * It should return early if the document has already been set.
+     */
+    public function testDocumentFromRegistryAlreadySet()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * Is should return early if the node is not managed.
+     */
+    public function testDocumentFromRegistryNoNode()
+    {
+        $this->hydrateEvent->hasDocument()->willReturn(true);
+        $this->hydrateEvent->getLocale()->willReturn('fr');
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
+        $this->subscriber->handleDocumentFromRegistry($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should register documents on the HYDRATE event.
+     */
+    public function testHandleRegisterHydrate()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getLocale()->willReturn('fr');
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldBeCalled();
+
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should not register documents on the HYDRATE event when there is already a document.
+     */
+    public function testHandleRegisterHydrateAlreadyExisting()
+    {
+        $this->hydrateEvent->getDocument()->willReturn($this->document);
+        $this->hydrateEvent->getNode()->willReturn($this->node->reveal());
+        $this->hydrateEvent->getLocale()->willReturn('fr');
+
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldNotBeCalled();
+
+        $this->subscriber->handleHydrate($this->hydrateEvent->reveal());
+    }
+
+    /**
+     * It should register documents on the PERSIST event.
+     */
+    public function testHandleRegisterPersist()
+    {
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->getLocale()->willReturn('fr');
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(false);
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldBeCalled();
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should not register on PERSIST when there is already a document.
+     */
+    public function testHandleRegisterPersistAlreadyExists()
+    {
+        $this->persistEvent->getDocument()->willReturn($this->document);
+        $this->persistEvent->getNode()->willReturn($this->node->reveal());
+        $this->persistEvent->getLocale()->willReturn('fr');
+
+        $this->registry->registerDocument($this->document, $this->node->reveal(), 'fr')->shouldNotBeCalled();
+        $this->registry->hasNode($this->node->reveal(), 'fr')->willReturn(true);
+
+        $this->subscriber->handlePersist($this->persistEvent->reveal());
+    }
+
+    /**
+     * It should deregister the document on the REMOVE event.
+     */
+    public function testHandleRemove()
+    {
+        $this->removeEvent->getDocument()->willReturn($this->document);
+        $this->registry->deregisterDocument($this->document)->shouldBeCalled();
+        $this->subscriber->handleRemove($this->removeEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\DocumentManager\Event\FindEvent;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
@@ -23,7 +24,7 @@ use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class FindSubscriberTest extends \PHPUnit_Framework_TestCase
+class FindSubscriberTest extends TestCase
 {
     public function setUp()
     {
@@ -66,7 +67,7 @@ class FindSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         if ($shouldThrow) {
             $this->metadataFactory->getAliases()->willReturn(['test1', 'test2']);
-            $this->setExpectedException(DocumentManagerException::class);
+            $this->expectException(DocumentManagerException::class);
         }
         if ('alias' === $type) {
             $this->metadataFactory->hasAlias($typeOrClass)->willReturn(true);

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
+
+use PHPCR\NodeInterface;
+use Prophecy\Argument;
+use Sulu\Component\DocumentManager\Event\FindEvent;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\MetadataFactoryInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class FindSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->metadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $this->metadata = $this->prophesize(Metadata::class);
+        $this->document = new \stdClass();
+        $this->subscriber = new FindSubscriber(
+            $this->metadataFactory->reveal(),
+            $this->nodeManager->reveal(),
+            $this->eventDispatcher->reveal()
+        );
+    }
+
+    /**
+     * It should find an existing document.
+     */
+    public function testFind()
+    {
+        $this->doTestFind(['type' => null]);
+    }
+
+    public function provideFindWithTypeOrClass()
+    {
+        return [
+            ['alias', 'page', false],
+            ['class', 'stdClass', false],
+            ['class', 'SomeUnknownClass', true],
+        ];
+    }
+
+    /**
+     * It should find existing document of specified type or class.
+     *
+     * @dataProvider provideFindWithTypeOrClass
+     */
+    public function testFindWithTypeOrClass($type, $typeOrClass, $shouldThrow)
+    {
+        if ($shouldThrow) {
+            $this->metadataFactory->getAliases()->willReturn(['test1', 'test2']);
+            $this->setExpectedException(DocumentManagerException::class);
+        }
+        if ('alias' === $type) {
+            $this->metadataFactory->hasAlias($typeOrClass)->willReturn(true);
+            $this->metadataFactory->getMetadataForAlias($typeOrClass)->willReturn($this->metadata);
+            $this->metadata->getClass()->willReturn('stdClass');
+        } else {
+            $this->metadataFactory->hasAlias($typeOrClass)->willReturn(false);
+        }
+        $options = [
+            'type' => $typeOrClass,
+        ];
+
+        $this->doTestFind($options);
+    }
+
+    private function doTestFind($options)
+    {
+        $locale = 'fr';
+        $path = '/path/to';
+
+        $this->nodeManager->find($path)->willReturn($this->node->reveal());
+        $this->eventDispatcher
+            ->dispatch(Events::HYDRATE, Argument::type(HydrateEvent::class))
+            ->will(function ($args) {
+                $args[1]->setDocument(new \stdClass());
+            });
+
+        $event = new FindEvent($path, $locale, $options);
+        $this->subscriber->handleFind($event);
+        $this->assertInstanceOf('stdClass', $event->getDocument());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\ClearEvent;
+use Sulu\Component\DocumentManager\Event\CopyEvent;
+use Sulu\Component\DocumentManager\Event\FlushEvent;
+use Sulu\Component\DocumentManager\Event\MoveEvent;
+use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\NodeHelperInterface;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber;
+
+class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    const SRC_PATH = '/path/to';
+
+    const DST_PATH = '/dest/path';
+
+    const DST_NAME = 'foo';
+
+    /**
+     * @var NodeManager
+     */
+    private $nodeManager;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var NodeHelperInterface
+     */
+    private $nodeHelper;
+
+    /**
+     * @var MoveEvent
+     */
+    private $moveEvent;
+
+    /**
+     * @var CopyEvent
+     */
+    private $copyEvent;
+
+    /**
+     * @var ClearEvent
+     */
+    private $clearEvent;
+
+    /**
+     * @var FlushEvent
+     */
+    private $flushEvent;
+
+    /**
+     * @var RefreshEvent
+     */
+    private $refreshEvent;
+
+    /**
+     * @var \stdClass
+     */
+    private $document;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var GeneralSubscriber
+     */
+    private $generalSubscriber;
+
+    public function setUp()
+    {
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->nodeHelper = $this->prophesize(NodeHelperInterface::class);
+
+        $this->moveEvent = $this->prophesize(MoveEvent::class);
+        $this->copyEvent = $this->prophesize(CopyEvent::class);
+        $this->clearEvent = $this->prophesize(ClearEvent::class);
+        $this->flushEvent = $this->prophesize(FlushEvent::class);
+        $this->refreshEvent = $this->prophesize(RefreshEvent::class);
+
+        $this->document = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+
+        $this->generalSubscriber = new GeneralSubscriber(
+            $this->documentRegistry->reveal(),
+            $this->nodeManager->reveal(),
+            $this->nodeHelper->reveal()
+        );
+    }
+
+    /**
+     * It should move a document.
+     */
+    public function testHandleMove()
+    {
+        $this->moveEvent->getDocument()->willReturn($this->document);
+        $this->moveEvent->getDestId()->willReturn(self::DST_PATH);
+        $this->moveEvent->getDestName()->willReturn(self::DST_NAME);
+
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->node->getPath()->willReturn(self::SRC_PATH);
+
+        $this->nodeHelper->move($this->node->reveal(), self::DST_PATH, self::DST_NAME)->shouldBeCalled();
+
+        $this->generalSubscriber->handleMove($this->moveEvent->reveal());
+    }
+
+    /**
+     * It should copy a document.
+     */
+    public function testHandleCopy()
+    {
+        $this->copyEvent->getDocument()->willReturn($this->document);
+        $this->copyEvent->getDestId()->willReturn(self::DST_PATH);
+        $this->copyEvent->getDestName()->willReturn(self::DST_NAME);
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+        $this->node->getPath()->willReturn(self::SRC_PATH);
+        $this->nodeHelper->copy($this->node->reveal(), self::DST_PATH, self::DST_NAME)->willReturn('foobar');
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('foobar');
+        $this->nodeManager->find('foobar')->willReturn($node->reveal());
+        $this->copyEvent->setCopiedNode($node->reveal())->shouldBeCalled();
+
+        $this->generalSubscriber->handleCopy($this->copyEvent->reveal());
+    }
+
+    /**
+     * It should clear/reset the PHPCR session.
+     */
+    public function testHandleClear()
+    {
+        $this->nodeManager->clear()->shouldBeCalled();
+        $this->generalSubscriber->handleClear($this->clearEvent->reveal());
+    }
+
+    /**
+     * It should save the PHPCR session.
+     */
+    public function testHandleFlush()
+    {
+        $this->nodeManager->save()->shouldBeCalled();
+        $this->generalSubscriber->handleFlush($this->flushEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\ClearEvent;
 use Sulu\Component\DocumentManager\Event\CopyEvent;
@@ -22,7 +23,7 @@ use Sulu\Component\DocumentManager\NodeHelperInterface;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber;
 
-class GeneralSubscriberTest extends \PHPUnit_Framework_TestCase
+class GeneralSubscriberTest extends TestCase
 {
     const SRC_PATH = '/path/to';
 

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+
+use PHPCR\Query\QueryInterface;
+use PHPCR\Query\QueryManagerInterface;
+use PHPCR\Query\QueryResultInterface;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
+use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
+use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
+use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
+use Sulu\Component\DocumentManager\Query\Query;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @var WorkspaceInterface
+     */
+    private $workspace;
+
+    /**
+     * @var QueryManagerInterface
+     */
+    private $queryManager;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var QueryInterface
+     */
+    private $phpcrQuery;
+
+    /**
+     * @var QueryResultInterface
+     */
+    private $phpcrResult;
+
+    /**
+     * @var QueryCreateEvent
+     */
+    private $queryCreateEvent;
+
+    /**
+     * @var QueryExecuteEvent
+     */
+    private $queryExecuteEvent;
+
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var QuerySubscriber
+     */
+    private $subscriber;
+
+    public function setUp()
+    {
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->workspace = $this->prophesize(WorkspaceInterface::class);
+        $this->queryManager = $this->prophesize(QueryManagerInterface::class);
+        $this->dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->phpcrQuery = $this->prophesize(QueryInterface::class);
+        $this->phpcrResult = $this->prophesize(QueryResultInterface::class);
+        $this->queryCreateEvent = $this->prophesize(QueryCreateEvent::class);
+        $this->queryExecuteEvent = $this->prophesize(QueryExecuteEvent::class);
+        $this->query = $this->prophesize(Query::class);
+
+        $this->subscriber = new QuerySubscriber(
+            $this->session->reveal(),
+            $this->dispatcher->reveal()
+        );
+
+        $this->session->getWorkspace()->willReturn($this->workspace->reveal());
+        $this->workspace->getQueryManager()->willReturn($this->queryManager->reveal());
+    }
+
+    /**
+     * It should provide a Query object from a JCR-SQL2 string.
+     */
+    public function testHandleCreate()
+    {
+        $query = 'SELECT * FROM [nt:unstructured]';
+        $locale = 'fr';
+        $primarySelector = 'p';
+
+        $this->queryCreateEvent->getInnerQuery()->willReturn($query);
+        $this->queryCreateEvent->getLocale()->willReturn($locale);
+        $this->queryCreateEvent->getOptions()->willReturn([]);
+        $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
+        $this->queryManager->createQuery($query, 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
+        $this->queryCreateEvent->setQuery(new Query(
+            $this->phpcrQuery->reveal(),
+            $this->dispatcher->reveal(),
+            $locale,
+            [],
+            $primarySelector
+        ))->shouldBeCalled();
+
+        $this->subscriber->handleCreate($this->queryCreateEvent->reveal());
+    }
+
+    /**
+     * It should provide a Query object for a PHPCR query object.
+     */
+    public function testHandleCreateFromPhpcrQuery()
+    {
+        $locale = 'fr';
+        $primarySelector = 'p';
+
+        $this->queryCreateEvent->getInnerQuery()->willReturn($this->phpcrQuery->reveal());
+        $this->queryCreateEvent->getLocale()->willReturn($locale);
+        $this->queryCreateEvent->getOptions()->willReturn([]);
+        $this->queryCreateEvent->getPrimarySelector()->willReturn($primarySelector);
+        $this->queryManager->createQuery($this->phpcrQuery->reveal(), 'JCR-SQL2')->willReturn($this->phpcrQuery->reveal());
+        $this->queryCreateEvent->setQuery(new Query(
+            $this->phpcrQuery->reveal(),
+            $this->dispatcher->reveal(),
+            $locale,
+            [],
+            $primarySelector
+        ))->shouldBeCalled();
+
+        $this->subscriber->handleCreate($this->queryCreateEvent->reveal());
+    }
+
+    /**
+     * It should handle query execution and set the result.
+     */
+    public function testHandleQueryExecute()
+    {
+        $locale = 'fr';
+        $primarySelector = 'p';
+
+        $this->query->getLocale()->willReturn($locale);
+        $this->query->getPhpcrQuery()->willReturn($this->phpcrQuery->reveal());
+        $this->phpcrQuery->execute()->willReturn($this->phpcrResult->reveal());
+        $this->query->getPrimarySelector()->willReturn($primarySelector);
+        $this->queryExecuteEvent->getQuery()->willReturn($this->query->reveal());
+        $this->queryExecuteEvent->getOptions()->willReturn([]);
+
+        $this->queryExecuteEvent->setResult(
+            new QueryResultCollection(
+                $this->phpcrResult->reveal(),
+                $this->dispatcher->reveal(),
+                $locale
+            )
+        )->shouldBeCalled();
+
+        $this->subscriber->handleQueryExecute($this->queryExecuteEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -16,6 +16,7 @@ use PHPCR\Query\QueryManagerInterface;
 use PHPCR\Query\QueryResultInterface;
 use PHPCR\SessionInterface;
 use PHPCR\WorkspaceInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Collection\QueryResultCollection;
 use Sulu\Component\DocumentManager\Event\QueryCreateEvent;
 use Sulu\Component\DocumentManager\Event\QueryExecuteEvent;
@@ -23,7 +24,7 @@ use Sulu\Component\DocumentManager\Query\Query;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class QuerySubscriberTest extends \PHPUnit_Framework_TestCase
+class QuerySubscriberTest extends TestCase
 {
     /**
      * @var SessionInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\HydrateEvent;
+use Sulu\Component\DocumentManager\Event\RefreshEvent;
+use Sulu\Component\DocumentManager\Event\RemoveDraftEvent;
+use Sulu\Component\DocumentManager\Events;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\RefreshSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var DocumentRegistry
+     */
+    private $documentRegistry;
+
+    /**
+     * @var RefreshSubscriber
+     */
+    private $refreshSubscriber;
+
+    public function setUp()
+    {
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+
+        $this->refreshSubscriber = new RefreshSubscriber(
+            $this->eventDispatcher->reveal(),
+            $this->documentRegistry->reveal()
+        );
+    }
+
+    public function testRefreshDocument()
+    {
+        $document = new \stdClass();
+        $node = $this->prophesize(NodeInterface::class);
+
+        $refreshEvent = $this->prophesize(RefreshEvent::class);
+        $refreshEvent->getDocument()->willReturn($document);
+        $this->documentRegistry->getNodeForDocument($document)->willReturn($node->reveal());
+        $node->revert()->shouldBeCalled();
+        $this->documentRegistry->getLocaleForDocument($document)->willReturn('fr');
+
+        $event = new HydrateEvent($node->reveal(), 'fr');
+        $this->eventDispatcher->dispatch(Events::REFRESH, $event);
+
+        $this->refreshSubscriber->refreshDocument($refreshEvent->reveal());
+    }
+
+    public function testRefreshDocumentForDeleteDraft()
+    {
+        $document = new \stdClass();
+        $node = $this->prophesize(NodeInterface::class);
+
+        $removeDraftEvent = $this->prophesize(RemoveDraftEvent::class);
+        $removeDraftEvent->getNode()->willReturn($node->reveal());
+        $removeDraftEvent->getLocale()->willReturn('de');
+        $removeDraftEvent->getDocument()->willReturn($document);
+
+        $hydrateEvent = new HydrateEvent($node->reveal(), 'de', ['rehydrate' => true]);
+        $hydrateEvent->setDocument($document);
+
+        $this->eventDispatcher->dispatch(Events::HYDRATE, $hydrateEvent)->shouldBeCalled();
+
+        $this->refreshSubscriber->refreshDocumentForDeleteDraft($removeDraftEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\HydrateEvent;
 use Sulu\Component\DocumentManager\Event\RefreshEvent;
@@ -20,7 +21,7 @@ use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\RefreshSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class RefreshSubscriberTest extends \PHPUnit_Framework_TestCase
+class RefreshSubscriberTest extends TestCase
 {
     /**
      * @var EventDispatcherInterface

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use Sulu\Component\DocumentManager\DocumentRegistry;
+use Sulu\Component\DocumentManager\Event\RemoveEvent;
+use Sulu\Component\DocumentManager\NodeManager;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber;
+
+class RemoveSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->nodeManager = $this->prophesize(NodeManager::class);
+        $this->documentRegistry = $this->prophesize(DocumentRegistry::class);
+        $this->removeEvent = $this->prophesize(RemoveEvent::class);
+        $this->document = new \stdClass();
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->node1 = $this->prophesize(NodeInterface::class);
+        $this->node2 = $this->prophesize(NodeInterface::class);
+        $this->property1 = $this->prophesize(PropertyInterface::class);
+        $this->property2 = $this->prophesize(PropertyInterface::class);
+
+        $this->subscriber = new RemoveSubscriber(
+            $this->documentRegistry->reveal(),
+            $this->nodeManager->reveal()
+        );
+
+        $this->documentRegistry->getNodeForDocument($this->document)->willReturn($this->node->reveal());
+    }
+
+    /**
+     * It should remove nodes from the PHPCR session.
+     */
+    public function testHandleRemove()
+    {
+        $this->removeEvent->getDocument()->willReturn($this->document);
+        $this->node->remove()->shouldBeCalled();
+
+        $this->subscriber->handleRemove($this->removeEvent->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
@@ -13,12 +13,13 @@ namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\DocumentManager\Event\RemoveEvent;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber;
 
-class RemoveSubscriberTest extends \PHPUnit_Framework_TestCase
+class RemoveSubscriberTest extends TestCase
 {
     public function setUp()
     {

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+
+use PHPCR\NodeInterface;
+use Sulu\Component\DocumentManager\Event\ReorderEvent;
+use Sulu\Component\DocumentManager\NodeHelperInterface;
+use Sulu\Component\DocumentManager\Subscriber\Phpcr\ReorderSubscriber;
+
+class ReorderSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NodeHelperInterface
+     */
+    private $nodeHelper;
+
+    /**
+     * @var ReorderSubscriber
+     */
+    private $reorderSubscriber;
+
+    public function setUp()
+    {
+        $this->nodeHelper = $this->prophesize(NodeHelperInterface::class);
+        $this->reorderSubscriber = new ReorderSubscriber(
+            $this->nodeHelper->reveal()
+        );
+    }
+
+    public function testHandleReorder()
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $event = $this->prophesize(ReorderEvent::class);
+
+        $event->getNode()->willReturn($node->reveal());
+        $event->getDestId()->willReturn('uuid');
+
+        $this->nodeHelper->reorder($node->reveal(), 'uuid');
+
+        $this->reorderSubscriber->handleReorder($event->reveal());
+    }
+}

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
@@ -12,11 +12,12 @@
 namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
 
 use PHPCR\NodeInterface;
+use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Event\ReorderEvent;
 use Sulu\Component\DocumentManager\NodeHelperInterface;
 use Sulu\Component\DocumentManager\Subscriber\Phpcr\ReorderSubscriber;
 
-class ReorderSubscriberTest extends \PHPUnit_Framework_TestCase
+class ReorderSubscriberTest extends TestCase
 {
     /**
      * @var NodeHelperInterface
@@ -41,8 +42,8 @@ class ReorderSubscriberTest extends \PHPUnit_Framework_TestCase
         $node = $this->prophesize(NodeInterface::class);
         $event = $this->prophesize(ReorderEvent::class);
 
-        $event->getNode()->willReturn($node->reveal());
-        $event->getDestId()->willReturn('uuid');
+        $event->getNode()->willReturn($node->reveal())->shouldBeCalled();
+        $event->getDestId()->willReturn('uuid')->shouldBeCalled();
 
         $this->nodeHelper->reorder($node->reveal(), 'uuid');
 

--- a/src/Sulu/Component/DocumentManager/Tests/symfony-di/core.xml
+++ b/src/Sulu/Component/DocumentManager/Tests/symfony-di/core.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <!-- Core -->
+        <service id="sulu_document_manager.event_dispatcher.debug" class="Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher" public="false">
+            <argument type="service" id="service_container"/>
+            <argument type="service" id="debug.stopwatch"/>
+            <argument type="service" id="logger"/>
+            <tag name="monolog.logger" channel="sulu_document_manager"/>
+        </service>
+
+        <service id="sulu_document_manager.event_dispatcher.standard" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher" public="false">
+            <argument type="service" id="service_container"/>
+        </service>
+
+        <service id="sulu_document_manager.document_manager" class="Sulu\Component\DocumentManager\DocumentManager">
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <argument type="service" id="sulu_document_manager.node_manager"/>
+        </service>
+
+        <service id="sulu_document_manager.document_registry" class="Sulu\Component\DocumentManager\DocumentRegistry" public="false">
+            <argument>%sulu_document_manager.default_locale%</argument>
+        </service>
+
+        <service id="sulu_document_manager.node_manager" class="Sulu\Component\DocumentManager\NodeManager" public="false">
+            <argument type="service" id="doctrine_phpcr.session"/>
+        </service>
+
+        <service id="sulu_document_manager.node_helper" class="Sulu\Component\DocumentManager\NodeHelper"/>
+
+        <service id="sulu_document_manager.metadata_factory.base" class="Sulu\Component\DocumentManager\Metadata\BaseMetadataFactory" public="false">
+            <argument type="service" id="sulu_document_manager.event_dispatcher" />
+            <argument>%sulu_document_manager.mapping%</argument>
+        </service>
+
+        <service id="sulu_document_manager.metadata_factory" class="Sulu\Component\DocumentManager\Metadata\MetadataFactory" public="false">
+            <argument type="service" id="sulu_document_manager.metadata_factory.base"/>
+        </service>
+
+        <service id="sulu_document_manager.slugifier" class="Symfony\Cmf\Api\Slugifier\CallbackSlugifier" public="false">
+            <argument>Ferrandini\Urlizer::urlize</argument>
+        </service>
+
+        <service id="sulu_document_manager.node_name_slugifier"
+                 class="Sulu\Component\DocumentManager\Slugifier\NodeNameSlugifier" public="false">
+            <argument type="service" id="sulu_document_manager.slugifier"/>
+        </service>
+
+        <service id="sulu_document_manager.namespace_registry" class="Sulu\Component\DocumentManager\NamespaceRegistry" public="false">
+            <argument>%sulu_document_manager.namespace_mapping%</argument>
+        </service>
+
+        <service id="sulu_document_manager.property_encoder" class="Sulu\Component\DocumentManager\PropertyEncoder" public="false">
+            <argument type="service" id="sulu_document_manager.namespace_registry"/>
+        </service>
+
+        <service id="sulu_document_manager.name_resolver" class="Sulu\Component\DocumentManager\NameResolver" public="false"/>
+
+        <!-- Utilities -->
+        <service id="sulu_document_manager.path_segment_registry" class="Sulu\Component\DocumentManager\PathSegmentRegistry">
+            <argument type="collection">
+            </argument>
+        </service>
+
+        <service id="sulu_document_manager.document_inspector" class="Sulu\Component\DocumentManager\DocumentInspector">
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <argument type="service" id="sulu_document_manager.path_segment_registry"/>
+            <argument type="service" id="sulu_document_manager.proxy_factory"/>
+        </service>
+
+        <!-- Proxy manager -->
+        <service id="sulu_document_manager.proxy_factory" class="Sulu\Component\DocumentManager\ProxyFactory">
+            <argument type="service" id="sulu_document_manager.proxy_manager.factory.ghost"/>
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
+        </service>
+
+        <service id="sulu_document_manager.proxy_manager.factory.ghost" class="ProxyManager\Factory\LazyLoadingGhostFactory"/>
+
+    </services>
+
+</container>

--- a/src/Sulu/Component/DocumentManager/Tests/symfony-di/subscribers.xml
+++ b/src/Sulu/Component/DocumentManager/Tests/symfony-di/subscribers.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <!-- Behavior Subscribers -->
+        <service id="sulu_document_manager.subscriber.behavior.auto_name" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AutoNameSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <argument type="service" id="sulu_document_manager.node_name_slugifier"/>
+            <argument type="service" id="sulu_document_manager.name_resolver"/>
+            <argument type="service" id="sulu_document_manager.node_manager"/>
+            <argument type="service" id="doctrine_phpcr.session"/>
+            <argument type="service" id="doctrine_phpcr.session"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.behavior.path.explicit" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Path\ExplicitSubscriber">
+            <argument type="service" id="sulu_document_manager.node_manager"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.suscriber.behavior.timestamp" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Audit\TimestampSubscriber">
+            <argument type="service" id="sulu_document_manager.property_encoder"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.suscriber.behavior.node_name" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\NodeNameSubscriber">
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.suscriber.behavior.uuid" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\UuidSubscriber">
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.suscriber.behavior.locale" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\LocaleSubscriber">
+            <tag name="sulu_document_manager.event_subscriber"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+        </service>
+
+        <service id="sulu_document_manager.suscriber.behavior.parent" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ParentSubscriber">
+            <argument type="service" id="sulu_document_manager.proxy_factory"/>
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <argument type="service" id="sulu_document_manager.document_manager"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.suscriber.behavior.children" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\ChildrenSubscriber">
+            <argument type="service" id="sulu_document_manager.proxy_factory"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.behavior.path" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\PathSubscriber">
+            <argument type="service" id="sulu_document_manager.document_inspector"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <!-- Core Subscribers -->
+        <service id="sulu_document_manager.subscriber.core.instantiator" class="Sulu\Component\DocumentManager\Subscriber\Core\InstantiatorSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.core.registrator" class="Sulu\Component\DocumentManager\Subscriber\Core\RegistratorSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.core.mapping" class="Sulu\Component\DocumentManager\Subscriber\Core\MappingSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory" />
+            <argument type="service" id="sulu_document_manager.property_encoder" />
+            <argument type="service" id="sulu_document_manager.proxy_factory"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.reorder" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\ReorderSubscriber">
+            <argument type="service" id="sulu_document_manager.node_helper"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.mixin" class="Sulu\Component\DocumentManager\Subscriber\Behavior\Mapping\MixinSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <!-- PHPCR subscribers -->
+        <service id="sulu_document_manager.subscriber.phpcr.find" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\FindSubscriber">
+            <argument type="service" id="sulu_document_manager.metadata_factory"/>
+            <argument type="service" id="sulu_document_manager.node_manager"/>
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.query" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\QuerySubscriber">
+            <argument type="service" id="doctrine_phpcr.session"/>
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.general" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\GeneralSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <argument type="service" id="sulu_document_manager.node_manager"/>
+            <argument type="service" id="sulu_document_manager.node_helper"/>
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.remove" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\RemoveSubscriber">
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <argument type="service" id="sulu_document_manager.node_manager"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+
+        <service id="sulu_document_manager.subscriber.phpcr.refresh" class="Sulu\Component\DocumentManager\Subscriber\Phpcr\RefreshSubscriber">
+            <argument type="service" id="sulu_document_manager.event_dispatcher"/>
+            <argument type="service" id="sulu_document_manager.document_registry"/>
+            <tag name="sulu_document_manager.event_subscriber"/>
+        </service>
+    </services>
+</container>

--- a/src/Sulu/Component/DocumentManager/Version.php
+++ b/src/Sulu/Component/DocumentManager/Version.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\DocumentManager;
+
+/**
+ * Represents the version information on a document.
+ */
+class Version
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @var int
+     */
+    private $author;
+
+    /**
+     * @var \DateTime
+     */
+    private $authored;
+
+    /**
+     * @param string $id
+     * @param string $locale
+     * @param int $author
+     * @param \DateTime $authored
+     */
+    public function __construct($id, $locale, $author, $authored)
+    {
+        $this->id = $id;
+        $this->locale = $locale;
+        $this->author = $author;
+        $this->authored = $authored;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getAuthored()
+    {
+        return $this->authored;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Move document manager components to this repository.

#### Why?

For better maintenance and compatibility.

See https://github.com/sulu/sulu/pull/3981/commits/9b8baeb5c89011d7c06d148f126fdbf84d8610ac for changes

#### TODO

 - [ ] `AutoNameSubscriberTest::testAlreadyHasNode`: This test did not perform any assertions: Don't know if there is a bug or the test is just really strange as most functions are not called when I add shouldBeCalled.