### PR TITLE
fix margins for pagination buttons in datagrid

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
@@ -2,9 +2,13 @@
 
 $borderRadius: 4px;
 $buttonWidth: 33px;
+$paginationColor: $gray;
+$buttonBackgroundColor: $wildSand;
+$buttonBorderColor: $scorpion;
+$buttonActiveColor: $blueZodiac;
 
 .pagination {
-    color: $gray;
+    color: $paginationColor;
     font-size: 12px;
     display: flex;
     justify-content: space-between;
@@ -23,15 +27,15 @@ $buttonWidth: 33px;
 .next,
 .previous {
     display: inline-block;
-    height: 40px;
+    height: 30px;
     width: $buttonWidth;
-    background-color: $white;
-    border: 1px solid $mischka;
+    background-color: $buttonBackgroundColor;
+    border: 1px solid $buttonBorderColor;
     text-align: center;
-    font-size: 18px;
+    font-size: 12px;
 
     &:not(:disabled) {
-        color: $blueZodiac;
+        color: $buttonActiveColor;
         cursor: pointer;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -185,7 +185,6 @@ $borderWidth: 1px;
         visibility: hidden;
         width: 100%;
         height: 100%;
-        padding: 0;
         border: none;
         color: $buttonCellBackgroundColorHover;
         cursor: pointer;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/global.scss
@@ -36,6 +36,7 @@ h1 {
 
 button {
     border-radius: 0;
+    padding: 0;
 }
 
 input {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
@@ -1,7 +1,6 @@
 .datagrid {
     display: flex;
     flex-direction: column;
-    height: 100%;
 }
 
 .toolbar {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -57,7 +57,7 @@ test('Should execute POST request and return JSON', () => {
         json: jest.fn(),
         ok: true,
     };
-    response.json.mockReturnValue(Promise.resolve({test: '', value: 'test'}))
+    response.json.mockReturnValue(Promise.resolve({test: '', value: 'test'}));
     const promise = new Promise((resolve) => resolve(response));
 
     window.fetch = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/datagrid.scss
@@ -1,8 +1,7 @@
 @import '../../containers/Application/variables.scss';
 
 .datagrid {
-    height: 100%;
-    padding: $viewPadding;
+    margin: $viewPadding;
     display: flex;
     flex-direction: column;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds some margin after the pagination elements in the datagrid view.

#### Why?

Bedcause it does not look good if the pagination icons are on the very bottom of the screen with no margin.