### PR TITLE
Remove multiple requests for SingleMediaUpload

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -152,7 +152,7 @@ export default class ResourceStore {
 
     @action delete(): Promise<*> {
         if (!this.data.id) {
-            throw new Error('Can not delete resource with an undefined "id"');
+            throw new Error('Cannot delete resource with an undefined "id"');
         }
 
         this.saving = true;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -16,7 +16,8 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Ob
 
         this.mediaUploadStore = new MediaUploadStore(
             // TODO remove 'en' and determine language to upload
-            new ResourceStore('media', value ? value.id : undefined, {locale: observable.box('en')})
+            new ResourceStore('media', value ? value.id : undefined, {locale: observable.box('en')}),
+            observable.box('en')
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -2,11 +2,11 @@
 import React from 'react';
 import {observable} from 'mobx';
 import type {FieldTypeProps} from 'sulu-admin-bundle';
-import {ResourceStore} from 'sulu-admin-bundle/stores';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 import SingleMediaUploadComponent from '../../SingleMediaUpload';
+import type {Media} from '../../../types';
 
-export default class SingleMediaUpload extends React.Component<FieldTypeProps<Object>> {
+export default class SingleMediaUpload extends React.Component<FieldTypeProps<Media>> {
     mediaUploadStore: MediaUploadStore;
 
     constructor(props: FieldTypeProps<Object>) {
@@ -15,8 +15,8 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Ob
         const {value} = this.props;
 
         this.mediaUploadStore = new MediaUploadStore(
+            value,
             // TODO remove 'en' and determine language to upload
-            new ResourceStore('media', value ? value.id : undefined, {locale: observable.box('en')}),
             observable.box('en')
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
@@ -132,5 +132,25 @@ test('Create a MediaUploadStore when constructed', () => {
     );
 
     expect(singleMediaUpload.instance().mediaUploadStore).toBeInstanceOf(MediaUploadStore);
-    expect(singleMediaUpload.instance().mediaUploadStore.resourceStore.resourceKey).toEqual('media');
+    expect(singleMediaUpload.instance().mediaUploadStore.media).toEqual(undefined);
+});
+
+test('Create a MediaUploadStore when constructed with data', () => {
+    const data = {
+        id: 1,
+        mimeType: 'image/jpeg',
+        thumbnails: {},
+        url: '',
+    };
+    const schemaOptions = {
+        collection_id: {
+            value: 2,
+        },
+    };
+    const singleMediaUpload = shallow(
+        <SingleMediaUpload onChange={jest.fn()} schemaOptions={schemaOptions} value={data} />
+    );
+
+    expect(singleMediaUpload.instance().mediaUploadStore).toBeInstanceOf(MediaUploadStore);
+    expect(singleMediaUpload.instance().mediaUploadStore.media).toEqual(data);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -5,13 +5,10 @@ import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import Dropzone from 'react-dropzone';
-import {ResourceStore} from 'sulu-admin-bundle/stores';
 import MediaUploadStore from '../../stores/MediaUploadStore';
 import MediaItem from './MediaItem';
 import DropzoneOverlay from './DropzoneOverlay';
 import dropzoneStyles from './dropzone.scss';
-
-const RESOURCE_KEY = 'media';
 
 type Props = {
     children: any,
@@ -82,7 +79,7 @@ export default class MultiMediaDropzone extends React.Component<Props> {
         }
 
         files.forEach((file) => {
-            const mediaUploadStore = new MediaUploadStore(new ResourceStore(RESOURCE_KEY, undefined), locale);
+            const mediaUploadStore = new MediaUploadStore(undefined, locale);
             const uploadPromise = mediaUploadStore.create(collectionId, file);
 
             uploadPromises.push(uploadPromise);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -82,7 +82,7 @@ export default class MultiMediaDropzone extends React.Component<Props> {
         }
 
         files.forEach((file) => {
-            const mediaUploadStore = new MediaUploadStore(new ResourceStore(RESOURCE_KEY, undefined, {locale}));
+            const mediaUploadStore = new MediaUploadStore(new ResourceStore(RESOURCE_KEY, undefined), locale);
             const uploadPromise = mediaUploadStore.create(collectionId, file);
 
             uploadPromises.push(uploadPromise);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -40,7 +40,7 @@ export default class SingleMediaUpload extends React.Component<Props> {
             mediaUploadStore,
         } = this.props;
 
-        if (!mediaUploadStore.id && !collectionId) {
+        if (!mediaUploadStore.media && !collectionId) {
             throw new Error('If a new item is supposed to be uploaded a "collectionId" is required!');
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {observable} from 'mobx';
 import {render, shallow} from 'enzyme';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import SingleMediaUpload from '../SingleMediaUpload';
@@ -26,7 +27,7 @@ jest.mock('sulu-admin-bundle/utils', () => ({
 }));
 
 test('Render a SingleMediaUpload', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
 
     expect(
         render(<SingleMediaUpload collectionId={5} mediaUploadStore={mediaUploadStore} uploadText="Upload media" />)
@@ -34,7 +35,7 @@ test('Render a SingleMediaUpload', () => {
 });
 
 test('Render a SingleMediaUpload with an empty icon if no image is passed', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'), observable.box('en'));
     mediaUploadStore.getThumbnail.mockReturnValue(undefined);
 
     expect(
@@ -43,7 +44,7 @@ test('Render a SingleMediaUpload with an empty icon if no image is passed', () =
 });
 
 test('Render a SingleMediaUpload with the round skin', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
 
     expect(render(
         <SingleMediaUpload
@@ -56,7 +57,7 @@ test('Render a SingleMediaUpload with the round skin', () => {
 });
 
 test('Render a SingleMediaUpload with a different image size', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
 
     expect(render(
         <SingleMediaUpload
@@ -67,7 +68,7 @@ test('Render a SingleMediaUpload with a different image size', () => {
 });
 
 test('Render a SingleMediaUpload without delete and download button', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
 
     expect(render(
         <SingleMediaUpload
@@ -81,7 +82,7 @@ test('Render a SingleMediaUpload without delete and download button', () => {
 
 test('Call update on MediaUploadStore if id is given and drop event occurs', () => {
     const uploadCompleteSpy = jest.fn();
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
 
     const promise = Promise.resolve({});
     mediaUploadStore.update.mockReturnValue(promise);
@@ -107,7 +108,7 @@ test('Call update on MediaUploadStore if id is given and drop event occurs', () 
 
 test('Call create with passed collectionId if id is not given and drop event occurs', () => {
     const uploadCompleteSpy = jest.fn();
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'), observable.box('en'));
 
     const promise = Promise.resolve({});
     mediaUploadStore.create.mockReturnValue(promise);
@@ -139,7 +140,7 @@ test('Download the image when the download button is clicked', () => {
         id: 1,
         url: 'test.jpg',
     };
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     const singleMediaUpload = shallow(
         <SingleMediaUpload
@@ -153,7 +154,7 @@ test('Download the image when the download button is clicked', () => {
 });
 
 test('Delete the image when the delete button is clicked and the overlay is confirmed', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
     const deletePromise = Promise.resolve();
     mediaUploadStore.delete.mockReturnValue(deletePromise);
 
@@ -186,7 +187,7 @@ test('Delete the image when the delete button is clicked and the overlay is conf
 });
 
 test('Throw exception if neither the collectionId nor the id from the image is given', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'), observable.box('en'));
     expect(() => shallow(
         <SingleMediaUpload mediaUploadStore={mediaUploadStore} uploadText="UploadMedia" />
     )).toThrow('"collectionId"');

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
@@ -2,24 +2,17 @@
 import React from 'react';
 import {observable} from 'mobx';
 import {render, shallow} from 'enzyme';
-import {ResourceStore} from 'sulu-admin-bundle/stores';
 import SingleMediaUpload from '../SingleMediaUpload';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 
-jest.mock('../../../stores/MediaUploadStore', () => jest.fn(function(resourceStore) {
-    this.id = resourceStore.id;
+jest.mock('../../../stores/MediaUploadStore', () => jest.fn(function(media) {
+    this.id = media ? media.id : undefined;
     this.create = jest.fn();
     this.update = jest.fn();
     this.delete = jest.fn();
     this.getThumbnail = jest.fn((size) => size);
-    this.downloadUrl = resourceStore.data.url ? resourceStore.data.url : undefined;
-}));
-
-jest.mock('sulu-admin-bundle/stores', () => ({
-    ResourceStore: jest.fn(function(resourceKey, id) {
-        this.id = id;
-        this.data = {};
-    }),
+    this.downloadUrl = media ? media.url : undefined;
+    this.media = media;
 }));
 
 jest.mock('sulu-admin-bundle/utils', () => ({
@@ -27,7 +20,10 @@ jest.mock('sulu-admin-bundle/utils', () => ({
 }));
 
 test('Render a SingleMediaUpload', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
 
     expect(
         render(<SingleMediaUpload collectionId={5} mediaUploadStore={mediaUploadStore} uploadText="Upload media" />)
@@ -35,7 +31,10 @@ test('Render a SingleMediaUpload', () => {
 });
 
 test('Render a SingleMediaUpload with an empty icon if no image is passed', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        undefined,
+        observable.box('en')
+    );
     mediaUploadStore.getThumbnail.mockReturnValue(undefined);
 
     expect(
@@ -44,7 +43,10 @@ test('Render a SingleMediaUpload with an empty icon if no image is passed', () =
 });
 
 test('Render a SingleMediaUpload with the round skin', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
 
     expect(render(
         <SingleMediaUpload
@@ -57,7 +59,10 @@ test('Render a SingleMediaUpload with the round skin', () => {
 });
 
 test('Render a SingleMediaUpload with a different image size', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
 
     expect(render(
         <SingleMediaUpload
@@ -68,7 +73,10 @@ test('Render a SingleMediaUpload with a different image size', () => {
 });
 
 test('Render a SingleMediaUpload without delete and download button', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
 
     expect(render(
         <SingleMediaUpload
@@ -82,7 +90,10 @@ test('Render a SingleMediaUpload without delete and download button', () => {
 
 test('Call update on MediaUploadStore if id is given and drop event occurs', () => {
     const uploadCompleteSpy = jest.fn();
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
 
     const promise = Promise.resolve({});
     mediaUploadStore.update.mockReturnValue(promise);
@@ -108,7 +119,10 @@ test('Call update on MediaUploadStore if id is given and drop event occurs', () 
 
 test('Call create with passed collectionId if id is not given and drop event occurs', () => {
     const uploadCompleteSpy = jest.fn();
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        undefined,
+        observable.box('en')
+    );
 
     const promise = Promise.resolve({});
     mediaUploadStore.create.mockReturnValue(promise);
@@ -135,12 +149,10 @@ test('Call create with passed collectionId if id is not given and drop event occ
 test('Download the image when the download button is clicked', () => {
     window.location.assign = jest.fn();
 
-    const resourceStore = new ResourceStore('media', 1);
-    resourceStore.data = {
-        id: 1,
-        url: 'test.jpg',
-    };
-    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: 'test.jpg'},
+        observable.box('en')
+    );
 
     const singleMediaUpload = shallow(
         <SingleMediaUpload
@@ -154,7 +166,10 @@ test('Download the image when the download button is clicked', () => {
 });
 
 test('Delete the image when the delete button is clicked and the overlay is confirmed', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
     const deletePromise = Promise.resolve();
     mediaUploadStore.delete.mockReturnValue(deletePromise);
 
@@ -186,8 +201,11 @@ test('Delete the image when the delete button is clicked and the overlay is conf
     });
 });
 
-test('Throw exception if neither the collectionId nor the id from the image is given', () => {
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media'), observable.box('en'));
+test('Throw exception if neither the collectionId nor the media is given', () => {
+    const mediaUploadStore = new MediaUploadStore(
+        undefined,
+        observable.box('en')
+    );
     expect(() => shallow(
         <SingleMediaUpload mediaUploadStore={mediaUploadStore} uploadText="UploadMedia" />
     )).toThrow('"collectionId"');

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -1,5 +1,6 @@
 // @flow
 import {action, computed, observable} from 'mobx';
+import type {IObservableValue} from 'mobx';
 import {ResourceMetadataStore, ResourceStore} from 'sulu-admin-bundle/stores';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
 
@@ -8,29 +9,21 @@ const RESOURCE_KEY = 'media';
 export default class MediaUploadStore {
     @observable uploading: boolean;
     @observable progress: number;
+    locale: IObservableValue<string>;
     resourceStore: ResourceStore;
 
-    constructor(resourceStore: ResourceStore) {
+    constructor(resourceStore: ResourceStore, locale: IObservableValue<string>) {
         if (resourceStore.resourceKey !== RESOURCE_KEY) {
             throw new Error('The MediaUploadStore needs a "ResourceStore" with the "media" resourceKey!');
         }
         this.resourceStore = resourceStore;
+        this.locale = locale;
     }
 
     @computed get id(): ?number | string {
         const {resourceStore} = this;
 
         return resourceStore.data.id || resourceStore.id;
-    }
-
-    @computed get locale(): string {
-        const {resourceStore} = this;
-
-        if (!resourceStore.locale) {
-            throw new Error('The MediaUploadStore needs a localized "ResourceStore"!');
-        }
-
-        return resourceStore.locale.get();
     }
 
     @computed get downloadUrl(): ?string {
@@ -99,7 +92,7 @@ export default class MediaUploadStore {
         const endpoint = ResourceMetadataStore.getEndpoint(RESOURCE_KEY);
         const queryString = ResourceRequester.buildQueryString({
             action: 'new-version',
-            locale: this.locale,
+            locale: this.locale.get(),
         });
         const url = endpoint + '/' + id + queryString;
 
@@ -112,7 +105,7 @@ export default class MediaUploadStore {
     create(collectionId: string | number, file: File): Promise<*> {
         const endpoint = ResourceMetadataStore.getEndpoint(RESOURCE_KEY);
         const queryString = ResourceRequester.buildQueryString({
-            locale: this.locale,
+            locale: this.locale.get(),
             collection: collectionId,
         });
         const url = endpoint + queryString;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -82,7 +82,11 @@ export default class MediaUploadStore {
     }
 
     @action delete() {
-        return this.resourceStore.delete();
+        if (!this.id) {
+            throw new Error('The "id" property must be available for deleting a media');
+        }
+
+        return ResourceRequester.delete(RESOURCE_KEY, this.id);
     }
 
     update(file: File): Promise<*> {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
@@ -43,7 +43,7 @@ test('Calling the "update" method should make a "POST" request to the media upda
         this.send = jest.fn();
     });
 
-    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1, {locale: observable.box('en')}));
+    const mediaUploadStore = new MediaUploadStore(new ResourceStore('media', 1), observable.box('en'));
     const fileData = new File([''], 'fileName');
 
     mediaUploadStore.update(fileData);
@@ -62,7 +62,8 @@ test('Calling the "create" method should make a "POST" request to the media upda
     });
 
     const mediaUploadStore = new MediaUploadStore(
-        new ResourceStore('media', undefined, {locale: observable.box('en')})
+        new ResourceStore('media', undefined),
+        observable.box('en')
     );
     const fileData = new File([''], 'fileName');
 
@@ -72,11 +73,17 @@ test('Calling the "create" method should make a "POST" request to the media upda
 
 test('Calling "delete" method should call the "delete" method of the ResourceRequester', () => {
     const resourceStore = new ResourceStore('media', 2);
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
+
+    const promise = Promise.resolve();
+    ResourceRequester.delete.mockReturnValue(promise);
 
     mediaUploadStore.delete();
-
     expect(ResourceRequester.delete).toBeCalledWith('media', 2);
+
+    return promise.then(() => {
+        expect(mediaUploadStore.data).toEqual({});
+    });
 });
 
 test('After the request was successful the progress will be reset', (done) => {
@@ -87,8 +94,8 @@ test('After the request was successful the progress will be reset', (done) => {
         this.send = jest.fn();
     });
 
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const resourceStore = new ResourceStore('media', 1);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
     const fileData = new File([''], 'fileName');
 
     mediaUploadStore.update(fileData);
@@ -110,68 +117,60 @@ test('After the request was successful the progress will be reset', (done) => {
 
 test('Should return thumbnail path if available', () => {
     const thumbnailUrl = '/media/uploads/400x400/test.png';
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
+    const resourceStore = new ResourceStore('media', 1);
     resourceStore.data = {
         thumbnails: {
             'sulu-400x400-inset': thumbnailUrl,
         },
     };
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     expect(mediaUploadStore.getThumbnail('sulu-400x400-inset')).toEqual(thumbnailUrl);
 });
 
 test('Should return undefined if thumbnail is not available yet', () => {
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const resourceStore = new ResourceStore('media', 1);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     expect(mediaUploadStore.getThumbnail('100x100')).toEqual(undefined);
 });
 
 test('Should return the mime type of the media if available', () => {
     const mimeType = 'image/jpg';
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
+    const resourceStore = new ResourceStore('media', 1);
     resourceStore.data = {
         mimeType,
     };
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     expect(mediaUploadStore.mimeType).toEqual(mimeType);
 });
 
 test('Should return undefined if the mime type is not available yet', () => {
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const resourceStore = new ResourceStore('media', 1);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     expect(mediaUploadStore.mimeType).toEqual(undefined);
 });
 
 test('Should return downloadUrl if available', () => {
     const url = 'test.jpg';
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
+    const resourceStore = new ResourceStore('media', 1);
     resourceStore.data = {
         url,
     };
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     expect(mediaUploadStore.downloadUrl).toEqual(url);
 });
 
 test('Should return undefined if downloadUrl is not available', () => {
-    const resourceStore = new ResourceStore('media', 1, {locale: observable.box('en')});
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
+    const resourceStore = new ResourceStore('media', 1);
+    const mediaUploadStore = new MediaUploadStore(resourceStore, observable.box('en'));
 
     expect(mediaUploadStore.downloadUrl).toEqual(undefined);
 });
 
-test('Should throw an error if locale not available', () => {
-    const resourceStore = new ResourceStore('media', 1);
-    resourceStore.data = {};
-    const mediaUploadStore = new MediaUploadStore(resourceStore);
-
-    expect(() => mediaUploadStore.locale).toThrow(/localized/);
-});
-
 test('Should throw an error if passed resourceStore does not load media', () => {
-    expect(() => new MediaUploadStore(new ResourceStore('account', 3))).toThrow('"media"');
+    expect(() => new MediaUploadStore(new ResourceStore('account', 3), observable.box('en'))).toThrow('"media"');
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/types.js
@@ -1,0 +1,7 @@
+// @flow
+export type Media = {|
+    id: number,
+    mimeType: string,
+    thumbnails: {[key: string]: string},
+    url: string,
+|};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -38,7 +38,7 @@ class MediaDetail extends React.Component<Props> {
         }
 
         router.bind('locale', locale);
-        this.mediaUploadStore = new MediaUploadStore(resourceStore);
+        this.mediaUploadStore = new MediaUploadStore(resourceStore, locale);
     }
 
     componentWillUnmount() {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -38,7 +38,7 @@ class MediaDetail extends React.Component<Props> {
         }
 
         router.bind('locale', locale);
-        this.mediaUploadStore = new MediaUploadStore(resourceStore, locale);
+        this.mediaUploadStore = new MediaUploadStore(resourceStore.data, locale);
     }
 
     componentWillUnmount() {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -44,6 +44,7 @@ jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
 
 jest.mock('../../../stores/MediaUploadStore', () => jest.fn(function() {
     this.id = 1;
+    this.media = {};
     this.update = jest.fn();
     this.upload = jest.fn();
     this.getThumbnail = jest.fn((size) => size);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the need for mutliple Requests in the SingleMediaUploadStore. For that the dependency on the ResourceStore was removed, which caused this request.

#### Why?

Because this way it is more performant and works the same way as in #3989.