### PR TITLE
WIP: Remove sulu.rlp tag from test templates

### DIFF
--- a/app/Resources/templates/pages/default.xml
+++ b/app/Resources/templates/pages/default.xml
@@ -32,8 +32,6 @@
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="article" type="text_editor">

--- a/src/Sulu/Bundle/AdminBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/AdminBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/app/Resources/pages/default.xml
@@ -28,8 +28,6 @@
             <meta>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
     </properties>
 </template>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/app/Resources/pages/overview.xml
@@ -13,9 +13,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/CategoryBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/ContactBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/ContactBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/ContentBundle/Behat/ContentContext.php
+++ b/src/Sulu/Bundle/ContentBundle/Behat/ContentContext.php
@@ -61,8 +61,6 @@ class ContentContext extends BaseStructureContext implements SnippetAcceptingCon
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
 %s

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/article.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/article.xml
@@ -12,8 +12,6 @@
     <properties>
         <property name="title" type="text_line"/>
         <property name="article" type="text_area"/>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/block.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/block.xml
@@ -11,9 +11,7 @@
 
     <properties>
         <property name="title" type="text_line"/>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
 
         <block name="article" default-type="test">
             <types>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/blocks.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/blocks.xml
@@ -32,8 +32,6 @@
             </meta>
 
             <indexField />
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <block name="block"

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/complex.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/complex.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <block name="block1" 

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/contact.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/contact.xml
@@ -10,9 +10,7 @@
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
         <property name="title" type="text_line">
             <tag name="sulu.rlp.part" />
         </property>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/default.xml
@@ -18,9 +18,7 @@
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
         <property name="tags" type="tag_list"/>
-        <property name="url" type="resource_locator" mandatory="false">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="false"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/html5.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/html5.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
         <property name="tags" type="tag_list"/>
-        <property name="url" type="resource_locator" mandatory="false">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="false"/>
         <property name="article" type="text_area" mandatory="false"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/internal_link_page.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/internal_link_page.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="the_internal_link" type="single_internal_link"/>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/internallinks.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/internallinks.xml
@@ -11,9 +11,7 @@
 
     <properties>
         <property name="title" type="text_line"/>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
         <property name="internalLinks" type="internal_links"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/invalidhtml.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/invalidhtml.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
         <property name="tags" type="tag_list"/>
-        <property name="url" type="resource_locator" mandatory="false">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="false"/>
         <property name="article" type="text_area" mandatory="false"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/mandatory.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/mandatory.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="mandatory" type="text_line" mandatory="true">

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/overview.xml
@@ -16,9 +16,7 @@
         <property name="subtitle" type="text_line">
             <tag name="sulu.rlp.part"/>
         </property>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
         <property name="article" type="text_line" minOccurs="1" maxOccurs="10"/>
         <property name="external_url" type="url" />

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/section.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/section.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <section name="section">

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/simple.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/simple.xml
@@ -11,8 +11,6 @@
 
     <properties>
         <property name="title" type="text_line"/>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/singleinternallink.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/singleinternallink.xml
@@ -11,9 +11,7 @@
 
     <properties>
         <property name="title" type="text_line"/>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
         <property name="singleInternalLink" type="single_internal_link"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/smartcontent.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/smartcontent.xml
@@ -13,9 +13,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="false">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="false"/>
         <property name="smart_content" type="smart_content">
             <meta>
                 <title lang="en">Smart Content</title>

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/test_page.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/test_page.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/with_snippet.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/app/Resources/pages/with_snippet.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="internal_link" type="snippet"/>

--- a/src/Sulu/Bundle/CoreBundle/Content/templates/external-link.xml
+++ b/src/Sulu/Bundle/CoreBundle/Content/templates/external-link.xml
@@ -23,8 +23,6 @@
             <meta>
                 <title lang="de">Link</title>
                 <title lang="en">Link</title>
-            </meta>
-            <tag name="sulu.rlp"/>
-        </property>
+            </meta/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/CoreBundle/Content/templates/internal-link.xml
+++ b/src/Sulu/Bundle/CoreBundle/Content/templates/internal-link.xml
@@ -23,8 +23,6 @@
             <meta>
                 <title lang="de">Interner Knoten</title>
                 <title lang="en">Internal Node</title>
-            </meta>
-            <tag name="sulu.rlp"/>
-        </property>
+            </meta/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
             </meta>
 
             <indexField />
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="default" type="text_area">

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/app/Resources/pages/overview.xml
@@ -17,8 +17,6 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/LocationBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/LocationBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/LocationBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/LocationBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
             </meta>
 
             <indexField />
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="default" type="text_area">

