### PR TITLE
Cleanup ContentTypeInterface for 2.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 ## dev-develop
 
+### Content Types
+
+The following functions where removed from the `ContentTypeInterface`:
+
+ - getTemplate
+ - getDefaultParams
+ - getDefaultValue
+
+When you have a custom content type you need to register a field type on the same name.
+
 ### Test Setup changed
 
 If you use the SuluTestBundle to test your custom sulu bundles you maybe need to change in your test config.yml

--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/single.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/macros/single.html.twig
@@ -4,7 +4,15 @@
         {{ property.getTitle(userLocale) }}
     </label>
 
-    {% include type.template %}
+    {% if type.template|default(false) %}
+        {% include type.template %}
+    {% else %}
+        <div>
+            <span class="badge badge-red">Template for content type "{{ type.name }}" was not defined.</span>
+        </div>
+
+        <div class="block-content" data-sort-mode-id="{{ id|raw }}"></div>
+    {% endif %}
 
     {% if property.getInfoText(userLocale) %}
         <div class="input-description">{{ property.getInfoText(userLocale) }}</div>

--- a/src/Sulu/Component/Content/ContentTypeInterface.php
+++ b/src/Sulu/Component/Content/ContentTypeInterface.php
@@ -96,31 +96,6 @@ interface ContentTypeInterface
     );
 
     /**
-     * TODO: Remove this before 2.0 release.
-     *
-     * Returns a template to render a form.
-     *
-     * @return string
-     */
-    public function getTemplate();
-
-    /**
-     * Returns default parameters.
-     *
-     * @param PropertyInterface|null $property
-     *
-     * @return array
-     */
-    public function getDefaultParams(PropertyInterface $property = null);
-
-    /**
-     * returns default value of content type.
-     *
-     * @return mixed
-     */
-    public function getDefaultValue();
-
-    /**
      * Prepare view data (or metadata) for the template.
      *
      * @param PropertyInterface $property


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove unneeded functions from the ContentTypeInterface.

#### Why?

A content type does not longer need a template it need a field type be configured on this tag.

#### BC Breaks/Deprecations

getTemplate is not longer needed to be implement for Content Types.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
