### PR TITLE
Add notes to account and contact

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -345,6 +345,21 @@ class Account extends ApiWrapper
         return $emails;
     }
 
+    public function setNote(?string $note)
+    {
+        return $this->entity->setNote($note);
+    }
+
+    /**
+     * @VirtualProperty
+     * @SerializedName("note")
+     * @Groups({"fullAccount"})
+     */
+    public function getNote(): ?string
+    {
+        return $this->entity->getNote();
+    }
+
     /**
      * Add notes.
      *

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -368,6 +368,21 @@ class Contact extends ApiWrapper
         return $this;
     }
 
+    public function setNote(?string $note)
+    {
+        return $this->entity->setNote($note);
+    }
+
+    /**
+     * @VirtualProperty
+     * @SerializedName("note")
+     * @Groups({"fullContact"})
+     */
+    public function getNote(): ?string
+    {
+        return $this->entity->getNote();
+    }
+
     /**
      * Add note.
      *

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -284,6 +284,9 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
         if (!$patch || null !== $this->getProperty($data, 'avatar')) {
             $this->setAvatar($contact, $this->getProperty($data, 'avatar'));
         }
+        if (!$patch || null !== $this->getProperty($data, 'note')) {
+            $contact->setNote($this->getProperty($data, 'note'));
+        }
         if (!$patch || null !== $this->getProperty($data, 'medias')) {
             $this->setMedias($contact, $this->getProperty($data, 'medias', []));
         }

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -507,6 +507,10 @@ class AccountController extends RestController implements ClassResourceInterface
             $account->setUid($request->get('uid'));
         }
 
+        if (null !== $request->get('note')) {
+            $account->setNote($request->get('note'));
+        }
+
         if (array_key_exists('id', $request->get('logo', []))) {
             $accountManager->setLogo($account, $request->get('logo')['id']);
         }
@@ -585,6 +589,10 @@ class AccountController extends RestController implements ClassResourceInterface
 
         if (null !== $request->get('uid')) {
             $account->setUid($request->get('uid'));
+        }
+
+        if (null !== $request->get('note')) {
+            $account->setNote($request->get('note'));
         }
 
         if (array_key_exists('id', $request->get('logo', []))) {

--- a/src/Sulu/Bundle/ContactBundle/Entity/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Account.php
@@ -168,8 +168,14 @@ class Account implements AccountInterface
 
     /**
      * @var Collection
+     * @deprecated
      */
     protected $notes;
+
+    /**
+     * @var string
+     */
+    protected $note;
 
     /**
      * @var Collection
@@ -333,6 +339,18 @@ class Account implements AccountInterface
     public function getEmails(): Collection
     {
         return $this->emails;
+    }
+
+    public function setNote(?string $note): self
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
     }
 
     public function addNote(Note $note): AccountInterface

--- a/src/Sulu/Bundle/ContactBundle/Entity/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Account.php
@@ -168,6 +168,7 @@ class Account implements AccountInterface
 
     /**
      * @var Collection
+     *
      * @deprecated
      */
     protected $notes;

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -88,8 +88,15 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
     protected $creator;
 
     /**
+     * @var string
+     */
+    protected $note;
+
+    /**
      * @var Collection
      * @Groups({"fullContact"})
+     *
+     * @deprecated
      */
     protected $notes;
 
