### PR TITLE
Fix correct url in preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for Sulu
 * dev-master
     * BUGFIX      #4042 [AudienceTargetingBundle] Add symfony 3.4.12 as conflict to fix caching tests
     * HOTFIX      #4019 [Component]               Fix handling of authored date on safari
+    * HOTFIX      #4027 [PreviewBundle]           Fix correct url in preview
     * HOTFIX      #4017 [SnippetBundle]           Fix snippet conflict overlay
     * BUGFIX      #4044 [PreviewBundle]           Fixed support method for PageRouteDefaultsProvider
     * HOTFIX      #4044 [Webspace]                Fixed document creation in webspace-initializer

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -113,7 +113,7 @@ class Preview implements PreviewInterface
         $this->save($token, $object);
 
         $id = $provider->getId($object);
-        $html = $this->replaceLinks($this->renderer->render($object, $id, $webspaceKey, $locale, true, $targetGroupId));
+        $html = $this->renderer->render($object, $id, $webspaceKey, $locale, true, $targetGroupId);
 
         $extractor = new RdfaExtractor($html);
 
@@ -130,9 +130,7 @@ class Preview implements PreviewInterface
         if (0 === count($context)) {
             $id = $provider->getId($object);
 
-            return $this->replaceLinks(
-                $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId)
-            );
+            return $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId);
         }
 
         // context
@@ -146,7 +144,7 @@ class Preview implements PreviewInterface
 
         $this->save($token, $object);
 
-        return $this->replaceLinks($this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId));
+        return $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId);
     }
 
     /**
@@ -157,19 +155,7 @@ class Preview implements PreviewInterface
         $object = $this->fetch($token);
         $id = $this->getProvider(get_class($object))->getId($object);
 
-        return $this->replaceLinks($this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId));
-    }
-
-    /**
-     * Replaces links with "#".
-     *
-     * @param string $html
-     *
-     * @return string
-     */
-    protected function replaceLinks($html)
-    {
-        return preg_replace('/((?:a|form)(?:[^>]*)(?:href|action))="[^"]*"/', '$1="#"', $html);
+        return $this->renderer->render($object, $id, $webspaceKey, $locale, false, $targetGroupId);
     }
 
     /**

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -168,15 +168,12 @@ class PreviewRenderer implements PreviewRendererInterface
         // get server parameters
         $server = [
             'SERVER_NAME' => null,
+            'HTTP_HOST' => null,
             'SERVER_PORT' => null,
         ];
-        if ($currentRequest) {
-            $server['SERVER_NAME'] = $currentRequest->getHost();
-            $server['SERVER_PORT'] = $currentRequest->getPort();
 
-            if ('https' === $currentRequest->getScheme()) {
-                $server['HTTPS'] = 'on';
-            }
+        if ($currentRequest) {
+            $server = $currentRequest->server->all();
         }
 
         $request = new Request($query, $request, $defaults, [], [], $server);

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -35,10 +35,12 @@
             <argument type="service" id="sulu_preview.preview.kernel_factory"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument type="collection">
                 <argument type="string" key="analyticsKey">%sulu_preview.defaults.analytics_key%</argument>
             </argument>
             <argument type="string">%kernel.environment%</argument>
+            <argument type="string">%sulu_websocket.server.http_host%</argument>
             <argument type="expression">
                 container.hasParameter('sulu_audience_targeting.headers.target_group')
                     ? parameter('sulu_audience_targeting.headers.target_group')

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -176,7 +176,7 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
         $changes = $preview->update($token, 'sulu_io', 'de', ['title' => 'SULU']);
 
-        $this->assertEquals(['title' => [['property' => 'title', 'href' => '#', 'html' => 'SULU']]], $changes);
+        $this->assertEquals(['title' => [['property' => 'title', 'href' => '/test', 'html' => 'SULU']]], $changes);
     }
 
     public function testUpdateNoData()
@@ -302,7 +302,7 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
             ['title' => 'SULU']
         );
 
-        $this->assertEquals('<html><body><a property="title" href="#">SULU</a></html></body>', $response);
+        $this->assertEquals('<html><body><a property="title" href="/test">SULU</a></html></body>', $response);
     }
 
     public function testUpdateContextNoContext()
@@ -356,7 +356,7 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
             ['title' => 'SULU']
         );
 
-        $this->assertEquals('<html><body><a property="title" href="#">SULU</a></html></body>', $response);
+        $this->assertEquals('<html><body><a property="title" href="/test">SULU</a></html></body>', $response);
     }
 
     public function testUpdateContextNoData()
@@ -470,7 +470,7 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
         $preview = $this->getPreview([get_class($object->reveal()) => $provider]);
         $response = $preview->render($token, 'sulu_io', 'de');
 
-        $this->assertEquals('<a property="title" href="#">test</a>', $response);
+        $this->assertEquals('<a property="title" href="/test">test</a>', $response);
     }
 
     public function testRenderWithStyle()
@@ -520,10 +520,10 @@ class PreviewTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             '<link rel="stylesheet" type="text/css" href="theme.css">' .
-            '<a property="title" href="#">test</a>' .
-            '<a href="#">test</a>' .
-            '<form action="#"></form>' .
-            '<form class="form" action="#"></form>',
+            '<a property="title" href="/test">test</a>' .
+            '<a href="/test">test</a>' .
+            '<form action="/test"></form>' .
+            '<form class="form" action="/test"></form>',
             $response
         );
     }

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -158,7 +158,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider portalDataProvider
      */
-    public function testRender1($scheme, $portalUrl)
+    public function testRender($scheme, $portalUrl)
     {
         $object = $this->prophesize(\stdClass::class);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix preview host replacement for render calls.

#### Why?

Subrequest (e.g. twig render) are created with Request::create which will replace currently `SERVER_PROTOCOL`, `HTTP_HOST`, and [many other headers](https://github.com/symfony/symfony/blob/v3.4.11/src/Symfony/Component/HttpFoundation/Request.php#L344-L357) which are currently not set in our Preview Request. If we forward them correctly in the preview they will not be overwritten by defaults.

#### Example Usage

1. Open page in backend
2. Use render function in template to render a sulu:link on a webspace with {host}
3. without this fix localhost would be used instead of the current domain

