### PR TITLE
Change: always show content type in collapsed block

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
+++ b/src/Sulu/Bundle/ContentBundle/Resources/views/Template/content-types/block.html.twig
@@ -33,9 +33,7 @@
                         <input type="hidden" data-mapper-property="type" value="{{ type.name }}"/>
 
                         <div class="collapsed-container empty">
-                            {% if property.types|length > 1 %}
-                                <div class="type">{{ type.getTitle(userLocale) }}</div>
-                            {% endif %}
+                            <div class="type">{{ type.getTitle(userLocale) }}</div>
                             <div class="title"></div>
                             <div class="image"></div>
                             <div class="text hidden"></div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Change: always show content type in collapsed block

#### Why?

Previously, the content type of a collapsed block would only be shown if
there was more than 1 type defined for the given block. However, for
editors that makes it impossible to see what kind of content is in that
spot. This change will make it so the content type is always shown.
