### PR TITLE
Fix naming of category tables and fields

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -209,6 +209,34 @@ ALTER TABLE me_file_version_meta CHANGE title title VARCHAR(191) NOT NULL;
 ALTER TABLE me_file_versions CHANGE name name VARCHAR(191) NOT NULL;
 ```
 
+Create new tables ca_category_translations_keywords and ca_category_translations_medias
+
+```sql
+CREATE TABLE ca_category_translation_keywords (idKeywords INT NOT NULL, idCategoryTranslations INT NOT NULL, INDEX IDX_D15FBE37F9FC9F05 (idKeywords), INDEX IDX_D15FBE3717CA14DA (idCategoryTranslations), PRIMARY KEY(idKeywords, idCategoryTranslations)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB;
+ALTER TABLE ca_category_translation_keywords ADD CONSTRAINT FK_D15FBE37F9FC9F05 FOREIGN KEY (idKeywords) REFERENCES ca_keywords (id);
+ALTER TABLE ca_category_translation_keywords ADD CONSTRAINT FK_D15FBE3717CA14DA FOREIGN KEY (idCategoryTranslations) REFERENCES ca_category_translations (id);
+
+CREATE TABLE ca_category_translation_medias (idCategoryTranslations INT NOT NULL, idMedia INT NOT NULL, INDEX IDX_39FC41BA17CA14DA (idCategoryTranslations), INDEX IDX_39FC41BA7DE8E211 (idMedia), PRIMARY KEY(idCategoryTranslations, idMedia)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB;
+ALTER TABLE ca_category_translation_medias ADD CONSTRAINT FK_39FC41BA17CA14DA FOREIGN KEY (idCategoryTranslations) REFERENCES ca_category_translations (id) ON DELETE CASCADE;
+ALTER TABLE ca_category_translation_medias ADD CONSTRAINT FK_39FC41BA7DE8E211 FOREIGN KEY (idMedia) REFERENCES me_media (id) ON DELETE CASCADE;
+```
+
+**Migrations**
+
+Migrate values from ca_category_translations_keywords to ca_category_translation_keywords:
+
+```sql
+INSERT INTO ca_category_translation_keywords (idKeywords, idCategoryTranslations) SELECT keyword_id, category_meta_id FROM ca_category_translations_keywords;
+DROP TABLE ca_category_translations_keywords;
+```
+
+Migrate values from category_translation_media_interface to ca_category_translations_medias:
+
+```sql
+INSERT INTO ca_category_translation_medias (idCategoryTranslations, idMedia) SELECT category_translation_id, media_interface_id FROM category_translation_media_interface;
+DROP TABLE category_translation_media_interface;
+```
+
 ## 1.6.17
 
 ### Address latitude/longitude

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -209,7 +209,7 @@ ALTER TABLE me_file_version_meta CHANGE title title VARCHAR(191) NOT NULL;
 ALTER TABLE me_file_versions CHANGE name name VARCHAR(191) NOT NULL;
 ```
 
-Create new tables ca_category_translations_keywords and ca_category_translations_medias
+Create new tables ca_category_translations_keywords and ca_category_translation_medias
 
 ```sql
 CREATE TABLE ca_category_translation_keywords (idKeywords INT NOT NULL, idCategoryTranslations INT NOT NULL, INDEX IDX_D15FBE37F9FC9F05 (idKeywords), INDEX IDX_D15FBE3717CA14DA (idCategoryTranslations), PRIMARY KEY(idKeywords, idCategoryTranslations)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB;
@@ -230,7 +230,7 @@ INSERT INTO ca_category_translation_keywords (idKeywords, idCategoryTranslations
 DROP TABLE ca_category_translations_keywords;
 ```
 
-Migrate values from category_translation_media_interface to ca_category_translations_medias:
+Migrate values from category_translation_media_interface to ca_category_translation_medias:
 
 ```sql
 INSERT INTO ca_category_translation_medias (idCategoryTranslations, idMedia) SELECT category_translation_id, media_interface_id FROM category_translation_media_interface;

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/CategoryTranslation.orm.xml
@@ -13,6 +13,14 @@
         <field name="description" type="text" column="description" nullable="true"/>
 
         <many-to-many field="medias" target-entity="Sulu\Bundle\MediaBundle\Entity\MediaInterface">
+            <join-table name="ca_category_translation_medias">
+                <join-columns>
+                    <join-column name="idCategoryTranslations" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="idMedia" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
+                </inverse-join-columns>
+            </join-table>
             <order-by>
                 <order-by-field name="id" direction="ASC"/>
             </order-by>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/doctrine/Keyword.orm.xml
@@ -21,12 +21,12 @@
 
         <many-to-many target-entity="Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface" field="categoryTranslations"
                       inversed-by="keywords">
-            <join-table name="ca_category_translations_keywords">
+            <join-table name="ca_category_translation_keywords">
                 <join-columns>
-                    <join-column name="keyword_id" referenced-column-name="id"/>
+                    <join-column name="idKeywords" referenced-column-name="id"/>
                 </join-columns>
                 <inverse-join-columns>
-                    <join-column name="category_meta_id" referenced-column-name="id"/>
+                    <join-column name="idCategoryTranslations" referenced-column-name="id"/>
                 </inverse-join-columns>
             </join-table>
         </many-to-many>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix naming of category tables and fields.

#### Why?

Currently the naming of the fields are auto generated and one table has interface in it and the other table has a false field name.

#### BC Breaks/Deprecations

Manual database migration is needed as schema update will not work here.