### PR TITLE
Remember active Page in WebspaceOverview

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -179,7 +179,7 @@ export default class Datagrid extends React.Component<Props> {
                 </div>
                 <div className={datagridStyles.datagrid}>
                     <Adapter
-                        active={store.active}
+                        active={store.active.get()}
                         activeItems={store.activeItems}
                         data={store.data}
                         disabledIds={disabledIds}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/README.md
@@ -54,14 +54,14 @@ The `LoadingStrategy` is only responsible for loading the data from the server. 
 following interface:
 
 ```javascript static
-load(resourceKey: string, options: LoadOptions, parent: ?string | number)
+load(resourceKey: string, options: LoadOptions, parentId: ?string | number)
 ```
 
 The `LoadingStrategy` has a reference to the `StructureStrategy`, and therefore can use its methods like `clear` and
 `addItem` to alter its data. The `resourceKey` defines for which entity the data is loaded, and is required because
 the `LoadingStrategies` make use of the [`ResourceRequester` service](#resourcerequester). The `options` can contain
 more parameters being added to the URL the request will be sent to, e.g. the currently active element will be added as
-`parent` automatically. Finally the optional `parent` paramter will be passed if a nested hierarchy is supported by
+`parentId` automatically. Finally the optional `parentId` parameter will be passed if a nested hierarchy is supported by
 the underlying `StructureStrategy`.
 
 Sulu is delivered with a few `LoadingStrategy` implementations:
@@ -86,8 +86,8 @@ the first level describes the columns and the second level describes the items.
 The `StructureStrategy`'s most important property is the `data` property, which returns the underlying data.
 
 Furthermore the `StructureStrategy` has to define a parameterless `clear` method, which will be called e.g. when the
-adapter is changed and has to remove all items. It can also receive an argument describing its parent, which should
-make the `StructureStrategy` only remove items being children from this parent.
+adapter is changed and has to remove all items. It can also receive an argument describing the id of its parent, which
+should make the `StructureStrategy` only remove items being children from this parent.
 
 In order to add items to the `StructureStrategy` there is a `addItem` method, which takes the item itself, and its
 parent. This method can add an envelope around the actual item before adding it to the data property if necessary.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/AbstractLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/AbstractLoadingStrategy.js
@@ -1,8 +1,12 @@
 // @flow
-import type {LoadingStrategyInterface, LoadOptions, ItemEnhancer} from '../types';
+import type {LoadingStrategyInterface, LoadOptions, ItemEnhancer, StructureStrategyInterface} from '../types';
 
 export default class AbstractLoadingStrategy implements LoadingStrategyInterface {
-    paginationAdapter = undefined;
+    structureStrategy: StructureStrategyInterface;
+
+    setStructureStrategy(structureStrategy: StructureStrategyInterface) {
+        this.structureStrategy = structureStrategy;
+    }
 
     // eslint-disable-next-line no-unused-vars
     load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer): Promise<Object> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/AbstractLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/AbstractLoadingStrategy.js
@@ -1,5 +1,5 @@
 // @flow
-import type {LoadingStrategyInterface, LoadOptions, ItemEnhancer, StructureStrategyInterface} from '../types';
+import type {LoadingStrategyInterface, LoadOptions, StructureStrategyInterface} from '../types';
 
 export default class AbstractLoadingStrategy implements LoadingStrategyInterface {
     structureStrategy: StructureStrategyInterface;
@@ -9,7 +9,7 @@ export default class AbstractLoadingStrategy implements LoadingStrategyInterface
     }
 
     // eslint-disable-next-line no-unused-vars
-    load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer): Promise<Object> {
+    load(resourceKey: string, options: LoadOptions): Promise<Object> {
         throw new Error('Not implemented');
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/FullLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/FullLoadingStrategy.js
@@ -1,17 +1,16 @@
 // @flow
 import {action} from 'mobx';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {ItemEnhancer, LoadOptions} from '../types';
+import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 
 export default class FullLoadingStrategy extends AbstractLoadingStrategy {
-    load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer) {
+    load(resourceKey: string, options: LoadOptions, parent: ?string | number) {
         return ResourceRequester
             .getList(resourceKey, {...options, page: undefined, limit: undefined}).then(action((response) => {
                 const responseData = response._embedded[resourceKey];
-                data.splice(0, data.length);
-                data.push(...responseData.map(enhanceItem));
-
+                this.structureStrategy.clear(parent);
+                responseData.forEach((item) => this.structureStrategy.addItem(item, parent));
                 return response;
             }));
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/FullLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/FullLoadingStrategy.js
@@ -5,12 +5,12 @@ import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 
 export default class FullLoadingStrategy extends AbstractLoadingStrategy {
-    load(resourceKey: string, options: LoadOptions, parent: ?string | number) {
+    load(resourceKey: string, options: LoadOptions, parentId: ?string | number) {
         return ResourceRequester
             .getList(resourceKey, {...options, page: undefined, limit: undefined}).then(action((response) => {
                 const responseData = response._embedded[resourceKey];
-                this.structureStrategy.clear(parent);
-                responseData.forEach((item) => this.structureStrategy.addItem(item, parent));
+                this.structureStrategy.clear(parentId);
+                responseData.forEach((item) => this.structureStrategy.addItem(item, parentId));
                 return response;
             }));
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/InfiniteLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/InfiniteLoadingStrategy.js
@@ -1,14 +1,14 @@
 // @flow
 import {action} from 'mobx';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {ItemEnhancer, LoadOptions} from '../types';
+import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 
 export default class InfiniteLoadingStrategy extends AbstractLoadingStrategy {
-    load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer) {
+    load(resourceKey: string, options: LoadOptions, parent: ?string | number) {
         return ResourceRequester.getList(resourceKey, {...options, limit: 50}).then(action((response) => {
             const responseData = response._embedded[resourceKey];
-            data.push(...responseData.map(enhanceItem));
+            responseData.forEach((item) => this.structureStrategy.addItem(item, parent));
 
             return response;
         }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/InfiniteLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/InfiniteLoadingStrategy.js
@@ -5,10 +5,10 @@ import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 
 export default class InfiniteLoadingStrategy extends AbstractLoadingStrategy {
-    load(resourceKey: string, options: LoadOptions, parent: ?string | number) {
+    load(resourceKey: string, options: LoadOptions, parentId: ?string | number) {
         return ResourceRequester.getList(resourceKey, {...options, limit: 50}).then(action((response) => {
             const responseData = response._embedded[resourceKey];
-            responseData.forEach((item) => this.structureStrategy.addItem(item, parent));
+            responseData.forEach((item) => this.structureStrategy.addItem(item, parentId));
 
             return response;
         }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/PaginatedLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/PaginatedLoadingStrategy.js
@@ -5,11 +5,11 @@ import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 
 export default class PaginatedLoadingStrategy extends AbstractLoadingStrategy {
-    load(resourceKey: string, options: LoadOptions, parent: ?string | number) {
+    load(resourceKey: string, options: LoadOptions, parentId: ?string | number) {
         return ResourceRequester.getList(resourceKey, {...options, limit: 10}).then(action((response) => {
             const responseData = response._embedded[resourceKey];
-            this.structureStrategy.clear(parent);
-            responseData.forEach((item) => this.structureStrategy.addItem(item, parent));
+            this.structureStrategy.clear(parentId);
+            responseData.forEach((item) => this.structureStrategy.addItem(item, parentId));
 
             return response;
         }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/PaginatedLoadingStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/loadingStrategies/PaginatedLoadingStrategy.js
@@ -1,15 +1,15 @@
 // @flow
 import {action} from 'mobx';
 import ResourceRequester from '../../../services/ResourceRequester';
-import type {ItemEnhancer, LoadOptions} from '../types';
+import type {LoadOptions} from '../types';
 import AbstractLoadingStrategy from './AbstractLoadingStrategy';
 
 export default class PaginatedLoadingStrategy extends AbstractLoadingStrategy {
-    load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer) {
+    load(resourceKey: string, options: LoadOptions, parent: ?string | number) {
         return ResourceRequester.getList(resourceKey, {...options, limit: 10}).then(action((response) => {
             const responseData = response._embedded[resourceKey];
-            data.splice(0, data.length);
-            data.push(...responseData.map(enhanceItem));
+            this.structureStrategy.clear(parent);
+            responseData.forEach((item) => this.structureStrategy.addItem(item, parent));
 
             return response;
         }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -104,6 +104,7 @@ export default class DatagridStore {
         }
 
         if (this.structureStrategy) {
+            loadingStrategy.setStructureStrategy(this.structureStrategy);
             this.structureStrategy.clear();
         }
 
@@ -113,6 +114,10 @@ export default class DatagridStore {
     @action updateStructureStrategy = (structureStrategy: StructureStrategyInterface) => {
         if (this.structureStrategy === structureStrategy) {
             return;
+        }
+
+        if (this.loadingStrategy) {
+            this.loadingStrategy.setStructureStrategy(structureStrategy);
         }
 
         this.structureStrategy = structureStrategy;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -200,14 +200,15 @@ export default class DatagridStore {
 
         this.setDataLoading(true);
 
-        const data = this.structureStrategy.getData(this.active.get());
-        if (!data) {
+        const active = this.active.get();
+        if (active && !this.structureStrategy.findById(active)) {
+            // TODO reset datagrid completely and reload with new active item
             throw new Error('The active item does not exist in the Datagrid');
         }
 
         const options = {...observableOptions, ...this.options};
-        if (this.active.get()) {
-            options.parentId = this.active.get();
+        if (active) {
+            options.parentId = active;
         }
 
         options.sortBy = this.sortColumn.get();
@@ -219,12 +220,7 @@ export default class DatagridStore {
 
         log.info('Datagrid loads "' + this.resourceKey + '" data with the following options:', options);
 
-        this.loadingStrategy.load(
-            data,
-            this.resourceKey,
-            options,
-            this.structureStrategy.enhanceItem
-        ).then(action((response) => {
+        this.loadingStrategy.load(this.resourceKey, options, active).then(action((response) => {
             this.handleResponse(response);
         }));
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -14,13 +14,13 @@ import metadataStore from './MetadataStore';
 
 export default class DatagridStore {
     @observable pageCount: number = 0;
-    @observable active: ?string | number = undefined;
     @observable selections: Array<Object> = [];
     @observable dataLoading: boolean = true;
     @observable schemaLoading: boolean = true;
     @observable loadingStrategy: LoadingStrategyInterface;
     @observable structureStrategy: StructureStrategyInterface;
     @observable options: Object;
+    active: IObservableValue<?string | number> = observable.box();
     sortColumn: IObservableValue<string> = observable.box();
     sortOrder: IObservableValue<SortOrder> = observable.box();
     searchTerm: IObservableValue<?string> = observable.box();
@@ -195,14 +195,14 @@ export default class DatagridStore {
 
         this.setDataLoading(true);
 
-        const data = this.structureStrategy.getData(this.active);
+        const data = this.structureStrategy.getData(this.active.get());
         if (!data) {
             throw new Error('The active item does not exist in the Datagrid');
         }
 
         const options = {...observableOptions, ...this.options};
-        if (this.active) {
-            options.parentId = this.active;
+        if (this.active.get()) {
+            options.parentId = this.active.get();
         }
 
         options.sortBy = this.sortColumn.get();
@@ -242,7 +242,7 @@ export default class DatagridStore {
     }
 
     @action setActive(active: ?string | number) {
-        this.active = active;
+        this.active.set(active);
     }
 
     @action activate(id: ?string | number) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/ColumnStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/ColumnStructureStrategy.js
@@ -98,7 +98,7 @@ export default class ColumnStructureStrategy implements StructureStrategyInterfa
         const resourceKey = Object.keys(item._embedded)[0];
         const childItems = item._embedded[resourceKey];
 
-        if (childItems.length > 0 && !this.rawData.has(item.id)) {
+        if (Array.isArray(childItems) && !this.rawData.has(item.id)) {
             this.rawData.set(item.id, []);
             childItems.forEach((childItem) => {
                 this.addItem(childItem, item.id);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/ColumnStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/ColumnStructureStrategy.js
@@ -2,8 +2,8 @@
 import {action, computed, observable} from 'mobx';
 import type {ColumnItem, StructureStrategyInterface} from '../types';
 
-function removeColumnsAfterIndex(parents, columnIndex: number, rawData) {
-    parents.filter((parent, index) => index > columnIndex).forEach((parent) => rawData.delete(parent));
+function removeColumnsAfterIndex(parentIds, columnIndex: number, rawData) {
+    parentIds.filter((parentId, index) => index > columnIndex).forEach((parentId) => rawData.delete(parentId));
 }
 
 export default class ColumnStructureStrategy implements StructureStrategyInterface {
@@ -74,19 +74,19 @@ export default class ColumnStructureStrategy implements StructureStrategyInterfa
         }
     }
 
-    @action clear(parent: ?string | number) {
-        removeColumnsAfterIndex(this.activeItems, this.activeItems.indexOf(parent), this.rawData);
-        const column = this.rawData.get(parent);
+    @action clear(parentId: ?string | number) {
+        removeColumnsAfterIndex(this.activeItems, this.activeItems.indexOf(parentId), this.rawData);
+        const column = this.rawData.get(parentId);
         if (column && column.length > 0) {
             column.splice(0, column.length);
         }
     }
 
-    addItem(item: Object, parent: ?string | number) {
-        let column = this.rawData.get(parent);
+    addItem(item: Object, parentId: ?string | number) {
+        let column = this.rawData.get(parentId);
         if (!column) {
             column = [];
-            this.rawData.set(parent, column);
+            this.rawData.set(parentId, column);
         }
 
         column.push(item);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
@@ -13,9 +13,11 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         this.data = [];
     }
 
-    @action clear(parent: ?string | number) {
-        if (parent !== undefined) {
-            throw new Error('This StructureStrategy does not support nesting, therefore the parent should not be set');
+    @action clear(parentId: ?string | number) {
+        if (parentId !== undefined) {
+            throw new Error(
+                'This StructureStrategy does not support nesting, therefore the parentId should not be set'
+            );
         }
 
         this.data.splice(0, this.data.length);
@@ -30,9 +32,11 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         return this.data.find((item) => item.id === identifier);
     }
 
-    addItem(item: Object, parent: ?string | number): void {
-        if (parent !== undefined) {
-            throw new Error('This StructureStrategy does not support nesting, therefore the parent should not be set');
+    addItem(item: Object, parentId: ?string | number): void {
+        if (parentId !== undefined) {
+            throw new Error(
+                'This StructureStrategy does not support nesting, therefore the parentId should not be set'
+            );
         }
 
         this.data.push(item);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/FlatStructureStrategy.js
@@ -13,11 +13,11 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         this.data = [];
     }
 
-    getData() {
-        return this.data;
-    }
+    @action clear(parent: ?string | number) {
+        if (parent !== undefined) {
+            throw new Error('This StructureStrategy does not support nesting, therefore the parent should not be set');
+        }
 
-    @action clear() {
         this.data.splice(0, this.data.length);
     }
 
@@ -30,7 +30,11 @@ export default class FlatStructureStrategy implements StructureStrategyInterface
         return this.data.find((item) => item.id === identifier);
     }
 
-    enhanceItem(item: Object): Object {
-        return item;
+    addItem(item: Object, parent: ?string | number): void {
+        if (parent !== undefined) {
+            throw new Error('This StructureStrategy does not support nesting, therefore the parent should not be set');
+        }
+
+        this.data.push(item);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
@@ -45,19 +45,19 @@ function removeRecursive(items: Array<TreeItem>, identifier: string | number): b
     return false;
 }
 
-function findChildrenForParentId(tree: Array<TreeItem>, parent: ?string | number): ?Array<TreeItem> {
-    if (parent === undefined) {
+function findChildrenForParentId(tree: Array<TreeItem>, parentId: ?string | number): ?Array<TreeItem> {
+    if (parentId === undefined) {
         return tree;
     }
 
     for (let i = 0; i < tree.length; i++) {
         const item = tree[i];
         const {data, children} = item;
-        if (parent === data.id) {
+        if (parentId === data.id) {
             return children;
         }
 
-        const childResult = findChildrenForParentId(children, parent);
+        const childResult = findChildrenForParentId(children, parentId);
         if (childResult) {
             return childResult;
         }
@@ -86,11 +86,11 @@ export default class TreeStructureStrategy implements StructureStrategyInterface
         }
     }
 
-    addItem(item: Object, parent: ?string | number): void {
-        const children = findChildrenForParentId(this.data, parent);
+    addItem(item: Object, parentId: ?string | number): void {
+        const children = findChildrenForParentId(this.data, parentId);
 
         if (!children) {
-            throw new Error('Cannot add items to non-existing parent "' + (parent ? parent : 'undefined') + '"!');
+            throw new Error('Cannot add items to non-existing parentId "' + (parentId ? parentId : 'undefined') + '"!');
         }
 
         children.push({
@@ -107,8 +107,8 @@ export default class TreeStructureStrategy implements StructureStrategyInterface
         }
     }
 
-    @action clear(parent: ?string | number) {
-        const children = findChildrenForParentId(this.data, parent);
+    @action clear(parentId: ?string | number) {
+        const children = findChildrenForParentId(this.data, parentId);
         if (!children || children.length === 0) {
             return;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/AdapterSwitch.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/AdapterSwitch.test.js
@@ -23,10 +23,9 @@ class StructureStrategy {
     data: Array<Object>;
     visibleItems: Array<Object>;
 
+    addItem = jest.fn();
     clear = jest.fn();
-    getData = jest.fn();
     findById = jest.fn();
-    enhanceItem = jest.fn();
     remove = jest.fn();
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/AdapterSwitch.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/AdapterSwitch.test.js
@@ -12,10 +12,11 @@ jest.mock('../registries/DatagridAdapterRegistry', () => ({
 }));
 
 class LoadingStrategy {
-    load = jest.fn();
     destroy = jest.fn();
     initialize = jest.fn();
+    load = jest.fn();
     reset = jest.fn();
+    setStructureStrategy = jest.fn();
 }
 
 class StructureStrategy {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -84,10 +84,11 @@ jest.mock('../../../utils/Translator', () => ({
 }));
 
 class LoadingStrategy {
-    load = jest.fn();
     destroy = jest.fn();
     initialize = jest.fn();
+    load = jest.fn();
     reset = jest.fn();
+    setStructureStrategy = jest.fn();
 }
 
 class StructureStrategy {
@@ -332,11 +333,11 @@ test('DatagridStore should be initialized correctly on init and update', () => {
 test('DatagridStore should be updated with current active element', () => {
     datagridAdapterRegistry.get.mockReturnValue(class TestAdapter extends AbstractAdapter {
         static LoadingStrategy = class {
-            paginationAdapter = undefined;
-            load = jest.fn();
             destroy = jest.fn();
             initialize = jest.fn();
+            load = jest.fn();
             reset = jest.fn();
+            setStructureStrategy = jest.fn();
         };
 
         static StructureStrategy = class {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -18,6 +18,9 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function() {
     this.setActive = jest.fn();
     this.activeItems = [];
     this.activate = jest.fn();
+    this.active = {
+        get: jest.fn(),
+    };
     this.deactivate = jest.fn();
     this.delete = jest.fn();
     this.sort = jest.fn();
@@ -130,7 +133,7 @@ test('Render TableAdapter with correct values', () => {
     ];
 
     const datagridStore = new DatagridStore('test', {page: observable.box(1)});
-    datagridStore.active = 3;
+    datagridStore.active.get.mockReturnValue(3);
     datagridStore.selectionIds.push(1, 3);
     const editClickSpy = jest.fn();
 
@@ -362,7 +365,7 @@ test('DatagridStore should be updated with current active element', () => {
         }
     });
     const datagridStore = new DatagridStore('test', {page: observable.box(1)});
-    expect(datagridStore.active).toBe(undefined);
+    expect(datagridStore.active.get()).toBe(undefined);
     mount(<Datagrid adapters={['test']} store={datagridStore} />);
 
     expect(datagridStore.activate).toBeCalledWith('some-uuid');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -95,10 +95,9 @@ class StructureStrategy {
     data: Array<Object>;
     visibleItems: Array<Object>;
 
+    addItem = jest.fn();
     clear = jest.fn();
-    getData = jest.fn();
     findById = jest.fn();
-    enhanceItem = jest.fn();
     remove = jest.fn();
 }
 
@@ -343,10 +342,9 @@ test('DatagridStore should be updated with current active element', () => {
         static StructureStrategy = class {
             data = [];
             visibleItems = [];
+            addItem = jest.fn();
             clear = jest.fn();
-            getData = jest.fn();
             findById = jest.fn();
-            enhanceItem = jest.fn();
             remove = jest.fn();
         };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/FullLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/FullLoadingStrategy.test.js
@@ -67,19 +67,19 @@ test('Should load items and replace existing entries in array', () => {
     });
 
     ResourceRequester.getList.mockReturnValue(promise);
-    const parent = 15;
+    const parentId = 15;
     fullLoadingStrategy.load(
         'snippets',
         {
             locale: 'en',
         },
-        parent
+        parentId
     );
 
     return promise.then(() => {
-        expect(structureStrategy.clear).toBeCalledWith(parent);
-        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parent);
-        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parent);
+        expect(structureStrategy.clear).toBeCalledWith(parentId);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parentId);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parentId);
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
@@ -69,20 +69,20 @@ test('Should load items and add to existing entries in array', () => {
     });
 
     ResourceRequester.getList.mockReturnValue(promise);
-    const parent = 17;
+    const parentId = 17;
     infiniteLoadingStrategy.load(
         'snippets',
         {
             page: 1,
             locale: 'en',
         },
-        parent
+        parentId
     );
 
     return promise.then(() => {
         expect(structureStrategy.clear).not.toBeCalled();
-        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parent);
-        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parent);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parentId);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parentId);
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/InfiniteLoadingStrategy.test.js
@@ -15,10 +15,19 @@ jest.mock('../../../Datagrid/stores/MetadataStore', () => ({
     getSchema: jest.fn().mockReturnValue(Promise.resolve()),
 }));
 
+class StructureStrategy {
+    addItem = jest.fn();
+    clear = jest.fn();
+    data = [];
+    findById = jest.fn();
+    remove = jest.fn();
+    visibleItems = [];
+}
+
 test('Should load items and add to empty array', () => {
     const infiniteLoadingStrategy = new InfiniteLoadingStrategy();
-    const enhanceItem = jest.fn((item) => item);
-    const data = [];
+    const structureStrategy = new StructureStrategy();
+    infiniteLoadingStrategy.setStructureStrategy(structureStrategy);
 
     const promise = Promise.resolve({
         _embedded: {
@@ -31,29 +40,24 @@ test('Should load items and add to empty array', () => {
 
     ResourceRequester.getList.mockReturnValue(promise);
     infiniteLoadingStrategy.load(
-        data,
         'snippets',
         {
             page: 2,
         },
-        enhanceItem
+        undefined
     );
 
     return promise.then(() => {
-        expect(data).toEqual([
-            {id: 1},
-            {id: 2},
-        ]);
+        expect(structureStrategy.clear).not.toBeCalled();
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, undefined);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, undefined);
     });
 });
 
 test('Should load items and add to existing entries in array', () => {
     const infiniteLoadingStrategy = new InfiniteLoadingStrategy();
-    const enhanceItem = jest.fn((item) => item);
-    const data = [
-        {id: 3},
-        {id: 5},
-    ];
+    const structureStrategy = new StructureStrategy();
+    infiniteLoadingStrategy.setStructureStrategy(structureStrategy);
 
     const promise = Promise.resolve({
         _embedded: {
@@ -65,42 +69,35 @@ test('Should load items and add to existing entries in array', () => {
     });
 
     ResourceRequester.getList.mockReturnValue(promise);
+    const parent = 17;
     infiniteLoadingStrategy.load(
-        data,
         'snippets',
         {
             page: 1,
             locale: 'en',
         },
-        enhanceItem
+        parent
     );
 
     return promise.then(() => {
-        expect(enhanceItem.mock.calls[0][0]).toEqual({id: 1});
-        expect(enhanceItem.mock.calls[1][0]).toEqual({id: 2});
-
-        expect(data).toEqual([
-            {id: 3},
-            {id: 5},
-            {id: 1},
-            {id: 2},
-        ]);
+        expect(structureStrategy.clear).not.toBeCalled();
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parent);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parent);
     });
 });
 
 test('Should load items with correct options', () => {
     const infiniteLoadingStrategy = new InfiniteLoadingStrategy();
-    const enhanceItem = jest.fn();
-    const data = [];
+    const structureStrategy = new StructureStrategy();
+    infiniteLoadingStrategy.setStructureStrategy(structureStrategy);
 
     infiniteLoadingStrategy.load(
-        data,
         'snippets',
         {
             page: 2,
             locale: 'en',
         },
-        enhanceItem
+        undefined
     );
 
     expect(ResourceRequester.getList).toBeCalledWith('snippets', {limit: 50, page: 2, locale: 'en'});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
@@ -15,10 +15,19 @@ jest.mock('../../../Datagrid/stores/MetadataStore', () => ({
     getSchema: jest.fn().mockReturnValue(Promise.resolve()),
 }));
 
+class StructureStrategy {
+    addItem = jest.fn();
+    clear = jest.fn();
+    data = [];
+    findById = jest.fn();
+    remove = jest.fn();
+    visibleItems = [];
+}
+
 test('Should load items and add to empty array', () => {
     const paginatedLoadingStrategy = new PaginatedLoadingStrategy();
-    const enhanceItem = jest.fn((item) => item);
-    const data = [];
+    const structureStrategy = new StructureStrategy();
+    paginatedLoadingStrategy.setStructureStrategy(structureStrategy);
 
     const promise = Promise.resolve({
         _embedded: {
@@ -31,29 +40,24 @@ test('Should load items and add to empty array', () => {
 
     ResourceRequester.getList.mockReturnValue(promise);
     paginatedLoadingStrategy.load(
-        data,
         'snippets',
         {
             page: 2,
         },
-        enhanceItem
+        undefined
     );
 
     return promise.then(() => {
-        expect(data).toEqual([
-            {id: 1},
-            {id: 2},
-        ]);
+        expect(structureStrategy.clear).toBeCalledWith(undefined);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, undefined);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, undefined);
     });
 });
 
 test('Should load items and replace existing entries in array', () => {
     const paginatedLoadingStrategy = new PaginatedLoadingStrategy();
-    const enhanceItem = jest.fn((item) => item);
-    const data = [
-        {id: 3},
-        {id: 5},
-    ];
+    const structureStrategy = new StructureStrategy();
+    paginatedLoadingStrategy.setStructureStrategy(structureStrategy);
 
     const promise = Promise.resolve({
         _embedded: {
@@ -65,39 +69,35 @@ test('Should load items and replace existing entries in array', () => {
     });
 
     ResourceRequester.getList.mockReturnValue(promise);
+    const parent = 15;
     paginatedLoadingStrategy.load(
-        data,
         'snippets',
         {
             page: 1,
             locale: 'en',
         },
-        enhanceItem
+        parent
     );
 
     return promise.then(() => {
-        expect(enhanceItem.mock.calls[0][0]).toEqual({id: 1});
-        expect(enhanceItem.mock.calls[1][0]).toEqual({id: 2});
-
-        expect(data).toEqual([
-            {id: 1},
-            {id: 2},
-        ]);
+        expect(structureStrategy.clear).toBeCalledWith(parent);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parent);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parent);
     });
 });
 
 test('Should load items with correct options', () => {
     const paginatedLoadingStrategy = new PaginatedLoadingStrategy();
-    const enhanceItem = jest.fn();
-    const data = [];
+    const structureStrategy = new StructureStrategy();
+    paginatedLoadingStrategy.setStructureStrategy(structureStrategy);
 
     paginatedLoadingStrategy.load(
-        data, 'snippets',
+        'snippets',
         {
             page: 2,
             locale: 'en',
         },
-        enhanceItem
+        undefined
     );
 
     expect(ResourceRequester.getList).toBeCalledWith('snippets', {limit: 10, page: 2, locale: 'en'});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/loadingStrategies/PaginatedLoadingStrategy.test.js
@@ -69,20 +69,20 @@ test('Should load items and replace existing entries in array', () => {
     });
 
     ResourceRequester.getList.mockReturnValue(promise);
-    const parent = 15;
+    const parentId = 15;
     paginatedLoadingStrategy.load(
         'snippets',
         {
             page: 1,
             locale: 'en',
         },
-        parent
+        parentId
     );
 
     return promise.then(() => {
-        expect(structureStrategy.clear).toBeCalledWith(parent);
-        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parent);
-        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parent);
+        expect(structureStrategy.clear).toBeCalledWith(parentId);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 1}, parentId);
+        expect(structureStrategy.addItem).toBeCalledWith({id: 2}, parentId);
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/registries/DatagridAdapterRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/registries/DatagridAdapterRegistry.test.js
@@ -19,10 +19,9 @@ class StructureStrategy {
     data: Array<Object>;
     visibleItems: Array<Object>;
 
+    addItem = jest.fn();
     clear = jest.fn();
-    getData = jest.fn();
     findById = jest.fn();
-    enhanceItem = jest.fn();
     remove = jest.fn();
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/registries/DatagridAdapterRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/registries/DatagridAdapterRegistry.test.js
@@ -8,10 +8,11 @@ beforeEach(() => {
 });
 
 class LoadingStrategy {
-    load = jest.fn();
     destroy = jest.fn();
     initialize = jest.fn();
+    load = jest.fn();
     reset = jest.fn();
+    setStructureStrategy = jest.fn();
 }
 
 class StructureStrategy {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -538,7 +538,7 @@ test('Should reset the data array and set page to 1 when the reload method is ca
 
             datagridStore.reload();
             expect(structureStrategy.clear).toBeCalled();
-            expect(datagridStore.active).toBe(undefined);
+            expect(datagridStore.active.get()).toBe(undefined);
 
             expect(page.get()).toBe(1);
             expect(loadingStrategy.load).toBeCalled();
@@ -787,7 +787,7 @@ test('Should trigger a mobx autorun if activate is called with the same id', () 
 
     let lastActive;
     const autorunDisposer = autorun(() => {
-        lastActive = datagridStore.active;
+        lastActive = datagridStore.active.get();
     });
     lastActive = undefined;
     datagridStore.activate(3);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -14,14 +14,16 @@ jest.mock('../../../../services/ResourceRequester', () => ({
 }));
 
 function LoadingStrategy() {
-    this.load = jest.fn().mockReturnValue({then: jest.fn()});
-    this.initialize = jest.fn();
-    this.reset = jest.fn();
     this.destroy = jest.fn();
+    this.initialize = jest.fn();
+    this.load = jest.fn().mockReturnValue({then: jest.fn()});
+    this.reset = jest.fn();
+    this.setStructureStrategy = jest.fn();
 }
 
 function OtherLoadingStrategy() {
     this.load = jest.fn().mockReturnValue({then: jest.fn()});
+    this.setStructureStrategy = jest.fn();
 }
 
 class StructureStrategy {
@@ -34,6 +36,15 @@ class StructureStrategy {
     deactivate = jest.fn();
     remove = jest.fn();
 }
+
+test('The loading strategy should get passed the structure strategy', () => {
+    const loadingStrategy = new LoadingStrategy();
+    const structureStrategy = new StructureStrategy();
+
+    const datagridStore = new DatagridStore('tests', {});
+    datagridStore.updateStrategies(loadingStrategy, structureStrategy);
+    expect(loadingStrategy.setStructureStrategy).toBeCalledWith(structureStrategy);
+});
 
 test('The loading strategy should be called when a request is sent', () => {
     const loadingStrategy = new LoadingStrategy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -28,13 +28,13 @@ function OtherLoadingStrategy() {
 
 class StructureStrategy {
     @observable data = [];
+    addItem = jest.fn();
     clear = jest.fn();
     activeItems = [];
-    getData = jest.fn().mockReturnValue(this.data);
-    enhanceItem = jest.fn((item) => item);
     activate = jest.fn();
     deactivate = jest.fn();
     remove = jest.fn();
+    findById = jest.fn();
 }
 
 test('The loading strategy should get passed the structure strategy', () => {
@@ -64,11 +64,9 @@ test('The loading strategy should be called when a request is sent', () => {
         }
     );
 
-    structureStrategy.getData.mockReturnValue([]);
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     expect(loadingStrategy.load).toBeCalledWith(
-        toJS(datagridStore.data),
         'tests',
         {
             additionalValue: 5,
@@ -76,7 +74,7 @@ test('The loading strategy should be called when a request is sent', () => {
             page: 1,
             test: 'value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     datagridStore.destroy();
@@ -98,19 +96,16 @@ test('The loading strategy should be called with a different resourceKey when a 
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             locale: undefined,
             page: 1,
             test: 'value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     datagridStore.destroy();
@@ -132,31 +127,27 @@ test('The loading strategy should be called with a different page when a request
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             locale: undefined,
             page: 1,
             test: 'value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     page.set(3);
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             locale: undefined,
             page: 3,
             test: 'value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     datagridStore.destroy();
@@ -178,30 +169,27 @@ test('The loading strategy should be called with a different locale when a reque
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     expect(loadingStrategy.load).toBeCalledWith(
-        data, 'snippets',
+        'snippets',
         {
             locale: 'en',
             page: 1,
             test: 'value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     locale.set('de');
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             locale: 'de',
             page: 1,
             test: 'value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     datagridStore.destroy();
@@ -218,20 +206,17 @@ test('The loading strategy should be called with the defined sortings', () => {
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
     datagridStore.sort('title', 'desc');
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             page: 1,
             sortBy: 'title',
             sortOrder: 'desc',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     datagridStore.destroy();
@@ -248,21 +233,18 @@ test('The loading strategy should be called with the defined search', () => {
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
     structureStrategy.clear = jest.fn();
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     datagridStore.search('search-value');
 
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             page: 1,
             search: 'search-value',
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     expect(structureStrategy.clear).toBeCalled();
@@ -281,19 +263,18 @@ test('The loading strategy should be called with the active item as parentId', (
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
-    datagridStore.updateStrategies(loadingStrategy, structureStrategy);
+    structureStrategy.findById.mockReturnValue({});
     datagridStore.setActive('some-uuid');
+    datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
+    expect(structureStrategy.findById).toBeCalledWith('some-uuid');
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             page: 1,
             parentId: 'some-uuid',
         },
-        structureStrategy.enhanceItem
+        'some-uuid'
     );
 
     datagridStore.destroy();
@@ -313,18 +294,15 @@ test('The active item should not be passed as parent if undefined', () => {
         }
     );
 
-    const data = [{id: 1}];
-    structureStrategy.getData.mockReturnValue(data);
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     expect(loadingStrategy.load).toBeCalledWith(
-        data,
         'snippets',
         {
             page: 1,
             parent: 9,
         },
-        structureStrategy.enhanceItem
+        undefined
     );
 
     datagridStore.destroy();
@@ -540,7 +518,9 @@ test('Should reset the data array and set page to 1 when the reload method is ca
 
     locale.set('en');
     page.set(3);
+    structureStrategy.findById.mockReturnValue({});
     datagridStore.setActive(1);
+    expect(structureStrategy.findById).toBeCalledWith(1);
 
     when(
         () => !datagridStore.loading,
@@ -793,6 +773,8 @@ test('Should trigger a mobx autorun if activate is called with the same id', () 
     const datagridStore = new DatagridStore('snippets', {page});
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();
+    structureStrategy.findById.mockReturnValue({});
+
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
     datagridStore.activate(3);
 
@@ -813,6 +795,7 @@ test('Should call the activate method of the structure strategy if an item gets 
 
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();
+    structureStrategy.findById.mockReturnValue({});
     datagridStore.updateStrategies(loadingStrategy, structureStrategy);
 
     datagridStore.activate(3);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/ColumnStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/ColumnStructureStrategy.test.js
@@ -153,10 +153,18 @@ test('Should add the items in a recursive way', () => {
 test('Should add the items in a recursive way with a different resourceKey', () => {
     const columnStructureStrategy = new ColumnStructureStrategy();
 
-    const child2 = {id: 5, hasChildren: false};
+    const child2 = {id: 5,
+        hasChildren: false,
+        _embedded: {
+            categories: [],
+        },
+    };
     const child3 = {
         id: 2,
         hasChildren: true,
+        _embedded: {
+            categories: null,
+        },
     };
 
     const child1 = {
@@ -174,6 +182,7 @@ test('Should add the items in a recursive way with a different resourceKey', () 
     expect(columnStructureStrategy.data).toEqual([
         [child1],
         [child2, child3],
+        [],
     ]);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/FlatStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/FlatStructureStrategy.test.js
@@ -7,12 +7,6 @@ test('Should be empty after intialization', () => {
     expect(toJS(flatStructureStrategy.data)).toEqual([]);
 });
 
-test('Should return the array on a getData call', () => {
-    const flatStructureStrategy = new FlatStructureStrategy();
-    flatStructureStrategy.data = [{id: 1}];
-    expect(flatStructureStrategy.getData()).toBe(flatStructureStrategy.data);
-});
-
 test('Should be empty after clear was called', () => {
     const flatStructureStrategy = new FlatStructureStrategy();
     flatStructureStrategy.data = [{id: 1}];
@@ -21,9 +15,14 @@ test('Should be empty after clear was called', () => {
     expect(toJS(flatStructureStrategy.data)).toEqual([]);
 });
 
-test('Should not enhance the items', () => {
+test('Should add an item to the structure', () => {
     const flatStructureStrategy = new FlatStructureStrategy();
-    expect(flatStructureStrategy.enhanceItem({id: 1})).toEqual({id: 1});
+    flatStructureStrategy.addItem({id: 1});
+    flatStructureStrategy.addItem({id: 2});
+
+    expect(flatStructureStrategy.data).toHaveLength(2);
+    expect(flatStructureStrategy.data[0]).toEqual({id: 1});
+    expect(flatStructureStrategy.data[1]).toEqual({id: 2});
 });
 
 test('Should return all current items as visible items', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/TreeStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/TreeStructureStrategy.test.js
@@ -79,96 +79,6 @@ test('Should return the visible data as flat list', () => {
     expect(treeStructureStrategy.visibleItems[5].title).toEqual('Test2.2');
 });
 
-test('Should return the correct child array on a getData call', () => {
-    const treeStructureStrategy = new TreeStructureStrategy();
-
-    const test1 = {
-        data: {
-            id: 2,
-            title: 'Test1',
-        },
-        children: [],
-        hasChildren: false,
-    };
-    const test21 = {
-        data: {
-            id: 4,
-            title: 'Test2.1',
-        },
-        children: [],
-        hasChildren: false,
-    };
-    const test22 = {
-        data: {
-            id: 5,
-            title: 'Test2.2',
-        },
-        children: [],
-        hasChildren: false,
-    };
-    const test2 = {
-        data: {
-            id: 3,
-            title: 'Test2',
-        },
-        children: [
-            test21,
-            test22,
-        ],
-        hasChildren: true,
-    };
-    const test31 = {
-        data: {
-            id: 7,
-            title: 'Test3.1',
-        },
-        children: [],
-        hasChildren: false,
-    };
-    const test32 = {
-        data: {
-            id: 8,
-            title: 'Test3.2',
-        },
-        children: [],
-        hasChildren: false,
-    };
-    const test3 = {
-        data: {
-            id: 6,
-            title: 'Test3',
-        },
-        children: [
-            test31,
-            test32,
-        ],
-        hasChildren: true,
-    };
-
-    const data = [
-        {
-            data: {
-                id: 1,
-                title: 'Homepage',
-            },
-            children: [
-                test1,
-                test2,
-                test3,
-            ],
-            hasChildren: true,
-        },
-    ];
-
-    treeStructureStrategy.data = data;
-    expect(toJS(treeStructureStrategy.getData(test1.data.id))).toEqual(test1.children);
-    expect(toJS(treeStructureStrategy.getData(test2.data.id))).toEqual(test2.children);
-    expect(toJS(treeStructureStrategy.getData(test21.data.id))).toEqual(test21.children);
-    expect(toJS(treeStructureStrategy.getData(test31.data.id))).toEqual(test31.children);
-    expect(toJS(treeStructureStrategy.getData(undefined))).toEqual(data);
-    expect(toJS(treeStructureStrategy.getData('test'))).toEqual(undefined);
-});
-
 test('Should be empty after clear was called', () => {
     const treeStructureStrategy = new TreeStructureStrategy();
     treeStructureStrategy.data = [
@@ -185,16 +95,71 @@ test('Should be empty after clear was called', () => {
     expect(toJS(treeStructureStrategy.data.length)).toEqual(0);
 });
 
-test('Should enhance the items with data and children', () => {
+test('Should only clear children under given parent', () => {
     const treeStructureStrategy = new TreeStructureStrategy();
-    expect(treeStructureStrategy.enhanceItem({id: 1, hasChildren: false})).toEqual({
-        data: {
-            id: 1,
+    treeStructureStrategy.data = [
+        {
+            data: {
+                id: 1,
+            },
+            children: [
+                {
+                    data: {
+                        id: 4,
+                    },
+                    children: [],
+                    hasChildren: true,
+                },
+            ],
             hasChildren: false,
         },
-        children: [],
+    ];
+
+    treeStructureStrategy.clear(1);
+    expect(toJS(treeStructureStrategy.data.length)).toEqual(1);
+    expect(toJS(treeStructureStrategy.data[0].children.length)).toEqual(0);
+});
+
+test('Should recursively add the items with data and children', () => {
+    const treeStructureStrategy = new TreeStructureStrategy();
+
+    const child4 = {
+        id: 6,
         hasChildren: false,
-    });
+    };
+    const child2 = {
+        id: 2,
+        hasChildren: false,
+    };
+    const child3 = {
+        id: 3,
+        hasChildren: true,
+        _embedded: {
+            nodes: [
+                child4,
+            ],
+        },
+    };
+    const child1 = {
+        id: 1,
+        hasChildren: true,
+        _embedded: {
+            nodes: [
+                child2,
+                child3,
+            ],
+        },
+    };
+
+    treeStructureStrategy.addItem(child1);
+    expect(treeStructureStrategy.data).toHaveLength(1);
+    expect(treeStructureStrategy.data[0].data.id).toEqual(1);
+    expect(treeStructureStrategy.data[0].children).toHaveLength(2);
+    expect(treeStructureStrategy.data[0].children[0].data.id).toEqual(2);
+    expect(treeStructureStrategy.data[0].children[0].children).toHaveLength(0);
+    expect(treeStructureStrategy.data[0].children[1].data.id).toEqual(3);
+    expect(treeStructureStrategy.data[0].children[1].children).toHaveLength(1);
+    expect(treeStructureStrategy.data[0].children[1].children[0].data.id).toEqual(6);
 });
 
 test('Should find nested items by id or return undefined', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -60,7 +60,7 @@ export type LoadOptions = {
 
 export interface LoadingStrategyInterface {
     constructor(): void,
-    load(resourceKey: string, options: LoadOptions, parent: ?string | number): Promise<Object>,
+    load(resourceKey: string, options: LoadOptions, parentId: ?string | number): Promise<Object>,
     setStructureStrategy(structureStrategy: StructureStrategyInterface): void,
 }
 
@@ -71,10 +71,10 @@ export interface StructureStrategyInterface {
     +activeItems?: Array<*>,
     +activate?: (id: ?string | number) => void,
     +deactivate?: (id: ?string | number) => void,
-    addItem(item: Object, parent: ?string | number): void,
+    addItem(item: Object, parentId: ?string | number): void,
     remove(id: string | number): void,
     findById(identifier: string | number): ?Object,
-    clear(parent: ?string | number): void,
+    clear(parentId: ?string | number): void,
 }
 
 export type TreeItem = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -63,6 +63,7 @@ export type ItemEnhancer = (item: Object) => Object;
 export interface LoadingStrategyInterface {
     constructor(): void,
     load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer): Promise<Object>,
+    setStructureStrategy(structureStrategy: StructureStrategyInterface): void,
 }
 
 export interface StructureStrategyInterface {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -58,11 +58,9 @@ export type LoadOptions = {
     sortOrder?: SortOrder,
 };
 
-export type ItemEnhancer = (item: Object) => Object;
-
 export interface LoadingStrategyInterface {
     constructor(): void,
-    load(data: Array<Object>, resourceKey: string, options: LoadOptions, enhanceItem: ItemEnhancer): Promise<Object>,
+    load(resourceKey: string, options: LoadOptions, parent: ?string | number): Promise<Object>,
     setStructureStrategy(structureStrategy: StructureStrategyInterface): void,
 }
 
@@ -73,11 +71,10 @@ export interface StructureStrategyInterface {
     +activeItems?: Array<*>,
     +activate?: (id: ?string | number) => void,
     +deactivate?: (id: ?string | number) => void,
+    addItem(item: Object, parent: ?string | number): void,
     remove(id: string | number): void,
-    getData(parent: ?string | number): ?Array<*>,
-    enhanceItem(item: Object): Object,
     findById(identifier: string | number): ?Object,
-    clear(): void,
+    clear(parent: ?string | number): void,
 }
 
 export type TreeItem = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -6,7 +6,7 @@ import initializer from '../../services/Initializer';
 import type {Contact, User} from './types';
 
 class UserStore {
-    persistentSettings: {[string]: *} = {};
+    persistentSettings: {[string]: string | number} = {};
 
     @observable user: ?User = undefined;
     @observable contact: ?Contact = undefined;
@@ -120,7 +120,7 @@ class UserStore {
         });
     }
 
-    setPersistentSetting(key: string, value: *) {
+    setPersistentSetting(key: string, value: string | number) {
         this.persistentSettings[key] = value;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -13,8 +13,13 @@ import {translate} from '../../utils/Translator';
 import datagridStyles from './datagrid.scss';
 
 const USER_SETTING_PREFIX = 'sulu_admin.datagrid';
+const USER_SETTING_ACTIVE = 'active';
 const USER_SETTING_SORT_COLUMN = 'sort_column';
 const USER_SETTING_SORT_ORDER = 'sort_order';
+
+function getActiveSettingKey(resourceKey): string {
+    return [USER_SETTING_PREFIX, resourceKey, USER_SETTING_ACTIVE].join('.');
+}
 
 function getSortColumnSettingKey(resourceKey): string {
     return [USER_SETTING_PREFIX, resourceKey, USER_SETTING_SORT_COLUMN].join('.');
@@ -30,6 +35,7 @@ class Datagrid extends React.Component<ViewProps> {
     locale: IObservableValue<string> = observable.box();
     datagridStore: DatagridStore;
     @observable deleting = false;
+    activeDisposer: () => void;
     sortColumnDisposer: () => void;
     sortOrderDisposer: () => void;
 
@@ -41,6 +47,7 @@ class Datagrid extends React.Component<ViewProps> {
         } = route;
 
         return {
+            active: userStore.getPersistentSetting(getActiveSettingKey(resourceKey)),
             sortColumn: userStore.getPersistentSetting(getSortColumnSettingKey(resourceKey)),
             sortOrder: userStore.getPersistentSetting(getSortOrderSettingKey(resourceKey)),
         };
@@ -87,6 +94,7 @@ class Datagrid extends React.Component<ViewProps> {
         router.bind('search', this.datagridStore.searchTerm);
 
         const {
+            active,
             sortColumn,
             sortOrder,
         } = this.datagridStore;
@@ -97,10 +105,19 @@ class Datagrid extends React.Component<ViewProps> {
         this.sortOrderDisposer = autorun(
             () => userStore.setPersistentSetting(getSortOrderSettingKey(resourceKey), sortOrder.get())
         );
+        this.activeDisposer = autorun(
+            () => {
+                const activeValue = active.get();
+                if (activeValue) {
+                    userStore.setPersistentSetting(getActiveSettingKey(resourceKey), activeValue);
+                }
+            }
+        );
     }
 
     componentWillUnmount() {
         this.datagridStore.destroy();
+        this.activeDisposer();
         this.sortColumnDisposer();
         this.sortOrderDisposer();
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -80,6 +80,7 @@ class Datagrid extends React.Component<ViewProps> {
         }
 
         this.datagridStore = new DatagridStore(resourceKey, observableOptions, apiOptions);
+        router.bind('active', this.datagridStore.active);
 
         router.bind('sortColumn', this.datagridStore.sortColumn);
         router.bind('sortOrder', this.datagridStore.sortOrder);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -272,14 +272,17 @@ test('Should destroy the store on unmount', () => {
     expect(datagrid.instance().sortColumnDisposer).toBeDefined();
     expect(datagrid.instance().sortOrderDisposer).toBeDefined();
 
+    const activeDisposerSpy = jest.fn();
     const sortColumnDisposerSpy = jest.fn();
     const sortOrderDisposerSpy = jest.fn();
+    datagrid.instance().activeDisposer = activeDisposerSpy;
     datagrid.instance().sortColumnDisposer = sortColumnDisposerSpy;
     datagrid.instance().sortOrderDisposer = sortOrderDisposerSpy;
 
     datagrid.unmount();
 
     expect(datagridStore.destroy).toBeCalled();
+    expect(activeDisposerSpy).toBeCalledWith();
     expect(sortColumnDisposerSpy).toBeCalledWith();
     expect(sortOrderDisposerSpy).toBeCalledWith();
 });
@@ -435,6 +438,8 @@ test('Should load the route attributes from the UserStore', () => {
 
     userStore.getPersistentSetting.mockImplementation((key) => {
         switch(key) {
+            case 'sulu_admin.datagrid.test.active':
+                return 'some-uuid';
             case 'sulu_admin.datagrid.test.sort_column':
                 return 'title';
             case 'sulu_admin.datagrid.test.sort_order':
@@ -447,6 +452,7 @@ test('Should load the route attributes from the UserStore', () => {
             resourceKey: 'test',
         },
     })).toEqual({
+        active: 'some-uuid',
         sortColumn: 'title',
         sortOrder: 'desc',
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -25,6 +25,9 @@ jest.mock(
         this.options = options;
         this.loading = false;
         this.pageCount = 3;
+        this.active = {
+            get: jest.fn(),
+        };
         this.sortColumn = {
             get: jest.fn(),
         };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -267,6 +267,7 @@ test('Should destroy the store on unmount', () => {
     expect(router.bind).toBeCalledWith('locale', locale);
     expect(router.bind).toBeCalledWith('sortColumn', datagridStore.sortColumn);
     expect(router.bind).toBeCalledWith('sortOrder', datagridStore.sortOrder);
+    expect(router.bind).toBeCalledWith('active', datagridStore.active);
 
     expect(datagrid.instance().sortColumnDisposer).toBeDefined();
     expect(datagrid.instance().sortOrderDisposer).toBeDefined();

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -169,7 +169,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $excludeGhosts = $this->getBooleanRequestParameter($request, 'exclude-ghosts', false, false);
         $excludeShadows = $this->getBooleanRequestParameter($request, 'exclude-shadows', false, false);
         $webspaceNodes = $this->getRequestParameter($request, 'webspace-nodes');
-        $tree = $this->getBooleanRequestParameter($request, 'tree', false, false);
         $locale = $this->getRequestParameter($request, 'language', true);
         $webspaceKey = $this->getRequestParameter($request, 'webspace');
 
@@ -181,16 +180,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
             ->setResolveConcreteLocales(true)
             ->addProperties($properties)
             ->getMapping();
-
-        try {
-            if ($tree) {
-                return $this->getTreeContent($uuid, $locale, $webspaceKey, $webspaceNodes, $mapping, $user);
-            }
-        } catch (EntityNotFoundException $e) {
-            $view = $this->view($e->toArray(), 404);
-
-            return $this->handleView($view);
-        }
 
         $data = $this->get('sulu_content.content_repository')->find($uuid, $locale, $webspaceKey, $mapping, $user);
         $view = $this->view($data);
@@ -471,6 +460,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
         $properties = array_filter(explode(',', $request->get('fields', '')));
         $excludeGhosts = $this->getBooleanRequestParameter($request, 'exclude-ghosts', false, false);
         $excludeShadows = $this->getBooleanRequestParameter($request, 'exclude-shadows', false, false);
+        $expandedIds = $this->getRequestParameter($request, 'expandedIds', false);
         $webspaceNodes = $this->getRequestParameter($request, 'webspace-nodes');
         $locale = $this->getLocale($request);
         $webspaceKey = $this->getRequestParameter($request, 'webspace', false);
@@ -497,6 +487,16 @@ class NodeController extends RestController implements ClassResourceInterface, S
             ->addProperties($properties)
             ->setResolveUrl(true)
             ->getMapping();
+
+        try {
+            if ($expandedIds) {
+                return $this->getTreeContent($expandedIds, $locale, $webspaceKey, $webspaceNodes, $mapping, $user);
+            }
+        } catch (EntityNotFoundException $e) {
+            $view = $this->view($e->toArray(), 404);
+
+            return $this->handleView($view);
+        }
 
         $contents = [];
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -98,6 +98,8 @@ class WebspaceOverview extends React.Component<ViewProps> {
         apiOptions.webspace = this.webspace;
 
         this.datagridStore = new DatagridStore('pages', observableOptions, apiOptions);
+        router.bind('active', this.datagridStore.active);
+
         WebspaceStore.loadWebspaces()
             .then(action((webspaces) => {
                 this.webspaces = webspaces;

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -30,6 +30,7 @@ class WebspaceOverview extends React.Component<ViewProps> {
     }
 
     @action handleWebspaceChange = (value: string) => {
+        this.datagridStore.destroy();
         this.webspace.set(value);
         this.setDefaultLocaleForWebspace();
     };

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -1,21 +1,18 @@
 // @flow
 import React from 'react';
-import {observable} from 'mobx';
 import {mount} from 'enzyme';
 import {findWithToolbarFunction} from 'sulu-admin-bundle/utils/TestHelper';
 import WebspaceStore from '../../../stores/WebspaceStore';
-
-let mockActive = {
-    get: jest.fn(),
-    set: jest.fn(),
-};
 
 jest.mock('sulu-admin-bundle/containers', () => ({
     withToolbar: jest.fn((Component) => Component),
     Datagrid: require('sulu-admin-bundle/containers/Datagrid/Datagrid').default,
     DatagridStore: jest.fn(function() {
         this.activeItems = [];
-        this.active = mockActive;
+        this.active = {
+            get: jest.fn(),
+            set: jest.fn(),
+        };
         this.sortColumn = {
             get: jest.fn(),
         };

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -9,6 +9,9 @@ jest.mock('sulu-admin-bundle/containers', () => ({
     Datagrid: require('sulu-admin-bundle/containers/Datagrid/Datagrid').default,
     DatagridStore: jest.fn(function() {
         this.activeItems = [];
+        this.active = {
+            get: jest.fn(),
+        };
         this.sortColumn = {
             get: jest.fn(),
         };

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -1,17 +1,21 @@
 // @flow
 import React from 'react';
+import {observable} from 'mobx';
 import {mount} from 'enzyme';
 import {findWithToolbarFunction} from 'sulu-admin-bundle/utils/TestHelper';
 import WebspaceStore from '../../../stores/WebspaceStore';
+
+let mockActive = {
+    get: jest.fn(),
+    set: jest.fn(),
+};
 
 jest.mock('sulu-admin-bundle/containers', () => ({
     withToolbar: jest.fn((Component) => Component),
     Datagrid: require('sulu-admin-bundle/containers/Datagrid/Datagrid').default,
     DatagridStore: jest.fn(function() {
         this.activeItems = [];
-        this.active = {
-            get: jest.fn(),
-        };
+        this.active = mockActive;
         this.sortColumn = {
             get: jest.fn(),
         };
@@ -141,6 +145,7 @@ test('Should change webspace when value of webspace select is changed', () => {
         webspaceOverview.update();
         webspaceOverview.find('WebspaceSelect').prop('onChange')('sulu_blog');
         expect(webspaceOverview.instance().datagridStore.destroy).toBeCalledWith();
+        expect(webspaceOverview.instance().datagridStore.active.set).toBeCalledWith(undefined);
         expect(webspaceOverview.instance().webspace.get()).toBe('sulu_blog');
         expect(webspaceOverview.instance().locale.get()).toBe('de');
         expect(userStore.setPersistentSetting).lastCalledWith('sulu_content.webspace_overview.webspace', 'sulu_blog');
@@ -157,7 +162,7 @@ test('Should change webspace when value of webspace select is changed', () => {
     });
 });
 
-test('Should load webspace route attribute from userStore', () => {
+test('Should load webspace and active route attribute from userStore', () => {
     const WebspaceOverview = require('../WebspaceOverview').default;
     const userStore = require('sulu-admin-bundle/stores').userStore;
 
@@ -165,10 +170,15 @@ test('Should load webspace route attribute from userStore', () => {
         if (key === 'sulu_content.webspace_overview.webspace') {
             return 'sulu';
         }
+
+        if (key === 'sulu_content.webspace_overview.webspace.sulu.active') {
+            return 'some-uuid';
+        }
     });
 
     // $FlowFixMe
     expect(WebspaceOverview.getDerivedRouteAttributes()).toEqual({
+        active: 'some-uuid',
         webspace: 'sulu',
     });
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -137,6 +137,7 @@ test('Should change webspace when value of webspace select is changed', () => {
 
         webspaceOverview.update();
         webspaceOverview.find('WebspaceSelect').prop('onChange')('sulu_blog');
+        expect(webspaceOverview.instance().datagridStore.destroy).toBeCalledWith();
         expect(webspaceOverview.instance().webspace.get()).toBe('sulu_blog');
         expect(webspaceOverview.instance().locale.get()).toBe('de');
         expect(userStore.setPersistentSetting).lastCalledWith('sulu_content.webspace_overview.webspace', 'sulu_blog');

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -189,4 +189,5 @@ test('Should bind router', () => {
     expect(router.bind).toBeCalledWith('page', page, '1');
     expect(router.bind).toBeCalledWith('locale', locale);
     expect(router.bind).toBeCalledWith('webspace', webspace);
+    expect(router.bind).toBeCalledWith('active', webspaceOverview.instance().datagridStore.active);
 });

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
@@ -211,7 +211,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $this->assertEquals($page1->getUuid(), $result['id']);
         $this->assertTrue($result['hasChildren']);
-        $this->assertEmpty($result['_embedded']['nodes']);
+        $this->assertEmpty($result['_embedded']['pages']);
     }
 
     public function testGetTree()
@@ -242,37 +242,37 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]['id']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertCount(0, $layer[0]['_embedded']['nodes']);
+        $this->assertNull($layer[0]['_embedded']['pages']);
         $this->assertEquals($page2->getUuid(), $layer[1]['id']);
         $this->assertTrue($layer[1]['hasChildren']);
-        $this->assertCount(2, $layer[1]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[1]['_embedded']['pages']);
 
-        $layer = $layer[1]['_embedded']['nodes'];
+        $layer = $layer[1]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page5->getUuid(), $layer[0]['id']);
         $this->assertFalse($layer[0]['hasChildren']);
-        $this->assertCount(0, $layer[0]['_embedded']['nodes']);
+        $this->assertNull($layer[0]['_embedded']['pages']);
         $this->assertEquals($page6->getUuid(), $layer[1]['id']);
         $this->assertTrue($layer[1]['hasChildren']);
-        $this->assertCount(2, $layer[1]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[1]['_embedded']['pages']);
 
-        $layer = $layer[1]['_embedded']['nodes'];
+        $layer = $layer[1]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page9->getUuid(), $layer[0]['id']);
         $this->assertFalse($layer[0]['hasChildren']);
-        $this->assertCount(0, $layer[0]['_embedded']['nodes']);
+        $this->assertNull($layer[0]['_embedded']['pages']);
         $this->assertEquals($page10->getUuid(), $layer[1]['id']);
         $this->assertTrue($layer[1]['hasChildren']);
-        $this->assertCount(2, $layer[1]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[1]['_embedded']['pages']);
 
-        $layer = $layer[1]['_embedded']['nodes'];
+        $layer = $layer[1]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page11->getUuid(), $layer[0]['id']);
         $this->assertFalse($layer[0]['hasChildren']);
-        $this->assertCount(0, $layer[0]['_embedded']['nodes']);
+        $this->assertNull($layer[0]['_embedded']['pages']);
         $this->assertEquals($page12->getUuid(), $layer[1]['id']);
         $this->assertTrue($layer[1]['hasChildren']);
-        $this->assertCount(0, $layer[1]['_embedded']['nodes']);
+        $this->assertNull($layer[1]['_embedded']['pages']);
     }
 
     public function testLinkedInternal()
@@ -363,18 +363,18 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertEquals($this->sessionManager->getContentNode('sulu_io')->getIdentifier(), $layer[0]['id']);
         $this->assertEquals('Sulu CMF', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertCount(2, $layer[0]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[0]['_embedded']['pages']);
 
-        $layer = $layer[0]['_embedded']['nodes'];
+        $layer = $layer[0]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]['id']);
         $this->assertEquals('test-1', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertEmpty($layer[0]['_embedded']['nodes']);
+        $this->assertEmpty($layer[0]['_embedded']['pages']);
         $this->assertEquals($page2->getUuid(), $layer[1]['id']);
         $this->assertEquals('test-2', $layer[1]['title']);
         $this->assertFalse($layer[1]['hasChildren']);
-        $this->assertEmpty($layer[1]['_embedded']['nodes']);
+        $this->assertEmpty($layer[1]['_embedded']['pages']);
     }
 
     public function testCGetActionAllWebspaceNodes()
@@ -402,22 +402,22 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertEquals($this->sessionManager->getContentNode('sulu_io')->getIdentifier(), $layer[1]['id']);
         $this->assertEquals('Sulu CMF', $layer[1]['title']);
         $this->assertTrue($layer[1]['hasChildren']);
-        $this->assertCount(2, $layer[1]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[1]['_embedded']['pages']);
         $this->assertEquals($this->sessionManager->getContentNode('test_io')->getIdentifier(), $layer[2]['id']);
         $this->assertEquals('Test CMF', $layer[2]['title']);
         $this->assertTrue($layer[2]['hasChildren']);
-        $this->assertCount(0, $layer[2]['_embedded']['nodes']);
+        $this->assertNull($layer[2]['_embedded']['pages']);
 
-        $layer = $layer[1]['_embedded']['nodes'];
+        $layer = $layer[1]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]['id']);
         $this->assertEquals('test-1', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertEmpty($layer[0]['_embedded']['nodes']);
+        $this->assertEmpty($layer[0]['_embedded']['pages']);
         $this->assertEquals($page2->getUuid(), $layer[1]['id']);
         $this->assertEquals('test-2', $layer[1]['title']);
         $this->assertFalse($layer[1]['hasChildren']);
-        $this->assertEmpty($layer[1]['_embedded']['nodes']);
+        $this->assertEmpty($layer[1]['_embedded']['pages']);
     }
 
     public function testGetTreeActionSingleWebspaceNodes()
@@ -452,24 +452,24 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertEquals($this->sessionManager->getContentNode('sulu_io')->getIdentifier(), $layer[0]['id']);
         $this->assertEquals('Sulu CMF', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertCount(2, $layer[0]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[0]['_embedded']['pages']);
 
-        $layer = $layer[0]['_embedded']['nodes'];
+        $layer = $layer[0]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]['id']);
         $this->assertEquals('test-1', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertCount(1, $layer[0]['_embedded']['nodes']);
+        $this->assertCount(1, $layer[0]['_embedded']['pages']);
         $this->assertEquals($page2->getUuid(), $layer[1]['id']);
         $this->assertEquals('test-2', $layer[1]['title']);
         $this->assertFalse($layer[1]['hasChildren']);
-        $this->assertEmpty($layer[1]['_embedded']['nodes']);
+        $this->assertEmpty($layer[1]['_embedded']['pages']);
 
-        $layer = $layer[0]['_embedded']['nodes'];
+        $layer = $layer[0]['_embedded']['pages'];
         $this->assertEquals($page11->getUuid(), $layer[0]['id']);
         $this->assertEquals('test-1-1', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertEmpty($layer[0]['_embedded']['nodes']);
+        $this->assertEmpty($layer[0]['_embedded']['pages']);
     }
 
     public function testGetTreeActionAllWebspaceNodes()
@@ -503,28 +503,28 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertEquals($this->sessionManager->getContentNode('sulu_io')->getIdentifier(), $layer[1]['id']);
         $this->assertEquals('Sulu CMF', $layer[1]['title']);
         $this->assertTrue($layer[1]['hasChildren']);
-        $this->assertCount(2, $layer[1]['_embedded']['nodes']);
+        $this->assertCount(2, $layer[1]['_embedded']['pages']);
         $this->assertEquals($this->sessionManager->getContentNode('test_io')->getIdentifier(), $layer[2]['id']);
         $this->assertEquals('Test CMF', $layer[2]['title']);
         $this->assertTrue($layer[2]['hasChildren']);
-        $this->assertCount(0, $layer[2]['_embedded']['nodes']);
+        $this->assertNull($layer[2]['_embedded']['pages']);
 
-        $layer = $layer[1]['_embedded']['nodes'];
+        $layer = $layer[1]['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]['id']);
         $this->assertEquals('test-1', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertCount(1, $layer[0]['_embedded']['nodes']);
+        $this->assertCount(1, $layer[0]['_embedded']['pages']);
         $this->assertEquals($page2->getUuid(), $layer[1]['id']);
         $this->assertEquals('test-2', $layer[1]['title']);
         $this->assertFalse($layer[1]['hasChildren']);
-        $this->assertEmpty($layer[1]['_embedded']['nodes']);
+        $this->assertEmpty($layer[1]['_embedded']['pages']);
 
-        $layer = $layer[0]['_embedded']['nodes'];
+        $layer = $layer[0]['_embedded']['pages'];
         $this->assertEquals($page11->getUuid(), $layer[0]['id']);
         $this->assertEquals('test-1-1', $layer[0]['title']);
         $this->assertTrue($layer[0]['hasChildren']);
-        $this->assertEmpty($layer[0]['_embedded']['nodes']);
+        $this->assertEmpty($layer[0]['_embedded']['pages']);
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
@@ -233,8 +233,8 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $client->request(
             'GET',
-            sprintf('/api/nodes/%s', $page10->getUuid()),
-            ['webspace' => 'sulu_io', 'language' => 'de', 'tree' => true, 'fields' => 'title']
+            '/api/nodes',
+            ['webspace' => 'sulu_io', 'language' => 'de', 'expandedIds' => $page10->getUuid(), 'fields' => 'title']
         );
         $result = json_decode($client->getResponse()->getContent(), true);
 
@@ -432,9 +432,9 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $client->request(
             'GET',
-            '/api/nodes/' . $page1->getUuid(),
+            '/api/nodes',
             [
-                'tree' => 'true',
+                'expandedIds' => $page1->getUuid(),
                 'webspace' => 'sulu_io',
                 'language' => 'de',
                 'webspace-nodes' => 'single',
@@ -484,9 +484,9 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $client->request(
             'GET',
-            '/api/nodes/' . $page1->getUuid(),
+            '/api/nodes',
             [
-                'tree' => 'true',
+                'expandedIds' => $page1->getUuid(),
                 'webspace' => 'sulu_io',
                 'language' => 'de',
                 'webspace-nodes' => 'all',

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -340,7 +340,7 @@ class NodeControllerTest extends SuluTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', '/api/nodes/not-existing-id?webspace=sulu_io&language=en&fields=title,order,published&tree=true');
+        $client->request('GET', '/api/nodes?expandedIds=not-existing-id&webspace=sulu_io&language=en&fields=title,order,published');
         $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
@@ -988,7 +988,7 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request(
             'GET',
-            '/api/nodes?id=' . $data[2]['id'] . '&tree=true&webspace=sulu_io&language=en&exclude-ghosts=false'
+            '/api/nodes?expandedIds=' . $data[2]['id'] . '&fields=title&webspace=sulu_io&language=en&exclude-ghosts=false'
         );
 
         $response = $client->getResponse()->getContent();
@@ -998,22 +998,22 @@ class NodeControllerTest extends SuluTestCase
         // check if tree is correctly loaded till the given id
         $node1 = $response->_embedded->nodes[0];
         $this->assertEquals($data[0]['path'], $node1->path);
-        $this->assertFalse($node1->hasSub);
+        $this->assertFalse($node1->hasChildren);
         $this->assertEmpty($node1->_embedded->nodes);
 
         $node2 = $response->_embedded->nodes[1];
         $this->assertEquals($data[1]['path'], $node2->path);
-        $this->assertTrue($node2->hasSub);
+        $this->assertTrue($node2->hasChildren);
         $this->assertCount(2, $node2->_embedded->nodes);
 
         $node3 = $node2->_embedded->nodes[0];
         $this->assertEquals($data[2]['path'], $node3->path);
-        $this->assertFalse($node3->hasSub);
+        $this->assertFalse($node3->hasChildren);
         $this->assertCount(0, $node3->_embedded->nodes);
 
         $node4 = $node2->_embedded->nodes[1];
         $this->assertEquals($data[3]['path'], $node4->path);
-        $this->assertTrue($node4->hasSub);
+        $this->assertTrue($node4->hasChildren);
         $this->assertCount(0, $node4->_embedded->nodes);
     }
 
@@ -1932,12 +1932,12 @@ class NodeControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
-            '/api/nodes?uuid=' . $securedPage->getUuid() . '&tree=true&webspace=sulu_io&language=en'
+            '/api/nodes?expandedIds=' . $securedPage->getUuid() . '&fields=title&webspace=sulu_io&language=en'
         );
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertArrayHasKey('_permissions', $response['_embedded']['nodes'][0]['_embedded'][0]);
+        $this->assertArrayHasKey('_permissions', $response['_embedded']['nodes'][0]);
 
         $client->request('GET', '/api/nodes/' . $securedPage->getUuid() . '?language=en&webspace=sulu_io');
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -999,22 +999,22 @@ class NodeControllerTest extends SuluTestCase
         $node1 = $response->_embedded->nodes[0];
         $this->assertEquals($data[0]['path'], $node1->path);
         $this->assertFalse($node1->hasChildren);
-        $this->assertEmpty($node1->_embedded->nodes);
+        $this->assertEmpty($node1->_embedded->pages);
 
         $node2 = $response->_embedded->nodes[1];
         $this->assertEquals($data[1]['path'], $node2->path);
         $this->assertTrue($node2->hasChildren);
-        $this->assertCount(2, $node2->_embedded->nodes);
+        $this->assertCount(2, $node2->_embedded->pages);
 
-        $node3 = $node2->_embedded->nodes[0];
+        $node3 = $node2->_embedded->pages[0];
         $this->assertEquals($data[2]['path'], $node3->path);
         $this->assertFalse($node3->hasChildren);
-        $this->assertCount(0, $node3->_embedded->nodes);
+        $this->assertCount(0, $node3->_embedded->pages);
 
-        $node4 = $node2->_embedded->nodes[1];
+        $node4 = $node2->_embedded->pages[1];
         $this->assertEquals($data[3]['path'], $node4->path);
         $this->assertTrue($node4->hasChildren);
-        $this->assertCount(0, $node4->_embedded->nodes);
+        $this->assertNull($node4->_embedded->pages);
     }
 
     public function testGetFlat()

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -745,7 +745,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]->getId());
         $this->assertTrue($layer[0]->hasChildren());
-        $this->assertCount(0, $layer[0]->getChildren());
+        $this->assertNull($layer[0]->getChildren());
         $this->assertEquals($page2->getUuid(), $layer[1]->getId());
         $this->assertTrue($layer[1]->hasChildren());
         $this->assertCount(2, $layer[1]->getChildren());
@@ -754,7 +754,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(2, $layer);
         $this->assertEquals($page5->getUuid(), $layer[0]->getId());
         $this->assertFalse($layer[0]->hasChildren());
-        $this->assertCount(0, $layer[0]->getChildren());
+        $this->assertNull($layer[0]->getChildren());
         $this->assertEquals($page6->getUuid(), $layer[1]->getId());
         $this->assertTrue($layer[1]->hasChildren());
         $this->assertCount(2, $layer[1]->getChildren());
@@ -763,7 +763,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(2, $layer);
         $this->assertEquals($page9->getUuid(), $layer[0]->getId());
         $this->assertFalse($layer[0]->hasChildren());
-        $this->assertCount(0, $layer[0]->getChildren());
+        $this->assertNull($layer[0]->getChildren());
         $this->assertEquals($page10->getUuid(), $layer[1]->getId());
         $this->assertTrue($layer[1]->hasChildren());
         $this->assertCount(2, $layer[1]->getChildren());
@@ -772,10 +772,10 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertCount(2, $layer);
         $this->assertEquals($page11->getUuid(), $layer[0]->getId());
         $this->assertFalse($layer[0]->hasChildren());
-        $this->assertCount(0, $layer[0]->getChildren());
+        $this->assertNull($layer[0]->getChildren());
         $this->assertEquals($page12->getUuid(), $layer[1]->getId());
         $this->assertTrue($layer[1]->hasChildren());
-        $this->assertCount(0, $layer[1]->getChildren());
+        $this->assertNull($layer[1]->getChildren());
     }
 
     public function testFindParentsWithSiblingsByUuidWithoutWebspaceKey()

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -77,6 +77,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
 
             this.loading = false;
             this.pageCount = 3;
+            this.active = {
+                get: jest.fn(),
+            };
             this.sortColumn = {
                 get: jest.fn(),
             };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -63,6 +63,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
             });
             this.loading = false;
             this.pageCount = 3;
+            this.active = {
+                get: jest.fn(),
+            };
             this.sortColumn = {
                 get: jest.fn(),
             };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -62,6 +62,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
             });
             this.loading = false;
             this.pageCount = 3;
+            this.active = {
+                get: jest.fn(),
+            };
             this.sortColumn = {
                 get: jest.fn(),
             };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -55,6 +55,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
 
             this.loading = false;
             this.pageCount = 3;
+            this.active = {
+                get: jest.fn(),
+            };
             this.sortColumn = {
                 get: jest.fn(),
             };

--- a/src/Sulu/Component/Content/Repository/Content.php
+++ b/src/Sulu/Component/Content/Repository/Content.php
@@ -34,7 +34,7 @@ use Sulu\Exception\FeatureNotImplementedException;
  *      )
  * )
  * @Relation(
- *      "nodes",
+ *      "pages",
  *      embedded = @Embedded("expr(object.getChildren())")
  * )
  */
@@ -94,7 +94,7 @@ class Content implements \ArrayAccess
     /**
      * @var Content[]
      */
-    private $children = [];
+    private $children;
 
     /**
      * @var array

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -208,7 +208,7 @@ class ContentRepository implements ContentRepositoryInterface
 
         $result = $this->resolveQueryBuilder($queryBuilder, $locale, $locales, $mapping, $user);
 
-        return $this->generateTreeByPath($result);
+        return $this->generateTreeByPath($result, $uuid);
     }
 
     /**
@@ -306,7 +306,7 @@ class ContentRepository implements ContentRepositoryInterface
      *
      * @return Content[]
      */
-    private function generateTreeByPath(array $contents)
+    private function generateTreeByPath(array $contents, $uuid)
     {
         $childrenByPath = [];
 
@@ -326,10 +326,15 @@ class ContentRepository implements ContentRepositoryInterface
 
         foreach ($contents as $content) {
             if (!isset($childrenByPath[$content->getPath()])) {
+                if ($content->getId() === $uuid) {
+                    $content->setChildren([]);
+                }
+
                 continue;
             }
 
             ksort($childrenByPath[$content->getPath()]);
+
             $content->setChildren(array_values($childrenByPath[$content->getPath()]));
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will remember the active page in each webspace for the current session.

#### Why?

Because this way it will be much more convenient t work with.

#### To Do

- [x] ~~~Create a documentation PR~~~
- [x] Add breaking changes to UPGRADE.md
- [x] Reset active item when switching between webspaces
- [x] Make `enhanceItem` of `StructureStrategy` to `addItem` and allow it to be called recursively by `TreeStructure` and `ColumnStructure`?
- [x] ~~~Remove `AbstractLoadingStrategy`~~~
- [x] Remove `getData` from `StructureStrategyInterface`?
- [x] Add `active` router parameter to Datagrid for Categories
- [x] If item without child is activated, then the datagrid is not correctly restored when initialized with that active id (The active item is visible but not activated, hence also it's children are not shown)