### PR TITLE
Add support for multi image format support jpg, png, webp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ phpunit.stdout
 /tests/Resources/cache/
 /src/Sulu/Bundle/*/Tests/var/
 /src/Sulu/Bundle/*/Tests/Application/var/
+/src/Sulu/Bundle/*/Tests/Application/public/uploads
 /src/Sulu/Bundle/*/Resources/app/cache
 /src/Sulu/Bundle/*/Tests/app/cache
 /src/Sulu/Bundle/*/Tests/Resources/app/cache

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1375,11 +1375,17 @@ sulu_media:
 To allow adding new features some interfaces where changed and needs to be updated if you did build something on top 
 of them:
 
-- FileVersion
-- MediaImageExtractor
-- MediaImageExtractorInterface
-- LocalStorage
-- StorageInterface
+ - StorageInterface
+ - LocalStorage
+ - FormatManagerInterface
+ - FormatManager
+ - FormatCacheInterface
+ - LocalFormatCache
+ - ImageConverterInterface
+ - ImagineImageConverter
+ - MediaExtractorInterface
+ - MediaImageExtractor
+ - FileVersion::getStorageOptions
 
 ### Test Setup
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -120,7 +120,6 @@ class MediaController extends AbstractMediaController implements
             $format = $this->getFormatManager()->getFormats(
                 $listResponse[$i]['id'],
                 $listResponse[$i]['name'],
-                $listResponse[$i]['storageOptions'],
                 $listResponse[$i]['version'],
                 $listResponse[$i]['subVersion'],
                 $listResponse[$i]['mimeType']

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -59,11 +59,6 @@ class FileVersion implements AuditableInterface
     private $storageOptions;
 
     /**
-     * @var string
-     */
-    private $storageType;
-
-    /**
      * @var int
      */
     private $downloadCounter = 0;
@@ -630,30 +625,6 @@ class FileVersion implements AuditableInterface
     public function isActive()
     {
         return $this->version === $this->file->getVersion();
-    }
-
-    /**
-     * Set storageType.
-     *
-     * @param string $storageType
-     *
-     * @return FileVersion
-     */
-    public function setStorageType($storageType)
-    {
-        $this->storageType = $storageType;
-
-        return $this;
-    }
-
-    /**
-     * Get storageType.
-     *
-     * @return string
-     */
-    public function getStorageType()
-    {
-        return $this->storageType;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
@@ -23,37 +23,35 @@ interface FormatCacheInterface
      * @param string $content
      * @param int $id
      * @param string $fileName
-     * @param array $options
      * @param string $format
      *
      * @return bool
      */
-    public function save($content, $id, $fileName, $options, $format);
+    public function save($content, $id, $fileName, $format);
 
     /**
      * Delete the image by the given parameters.
      *
      * @param int $id
      * @param string $fileName
-     * @param string $options
+     * @param string $format
      *
      * @return bool
      */
-    public function purge($id, $fileName, $options);
+    public function purge($id, $fileName, $format);
 
     /**
      * Return the url to an specific format of an media.
      *
      * @param int $id
      * @param string $fileName
-     * @param array $options
      * @param string $format
      * @param int $version
      * @param int $subVersion
      *
      * @return string
      */
-    public function getMediaUrl($id, $fileName, $options, $format, $version, $subVersion);
+    public function getMediaUrl($id, $fileName, $format, $version, $subVersion);
 
     /**
      * Return the id and the format of a media.

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -23,32 +23,23 @@ interface FormatManagerInterface
      * Return the image by a given url.
      *
      * @param int $id
-     * @param string $formatName
+     * @param string $formatKey
+     * @param string $imageFormat
      *
      * @return Response
      */
-    public function returnImage($id, $formatName);
-
-    /**
-     * Return media id and format.
-     *
-     * @param string $url
-     *
-     * @return array
-     */
-    public function getMediaProperties($url);
+    public function returnImage($id, $formatKey, $imageFormat);
 
     /**
      * @param int $id
      * @param string $fileName
-     * @param array $storageOptions
      * @param int $version
      * @param int $subVersion
      * @param string $mimeType
      *
      * @return array
      */
-    public function getFormats($id, $fileName, $storageOptions, $version, $subVersion, $mimeType);
+    public function getFormats($id, $fileName, $version, $subVersion, $mimeType);
 
     /**
      * Returns a definition of a format with a given key.
@@ -75,11 +66,10 @@ interface FormatManagerInterface
      * @param int $idMedia
      * @param string $fileName
      * @param string $mimeType
-     * @param string $options
      *
      * @return bool
      */
-    public function purge($idMedia, $fileName, $mimeType, $options);
+    public function purge($idMedia, $fileName, $mimeType);
 
     /**
      * Clears the format cache.

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImageConverterInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImageConverterInterface.php
@@ -26,8 +26,19 @@ interface ImageConverterInterface
      *
      * @param FileVersion $media
      * @param string $formatKey
+     * @param string $imageFormat
      *
      * @return ImageInterface
      */
-    public function convert(FileVersion $fileVersion, $formatKey);
+    public function convert(FileVersion $fileVersion, $formatKey, $imageFormat);
+
+    /**
+     * Get supported image formats by mimeType.
+     * The first returned image format will be used as default.
+     *
+     * @param string $mimeType
+     *
+     * @return string[]
+     */
+    public function getSupportedOutputImageFormats(?string $mimeType): array;
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -407,8 +407,7 @@ class MediaManager implements MediaManagerInterface
             $this->formatManager->purge(
                 $mediaEntity->getId(),
                 $currentFileVersion->getName(),
-                $currentFileVersion->getMimeType(),
-                $currentFileVersion->getStorageOptions()
+                $currentFileVersion->getMimeType()
             );
         } else {
             // not setable in update
@@ -427,8 +426,7 @@ class MediaManager implements MediaManagerInterface
                 $this->formatManager->purge(
                     $mediaEntity->getId(),
                     $currentFileVersion->getName(),
-                    $currentFileVersion->getMimeType(),
-                    $currentFileVersion->getStorageOptions()
+                    $currentFileVersion->getMimeType()
                 );
             }
         }
