### PR TITLE
implement error snackbar

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
@@ -1,7 +1,7 @@
 The `Toolbar` component serves as container for `Controls`. The `Controls` component groups components which provide
 the user interaction like `Button`, `Select` or `Dropdown`.
 
-```
+```javascript
 const Toolbar = require('./Toolbar').default;
 
 <Toolbar>
@@ -15,7 +15,7 @@ const Toolbar = require('./Toolbar').default;
 The space inside of the `Toolbar` will be divided fairly for all the `Controls` children. Inside of the `Controls`
 component you can group the items by using the `Items` component.
 
-```
+```javascript
 const Toolbar = require('./Toolbar').default;
 
 <Toolbar>
@@ -52,7 +52,7 @@ const Toolbar = require('./Toolbar').default;
 
 The appearance of the `Toolbar` can be changed by passing the attribute `skin`. Available skins are `light` and `dark`. 
 
-```
+```javascript
 const Toolbar = require('./Toolbar').default;
 
 <Toolbar skin="dark">
@@ -83,6 +83,22 @@ const Toolbar = require('./Toolbar').default;
                 },
             ]}
         />
+    </Toolbar.Controls>
+</Toolbar>
+```
+
+The toolbar can also show an error using a snackbar. The error will fill the entire toolbar and hide any controls
+behind it.
+
+```javascript
+const Toolbar = require('./Toolbar').default;
+
+initialState = {error: true};
+
+<Toolbar>
+    {state.error && <Toolbar.Snackbar onCloseClick={() => setState({error: false})} />}
+    <Toolbar.Controls>
+        <Toolbar.Button onClick={() => setState({error: true})}>Cause error</Toolbar.Button>
     </Toolbar.Controls>
 </Toolbar>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
@@ -87,7 +87,7 @@ const Toolbar = require('./Toolbar').default;
 </Toolbar>
 ```
 
-The toolbar can also show an error using a snackbar. The error will fill the entire toolbar and hide any controls
+The toolbar can also show error using a snackbar. The error will fill the entire toolbar and hide any controls
 behind it.
 
 ```javascript
@@ -96,9 +96,29 @@ const Toolbar = require('./Toolbar').default;
 initialState = {error: true};
 
 <Toolbar>
-    {state.error && <Toolbar.Snackbar onCloseClick={() => setState({error: false})} />}
+    {state.error && <Toolbar.Snackbar onCloseClick={() => setState({error: false})} type="error" />}
     <Toolbar.Controls>
         <Toolbar.Button onClick={() => setState({error: true})}>Cause error</Toolbar.Button>
+    </Toolbar.Controls>
+</Toolbar>
+```
+
+In the same way it is possible to show success messages.
+
+```javascript
+const Toolbar = require('./Toolbar').default;
+
+initialState = {success: false};
+
+const buttonClick = () => {
+    setState({success: true});
+    setTimeout(() => setState({success: false}), 1500);
+};
+
+<Toolbar>
+    {state.success && <Toolbar.Snackbar type="success" />}
+    <Toolbar.Controls>
+        <Toolbar.Button onClick={buttonClick}>Cause success</Toolbar.Button>
     </Toolbar.Controls>
 </Toolbar>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
@@ -7,6 +7,7 @@ import snackbarStyles from './snackbar.scss';
 
 type Props = {|
     onCloseClick?: () => void,
+    onClick?: () => void,
     type: 'error' | 'success',
 |};
 
