### PR TITLE
Open overlay to copy content when Ghost form is opened

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Column.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Column.js
@@ -4,11 +4,9 @@ import React from 'react';
 import classNames from 'classnames';
 import Loader from '../Loader';
 import Item from './Item';
-import type {ItemButtonConfig} from './types';
 import columnStyles from './column.scss';
 
 type Props = {|
-    buttons?: Array<ItemButtonConfig>,
     children?: ChildrenArray<Element<typeof Item>>,
     index?: number,
     loading: boolean,
@@ -29,13 +27,12 @@ export default class Column extends React.Component<Props> {
             return null;
         }
 
-        const {buttons, onItemClick} = this.props;
+        const {onItemClick} = this.props;
 
         return React.Children.map(originalItems, (column) => {
             return React.cloneElement(
                 column,
                 {
-                    buttons: buttons,
                     onClick: onItemClick,
                 }
             );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
@@ -7,15 +7,14 @@ import classNames from 'classnames';
 import Column from './Column';
 import Item from './Item';
 import Toolbar from './Toolbar';
-import type {ItemButtonConfig, ToolbarItemConfig} from './types';
+import type { ToolbarItemConfig} from './types';
 import columnListStyles from './columnList.scss';
 
-type Props = {
+type Props = {|
     children: ChildrenArray<Element<typeof Column>>,
-    buttons?: Array<ItemButtonConfig>,
     toolbarItems: Array<ToolbarItemConfig>,
     onItemClick: (id: string | number) => void,
-};
+|};
 
 @observer
 export default class ColumnList extends React.Component<Props> {
@@ -119,7 +118,6 @@ export default class ColumnList extends React.Component<Props> {
                 column,
                 {
                     index: index,
-                    buttons: this.props.buttons,
                     onActive: this.handleActive,
                     onItemClick: onItemClick,
                     scrolling,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/README.md
@@ -1,6 +1,7 @@
 The `ColumnList` component consists out of three parts: `ColumnList`, `Column` and `Item`. The `toolbarItems` prop
 can be used to configure the toolbar above every column. There is also a `indicators` prop on the `Item`, which
-contains an array of JSX, that will be displayed on the right side of the item.
+contains an array of JSX, that will be displayed on the right side of the item. `buttons` are also added on the `Item`,
+because they can differ from `Item` to `Item`.
 
 ```
 const Icon = require('../Icon').default;
@@ -76,17 +77,17 @@ const indicators = [
 <div style={{height: '60vh'}}>
     <ColumnList buttons={buttons} onItemClick={handleItemClick} toolbarItems={toolbarItems}>
         <ColumnList.Column>
-            <ColumnList.Item id="1">Google 1</ColumnList.Item>
-            <ColumnList.Item id="2" hasChildren="true" disabled={true}>Apple 1</ColumnList.Item>
-            <ColumnList.Item id="3">Microsoft 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="1">Google 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="2" hasChildren="true" disabled={true}>Apple 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="3">Microsoft 1</ColumnList.Item>
         </ColumnList.Column>
         <ColumnList.Column>
-            <ColumnList.Item id="1-1" indicators={indicators}>Item 1</ColumnList.Item>
-            <ColumnList.Item id="1-2" hasChildren="true" indicators={indicators}>Item 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="1-1" indicators={indicators}>Item 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="1-2" hasChildren="true" indicators={indicators}>Item 1</ColumnList.Item>
         </ColumnList.Column>
         <ColumnList.Column>
-            <ColumnList.Item id="1-1-1">Item 1</ColumnList.Item>
-            <ColumnList.Item id="1-1-2">Item 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="1-1-1">Item 1</ColumnList.Item>
+            <ColumnList.Item buttons={buttons} id="1-1-2">Item 1</ColumnList.Item>
         </ColumnList.Column>
         <ColumnList.Column />
     </ColumnList>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Column.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Column.test.js
@@ -4,16 +4,5 @@ import {render} from 'enzyme';
 import Column from '../Column';
 
 test('Should render column with toolbar', () => {
-    const buttonsConfig = [
-        {
-            icon: 'fa-heart',
-            onClick: () => {},
-        },
-        {
-            icon: 'fa-pencil',
-            onClick: () => {},
-        },
-    ];
-
-    expect(render(<Column index={0} buttons={buttonsConfig} />)).toMatchSnapshot();
+    expect(render(<Column index={0} />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
@@ -64,22 +64,21 @@ test('The ColumnList component should render in a non-scrolling container', () =
 
     expect(render(
         <ColumnList
-            buttons={buttonsConfig}
             onItemClick={onItemClick}
             toolbarItems={toolbarItems}
         >
             <Column>
-                <Item id="1" selected={true}>Item 1</Item>
-                <Item id="2" hasChildren={true}>Item 1</Item>
+                <Item buttons={buttonsConfig} id="1" selected={true}>Item 1</Item>
+                <Item buttons={buttonsConfig} id="2" hasChildren={true}>Item 1</Item>
                 <Item id="3">Item 1</Item>
             </Column>
             <Column>
-                <Item id="1-1">Item 1</Item>
-                <Item id="1-2" hasChildren={true}>Item 1</Item>
+                <Item buttons={buttonsConfig} id="1-1">Item 1</Item>
+                <Item buttons={buttonsConfig} id="1-2" hasChildren={true}>Item 1</Item>
             </Column>
             <Column>
-                <Item id="1-1-1">Item 1</Item>
-                <Item id="1-1-2">Item 1</Item>
+                <Item buttons={buttonsConfig} id="1-1-1">Item 1</Item>
+                <Item buttons={buttonsConfig} id="1-1-2">Item 1</Item>
             </Column>
             <Column loading={true} />
         </ColumnList>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
@@ -160,20 +160,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
         >
           <span
             class="buttons"
-          >
-            <span
-              aria-label="fa-heart"
-              class="button fa fa-heart clickable"
-              role="button"
-              tabindex="0"
-            />
-            <span
-              aria-label="fa-pencil"
-              class="button fa fa-pencil clickable"
-              role="button"
-              tabindex="0"
-            />
-          </span>
+          />
           <span
             class="text"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/toolbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/toolbar.scss
@@ -3,8 +3,6 @@
 
 $itemBackgroundColorPrimary: $silver;
 $itemBackgroundColorSecondary: $shakespeare;
-$itemBorderColor: $black;
-$itemBorderColorSecondary: $concrete;
 
 $borderRadius: 3px;
 $dropdownContainerBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
@@ -21,11 +19,11 @@ $dropdownContainerBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
     text-align: center;
     padding: 5px 0;
     cursor: pointer;
-    border-left: 1px solid $itemBorderColor;
+    margin-left: 1px;
 
     &:first-child {
         border-top-left-radius: $borderRadius;
-        border-left: none;
+        margin-left: 0;
     }
 
     &:last-child {
@@ -38,8 +36,6 @@ $dropdownContainerBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
 
     &.secondary {
         background: $itemBackgroundColorSecondary;
-        border-left: 1px solid $itemBorderColorSecondary;
-        border-right: 1px solid $itemBorderColorSecondary;
         color: $white;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -54,7 +54,7 @@ exports[`DatePicker should render 1`] = `
               }
             }
           >
-            <Component
+            <DateTime
               className=""
               closeOnSelect={true}
               closeOnTab={true}
@@ -71,6 +71,8 @@ exports[`DatePicker should render 1`] = `
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
+              onNavigateBack={[Function]}
+              onNavigateForward={[Function]}
               onViewModeChange={[Function]}
               open={false}
               renderInput={[Function]}
@@ -672,7 +674,7 @@ exports[`DatePicker should render 1`] = `
                   </Component>
                 </div>
               </div>
-            </Component>
+            </DateTime>
           </div>
         </div>
       </Portal>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/GhostIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/GhostIndicator.js
@@ -1,0 +1,13 @@
+// @flow
+import React from 'react';
+import ghostIndicatorStyles from './ghostIndicator.scss';
+
+type Props = {
+    locale: string,
+};
+
+export default class GhostIndicator extends React.Component<Props> {
+    render() {
+        return <span className={ghostIndicatorStyles.ghostIndicator}>{this.props.locale}</span>;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/README.md
@@ -1,0 +1,10 @@
+The `GhostIndicator` is used to indicate that a certain Entity, e.g. a Category or a Page, is not available in the
+desired language. Instead it shows the name of the locale, from which the fallback has been loaded.
+
+```
+<GhostIndicator locale="de-at" />
+```
+
+```
+<GhostIndicator locale="en" />
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/ghostIndicator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/ghostIndicator.scss
@@ -3,6 +3,7 @@
 $ghostIndicatorColor: $shakespeare;
 
 .ghost-indicator {
+    display: block;
     color: $ghostIndicatorColor;
     border: 1px solid $ghostIndicatorColor;
     border-radius: 3px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/ghostIndicator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/ghostIndicator.scss
@@ -1,0 +1,13 @@
+@import '../../containers/Application/colors.scss';
+
+$ghostIndicatorColor: $shakespeare;
+
+.ghost-indicator {
+    color: $ghostIndicatorColor;
+    border: 1px solid $ghostIndicatorColor;
+    border-radius: 3px;
+    font-size: 8px;
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: 5px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/index.js
@@ -1,0 +1,4 @@
+// @flow
+import GhostIndicator from './GhostIndicator';
+
+export default GhostIndicator;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/GhostIndicator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/GhostIndicator.test.js
@@ -1,0 +1,8 @@
+// @flow
+import React from 'react';
+import {render} from 'enzyme';
+import GhostIndicator from '../GhostIndicator';
+
+test('Should render with given locale', () => {
+    expect(render(<GhostIndicator locale="de-at" />)).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/__snapshots__/GhostIndicator.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/GhostIndicator/tests/__snapshots__/GhostIndicator.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should render with given locale 1`] = `
+<span
+  class="ghostIndicator"
+>
+  de-at
+</span>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/README.md
@@ -23,6 +23,7 @@ The "light" style looks like as in the following example:
 
 In most cases the state management of the radio buttons will be the same.
 For that matter the `RadioGroup` component makes the use of the radio buttons more convenient.
+
 ```
 const RadioGroup = require('./RadioGroup').default;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/Radio.js
@@ -12,6 +12,7 @@ type Props = SwitchProps & {
 
 export default class Radio extends React.PureComponent<Props> {
     static defaultProps = {
+        checked: false,
         skin: 'dark',
     };
 
@@ -28,6 +29,7 @@ export default class Radio extends React.PureComponent<Props> {
             checked,
             children,
         } = this.props;
+
         const radioClass = classNames(
             radioStyles.radio,
             radioStyles[this.props.skin]

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Radio/RadioGroup.js
@@ -5,7 +5,7 @@ import Radio from './Radio';
 
 type Props = {
     value: string,
-    onChange?: () => void,
+    onChange?: (value: ?string | number) => void,
     className?: string,
     children: ChildrenArray<Element<typeof Radio>>,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -5,46 +5,40 @@ import Input from '../Input';
 import resourceLocatorStyles from './resourceLocator.scss';
 
 type Props = {|
-    value: string,
-    onChange: (value: string) => void,
+    value: ?string,
+    onChange: (value: ?string) => void,
     onBlur?: () => void,
     mode: 'full' | 'leaf',
 |};
 
 export default class ResourceLocator extends React.PureComponent<Props> {
-    static defaultProps = {
-        value: '/',
-    };
-
-    fixed: string = '';
+    fixed: string = '/';
 
     constructor(props: Props) {
         super(props);
 
         const {value, mode} = this.props;
 
-        switch (mode) {
-            case 'full':
-                this.fixed = '/';
-                break;
-            case 'leaf':
-                const parts = value.split('/');
-                parts.pop();
-                this.fixed = parts.join('/') + '/';
-                break;
-            default:
-                throw new Error('Unknown mode given: "' + mode + '"');
+        if (mode === 'leaf' && value) {
+            const parts = value.split('/');
+            parts.pop();
+            this.fixed = parts.join('/') + '/';
         }
     }
 
     @computed get changeableValue() {
-        return this.props.value.substring(this.fixed.length);
+        const {value} = this.props;
+        if (!value) {
+            return undefined;
+        }
+
+        return value.substring(this.fixed.length);
     }
 
     handleChange = (value: ?string) => {
         const {onChange} = this.props;
 
-        onChange(value ? this.fixed + value : this.fixed);
+        onChange(value ? this.fixed + value : undefined);
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -10,10 +10,22 @@ test('ResourceLocator should render with type full', () => {
         .toMatchSnapshot();
 });
 
+test('ResourceLocator should render with type full and a value of undefined', () => {
+    const onChange = jest.fn();
+    expect(render(<ResourceLocator value={undefined} mode="full" onChange={onChange} onBlur={jest.fn()} />))
+        .toMatchSnapshot();
+});
+
 test('ResourceLocator should render with type leaf', () => {
     const onChange = jest.fn();
     const value = '/parent/child';
     expect(render(<ResourceLocator value={value} mode="leaf" onChange={onChange} onBlur={jest.fn()} />))
+        .toMatchSnapshot();
+});
+
+test('ResourceLocator should render with type leaf and a value of undefined', () => {
+    const onChange = jest.fn();
+    expect(render(<ResourceLocator value={undefined} mode="leaf" onChange={onChange} onBlur={jest.fn()} />))
         .toMatchSnapshot();
 });
 
@@ -35,6 +47,13 @@ test('ResourceLocator should call the onChange callback when the input changes w
     );
     resourceLocator.find('Input').props().onChange('child-new');
     expect(onChange).toHaveBeenCalledWith('/parent/child-new');
+});
+
+test('ResourceLocator should call the onChange callback with undefined if no input is given', () => {
+    const onChange = jest.fn();
+    const resourceLocator = mount(<ResourceLocator value="/url" mode="leaf" onChange={onChange} />);
+    resourceLocator.find('Input').prop('onChange')(undefined);
+    expect(onChange).toHaveBeenCalledWith(undefined);
 });
 
 test('ResourceLocator should call the onBlur callback when the Input finishes editing', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/__snapshots__/ResourceLocator.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/__snapshots__/ResourceLocator.test.js.snap
@@ -20,6 +20,26 @@ exports[`ResourceLocator should render with type full 1`] = `
 </div>
 `;
 
+exports[`ResourceLocator should render with type full and a value of undefined 1`] = `
+<div
+  class="resourceLocator"
+>
+  <span
+    class="fixed"
+  >
+    /
+  </span>
+  <label
+    class="input default"
+  >
+    <input
+      type="text"
+      value=""
+    />
+  </label>
+</div>
+`;
+
 exports[`ResourceLocator should render with type leaf 1`] = `
 <div
   class="resourceLocator"
@@ -35,6 +55,26 @@ exports[`ResourceLocator should render with type leaf 1`] = `
     <input
       type="text"
       value="child"
+    />
+  </label>
+</div>
+`;
+
+exports[`ResourceLocator should render with type leaf and a value of undefined 1`] = `
+<div
+  class="resourceLocator"
+>
+  <span
+    class="fixed"
+  >
+    /
+  </span>
+  <label
+    class="input default"
+  >
+    <input
+      type="text"
+      value=""
     />
   </label>
 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
@@ -3,7 +3,6 @@ $marginBottom: 10px;
 
 .label {
     display: flex;
-    align-items: center;
     cursor: pointer;
 
     & > div {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
@@ -61,19 +61,26 @@ export default class ColumnListAdapter extends AbstractAdapter {
         } = this.props;
 
         const buttons = [];
+        const ghostButtons = [];
 
         if (onItemClick) {
             buttons.push({
                 icon: 'su-pen',
                 onClick: onItemClick,
             });
+            ghostButtons.push({
+                icon: 'su-plus-circle',
+                onClick: onItemClick,
+            });
         }
 
         if (onItemSelectionChange) {
-            buttons.push({
+            const checkButton = {
                 icon: 'su-check',
                 onClick: this.handleItemSelectionChange,
-            });
+            };
+            buttons.push(checkButton);
+            ghostButtons.push(checkButton);
         }
 
         const toolbarItems = [];
@@ -111,7 +118,7 @@ export default class ColumnListAdapter extends AbstractAdapter {
 
         return (
             <div className={columnListAdapterStyles.columnListAdapter}>
-                <ColumnList buttons={buttons} onItemClick={this.handleItemClick} toolbarItems={toolbarItems}>
+                <ColumnList onItemClick={this.handleItemClick} toolbarItems={toolbarItems}>
                     {this.props.data.map((items, index) => (
                         <ColumnList.Column
                             key={index}
@@ -121,6 +128,7 @@ export default class ColumnListAdapter extends AbstractAdapter {
                                 // TODO: Don't access hasChildren, published, publishedState, title or type directly
                                 <ColumnList.Item
                                     active={activeItems ? activeItems.includes(item.id) : undefined}
+                                    buttons={item.type && item.type.name === 'ghost' ? ghostButtons : buttons}
                                     disabled={disabledIds.includes(item.id)}
                                     hasChildren={item.hasChildren}
                                     id={item.id}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import ColumnList from '../../../components/ColumnList';
+import GhostIndicator from '../../../components/GhostIndicator';
 import PublishIndicator from '../../../components/PublishIndicator';
 import {translate} from '../../../utils/Translator';
 import FullLoadingStrategy from '../loadingStrategies/FullLoadingStrategy';
@@ -117,21 +118,26 @@ export default class ColumnListAdapter extends AbstractAdapter {
                             loading={index >= this.props.data.length - 1 && loading}
                         >
                             {items.map((item: Object) => (
-                                // TODO: Don't access "hasChildren", "published", "publishedState" or "title" directly
+                                // TODO: Don't access hasChildren, published, publishedState, title or type directly
                                 <ColumnList.Item
                                     active={activeItems ? activeItems.includes(item.id) : undefined}
                                     disabled={disabledIds.includes(item.id)}
                                     hasChildren={item.hasChildren}
                                     id={item.id}
+                                    indicators={item.type && item.type.name === 'ghost'
+                                        ? [
+                                            <GhostIndicator key={'ghost'} locale={item.type.value} />,
+                                        ]
+                                        : [
+                                            <PublishIndicator
+                                                key={'publish'}
+                                                draft={item.publishedState === undefined ? false : !item.publishedState}
+                                                published={item.publishedState === undefined ? false : item.published}
+                                            />,
+                                        ]
+                                    }
                                     key={item.id}
                                     selected={selections.includes(item.id)}
-                                    indicators={[
-                                        <PublishIndicator
-                                            key={1}
-                                            draft={item.publishedState === undefined ? false : !item.publishedState}
-                                            published={item.publishedState === undefined ? false : item.published}
-                                        />,
-                                    ]}
                                 >
                                     {item.title}
                                 </ColumnList.Item>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TreeTableAdapter.js
@@ -78,7 +78,7 @@ export default class TreeTableAdapter extends AbstractTableAdapter {
 
         if (onAddClick) {
             buttons.push({
-                icon: 'su-plus',
+                icon: 'su-plus-circle',
                 onClick: onAddClick,
             });
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
@@ -7,18 +7,21 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: (key) => key,
 }));
 
-test('Render data with edit button', () => {
+test('Render different kind of data with edit button', () => {
     const data = [
         [
             {
                 id: 1,
                 title: 'Page 1',
                 hasChildren: true,
+                publishedState: false,
             },
             {
                 id: 2,
                 title: 'Page 2',
                 hasChildren: false,
+                publishedState: false,
+                published: '2017-08-23',
             },
         ],
         [
@@ -26,6 +29,21 @@ test('Render data with edit button', () => {
                 id: 4,
                 title: 'Page 2.1',
                 hasChildren: true,
+                type: {
+                    name: 'ghost',
+                    value: 'nl',
+                },
+            },
+            {
+                id: 5,
+                title: 'Page 2.2',
+                hasChildren: true,
+                publishedState: false,
+                published: '2017-07-02',
+                type: {
+                    name: 'ghost',
+                    value: 'nl',
+                },
             },
         ],
         [],
@@ -229,54 +247,6 @@ test('Render data with loading column', () => {
                 id: 2,
                 title: 'Page 2',
                 hasChildren: false,
-            },
-        ],
-        [],
-    ];
-
-    const columnListAdapter = render(
-        <ColumnListAdapter
-            active={1}
-            activeItems={[1]}
-            data={data}
-            disabledIds={[]}
-            loading={true}
-            onAddClick={undefined}
-            onAllSelectionChange={undefined}
-            onDeleteClick={jest.fn()}
-            onItemActivation={jest.fn()}
-            onItemClick={undefined}
-            onItemDeactivation={jest.fn()}
-            onItemSelectionChange={undefined}
-            onPageChange={jest.fn()}
-            onSort={jest.fn()}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
-        />
-    );
-
-    expect(columnListAdapter).toMatchSnapshot();
-});
-
-test('Render data with published and draft state', () => {
-    const data = [
-        [
-            {
-                id: 1,
-                title: 'Page 1',
-                hasChildren: true,
-                publishedState: false,
-            },
-            {
-                id: 2,
-                title: 'Page 2',
-                hasChildren: false,
-                publishedState: false,
-                published: '2017-05-12',
             },
         ],
         [],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TreeTableAdapter.test.js
@@ -602,7 +602,7 @@ test('Click on add should execute onAddClick callback', () => {
     );
     const buttons = treeListAdapter.find('Table').prop('buttons');
     expect(buttons).toHaveLength(1);
-    expect(buttons[0].icon).toBe('su-plus');
+    expect(buttons[0].icon).toBe('su-plus-circle');
 
     buttons[0].onClick(1);
     expect(rowAddClickSpy).toBeCalledWith(1);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -150,210 +150,6 @@ exports[`Render data with disabled items 1`] = `
 </div>
 `;
 
-exports[`Render data with edit button 1`] = `
-<div
-  class="columnListAdapter"
->
-  <div
-    class="columnListToolbarContainer"
-  >
-    <div
-      class="toolbarContainer"
-      style="margin-left:0"
-    >
-      <div
-        class="toolbar"
-      >
-        <div
-          class="item primary"
-        >
-          <span
-            aria-label="su-cog"
-            class="su-cog"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
-    >
-      <div
-        class="columnList"
-      >
-        <div
-          class="column"
-        >
-          <div
-            class="item"
-          >
-            <span
-              class="buttons"
-            >
-              <span
-                aria-label="su-pen"
-                class="button su-pen clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            <span
-              class="text"
-            >
-              <div
-                aria-label="Page 1"
-                class="croppedText"
-                title="Page 1"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  Pag
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    e 1
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  Page 1
-                </div>
-              </div>
-            </span>
-            <span
-              class="indicator"
-            />
-            <span
-              class="children"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right"
-              />
-            </span>
-          </div>
-          <div
-            class="item active"
-          >
-            <span
-              class="buttons"
-            >
-              <span
-                aria-label="su-pen"
-                class="button su-pen clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            <span
-              class="text"
-            >
-              <div
-                aria-label="Page 2"
-                class="croppedText"
-                title="Page 2"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  Pag
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    e 2
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  Page 2
-                </div>
-              </div>
-            </span>
-            <span
-              class="indicator"
-            />
-            <span
-              class="children"
-            />
-          </div>
-        </div>
-        <div
-          class="column"
-        >
-          <div
-            class="item active"
-          >
-            <span
-              class="buttons"
-            >
-              <span
-                aria-label="su-pen"
-                class="button su-pen clickable"
-                role="button"
-                tabindex="0"
-              />
-            </span>
-            <span
-              class="text"
-            >
-              <div
-                aria-label="Page 2.1"
-                class="croppedText"
-                title="Page 2.1"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  Page
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                     2.1
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  Page 2.1
-                </div>
-              </div>
-            </span>
-            <span
-              class="indicator"
-            />
-            <span
-              class="children"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right"
-              />
-            </span>
-          </div>
-        </div>
-        <div
-          class="column"
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Render data with loading column 1`] = `
 <div
   class="columnListAdapter"
@@ -472,165 +268,6 @@ exports[`Render data with loading column 1`] = `
             <span
               class="indicator"
             />
-            <span
-              class="children"
-            />
-          </div>
-        </div>
-        <div
-          class="column"
-        >
-          <div
-            class="loader"
-          >
-            <div
-              class="spinner"
-              style="width:40px;height:40px"
-            >
-              <div
-                class="doubleBounce1"
-              />
-              <div
-                class="doubleBounce2"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Render data with published and draft state 1`] = `
-<div
-  class="columnListAdapter"
->
-  <div
-    class="columnListToolbarContainer"
-  >
-    <div
-      class="toolbarContainer"
-      style="margin-left:0"
-    >
-      <div
-        class="toolbar"
-      >
-        <div
-          class="item primary"
-        >
-          <span
-            aria-label="su-cog"
-            class="su-cog"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
-    >
-      <div
-        class="columnList"
-      >
-        <div
-          class="column"
-        >
-          <div
-            class="item active"
-          >
-            <span
-              class="buttons"
-            />
-            <span
-              class="text"
-            >
-              <div
-                aria-label="Page 1"
-                class="croppedText"
-                title="Page 1"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  Pag
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    e 1
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  Page 1
-                </div>
-              </div>
-            </span>
-            <span
-              class="indicator"
-            >
-              <span
-                class="draft"
-              />
-            </span>
-            <span
-              class="children"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right"
-              />
-            </span>
-          </div>
-          <div
-            class="item"
-          >
-            <span
-              class="buttons"
-            />
-            <span
-              class="text"
-            >
-              <div
-                aria-label="Page 2"
-                class="croppedText"
-                title="Page 2"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  Pag
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    e 2
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  Page 2
-                </div>
-              </div>
-            </span>
-            <span
-              class="indicator"
-            >
-              <span
-                class="published"
-              />
-              <span
-                class="draft"
-              />
-            </span>
             <span
               class="children"
             />
@@ -836,6 +473,287 @@ exports[`Render data without edit button 1`] = `
             </span>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render different kind of data with edit button 1`] = `
+<div
+  class="columnListAdapter"
+>
+  <div
+    class="columnListToolbarContainer"
+  >
+    <div
+      class="toolbarContainer"
+      style="margin-left:0"
+    >
+      <div
+        class="toolbar"
+      >
+        <div
+          class="item primary"
+        >
+          <span
+            aria-label="su-cog"
+            class="su-cog"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
+    >
+      <div
+        class="columnList"
+      >
+        <div
+          class="column"
+        >
+          <div
+            class="item"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-pen"
+                class="button su-pen clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 1"
+                class="croppedText"
+                title="Page 1"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Pag
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e 1
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 1
+                </div>
+              </div>
+            </span>
+            <span
+              class="indicator"
+            >
+              <span
+                class="draft"
+              />
+            </span>
+            <span
+              class="children"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right"
+              />
+            </span>
+          </div>
+          <div
+            class="item active"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-pen"
+                class="button su-pen clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 2"
+                class="croppedText"
+                title="Page 2"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Pag
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e 2
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 2
+                </div>
+              </div>
+            </span>
+            <span
+              class="indicator"
+            >
+              <span
+                class="published"
+              />
+              <span
+                class="draft"
+              />
+            </span>
+            <span
+              class="children"
+            />
+          </div>
+        </div>
+        <div
+          class="column"
+        >
+          <div
+            class="item active"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-pen"
+                class="button su-pen clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 2.1"
+                class="croppedText"
+                title="Page 2.1"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Page
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                     2.1
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 2.1
+                </div>
+              </div>
+            </span>
+            <span
+              class="indicator"
+            >
+              <span
+                class="ghostIndicator"
+              >
+                nl
+              </span>
+            </span>
+            <span
+              class="children"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right"
+              />
+            </span>
+          </div>
+          <div
+            class="item"
+          >
+            <span
+              class="buttons"
+            >
+              <span
+                aria-label="su-pen"
+                class="button su-pen clickable"
+                role="button"
+                tabindex="0"
+              />
+            </span>
+            <span
+              class="text"
+            >
+              <div
+                aria-label="Page 2.2"
+                class="croppedText"
+                title="Page 2.2"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Page
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                     2.2
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Page 2.2
+                </div>
+              </div>
+            </span>
+            <span
+              class="indicator"
+            >
+              <span
+                class="ghostIndicator"
+              >
+                nl
+              </span>
+            </span>
+            <span
+              class="children"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right"
+              />
+            </span>
+          </div>
+        </div>
+        <div
+          class="column"
+        />
       </div>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -637,8 +637,8 @@ exports[`Render different kind of data with edit button 1`] = `
               class="buttons"
             >
               <span
-                aria-label="su-pen"
-                class="button su-pen clickable"
+                aria-label="su-plus-circle"
+                class="button su-plus-circle clickable"
                 role="button"
                 tabindex="0"
               />
@@ -697,8 +697,8 @@ exports[`Render different kind of data with edit button 1`] = `
               class="buttons"
             >
               <span
-                aria-label="su-pen"
-                class="button su-pen clickable"
+                aria-label="su-plus-circle"
+                class="button su-plus-circle clickable"
                 role="button"
                 tabindex="0"
               />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/GhostDialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/GhostDialog.js
@@ -1,0 +1,74 @@
+// @flow
+import React from 'react';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import Dialog from '../../components/Dialog';
+import SingleSelect from '../../components/SingleSelect';
+import {translate} from '../../utils/Translator';
+import ghostDialogStyles from './ghostDialog.scss';
+
+type Props = {
+    locales: Array<string>,
+    onCancel: () => void,
+    onConfirm: (locale: string) => void,
+    open: boolean,
+};
+
+@observer
+export default class GhostDialog extends React.Component<Props> {
+    @observable selectedLocale: string;
+
+    constructor(props: Props) {
+        super(props);
+
+        this.selectedLocale = this.props.locales[0];
+    }
+
+    handleCancel = () => {
+        this.props.onCancel();
+    };
+
+    handleConfirm = () => {
+        this.props.onConfirm(this.selectedLocale);
+    };
+
+    @action handleLocaleChange = (locale: string | number) => {
+        if (typeof locale !== 'string') {
+            throw new Error('Only strings are accepted as locales! This should not happen and is likely a bug.');
+        }
+
+        this.selectedLocale = locale;
+    };
+
+    render() {
+        const {
+            locales,
+            open,
+        } = this.props;
+
+        return (
+            <Dialog
+                cancelText={translate('sulu_admin.no')}
+                onCancel={this.handleCancel}
+                confirmText={translate('sulu_admin.yes')}
+                onConfirm={this.handleConfirm}
+                open={open}
+                title={translate('sulu_admin.ghost_dialog_title')}
+            >
+                <div className={ghostDialogStyles.ghostDialog}>
+                    <p>{translate('sulu_admin.ghost_dialog_description')}</p>
+                    <label className={ghostDialogStyles.label}>{translate('sulu_admin.choose_language')}</label>
+                    <div className={ghostDialogStyles.localeSelect}>
+                        <SingleSelect onChange={this.handleLocaleChange} value={this.selectedLocale}>
+                            {locales.map((locale) => (
+                                <SingleSelect.Option key={locale} value={locale}>
+                                    {locale}
+                                </SingleSelect.Option>
+                            ))}
+                        </SingleSelect>
+                    </div>
+                </div>
+            </Dialog>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -6,8 +6,8 @@ import type {FieldTypeProps} from '../../../types';
 
 const PART_TAG = 'sulu.rlp.part';
 
-export default class ResourceLocator extends React.Component<FieldTypeProps<string>> {
-    constructor(props: FieldTypeProps<string>) {
+export default class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
+    constructor(props: FieldTypeProps<?string>) {
         super(props);
 
         const {dataPath, onChange, fieldTypeOptions, formInspector, value} = this.props;
@@ -18,8 +18,7 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<stri
         }
 
         formInspector.addFinishFieldHandler((finishedFieldDataPath, finishedFieldSchemaPath) => {
-            if (formInspector.id) {
-                // do not generate resource locator if on edit form
+            if (value !== undefined) {
                 return;
             }
 
@@ -50,10 +49,6 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<stri
                 onChange(response.resourcelocator);
             });
         });
-
-        if (value === undefined || value === '') {
-            onChange('/');
-        }
     }
 
     handleBlur = () => {
@@ -74,10 +69,6 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<stri
 
         if (mode !== 'leaf' && mode !== 'full') {
             throw new Error('The "mode" schema option must be either "leaf" or "full"!');
-        }
-
-        if (!value) {
-            return null;
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/ghostDialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/ghostDialog.scss
@@ -1,0 +1,18 @@
+@import '../../containers/Application/colors.scss';
+
+$ghostDialogLabelColor: $scorpion;
+
+.ghost-dialog {
+    text-align: left;
+}
+
+.locale-select {
+    width: 50%;
+}
+
+.label {
+    display: block;
+    color: $ghostDialogLabelColor;
+    font-size: 12px;
+    margin-bottom: 5px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/FormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/FormStore.js
@@ -243,6 +243,15 @@ export default class FormStore {
         });
     }
 
+    copyFromLocale(locale: string) {
+        return this.resourceStore.copyFromLocale(locale, this.options)
+            .then((response) => {
+                if (this.hasTypes) {
+                    this.setType(response[TYPE]);
+                }
+            });
+    }
+
     set(name: string, value: mixed) {
         this.resourceStore.set(name, value);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react';
+import {mount} from 'enzyme';
+import pretty from 'pretty';
+import GhostDialog from '../GhostDialog';
+
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn(),
+}));
+
+afterEach(() => {
+    if (document.body) {
+        document.body.innerHTML = '';
+    }
+});
+
+test('Should render a Dialog', () => {
+    const body = document.body;
+
+    mount(<GhostDialog onCancel={jest.fn()} onConfirm={jest.fn()} open={true} locales={['en', 'de']} />);
+
+    expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
+});
+
+test('Should call onCancel callback if user chooses not to copy content', () => {
+    const cancelSpy = jest.fn();
+    const ghostDialog = mount(
+        <GhostDialog onCancel={cancelSpy} onConfirm={jest.fn()} open={true} locales={['en', 'de']} />
+    );
+
+    ghostDialog.find('Button[skin="secondary"]').simulate('click');
+
+    expect(cancelSpy).toBeCalledWith();
+});
+
+test('Should call onConfirm callback with chosen locale if user chooses to copy content', () => {
+    const confirmSpy = jest.fn();
+    const ghostDialog = mount(
+        <GhostDialog onCancel={jest.fn()} onConfirm={confirmSpy} open={true} locales={['en', 'de']} />
+    );
+
+    ghostDialog.find('SingleSelect').prop('onChange')('de');
+    ghostDialog.find('Button[skin="primary"]').simulate('click');
+
+    expect(confirmSpy).toBeCalledWith('de');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should render a Dialog 1`] = `
+"<div>
+  <div class=\\"backdrop visible fixed\\"></div>
+</div>
+<div>
+  <div class=\\"dialogContainer\\">
+    <div class=\\"dialog\\">
+      <section class=\\"content\\">
+        <header></header>
+        <article>
+          <div class=\\"ghostDialog\\">
+            <p></p>
+            <label class=\\"label\\"></label>
+            <div class=\\"localeSelect\\">
+              <div class=\\"select\\">
+                <button class=\\"displayValue\\" type=\\"button\\">
+                  <div title=\\"en\\" aria-label=\\"en\\" class=\\"croppedText\\">
+                    <div class=\\"front\\" aria-hidden=\\"true\\">e</div>
+                    <div class=\\"back\\" aria-hidden=\\"true\\"><span>n</span></div>
+                    <div class=\\"whole\\">en</div>
+                  </div><span class=\\"toggle su-angle-down\\" aria-label=\\"su-angle-down\\"></span></button>
+              </div>
+            </div>
+          </div>
+        </article>
+        <footer>
+          <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"></span></button>
+          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\"></span></button>
+        </footer>
+      </section>
+    </div>
+  </div>
+</div>"
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -117,54 +117,6 @@ test('Throw an exception if a no generationUrl is passed', () => {
     ).toThrow(/"generationUrl"/);
 });
 
-test('Set default value correctly with undefined value', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
-    const changeSpy = jest.fn();
-
-    shallow(
-        <ResourceLocator
-            dataPath=""
-            error={undefined}
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
-            formInspector={formInspector}
-            maxOccurs={undefined}
-            minOccurs={undefined}
-            onChange={changeSpy}
-            onFinish={jest.fn()}
-            schemaPath=""
-            showAllErrors={false}
-            types={undefined}
-            value={undefined}
-        />
-    );
-
-    expect(changeSpy).toBeCalledWith('/');
-});
-
-test('Set default value correctly with empty string', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
-    const changeSpy = jest.fn();
-
-    shallow(
-        <ResourceLocator
-            dataPath=""
-            error={undefined}
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
-            formInspector={formInspector}
-            maxOccurs={undefined}
-            minOccurs={undefined}
-            onChange={changeSpy}
-            onFinish={jest.fn()}
-            schemaPath=""
-            showAllErrors={false}
-            types={undefined}
-            value=""
-        />
-    );
-
-    expect(changeSpy).toBeCalledWith('/');
-});
-
 test('Set default mode correctly', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const resourceLocator = mount(
@@ -238,7 +190,7 @@ test('Should not request a new URL if on an edit form', () =>{
     expect(Requester.post).not.toBeCalled();
 });
 
-test('Should request a new URL if on an add form', () => {
+test('Should request a new URL if no URL was defined', () => {
     const formInspector = new FormInspector(
         new FormStore(
             new ResourceStore('test', undefined, {locale: observable.box('en')})
@@ -259,7 +211,7 @@ test('Should request a new URL if on an add form', () => {
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 
@@ -290,7 +242,48 @@ test('Should request a new URL if on an add form', () => {
     });
 });
 
-test('Should request a new URL including the options from the FormStore if on an add form', () => {
+test('Should not request a new URL if URL was defined', () => {
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
+    const changeSpy = jest.fn();
+
+    shallow(
+        <ResourceLocator
+            dataPath="/block/0/url"
+            error={undefined}
+            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            formInspector={formInspector}
+            maxOccurs={undefined}
+            minOccurs={undefined}
+            onChange={changeSpy}
+            onFinish={jest.fn()}
+            schemaPath="/url"
+            showAllErrors={false}
+            types={undefined}
+            value="/url"
+        />
+    );
+
+    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
+
+    formInspector.getValuesByTag.mockReturnValue(['te', 'st']);
+    formInspector.getSchemaEntryByPath.mockReturnValue({
+        tags: [
+            {name: 'sulu.rlp.part'},
+        ],
+    });
+
+    finishFieldHandler('/block/0/url', '/url');
+
+    expect(formInspector.getSchemaEntryByPath).not.toBeCalled();
+    expect(formInspector.getValuesByTag).not.toBeCalled();
+    expect(Requester.post).not.toBeCalled();
+});
+
+test('Should request a new URL including the options from the FormStore if no URL was defined', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test'), {webspace: 'example'}));
     const changeSpy = jest.fn();
 
@@ -307,7 +300,7 @@ test('Should request a new URL including the options from the FormStore if on an
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 
@@ -354,7 +347,7 @@ test('Should not request a new URL if no parts are available', () => {
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 
@@ -388,7 +381,7 @@ test('Should not request a new URL if only empty parts are available', () => {
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 
@@ -422,7 +415,7 @@ test('Should not request a new URL if a field without the "sulu.rlp.part" tag ha
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 
@@ -456,7 +449,7 @@ test('Should not request a new URL if a field without any tags has finished edit
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 
@@ -487,7 +480,7 @@ test('Should not request a new URL if the resource locator field has already bee
             schemaPath="/url"
             showAllErrors={false}
             types={undefined}
-            value="/test/xxx"
+            value={undefined}
         />
     );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
@@ -10,6 +10,7 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
     this.save = jest.fn().mockReturnValue(Promise.resolve());
     this.set = jest.fn();
     this.change = jest.fn();
+    this.copyFromLocale = jest.fn();
     this.data = {};
     this.loading = false;
 
@@ -761,5 +762,28 @@ test('Remember fields being finished as modified fields and forget about them af
     return formStore.save().then(() => {
         expect(formStore.isFieldModified('/block/0/text')).toEqual(false);
         expect(formStore.isFieldModified('/block/1/text')).toEqual(false);
+    });
+});
+
+test('Set new type after copying from different locale', () => {
+    const schemaTypesPromise = Promise.resolve({
+        sidebar: {key: 'sidebar', title: 'Sidebar'},
+        footer: {key: 'footer', title: 'Footer'},
+    });
+
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const resourceStore = new ResourceStore('test', 5);
+    const formStore = new FormStore(resourceStore);
+
+    resourceStore.copyFromLocale.mockReturnValue(Promise.resolve({template: 'sidebar'}));
+
+    return schemaTypesPromise.then(() => {
+        formStore.setType('footer');
+        const promise = formStore.copyFromLocale('de');
+
+        return promise.then(() => {
+            expect(formStore.type).toEqual('sidebar');
+        });
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/ResourceRequester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/ResourceRequester.js
@@ -32,6 +32,11 @@ export default class ResourceRequester {
         return Requester.post(endpoint + ResourceRequester.buildQueryString(queryOptions), data);
     }
 
+    static postWithId(resourceKey: string, id: number | string, data: Object, queryOptions: ?Object) {
+        const endpoint = resourceMetadataStore.getEndpoint(resourceKey);
+        return Requester.post(endpoint + '/' + id + ResourceRequester.buildQueryString(queryOptions), data);
+    }
+
     static put(resourceKey: string, id: number | string, data: Object, queryOptions: ?Object) {
         const endpoint = resourceMetadataStore.getEndpoint(resourceKey);
         return Requester.put(endpoint + '/' + id + ResourceRequester.buildQueryString(queryOptions), data);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/ResourceRequester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/ResourceRequester/tests/ResourceRequester.test.js
@@ -6,6 +6,7 @@ import Requester from '../../Requester/Requester';
 jest.mock('../../Requester/Requester', () => ({
     get: jest.fn(),
     put: jest.fn(),
+    post: jest.fn(),
     delete: jest.fn(),
 }));
 
@@ -106,4 +107,20 @@ test('Should send a delete request with passed options as query parameters', () 
     Requester.delete.mockReturnValue({});
     ResourceRequester.delete('snippets', 5, options);
     expect(Requester.delete).toBeCalledWith('/snippets/5?locale=en&webspace=sulu');
+});
+
+test('Should send a post request and return the promise', () => {
+    const promise = {};
+    Requester.post.mockReturnValue(promise);
+    const result = ResourceRequester.post('snippets', {});
+    expect(Requester.post).toBeCalledWith('/snippets', {});
+    expect(result).toBe(promise);
+});
+
+test('Should send a post request with an ID and return the promise', () => {
+    const promise = {};
+    Requester.post.mockReturnValue(promise);
+    const result = ResourceRequester.postWithId('snippets', 5, {});
+    expect(Requester.post).toBeCalledWith('/snippets/5', {});
+    expect(result).toBe(promise);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -177,6 +177,26 @@ export default class ResourceStore {
             }));
     }
 
+    copyFromLocale(locale: string, options: Object = {}) {
+        if (!this.id) {
+            throw new Error('Copying from another locale does not work for new objects!');
+        }
+
+        if (!this.locale) {
+            throw new Error('Copying from another locale does only work for objects with locales!');
+        }
+
+        return ResourceRequester
+            .postWithId(
+                this.resourceKey,
+                this.id,
+                {},
+                {action: 'copy-locale', locale: locale, dest: this.locale.get(), ...options}
+            ).then(action((response) => {
+                this.data = response;
+            }));
+    }
+
     @action set(name: string, value: mixed) {
         if (name === 'id' && (typeof value === 'string' || typeof value === 'number')) {
             this.id = value;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -194,6 +194,7 @@ export default class ResourceStore {
                 {action: 'copy-locale', locale: locale, dest: this.locale.get(), ...options}
             ).then(action((response) => {
                 this.data = response;
+                return response;
             }));
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -590,7 +590,7 @@ test('Should render save button disabled only if form is not dirty', () => {
 
 test('Should save form when submitted', (done) => {
     const ResourceRequester = require('../../../services/ResourceRequester');
-    ResourceRequester.put.mockReturnValue(Promise.resolve());
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const metadataStore = require('../../../containers/Form/stores/MetadataStore');
@@ -642,7 +642,7 @@ test('Should save form when submitted', (done) => {
 
 test('Should save form when submitted with parent', (done) => {
     const ResourceRequester = require('../../../services/ResourceRequester');
-    ResourceRequester.put.mockReturnValue(Promise.resolve());
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const metadataStore = require('../../../containers/Form/stores/MetadataStore');

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -13,6 +13,8 @@
     "sulu_admin.confirm": "Bestätigen",
     "sulu_admin.ok": "Ok",
     "sulu_admin.cancel": "Abbrechen",
+    "sulu_admin.yes": "Ja",
+    "sulu_admin.no": "Nein",
     "sulu_admin.error_required": "Dieses Feld muss ausgefüllt werden",
     "sulu_admin.error_minlength": "Die minimale Länge dieses Feldes wurde unterschritten",
     "sulu_admin.error_minitems": "Dieses Feld hat zu wenig Zuweisungen",
@@ -37,5 +39,8 @@
     "sulu_admin.changer": "Autor",
     "sulu_admin.changed": "Geändert am",
     "sulu_admin.delete_warning_title": "Löschen?",
-    "sulu_admin.delete_warning_text": "Diese Operation löscht Daten und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?"
+    "sulu_admin.delete_warning_text": "Diese Operation löscht Daten und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
+    "sulu_admin.ghost_dialog_title": "Sprachvariante kopieren?",
+    "sulu_admin.ghost_dialog_description": "Diese Seite existiert nicht in dieser Sprache. Wollen Sie den Inhalt aus einer anderen Sprache kopieren?",
+    "sulu_admin.choose_language": "Sprache wählen"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -13,6 +13,8 @@
     "sulu_admin.confirm": "Confirm",
     "sulu_admin.ok": "Ok",
     "sulu_admin.cancel": "Cancel",
+    "sulu_admin.yes": "Yes",
+    "sulu_admin.no": "No",
     "sulu_admin.error_required": "This field must have a value",
     "sulu_admin.error_minlength": "The minimal length of this field was undershot",
     "sulu_admin.error_minitems": "This field has too few selections",
@@ -37,5 +39,8 @@
     "sulu_admin.changer": "Author",
     "sulu_admin.changed": "Changed on",
     "sulu_admin.delete_warning_title": "Delete?",
-    "sulu_admin.delete_warning_text": "This operation deletes data and cannot be undone. Do you really wish to proceed?"
+    "sulu_admin.delete_warning_text": "This operation deletes data and cannot be undone. Do you really wish to proceed?",
+    "sulu_admin.ghost_dialog_title": "Copy language?",
+    "sulu_admin.ghost_dialog_description": "This page does not exist in this language. Do you want to copy content from another language?",
+    "sulu_admin.choose_language": "Choose language"
 }

--- a/src/Sulu/Bundle/ContentBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/PageController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\ContentBundle\Controller;
 
+use FOS\RestBundle\Controller\Annotations\Post;
 use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,6 +40,14 @@ class PageController extends NodeController
         }
 
         return $this->transformResponse(parent::cgetAction($request));
+    }
+
+    /**
+     * @Post("/pages/{uuid}")
+     */
+    public function postTriggerAction($uuid, Request $request)
+    {
+        return parent::postTriggerAction($uuid, $request);
     }
 
     protected function cgetContent(Request $request)

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/WebspaceStore.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/stores/WebspaceStore/WebspaceStore.js
@@ -3,7 +3,7 @@ import {Requester} from 'sulu-admin-bundle/services';
 import type {Webspace} from './types';
 
 class WebspaceStore {
-    baseUrl: string = '/admin/api/webspaces';
+    baseUrl: string = '/admin/api/webspaces'; // TODO get URL from server
 
     webspacePromise: Promise<Object>;
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -97,4 +97,17 @@ class PageControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('id', $page2);
         $this->assertObjectNotHasAttribute('uuid', $page2);
     }
+
+    public function testPostTriggerAction()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $webspaceUuid = $this->session->getNode('/cmf/sulu_io/contents')->getIdentifier();
+
+        $client->request(
+            'POST',
+            '/api/pages/' . $webspaceUuid . '?webspace=sulu_io&action=copy-locale&locale=en&dest=de'
+        );
+        $this->assertHttpStatusCode(200, $client->getResponse());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will open a overlay asking if a new page should be created or the content from a different locale should be copied. This is implemented within the `Form` component, so that it is available for all other entities as well.

#### Why?

Because we want to make editing pages as convenient for the content manager as possible.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [ ] Grey out Title of ghost page in `ColumnListAdapter` (bites with disabled functionality)
- [x] Use plus icon instead of pencil in edit button if ghost page