### PR TITLE
Fix accidentally overwrites of unselected author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.6
+    * HOTIFX      #4026  [Component]               Fix accidentally overwrites of unselected author
+
 * 1.6.29 (2019-10-24)
     * BUGFIX      #4644  [LocationBundle]          Fix location content type default map provider option
     * ENHANCEMENT #4812  [MediaBundle]             Optimize gif image output


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix accidentally overwrites of unselected author.

#### Why?

Currently its not possible to unset an author as everytime the creator will be set instead.
