### PR TITLE
avoid returning the same id multiple times in filter query of smart content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG for Sulu
     * HOTFIX      #4063 [ContentComponent]      Fixed copy language function, which didn't copy the extension data
     * HOTFIX      #4056 [MediaBundle]           Added security-check for collection permission to media-controller
     * HOTFIX      #5060 [MediaBundle]           Added escaping of media edit overlay title
+    * HOTFIX      #4067 [SmartContent]          Avoid returning the same id multiple times in filter query of smart content
     * HOTFIX      #4058 [ContactBundle]         Added escaping of name in contact-list
     * HOTFIX      #4058 [ContactBundle]         Added escaping for address and bank-accounts
     * HOTFIX      #4058 [MediaBundle]           Added escaping of name in media-list

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -60,8 +60,8 @@ trait DataProviderRepositoryTrait
 
         $queryBuilder = $this->createQueryBuilder('c')
             ->select('c.id')
-            ->orderBy('c.id', 'ASC')
-            ->groupBy('c.id');
+            ->distinct()
+            ->orderBy('c.id', 'ASC');
 
         $tagRelation = $this->appendTagsRelation($queryBuilder, 'c');
         $categoryRelation = $this->appendCategoriesRelation($queryBuilder, 'c');

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -69,6 +69,10 @@ trait DataProviderRepositoryTrait
         if (array_key_exists('sortBy', $filters) && is_array($filters['sortBy'])) {
             $sortMethod = array_key_exists('sortMethod', $filters) ? $filters['sortMethod'] : 'asc';
             $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, 'c', $locale);
+
+            foreach ($filters['sortBy'] as $sortColumn) {
+                $queryBuilder->addSelect($sortColumn);
+            }
         }
 
         $parameter = array_merge($parameter, $this->append($queryBuilder, 'c', $locale, $options));

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -60,6 +60,7 @@ trait DataProviderRepositoryTrait
 
         $queryBuilder = $this->createQueryBuilder('c')
             ->select('c.id')
+            ->distinct()
             ->orderBy('c.id', 'ASC');
 
         $tagRelation = $this->appendTagsRelation($queryBuilder, 'c');
@@ -194,10 +195,8 @@ trait DataProviderRepositoryTrait
         switch ($operator) {
             case 'or':
                 return $this->appendRelationOr($queryBuilder, $relation, $values, $alias);
-                break;
             case 'and':
                 return $this->appendRelationAnd($queryBuilder, $relation, $values, $alias);
-                break;
         }
 
         return [];

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -60,8 +60,8 @@ trait DataProviderRepositoryTrait
 
         $queryBuilder = $this->createQueryBuilder('c')
             ->select('c.id')
-            ->distinct()
-            ->orderBy('c.id', 'ASC');
+            ->orderBy('c.id', 'ASC')
+            ->groupBy('c.id');
 
         $tagRelation = $this->appendTagsRelation($queryBuilder, 'c');
         $categoryRelation = $this->appendCategoriesRelation($queryBuilder, 'c');

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\SmartContent\Tests\Orm;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\QueryBuilder;
+use Prophecy\Argument;
+use Sulu\Component\SmartContent\Orm\DataProviderRepositoryTrait;
+
+class Query extends AbstractQuery
+{
+    public function setFirstResult()
+    {
+    }
+
+    public function setMaxResults()
+    {
+    }
+
+    public function getSQL()
+    {
+    }
+
+    public function _doExecute()
+    {
+    }
+}
+
+class DataProviderRepositoryTraitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DataProviderRepositoryTrait
+     */
+    private $dataProviderRepositoryTrait;
+
+    public function setUp()
+    {
+        $this->dataProviderRepositoryTrait = $this->getMockForTrait(DataProviderRepositoryTrait::class);
+    }
+
+    public function testFindByFiltersIds()
+    {
+        $findByFiltersIdsReflection = new \ReflectionMethod(
+            get_class($this->dataProviderRepositoryTrait),
+            'findByFiltersIds'
+        );
+        $findByFiltersIdsReflection->setAccessible(true);
+
+        $query = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $query->method('setMaxResults')->willReturn($query);
+        $query->method('getScalarResult')->willReturn([]);
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->distinct(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->orderBy(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->getQuery()->willReturn($query);
+
+        $this->dataProviderRepositoryTrait->method('createQueryBuilder')->willReturn($queryBuilder->reveal());
+
+        $findByFiltersIdsReflection->invoke($this->dataProviderRepositoryTrait, [], 1, 5, null, 'de');
+
+        // using distinct here is essential, since due to our joins multiple rows might be returned
+        // this makes problems if also a limit is used
+        $queryBuilder->distinct()->shouldBeCalled();
+    }
+}

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -62,7 +62,7 @@ class DataProviderRepositoryTraitTest extends \PHPUnit_Framework_TestCase
         $query->method('getScalarResult')->willReturn([]);
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
-        $queryBuilder->groupBy(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->distinct(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->orderBy(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);
 
@@ -70,8 +70,8 @@ class DataProviderRepositoryTraitTest extends \PHPUnit_Framework_TestCase
 
         $findByFiltersIdsReflection->invoke($this->dataProviderRepositoryTrait, [], 1, 5, null, 'de');
 
-        // using groupBy here is essential, since due to our joins multiple rows might be returned
+        // using distinct here is essential, since due to our joins multiple rows might be returned
         // this makes problems if also a limit is used
-        $queryBuilder->groupBy('c.id')->shouldBeCalled();
+        $queryBuilder->distinct()->shouldBeCalled();
     }
 }

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -62,7 +62,7 @@ class DataProviderRepositoryTraitTest extends \PHPUnit_Framework_TestCase
         $query->method('getScalarResult')->willReturn([]);
         $queryBuilder = $this->prophesize(QueryBuilder::class);
         $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
-        $queryBuilder->distinct(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->groupBy(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->orderBy(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->getQuery()->willReturn($query);
 
@@ -70,8 +70,8 @@ class DataProviderRepositoryTraitTest extends \PHPUnit_Framework_TestCase
 
         $findByFiltersIdsReflection->invoke($this->dataProviderRepositoryTrait, [], 1, 5, null, 'de');
 
-        // using distinct here is essential, since due to our joins multiple rows might be returned
+        // using groupBy here is essential, since due to our joins multiple rows might be returned
         // this makes problems if also a limit is used
-        $queryBuilder->distinct()->shouldBeCalled();
+        $queryBuilder->groupBy('c.id')->shouldBeCalled();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR avoids returning the same ID multiple times in the ID query of the smart content.

#### Why?

If a media has assigned Category A and B and a SmartContent using the `media` data provider has an or filter on Category A and B, then the ID query from the `DataProviderRepositoryTrait` returns the same media ID twice. That only matters if there is also a limit (either in the smart content overlay or using the `max_per_page` param in the template XML), because then less items will be returned in the final query.