@@ -709,8 +707,7 @@ class MediaManager implements MediaManagerInterface
                 $this->formatManager->purge(
                     $mediaEntity->getId(),
                     $fileVersion->getName(),
-                    $fileVersion->getMimeType(),
-                    $fileVersion->getStorageOptions()
+                    $fileVersion->getMimeType()
                 );
 
                 $this->storage->remove($fileVersion->getStorageOptions());
@@ -778,7 +775,6 @@ class MediaManager implements MediaManagerInterface
                 $formatUrls[$media->getId()] = $this->formatManager->getFormats(
                     $previewImage->getId(),
                     $previewImage->getName(),
-                    $previewImage->getStorageOptions(),
                     $previewImage->getVersion(),
                     $previewImage->getSubVersion(),
                     $previewImage->getMimeType()
@@ -787,7 +783,6 @@ class MediaManager implements MediaManagerInterface
                 $formatUrls[$media->getId()] = $this->formatManager->getFormats(
                     $media->getId(),
                     $media->getName(),
-                    $media->getStorageOptions(),
                     $media->getVersion(),
                     $media->getSubVersion(),
                     $media->getMimeType()
@@ -826,7 +821,6 @@ class MediaManager implements MediaManagerInterface
                     $this->formatManager->getFormats(
                         $previewImage->getId(),
                         $latestVersion->getName(),
-                        $latestVersion->getStorageOptions(),
                         $latestVersion->getVersion(),
                         $latestVersion->getSubVersion(),
                         $latestVersion->getMimeType()
@@ -838,7 +832,6 @@ class MediaManager implements MediaManagerInterface
                 $this->formatManager->getFormats(
                     $media->getId(),
                     $media->getName(),
-                    $media->getStorageOptions(),
                     $media->getVersion(),
                     $media->getSubVersion(),
                     $media->getMimeType()

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -47,12 +47,11 @@
         <service id="sulu_media.file_validator" class="%sulu_media.file_validator.class%" />
 
         <service id="sulu_media.format_cache_clearer" class="%sulu_media.format_cache_clearer.class%" />
-        <service id="sulu_media.format_cache" class="%sulu_media.format_cache.class%">
+        <service id="sulu_media.format_cache" class="%sulu_media.format_cache.class%" public="true">
             <argument type="service" id="filesystem"/>
             <argument>%sulu_media.format_cache.path%</argument>
             <argument>%sulu_media.format_cache.media_proxy_path%</argument>
             <argument>%sulu_media.format_cache.segments%</argument>
-            <argument>%sulu_media.image.formats%</argument>
             <tag name="sulu_media.format_cache" alias="local" />
         </service>
 
@@ -71,6 +70,7 @@
             <argument type="service" id="sulu_media.image.scaler" />
             <argument type="service" id="sulu_media.image.cropper" />
             <argument>%sulu_media.image.formats%</argument>
+            <argument>%sulu_media.format_manager.mime_types%</argument>
         </service>
 
         <service id="sulu_media.image.media_extractor" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\MediaImageExtractor">
@@ -163,7 +163,6 @@
             <argument type="string">%sulu_media.format_cache.save_image%</argument>
             <argument type="string">%sulu_media.format_manager.response_headers%</argument>
             <argument>%sulu_media.image.formats%</argument>
-            <argument>%sulu_media.format_manager.mime_types%</argument>
             <argument type="service" id="logger" on-invalid="null"/>
         </service>
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -275,7 +275,6 @@ class MediaControllerTest extends SuluTestCase
         $fileVersion->setChanged(new \DateTime('1937-04-20'));
         $fileVersion->setCreated(new \DateTime('1937-04-20'));
         $fileVersion->setStorageOptions(['segment' => '1', 'fileName' => $name . '.' . $extension]);
-
         $storagePath = $this->getStoragePath();
 
         if (!file_exists($storagePath . '/1')) {
@@ -359,7 +358,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
-            '/uploads/media/sulu-50x50/01/' . $media->getId() . '-photo.jpeg'
+            '/uploads/media/sulu-50x50/1/' . $media->getId() . '-photo.jpg'
         );
 
         $response = $client->getResponse();
@@ -379,7 +378,7 @@ class MediaControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
-            '/uploads/media/50x50/01/0-photo.jpeg'
+            '/uploads/media/50x50/1/0-photo.jpg'
         );
         $this->assertFalse($client->getResponse()->isCacheable());
         $this->assertEmpty($client->getResponse()->getExpires());
@@ -395,7 +394,7 @@ class MediaControllerTest extends SuluTestCase
         ob_start();
         $client->request(
             'GET',
-            '/media/' . $media->getId() . '/download/photo.jpeg'
+            '/media/' . $media->getId() . '/download/photo.jpg'
         );
         ob_end_clean();
         $this->assertEquals(
@@ -414,7 +413,7 @@ class MediaControllerTest extends SuluTestCase
         ob_start();
         $client->request(
             'GET',
-            '/media/' . $media->getId() . '/download/photo.jpeg?inline=1'
+            '/media/' . $media->getId() . '/download/photo.jpg?inline=1'
         );
         ob_end_clean();
         $this->assertEquals(

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -106,6 +106,21 @@ class MediaStreamControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
+    public function testGetImageAction()
+    {
+        $client = $this->createAuthenticatedClient();
+        $filePath = $this->createMediaFile('test.jpg');
+        $media = $this->createMedia($filePath, 'Test jpg');
+
+        $client->request('GET', $media->getFormats()['small-inset']);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $this->assertSame('image/jpeg', $client->getResponse()->headers->get('Content-Type'));
+
+        $client->request('GET', $media->getFormats()['small-inset.gif']);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $this->assertSame('image/gif', $client->getResponse()->headers->get('Content-Type'));
+    }
+
     public function testDownloadActionForNonExistingMedia()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/LocalFormatCacheTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/LocalFormatCacheTest.php
@@ -54,11 +54,9 @@ class LocalFormatCacheTest extends TestCase
         $version = 2;
         $subVersion = 3;
         $fileId = 1;
-        $segment = ($fileId % $this->segments);
         $format = 'sulu-50x50';
         $fileName = 'Test With Spaces & Co.jpg';
-        $filePath = $this->localStorage->getMediaUrl($fileId, $fileName, [], $format, $version, $subVersion);
-        $encodedFileName = 'Test%20With%20Spaces%20%26%20Co.jpg';
+        $filePath = $this->localStorage->getMediaUrl($fileId, $fileName, $format, $version, $subVersion);
 
         $this->assertSame(
             '/uploads/media/sulu-50x50/01/1-Test%20With%20Spaces%20%26%20Co.jpg?v=2-3',

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
@@ -92,21 +92,28 @@ class ImagineImageConverterTest extends TestCase
                 '640x480' => [
                     'options' => [],
                 ],
+            ],
+            [
+                'image/*',
+                'application/pdf',
+                'video/*',
             ]
         );
     }
 
-    public function testConvertIsBinaryString()
+    public function testConvert()
     {
         $imagineImage = $this->prophesize(ImageInterface::class);
         $palette = $this->prophesize(PaletteInterface::class);
 
         $fileVersion = new FileVersion();
-        $fileVersion->setStorageOptions([]);
+        $fileVersion->setName('test.jpg');
+        $fileVersion->setVersion(1);
+        $fileVersion->setStorageOptions(['option' => 1]);
 
-        $this->storage->load([])->willReturn('image-content');
-        $this->mediaImageExtractor->extract('image-content')->willReturn('image-content');
-        $this->imagine->read('image-content')->willReturn($imagineImage->reveal());
+        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->mediaImageExtractor->extract('image-resource')->willReturn('image-resource');
+        $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
         $imagineImage->palette()->willReturn($palette->reveal());
         $imagineImage->strip()->shouldBeCalled();
@@ -115,11 +122,11 @@ class ImagineImageConverterTest extends TestCase
 
         $imagineImage->interlace(ImageInterface::INTERLACE_PLANE)->shouldBeCalled();
 
-        $imagineImage->get('jpg', [])->willReturn('new-image-content');
+        $imagineImage->get('jpg', [])->willReturn('new-image-resource');
 
         $this->focus->focus(Argument::any())->shouldNotBeCalled();
 
-        $this->assertEquals('new-image-content', $this->imagineImageConverter->convert($fileVersion, '640x480'));
+        $this->assertEquals('new-image-resource', $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg'));
     }
 
     public function testConvertNoFocusOnInset()
@@ -130,11 +137,11 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions([]);
+        $fileVersion->setStorageOptions(['option' => 1]);
 
-        $this->storage->load([])->willReturn('image-content');
-        $this->mediaImageExtractor->extract('image-content')->willReturn('image-content');
-        $this->imagine->read('image-content')->willReturn($imagineImage->reveal());
+        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->mediaImageExtractor->extract('image-resource')->willReturn('image-resource');
+        $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
         $imagineImage->metadata()->willReturn(['']);
         $imagineImage->palette()->willReturn($palette->reveal());
@@ -142,11 +149,11 @@ class ImagineImageConverterTest extends TestCase
         $imagineImage->layers()->willReturn(['']);
         $imagineImage->interlace(ImageInterface::INTERLACE_PLANE)->shouldBeCalled();
 
-        $imagineImage->get('jpg', [])->willReturn('new-image-content');
+        $imagineImage->get('jpg', [])->willReturn('new-image-resource');
 
         $this->focus->focus(Argument::any())->shouldNotBeCalled();
 
-        $this->assertEquals('new-image-content', $this->imagineImageConverter->convert($fileVersion, '640x480'));
+        $this->assertEquals('new-image-resource', $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg'));
     }
 
     public function testConvertWithImageExtension()
@@ -157,12 +164,12 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.svg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions([]);
+        $fileVersion->setStorageOptions(['option' => 1]);
         $fileVersion->setMimeType('image/svg+xml');
 
-        $this->storage->load([])->willReturn('image-content');
-        $this->mediaImageExtractor->extract('image-content')->willReturn('image-content');
-        $this->imagine->read('image-content')->willReturn($imagineImage->reveal());
+        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->mediaImageExtractor->extract('image-resource')->willReturn('image-resource');
+        $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
         $imagineImage->metadata()->willReturn(['']);
         $imagineImage->palette()->willReturn($palette->reveal());
@@ -170,9 +177,9 @@ class ImagineImageConverterTest extends TestCase
         $imagineImage->layers()->willReturn(['']);
         $imagineImage->interlace(ImageInterface::INTERLACE_PLANE)->shouldBeCalled();
 
-        $imagineImage->get('png', [])->willReturn('new-image-content');
+        $imagineImage->get('png', [])->willReturn('new-image-resource');
 
-        $this->assertEquals('new-image-content', $this->imagineImageConverter->convert($fileVersion, '640x480'));
+        $this->assertEquals('new-image-resource', $this->imagineImageConverter->convert($fileVersion, '640x480', 'png'));
     }
 
     public function testConvertCmykToRgb()
@@ -184,11 +191,11 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions([]);
+        $fileVersion->setStorageOptions(['option' => 1]);
 
-        $this->storage->load([])->willReturn('image-content');
-        $this->mediaImageExtractor->extract('image-content')->willReturn('image-content');
-        $this->imagine->read('image-content')->willReturn($imagineImage->reveal());
+        $this->storage->load(['option' => 1])->willReturn('image-resource');
+        $this->mediaImageExtractor->extract('image-resource')->willReturn('image-resource');
+        $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
 
         $imagineImage->metadata()->willReturn(['']);
         $imagineImage->palette()->willReturn($palette->reveal());
@@ -197,9 +204,9 @@ class ImagineImageConverterTest extends TestCase
         $imagineImage->usePalette(Argument::type(RGB::class))->shouldBeCalled();
         $imagineImage->interlace(ImageInterface::INTERLACE_PLANE)->shouldBeCalled();
 
-        $imagineImage->get('jpg', [])->willReturn('new-image-content');
+        $imagineImage->get('jpg', [])->willReturn('new-image-resource');
 
-        $this->assertEquals('new-image-content', $this->imagineImageConverter->convert($fileVersion, '640x480'));
+        $this->assertEquals('new-image-resource', $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg'));
     }
 
     public function testConvertNotExistingMedia()
@@ -209,11 +216,11 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion = new FileVersion();
         $fileVersion->setName('test.jpg');
         $fileVersion->setVersion(1);
-        $fileVersion->setStorageOptions([]);
+        $fileVersion->setStorageOptions(['option' => 1]);
 
-        $this->storage->load([])->willThrow(ImageProxyMediaNotFoundException::class);
+        $this->storage->load(['option' => 1])->willThrow(ImageProxyMediaNotFoundException::class);
 
-        $this->imagineImageConverter->convert($fileVersion, '640x480');
+        $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg');
     }
 
     public function testConvertAutorotate()
@@ -240,6 +247,6 @@ class ImagineImageConverterTest extends TestCase
 
         $imagineImage->get('jpg', [])->willReturn('new-image-content');
 
-        $this->assertEquals('new-image-content', $this->imagineImageConverter->convert($fileVersion, '640x480'));
+        $this->assertEquals('new-image-content', $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg'));
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -267,8 +267,7 @@ class MediaManagerTest extends TestCase
         $this->formatManager->purge(
             1,
             'test',
-            'image/png',
-            ['segment' => '01', 'fileName' => 'test.jpg']
+            'image/png'
         )->shouldBeCalled();
 
         $this->mediaRepository->findMediaById(1)->willReturn($media);
@@ -386,7 +385,7 @@ class MediaManagerTest extends TestCase
         $fileVersion->setFocusPointX(1)->shouldBeCalled();
         $fileVersion->setFocusPointY(2)->shouldBeCalled();
         $fileVersion->increaseSubVersion()->shouldBeCalled();
-        $this->formatManager->purge(1, 'test', 'image/jpeg', [])->shouldBeCalled();
+        $this->formatManager->purge(1, 'test', 'image/jpeg')->shouldBeCalled();
 
         $this->mediaManager->save(null, ['id' => 1, 'locale' => 'en', 'focusPointX' => 1, 'focusPointY' => 2], 1);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs |  #3729 ~~#1139 #595~~
| License | MIT

#### What's in this PR?

Implements several bc breaks in the storage and image format services and interfaces so that in the future the following features can be implemented without breaking the interfaces:

 - ~~ExternalStorage: can be implemented using flysystem~~ see #4264
 - Support WebP: every image should be possible be requested in other formats

#### Why?

~~It allow to create later a FlysystemStorage based on the ExternalStorageInterface.~~ see #4264
It allow to create later that image formats are outputed in other formats `50x50.webp`

#### Example Usage

Upload an image over the UI it should be converted still correctly.
You can change the extension in the url so you will get another image format.

#### BC Breaks/Deprecations

See UPGRADE.md

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
