### PR TITLE
Fix positioning of elements in ColumnList

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
@@ -36,7 +36,7 @@ $itemHeight: 40px;
 
     .children {
         font-weight: normal;
-        width: 36px;
+        width: 25px;
     }
 }
 
@@ -49,10 +49,6 @@ $itemHeight: 40px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-
-    &:last-child {
-        margin-right: 5px;
-    }
 }
 
 .buttons {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/publishIndicator.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/publishIndicator.scss
@@ -7,7 +7,8 @@ $indicatorDimension: 18px;
 
 .published,
 .draft {
-    display: inline-block;
+    display: block;
+    float: left;
     border: 2px $indicatorBorderColor solid;
     border-radius: 50%;
     height: $indicatorDimension;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR centers the `PublishIndicator` component in the `ColumnList`.

#### Why?

Because we have used `display: inline-block` before on the `PublishIndicator`, the wrapping element added a few pixels on the bottom. A pure block elemnt doesn't suffer from this problem.