### PR TITLE
Fixed document creation in webspace-initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * BUGFIX      #4042 [AudienceTargetingBundle] Add symfony 3.4.12 as conflict to fix caching tests
     * HOTFIX      #4019 [Component]               Fix handling of authored date on safari
     * HOTFIX      #4017 [SnippetBundle]           Fix snippet conflict overlay
+    * HOTFIX      #4044 [Webspace]                Fixed document creation in webspace-initializer
 
 * 1.6.19 (2018-05-24)
     * HOTFIX      #3980 [PreviewBundle]           Fix kernel.project_dir parameter for PreviewKernel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * BUGFIX      #4042 [AudienceTargetingBundle] Add symfony 3.4.12 as conflict to fix caching tests
     * HOTFIX      #4019 [Component]               Fix handling of authored date on safari
     * HOTFIX      #4017 [SnippetBundle]           Fix snippet conflict overlay
+    * BUGFIX      #4044 [PreviewBundle]           Fixed support method for PageRouteDefaultsProvider
     * HOTFIX      #4044 [Webspace]                Fixed document creation in webspace-initializer
 
 * 1.6.19 (2018-05-24)

--- a/src/Sulu/Bundle/ContentBundle/Preview/PageRouteDefaultsProvider.php
+++ b/src/Sulu/Bundle/ContentBundle/Preview/PageRouteDefaultsProvider.php
@@ -88,7 +88,10 @@ class PageRouteDefaultsProvider implements RouteDefaultsProviderInterface
      */
     public function supports($entityClass)
     {
-        return HomeDocument::class === $entityClass || PageDocument::class === $entityClass;
+        return HomeDocument::class === $entityClass
+            || PageDocument::class === $entityClass
+            || is_subclass_of($entityClass, HomeDocument::class)
+            || is_subclass_of($entityClass, PageDocument::class);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -109,7 +109,8 @@ class WebspaceInitializer implements InitializerInterface
 
             $persistOptions = ['ignore_required' => true];
             if (!$homeDocument) {
-                $homeDocument = new HomeDocument();
+                /** @var HomeDocument $homeDocument */
+                $homeDocument = $this->documentManager->create('home');
                 $persistOptions['path'] = $homePath;
                 $persistOptions['auto_create'] = true;
             } else {

--- a/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
@@ -117,18 +117,20 @@ class WebspaceInitializerTest extends \PHPUnit_Framework_TestCase
         $this->pathBuilder->build(['%base%', 'webspace1', '%route%'])->willReturn('/cmf/webspace1/routes');
         $this->pathBuilder->build(['%base%', 'webspace2', '%route%'])->willReturn('/cmf/webspace2/routes');
 
-        $routeNode = $this->prophesize(RouteDocument::class);
-        $this->documentManager->create('route')->willReturn($routeNode->reveal());
+        $routeDocument = $this->prophesize(RouteDocument::class);
+        $this->documentManager->create('route')->willReturn($routeDocument->reveal());
 
+        $homeDocument = $this->prophesize(HomeDocument::class);
+        $this->documentManager->create('home')->willReturn($homeDocument->reveal());
         $this->documentManager->find(
             '/cmf/webspace1/contents',
             'en',
             ['load_ghost_content' => false]
-        )->willReturn(new HomeDocument());
+        )->willReturn($homeDocument->reveal());
         $this->documentManager->find(Argument::cetera())->willThrow(DocumentNotFoundException::class);
 
         $this->documentManager->persist(
-            Argument::type(HomeDocument::class),
+            $homeDocument->reveal(),
             'de',
             [
                 'path' => '/cmf/webspace1/contents',
@@ -137,14 +139,14 @@ class WebspaceInitializerTest extends \PHPUnit_Framework_TestCase
             ]
         )->shouldBeCalled();
         $this->documentManager->persist(
-            Argument::type(HomeDocument::class),
+            $homeDocument->reveal(),
             'en',
             [
                 'ignore_required' => true,
             ]
         )->shouldBeCalled();
         $this->documentManager->persist(
-            Argument::type(HomeDocument::class),
+            $homeDocument->reveal(),
             'de',
             [
                 'path' => '/cmf/webspace2/contents',
@@ -153,27 +155,27 @@ class WebspaceInitializerTest extends \PHPUnit_Framework_TestCase
             ]
         )->shouldBeCalled();
 
-        $this->documentManager->publish(Argument::type(HomeDocument::class), 'de')->shouldBeCalledTimes(2);
-        $this->documentManager->publish(Argument::type(HomeDocument::class), 'en')->shouldBeCalledTimes(1);
+        $this->documentManager->publish($homeDocument->reveal(), 'de')->shouldBeCalledTimes(2);
+        $this->documentManager->publish($homeDocument->reveal(), 'en')->shouldBeCalledTimes(1);
 
         $this->documentManager->persist(
-            Argument::type(RouteDocument::class),
+            $routeDocument->reveal(),
             'de',
             ['path' => '/cmf/webspace1/routes/de', 'auto_create' => true]
         )->shouldBeCalled();
         $this->documentManager->persist(
-            Argument::type(RouteDocument::class),
+            $routeDocument->reveal(),
             'en',
             ['path' => '/cmf/webspace1/routes/en', 'auto_create' => true]
         )->shouldBeCalled();
         $this->documentManager->persist(
-            Argument::type(RouteDocument::class),
+            $routeDocument->reveal(),
             'de',
             ['path' => '/cmf/webspace2/routes/de', 'auto_create' => true]
         )->shouldBeCalled();
 
-        $this->documentManager->publish(Argument::type(RouteDocument::class), 'de')->shouldBeCalledTimes(2);
-        $this->documentManager->publish(Argument::type(RouteDocument::class), 'en')->shouldBeCalledTimes(1);
+        $this->documentManager->publish($routeDocument->reveal(), 'de')->shouldBeCalledTimes(2);
+        $this->documentManager->publish($routeDocument->reveal(), 'en')->shouldBeCalledTimes(1);
 
         $this->documentManager->flush()->shouldBeCalled();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the webspace-initializer when the home document was extended.

#### Why?

The initializer uses the class hardcoded.