### PR TITLE
fix reset of page in datagrid when search or sort is set initially

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -42,36 +42,21 @@ export default class DatagridStore {
         this.options = options;
         this.sendRequestDisposer = autorun(this.sendRequest);
 
+        const callResetForChangedObservable = (change: IValueWillChange<*>) => {
+            if (this.initialized && change.object.get() !== change.newValue) {
+                this.reset();
+            }
+            return change;
+        };
+
         const {locale} = this.observableOptions;
         if (locale) {
-            this.localeDisposer = intercept(locale, '', (change: IValueWillChange<number>) => {
-                if (locale.get() !== change.newValue) {
-                    this.reset();
-                }
-                return change;
-            });
+            this.localeDisposer = intercept(locale, '', callResetForChangedObservable);
         }
 
-        this.searchDisposer = intercept(this.searchTerm, '', (change: IValueWillChange<string>) => {
-            if (this.searchTerm.get() !== change.newValue) {
-                this.reset();
-            }
-            return change;
-        });
-
-        this.sortColumnDisposer = intercept(this.sortColumn, '', (change: IValueWillChange<string>) => {
-            if (this.sortColumn.get() !== change.newValue) {
-                this.reset();
-            }
-            return change;
-        });
-
-        this.sortOrderDisposer = intercept(this.sortOrder, '', (change: IValueWillChange<SortOrder>) => {
-            if (this.sortOrder.get() !== change.newValue) {
-                this.reset();
-            }
-            return change;
-        });
+        this.searchDisposer = intercept(this.searchTerm, '', callResetForChangedObservable);
+        this.sortColumnDisposer = intercept(this.sortColumn, '', callResetForChangedObservable);
+        this.sortOrderDisposer = intercept(this.sortOrder, '', callResetForChangedObservable);
 
         metadataStore.getSchema(this.resourceKey)
             .then(action((schema) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -546,6 +546,20 @@ test('Should reset page count to 0 and page to 1 when locale is changed', () => 
     datagridStore.destroy();
 });
 
+test('Should not reset page count to 0 and page to 1 when locale is changed before completely initialized', () => {
+    const page = observable.box(3);
+    const locale = observable.box('en');
+    const datagridStore = new DatagridStore('snippets', {page, locale});
+
+    datagridStore.setPage(2);
+    datagridStore.pageCount = 7;
+    locale.set('de');
+
+    expect(page.get()).toEqual(2);
+    expect(datagridStore.pageCount).toEqual(7);
+    datagridStore.destroy();
+});
+
 test('Should not reset page count to 0 and page to 1 when locale stays the same', () => {
     const page = observable.box(3);
     const locale = observable.box('en');
@@ -580,6 +594,20 @@ test('Should reset page count to 0 and page to 1 when search is changed', () => 
     expect(structureStrategy.clear).toBeCalled();
     expect(page.get()).toEqual(1);
     expect(datagridStore.pageCount).toEqual(0);
+    datagridStore.destroy();
+});
+
+test('Should not reset page count to 0 and page to 1 when search is changed before completely initialized', () => {
+    const page = observable.box(3);
+    const locale = observable.box('en');
+    const datagridStore = new DatagridStore('snippets', {page, locale});
+
+    datagridStore.setPage(2);
+    datagridStore.pageCount = 7;
+    datagridStore.searchTerm.set('test');
+
+    expect(page.get()).toEqual(2);
+    expect(datagridStore.pageCount).toEqual(7);
     datagridStore.destroy();
 });
 
@@ -622,6 +650,20 @@ test('Should reset page count to 0 and page to 1 when sort column is changed', (
     datagridStore.destroy();
 });
 
+test('Should not reset page count to 0 and page to 1 when sort column is changed', () => {
+    const page = observable.box(3);
+    const locale = observable.box('en');
+    const datagridStore = new DatagridStore('snippets', {page, locale});
+
+    datagridStore.setPage(2);
+    datagridStore.pageCount = 7;
+    datagridStore.sortColumn.set('test');
+
+    expect(page.get()).toEqual(2);
+    expect(datagridStore.pageCount).toEqual(7);
+    datagridStore.destroy();
+});
+
 test('Should not reset page count to 0 and page to 1 when sort column stays the same', () => {
     const page = observable.box(3);
     const locale = observable.box('en');
@@ -658,6 +700,20 @@ test('Should reset page count to 0 and page to 1 when sort order is changed', ()
     expect(structureStrategy.clear).toBeCalled();
     expect(page.get()).toEqual(1);
     expect(datagridStore.pageCount).toEqual(0);
+    datagridStore.destroy();
+});
+
+test('Should not reset page count to 0 and page to 1 when sort order is changed before completely initialized', () => {
+    const page = observable.box(3);
+    const locale = observable.box('en');
+    const datagridStore = new DatagridStore('snippets', {page, locale});
+
+    datagridStore.setPage(2);
+    datagridStore.pageCount = 7;
+    datagridStore.sortOrder.set('asc');
+
+    expect(page.get()).toEqual(2);
+    expect(datagridStore.pageCount).toEqual(7);
     datagridStore.destroy();
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR only resets the page of the datagrid when an observable changed if the datagrid was not completely initialized yet.

#### Why?

When you follow these instructions the page was reset to 1, although this shouldn't be the case:

1. Open a datagrid (e.g. for snippets)
2. Search for something you end up with multiple pages of results
3. Go to the second page
4. Edit one of the entries
5. Click the back link in the form
6. The search term is still in the datagrid, but you are on the first page now