### PR TITLE
fix required validation for Input field

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -38,7 +38,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
     };
 
     handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
-        this.props.onChange(event.currentTarget.value || null, event);
+        this.props.onChange(event.currentTarget.value || undefined, event);
     };
 
     handleKeyPress = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -37,9 +37,9 @@ test('Input should render with value', () => {
     expect(render(<Input value="My value" onChange={onChange} onBlur={jest.fn()} />)).toMatchSnapshot();
 });
 
-test('Input should render null value as empty string', () => {
+test('Input should render undefined value as empty string', () => {
     const onChange = jest.fn();
-    expect(render(<Input value={null} onChange={onChange} onBlur={jest.fn()} />)).toMatchSnapshot();
+    expect(render(<Input value={undefined} onChange={onChange} onBlur={jest.fn()} />)).toMatchSnapshot();
 });
 
 test('Input should call the callback when the input changes', () => {
@@ -50,12 +50,12 @@ test('Input should call the callback when the input changes', () => {
     expect(onChange).toHaveBeenCalledWith('my-value', event);
 });
 
-test('Input should call the callback with null if the input value is removed', () => {
+test('Input should call the callback with undefined if the input value is removed', () => {
     const onChange = jest.fn();
     const input = shallow(<Input value="My value" onChange={onChange} onBlur={jest.fn()} />);
     const event = {currentTarget: {value: ''}};
     input.find('input').simulate('change', event);
-    expect(onChange).toHaveBeenCalledWith(null, event);
+    expect(onChange).toHaveBeenCalledWith(undefined, event);
 });
 
 test('Input should call the callback when icon was clicked', () => {
@@ -68,15 +68,15 @@ test('Input should call the callback when icon was clicked', () => {
 
 test('Input should render with a loader', () => {
     const onChange = jest.fn();
-    expect(render(<Input value={null} loading={true} onChange={onChange} onBlur={jest.fn()} />)).toMatchSnapshot();
+    expect(render(<Input value={undefined} loading={true} onChange={onChange} onBlur={jest.fn()} />)).toMatchSnapshot();
 });
 
 test('Input should render collapsed', () => {
-    expect(render(<Input value={null} onChange={jest.fn()} collapsed={true} />)).toMatchSnapshot();
+    expect(render(<Input value={undefined} onChange={jest.fn()} collapsed={true} />)).toMatchSnapshot();
 });
 
 test('Input should render append container when onClearClick callback is provided', () => {
-    expect(render(<Input value={null} onChange={jest.fn()} onClearClick={jest.fn()} />)).toMatchSnapshot();
+    expect(render(<Input value={undefined} onChange={jest.fn()} onClearClick={jest.fn()} />)).toMatchSnapshot();
 });
 
 test('Input should render append container with icon when onClearClick callback is provided and value is set', () => {
@@ -92,7 +92,7 @@ test('Input should should call the callback when clear icon was clicked', () => 
 
 test('Input should render with dark skin', () => {
     expect(
-        render(<Input icon="su-pen" value={null} onChange={jest.fn()} onClearClick={jest.fn()} skin="dark" />)
+        render(<Input icon="su-pen" value={undefined} onChange={jest.fn()} onClearClick={jest.fn()} skin="dark" />)
     ).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -54,17 +54,6 @@ exports[`Input should render collapsed 1`] = `
 </label>
 `;
 
-exports[`Input should render null value as empty string 1`] = `
-<label
-  class="input default"
->
-  <input
-    type="text"
-    value=""
-  />
-</label>
-`;
-
 exports[`Input should render undefined value as empty string 1`] = `
 <label
   class="input default"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -65,6 +65,17 @@ exports[`Input should render null value as empty string 1`] = `
 </label>
 `;
 
+exports[`Input should render undefined value as empty string 1`] = `
+<label
+  class="input default"
+>
+  <input
+    type="text"
+    value=""
+  />
+</label>
+`;
+
 exports[`Input should render with a loader 1`] = `
 <label
   class="input default"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/Number.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/Number.js
@@ -31,13 +31,13 @@ export default class Number extends React.PureComponent<Props> {
     };
 
     handleChange = (value: ?string, event: SyntheticEvent<HTMLInputElement>) => {
-        let number = null;
+        let number = undefined;
 
         if (value) {
             number = parseFloat(value);
 
             if (isNaN(number)) {
-                number = null;
+                number = undefined;
             }
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/tests/Number.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Number/tests/Number.test.js
@@ -4,33 +4,33 @@ import {render, shallow} from 'enzyme';
 import Number from '../Number';
 
 test('Number should render', () => {
-    expect(render(<Number value={null} onChange={jest.fn()} />)).toMatchSnapshot();
+    expect(render(<Number value={undefined} onChange={jest.fn()} />)).toMatchSnapshot();
 });
 
 test('Number should call onChange with parsed value', () => {
     const onChange = jest.fn();
-    const number = shallow(<Number value={null} onChange={onChange} />);
+    const number = shallow(<Number value={undefined} onChange={onChange} />);
 
     const event = {};
     number.find('Input').simulate('change', '10.2', event);
 });
 
-test('Number should call onChange with null when value isn`t a float', () => {
+test('Number should call onChange with undefined when value isn`t a float', () => {
     const onChange = jest.fn();
-    const number = shallow(<Number value={null} onChange={onChange} />);
+    const number = shallow(<Number value={undefined} onChange={onChange} />);
 
     const event = {};
     number.find('Input').simulate('change', 'xxx', event);
 
-    expect(onChange).toBeCalledWith(null, event);
+    expect(onChange).toBeCalledWith(undefined, event);
 });
 
-test('Number should call onChange with null when value is null', () => {
+test('Number should call onChange with undefined when value is undefined', () => {
     const onChange = jest.fn();
-    const number = shallow(<Number value={null} onChange={onChange} />);
+    const number = shallow(<Number value={undefined} onChange={onChange} />);
 
     const event = {};
-    number.find('Input').simulate('change', null, event);
+    number.find('Input').simulate('change', undefined, event);
 
-    expect(onChange).toBeCalledWith(null, event);
+    expect(onChange).toBeCalledWith(undefined, event);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -9,6 +9,13 @@ const defaultOptions = {
     },
 };
 
+function transformData(data: Object) {
+    return Object.keys(data).reduce((transformedData: Object, key) => {
+        transformedData[key] = data[key] === undefined ? null : data[key];
+        return transformedData;
+    }, {});
+}
+
 function handleResponse(response: Response) {
     for (const handleResponseHook of Requester.handleResponseHooks) {
         handleResponseHook(response);
@@ -35,12 +42,12 @@ export default class Requester {
     }
 
     static post(url: string, data: Object): Promise<Object> {
-        return fetch(url, {...defaultOptions, method: 'POST', body: JSON.stringify(data)})
+        return fetch(url, {...defaultOptions, method: 'POST', body: JSON.stringify(transformData(data))})
             .then(handleResponse);
     }
 
     static put(url: string, data: Object): Promise<Object> {
-        return fetch(url, {...defaultOptions, method: 'PUT', body: JSON.stringify(data)})
+        return fetch(url, {...defaultOptions, method: 'PUT', body: JSON.stringify(transformData(data))})
             .then(handleResponse);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import Requester from '../Requester';
 
 test('Should execute GET request and return JSON', () => {
@@ -56,6 +56,7 @@ test('Should execute POST request and return JSON', () => {
     const data = {
         title: 'Titel',
         description: 'Description',
+        test: undefined,
     };
     const requestPromise = Requester.post('/some-url', data).then((response) => {
         expect(response).toBe('test');
@@ -63,7 +64,11 @@ test('Should execute POST request and return JSON', () => {
 
     expect(window.fetch).toBeCalledWith('/some-url', {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: JSON.stringify({
+            title: 'Titel',
+            description: 'Description',
+            test: null,
+        }),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     });
@@ -85,6 +90,7 @@ test('Should execute PUT request and return JSON', () => {
     const data = {
         title: 'Titel',
         description: 'Description',
+        test: undefined,
     };
     const requestPromise = Requester.put('/some-url', data).then((response) => {
         expect(response).toBe('test');
@@ -92,7 +98,11 @@ test('Should execute PUT request and return JSON', () => {
 
     expect(window.fetch).toBeCalledWith('/some-url', {
         method: 'PUT',
-        body: JSON.stringify(data),
+        body: JSON.stringify({
+            title: 'Titel',
+            description: 'Description',
+            test: null,
+        }),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | https://github.com/sulu/sulu/pull/4003
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR sets the empty value returned for the `Number` and `Input` fields to `undefined` instead of `null`. Since `JSON.stringify` seems to remove values from objects being `undefined` the `Requester` also has to replace `undefined` with `null` before actually sending the request.

#### Why?

An empty `Input` or `Number` field was not recognized as `required` anymore by JSON Schema, because `null` seems to be interpreted as a value sufficient for `required` fields.