### PR TITLE
fix moving categories to top level after saving

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,12 @@
 
 ## dev-develop
 
+### parent query parameter
+
+The `parent` query parameter, which is used in quite some controllers like for pages and categories, was renamed to
+`parentId`, because it only references the id, and not the entire reference. This is also the new convention within
+our new Admin, so if your API should work with it, you have to name the query paramter `parentId`.
+
 ### Highlight section
 
 In previous versions of Sulu a section named `highlight` had a special design in the administratin interface. Its

--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -360,7 +360,6 @@ class Category extends ApiEntityWrapper
      * This method is used to serialize the parent-id.
      *
      * @VirtualProperty
-     * @SerializedName("parent")
      * @Groups({"fullCategory","partialCategory"})
      *
      * @return null|Category

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -221,7 +221,7 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('Third Category', $response->name);
         $this->assertEquals('en', $response->locale);
         $this->assertEquals($this->category3->getId(), $response->id);
-        $this->assertEquals($this->category1->getId(), $response->parent);
+        $this->assertEquals($this->category1->getId(), $response->parentId);
     }
 
     public function testGetByIdWithNoLocale()
@@ -1010,7 +1010,7 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('New Category', $response->name);
         $this->assertEquals('new-category-key', $response->key);
         $this->assertEquals('en', $response->defaultLocale);
-        $this->assertEquals($this->category1->getId(), $response->parent);
+        $this->assertEquals($this->category1->getId(), $response->parentId);
 
         $client->request(
             'GET',
@@ -1331,7 +1331,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals($parentId, $response['parent']);
+        $this->assertEquals($parentId, $response['parentId']);
 
         $client->request(
             'GET',
@@ -1340,7 +1340,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals($parentId, $response['parent']);
+        $this->assertEquals($parentId, $response['parentId']);
     }
 
     public function testMoveRoot()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4079
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR renames the `parent` parameter in the response of the `CategoryController` to `parentId`. This fixes the problem that a category already ends up on the toplevel after it is being saved.

#### Why?

Because this problem was introduced in #4079, where the renaming from `parent` to `parentId` obviously wasn't done everywhere.

#### BC Breaks/Deprecations

The `parent` field is now called `parentId` in the `CategoryController` response.

#### To Do

- [x] Add breaking changes to UPGRADE.md
