### PR TITLE
remove reset of page when returning from a form to the datagrid

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -104,7 +104,6 @@ export default class DatagridStore {
         loadingStrategy: LoadingStrategyInterface,
         structureStrategy: StructureStrategyInterface
     ) => {
-        this.reset();
         this.updateLoadingStrategy(loadingStrategy);
         this.updateStructureStrategy(structureStrategy);
     };
@@ -112,6 +111,10 @@ export default class DatagridStore {
     @action updateLoadingStrategy = (loadingStrategy: LoadingStrategyInterface) => {
         if (this.loadingStrategy && this.loadingStrategy === loadingStrategy) {
             return;
+        }
+
+        if (this.loadingStrategy) {
+            this.reset();
         }
 
         if (this.structureStrategy) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -15,6 +15,10 @@ function LoadingStrategy() {
     this.destroy = jest.fn();
 }
 
+function OtherLoadingStrategy() {
+    this.load = jest.fn().mockReturnValue({then: jest.fn()});
+}
+
 class StructureStrategy {
     @observable data = [];
     clear = jest.fn();
@@ -677,17 +681,18 @@ test('Should not reset page count to 0 and page to 1 when sort order stays the s
     datagridStore.destroy();
 });
 
-test('Should reset page count and page when strategy changes', () => {
+test('Should reset page count and page when loading strategy changes', () => {
     const page = observable.box();
     const datagridStore = new DatagridStore('snippets', {page});
 
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();
+    const otherLoadingStrategy = new OtherLoadingStrategy();
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     datagridStore.setPage(5);
     datagridStore.pageCount = 7;
-    datagridStore.updateStrategies(loadingStrategy, structureStrategy);
+    datagridStore.updateStrategies(otherLoadingStrategy, structureStrategy);
 
     expect(page.get()).toEqual(1);
     expect(datagridStore.pageCount).toEqual(0);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4002
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR only reset the page of the datagrid when the loading strategy was already set before and changed afterwards.

#### Why?

Because otherwise the page will always be reset to 1, even when returning from a form where a page is initially passed to the URL. This was introduced with the refactoring in #4002.