### PR TITLE
Removed password-hash from user-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * HOTFIX      #4057 [SecurityBundle]        Removed password-hash from user-api
+
 * 1.5.16 (2018-06-29)
     * ENHANCEMENT #4028 [MediaBundle]           Log errors in image generation
     * ENHANCEMENT #3850 [SecurityBundle]        Allow user to be null for security config

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -76,19 +76,9 @@ class UserController extends RestController implements ClassResourceInterface, S
             'email',
             $this->container->getParameter('sulu.model.user.class')
         );
-        $this->fieldDescriptors['password'] = new DoctrineFieldDescriptor(
-            'password',
-            'password',
-            $this->container->getParameter('sulu.model.user.class')
-        );
         $this->fieldDescriptors['locale'] = new DoctrineFieldDescriptor(
             'locale',
             'locale',
-            $this->container->getParameter('sulu.model.user.class')
-        );
-        $this->fieldDescriptors['salt'] = new DoctrineFieldDescriptor(
-            'salt',
-            'salt',
             $this->container->getParameter('sulu.model.user.class')
         );
         $this->fieldDescriptors['apiKey'] = new DoctrineFieldDescriptor(
@@ -269,7 +259,7 @@ class UserController extends RestController implements ClassResourceInterface, S
         if (null == $request->get('username')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.user.class'), 'username');
         }
-        if (null === $request->get('password')) {
+        if ($request->isMethod('POST') && null === $request->get('password')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.user.class'), 'password');
         }
         if (null == $request->get('locale')) {

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
@@ -41,7 +41,6 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
 
     /**
      * @var string
-     * @Expose
      */
     protected $password;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the password hash from the user api.