### PR TITLE
remove finally because edge does not support it yet

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AutoComplete/stores/AutoCompleteStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AutoComplete/stores/AutoCompleteStore.js
@@ -36,9 +36,12 @@ export default class AutoCompleteStore {
         }).then(action((response) => {
             this.clearSearchResults();
             this.searchResults.push(...response._embedded[resourceKey]);
-            return this.searchResults;
-        })).finally(action(() => {
             this.loading = false;
-        }));
+            return this.searchResults;
+        })).catch(action(() => {
+            this.loading = false;
+        })).then(() => {
+            return [];
+        });
     };
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Initializer/tests/Initializer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Initializer/tests/Initializer.test.js
@@ -132,7 +132,7 @@ test('Should initialize when everything works', () => {
     expect(initializer.loading).toBe(true);
 
     return initPromise
-        .finally(() => {
+        .then(() => {
             expect(setTranslations).toBeCalledWith(translationData);
             expect(initializer.initializedTranslationsLocale).toBe('en');
             expect(moment.locale).toBeCalledWith('en-US');
@@ -202,7 +202,7 @@ test('Should not reinitialize everything when it was already initialized', () =>
     expect(initializer.loading).toBe(true);
 
     return initPromise
-        .finally(() => {
+        .then(() => {
             expect(setTranslations).not.toBeCalled();
 
             // static things
@@ -251,7 +251,7 @@ test('Should not crash when the config request throws an 401 error', () => {
     expect(initializer.loading).toBe(true);
 
     return initPromise
-        .finally(() => {
+        .catch(() => {
             expect(setTranslations).toBeCalledWith(translationData);
             expect(initializer.initializedTranslationsLocale).toBe('en');
             expect(initializer.initialized).toBe(false);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -57,7 +57,7 @@ test('Should execute POST request and return JSON', () => {
         json: jest.fn(),
         ok: true,
     };
-    response.json.mockReturnValue(Promise.resolve({test: '', value: 'test'}))
+    response.json.mockReturnValue(Promise.resolve({test: '', value: 'test'}));
     const promise = new Promise((resolve) => resolve(response));
 
     window.fetch = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -89,25 +89,28 @@ class UserStore {
         if (this.resetSuccess) {
             // if email was already sent use different api
             return Requester.post(Config.endpoints.resetResend, {user: user})
+                .then(() => {
+                    this.setLoading(false);
+                })
                 .catch((error) => {
                     if (error.status !== 400) {
                         return Promise.reject(error);
                     }
-                })
-                .finally(() => {
                     this.setLoading(false);
                 });
         }
 
         return Requester.post(Config.endpoints.reset, {user: user})
+            .then(() => {
+                this.setLoading(false);
+                this.setResetSuccess(true);
+            })
             .catch((error) => {
+                this.setLoading(false);
+                this.setResetSuccess(true);
                 if (error.status !== 400) {
                     return Promise.reject(error);
                 }
-            })
-            .finally(() => {
-                this.setLoading(false);
-                this.setResetSuccess(true);
             });
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -115,7 +115,7 @@ test('Should show error when login is not working and error status is 401', () =
     expect(userStore.loading).toBe(true);
 
     return loginPromise
-        .finally(() => {
+        .then(() => {
             expect(Requester.post).toBeCalledWith('login_check_url', {username: 'test', password: 'password'});
             expect(initializer.initialize).not.toBeCalled();
             expect(userStore.loginError).toBe(true);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ entries.unshift('core-js/fn/array/includes');
 entries.unshift('core-js/fn/array/find-index');
 entries.unshift('core-js/fn/array/fill');
 entries.unshift('core-js/fn/array/from');
-entries.unshift('core-js/fn/promise');
+entries.unshift('core-js/library/fn/promise');
 entries.unshift('core-js/fn/symbol');
 entries.unshift('whatwg-fetch');
 entries.unshift('url-search-params-polyfill');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ entries.unshift('core-js/fn/array/includes');
 entries.unshift('core-js/fn/array/find-index');
 entries.unshift('core-js/fn/array/fill');
 entries.unshift('core-js/fn/array/from');
-entries.unshift('core-js/library/fn/promise');
+entries.unshift('core-js/fn/promise');
 entries.unshift('core-js/fn/symbol');
 entries.unshift('whatwg-fetch');
 entries.unshift('url-search-params-polyfill');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the `finally` calls on promises.

#### Why?

Because Edge does not support it yet.