### PR TITLE
always activate WebLink component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -41,6 +41,9 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                             ],
                         ],
                     ],
+                    'web_link' => [
+                        'enabled' => true,
+                    ],
                 ]
             );
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4091 
| Related issues/PRs | #---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes sure to always have the `WebLink` component activated, since we are using it in order to use HTTP2 pushes for some of our resources.

#### Why?

Because that doesn't seem to be always the case, as @alexander-schranz has mentioned in [his comment of the original issue](https://github.com/sulu/sulu/issues/4091#issuecomment-410613925).