### PR TITLE
Move titles resp. webspace select and datagrid toolbar into the same line

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -2,6 +2,7 @@
 import {observer} from 'mobx-react';
 import {observable, action, computed} from 'mobx';
 import React, {Fragment} from 'react';
+import type {Node} from 'react';
 import equal from 'fast-deep-equal';
 import type {SortOrder} from './types';
 import DatagridStore from './stores/DatagridStore';
@@ -14,6 +15,7 @@ import datagridStyles from './datagrid.scss';
 type Props = {|
     adapters: Array<string>,
     disabledIds: Array<string | number>,
+    header?: Node,
     onItemClick?: (itemId: string | number) => void,
     onAddClick?: (id: string | number) => void,
     selectable: boolean,
@@ -124,6 +126,7 @@ export default class Datagrid extends React.Component<Props> {
         const {
             adapters,
             disabledIds,
+            header,
             onItemClick,
             onAddClick,
             searchable,
@@ -134,15 +137,18 @@ export default class Datagrid extends React.Component<Props> {
 
         return (
             <Fragment>
-                <div className={datagridStyles.toolbar}>
-                    {searchable &&
-                        <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
-                    }
-                    <AdapterSwitch
-                        adapters={adapters}
-                        currentAdapter={this.currentAdapterKey}
-                        onAdapterChange={this.handleAdapterChange}
-                    />
+                <div className={datagridStyles.headerContainer}>
+                    {header}
+                    <div className={datagridStyles.toolbar}>
+                        {searchable &&
+                            <Search onSearch={this.handleSearch} value={store.searchTerm.get()} />
+                        }
+                        <AdapterSwitch
+                            adapters={adapters}
+                            currentAdapter={this.currentAdapterKey}
+                            onAdapterChange={this.handleAdapterChange}
+                        />
+                    </div>
                 </div>
                 <div className={datagridStyles.datagrid}>
                     <Adapter

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
@@ -4,10 +4,19 @@
     height: 100%;
 }
 
+.header-container {
+    display: flex;
+    margin-bottom: 40px;
+
+    .toolbar {
+        flex-grow: 1;
+    }
+}
+
 .toolbar {
-    margin-bottom: 30px;
     display: flex;
     justify-content: flex-end;
+    align-items: center;
 
     & > * {
         height: 30px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
@@ -7,6 +7,7 @@
 .header-container {
     display: flex;
     margin-bottom: 40px;
+    align-items: center;
 
     .toolbar {
         flex-grow: 1;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -167,7 +167,7 @@ test('Render the adapter in non-selectable mode', () => {
 test('Render the adapter in non-searchable mode', () => {
     const datagridStore = new DatagridStore('test', {page: observable.box(1)});
     expect(
-        render(<Datagrid adapters={['test']} searchable={false} store={datagridStore} />)
+        render(<Datagrid adapters={['test']} header={<h1>Title</h1>} searchable={false} store={datagridStore} />)
     ).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -3,8 +3,15 @@
 exports[`Render the adapter in non-searchable mode 1`] = `
 Array [
   <div
-    class="toolbar"
-  />,
+    class="headerContainer"
+  >
+    <h1>
+      Title
+    </h1>
+    <div
+      class="toolbar"
+    />
+  </div>,
   <div
     class="datagrid"
   >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -138,9 +138,9 @@ class Datagrid extends React.Component<ViewProps> {
 
         return (
             <div className={datagridStyles.datagrid}>
-                {title && <h1>{translate(title)}</h1>}
                 <DatagridContainer
                     adapters={adapters}
+                    header={title && <h1 className={datagridStyles.header}>{translate(title)}</h1>}
                     onAddClick={addRoute && this.handleAddClick}
                     onItemClick={editRoute && this.handleEditClick}
                     searchable={searchable}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/datagrid.scss
@@ -2,10 +2,8 @@
 
 .datagrid {
     margin: $viewPadding;
-    display: flex;
-    flex-direction: column;
+}
 
-    > :not(h1) {
-        flex-grow: 1;
-    }
+.header {
+    margin: 0;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -4,30 +4,36 @@ exports[`Should render the datagrid with a title 1`] = `
 <div
   class="datagrid"
 >
-  <h1>
-    Snippets
-  </h1>
   <div
-    class="toolbar"
+    class="headerContainer"
   >
-    <label
-      class="input dark collapsed hasAppendIcon"
+    <h1
+      class="header"
     >
-      <div
-        class="prependedContainer dark collapsed"
+      Snippets
+    </h1>
+    <div
+      class="toolbar"
+    >
+      <label
+        class="input dark collapsed hasAppendIcon"
       >
-        <span
-          aria-label="su-search"
-          class="icon dark iconClickable collapsed su-search clickable"
-          role="button"
-          tabindex="0"
+        <div
+          class="prependedContainer dark collapsed"
+        >
+          <span
+            aria-label="su-search"
+            class="icon dark iconClickable collapsed su-search clickable"
+            role="button"
+            tabindex="0"
+          />
+        </div>
+        <input
+          type="text"
+          value=""
         />
-      </div>
-      <input
-        type="text"
-        value=""
-      />
-    </label>
+      </label>
+    </div>
   </div>
   <div
     class="datagrid"
@@ -180,26 +186,30 @@ exports[`Should render the datagrid with the correct resourceKey 1`] = `
   class="datagrid"
 >
   <div
-    class="toolbar"
+    class="headerContainer"
   >
-    <label
-      class="input dark collapsed hasAppendIcon"
+    <div
+      class="toolbar"
     >
-      <div
-        class="prependedContainer dark collapsed"
+      <label
+        class="input dark collapsed hasAppendIcon"
       >
-        <span
-          aria-label="su-search"
-          class="icon dark iconClickable collapsed su-search clickable"
-          role="button"
-          tabindex="0"
+        <div
+          class="prependedContainer dark collapsed"
+        >
+          <span
+            aria-label="su-search"
+            class="icon dark iconClickable collapsed su-search clickable"
+            role="button"
+            tabindex="0"
+          />
+        </div>
+        <input
+          type="text"
+          value=""
         />
-      </div>
-      <input
-        type="text"
-        value=""
-      />
-    </label>
+      </label>
+    </div>
   </div>
   <div
     class="datagrid"

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -2,7 +2,7 @@
 import {action, autorun, observable, computed} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
-import React, {Fragment} from 'react';
+import React from 'react';
 import {Datagrid, DatagridStore, withToolbar} from 'sulu-admin-bundle/containers';
 import {Loader} from 'sulu-admin-bundle/components';
 import {userStore} from 'sulu-admin-bundle/stores';
@@ -136,8 +136,11 @@ class WebspaceOverview extends React.Component<ViewProps> {
         return (
             <div className={webspaceOverviewStyles.webspaceOverview}>
                 {this.webspaces
-                    ? <Fragment>
-                        <div className={webspaceOverviewStyles.webspaceSelect}>
+                    ? <Datagrid
+                        adapters={['column_list', 'tree_table']}
+                        onAddClick={this.handleAddClick}
+                        onItemClick={this.handleEditClick}
+                        header={this.webspace &&
                             <WebspaceSelect value={this.webspace.get()} onChange={this.handleWebspaceChange}>
                                 {this.webspaces.map((webspace) => (
                                     <WebspaceSelect.Item key={webspace.key} value={webspace.key}>
@@ -145,16 +148,11 @@ class WebspaceOverview extends React.Component<ViewProps> {
                                     </WebspaceSelect.Item>
                                 ))}
                             </WebspaceSelect>
-                        </div>
-                        <Datagrid
-                            adapters={['column_list', 'tree_table']}
-                            onAddClick={this.handleAddClick}
-                            onItemClick={this.handleEditClick}
-                            selectable={false}
-                            searchable={false}
-                            store={this.datagridStore}
-                        />
-                    </Fragment>
+                        }
+                        selectable={false}
+                        searchable={false}
+                        store={this.datagridStore}
+                    />
                     : <div>
                         <Loader />
                     </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
@@ -28,35 +28,39 @@ exports[`Render WebspaceOverview 1`] = `
     </div>
   </div>
   <div
-    class="toolbar"
+    class="headerContainer"
   >
-    <div>
-      <button
-        class="button icon active button"
-        type="button"
-      >
-        <span
-          class="text"
+    <div
+      class="toolbar"
+    >
+      <div>
+        <button
+          class="button icon active button"
+          type="button"
         >
           <span
-            aria-label="su-columns"
-            class="su-columns"
-          />
-        </span>
-      </button>
-      <button
-        class="button icon button"
-        type="button"
-      >
-        <span
-          class="text"
+            class="text"
+          >
+            <span
+              aria-label="su-columns"
+              class="su-columns"
+            />
+          </span>
+        </button>
+        <button
+          class="button icon button"
+          type="button"
         >
           <span
-            aria-label="su-columns"
-            class="su-columns"
-          />
-        </span>
-      </button>
+            class="text"
+          >
+            <span
+              aria-label="su-columns"
+              class="su-columns"
+            />
+          </span>
+        </button>
+      </div>
     </div>
   </div>
   <div

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
@@ -5,7 +5,7 @@ exports[`Render WebspaceOverview 1`] = `
   class="webspaceOverview"
 >
   <div
-    class="webspaceSelect"
+    class="headerContainer"
   >
     <div
       class="webspaceSelect"
@@ -26,10 +26,6 @@ exports[`Render WebspaceOverview 1`] = `
         />
       </button>
     </div>
-  </div>
-  <div
-    class="headerContainer"
-  >
     <div
       class="toolbar"
     >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -44,8 +44,12 @@ exports[`Render the MediaCollection 1`] = `
       </div>
     </div>
     <div
-      class="toolbar"
-    />
+      class="headerContainer"
+    >
+      <div
+        class="toolbar"
+      />
+    </div>
     <div
       class="datagrid"
     >
@@ -152,26 +156,30 @@ exports[`Render the MediaCollection 1`] = `
   />
   <div>
     <div
-      class="toolbar"
+      class="headerContainer"
     >
-      <label
-        class="input dark collapsed hasAppendIcon"
+      <div
+        class="toolbar"
       >
-        <div
-          class="prependedContainer dark collapsed"
+        <label
+          class="input dark collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="icon dark iconClickable collapsed su-search clickable"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="icon dark iconClickable collapsed su-search clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            type="text"
+            value=""
           />
-        </div>
-        <input
-          type="text"
-          value=""
-        />
-      </label>
+        </label>
+      </div>
     </div>
     <div
       class="datagrid"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
@@ -22,7 +22,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                   <div><span class=\\"su-plus clickable\\" aria-label=\\"su-plus\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-pen clickable\\" aria-label=\\"su-pen\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-trash-alt clickable\\" aria-label=\\"su-trash-alt\\"
                       role=\\"button\\" tabindex=\\"0\\"></span></div>
                 </div>
-                <div class=\\"toolbar\\"></div>
+                <div class=\\"headerContainer\\">
+                  <div class=\\"toolbar\\"></div>
+                </div>
                 <div class=\\"datagrid\\">
                   <section>
                     <ul class=\\"folderList\\">
@@ -57,11 +59,13 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
               </div>
               <div class=\\"divider\\"></div>
               <div>
-                <div class=\\"toolbar\\">
-                  <label class=\\"input dark collapsed hasAppendIcon\\">
-                    <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
-                    <input type=\\"text\\" value=\\"\\">
-                  </label>
+                <div class=\\"headerContainer\\">
+                  <div class=\\"toolbar\\">
+                    <label class=\\"input dark collapsed hasAppendIcon\\">
+                      <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+                      <input type=\\"text\\" value=\\"\\">
+                    </label>
+                  </div>
                 </div>
                 <div class=\\"datagrid\\">
                   <section>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -22,7 +22,9 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                   <div><span class=\\"su-plus clickable\\" aria-label=\\"su-plus\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-pen clickable\\" aria-label=\\"su-pen\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-trash-alt clickable\\" aria-label=\\"su-trash-alt\\"
                       role=\\"button\\" tabindex=\\"0\\"></span></div>
                 </div>
-                <div class=\\"toolbar\\"></div>
+                <div class=\\"headerContainer\\">
+                  <div class=\\"toolbar\\"></div>
+                </div>
                 <div class=\\"datagrid\\">
                   <section>
                     <ul class=\\"folderList\\">
@@ -57,11 +59,13 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
               </div>
               <div class=\\"divider\\"></div>
               <div>
-                <div class=\\"toolbar\\">
-                  <label class=\\"input dark collapsed hasAppendIcon\\">
-                    <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
-                    <input type=\\"text\\" value=\\"\\">
-                  </label>
+                <div class=\\"headerContainer\\">
+                  <div class=\\"toolbar\\">
+                    <label class=\\"input dark collapsed hasAppendIcon\\">
+                      <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+                      <input type=\\"text\\" value=\\"\\">
+                    </label>
+                  </div>
                 </div>
                 <div class=\\"datagrid\\">
                   <section>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -56,8 +56,12 @@ exports[`Render a simple MediaOverview 1`] = `
         </div>
       </div>
       <div
-        class="toolbar"
-      />
+        class="headerContainer"
+      >
+        <div
+          class="toolbar"
+        />
+      </div>
       <div
         class="datagrid"
       >
@@ -164,53 +168,57 @@ exports[`Render a simple MediaOverview 1`] = `
     />
     <div>
       <div
-        class="toolbar"
+        class="headerContainer"
       >
-        <label
-          class="input dark collapsed hasAppendIcon"
+        <div
+          class="toolbar"
         >
-          <div
-            class="prependedContainer dark collapsed"
+          <label
+            class="input dark collapsed hasAppendIcon"
           >
-            <span
-              aria-label="su-search"
-              class="icon dark iconClickable collapsed su-search clickable"
-              role="button"
-              tabindex="0"
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="icon dark iconClickable collapsed su-search clickable"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
             />
+          </label>
+          <div>
+            <button
+              class="button icon active button"
+              type="button"
+            >
+              <span
+                class="text"
+              >
+                <span
+                  aria-label="su-th-large"
+                  class="su-th-large"
+                />
+              </span>
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                class="text"
+              >
+                <span
+                  aria-label="su-align-justify"
+                  class="su-align-justify"
+                />
+              </span>
+            </button>
           </div>
-          <input
-            type="text"
-            value=""
-          />
-        </label>
-        <div>
-          <button
-            class="button icon active button"
-            type="button"
-          >
-            <span
-              class="text"
-            >
-              <span
-                aria-label="su-th-large"
-                class="su-th-large"
-              />
-            </span>
-          </button>
-          <button
-            class="button icon button"
-            type="button"
-          >
-            <span
-              class="text"
-            >
-              <span
-                aria-label="su-align-justify"
-                class="su-align-justify"
-              />
-            </span>
-          </button>
         </div>
       </div>
       <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The datagrid has now a title attribute, which can contain any JSX. The toolbar for the Datagrid (containing the adapter switch) will appear middled right next to it.

#### Why?

This saves some visual space.