### PR TITLE
Remove validation-state from rendered link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG for Sulu
 ==================
 
-* dev-develop
+* dev-master
     * BUGFIX      #4109 [ContentBundle]         Remove validation-state from rendered link
 
 * 1.6.21 (2018-07-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * BUGFIX      #4109 [ContentBundle]         Remove validation-state from rendered link
+
 * 1.6.21 (2018-07-18)
     * HOTFIX      #4063 [ContentComponent]      Fixed copy language function, which didn't copy the extension data
     * HOTFIX      #4056 [MediaBundle]           Added security-check for collection permission to media-controller

--- a/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/ContentBundle/Markup/LinkTag.php
@@ -62,7 +62,7 @@ class LinkTag implements TagInterface
 
             $htmlAttributes = array_map(
                 function ($value, $name) {
-                    if (in_array($name, ['provider', 'content']) || empty($value)) {
+                    if (in_array($name, ['provider', 'content', 'validation-state']) || empty($value)) {
                         return;
                     }
 

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -297,6 +297,49 @@ class LinkTagTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testParseAllValidationState()
+    {
+        $this->providers['article']->preload(['123-123-123'], 'de', true)
+            ->willReturn(
+                [
+                    new LinkItem('123-123-123', 'Page-Title 1', '/de/test-1', true),
+                ]
+            );
+
+        $tag1 = '<sulu:link href="123-123-123" title="Test-Title" target="_blank" provider="article" sulu:validation-state="unpublished">Test-Content</sulu:link>';
+        $tag2 = '<sulu:link href="123-123-123" title="Test-Title" target="_blank" provider="article" sulu:validation-state="removed">Test-Content</sulu:link>';
+
+        $result = $this->linkTag->parseAll(
+            [
+                $tag1 => [
+                    'href' => '123-123-123',
+                    'title' => 'Test-Title',
+                    'target' => '_blank',
+                    'content' => 'Test-Content',
+                    'provider' => 'article',
+                    'validation-state' => 'unpublished',
+                ],
+                $tag2 => [
+                    'href' => '123-123-123',
+                    'title' => 'Test-Title',
+                    'target' => '_blank',
+                    'content' => 'Test-Content',
+                    'provider' => 'article',
+                    'validation-state' => 'removed',
+                ],
+            ],
+            'de'
+        );
+
+        $this->assertEquals(
+            [
+                $tag1 => '<a href="/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+                $tag2 => '<a href="/de/test-1" title="Test-Title" target="_blank">Test-Content</a>',
+            ],
+            $result
+        );
+    }
+
     public function testValidate()
     {
         $this->providers['article']->preload(['123-123-123'], 'de', false)


### PR DESCRIPTION
The LinkTag adds an attribute named `validation-state` if the target is not published.
After publishing the target page and not editing the link again the resulting link contains the invalid attribute.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

The LinkTag adds an attribute named `validation-state` if the target is not published.
After publishing the target page and not editing the link again the resulting link contains the invalid attribute.

#### Why?

Invalid attribute is rendered