### PR TITLE
add rule to check if only a single prop is on multiline JSX

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -109,6 +109,13 @@
             "error",
             "line-aligned"
         ],
+        "react/jsx-max-props-per-line": [
+            "error",
+            {
+                "maximum": 1,
+                "when": "multiline"
+            }
+        ],
         "react/jsx-wrap-multilines": "error",
         "react/jsx-pascal-case": "error",
         "react/jsx-tag-spacing": [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This rule defines that there should only be a single prop in a line in JSX if the JSX element spans over multiple lines.

#### Why?

Because this way it is consistent.

#### Example Usage

~~~javascript
// valid
<Test
    prop1="value1"
    prop2="value2"
    prop3="value3"
/>

// invalid
<Test
    prop1="value1"
    prop2="value2" prop3="value3"
/>
~~~