@@ -473,6 +480,18 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
     public function getCreator()
     {
         return $this->creator;
+    }
+
+    public function setNote(?string $note): self
+    {
+        $this->note = $note;
+
+        return $this;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Account.orm.xml
@@ -29,6 +29,8 @@
 
         <field name="corporation" type="string" column="corporation" length="255" nullable="true"/>
 
+        <field name="note" type="text" column="note" nullable="true"/>
+
         <!-- financial infos -->
         <field name="uid" type="string" column="uid" length="50" nullable="true" />
         <field name="registerNumber" type="string" column="registerNumber" nullable="true" />

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Contact.orm.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/doctrine/Contact.orm.xml
@@ -24,6 +24,8 @@
         <field name="newsletter" type="boolean" column="newsletter" nullable="true"/>
         <field name="gender" type="string" column="gender" length="1" nullable="true"/>
 
+        <field name="note" type="text" column="note" nullable="true"/>
+
         <!-- relational data flattened -->
         <field name="mainEmail" type="string" column="mainEmail" nullable="true"/>
         <field name="mainPhone" type="string" column="mainPhone" nullable="true"/>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
@@ -38,7 +38,7 @@
             <property name="parent" type="single_account_selection" colspan="6">
                 <meta>
                     <title lang="en">Parent company</title>
-                    <title lang="de">Mutterfirma</title>
+                    <title lang="de">Dachgesellschaft</title>
                 </meta>
             </property>
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
@@ -27,6 +27,12 @@
                     <title lang="de">Name</title>
                 </meta>
             </property>
+            <property name="corporation" type="text_line">
+                <meta>
+                    <title lang="en">Corporation</title>
+                    <title lang="de">Gesellschaft</title>
+                </meta>
+            </property>
         </properties>
     </section>
 </properties>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
@@ -27,10 +27,25 @@
                     <title lang="de">Name</title>
                 </meta>
             </property>
+
             <property name="corporation" type="text_line">
                 <meta>
                     <title lang="en">Corporation</title>
                     <title lang="de">Gesellschaft</title>
+                </meta>
+            </property>
+
+            <property name="parent" type="single_account_selection" colspan="6">
+                <meta>
+                    <title lang="en">Parent company</title>
+                    <title lang="de">Mutterfirma</title>
+                </meta>
+            </property>
+
+            <property name="uid" type="text_line" colspan="6">
+                <meta>
+                    <title lang="en">UID</title>
+                    <title lang="de">UID</title>
                 </meta>
             </property>
         </properties>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Account.xml
@@ -48,6 +48,13 @@
                     <title lang="de">UID</title>
                 </meta>
             </property>
+
+            <property name="note" type="text_area">
+                <meta>
+                    <title lang="en">Note</title>
+                    <title lang="de">Notiz</title>
+                </meta>
+            </property>
         </properties>
     </section>
 </properties>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
@@ -23,7 +23,7 @@
         <properties>
             <property name="formOfAddress" type="single_select" mandatory="true" colspan="3" spaceAfter="9">
                 <meta>
-                    <title lang="en">Salutation</title>
+                    <title lang="en">Form of Address</title>
                     <title lang="de">Anrede</title>
                 </meta>
                 <params>
@@ -69,7 +69,7 @@
             <property name="salutation" type="text_line">
                 <meta>
                     <title lang="en">Salutation</title>
-                    <title lang="de">Anrede</title>
+                    <title lang="de">Grußformel</title>
                 </meta>
             </property>
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
@@ -72,6 +72,13 @@
                     <title lang="de">Anrede</title>
                 </meta>
             </property>
+
+            <property name="note" type="text_area">
+                <meta>
+                    <title lang="en">Note</title>
+                    <title lang="de">Notiz</title>
+                </meta>
+            </property>
         </properties>
     </section>
 </properties>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -567,6 +567,7 @@ class AccountControllerTest extends SuluTestCase
             '/api/accounts',
             [
                 'name' => 'ExampleCompany',
+                'note' => 'A small notice',
                 'parent' => ['id' => $this->account->getId()],
                 'logo' => ['id' => $this->logo->getId()],
                 'urls' => [
@@ -663,6 +664,7 @@ class AccountControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('ExampleCompany', $response->name);
+        $this->assertEquals('A small notice', $response->note);
         $this->assertEquals(1, $response->depth);
         $this->assertEquals($this->account->getId(), $response->parent->id);
         $this->assertEquals('erika.mustermann@muster.at', $response->emails[0]->email);
@@ -699,6 +701,7 @@ class AccountControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('ExampleCompany', $response->name);
+        $this->assertEquals('A small notice', $response->note);
         $this->assertEquals(1, $response->depth);
         $this->assertEquals($this->account->getId(), $response->parent->id);
         $this->assertEquals('erika.mustermann@muster.at', $response->emails[0]->email);
@@ -1237,6 +1240,7 @@ class AccountControllerTest extends SuluTestCase
             '/api/accounts/' . $this->account->getId(),
             [
                 'name' => 'ExampleCompany',
+                'note' => 'A small notice',
                 'logo' => ['id' => $this->logo->getId()],
                 'urls' => [
                     [
@@ -1358,6 +1362,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
+        $this->assertEquals('A small notice', $response->note);
 
         $this->assertEquals(2, count($response->urls));
         $this->assertEquals('http://example.company.com', $response->urls[0]->url);
@@ -1462,6 +1467,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
+        $this->assertEquals('A small notice', $response->note);
 
         $this->assertEquals(2, count($response->urls));
         $this->assertEquals('http://example.company.com', $response->urls[0]->url);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -1074,6 +1074,7 @@ class ContactControllerTest extends SuluTestCase
             [
                 'firstName' => 'John',
                 'lastName' => 'Doe',
+                'note' => 'A small notice',
                 'title' => $this->contactTitle->getId(),
                 'position' => [
                     'id' => $this->contactPosition->getId(),
@@ -1199,6 +1200,7 @@ class ContactControllerTest extends SuluTestCase
 
         $this->assertEquals('John', $response->firstName);
         $this->assertEquals('Doe', $response->lastName);
+        $this->assertEquals('A small notice', $response->note);
         $this->assertEquals('MSc', $response->title->title);
         $this->assertEquals('john.doe@muster.at', $response->emails[0]->email);
         $this->assertEquals('john.doe@muster.de', $response->emails[1]->email);
@@ -1238,6 +1240,7 @@ class ContactControllerTest extends SuluTestCase
 
         $this->assertEquals('John', $response->firstName);
         $this->assertEquals('Doe', $response->lastName);
+        $this->assertEquals('A small notice', $response->note);
         $this->assertEquals('MSc', $response->title->title);
         $this->assertEquals('john.doe@muster.at', $response->emails[0]->email);
         $this->assertEquals('john.doe@muster.de', $response->emails[1]->email);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a note field to both accounts and contacts.

#### Why?

Because we need this field and it was there before.

#### BC Breaks/Deprecations

The `notes` field is deprecated now, and is replaced by a simple text field. This means that there is only one note per account/contact now.

#### To Do

- [ ] Write migration
- [ ] Remove deprecated property and everything related to it