@@ -17,7 +18,7 @@ const ICONS = {
 
 export default class Snackbar extends React.Component<Props> {
     render() {
-        const {onCloseClick, type} = this.props;
+        const {onCloseClick, onClick, type} = this.props;
 
         const snackbarClass = classNames(
             snackbarStyles.snackbar,
@@ -25,7 +26,7 @@ export default class Snackbar extends React.Component<Props> {
         );
 
         return (
-            <div className={snackbarClass}>
+            <div className={snackbarClass} onClick={onClick}>
                 <Icon className={snackbarStyles.icon} name={ICONS[type]} />
                 {type !== 'success' &&
                     <div className={snackbarStyles.text}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
@@ -6,28 +6,38 @@ import Icon from '../Icon';
 import snackbarStyles from './snackbar.scss';
 
 type Props = {|
-    onCloseClick: () => void,
+    onCloseClick?: () => void,
+    type: 'error' | 'success',
 |};
+
+const ICONS = {
+    error: 'su-exclamation-triangle',
+    success: 'su-check',
+};
 
 export default class Snackbar extends React.Component<Props> {
     render() {
-        const {onCloseClick} = this.props;
+        const {onCloseClick, type} = this.props;
 
         const snackbarClass = classNames(
             snackbarStyles.snackbar,
-            snackbarStyles.error
+            snackbarStyles[type]
         );
 
         return (
             <div className={snackbarClass}>
-                <Icon className={snackbarStyles.icon} name="su-exclamation-triangle" />
-                <div className={snackbarStyles.text}>
-                    <strong>{translate('sulu_admin.error')}</strong>
-                    <button className={snackbarStyles.closeButton} onClick={onCloseClick}>
-                        {translate('sulu_admin.close')}
-                        <Icon className={snackbarStyles.closeButtonIcon} name="su-times" />
-                    </button>
-                </div>
+                <Icon className={snackbarStyles.icon} name={ICONS[type]} />
+                {type !== 'success' &&
+                    <div className={snackbarStyles.text}>
+                        <strong>{translate('sulu_admin.' + type)}</strong>
+                        {onCloseClick &&
+                            <button className={snackbarStyles.closeButton} onClick={onCloseClick}>
+                                {translate('sulu_admin.close')}
+                                <Icon className={snackbarStyles.closeButtonIcon} name="su-times" />
+                            </button>
+                        }
+                    </div>
+                }
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
@@ -9,6 +9,7 @@ type Props = {|
     onCloseClick?: () => void,
     onClick?: () => void,
     type: 'error' | 'success',
+    visible: boolean,
 |};
 
 const ICONS = {
@@ -17,12 +18,19 @@ const ICONS = {
 };
 
 export default class Snackbar extends React.Component<Props> {
+    static defaultProps = {
+        visible: true,
+    };
+
     render() {
-        const {onCloseClick, onClick, type} = this.props;
+        const {onCloseClick, onClick, type, visible} = this.props;
 
         const snackbarClass = classNames(
             snackbarStyles.snackbar,
-            snackbarStyles[type]
+            snackbarStyles[type],
+            {
+                [snackbarStyles.visible]: visible,
+            }
         );
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
@@ -29,6 +29,7 @@ export default class Snackbar extends React.Component<Props> {
             snackbarStyles.snackbar,
             snackbarStyles[type],
             {
+                [snackbarStyles.clickable]: onClick,
                 [snackbarStyles.visible]: visible,
             }
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Snackbar.js
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+import classNames from 'classnames';
+import {translate} from '../../utils/Translator';
+import Icon from '../Icon';
+import snackbarStyles from './snackbar.scss';
+
+type Props = {|
+    onCloseClick: () => void,
+|};
+
+export default class Snackbar extends React.Component<Props> {
+    render() {
+        const {onCloseClick} = this.props;
+
+        const snackbarClass = classNames(
+            snackbarStyles.snackbar,
+            snackbarStyles.error
+        );
+
+        return (
+            <div className={snackbarClass}>
+                <Icon className={snackbarStyles.icon} name="su-exclamation-triangle" />
+                <div className={snackbarStyles.text}>
+                    <strong>{translate('sulu_admin.error')}</strong>
+                    <button className={snackbarStyles.closeButton} onClick={onCloseClick}>
+                        {translate('sulu_admin.close')}
+                        <Icon className={snackbarStyles.closeButtonIcon} name="su-times" />
+                    </button>
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import Button from './Button';
 import Controls from './Controls';
 import Dropdown from './Dropdown';
+import Snackbar from './Snackbar';
 import Items from './Items';
 import Icons from './Icons';
 import Select from './Select';
@@ -12,7 +13,7 @@ import type {Skin} from './types';
 import toolbarStyles from './toolbar.scss';
 
 type Props = {
-    children: ChildrenArray<Element<typeof Controls>>,
+    children: ChildrenArray<false | Element<typeof Controls | typeof Snackbar>>,
     skin?: Skin,
 };
 
@@ -33,8 +34,14 @@ export default class Toolbar extends React.PureComponent<Props> {
 
     static Select = Select;
 
-    static createChildren(children: ChildrenArray<Element<typeof Controls>>, skin?: Skin) {
+    static Snackbar = Snackbar;
+
+    static createChildren(children: ChildrenArray<*>, skin?: Skin) {
         return React.Children.map(children, (child) => {
+            if (!child) {
+                return null;
+            }
+
             return React.cloneElement(
                 child,
                 {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
@@ -1,0 +1,56 @@
+@import '../../containers/Application/colors.scss';
+
+$snackbarErrorColor: $white;
+$snackbarErrorBackgroundColor: $roman;
+$snackbarIconErrorBackgroundColor: $persianRed;
+$closeButtonBorderColor: $white;
+
+.snackbar {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    display: flex;
+}
+
+.icon {
+    width: 60px;
+    background-color: $snackbarIconErrorBackgroundColor;
+    font-size: 20px;
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    justify-content: center;
+}
+
+.text {
+    font-size: 12px;
+    margin-left: 20px;
+}
+
+.close-button {
+    border: 1px solid $closeButtonBorderColor;
+    border-radius: 3px;
+    margin-left: 20px;
+    padding: 4px 20px;
+    cursor: pointer;
+}
+
+.close-button-icon {
+    font-size: 10px;
+    margin-left: 20px;
+}
+
+.error {
+    background-color: $snackbarErrorBackgroundColor;
+    color: $snackbarErrorColor;
+    display: flex;
+    align-items: center;
+
+    .close-button {
+        background-color: $snackbarErrorBackgroundColor;
+        color: $snackbarErrorColor;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
@@ -49,6 +49,13 @@ $closeButtonBorderColor: $white;
     color: $snackbarErrorColor;
     display: flex;
     align-items: center;
+    will-change: top, bottom;
+    transition: top .15s, bottom .15s;
+
+    &:not(.visible) {
+        top: -100%;
+        bottom: 100%;
+    }
 
     .icon {
         background-color: $snackbarIconErrorBackgroundColor;
@@ -64,6 +71,13 @@ $closeButtonBorderColor: $white;
     color: $snackbarSuccessColor;
     display: flex;
     align-items: center;
+    opacity: 0;
+    will-change: opacity;
+    transition: opacity .25s;
+
+    &.visible {
+        opacity: 1;
+    }
 
     .icon {
         background-color: $snackbarIconSuccessBackgroundColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
@@ -3,6 +3,8 @@
 $snackbarErrorColor: $white;
 $snackbarErrorBackgroundColor: $roman;
 $snackbarIconErrorBackgroundColor: $persianRed;
+$snackbarSuccessColor: $white;
+$snackbarIconSuccessBackgroundColor: $mantis;
 $closeButtonBorderColor: $white;
 
 .snackbar {
@@ -10,14 +12,12 @@ $closeButtonBorderColor: $white;
     top: 0;
     bottom: 0;
     left: 0;
-    right: 0;
     z-index: 1;
     display: flex;
 }
 
 .icon {
     width: 60px;
-    background-color: $snackbarIconErrorBackgroundColor;
     font-size: 20px;
     display: flex;
     align-items: center;
@@ -44,13 +44,28 @@ $closeButtonBorderColor: $white;
 }
 
 .error {
+    right: 0;
     background-color: $snackbarErrorBackgroundColor;
     color: $snackbarErrorColor;
     display: flex;
     align-items: center;
 
+    .icon {
+        background-color: $snackbarIconErrorBackgroundColor;
+    }
+
     .close-button {
         background-color: $snackbarErrorBackgroundColor;
         color: $snackbarErrorColor;
+    }
+}
+
+.success {
+    color: $snackbarSuccessColor;
+    display: flex;
+    align-items: center;
+
+    .icon {
+        background-color: $snackbarIconSuccessBackgroundColor;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/snackbar.scss
@@ -43,6 +43,10 @@ $closeButtonBorderColor: $white;
     margin-left: 20px;
 }
 
+.clickable {
+    cursor: pointer;
+}
+
 .error {
     right: 0;
     background-color: $snackbarErrorBackgroundColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
@@ -15,6 +15,10 @@ test('Render a success snackbar', () => {
     expect(render(<Snackbar type="success" />)).toMatchSnapshot();
 });
 
+test('Render a clickable success snackbar', () => {
+    expect(render(<Snackbar onClick={jest.fn()} type="success" />)).toMatchSnapshot();
+});
+
 test('Render an error snackbar', () => {
     expect(render(<Snackbar onCloseClick={jest.fn()} type="error" />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
@@ -7,13 +7,21 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-test('Render a snackbar', () => {
-    expect(render(<Snackbar onCloseClick={jest.fn()} />)).toMatchSnapshot();
+test('Render a success snackbar', () => {
+    expect(render(<Snackbar onCloseClick={jest.fn()} type="success" />)).toMatchSnapshot();
+});
+
+test('Render an error snackbar', () => {
+    expect(render(<Snackbar onCloseClick={jest.fn()} type="error" />)).toMatchSnapshot();
+});
+
+test('Render an error snackbar without close button', () => {
+    expect(render(<Snackbar type="error" />)).toMatchSnapshot();
 });
 
 test('Call onCloseClick callback when close button is clicked', () => {
     const closeClickSpy = jest.fn();
-    const snackbar = shallow(<Snackbar onCloseClick={closeClickSpy} />);
+    const snackbar = shallow(<Snackbar onCloseClick={closeClickSpy} type="error" />);
 
     snackbar.find('button').simulate('click');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
@@ -1,0 +1,21 @@
+// @flow
+import React from 'react';
+import {render, shallow} from 'enzyme';
+import Snackbar from '../Snackbar';
+
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Render a snackbar', () => {
+    expect(render(<Snackbar onCloseClick={jest.fn()} />)).toMatchSnapshot();
+});
+
+test('Call onCloseClick callback when close button is clicked', () => {
+    const closeClickSpy = jest.fn();
+    const snackbar = shallow(<Snackbar onCloseClick={closeClickSpy} />);
+
+    snackbar.find('button').simulate('click');
+
+    expect(closeClickSpy).toBeCalledWith();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
@@ -19,6 +19,15 @@ test('Render an error snackbar without close button', () => {
     expect(render(<Snackbar type="error" />)).toMatchSnapshot();
 });
 
+test('Click the snackbar should call the onClick callback', () => {
+    const clickSpy = jest.fn();
+    const snackbar = shallow(<Snackbar onClick={clickSpy} type="success" />);
+
+    snackbar.simulate('click');
+
+    expect(clickSpy).toBeCalledWith();
+});
+
 test('Call onCloseClick callback when close button is clicked', () => {
     const closeClickSpy = jest.fn();
     const snackbar = shallow(<Snackbar onCloseClick={closeClickSpy} type="error" />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Snackbar.test.js
@@ -7,8 +7,12 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+test('Render an invisible success snackbar', () => {
+    expect(render(<Snackbar type="success" visible={false} />)).toMatchSnapshot();
+});
+
 test('Render a success snackbar', () => {
-    expect(render(<Snackbar onCloseClick={jest.fn()} type="success" />)).toMatchSnapshot();
+    expect(render(<Snackbar type="success" />)).toMatchSnapshot();
 });
 
 test('Render an error snackbar', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toolbar.test.js
@@ -26,7 +26,7 @@ test('Render controls', () => {
 test('Render with Snackbar', () => {
     expect(render(
         <Toolbar>
-            <Snackbar onCloseClick={jest.fn()} />
+            <Snackbar onCloseClick={jest.fn()} type="error" />
             <Controls>
                 <Button onClick={jest.fn()}>Test</Button>
             </Controls>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toolbar.test.js
@@ -1,20 +1,34 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {render} from 'enzyme';
 import React from 'react';
-import Toolbar from '../Toolbar';
-import Controls from '../Controls';
 import Button from '../Button';
+import Controls from '../Controls';
+import Snackbar from '../Snackbar';
+import Toolbar from '../Toolbar';
 
-const clickSpy = jest.fn();
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
 
 test('Render controls', () => {
     expect(render(
         <Toolbar>
             <Controls>
-                <Button onClick={clickSpy}>Test</Button>
+                <Button onClick={jest.fn()}>Test</Button>
             </Controls>
             <Controls>
-                <Button onClick={clickSpy}>Test</Button>
+                <Button onClick={jest.fn()}>Test</Button>
+            </Controls>
+        </Toolbar>
+    )).toMatchSnapshot();
+});
+
+test('Render with Snackbar', () => {
+    expect(render(
+        <Toolbar>
+            <Snackbar onCloseClick={jest.fn()} />
+            <Controls>
+                <Button onClick={jest.fn()}>Test</Button>
             </Controls>
         </Toolbar>
     )).toMatchSnapshot();
@@ -24,10 +38,10 @@ test('Render dark theme', () => {
     expect(render(
         <Toolbar skin="dark">
             <Controls>
-                <Button onClick={clickSpy}>Test</Button>
+                <Button onClick={jest.fn()}>Test</Button>
             </Controls>
             <Controls>
-                <Button onClick={clickSpy}>Test</Button>
+                <Button onClick={jest.fn()}>Test</Button>
             </Controls>
         </Toolbar>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render a clickable success snackbar 1`] = `
+<div
+  class="snackbar success clickable visible"
+>
+  <span
+    aria-label="su-check"
+    class="icon su-check"
+  />
+</div>
+`;
+
 exports[`Render a success snackbar 1`] = `
 <div
   class="snackbar success visible"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render a snackbar 1`] = `
+<div
+  class="snackbar error"
+>
+  <span
+    aria-label="su-exclamation-triangle"
+    class="icon su-exclamation-triangle"
+  />
+  <div
+    class="text"
+  >
+    <strong>
+      sulu_admin.error
+    </strong>
+    <button
+      class="closeButton"
+    >
+      sulu_admin.close
+      <span
+        aria-label="su-times"
+        class="closeButtonIcon su-times"
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render a snackbar 1`] = `
+exports[`Render a success snackbar 1`] = `
+<div
+  class="snackbar success"
+>
+  <span
+    aria-label="su-check"
+    class="icon su-check"
+  />
+</div>
+`;
+
+exports[`Render an error snackbar 1`] = `
 <div
   class="snackbar error"
 >
@@ -23,6 +34,24 @@ exports[`Render a snackbar 1`] = `
         class="closeButtonIcon su-times"
       />
     </button>
+  </div>
+</div>
+`;
+
+exports[`Render an error snackbar without close button 1`] = `
+<div
+  class="snackbar error"
+>
+  <span
+    aria-label="su-exclamation-triangle"
+    class="icon su-exclamation-triangle"
+  />
+  <div
+    class="text"
+  >
+    <strong>
+      sulu_admin.error
+    </strong>
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render a success snackbar 1`] = `
 <div
-  class="snackbar success"
+  class="snackbar success visible"
 >
   <span
     aria-label="su-check"
@@ -13,7 +13,7 @@ exports[`Render a success snackbar 1`] = `
 
 exports[`Render an error snackbar 1`] = `
 <div
-  class="snackbar error"
+  class="snackbar error visible"
 >
   <span
     aria-label="su-exclamation-triangle"
@@ -40,7 +40,7 @@ exports[`Render an error snackbar 1`] = `
 
 exports[`Render an error snackbar without close button 1`] = `
 <div
-  class="snackbar error"
+  class="snackbar error visible"
 >
   <span
     aria-label="su-exclamation-triangle"
@@ -53,5 +53,16 @@ exports[`Render an error snackbar without close button 1`] = `
       sulu_admin.error
     </strong>
   </div>
+</div>
+`;
+
+exports[`Render an invisible success snackbar 1`] = `
+<div
+  class="snackbar success"
+>
+  <span
+    aria-label="su-check"
+    class="icon su-check"
+  />
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -65,3 +65,47 @@ exports[`Render dark theme 1`] = `
   </div>
 </nav>
 `;
+
+exports[`Render with Snackbar 1`] = `
+<nav
+  class="toolbar light"
+>
+  <div
+    class="snackbar error"
+  >
+    <span
+      aria-label="su-exclamation-triangle"
+      class="icon su-exclamation-triangle"
+    />
+    <div
+      class="text"
+    >
+      <strong>
+        sulu_admin.error
+      </strong>
+      <button
+        class="closeButton"
+      >
+        sulu_admin.close
+        <span
+          aria-label="su-times"
+          class="closeButtonIcon su-times"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="controls light"
+  >
+    <button
+      class="button light"
+    >
+      <span
+        class="label"
+      >
+        Test
+      </span>
+    </button>
+  </div>
+</nav>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -71,7 +71,7 @@ exports[`Render with Snackbar 1`] = `
   class="toolbar light"
 >
   <div
-    class="snackbar error"
+    class="snackbar error visible"
   >
     <span
       aria-label="su-exclamation-triangle"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/toolbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/toolbar.scss
@@ -1,6 +1,7 @@
 @import './variables.scss';
 
 .toolbar {
+    position: relative;
     display: flex;
     justify-content: space-between;
     height: $toolbarHeight;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/colors.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/colors.scss
@@ -18,6 +18,7 @@ $frenchGray: #babfc7;
 $gallery: #ededed;
 $gray: #878787;
 $java: #24b7c8;
+$mantis: #6ac86b;
 $mineShaft: #353535;
 $mischka: #dee0e7;
 $nobel: #b4b4b4;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -89,6 +89,14 @@ exports[`Application should not fail if current route does not exist 1`] = `
           class="toolbar light"
         >
           <div
+            class="snackbar success"
+          >
+            <span
+              aria-label="su-check"
+              class="icon su-check"
+            />
+          </div>
+          <div
             class="controls light"
           >
             <button
@@ -201,6 +209,14 @@ exports[`Application should render based on current route 1`] = `
         <nav
           class="toolbar light"
         >
+          <div
+            class="snackbar success"
+          >
+            <span
+              aria-label="su-check"
+              class="icon su-check"
+            />
+          </div>
           <div
             class="controls light"
           >
@@ -568,6 +584,28 @@ exports[`Application should render opened navigation 1`] = `
               <nav
                 className="toolbar light"
               >
+                <Snackbar
+                  key=".1"
+                  onClick={[Function]}
+                  skin="light"
+                  type="success"
+                  visible={false}
+                >
+                  <div
+                    className="snackbar success"
+                    onClick={[Function]}
+                  >
+                    <Icon
+                      className="icon"
+                      name="su-check"
+                    >
+                      <span
+                        aria-label="su-check"
+                        className="icon su-check"
+                      />
+                    </Icon>
+                  </div>
+                </Snackbar>
                 <Controls
                   key=".2"
                   skin="light"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -569,7 +569,7 @@ exports[`Application should render opened navigation 1`] = `
                 className="toolbar light"
               >
                 <Controls
-                  key=".0"
+                  key=".1"
                   skin="light"
                 >
                   <div
@@ -604,7 +604,7 @@ exports[`Application should render opened navigation 1`] = `
                   </div>
                 </Controls>
                 <Controls
-                  key=".1"
+                  key=".2"
                   skin="light"
                 >
                   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -89,7 +89,31 @@ exports[`Application should not fail if current route does not exist 1`] = `
           class="toolbar light"
         >
           <div
-            class="snackbar success"
+            class="snackbar error"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="icon su-exclamation-triangle"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+              <button
+                class="closeButton"
+              >
+                sulu_admin.close
+                <span
+                  aria-label="su-times"
+                  class="closeButtonIcon su-times"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="snackbar success clickable"
           >
             <span
               aria-label="su-check"
@@ -210,7 +234,31 @@ exports[`Application should render based on current route 1`] = `
           class="toolbar light"
         >
           <div
-            class="snackbar success"
+            class="snackbar error"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="icon su-exclamation-triangle"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+              <button
+                class="closeButton"
+              >
+                sulu_admin.close
+                <span
+                  aria-label="su-times"
+                  class="closeButtonIcon su-times"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="snackbar success clickable"
           >
             <span
               aria-label="su-check"
@@ -585,6 +633,49 @@ exports[`Application should render opened navigation 1`] = `
                 className="toolbar light"
               >
                 <Snackbar
+                  key=".0"
+                  onCloseClick={[Function]}
+                  skin="light"
+                  type="error"
+                  visible={false}
+                >
+                  <div
+                    className="snackbar error"
+                  >
+                    <Icon
+                      className="icon"
+                      name="su-exclamation-triangle"
+                    >
+                      <span
+                        aria-label="su-exclamation-triangle"
+                        className="icon su-exclamation-triangle"
+                      />
+                    </Icon>
+                    <div
+                      className="text"
+                    >
+                      <strong>
+                        sulu_admin.error
+                      </strong>
+                      <button
+                        className="closeButton"
+                        onClick={[Function]}
+                      >
+                        sulu_admin.close
+                        <Icon
+                          className="closeButtonIcon"
+                          name="su-times"
+                        >
+                          <span
+                            aria-label="su-times"
+                            className="closeButtonIcon su-times"
+                          />
+                        </Icon>
+                      </button>
+                    </div>
+                  </div>
+                </Snackbar>
+                <Snackbar
                   key=".1"
                   onClick={[Function]}
                   skin="light"
@@ -592,7 +683,7 @@ exports[`Application should render opened navigation 1`] = `
                   visible={false}
                 >
                   <div
-                    className="snackbar success"
+                    className="snackbar success clickable"
                     onClick={[Function]}
                   >
                     <Icon

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -569,7 +569,7 @@ exports[`Application should render opened navigation 1`] = `
                 className="toolbar light"
               >
                 <Controls
-                  key=".1"
+                  key=".2"
                   skin="light"
                 >
                   <div
@@ -604,7 +604,7 @@ exports[`Application should render opened navigation 1`] = `
                   </div>
                 </Controls>
                 <Controls
-                  key=".2"
+                  key=".3"
                   skin="light"
                 >
                   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AutoComplete/tests/__snapshots__/AutoComplete.test.js.snap
@@ -5,10 +5,10 @@ exports[`Render in loading state 1`] = `
   class="autoComplete"
 >
   <label
-    class="input"
+    class="input default"
   >
     <div
-      class="prependedContainer"
+      class="prependedContainer default"
     >
       <div
         class="spinner"
@@ -35,10 +35,10 @@ exports[`Render with given value 1`] = `
   class="autoComplete"
 >
   <label
-    class="input"
+    class="input default"
   >
     <div
-      class="prependedContainer"
+      class="prependedContainer default"
     >
       <div
         class="spinner"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -9,7 +9,7 @@ import FormInspector from './FormInspector';
 
 type Props = {
     store: FormStore,
-    onSubmit: (action: ?string) => void,
+    onSubmit: (action: ?string) => ?Promise<Object>,
 };
 
 @observer
@@ -23,7 +23,7 @@ export default class Form extends React.Component<Props> {
     /** @public */
     @action submit = (action: ?string) => {
         this.showAllErrors = true;
-        this.props.onSubmit(action);
+        return this.props.onSubmit(action);
     };
 
     handleChange = (name: string, value: mixed) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
@@ -282,3 +282,33 @@ const PageWithToolbar = withToolbar(Page, function() {
     <PageWithToolbar />
 </div>
 ```
+
+The `errors` property can be set to show an error instead of the toolbar.
+
+```
+const withToolbar = require('./withToolbar').default;
+const Toolbar = require('./Toolbar').default;
+
+initialState = {selectVal: 1}
+
+class Page extends React.PureComponent {
+    render() {
+        return (
+            <h1>Just an error...</h1>
+        );
+    }
+}
+
+const PageWithToolbar = withToolbar(Page, function() {
+    return {
+        errors: [
+            {code: 1000},
+        ],
+    };
+}, 'toolbar-demo-5');
+
+<div>
+    <Toolbar storeKey="toolbar-demo-5" />
+    <PageWithToolbar />
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
@@ -9,7 +9,7 @@ offer.
 
 Here is a basic example of the `Toolbar` component:
 
-```
+```javascript
 const withToolbar = require('./withToolbar').default;
 const Toolbar = require('./Toolbar').default;
 
@@ -50,7 +50,7 @@ offers three kinds of items which can be used by defining them inside the items 
 
 Here a `Toolbar` example which is using all three of them:
 
-```
+```javascript
 const withToolbar = require('./withToolbar').default;
 const Toolbar = require('./Toolbar').default;
 
@@ -129,7 +129,7 @@ and the option to show icons in order to display notifications or other state in
 
 Example with special control elements:
 
-```
+```javascript
 const withToolbar = require('./withToolbar').default;
 const Toolbar = require('./Toolbar').default;
 
@@ -197,7 +197,7 @@ const PageWithToolbar = withToolbar(Page, function() {
 Each item has also the possibility to show a loader instead of its text by using the `loading` property. This is useful
 when an asynchronous action is sent:
 
-```
+```javascript
 const withToolbar = require('./withToolbar').default;
 const Toolbar = require('./Toolbar').default;
 const observable = require('mobx').observable;
@@ -285,11 +285,9 @@ const PageWithToolbar = withToolbar(Page, function() {
 
 The `errors` property can be set to show an error instead of the toolbar.
 
-```
+```javascript
 const withToolbar = require('./withToolbar').default;
 const Toolbar = require('./Toolbar').default;
-
-initialState = {selectVal: 1}
 
 class Page extends React.PureComponent {
     render() {
@@ -309,6 +307,33 @@ const PageWithToolbar = withToolbar(Page, function() {
 
 <div>
     <Toolbar storeKey="toolbar-demo-5" />
+    <PageWithToolbar />
+</div>
+```
+
+Corresponding to that the `showSuccess` property can be used to show a success icon for 1.5 seconds.
+
+```javascript
+const extendObservable = require('mobx').extendObservable;
+const withToolbar = require('./withToolbar').default;
+const Toolbar = require('./Toolbar').default;
+
+class Page extends React.PureComponent {
+    render() {
+        return (
+            <h1>Just a success :-)</h1>
+        );
+    }
+}
+
+const PageWithToolbar = withToolbar(Page, function() {
+    return {
+        showSuccess: true,
+    };
+}, 'toolbar-demo-6');
+
+<div>
+    <Toolbar storeKey="toolbar-demo-6" />
     <PageWithToolbar />
 </div>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
@@ -315,6 +315,7 @@ Corresponding to that the `showSuccess` property can be used to show a success i
 
 ```javascript
 const extendObservable = require('mobx').extendObservable;
+const observable = require('mobx').observable;
 const withToolbar = require('./withToolbar').default;
 const Toolbar = require('./Toolbar').default;
 
@@ -328,7 +329,7 @@ class Page extends React.PureComponent {
 
 const PageWithToolbar = withToolbar(Page, function() {
     return {
-        showSuccess: true,
+        showSuccess: observable.box(true),
     };
 }, 'toolbar-demo-6');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -94,7 +94,10 @@ export default class Toolbar extends React.Component<*> {
         return (
             <ToolbarComponent>
                 {this.toolbarStore.errors.length > 0 &&
-                    <ToolbarComponent.Snackbar onCloseClick={this.handleSnackbarCloseClick} />
+                    <ToolbarComponent.Snackbar onCloseClick={this.handleSnackbarCloseClick} type="error" />
+                }
+                {this.toolbarStore.showSuccess &&
+                    <ToolbarComponent.Snackbar type="success" />
                 }
                 <ToolbarComponent.Controls>
                     {!!onNavigationButtonClick &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -87,12 +87,16 @@ export default class Toolbar extends React.Component<*> {
 
         return (
             <ToolbarComponent>
-                {this.toolbarStore.errors.length > 0 &&
-                    <ToolbarComponent.Snackbar onCloseClick={this.handleSnackbarCloseClick} type="error" />
-                }
-                {this.toolbarStore.showSuccess &&
-                    <ToolbarComponent.Snackbar onClick={onNavigationButtonClick} type="success" />
-                }
+                <ToolbarComponent.Snackbar
+                    onCloseClick={this.handleSnackbarCloseClick}
+                    type="error"
+                    visible={this.toolbarStore.errors.length > 0}
+                />
+                <ToolbarComponent.Snackbar
+                    onClick={onNavigationButtonClick}
+                    type="success"
+                    visible={this.toolbarStore.showSuccess}
+                />
                 <ToolbarComponent.Controls>
                     {!!onNavigationButtonClick &&
                     <ToolbarComponent.Button

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -1,5 +1,6 @@
 // @flow
 import {observer} from 'mobx-react';
+import {action} from 'mobx';
 import React from 'react';
 import Icon from '../../components/Icon';
 import ToolbarComponent from '../../components/Toolbar';
@@ -49,7 +50,7 @@ export default class Toolbar extends React.Component<*> {
         this.setStore(this.props.storeKey);
     }
 
-    componentWillUpdate(nextProps: ToolbarProps) {
+    componentDidUpdate(nextProps: ToolbarProps) {
         if (nextProps.storeKey) {
             this.setStore(nextProps.storeKey);
         }
@@ -67,6 +68,10 @@ export default class Toolbar extends React.Component<*> {
         if (this.props.onNavigationButtonClick) {
             this.props.onNavigationButtonClick();
         }
+    };
+
+    @action handleSnackbarCloseClick = () => {
+        this.toolbarStore.errors.pop();
     };
 
     render() {
@@ -88,6 +93,9 @@ export default class Toolbar extends React.Component<*> {
 
         return (
             <ToolbarComponent>
+                {this.toolbarStore.errors.length > 0 &&
+                    <ToolbarComponent.Snackbar onCloseClick={this.handleSnackbarCloseClick} />
+                }
                 <ToolbarComponent.Controls>
                     {!!onNavigationButtonClick &&
                     <ToolbarComponent.Button

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -64,12 +64,6 @@ export default class Toolbar extends React.Component<*> {
         }
     };
 
-    handleNavigationButtonClick = () => {
-        if (this.props.onNavigationButtonClick) {
-            this.props.onNavigationButtonClick();
-        }
-    };
-
     @action handleSnackbarCloseClick = () => {
         this.toolbarStore.errors.pop();
     };
@@ -97,12 +91,12 @@ export default class Toolbar extends React.Component<*> {
                     <ToolbarComponent.Snackbar onCloseClick={this.handleSnackbarCloseClick} type="error" />
                 }
                 {this.toolbarStore.showSuccess &&
-                    <ToolbarComponent.Snackbar type="success" />
+                    <ToolbarComponent.Snackbar onClick={onNavigationButtonClick} type="success" />
                 }
                 <ToolbarComponent.Controls>
                     {!!onNavigationButtonClick &&
                     <ToolbarComponent.Button
-                        onClick={this.handleNavigationButtonClick}
+                        onClick={onNavigationButtonClick}
                         primary={true}
                         icon={navigationOpen ? 'su-times' : 'su-bars'}
                     />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
@@ -1,20 +1,31 @@
 // @flow
-import {action, computed, observable} from 'mobx';
+import {action, autorun, computed, observable} from 'mobx';
 import type {Button, Select, ToolbarConfig, ToolbarItem} from '../types';
 
 const SHOW_SUCCESS_DURATION = 1500;
 
 export default class ToolbarStore {
     @observable config: ToolbarConfig = {};
+    showSuccessDisposer: () => void;
+
+    constructor() {
+        this.showSuccessDisposer = autorun(() => {
+            const {showSuccess} = this.config;
+            if (showSuccess && showSuccess.get()) {
+                setTimeout(action(() => {
+                    showSuccess.set(false);
+                }), SHOW_SUCCESS_DURATION);
+            }
+        });
+    }
+
+    destroy() {
+        this.clearConfig();
+        this.showSuccessDisposer();
+    }
 
     @action setConfig(config: ToolbarConfig) {
         this.config = config;
-
-        if (this.config.showSuccess) {
-            setTimeout(action(() => {
-                this.config.showSuccess = false;
-            }), SHOW_SUCCESS_DURATION);
-        }
     }
 
     @action clearConfig() {
@@ -38,7 +49,7 @@ export default class ToolbarStore {
             return false;
         }
 
-        return this.config.showSuccess;
+        return this.config.showSuccess.get();
     }
 
     hasBackButtonConfig(): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
@@ -17,6 +17,14 @@ export default class ToolbarStore {
         return !!this.config.disableAll;
     }
 
+    @computed get errors(): Array<*> {
+        if (!this.config.errors) {
+            return [];
+        }
+
+        return this.config.errors;
+    }
+
     hasBackButtonConfig(): boolean {
         return !!this.config.backButton;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
@@ -2,11 +2,19 @@
 import {action, computed, observable} from 'mobx';
 import type {Button, Select, ToolbarConfig, ToolbarItem} from '../types';
 
+const SHOW_SUCCESS_DURATION = 1500;
+
 export default class ToolbarStore {
     @observable config: ToolbarConfig = {};
 
     @action setConfig(config: ToolbarConfig) {
         this.config = config;
+
+        if (this.config.showSuccess) {
+            setTimeout(action(() => {
+                this.config.showSuccess = false;
+            }), SHOW_SUCCESS_DURATION);
+        }
     }
 
     @action clearConfig() {
@@ -23,6 +31,14 @@ export default class ToolbarStore {
         }
 
         return this.config.errors;
+    }
+
+    @computed get showSuccess(): boolean {
+        if (!this.config.showSuccess) {
+            return false;
+        }
+
+        return this.config.showSuccess;
     }
 
     hasBackButtonConfig(): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStorePool.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStorePool.js
@@ -26,7 +26,7 @@ class ToolbarStorePool {
             );
         }
 
-        this.stores[key].clearConfig();
+        this.stores[key].destroy();
         this.stores[key] = null;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -14,20 +14,14 @@ jest.mock('../stores/ToolbarStorePool', () => ({
 
 beforeEach(() => {
     toolbarStoreMock = {
+        errors: [],
         hasBackButtonConfig: jest.fn(),
-
         getBackButtonConfig: jest.fn(),
-
         hasItemsConfig: jest.fn(),
-
         getItemsConfig: jest.fn(),
-
         hasIconsConfig: jest.fn(),
-
         getIconsConfig: jest.fn(),
-
         hasLocaleConfig: jest.fn(),
-
         getLocaleConfig: jest.fn(),
     };
 });
@@ -72,8 +66,7 @@ test('Render the items from the ToolbarStore', () => {
         ]
     );
 
-    const view = render(<Toolbar storeKey={storeKey} />);
-    expect(view).toMatchSnapshot();
+    expect(render(<Toolbar storeKey={storeKey} />)).toMatchSnapshot();
     expect(toolbarStorePool.createStore).toBeCalledWith(storeKey);
 });
 
@@ -112,4 +105,36 @@ test('Render the items as disabled if one is loading', () => {
     expect(buttons.at(0).prop('disabled')).toBe(true);
     expect(buttons.at(1).prop('disabled')).toBe(true);
     expect(buttons.at(2).prop('disabled')).toBe(true);
+});
+
+test('Remove last error if close button on snackbar is clicked', () => {
+    const storeKey = 'testStore';
+
+    toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
+
+    toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
+    toolbarStoreMock.hasIconsConfig.mockReturnValue(false);
+    toolbarStoreMock.hasLocaleConfig.mockReturnValue(false);
+    toolbarStoreMock.hasBackButtonConfig.mockReturnValue(true);
+    toolbarStoreMock.getBackButtonConfig.mockReturnValue({});
+    toolbarStoreMock.errors.push({code: 100, message: 'Something went wrong'});
+
+    toolbarStoreMock.getItemsConfig.mockReturnValue(
+        [
+            {
+                type: 'button',
+                label: 'Add',
+                icon: 'fa-add-o',
+                disabled: false,
+            },
+        ]
+    );
+
+    const view = shallow(<Toolbar storeKey={storeKey} />);
+
+    expect(view.find('Snackbar')).toHaveLength(1);
+
+    expect(toolbarStoreMock.errors).toHaveLength(1);
+    view.find('Snackbar').simulate('closeClick');
+    expect(toolbarStoreMock.errors).toHaveLength(0);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -173,9 +173,9 @@ test('Remove last error if close button on snackbar is clicked', () => {
 
     const view = shallow(<Toolbar storeKey={storeKey} />);
 
-    expect(view.find('Snackbar')).toHaveLength(1);
+    expect(view.find('Snackbar[type="error"]')).toHaveLength(1);
 
     expect(toolbarStoreMock.errors).toHaveLength(1);
-    view.find('Snackbar').simulate('closeClick');
+    view.find('Snackbar[type="error"]').simulate('closeClick');
     expect(toolbarStoreMock.errors).toHaveLength(0);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -12,6 +12,10 @@ jest.mock('../stores/ToolbarStorePool', () => ({
     hasStore: jest.fn(),
 }));
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
 beforeEach(() => {
     toolbarStoreMock = {
         errors: [],
@@ -123,8 +127,8 @@ test('Show success message for some time', () => {
 
     const view = shallow(<Toolbar storeKey={storeKey} />);
 
-    expect(view.find('Snackbar')).toHaveLength(1);
-    expect(view.find('Snackbar').prop('type')).toEqual('success');
+    expect(view.find('Snackbar[type="success"]')).toHaveLength(1);
+    expect(view.find('Snackbar[type="success"]').prop('type')).toEqual('success');
 });
 
 test('Click on the success message should open the navigation', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -127,6 +127,27 @@ test('Show success message for some time', () => {
     expect(view.find('Snackbar').prop('type')).toEqual('success');
 });
 
+test('Click on the success message should open the navigation', () => {
+    const storeKey = 'testStore';
+    const navigationButtonClickSpy = jest.fn();
+
+    toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
+
+    toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
+    toolbarStoreMock.hasIconsConfig.mockReturnValue(false);
+    toolbarStoreMock.hasLocaleConfig.mockReturnValue(false);
+    toolbarStoreMock.hasBackButtonConfig.mockReturnValue(true);
+    toolbarStoreMock.getBackButtonConfig.mockReturnValue({});
+    toolbarStoreMock.getItemsConfig.mockReturnValue([]);
+    toolbarStoreMock.showSuccess = true;
+
+    const view = shallow(<Toolbar onNavigationButtonClick={navigationButtonClickSpy} storeKey={storeKey} />);
+
+    view.find('Snackbar[type="success"]').simulate('click');
+
+    expect(navigationButtonClickSpy).toBeCalledWith();
+});
+
 test('Remove last error if close button on snackbar is clicked', () => {
     const storeKey = 'testStore';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -15,6 +15,7 @@ jest.mock('../stores/ToolbarStorePool', () => ({
 beforeEach(() => {
     toolbarStoreMock = {
         errors: [],
+        showSuccess: false,
         hasBackButtonConfig: jest.fn(),
         getBackButtonConfig: jest.fn(),
         hasItemsConfig: jest.fn(),
@@ -105,6 +106,25 @@ test('Render the items as disabled if one is loading', () => {
     expect(buttons.at(0).prop('disabled')).toBe(true);
     expect(buttons.at(1).prop('disabled')).toBe(true);
     expect(buttons.at(2).prop('disabled')).toBe(true);
+});
+
+test('Show success message for some time', () => {
+    const storeKey = 'testStore';
+
+    toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
+
+    toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
+    toolbarStoreMock.hasIconsConfig.mockReturnValue(false);
+    toolbarStoreMock.hasLocaleConfig.mockReturnValue(false);
+    toolbarStoreMock.hasBackButtonConfig.mockReturnValue(true);
+    toolbarStoreMock.getBackButtonConfig.mockReturnValue({});
+    toolbarStoreMock.getItemsConfig.mockReturnValue([]);
+    toolbarStoreMock.showSuccess = true;
+
+    const view = shallow(<Toolbar storeKey={storeKey} />);
+
+    expect(view.find('Snackbar')).toHaveLength(1);
+    expect(view.find('Snackbar').prop('type')).toEqual('success');
 });
 
 test('Remove last error if close button on snackbar is clicked', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -5,6 +5,14 @@ exports[`Render the items from the ToolbarStore 1`] = `
   class="toolbar light"
 >
   <div
+    class="snackbar success"
+  >
+    <span
+      aria-label="su-check"
+      class="icon su-check"
+    />
+  </div>
+  <div
     class="controls light"
   >
     <ul

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -5,6 +5,30 @@ exports[`Render the items from the ToolbarStore 1`] = `
   class="toolbar light"
 >
   <div
+    class="snackbar error"
+  >
+    <span
+      aria-label="su-exclamation-triangle"
+      class="icon su-exclamation-triangle"
+    />
+    <div
+      class="text"
+    >
+      <strong>
+        sulu_admin.error
+      </strong>
+      <button
+        class="closeButton"
+      >
+        sulu_admin.close
+        <span
+          aria-label="su-times"
+          class="closeButtonIcon su-times"
+        />
+      </button>
+    </div>
+  </div>
+  <div
     class="snackbar success"
   >
     <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
-import {isObservable} from 'mobx';
+import {observable, isObservable, when} from 'mobx';
 import ToolbarStore from '../../stores/ToolbarStore';
 
 const toolbarStore = new ToolbarStore();
@@ -7,7 +7,7 @@ const toolbarStore = new ToolbarStore();
 jest.useFakeTimers();
 
 beforeEach(() => {
-    toolbarStore.clearConfig();
+    toolbarStore.destroy();
 });
 
 test('Set toolbar items and let mobx react', () => {
@@ -37,11 +37,15 @@ test('Get toolbar errors should return empty array if undefined', () => {
 
 test('Reset showSuccess after 1500ms', () => {
     toolbarStore.setConfig({
-        showSuccess: true,
+        showSuccess: observable.box(true),
     });
 
-    expect(toolbarStore.config.showSuccess).toEqual(true);
+    expect(toolbarStore.config.showSuccess.get()).toEqual(true);
 
-    jest.runAllTimers();
-    expect(toolbarStore.config.showSuccess).toEqual(false);
+    when(
+        () => toolbarStore.config.showSuccess.get() === false,
+        () => {
+            expect(toolbarStore.config.showSuccess.get()).toEqual(false);
+        }
+    );
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
@@ -4,6 +4,8 @@ import ToolbarStore from '../../stores/ToolbarStore';
 
 const toolbarStore = new ToolbarStore();
 
+jest.useFakeTimers();
+
 beforeEach(() => {
     toolbarStore.clearConfig();
 });
@@ -31,4 +33,15 @@ test('Set toolbar items and let mobx react', () => {
 
 test('Get toolbar errors should return empty array if undefined', () => {
     expect(toolbarStore.errors).toEqual([]);
+});
+
+test('Reset showSuccess after 1500ms', () => {
+    toolbarStore.setConfig({
+        showSuccess: true,
+    });
+
+    expect(toolbarStore.config.showSuccess).toEqual(true);
+
+    jest.runAllTimers();
+    expect(toolbarStore.config.showSuccess).toEqual(false);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
@@ -9,6 +9,7 @@ beforeEach(() => {
 });
 
 test('Set toolbar items and let mobx react', () => {
+    const errors = [{}];
     toolbarStore.setConfig({
         items: [
             {
@@ -18,10 +19,16 @@ test('Set toolbar items and let mobx react', () => {
                 onClick: () => {},
             },
         ],
+        errors,
     });
 
     expect(isObservable(toolbarStore.config.items)).toBe(true);
     expect(toolbarStore.config.items).toHaveLength(1);
     expect(toolbarStore.config.items[0].value).toBe('Test');
     expect(toolbarStore.config.items[0].icon).toBe('test');
+    expect(toolbarStore.errors).toEqual(errors);
+});
+
+test('Get toolbar errors should return empty array if undefined', () => {
+    expect(toolbarStore.errors).toEqual([]);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -29,4 +29,5 @@ export type ToolbarConfig = {
     icons?: Array<string>,
     items?: Array<ToolbarItem>,
     locale?: Select,
+    showSuccess?: boolean,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -17,10 +17,16 @@ export type ToolbarProps = {
     navigationOpen?: boolean,
 };
 
+type Error = {
+    code: number,
+    message: string,
+};
+
 export type ToolbarConfig = {
+    backButton?: Button,
+    disableAll?: boolean,
+    errors?: Array<Error>,
     icons?: Array<string>,
     items?: Array<ToolbarItem>,
     locale?: Select,
-    backButton?: Button,
-    disableAll?: boolean,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -1,14 +1,11 @@
 // @flow
+import type {IObservableValue} from 'mobx';
 import type {Button, Dropdown, Select} from '../../components/Toolbar/types';
 
 export type {Button, Dropdown, Select};
-
 export type ButtonItem = Button & { type: 'button' };
-
 export type DropdownItem = Dropdown & { type: 'dropdown' };
-
 export type SelectItem = Select & { type: 'select' };
-
 export type ToolbarItem = ButtonItem | DropdownItem | SelectItem;
 
 export type ToolbarProps = {
@@ -29,5 +26,5 @@ export type ToolbarConfig = {
     icons?: Array<string>,
     items?: Array<ToolbarItem>,
     locale?: Select,
-    showSuccess?: boolean,
+    showSuccess?: IObservableValue<boolean>,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -126,9 +126,12 @@ export default class ResourceStore {
                 this.data = response;
                 this.saving = false;
                 this.dirty = false;
+
+                return response;
             }))
-            .catch(action(() => {
+            .catch(action((error) => {
                 this.saving = false;
+                throw error;
             }));
     }
 
@@ -144,9 +147,12 @@ export default class ResourceStore {
                 this.data = response;
                 this.saving = false;
                 this.dirty = false;
+
+                return response;
             }))
-            .catch(action(() => {
+            .catch(action((error) => {
                 this.saving = false;
+                throw error;
             }));
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -11,7 +11,7 @@ jest.mock('../../../services/ResourceRequester', () => ({
 }));
 
 test('Should not be marked dirty when value is set', () => {
-    ResourceRequester.get.mockReturnValue(Promise.resolve());
+    ResourceRequester.get.mockReturnValue(Promise.resolve({}));
 
     const resourceStore = new ResourceStore('snippets', '1');
     expect(resourceStore.dirty).toBe(false);
@@ -22,7 +22,7 @@ test('Should not be marked dirty when value is set', () => {
 });
 
 test('Should be marked dirty when value is changed', () => {
-    ResourceRequester.get.mockReturnValue(Promise.resolve());
+    ResourceRequester.get.mockReturnValue(Promise.resolve({}));
 
     const resourceStore = new ResourceStore('snippets', '1');
     expect(resourceStore.dirty).toBe(false);
@@ -92,7 +92,7 @@ test('Loading flag should be set to true when loading', () => {
 });
 
 test('Loading flag should be set to false when loading has finished', () => {
-    const promise = Promise.resolve();
+    const promise = Promise.resolve({});
     ResourceRequester.get.mockReturnValue(promise);
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
     resourceStore.setLocale('en');
@@ -105,7 +105,7 @@ test('Loading flag should be set to false when loading has finished', () => {
 });
 
 test('Saving flag should be set to true when saving', () => {
-    ResourceRequester.put.mockReturnValue(Promise.resolve());
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
     resourceStore.saving = false;
     resourceStore.setLocale('en');
@@ -115,7 +115,7 @@ test('Saving flag should be set to true when saving', () => {
 });
 
 test('Saving flag should be set to false when saving has finished', () => {
-    const promise = Promise.resolve();
+    const promise = Promise.resolve({});
     ResourceRequester.put.mockReturnValue(promise);
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
     resourceStore.setLocale('en');
@@ -128,7 +128,7 @@ test('Saving flag should be set to false when saving has finished', () => {
 });
 
 test('Save the store should send a PUT request', () => {
-    ResourceRequester.put.mockReturnValue(Promise.resolve());
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', '3', {locale: observable.box()});
 
     if (!resourceStore.locale) {
@@ -144,7 +144,7 @@ test('Save the store should send a PUT request', () => {
 });
 
 test('Save the store should send a PUT request without a locale', () => {
-    ResourceRequester.post.mockReturnValue(Promise.resolve());
+    ResourceRequester.post.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', null, {locale: observable.box()});
 
     if (!resourceStore.locale) {
@@ -160,7 +160,7 @@ test('Save the store should send a PUT request without a locale', () => {
 });
 
 test('Save the store without an id should send a POST request', () => {
-    ResourceRequester.post.mockReturnValue(Promise.resolve());
+    ResourceRequester.post.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', null, {locale: observable.box()});
 
     if (!resourceStore.locale) {
@@ -176,7 +176,7 @@ test('Save the store without an id should send a POST request', () => {
 });
 
 test('Save the store without an id should send a POST request without a locale', () => {
-    ResourceRequester.post.mockReturnValue(Promise.resolve());
+    ResourceRequester.post.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', null, {});
     resourceStore.data = {title: 'Title'};
     resourceStore.dirty = false;
@@ -216,7 +216,7 @@ test('Saving and dirty flag should be set to false when creating has failed', (d
 });
 
 test('Saving flag should be set to true when deleting', () => {
-    ResourceRequester.delete.mockReturnValue(Promise.resolve());
+    ResourceRequester.delete.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
     resourceStore.data = {id: 1};
     resourceStore.saving = false;
@@ -227,7 +227,7 @@ test('Saving flag should be set to true when deleting', () => {
 });
 
 test('Saving flag and id should be reset to false when deleting has finished', () => {
-    const promise = Promise.resolve();
+    const promise = Promise.resolve({});
     ResourceRequester.delete.mockReturnValue(promise);
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
     resourceStore.data = {id: 1};
@@ -242,7 +242,7 @@ test('Saving flag and id should be reset to false when deleting has finished', (
 });
 
 test('Calling the delete method should send a DELETE request', () => {
-    ResourceRequester.delete.mockReturnValue(Promise.resolve());
+    ResourceRequester.delete.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', '3', {});
     resourceStore.data = {id: 3, title: 'Title'};
     resourceStore.dirty = false;
@@ -252,7 +252,7 @@ test('Calling the delete method should send a DELETE request', () => {
 });
 
 test('Saving flag should be set to true when saving', () => {
-    ResourceRequester.put.mockReturnValue(Promise.resolve());
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
     resourceStore.saving = false;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -185,6 +185,36 @@ test('Save the store without an id should send a POST request without a locale',
     expect(ResourceRequester.post).toBeCalledWith('snippets', {title: 'Title'}, {test: 10});
 });
 
+test('Saving and dirty flag should be set to false when creating has failed', (done) => {
+    const error = new Error('An error occured!');
+    const promise = Promise.reject(error);
+    ResourceRequester.post.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', undefined, {locale: observable.box()});
+
+    if (!resourceStore.locale) {
+        throw new Error('The resourceStore should have a locale');
+    }
+
+    resourceStore.locale.set('en');
+    resourceStore.saving = true;
+    resourceStore.dirty = true;
+
+    const savePromise = resourceStore.save();
+
+    return savePromise.catch((promiseError) => {
+        expect(promiseError).toBe(error);
+        when(
+            () => !resourceStore.saving,
+            (): void => {
+                expect(resourceStore.saving).toBe(false);
+                expect(resourceStore.dirty).toBe(true);
+                expect(resourceStore.data).toEqual({});
+                done();
+            }
+        );
+    });
+});
+
 test('Saving flag should be set to true when deleting', () => {
     ResourceRequester.delete.mockReturnValue(Promise.resolve());
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
@@ -230,6 +260,30 @@ test('Saving flag should be set to true when saving', () => {
     expect(resourceStore.saving).toBe(true);
 });
 
+test('Response should be returned when updating', () => {
+    const data = {};
+    const promise = Promise.resolve(data);
+    ResourceRequester.put.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    resourceStore.saving = false;
+
+    return resourceStore.save().then((responseData) => {
+        expect(responseData).toBe(data);
+    });
+});
+
+test('Response should be returned when creating', () => {
+    const data = {};
+    const promise = Promise.resolve(data);
+    ResourceRequester.post.mockReturnValue(promise);
+    const resourceStore = new ResourceStore('snippets', undefined, {locale: observable.box()});
+    resourceStore.saving = false;
+
+    return resourceStore.save().then((responseData) => {
+        expect(responseData).toBe(data);
+    });
+});
+
 test('Saving and dirty flag should be set and data should be updated to false when saving has finished', () => {
     const data = {changed: 'later'};
     const promise = Promise.resolve(data);
@@ -247,8 +301,9 @@ test('Saving and dirty flag should be set and data should be updated to false wh
     });
 });
 
-test('Saving and dirty flag should be set to false when saving has failed', (done) => {
-    const promise = Promise.reject(new Error('An error occured!'));
+test('Saving and dirty flag should be set to false when updating has failed', (done) => {
+    const error = new Error('An error occured!');
+    const promise = Promise.reject(error);
     ResourceRequester.get.mockReturnValue(Promise.resolve({title: 'Title to stay!'}));
     ResourceRequester.put.mockReturnValue(promise);
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
@@ -261,9 +316,10 @@ test('Saving and dirty flag should be set to false when saving has failed', (don
     resourceStore.saving = true;
     resourceStore.dirty = true;
 
-    resourceStore.save();
+    const savePromise = resourceStore.save();
 
-    return promise.catch(() => {
+    return savePromise.catch((promiseError) => {
+        expect(promiseError).toBe(error);
         when(
             () => !resourceStore.saving,
             (): void => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -17,7 +17,7 @@ class Form extends React.PureComponent<Props> {
     formStore: FormStore;
     form: ?FormContainer;
     @observable errors = [];
-    @observable showSuccess = false;
+    showSuccess = observable.box(false);
 
     @computed get hasOwnResourceStore() {
         const {
@@ -79,7 +79,7 @@ class Form extends React.PureComponent<Props> {
     }
 
     @action showSuccessSnackbar = () => {
-        this.showSuccess = true;
+        this.showSuccess.set(true);
     };
 
     handleSubmit = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -17,6 +17,7 @@ class Form extends React.PureComponent<Props> {
     formStore: FormStore;
     form: ?FormContainer;
     @observable errors = [];
+    @observable showSuccess = false;
 
     @computed get hasOwnResourceStore() {
         const {
@@ -77,6 +78,10 @@ class Form extends React.PureComponent<Props> {
         }
     }
 
+    @action showSuccessSnackbar = () => {
+        this.showSuccess = true;
+    };
+
     handleSubmit = () => {
         const {resourceStore, router} = this.props;
 
@@ -94,6 +99,7 @@ class Form extends React.PureComponent<Props> {
 
         return this.formStore.save()
             .then((response) => {
+                this.showSuccessSnackbar();
                 if (editRoute) {
                     router.navigate(editRoute, {id: resourceStore.id, locale: resourceStore.locale});
                 }
@@ -128,7 +134,7 @@ export default withToolbar(Form, function() {
     const {router} = this.props;
     const {backRoute, locales} = router.route.options;
     const formTypes = this.formStore.types;
-    const {errors, resourceStore} = this;
+    const {errors, resourceStore, showSuccess} = this;
 
     const backButton = backRoute
         ? {
@@ -188,5 +194,6 @@ export default withToolbar(Form, function() {
         errors,
         locale,
         items,
+        showSuccess,
     };
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import {default as FormContainer, FormStore} from '../../containers/Form';
 import {withToolbar} from '../../containers/Toolbar';
 import type {ViewProps} from '../../containers/ViewRenderer';
@@ -16,6 +16,7 @@ class Form extends React.PureComponent<Props> {
     resourceStore: ResourceStore;
     formStore: FormStore;
     form: ?FormContainer;
+    @observable errors = [];
 
     @computed get hasOwnResourceStore() {
         const {
@@ -91,14 +92,18 @@ class Form extends React.PureComponent<Props> {
             resourceStore.destroy();
         }
 
-        this.formStore.save()
-            .then(() => {
+        return this.formStore.save()
+            .then((response) => {
                 if (editRoute) {
                     router.navigate(editRoute, {id: resourceStore.id, locale: resourceStore.locale});
                 }
+
+                return response;
             })
-            .catch(() => {
-                // TODO show an error label
+            .catch((errorResponse) => {
+                return errorResponse.json().then(action((error) => {
+                    this.errors.push(error);
+                }));
             });
     };
 
@@ -123,7 +128,7 @@ export default withToolbar(Form, function() {
     const {router} = this.props;
     const {backRoute, locales} = router.route.options;
     const formTypes = this.formStore.types;
-    const {resourceStore} = this;
+    const {errors, resourceStore} = this;
 
     const backButton = backRoute
         ? {
@@ -180,6 +185,7 @@ export default withToolbar(Form, function() {
 
     return {
         backButton,
+        errors,
         locale,
         items,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -604,7 +604,7 @@ test('Should set showSuccess flag after form submission', (done) => {
     form.find('Form').at(1).instance().submit().then(() => {
         expect(resourceStore.destroy).not.toBeCalled();
         expect(ResourceRequester.put).toBeCalledWith('snippets', 8, {value: 'Value'}, {locale: 'en'});
-        expect(form.instance().showSuccess).toEqual(true);
+        expect(form.instance().showSuccess.get()).toEqual(true);
         done();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -564,6 +564,51 @@ test('Should save form when submitted', (done) => {
     jsonSchemaResolve({});
 });
 
+test('Should set showSuccess flag after form submission', (done) => {
+    const ResourceRequester = require('../../../services/ResourceRequester');
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const metadataStore = require('../../../containers/Form/stores/MetadataStore');
+    const resourceStore = new ResourceStore('snippets', 8, {locale: observable.box()});
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const schemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+
+    const jsonSchemaPromise = Promise.resolve({});
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+
+    const route = {
+        options: {
+            locales: [],
+        },
+    };
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+        attributes: {
+            id: 8,
+        },
+    };
+    const form = mount(<Form router={router} route={route} resourceStore={resourceStore} />);
+
+    resourceStore.locale.set('en');
+    resourceStore.data = {value: 'Value'};
+    resourceStore.loading = false;
+    resourceStore.destroy = jest.fn();
+
+    form.find('Form').at(1).instance().submit().then(() => {
+        expect(resourceStore.destroy).not.toBeCalled();
+        expect(ResourceRequester.put).toBeCalledWith('snippets', 8, {value: 'Value'}, {locale: 'en'});
+        expect(form.instance().showSuccess).toEqual(true);
+        done();
+    });
+});
+
 test('Should keep errors after form submission has failed', (done) => {
     const ResourceRequester = require('../../../services/ResourceRequester');
     const error = {code: 100, message: 'Something went wrong'};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -36,7 +36,7 @@ jest.mock('../../../services/ResourceRequester', () => ({
         then: jest.fn(),
     }),
     put: jest.fn(),
-    post: jest.fn().mockReturnValue(Promise.resolve()),
+    post: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 
 jest.mock('../../../containers/Form/stores/MetadataStore', () => ({
@@ -562,6 +562,54 @@ test('Should save form when submitted', (done) => {
     });
 
     jsonSchemaResolve({});
+});
+
+test('Should keep errors after form submission has failed', (done) => {
+    const ResourceRequester = require('../../../services/ResourceRequester');
+    const error = {code: 100, message: 'Something went wrong'};
+    const errorPromise = Promise.resolve(error);
+    const putPromise = Promise.reject({json: jest.fn().mockReturnValue(errorPromise)});
+    ResourceRequester.put.mockReturnValue(putPromise);
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const metadataStore = require('../../../containers/Form/stores/MetadataStore');
+    const resourceStore = new ResourceStore('snippets', 8, {locale: observable.box()});
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const schemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+
+    const jsonSchemaPromise = Promise.resolve({});
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+
+    const route = {
+        options: {
+            locales: [],
+        },
+    };
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+        attributes: {
+            id: 8,
+        },
+    };
+    const form = mount(<Form router={router} route={route} resourceStore={resourceStore} />);
+
+    resourceStore.locale.set('en');
+    resourceStore.data = {value: 'Value'};
+    resourceStore.loading = false;
+    resourceStore.destroy = jest.fn();
+
+    form.find('Form').at(1).instance().submit().then(() => {
+        expect(resourceStore.destroy).not.toBeCalled();
+        expect(ResourceRequester.put).toBeCalledWith('snippets', 8, {value: 'Value'}, {locale: 'en'});
+        expect(form.instance().errors).toEqual([error]);
+        done();
+    });
 });
 
 test('Should save form when submitted and redirect to editRoute', (done) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/__snapshots__/Form.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/__snapshots__/Form.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Should not show templates chooser in toolbar if types are not available 1`] = `
 Object {
   "backButton": undefined,
+  "errors": Array [],
   "items": Array [
     Object {
       "disabled": true,
@@ -20,6 +21,7 @@ Object {
 exports[`Should show loading templates chooser in toolbar while types are loading 1`] = `
 Object {
   "backButton": undefined,
+  "errors": Array [],
   "items": Array [
     Object {
       "disabled": true,
@@ -45,6 +47,7 @@ Object {
 exports[`Should show templates chooser in toolbar if types are available 1`] = `
 Object {
   "backButton": undefined,
+  "errors": Array [],
   "items": Array [
     Object {
       "disabled": true,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/__snapshots__/Form.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/__snapshots__/Form.test.js.snap
@@ -15,6 +15,7 @@ Object {
     },
   ],
   "locale": undefined,
+  "showSuccess": false,
 }
 `;
 
@@ -41,6 +42,7 @@ Object {
     },
   ],
   "locale": undefined,
+  "showSuccess": false,
 }
 `;
 
@@ -76,5 +78,6 @@ Object {
     },
   ],
   "locale": undefined,
+  "showSuccess": false,
 }
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -28,5 +28,7 @@
     "sulu_admin.reset_resend": "Erneut senden",
     "sulu_admin.forgot_password": "Passwort vergessen",
     "sulu_admin.reset_password_success": "Eine Email mit Anweisungen, wie Sie Ihr Passwort zurücksetzen können wurde gesendet, falls ein User gefunden wurde",
-    "sulu_admin.datagrid_search_placeholder": "Suche…"
+    "sulu_admin.datagrid_search_placeholder": "Suche…",
+    "sulu_admin.error": "Fehler",
+    "sulu_admin.close": "Schließen"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -28,5 +28,7 @@
     "sulu_admin.reset_resend": "Resend",
     "sulu_admin.forgot_password": "Forgot password",
     "sulu_admin.reset_password_success": "An email with instructions how to reset your password has been sent if a user was found",
-    "sulu_admin.datagrid_search_placeholder": "Search…"
+    "sulu_admin.datagrid_search_placeholder": "Search…",
+    "sulu_admin.error": "Error",
+    "sulu_admin.close": "Close"
 }

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
@@ -20,7 +20,7 @@ class PageForm extends React.Component<Props> {
     form: ?Form;
     @observable webspace: Webspace;
     @observable errors = [];
-    @observable showSuccess = false;
+    showSuccess = observable.box(false);
 
     constructor(props: Props) {
         super(props);
@@ -43,7 +43,7 @@ class PageForm extends React.Component<Props> {
     }
 
     @action showSuccessSnackbar = () => {
-        this.showSuccess = true;
+        this.showSuccess.set(true);
     };
 
     handleSubmit = (actionParameter) => {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
@@ -20,6 +20,7 @@ class PageForm extends React.Component<Props> {
     form: ?Form;
     @observable webspace: Webspace;
     @observable errors = [];
+    @observable showSuccess = false;
 
     constructor(props: Props) {
         super(props);
@@ -40,6 +41,10 @@ class PageForm extends React.Component<Props> {
     componentWillUnmount() {
         this.formStore.destroy();
     }
+
+    @action showSuccessSnackbar = () => {
+        this.showSuccess = true;
+    };
 
     handleSubmit = (actionParameter) => {
         const {resourceStore, router} = this.props;
@@ -65,6 +70,7 @@ class PageForm extends React.Component<Props> {
 
         return this.formStore.save(saveOptions)
             .then((response) => {
+                this.showSuccessSnackbar();
                 if (editRoute) {
                     router.navigate(
                         editRoute,
@@ -172,5 +178,6 @@ export default withToolbar(PageForm, function() {
         errors: this.errors,
         items,
         locale,
+        showSuccess: this.showSuccess,
     };
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/PageForm.js
@@ -19,6 +19,7 @@ class PageForm extends React.Component<Props> {
     formStore: FormStore;
     form: ?Form;
     @observable webspace: Webspace;
+    @observable errors = [];
 
     constructor(props: Props) {
         super(props);
@@ -40,7 +41,7 @@ class PageForm extends React.Component<Props> {
         this.formStore.destroy();
     }
 
-    handleSubmit = (action) => {
+    handleSubmit = (actionParameter) => {
         const {resourceStore, router} = this.props;
 
         const {
@@ -53,7 +54,7 @@ class PageForm extends React.Component<Props> {
 
         const saveOptions = {
             webspace: router.attributes.webspace,
-            action,
+            action: actionParameter,
             parent: undefined,
         };
 
@@ -62,14 +63,21 @@ class PageForm extends React.Component<Props> {
             saveOptions.parent = router.attributes.parentId;
         }
 
-        this.formStore.save(saveOptions)
-            .then(() => {
+        return this.formStore.save(saveOptions)
+            .then((response) => {
                 if (editRoute) {
                     router.navigate(
                         editRoute,
                         {id: resourceStore.id, locale: resourceStore.locale, webspace: router.attributes.webspace}
                     );
                 }
+
+                return response;
+            })
+            .catch((errorResponse) => {
+                return errorResponse.json().then(action((error) => {
+                    this.errors.push(error);
+                }));
             });
     };
 
@@ -161,7 +169,8 @@ export default withToolbar(PageForm, function() {
 
     return {
         backButton,
-        locale,
+        errors: this.errors,
         items,
+        locale,
     };
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/PageForm.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/PageForm.test.js
@@ -395,6 +395,58 @@ test('Should render save buttons disabled only if form is not dirty', () => {
     });
 });
 
+test('Should set showSuccess flag after form submission', (done) => {
+    const webspaceStore = require('../../../stores/WebspaceStore');
+    const webspace = {
+        key: 'sulu',
+        localizations: [{locale: 'en', default: false}, {locale: 'de', default: true}],
+        allLocalizations: [{localization: 'en', name: 'en'}, {localization: 'de', name: 'de'}],
+    };
+    const webspacePromise = Promise.resolve(webspace);
+    webspaceStore.loadWebspace.mockReturnValue(webspacePromise);
+    const PageForm = require('../PageForm').default;
+    const ResourceStore = require('sulu-admin-bundle/stores/ResourceStore').default;
+    const locale = observable.box();
+    const resourceStore = new ResourceStore('pages', undefined, {locale: locale});
+    const metadataStore = require('sulu-admin-bundle/containers/Form/stores/MetadataStore');
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const schemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+
+    const router = {
+        navigate: jest.fn(),
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: true,
+                editRoute: 'test_route',
+            },
+        },
+        attributes: {
+            webspace: 'sulu',
+            locale: 'de',
+            parentId: 'test-parent-id',
+        },
+    };
+
+    const pageForm = mount(<PageForm router={router} resourceStore={resourceStore} />);
+    pageForm.instance().formStore.save = jest.fn().mockReturnValue(Promise.resolve({}));
+
+    resourceStore.locale.set('de');
+    resourceStore.data = {value: 'Value'};
+    resourceStore.loading = false;
+    resourceStore.destroy = jest.fn();
+
+    pageForm.find('Form').at(0).instance().submit().then(() => {
+        expect(pageForm.instance().showSuccess).toEqual(true);
+        done();
+    });
+});
+
 test('Should keep errors after form submission has failed', (done) => {
     const webspaceStore = require('../../../stores/WebspaceStore');
     const webspace = {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/PageForm.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/PageForm.test.js
@@ -442,7 +442,7 @@ test('Should set showSuccess flag after form submission', (done) => {
     resourceStore.destroy = jest.fn();
 
     pageForm.find('Form').at(0).instance().submit().then(() => {
-        expect(pageForm.instance().showSuccess).toEqual(true);
+        expect(pageForm.instance().showSuccess.get()).toEqual(true);
         done();
     });
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/PageForm.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/PageForm.test.js
@@ -37,7 +37,7 @@ jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
         then: jest.fn(),
     }),
     put: jest.fn(),
-    post: jest.fn().mockReturnValue(Promise.resolve()),
+    post: jest.fn().mockReturnValue(Promise.resolve({})),
 }));
 
 jest.mock('sulu-admin-bundle/containers/Form/stores/MetadataStore', () => ({
@@ -392,6 +392,61 @@ test('Should render save buttons disabled only if form is not dirty', () => {
         resourceStore.dirty = true;
         expect(getSaveItem('Save as draft').disabled).toBe(false);
         expect(getSaveItem('Save and publish').disabled).toBe(false);
+    });
+});
+
+test('Should keep errors after form submission has failed', (done) => {
+    const webspaceStore = require('../../../stores/WebspaceStore');
+    const webspace = {
+        key: 'sulu',
+        localizations: [{locale: 'en', default: false}, {locale: 'de', default: true}],
+        allLocalizations: [{localization: 'en', name: 'en'}, {localization: 'de', name: 'de'}],
+    };
+    const webspacePromise = Promise.resolve(webspace);
+    webspaceStore.loadWebspace.mockReturnValue(webspacePromise);
+    const PageForm = require('../PageForm').default;
+    const ResourceStore = require('sulu-admin-bundle/stores/ResourceStore').default;
+    const locale = observable.box();
+    const resourceStore = new ResourceStore('pages', undefined, {locale: locale});
+    const metadataStore = require('sulu-admin-bundle/containers/Form/stores/MetadataStore');
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const schemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+
+    const router = {
+        navigate: jest.fn(),
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: true,
+                editRoute: 'test_route',
+            },
+        },
+        attributes: {
+            webspace: 'sulu',
+            locale: 'de',
+            parentId: 'test-parent-id',
+        },
+    };
+
+    const pageForm = mount(<PageForm router={router} resourceStore={resourceStore} />);
+    const error = {code: 100, message: 'Something went wrong'};
+    const errorPromise = Promise.resolve(error);
+    const formSavePromise = Promise.reject({json: jest.fn().mockReturnValue(errorPromise)});
+    pageForm.instance().formStore.save = jest.fn().mockReturnValue(formSavePromise);
+
+    resourceStore.locale.set('de');
+    resourceStore.data = {value: 'Value'};
+    resourceStore.loading = false;
+    resourceStore.destroy = jest.fn();
+
+    pageForm.find('Form').at(0).instance().submit().then(() => {
+        expect(pageForm.instance().errors).toEqual([error]);
+        done();
     });
 });
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/__snapshots__/PageForm.test.js.snap
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/__snapshots__/PageForm.test.js.snap
@@ -35,6 +35,7 @@ Object {
     },
   ],
   "locale": undefined,
+  "showSuccess": false,
 }
 `;
 
@@ -95,5 +96,6 @@ Object {
     ],
     "value": "de",
   },
+  "showSuccess": false,
 }
 `;

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/__snapshots__/PageForm.test.js.snap
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/PageForm/tests/__snapshots__/PageForm.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "backButton": Object {
     "onClick": [Function],
   },
+  "errors": Array [],
   "items": Array [
     Object {
       "icon": "su-save",
@@ -42,6 +43,7 @@ Object {
   "backButton": Object {
     "onClick": [Function],
   },
+  "errors": Array [],
   "items": Array [
     Object {
       "icon": "su-save",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a red snackbar on top of the toolbar if an error happened.

#### Why?

Because otherwise the user doesn't know that there was an issue.

#### To Do
- [x] Move removing of errors to view?
- [x] Fix returning save icon after first save