### PR TITLE
Show publish state in Form component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
@@ -123,7 +123,7 @@ test('The expanded prop should be set correct automatically', () => {
     expect(navigation.find('Item[value="contact"]').instance().props.expanded).toBe(true);
     expect(navigation.find('Item[value="settings"]').instance().props.expanded).toBe(false);
 
-    navigation.find('Item[value="settings"] Item .title').simulate('click');
+    navigation.find('Item[value="settings"] .title').simulate('click');
     expect(navigation.find('Item[value="contact"]').instance().props.expanded).toBe(false);
     expect(navigation.find('Item[value="settings"]').instance().props.expanded).toBe(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/PublishIndicator.js
@@ -16,10 +16,6 @@ export default class PublishIndicator extends React.Component<Props> {
     render() {
         const {draft, published} = this.props;
 
-        if (!draft && published) {
-            return null;
-        }
-
         return (
             <Fragment>
                 {published && <span className={publishIndicatorStyles.published} />}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/README.md
@@ -1,7 +1,6 @@
 The `PublishIndicator` is a simple component, which can be used to show the draft/publish state of an entity.
 
-It doesn't show anything if only `published` is set to `true`, because this is considered the default, to have less
-visual clutter in the UI.
+The `published` state is represented by a green circle.
 
 ```
 <PublishIndicator published={true} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/tests/PublishIndicator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PublishIndicator/tests/PublishIndicator.test.js
@@ -3,10 +3,10 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import PublishIndicator from '../PublishIndicator';
 
-test('Do not show anything if only the published icon would be shown', () => {
+test('Show only the publish icon', () => {
     const publishIndicator = shallow(<PublishIndicator published={true} />);
 
-    expect(publishIndicator.find('.published')).toHaveLength(0);
+    expect(publishIndicator.find('.published')).toHaveLength(1);
     expect(publishIndicator.find('.draft')).toHaveLength(0);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Icons.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Icons.js
@@ -1,13 +1,12 @@
 // @flow
-import type {ChildrenArray, Element} from 'react';
 import React from 'react';
+import type {ChildrenArray, Node} from 'react';
 import classNames from 'classnames';
-import Icon from '../Icon';
 import type {Skin} from './types';
 import iconsStyles from './icons.scss';
 
 type Props = {
-    children: ChildrenArray<Element<typeof Icon>>,
+    children: ChildrenArray<Node>,
     skin?: Skin,
 };
 
@@ -15,18 +14,6 @@ export default class Icons extends React.PureComponent<Props> {
     static defaultProps = {
         skin: 'light',
     };
-
-    static createChildren(children: ChildrenArray<Element<typeof Icon>>) {
-        return React.Children.map(children, (child) => {
-            return React.cloneElement(
-                child,
-                {
-                    ...child.props,
-                    className: iconsStyles.icon,
-                }
-            );
-        });
-    }
 
     render() {
         const {
@@ -41,7 +28,11 @@ export default class Icons extends React.PureComponent<Props> {
 
         return (
             <div className={iconsClass}>
-                {Icons.createChildren(children)}
+                {React.Children.map(children, (child) => (
+                    <div className={iconsStyles.icon}>
+                        {child}
+                    </div>
+                ))}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/icons.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/icons.scss
@@ -1,8 +1,9 @@
 @import './toolbar.scss';
 
 .icons {
+    display: flex;
+    align-items: center;
     padding: 0 20px;
-    line-height: $toolbarHeight;
     vertical-align: top;
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
@@ -18,6 +18,7 @@ import Masonry from './Masonry';
 import MultiItemSelection from './MultiItemSelection';
 import Overlay from './Overlay';
 import Popover from './Popover';
+import PublishIndicator from './PublishIndicator';
 import Navigation from './Navigation';
 import Backdrop from './Backdrop';
 import withContainerSize from './withContainerSize';
@@ -44,5 +45,6 @@ export {
     Navigation,
     Overlay,
     Popover,
+    PublishIndicator,
     withContainerSize,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
@@ -129,32 +129,37 @@ export default class ColumnListAdapter extends AbstractAdapter {
                             key={index}
                             loading={index >= this.props.data.length - 1 && loading}
                         >
-                            {items.map((item: Object) => (
-                                // TODO: Don't access hasChildren, published, publishedState, title or type directly
-                                <ColumnList.Item
-                                    active={activeItems ? activeItems.includes(item.id) : undefined}
-                                    buttons={item.type && item.type.name === 'ghost' ? ghostButtons : buttons}
-                                    disabled={disabledIds.includes(item.id)}
-                                    hasChildren={item.hasChildren}
-                                    id={item.id}
-                                    indicators={item.type && item.type.name === 'ghost'
-                                        ? [
-                                            <GhostIndicator key={'ghost'} locale={item.type.value} />,
-                                        ]
-                                        : [
-                                            <PublishIndicator
-                                                key={'publish'}
-                                                draft={item.publishedState === undefined ? false : !item.publishedState}
-                                                published={item.published === undefined ? false : !!item.published}
-                                            />,
-                                        ]
-                                    }
-                                    key={item.id}
-                                    selected={selections.includes(item.id)}
-                                >
-                                    {item.title}
-                                </ColumnList.Item>
-                            ))}
+                            {items.map((item: Object) => {
+                                const draft = item.publishedState === undefined ? false : !item.publishedState;
+                                const published = item.published === undefined ? false : !!item.published;
+
+                                return (
+                                    // TODO: Don't access hasChildren, published, publishedState, title or type directly
+                                    <ColumnList.Item
+                                        active={activeItems ? activeItems.includes(item.id) : undefined}
+                                        buttons={item.type && item.type.name === 'ghost' ? ghostButtons : buttons}
+                                        disabled={disabledIds.includes(item.id)}
+                                        hasChildren={item.hasChildren}
+                                        id={item.id}
+                                        indicators={item.type && item.type.name === 'ghost'
+                                            ? [
+                                                <GhostIndicator key={'ghost'} locale={item.type.value} />,
+                                            ]
+                                            : [
+                                                (draft || !published) && <PublishIndicator
+                                                    key={'publish'}
+                                                    draft={draft}
+                                                    published={published}
+                                                />,
+                                            ]
+                                        }
+                                        key={item.id}
+                                        selected={selections.includes(item.id)}
+                                    >
+                                        {item.title}
+                                    </ColumnList.Item>
+                                );})
+                            }
                         </ColumnList.Column>
                     ))}
                 </ColumnList>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
@@ -145,7 +145,7 @@ export default class ColumnListAdapter extends AbstractAdapter {
                                             <PublishIndicator
                                                 key={'publish'}
                                                 draft={item.publishedState === undefined ? false : !item.publishedState}
-                                                published={item.published === undefined ? false : item.published}
+                                                published={item.published === undefined ? false : !!item.published}
                                             />,
                                         ]
                                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/ColumnListAdapter.js
@@ -145,7 +145,7 @@ export default class ColumnListAdapter extends AbstractAdapter {
                                             <PublishIndicator
                                                 key={'publish'}
                                                 draft={item.publishedState === undefined ? false : !item.publishedState}
-                                                published={item.publishedState === undefined ? false : item.published}
+                                                published={item.published === undefined ? false : item.published}
                                             />,
                                         ]
                                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/README.md
@@ -161,9 +161,9 @@ const PageWithToolbar = withToolbar(Page, function() {
             }
         },
         icons: [
-            'fa-bell-o',
-            'fa-commenting',
-            'fa-exclamation-circle',
+            <Icon key="fa-bell-o" name="fa-bell-o" />,
+            <Icon key="fa-commenting" name="fa-commenting" />,
+            <Icon key="fa-exclamation-circle" name="fa-exclamation-circle" />,
         ],
         locale: {
             value: state.localeVal,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -2,7 +2,6 @@
 import {observer} from 'mobx-react';
 import {action} from 'mobx';
 import React from 'react';
-import Icon from '../../components/Icon';
 import ToolbarComponent from '../../components/Toolbar';
 import ToolbarStore from './stores/ToolbarStore';
 import toolbarStorePool, {DEFAULT_STORE_KEY} from './stores/ToolbarStorePool';
@@ -120,12 +119,7 @@ export default class Toolbar extends React.Component<*> {
                 <ToolbarComponent.Controls>
                     {this.toolbarStore.hasIconsConfig() &&
                     <ToolbarComponent.Icons>
-                        {this.toolbarStore.getIconsConfig().map((icon) => (
-                            <Icon
-                                key={icon}
-                                name={icon}
-                            />
-                        ))}
+                        {this.toolbarStore.getIconsConfig().map((icon) => icon)}
                     </ToolbarComponent.Icons>
                     }
                     {this.toolbarStore.hasLocaleConfig() &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
@@ -1,4 +1,5 @@
 // @flow
+import type {Node} from 'react';
 import {action, autorun, computed, observable} from 'mobx';
 import type {Button, Select, ToolbarConfig, ToolbarItemConfig} from '../types';
 
@@ -72,7 +73,7 @@ export default class ToolbarStore {
         return !!this.config.icons && !!this.config.icons.length;
     }
 
-    getIconsConfig(): Array<string> {
+    getIconsConfig(): Array<Node> {
         return this.config.icons || [];
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -31,15 +31,22 @@ beforeEach(() => {
     };
 });
 
-test('Render the items from the ToolbarStore', () => {
+test('Render the items and icons from the ToolbarStore', () => {
     const storeKey = 'testStore';
 
     toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
 
     toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
-    toolbarStoreMock.hasIconsConfig.mockReturnValue(false);
+    toolbarStoreMock.hasIconsConfig.mockReturnValue(true);
     toolbarStoreMock.hasLocaleConfig.mockReturnValue(false);
     toolbarStoreMock.hasBackButtonConfig.mockReturnValue(false);
+
+    toolbarStoreMock.getIconsConfig.mockReturnValue(
+        [
+            <p key={1}>Test1</p>,
+            <p key={2}>Test2</p>,
+        ]
+    );
 
     toolbarStoreMock.getItemsConfig.mockReturnValue(
         [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render the items from the ToolbarStore 1`] = `
+exports[`Render the items and icons from the ToolbarStore 1`] = `
 <nav
   class="toolbar light"
 >
@@ -81,6 +81,25 @@ exports[`Render the items from the ToolbarStore 1`] = `
   </div>
   <div
     class="controls light"
-  />
+  >
+    <div
+      class="icons light"
+    >
+      <div
+        class="icon"
+      >
+        <p>
+          Test1
+        </p>
+      </div>
+      <div
+        class="icon"
+      >
+        <p>
+          Test2
+        </p>
+      </div>
+    </div>
+  </div>
 </nav>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {observable, isObservable, when} from 'mobx';
 import ToolbarStore from '../../stores/ToolbarStore';
 
@@ -11,7 +11,11 @@ beforeEach(() => {
 });
 
 test('Set toolbar items and let mobx react', () => {
-    const errors = [{}];
+    const errors = [{
+        code: 100,
+        message: 'You failed!',
+    }];
+
     toolbarStore.setConfig({
         items: [
             {
@@ -24,10 +28,20 @@ test('Set toolbar items and let mobx react', () => {
         errors,
     });
 
+    const toolbarConfigItems = toolbarStore.config.items;
+    if (!toolbarConfigItems) {
+        throw new Error('The items should be set now!');
+    }
+
+    const buttonConfig = toolbarConfigItems[0];
+    if (buttonConfig.type !== 'button') {
+        throw new Error('The type should be set now to "button"!');
+    }
+
     expect(isObservable(toolbarStore.config.items)).toBe(true);
-    expect(toolbarStore.config.items).toHaveLength(1);
-    expect(toolbarStore.config.items[0].value).toBe('Test');
-    expect(toolbarStore.config.items[0].icon).toBe('test');
+    expect(toolbarConfigItems).toHaveLength(1);
+    expect(buttonConfig.value).toBe('Test');
+    expect(buttonConfig.icon).toBe('test');
     expect(toolbarStore.errors).toEqual(errors);
 });
 
@@ -40,12 +54,20 @@ test('Reset showSuccess after 1500ms', () => {
         showSuccess: observable.box(true),
     });
 
-    expect(toolbarStore.config.showSuccess.get()).toEqual(true);
+    const toolbarConfig = toolbarStore.config;
+    if (!toolbarConfig.showSuccess) {
+        throw new Error('The showSuccess flag should be set now!');
+    }
+
+    expect(toolbarConfig.showSuccess.get()).toEqual(true);
 
     when(
-        () => toolbarStore.config.showSuccess.get() === false,
-        () => {
-            expect(toolbarStore.config.showSuccess.get()).toEqual(false);
+        () => !!toolbarConfig.showSuccess && toolbarConfig.showSuccess.get() === false,
+        (): void => {
+            if (!toolbarConfig.showSuccess) {
+                throw new Error('The showSuccess flag should be set now!');
+            }
+            expect(toolbarConfig.showSuccess.get()).toEqual(false);
         }
     );
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -24,7 +24,7 @@ export type ToolbarConfig = {
     backButton?: Button,
     disableAll?: boolean,
     errors?: Array<Error>,
-    icons?: Array<string>,
+    icons?: Array<Node>,
     items?: Array<ToolbarItemConfig>,
     locale?: Select,
     showSuccess?: IObservableValue<boolean>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {action, computed, observable, isObservableArray} from 'mobx';
 import {observer} from 'mobx-react';
+import PublishIndicator from '../../components/PublishIndicator';
 import {default as FormContainer, FormStore} from '../../containers/Form';
 import {withToolbar} from '../../containers/Toolbar';
 import type {ViewProps} from '../../containers/ViewRenderer';
@@ -249,11 +250,26 @@ export default withToolbar(Form, function() {
         .map((toolbarAction) => toolbarAction.getToolbarItemConfig())
         .filter((item) => item !== undefined);
 
+    const icons = [];
+    const formData = this.formStore.data;
+
+    if (formData.hasOwnProperty('publishedState') || formData.hasOwnProperty('published')) {
+        const {publishedState, published} = formData;
+        icons.push(
+            <PublishIndicator
+                key={'publish'}
+                draft={publishedState === undefined ? false : !publishedState}
+                published={published === undefined ? false : !!published}
+            />
+        );
+    }
+
     return {
         backButton,
         errors,
         locale,
         items,
+        icons,
         showSuccess,
     };
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -4,7 +4,6 @@ import {observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import {findWithToolbarFunction} from '../../../utils/TestHelper';
 import AbstractToolbarAction from '../toolbarActions/AbstractToolbarAction';
-import PublishIndicator from '../../../components/PublishIndicator';
 
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -4,6 +4,7 @@ import {observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import {findWithToolbarFunction} from '../../../utils/TestHelper';
 import AbstractToolbarAction from '../toolbarActions/AbstractToolbarAction';
+import PublishIndicator from '../../../components/PublishIndicator';
 
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
 
@@ -279,6 +280,144 @@ test('Should add items defined in ToolbarActions to Toolbar', () => {
         {type: 'button', value: 'save'},
         {type: 'button', value: 'delete'},
     ]);
+});
+
+test('Should not add PublishIndicator if no publish status is available', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const toolbarFunction = findWithToolbarFunction(withToolbar, Form);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+
+    const route = {
+        options: {
+            locales: [],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route,
+        attributes: {},
+    };
+    const form = mount(<Form router={router} route={route} resourceStore={resourceStore} />);
+    resourceStore.setLocale('de');
+
+    const toolbarConfig = toolbarFunction.call(form.instance());
+
+    expect(toolbarConfig.icons).toHaveLength(0);
+});
+
+test('Should add PublishIndicator if publish status is available showing draft', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const toolbarFunction = findWithToolbarFunction(withToolbar, Form);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    resourceStore.data = {
+        publishedState: false,
+        published: false,
+    };
+
+    const route = {
+        options: {
+            locales: [],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route,
+        attributes: {},
+    };
+    const form = mount(<Form router={router} route={route} resourceStore={resourceStore} />);
+    resourceStore.setLocale('de');
+
+    const toolbarConfig = toolbarFunction.call(form.instance());
+
+    expect(toolbarConfig.icons).toHaveLength(1);
+    const publishIndicator = shallow(toolbarConfig.icons[0]);
+
+    expect(publishIndicator.instance().props).toEqual(expect.objectContaining({
+        draft: true,
+        published: false,
+    }));
+});
+
+test('Should add PublishIndicator if publish status is available showing published', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const toolbarFunction = findWithToolbarFunction(withToolbar, Form);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    resourceStore.data = {
+        publishedState: true,
+        published: '2018-07-05',
+    };
+
+    const route = {
+        options: {
+            locales: [],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route,
+        attributes: {},
+    };
+    const form = mount(<Form router={router} route={route} resourceStore={resourceStore} />);
+    resourceStore.setLocale('de');
+
+    const toolbarConfig = toolbarFunction.call(form.instance());
+
+    expect(toolbarConfig.icons).toHaveLength(1);
+    const publishIndicator = shallow(toolbarConfig.icons[0]);
+
+    expect(publishIndicator.instance().props).toEqual(expect.objectContaining({
+        draft: false,
+        published: true,
+    }));
+});
+
+test('Should add PublishIndicator if publish status is available showing published and draft', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const toolbarFunction = findWithToolbarFunction(withToolbar, Form);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    resourceStore.data = {
+        publishedState: false,
+        published: '2018-07-05',
+    };
+
+    const route = {
+        options: {
+            locales: [],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route,
+        attributes: {},
+    };
+    const form = mount(<Form router={router} route={route} resourceStore={resourceStore} />);
+    resourceStore.setLocale('de');
+
+    const toolbarConfig = toolbarFunction.call(form.instance());
+
+    expect(toolbarConfig.icons).toHaveLength(1);
+    const publishIndicator = shallow(toolbarConfig.icons[0]);
+
+    expect(publishIndicator.instance().props).toEqual(expect.objectContaining({
+        draft: true,
+        published: true,
+    }));
 });
 
 test('Should navigate to defined route on back button click', () => {

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -683,6 +683,7 @@ class NodeRepository implements NodeRepositoryInterface
         $data['path'] = $structure->getPath();
         $data['url'] = $structure->getResourceLocator();
         $data['publishedState'] = $structure->getPublishedState();
+        $data['published'] = $structure->getPublished();
 
         // prepare data
         $data['_links'] = [

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/ExcerptControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/ExcerptControllerTest.php
@@ -40,6 +40,7 @@ class ExcerptControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Excerpt Title', $response->title);
         $this->assertEquals(false, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
 
         $client->request('GET', '/api/page-excerpts/' . $webspaceUuid . '?locale=en&webspace=sulu_io');
         $this->assertHttpStatusCode(200, $client->getResponse());
@@ -47,6 +48,7 @@ class ExcerptControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Excerpt Title', $response->title);
         $this->assertEquals(false, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
     }
 
     public function testPutAndGetPublished()
@@ -62,6 +64,7 @@ class ExcerptControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Excerpt Title', $response->title);
         $this->assertEquals(true, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
 
         $client->request('GET', '/api/page-excerpts/' . $webspaceUuid . '?locale=en&webspace=sulu_io');
         $this->assertHttpStatusCode(200, $client->getResponse());
@@ -69,5 +72,6 @@ class ExcerptControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Excerpt Title', $response->title);
         $this->assertEquals(true, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SeoControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SeoControllerTest.php
@@ -40,6 +40,7 @@ class SeoControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('SEO Title', $response->title);
         $this->assertEquals(false, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
 
         $client->request('GET', '/api/page-seos/' . $webspaceUuid . '?locale=en&webspace=sulu_io');
         $this->assertHttpStatusCode(200, $client->getResponse());
@@ -47,6 +48,7 @@ class SeoControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('SEO Title', $response->title);
         $this->assertEquals(false, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
     }
 
     public function testPutAndGetPublished()
@@ -62,6 +64,7 @@ class SeoControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('SEO Title', $response->title);
         $this->assertEquals(true, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
 
         $client->request('GET', '/api/page-seos/' . $webspaceUuid . '?locale=en&webspace=sulu_io');
         $this->assertHttpStatusCode(200, $client->getResponse());
@@ -69,5 +72,6 @@ class SeoControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('SEO Title', $response->title);
         $this->assertEquals(true, $response->publishedState);
+        $this->assertObjectHasAttribute('published', $response);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the `PublishIndicator` in the Form component Toolbar.

#### Why?

To allow seeing the Content Manager whether or not the current page is published or in draf mode.

#### BC Breaks/Deprecations

The `icons` config option will now take JSX instead of strings.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [x] Use JSX instead of strings for icons toolbar config
- [x] Show the `PublishIndicator` if the `publishedState` and `published` property are on the loaded resource
- [x] Also show published state in form or show nothing then?