### PR TITLE
add eslint key-spacing rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,7 @@
                 "functions": "never"
             }
         ],
+        "key-spacing": "error",
         "no-alert": "error",
         "padded-blocks": [
             "error",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -117,6 +117,7 @@ $borderWidth: 1px;
 
         .button-cell {
             font-size: 16px;
+
             button {
                 visibility: visible;
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/registries/RouteRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/registries/RouteRegistry.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
 test('Clear routes from RouteRegistry', () => {
     routeRegistry.addCollection([
         {
-            name:'route',
+            name: 'route',
             view: 'view',
             path: '/route',
             options: {},

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -164,7 +164,7 @@ module.exports = { // eslint-disable-line
                     ],
                 },
                 {
-                    test:/\.(jpg|gif|png)(\?.*$|$)/,
+                    test: /\.(jpg|gif|png)(\?.*$|$)/,
                     use: [
                         {
                             loader: 'file-loader',
@@ -172,7 +172,7 @@ module.exports = { // eslint-disable-line
                     ],
                 },
                 {
-                    test:/\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
+                    test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
                     use: [
                         {
                             loader: 'file-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,7 @@ module.exports = { // eslint-disable-line no-undef
                 }),
             },
             {
-                test:/\.(jpg|gif|png)(\?.*$|$)/,
+                test: /\.(jpg|gif|png)(\?.*$|$)/,
                 use: [
                     {
                         loader: 'file-loader',
@@ -77,7 +77,7 @@ module.exports = { // eslint-disable-line no-undef
                 ],
             },
             {
-                test:/\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
+                test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
                 use: [
                     {
                         loader: 'file-loader',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a new eslint rule.

#### Why?

Because we want no wrong spaces around the colons in object literals.