--- a/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/pages/images.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/pages/images.xml
@@ -31,8 +31,6 @@
             </meta>
 
             <indexField />
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="images" type="media_selection">

--- a/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/app/Resources/pages/overview.xml
@@ -31,8 +31,6 @@
             </meta>
 
             <indexField />
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="default" type="text_area">

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/PreviewBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/app/Resources/pages/default.xml
@@ -11,8 +11,6 @@
 
     <properties>
         <property name="title" type="text_line"/>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/ResourceBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/ResourceBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/RouteBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/RouteBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/SearchBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/SearchBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/pages/default.xml
@@ -32,8 +32,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
     </properties>
 </template>

--- a/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/pages/hotel_page.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/pages/hotel_page.xml
@@ -32,8 +32,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="hotels" type="snippet" mandatory="true">

--- a/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/app/Resources/pages/overview.xml
@@ -13,8 +13,6 @@
         <property name="title" type="text_line">
             <tag name="sulu.rlp.part"/>
         </property>
-        <property name="url" type="resource_locator">
-            <tag name="sulu.rlp"/>
-        </property>
+        <property name="url" type="resource_locator"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/TagBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/TagBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
     </properties>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="false">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="false"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external_url" type="url" mandatory="false" />

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/pages/simple.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/app/Resources/pages/simple.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/WebsocketBundle/Tests/app/Resources/pages/default.xml
+++ b/src/Sulu/Bundle/WebsocketBundle/Tests/app/Resources/pages/default.xml
@@ -31,8 +31,6 @@
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
             </meta>
-
-            <tag name="sulu.rlp"/>
         </property>
 
         <property name="animals" type="snippet">

--- a/src/Sulu/Bundle/WebsocketBundle/Tests/app/Resources/pages/overview.xml
+++ b/src/Sulu/Bundle/WebsocketBundle/Tests/app/Resources/pages/overview.xml
@@ -14,9 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false"/>
         <property name="blog" type="text_area" mandatory="false"/>
         <property name="external" type="url" mandatory="false" />

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -35,8 +35,8 @@ class StructureXmlLoader extends AbstractLoader
      * @var array
      */
     private $requiredTagNames = [
-        'page' => ['sulu.rlp'],
-        'home' => ['sulu.rlp'],
+        'page' => ['sulu.rlp.part'],
+        'home' => ['sulu.rlp.part'],
         'snippet' => [],
     ];
 

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -35,8 +35,8 @@ class StructureXmlLoader extends AbstractLoader
      * @var array
      */
     private $requiredTagNames = [
-        'page' => ['sulu.rlp.part'],
-        'home' => ['sulu.rlp.part'],
+        'page' => [],
+        'home' => [],
         'snippet' => [],
     ];
 

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/data/apostrophe/apostrophe.xml
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/data/apostrophe/apostrophe.xml
@@ -33,8 +33,6 @@
                         <title lang="en">Resource Locator</title>
                         <title lang="de">Adresse</title>
                     </meta>
-
-                    <tag name="sulu.rlp"/>
                 </property>
             </properties>
         </section>

--- a/tests/Resources/DataFixtures/Page/template.xml
+++ b/tests/Resources/DataFixtures/Page/template.xml
@@ -51,9 +51,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
 
         <property name="article" type="text_area" mandatory="false">
             <tag name="sulu.node.title" priority="5"/>

--- a/tests/Resources/DataFixtures/Page/template_block.xml
+++ b/tests/Resources/DataFixtures/Page/template_block.xml
@@ -14,9 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_editor" mandatory="true"/>
         <block name="block1" default-type="default" minOccurs="2" maxOccurs="10" mandatory="true">
             <tag name="sulu.node.block" priority="20"/>

--- a/tests/Resources/DataFixtures/Page/template_block_type_without_meta.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_type_without_meta.xml
@@ -14,9 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <block name="block1" default-type="default" minOccurs="2" maxOccurs="10" mandatory="true">
             <meta>
                 <title lang="de">Block1 DE</title>

--- a/tests/Resources/DataFixtures/Page/template_block_types.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_types.xml
@@ -14,9 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <block name="block1" default-type="default" minOccurs="2" maxOccurs="10" mandatory="true">
             <meta>
                 <title lang="de">Block1 DE</title>

--- a/tests/Resources/DataFixtures/Page/template_boolean_params.xml
+++ b/tests/Resources/DataFixtures/Page/template_boolean_params.xml
@@ -31,8 +31,6 @@
             </params>
         </property>
 
