### PR TITLE
Make ColumnList, Table and Navigation more keyboard friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         "clearMocks": true,
         "transformIgnorePatterns": [
             "node_modules/(?!(sulu-(.*)-bundle|@ckeditor)/)"
-        ]
+        ],
+        "testURL": "http://localhost"
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -63,7 +63,7 @@ export default class Item extends React.Component<Props> {
         );
 
         return (
-            <div onClick={this.handleClick} className={itemClass}>
+            <div onClick={this.handleClick} className={itemClass} role="button">
                 <span className={itemStyles.buttons}>
                     {this.renderButtons()}
                 </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
@@ -48,6 +48,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
       >
         <div
           class="item selected"
+          role="button"
         >
           <span
             class="buttons"
@@ -100,158 +101,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
         </div>
         <div
           class="item"
-        >
-          <span
-            class="buttons"
-          >
-            <span
-              aria-label="fa-heart"
-              class="button fa fa-heart clickable"
-              role="button"
-              tabindex="0"
-            />
-            <span
-              aria-label="fa-pencil"
-              class="button fa fa-pencil clickable"
-              role="button"
-              tabindex="0"
-            />
-          </span>
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </span>
-        </div>
-        <div
-          class="item"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-      </div>
-      <div
-        class="column"
-      >
-        <div
-          class="item"
-        >
-          <span
-            class="buttons"
-          >
-            <span
-              aria-label="fa-heart"
-              class="button fa fa-heart clickable"
-              role="button"
-              tabindex="0"
-            />
-            <span
-              aria-label="fa-pencil"
-              class="button fa fa-pencil clickable"
-              role="button"
-              tabindex="0"
-            />
-          </span>
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-        <div
-          class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -307,12 +157,53 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
             />
           </span>
         </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
       </div>
       <div
         class="column"
       >
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -365,6 +256,122 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
         </div>
         <div
           class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          >
+            <span
+              aria-label="fa-heart"
+              class="button fa fa-heart clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="fa-pencil"
+              class="button fa fa-pencil clickable"
+              role="button"
+              tabindex="0"
+            />
+          </span>
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="column"
+      >
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          >
+            <span
+              aria-label="fa-heart"
+              class="button fa fa-heart clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="fa-pencil"
+              class="button fa fa-pencil clickable"
+              role="button"
+              tabindex="0"
+            />
+          </span>
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -472,6 +479,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
       >
         <div
           class="item selected"
+          role="button"
         >
           <span
             class="buttons"
@@ -511,6 +519,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
         </div>
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -555,6 +564,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
         </div>
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -598,6 +608,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
       >
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -637,6 +648,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
         </div>
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -685,6 +697,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
       >
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"
@@ -724,6 +737,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
         </div>
         <div
           class="item"
+          role="button"
         >
           <span
             class="buttons"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Item.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Should render item as disabled 1`] = `
 <div
   class="item disabled"
+  role="button"
 >
   <span
     class="buttons"
@@ -45,6 +46,7 @@ exports[`Should render item as disabled 1`] = `
 exports[`Should render item as not selected by default 1`] = `
 <div
   class="item"
+  role="button"
 >
   <span
     class="buttons"
@@ -87,6 +89,7 @@ exports[`Should render item as not selected by default 1`] = `
 exports[`Should render item as selected 1`] = `
 <div
   class="item selected"
+  role="button"
 >
   <span
     class="buttons"
@@ -129,6 +132,7 @@ exports[`Should render item as selected 1`] = `
 exports[`Should render item with indicators 1`] = `
 <div
   class="item"
+  role="button"
 >
   <span
     class="buttons"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -43,13 +43,12 @@ export default class Item extends React.PureComponent<Props> {
             itemStyles.item,
             {
                 [itemStyles.active]: active,
-                [itemStyles.hasChildren]: !!children,
             }
         );
 
         return (
             <div className={itemClass}>
-                <div className={itemStyles.title} onClick={this.handleClick}>
+                <div className={itemStyles.title} onClick={this.handleClick} role="button">
                     {icon && <Icon name={icon} />}
                     {title}
                 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Item.test.js.snap
@@ -6,6 +6,7 @@ exports[`The component should render 1`] = `
 >
   <div
     class="title"
+    role="button"
   >
     <span
       aria-label="su-search"
@@ -22,6 +23,7 @@ exports[`The component should render active 1`] = `
 >
   <div
     class="title"
+    role="button"
   >
     <span
       aria-label="su-search"
@@ -34,10 +36,11 @@ exports[`The component should render active 1`] = `
 
 exports[`The component should render with children 1`] = `
 <div
-  class="item hasChildren"
+  class="item"
 >
   <div
     class="title"
+    role="button"
   >
     <span
       aria-label="su-cog"
@@ -56,10 +59,11 @@ exports[`The component should render with children 1`] = `
 
 exports[`The component should render with children an active child and expanded 1`] = `
 <div
-  class="item active hasChildren"
+  class="item active"
 >
   <div
     class="title"
+    role="button"
   >
     <span
       aria-label="su-cog"
@@ -73,6 +77,7 @@ exports[`The component should render with children an active child and expanded 
     >
       <div
         class="title"
+        role="button"
       >
         Settings 1
       </div>
@@ -82,6 +87,7 @@ exports[`The component should render with children an active child and expanded 
     >
       <div
         class="title"
+        role="button"
       >
         Settings 2
       </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -59,6 +59,7 @@ exports[`The component should render and handle clicks correctly 1`] = `
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-search"
@@ -72,6 +73,7 @@ exports[`The component should render and handle clicks correctly 1`] = `
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="fa-bullseye"
@@ -154,6 +156,7 @@ exports[`The component should render with all available props and handle clicks 
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-search"
@@ -167,6 +170,7 @@ exports[`The component should render with all available props and handle clicks 
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-webspace"
@@ -180,6 +184,7 @@ exports[`The component should render with all available props and handle clicks 
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="fa-image"
@@ -193,6 +198,7 @@ exports[`The component should render with all available props and handle clicks 
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="fa-newspaper-o"
@@ -206,6 +212,7 @@ exports[`The component should render with all available props and handle clicks 
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="fa-sticky-note-o"
@@ -215,10 +222,11 @@ exports[`The component should render with all available props and handle clicks 
       </div>
     </div>
     <div
-      class="item active hasChildren"
+      class="item active"
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-user-1"
@@ -232,6 +240,7 @@ exports[`The component should render with all available props and handle clicks 
         >
           <div
             class="title"
+            role="button"
           >
             Contact 1
           </div>
@@ -241,6 +250,7 @@ exports[`The component should render with all available props and handle clicks 
         >
           <div
             class="title"
+            role="button"
           >
             Contact 2
           </div>
@@ -250,6 +260,7 @@ exports[`The component should render with all available props and handle clicks 
         >
           <div
             class="title"
+            role="button"
           >
             Contact 3
           </div>
@@ -263,10 +274,11 @@ exports[`The component should render with all available props and handle clicks 
       />
     </div>
     <div
-      class="item hasChildren"
+      class="item"
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="fa-gear"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -148,12 +148,14 @@ export default class Row extends React.PureComponent<Props> {
 
         return (
             <span
-                onClick={expanded === false ? this.handleExpand : this.handleCollapse}
                 className={tableStyles.toggleIcon}
             >
                 {isLoading
                     ? <Loader size={10} />
-                    : <Icon name={expanded === true ? 'su-angle-down' : 'su-angle-right'} />
+                    : <Icon
+                        onClick={expanded === false ? this.handleExpand : this.handleCollapse}
+                        name={expanded === true ? 'su-angle-down' : 'su-angle-right'}
+                    />
                 }
             </span>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -371,7 +371,7 @@ test('Collapse should be called correctly', () => {
         </Table>
     );
 
-    table.find('Row').at(1).find('span.toggleIcon').simulate('click');
+    table.find('Row').at(1).find('span.toggleIcon Icon').simulate('click');
     expect(onRowCollapse).toHaveBeenCalledTimes(1);
 });
 
@@ -407,6 +407,6 @@ test('Expand should be called correctly', () => {
         </Table>
     );
 
-    table.find('Row').at(1).find('span.toggleIcon').simulate('click');
+    table.find('Row').at(1).find('span.toggleIcon Icon').simulate('click');
     expect(onRowExpand).toHaveBeenCalledTimes(1);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
@@ -509,7 +509,9 @@ exports[`Render the Table component in tree structure 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Column Text
@@ -549,7 +551,9 @@ exports[`Render the Table component in tree structure 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Column Text

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TreeTableAdapter.test.js
@@ -371,11 +371,11 @@ test('Execute onItemActivation respectively onItemDeactivation callback when an 
     );
 
     // expand the row
-    treeListAdapter.find('Row[id=6]').find('span.toggleIcon').simulate('click');
+    treeListAdapter.find('Row[id=6]').find('span.toggleIcon Icon').simulate('click');
     expect(onItemActivationSpy).toBeCalledWith(6);
 
     // close the row
-    treeListAdapter.find('Row[id=3]').find('span.toggleIcon').simulate('click');
+    treeListAdapter.find('Row[id=3]').find('span.toggleIcon Icon').simulate('click');
     expect(onItemDeactivationSpy).toBeCalledWith(3);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -35,6 +35,7 @@ exports[`Render data with disabled items 1`] = `
         >
           <div
             class="item active selected"
+            role="button"
           >
             <span
               class="buttons"
@@ -93,6 +94,7 @@ exports[`Render data with disabled items 1`] = `
         >
           <div
             class="item active disabled"
+            role="button"
           >
             <span
               class="buttons"
@@ -185,6 +187,7 @@ exports[`Render data with loading column 1`] = `
         >
           <div
             class="item active"
+            role="button"
           >
             <span
               class="buttons"
@@ -232,6 +235,7 @@ exports[`Render data with loading column 1`] = `
           </div>
           <div
             class="item"
+            role="button"
           >
             <span
               class="buttons"
@@ -333,6 +337,7 @@ exports[`Render data with selection 1`] = `
         >
           <div
             class="item selected"
+            role="button"
           >
             <span
               class="buttons"
@@ -427,6 +432,7 @@ exports[`Render data without edit button 1`] = `
         >
           <div
             class="item"
+            role="button"
           >
             <span
               class="buttons"
@@ -514,6 +520,7 @@ exports[`Render different kind of data with edit button 1`] = `
         >
           <div
             class="item"
+            role="button"
           >
             <span
               class="buttons"
@@ -572,6 +579,7 @@ exports[`Render different kind of data with edit button 1`] = `
           </div>
           <div
             class="item active"
+            role="button"
           >
             <span
               class="buttons"
@@ -632,6 +640,7 @@ exports[`Render different kind of data with edit button 1`] = `
         >
           <div
             class="item active"
+            role="button"
           >
             <span
               class="buttons"
@@ -692,6 +701,7 @@ exports[`Render different kind of data with edit button 1`] = `
           </div>
           <div
             class="item"
+            role="button"
           >
             <span
               class="buttons"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/__snapshots__/TreeTableAdapter.test.js.snap
@@ -146,7 +146,9 @@ exports[`Render data with schema 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Test2
@@ -167,7 +169,9 @@ exports[`Render data with schema 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Test3
@@ -227,7 +231,9 @@ exports[`Render data with schema and selections 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Test2
@@ -248,7 +254,9 @@ exports[`Render data with schema and selections 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Test3
@@ -324,7 +332,9 @@ exports[`Render data with two columns 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Test2
@@ -354,7 +364,9 @@ exports[`Render data with two columns 1`] = `
             >
               <span
                 aria-label="su-angle-right"
-                class="su-angle-right"
+                class="su-angle-right clickable"
+                role="button"
+                tabindex="0"
               />
             </span>
             Test3

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -57,6 +57,7 @@ exports[`Should render navigation 1`] = `
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-options"
@@ -69,6 +70,7 @@ exports[`Should render navigation 1`] = `
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-article"
@@ -77,10 +79,11 @@ exports[`Should render navigation 1`] = `
       </div>
     </div>
     <div
-      class="item active hasChildren"
+      class="item active"
     >
       <div
         class="title"
+        role="button"
       >
         <span
           aria-label="su-options"
@@ -93,6 +96,7 @@ exports[`Should render navigation 1`] = `
         >
           <div
             class="title"
+            role="button"
           />
         </div>
         <div
@@ -100,6 +104,7 @@ exports[`Should render navigation 1`] = `
         >
           <div
             class="title"
+            role="button"
           />
         </div>
       </div>

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
@@ -104,6 +104,7 @@ exports[`Render WebspaceOverview 1`] = `
             >
               <div
                 class="item"
+                role="button"
               >
                 <span
                   class="buttons"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a few `role="button"` attributes to make navigating without the mouse easier, since these elements are now recognized as button by external tools as well.

#### Why?

The Vimium Plugin in Chrome didn't recognize some of the clickable areas as clickable. There is still more to do, but what is fixed here are the most common action.