### PR TITLE
Fixed bug when resource-tab set own locales

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -71,12 +71,6 @@ class Form extends React.PureComponent<Props> {
                 }
             }
 
-            if ((typeof locales === 'boolean' && locales === true)
-                || ((Array.isArray(locales) || isObservableArray(locales)) && locales.length > 0)
-            ) {
-                locale = observable.box(resourceStore.locale ? resourceStore.locale.get() : undefined);
-            }
-
             this.resourceStore = idQueryParameter
                 ? new ResourceStore(resourceKey, id, {locale: locale}, {}, idQueryParameter)
                 : new ResourceStore(resourceKey, id, {locale: locale});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -116,6 +116,82 @@ test('Should create a new resourceStore if the passed resourceKey differs with l
     expect(formResourceStore.locale.get()).toEqual('en');
 });
 
+test('Should create a new resourceStore if the passed resourceKey differs with own locales', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 10, {});
+    const route = {
+        options: {
+            resourceKey: 'pages',
+            locales: ['de', 'en'],
+        },
+    };
+    const router = {
+        attributes: {},
+        bind: jest.fn(),
+        route,
+    };
+
+    const form = mount(<Form resourceStore={resourceStore} router={router} route={route} />);
+    const formResourceStore = form.instance().resourceStore;
+
+    expect(resourceStore).not.toBe(formResourceStore);
+    expect(resourceStore.resourceKey).toEqual('snippets');
+    expect(formResourceStore.resourceKey).toEqual('pages');
+    expect(formResourceStore.locale.get()).toEqual(undefined);
+});
+
+test('Should create a new resourceStore if the passed resourceKey differs with own boolean locales', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const locale = observable.box('en');
+    const resourceStore = new ResourceStore('snippets', 10, {locale});
+    const route = {
+        options: {
+            resourceKey: 'pages',
+            locales: ['de', 'en'],
+        },
+    };
+    const router = {
+        attributes: {},
+        bind: jest.fn(),
+        route,
+    };
+
+    const form = mount(<Form resourceStore={resourceStore} router={router} route={route} />);
+    const formResourceStore = form.instance().resourceStore;
+
+    expect(resourceStore).not.toBe(formResourceStore);
+    expect(resourceStore.resourceKey).toEqual('snippets');
+    expect(formResourceStore.resourceKey).toEqual('pages');
+    expect(formResourceStore.locale.get()).toEqual('en');
+});
+
+test('Should create a new resourceStore if the passed resourceKey differs with own locales including locale', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 10, {});
+    const route = {
+        options: {
+            resourceKey: 'pages',
+            locales: true,
+        },
+    };
+    const router = {
+        attributes: {},
+        bind: jest.fn(),
+        route,
+    };
+
+    const form = mount(<Form resourceStore={resourceStore} router={router} route={route} />);
+    const formResourceStore = form.instance().resourceStore;
+
+    expect(resourceStore).not.toBe(formResourceStore);
+    expect(resourceStore.resourceKey).toEqual('snippets');
+    expect(formResourceStore.resourceKey).toEqual('pages');
+    expect(formResourceStore.locale.get()).toEqual(undefined);
+});
+
 test('Should instantiate the ResourceStore with the idQueryParameter if given', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -141,7 +141,7 @@ test('Should create a new resourceStore if the passed resourceKey differs with o
     expect(formResourceStore.locale.get()).toEqual(undefined);
 });
 
-test('Should create a new resourceStore if the passed resourceKey differs with own boolean locales', () => {
+test('Should create a new resourceStore if the passed resourceKey differs with own locales including locale', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const locale = observable.box('en');
@@ -167,7 +167,7 @@ test('Should create a new resourceStore if the passed resourceKey differs with o
     expect(formResourceStore.locale.get()).toEqual('en');
 });
 
-test('Should create a new resourceStore if the passed resourceKey differs with own locales including locale', () => {
+test('Should create a new resourceStore if the passed resourceKey differs with own boolean locales', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const resourceStore = new ResourceStore('snippets', 10, {});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes a bug when a resource-tab adds uses locales.

#### Why?

If you want to extend the account with localized content.

#### Example Usage

~~~php
    public function getRoutes(): array
    {
        return [
            (new Route('app.account.notes', '/notes', 'sulu_admin.form'))
                ->addOption('tabTitle', 'app.notes')
                ->addOption('backRoute', 'sulu_contact.accounts_datagrid')
                ->addOption('resourceKey', 'account_notes')
                ->addOption('locales', $locales)
                ->addAttributeDefault('locale', $locales ? $locales[0] : '')
                ->setParent('sulu_contact.account_edit_form'),
        ];
    }
~~~