-        <property name="url" type="text_line">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="text_line"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_duplicated_priority.xml
+++ b/tests/Resources/DataFixtures/Page/template_duplicated_priority.xml
@@ -13,9 +13,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1" />
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
         <property name="article" type="text_area" mandatory="false">
             <tag name="sulu.node.title" priority="10" />
         </property>
@@ -30,8 +28,6 @@
             </params>
         </property>
 
-        <property name="url" type="text_line">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="text_line"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_expression.xml
+++ b/tests/Resources/DataFixtures/Page/template_expression.xml
@@ -28,8 +28,6 @@
 
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_invalid_expression.xml
+++ b/tests/Resources/DataFixtures/Page/template_invalid_expression.xml
@@ -28,8 +28,6 @@
 
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_lifetime_0.xml
+++ b/tests/Resources/DataFixtures/Page/template_lifetime_0.xml
@@ -37,9 +37,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
 
         <property name="article" type="text_area" mandatory="false">
             <tag name="sulu.node.title" priority="5"/>

--- a/tests/Resources/DataFixtures/Page/template_load_internal.xml
+++ b/tests/Resources/DataFixtures/Page/template_load_internal.xml
@@ -39,9 +39,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
 
         <property name="article" type="text_area" mandatory="false">
             <tag name="sulu.node.title" priority="5"/>

--- a/tests/Resources/DataFixtures/Page/template_meta_params.xml
+++ b/tests/Resources/DataFixtures/Page/template_meta_params.xml
@@ -22,8 +22,6 @@
             </params>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_missing_mandatory.xml
+++ b/tests/Resources/DataFixtures/Page/template_missing_mandatory.xml
@@ -10,9 +10,7 @@
 
     <properties>
         <property name="title" type="textLine" mandatory="true"/>
-        <property name="url" type="resourceLocator" mandatory="true">
-            <tag name="sulu.rlp" />
-        </property>
+        <property name="url" type="resourceLocator" mandatory="true"/>
         <property name="article" type="textArea" mandatory="false"/>
         <property name="pages" type="smartContentSelection" mandatory="false"/>
 

--- a/tests/Resources/DataFixtures/Page/template_missing_title.xml
+++ b/tests/Resources/DataFixtures/Page/template_missing_title.xml
@@ -13,8 +13,6 @@
     <properties>
         <property name="article" type="text_editor"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_nesting_params.xml
+++ b/tests/Resources/DataFixtures/Page/template_nesting_params.xml
@@ -23,8 +23,6 @@
             </params>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_reserved.xml
+++ b/tests/Resources/DataFixtures/Page/template_reserved.xml
@@ -13,8 +13,6 @@
         <property name="title" type="text_line" mandatory="true"/>
         <property name="changed" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_sections.xml
+++ b/tests/Resources/DataFixtures/Page/template_sections.xml
@@ -34,9 +34,7 @@
             </meta>
             <properties>
                 <property name="url" type="resource_locator" mandatory="true" cssClass="test"
-                          colspan="6">
-                    <tag name="sulu.rlp" priority="1"/>
-                </property>
+                          colspan="6"/>
                 <property name="article" type="text_area" mandatory="false" colspan="6">
                     <tag name="sulu.node.title" priority="5"/>
                 </property>

--- a/tests/Resources/DataFixtures/Page/template_title_in_section.xml
+++ b/tests/Resources/DataFixtures/Page/template_title_in_section.xml
@@ -17,8 +17,6 @@
             </properties>
         </section>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
     </properties>
 </template>

--- a/tests/Resources/DataFixtures/Page/template_with_invalid_ignore.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_invalid_ignore.xml
@@ -17,9 +17,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
 
         <property name="test" type="test" onInvalid="ignore"/>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_with_xinclude_properties.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_xinclude_properties.xml
@@ -4,7 +4,5 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
         <property name="title" type="text_line" mandatory="true"/>
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
 </properties>

--- a/tests/Resources/DataFixtures/Page/template_without_invalid_ignore.xml
+++ b/tests/Resources/DataFixtures/Page/template_without_invalid_ignore.xml
@@ -17,9 +17,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
-            <tag name="sulu.rlp" priority="1"/>
-        </property>
+        <property name="url" type="resource_locator" mandatory="true"/>
 
         <property name="test" type="test"/>
     </properties>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove sulu.rlp tag from test templates.

#### Why?

Sulu.rlp tag is deprecated and should not longer be needed.

##### TODO

 - [ ] UPGRADE
 - [ ] Fix services which require them

![bildschirmfoto 2018-07-18 um 16 36 13](https://user-images.githubusercontent.com/1698337/42888530-c24e48b6-8aa8-11e8-8371-e5b7fa5028b9.png)

