### PR TITLE
Add symfony 3.4.12 as conflict to fix caching tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * BUGFIX      #4042 [AudienceTargetingBundle] Add symfony 3.4.12 as conflict to fix caching tests
     * HOTFIX      #4019 [Component]               Fix handling of authored date on safari
     * HOTFIX      #4017 [SnippetBundle]           Fix snippet conflict overlay
 

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "phpdocumentor/reflection-docblock": "~3.1"
     },
     "conflict": {
-        "symfony/symfony": "2.8.10",
+        "symfony/symfony": "2.8.10 || 3.4.12",
         "symfony/phpunit-bridge": "2.8.10",
         "symfony/monolog-bundle": "2.8.10",
         "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | https://github.com/symfony/symfony/pull/27467
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR fixes a regression introduced by https://github.com/symfony/symfony/pull/27467.

#### Why?

Because the tests should actually run :-)