### PR TITLE
Bugfix: Field date and time without utc calculation

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/fieldTransformers/DateFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/fieldTransformers/DateFieldTransformer.js
@@ -4,18 +4,20 @@ import log from 'loglevel';
 import type {Node} from 'react';
 import type {FieldTransformer} from '../types';
 
+const format = 'YYYY-MM-DD';
+
 export default class DateFieldTransformer implements FieldTransformer {
     transform(value: *): Node {
         if (!value) {
-            return;
+            return null;
         }
 
-        const momentObject = moment(value, moment.ISO_8601);
+        const momentObject = moment(value, format);
 
         if (!momentObject.isValid()) {
-            log.error('Invalid date given: "' + value + '". Format needs to be in "ISO 8601"');
+            log.error('Invalid date given: "' + value + '". Format needs to be "' + format + '"');
 
-            return;
+            return null;
         }
 
         return momentObject.format('L');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/fieldTransformers/TimeFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/fieldTransformers/TimeFieldTransformer.js
@@ -4,18 +4,20 @@ import log from 'loglevel';
 import type {Node} from 'react';
 import type {FieldTransformer} from '../types';
 
-export default class DateFieldTransformer implements FieldTransformer {
+const format = 'HH:mm:ss';
+
+export default class TimeFieldTransformer implements FieldTransformer {
     transform(value: *): Node {
         if (!value) {
-            return;
+            return null;
         }
 
-        const momentObject = moment(value, moment.ISO_8601);
+        const momentObject = moment(value, format);
 
         if (!momentObject.isValid()) {
-            log.error('Invalid date given: "' + value + '". Format needs to be in "ISO 8601"');
+            log.error('Invalid time given: "' + value + '". Format needs to be "' + format + '"');
 
-            return;
+            return null;
         }
 
         return momentObject.format('LT');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/fieldTransformers/DateFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/fieldTransformers/DateFieldTransformer.test.js
@@ -14,15 +14,15 @@ jest.mock('loglevel', () => ({
 }));
 
 test('Test undefined', () => {
-    expect(dateFieldTransformer.transform(undefined)).toBe(undefined);
+    expect(dateFieldTransformer.transform(undefined)).toBe(null);
 });
 
 test('Test invalid format', () => {
-    expect(dateFieldTransformer.transform('xxx')).toBe(undefined);
-    expect(log.error).toBeCalledWith('Invalid date given: "xxx". Format needs to be in "ISO 8601"');
+    expect(dateFieldTransformer.transform('xxx')).toBe(null);
+    expect(log.error).toBeCalledWith('Invalid date given: "xxx". Format needs to be "YYYY-MM-DD"');
 });
 
 test('Test valid example', () => {
-    expect(dateFieldTransformer.transform('2018-03-10T14:09:04+01:00')).toBe('03/10/2018');
+    expect(dateFieldTransformer.transform('2018-03-10')).toBe('03/10/2018');
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/fieldTransformers/TimeFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/fieldTransformers/TimeFieldTransformer.test.js
@@ -14,15 +14,15 @@ jest.mock('loglevel', () => ({
 }));
 
 test('Test undefined', () => {
-    expect(timeFieldTransformer.transform(undefined)).toBe(undefined);
+    expect(timeFieldTransformer.transform(undefined)).toBe(null);
 });
 
 test('Test invalid format', () => {
-    expect(timeFieldTransformer.transform('xxx')).toBe(undefined);
-    expect(log.error).toBeCalledWith('Invalid date given: "xxx". Format needs to be in "ISO 8601"');
+    expect(timeFieldTransformer.transform('xxx')).toBe(null);
+    expect(log.error).toBeCalledWith('Invalid time given: "xxx". Format needs to be "HH:mm:ss"');
 });
 
 test('Test valid example', () => {
-    expect(timeFieldTransformer.transform('2018-03-10T14:09:04+01:00')).toBe('2:09 PM');
+    expect(timeFieldTransformer.transform('14:09')).toBe('2:09 PM');
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/DatePicker.js
@@ -11,7 +11,7 @@ function createStringValue(value: ?Date) {
         return undefined;
     }
 
-    return moment.utc(value).format(format);
+    return moment(value).format(format);
 }
 
 function getValue(value: ?string): ?moment {
@@ -19,7 +19,7 @@ function getValue(value: ?string): ?moment {
         return undefined;
     }
 
-    const momentObject = moment.utc(value, format);
+    const momentObject = moment(value, format);
 
     if (!momentObject.isValid()) {
         return undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Time.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Time.js
@@ -11,7 +11,7 @@ function createStringValue(value: ?Date) {
         return undefined;
     }
 
-    return moment.utc(value).format(format);
+    return moment(value).format(format);
 }
 
 function getValue(value: ?string): ?moment {
@@ -19,7 +19,7 @@ function getValue(value: ?string): ?moment {
         return undefined;
     }
 
-    const momentObject = moment.utc(value, format);
+    const momentObject = moment(value, format);
 
     if (!momentObject.isValid()) {
         return undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Time.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Time.test.js
@@ -69,7 +69,7 @@ test('Should call onFinish callback on every onChange with correctly converted v
         />
     );
 
-    time.find(DatePickerComponent).simulate('change', new Date(Date.UTC(2018, 3, 15, 6, 32, 20)));
+    time.find(DatePickerComponent).simulate('change', new Date(2018, 3, 15, 6, 32, 20));
 
     expect(finishSpy).toBeCalled();
     expect(changeSpy).toBeCalledWith('06:32:20');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Do not calculate date and time with timezone offset from UTC.

#### Why?

Bugfix of wrong calculated dates and times.
