### PR TITLE
Fix conflict when saving snippet in new language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * BUGFIX      #4018 [SnippetBundle]         Fix conflict when saving snippet in new language
     * BUGFiX      #3995 [TestBundle]            Fix tests for latest Symfony version
 
 * 1.5.15 (2018-05-24)

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -201,7 +201,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     {
         $locale = $this->getLocale($request);
 
-        $snippet = $this->documentManager->find($uuid, $locale);
+        $snippet = $this->findDocument($uuid, $locale);
         $view = View::create($snippet);
 
         return $this->viewHandler->handle($view);
@@ -485,6 +485,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
             $locale,
             [
                 'load_ghost_content' => false,
+                'load_shadow_content' => false,
             ]
         );
     }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -93,6 +93,13 @@ class SnippetControllerTest extends SuluTestCase
                     'description' => 'Hello World',
                 ],
             ],
+            [
+                'nl',
+                [
+                    'title' => '',
+                    'description' => '',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related Issues | fixes #4016 
| Deprecations? | no
| License | MIT

#### What's in this PR?

Load snippet not in ghost language over getAction.

#### Why?

To avoid a conflict when creating a snippet in another language as it exist.

