### PR TITLE
Interpret .php as html request format to show correct error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * BUGFIX      #4013 [Components]            Fix 404 error page for .php requests
     * BUGFIX      #4018 [SnippetBundle]         Fix conflict when saving snippet in new language
     * BUGFiX      #3995 [TestBundle]            Fix tests for latest Symfony version
 

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/PortalInformationRequestProcessor.php
@@ -114,6 +114,10 @@ class PortalInformationRequestProcessor implements RequestProcessorInterface
             strlen($portalInformation->getUrl())
         );
 
+        if ('php' === $formatResult) {
+            $formatResult = 'html';
+        }
+
         return [$resourceLocator, $formatResult];
     }
 }

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
@@ -176,6 +176,33 @@ class PortalInformationRequestProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/test', $attributes->getAttribute('resourceLocatorPrefix'));
     }
 
+    public function testProcessWithPhpFormat()
+    {
+        $portalInformation = new PortalInformation(
+            RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            null,
+            null,
+            null,
+            'sulu.lo:8000/test.php'
+        );
+
+        $request = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_HOST' => 'sulu.lo', 'REQUEST_URI' => '/test.php']
+        );
+
+        $this->portalInformationRequestProcessor->process(
+            $request,
+            new RequestAttributes(['portalInformation' => $portalInformation])
+        );
+
+        $this->assertEquals('html', $request->getRequestFormat('default'));
+    }
+
     public function testValidate()
     {
         $this->assertTrue($this->portalInformationRequestProcessor->validate(new RequestAttributes()));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4011
| License | MIT

#### What's in this PR?

Interpret .php as html request format to show correct error page.

#### Why?

Else php will render the symfony standard error page.

#### Example Usage

`/test.php`

