### PR TITLE
Bugfix: Datagrid search reload

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -132,7 +132,7 @@ export default class Datagrid extends React.Component<Props> {
             <Fragment>
                 <div className={datagridStyles.toolbar}>
                     {searchable &&
-                        <Search onSearch={this.handleSearch} />
+                        <Search onSearch={this.handleSearch} value={store.searchTerm ? store.searchTerm.get() : null} />
                     }
                     <AdapterSwitch
                         adapters={adapters}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -132,7 +132,7 @@ export default class Datagrid extends React.Component<Props> {
             <Fragment>
                 <div className={datagridStyles.toolbar}>
                     {searchable &&
-                        <Search onSearch={this.handleSearch} value={store.searchTerm ? store.searchTerm.get() : null} />
+                        <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
                     }
                     <AdapterSwitch
                         adapters={adapters}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Search.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Search.js
@@ -23,7 +23,7 @@ export default class Search extends React.Component<Props> {
         this.value = value;
     }
 
-    updateState(value: ?string) {
+    updateValue(value: ?string) {
         this.setValue(value);
 
         if (value) {
@@ -32,12 +32,12 @@ export default class Search extends React.Component<Props> {
     }
 
     componentDidMount() {
-        this.updateState(this.props.value);
+        this.updateValue(this.props.value);
     }
 
     componentDidUpdate(prevProps: Props) {
         if (prevProps.value !== this.props.value) {
-            this.updateState(this.props.value);
+            this.updateValue(this.props.value);
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Search.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Search.js
@@ -7,12 +7,13 @@ import {translate} from '../../utils/Translator';
 
 type Props = {
     onSearch: (search: ?string) => void,
+    value: ?string,
 };
 
 @observer
 export default class Search extends React.Component<Props> {
     @observable collapsed: boolean = true;
-    @observable value: ?string = undefined;
+    @observable value: ?string;
 
     @action setCollapsed(collapsed: boolean) {
         this.collapsed = collapsed;
@@ -20,6 +21,24 @@ export default class Search extends React.Component<Props> {
 
     @action setValue(value: ?string) {
         this.value = value;
+    }
+
+    updateState(value: ?string) {
+        this.setValue(value);
+
+        if (value) {
+            this.setCollapsed(false);
+        }
+    }
+
+    componentDidMount() {
+        this.updateState(this.props.value);
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (prevProps.value !== this.props.value) {
+            this.updateState(this.props.value);
+        }
     }
 
     handleChange = (value: ?string) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -21,6 +21,9 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.sortOrder = {
         get: jest.fn(),
     };
+    this.searchTerm = {
+        get: jest.fn(),
+    };
     this.updateStrategies = jest.fn();
     this.getPage = jest.fn().mockReturnValue(4);
     this.pageCount = 7;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Search.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Search.test.js
@@ -19,7 +19,7 @@ test('The component should render collapsed', () => {
 
 test('The component should render not collapsed when value is given', () => {
     const search = shallow(
-        <Search onSearch={jest.fn()} value={'search-string'} />
+        <Search onSearch={jest.fn()} value="search-string" />
     );
 
     expect(search.render()).toMatchSnapshot();
@@ -27,7 +27,7 @@ test('The component should render not collapsed when value is given', () => {
 
 test('The component should update the value if a new one is provided', () => {
     const search = shallow(
-        <Search onSearch={jest.fn()} value={'search-string'} />
+        <Search onSearch={jest.fn()} value="search-string" />
     );
 
     expect(search.find('Input').prop('value')).toBe('search-string');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Search.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Search.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {render, shallow} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
 import React from 'react';
 import Search from '../Search';
 
@@ -11,15 +11,35 @@ jest.mock('../../../utils/Translator', () => ({
 
 test('The component should render collapsed', () => {
     const search = render(
-        <Search onSearch={jest.fn()} />
+        <Search onSearch={jest.fn()} value={null} />
     );
 
     expect(search).toMatchSnapshot();
 });
 
+test('The component should render not collapsed when value is given', () => {
+    const search = shallow(
+        <Search onSearch={jest.fn()} value={'search-string'} />
+    );
+
+    expect(search.render()).toMatchSnapshot();
+});
+
+test('The component should update the value if a new one is provided', () => {
+    const search = shallow(
+        <Search onSearch={jest.fn()} value={'search-string'} />
+    );
+
+    expect(search.find('Input').prop('value')).toBe('search-string');
+
+    search.setProps({value: 'new-search-string'});
+
+    expect(search.find('Input').prop('value')).toBe('new-search-string');
+});
+
 test('The component should expand the input when clicking on icon', () => {
     const search = shallow(
-        <Search onSearch={jest.fn()} />
+        <Search onSearch={jest.fn()} value={null} />
     );
 
     search.find('Input').simulate('iconClick');
@@ -30,7 +50,7 @@ test('The component should expand the input when clicking on icon', () => {
 test('The component should trigger the onSearch callback correctly if Input calls onBlur', () => {
     const onSearch = jest.fn();
     const search = shallow(
-        <Search onSearch={onSearch} />
+        <Search onSearch={onSearch} value={null} />
     );
 
     const input = search.find('Input');
@@ -47,7 +67,7 @@ test('The component should trigger the onSearch callback correctly if Input call
 test('The component should trigger the onSearch callback correctly if Input calls onKeyPress with enter', () => {
     const onSearch = jest.fn();
     const search = shallow(
-        <Search onSearch={onSearch} />
+        <Search onSearch={onSearch} value={null} />
     );
 
     const input = search.find('Input');
@@ -64,7 +84,7 @@ test('The component should trigger the onSearch callback correctly if Input call
 test('The component should clear the current value if Input calls onClearClick', () => {
     const onSearch = jest.fn();
     const search = shallow(
-        <Search onSearch={onSearch} />
+        <Search onSearch={onSearch} value={null} />
     );
 
     const input = search.find('Input');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Search.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Search.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {mount, render, shallow} from 'enzyme';
+import {render, shallow} from 'enzyme';
 import React from 'react';
 import Search from '../Search';
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Search.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Search.test.js.snap
@@ -43,3 +43,35 @@ exports[`The component should render collapsed 1`] = `
   />
 </label>
 `;
+
+exports[`The component should render not collapsed when value is given 1`] = `
+<label
+  class="input dark hasAppendIcon"
+>
+  <div
+    class="prependedContainer dark"
+  >
+    <span
+      aria-label="su-search"
+      class="icon dark iconClickable su-search clickable"
+      role="button"
+      tabindex="0"
+    />
+  </div>
+  <input
+    placeholder="sulu_admin.datagrid_search_placeholder"
+    type="text"
+    value="search-string"
+  />
+  <div
+    class="appendContainer"
+  >
+    <span
+      aria-label="su-times"
+      class="icon dark iconClickable su-times clickable"
+      role="button"
+      tabindex="0"
+    />
+  </div>
+</label>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -31,6 +31,9 @@ jest.mock(
         this.sortOrder = {
             get: jest.fn(),
         };
+        this.searchTerm = {
+            get: jest.fn(),
+        };
         this.updateStrategies = jest.fn();
         this.data = [
             {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -82,6 +82,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.sortOrder = {
                 get: jest.fn(),
             };
+            this.searchTerm = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -69,6 +69,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.sortOrder = {
                 get: jest.fn(),
             };
+            this.searchTerm = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -68,6 +68,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.sortOrder = {
                 get: jest.fn(),
             };
+            this.searchTerm = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -61,6 +61,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.sortOrder = {
                 get: jest.fn(),
             };
+            this.searchTerm = {
+                get: jest.fn(),
+            };
             this.data = (resourceKey === COLLECTIONS_RESOURCE_KEY)
                 ? collectionData
                 : mediaData;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Set value of datagrid search correctly when it's changing from above (for example router/store).

#### Why?

Current search wasn't visible in the input when opening direct link.