### PR TITLE
Add setNavigation to the upgrade

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,8 +4,9 @@
 
 ### Admin Navigation
 
-The admin navigation should not be built into the constructor anymore. Instead the `getNavigation` function from the
-`Admin` class should return a `Navigation` object. This makes it easier to override only this part of the Admin.
+The admin navigation should not be built into the constructor anymore. Instead of `setNavigation` 
+create `getNavigation` function in the `Admin` class which should return a `Navigation` object.
+This makes it easier to override only this part of the Admin.
 
 ### sulu.rlp tag deprecated
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add setNavigation to the upgrade.

#### Why?

Currently you get the following error message:

Attempted to call an undefined method named "setNavigation" of class "App/Admin/AppAdmin".

As I mostly would then search for `setNavigation` in the UPGRADE.md I add `setNavigation` to the UPGRADE.md sentence.

