### PR TITLE
Add keyboard shortcuts to AutoComplete components

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -67,6 +67,7 @@ class Configuration implements ConfigurationInterface
                                         ->children()
                                             ->arrayNode('auto_complete')
                                                 ->children()
+                                                    ->booleanNode('allow_add')->defaultFalse()->end()
                                                     ->scalarNode('id_property')->defaultValue('id')->end()
                                                     ->scalarNode('display_property')->isRequired()->end()
                                                     ->scalarNode('filter_parameter')->end()

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/AutoCompletePopover.js
@@ -8,6 +8,7 @@ import autoCompletePopoverStyles from './autoCompletePopover.scss';
 
 type Props = {
     anchorElement: ElementRef<*>,
+    idProperty: string,
     minWidth: number,
     onSelect: (suggestion: Object) => void,
     open: boolean,
@@ -18,6 +19,7 @@ type Props = {
 
 export default class AutoCompletePopover extends React.Component<Props> {
     static defaultProps = {
+        idProperty: 'id',
         minWidth: 0,
     };
 
@@ -31,6 +33,7 @@ export default class AutoCompletePopover extends React.Component<Props> {
     render() {
         const {
             anchorElement,
+            idProperty,
             minWidth,
             onSelect,
             open,
@@ -55,7 +58,7 @@ export default class AutoCompletePopover extends React.Component<Props> {
                         >
                             {suggestions.map((searchResult) => (
                                 <Suggestion
-                                    key={searchResult.id}
+                                    key={searchResult[idProperty]}
                                     minWidth={minWidth}
                                     onSelect={onSelect}
                                     query={query}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/suggestion.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/suggestion.scss
@@ -18,7 +18,8 @@ $suggestionTextColorDisabled: rgba($suggestionTextColor, .3);
     background: transparent;
     text-align: left;
 
-    &:not(:disabled):hover {
+    &:not(:disabled):hover,
+    &:not(:disabled):focus {
         color: $suggestionTextColorActive;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -53,6 +53,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
 
     render() {
         const {
+            inputClass,
             valid,
             icon,
             loading,
@@ -130,6 +131,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
                     }
 
                     <input
+                        className={inputClass}
                         ref={inputRef ? this.setInputRef : undefined}
                         name={name}
                         type={type}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
@@ -2,6 +2,7 @@
 import type {ElementRef} from 'react';
 
 export type InputProps<T: ?string | ?number> = {|
+    inputClass?: string,
     collapsed?: boolean,
     name?: string,
     icon?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -36,11 +36,18 @@ export default class MultiAutoComplete extends React.Component<Props> {
     };
 
     @observable labelRef: ElementRef<'label'>;
+    @observable inputRef: ElementRef<'input'>;
     @observable inputValue = '';
 
     @action setLabelRef = (labelRef: ?ElementRef<'label'>) => {
         if (labelRef) {
             this.labelRef = labelRef;
+        }
+    };
+
+    @action setInputRef = (inputRef: ?ElementRef<'input'>) => {
+        if (inputRef) {
+            this.inputRef = inputRef;
         }
     };
 
@@ -122,6 +129,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
 
         onChange([...value, newValue]);
         this.inputValue = '';
+        this.inputRef.focus();
 
         if (onFinish) {
             onFinish();
@@ -170,6 +178,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
                         ))}
                         <input
                             className={inputClass}
+                            ref={this.setInputRef}
                             onBlur={this.handleInputBlur}
                             onChange={this.handleInputChange}
                             onFocus={this.handleInputFocus}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -37,7 +37,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
 
     @observable labelRef: ElementRef<'label'>;
     @observable inputRef: ElementRef<'input'>;
-    @observable inputValue = '';
+    @observable inputValue: string = '';
 
     @action setLabelRef = (labelRef: ?ElementRef<'label'>) => {
         if (labelRef) {
@@ -100,7 +100,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
             return false;
         }
 
-        const item = value.find((item) => item[displayProperty] === this.inputValue);
+        const item = value.find((item) => item[displayProperty].toLowerCase() === this.inputValue.toLowerCase());
         if (allowAdd && !item) {
             this.handleSelect({[idProperty]: this.inputValue});
             return false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -87,6 +87,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
             displayProperty,
             idProperty,
             suggestions,
+            value,
         } = this.props;
 
         if (this.inputValue.length === 0) {
@@ -99,7 +100,8 @@ export default class MultiAutoComplete extends React.Component<Props> {
             return false;
         }
 
-        if (allowAdd) {
+        const item = value.find((item) => item[displayProperty] === this.inputValue);
+        if (allowAdd && !item) {
             this.handleSelect({[idProperty]: this.inputValue});
             return false;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -48,8 +48,13 @@ export default class MultiAutoComplete extends React.Component<Props> {
         return this.labelRef ? this.labelRef.scrollWidth - 10 : 0;
     }
 
-    @action handleDelete = (value: Object) => {
-        this.props.onChange(this.props.value.filter((item) => item != value));
+    @action handleDelete = (newValue: Object) => {
+        const {onChange, onFinish, value} = this.props;
+        onChange(value.filter((item) => item != newValue));
+
+        if (onFinish) {
+            onFinish();
+        }
     };
 
     @action handleInputChange = (event: SyntheticEvent<HTMLInputElement>) => {
@@ -60,11 +65,13 @@ export default class MultiAutoComplete extends React.Component<Props> {
     @action handleInputFocus = () => {
         Mousetrap.bind('enter', this.handleEnterAndComma);
         Mousetrap.bind(',', this.handleEnterAndComma);
+        Mousetrap.bind('backspace', this.handleBackspace);
     };
 
     @action handleInputBlur = () => {
         Mousetrap.unbind('enter');
         Mousetrap.unbind(',');
+        Mousetrap.unbind('backspace');
     };
 
     handleEnterAndComma = () => {
@@ -91,6 +98,19 @@ export default class MultiAutoComplete extends React.Component<Props> {
         }
 
         return false;
+    };
+
+    handleBackspace = () => {
+        const {value} = this.props;
+        if (this.inputValue.length > 0) {
+            return true;
+        }
+
+        if (value.length === 0) {
+            return false;
+        }
+
+        this.handleDelete(value[value.length - 1]);
     };
 
     @action handleSelect = (newValue: Object) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/README.md
@@ -2,6 +2,8 @@ This component is the counterpart of the [`SingleAutoComplete`](#singleautocompl
 assigning multiple items to it.
 
 ```javascript
+const MultiAutoComplete = require('./MultiAutoComplete').default;
+
 initialState = {
     value: [],
     loading: false,
@@ -40,7 +42,7 @@ const handleSearch = (value) => {
         loading: !!value,
         suggestions: [],
     }));
-    
+
     if (value) {
         // Fake Request
         setTimeout(() => {
@@ -61,6 +63,72 @@ const handleChange = (value) => {
 
 <MultiAutoComplete
     displayProperty="name"
+    loading={state.loading}
+    onChange={handleChange}
+    onSearch={handleSearch}
+    placeholder="Enter something fun..."
+    searchProperties={['name']}
+    suggestions={state.suggestions}
+    value={state.value}
+/>
+```
+
+If the `allowAdd` prop is set to true, then the user can also add new items on its own.
+
+```javascript
+const MultiAutoComplete = require('./MultiAutoComplete').default;
+
+initialState = {
+    value: [],
+    loading: false,
+    suggestions: [],
+}
+
+const data = [
+    {name: 'Harry Potter'},
+    {name: 'Lilly Potter'},
+    {name: 'James Potter'},
+    {name: 'Albus Dumbledore'},
+    {name: 'Severus Snape'},
+    {name: 'Ron Weasly'},
+    {name: 'Hermoine Granger'},
+    {name: 'Tom Riddle'},
+    {name: 'Bathilda Bagshot'},
+    {name: 'Susan Bones'},
+    {name: 'Marvolo Gaunt'},
+    {name: 'Godric Gryffindor'},
+];
+
+const handleSearch = (value) => {
+    const regexp = new RegExp(value, 'gi');
+
+    setState(() => ({
+        loading: !!value,
+        suggestions: [],
+    }));
+
+    if (value) {
+        // Fake Request
+        setTimeout(() => {
+            setState(() => ({
+                loading: false,
+                suggestions: data.filter((suggestion) => suggestion.name.match(regexp))
+            }));
+        }, 500);
+    }
+};
+
+const handleChange = (value) => {
+    setState(() => ({
+        value: value,
+        suggestions: [],
+    }));
+};
+
+<MultiAutoComplete
+    allowAdd={true}
+    displayProperty="name"
+    idProperty="name"
     loading={state.loading}
     onChange={handleChange}
     onSearch={handleSearch}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -300,7 +300,7 @@ test('Should trigger callbacks when input does not match a suggestion and allowA
     expect(finishSpy).toBeCalledWith();
 });
 
-test('Should not trigger callbacks when input does not match a suggestion but an already allowed value', () => {
+test('Should not trigger callbacks when input does not match a suggestion but an already added value', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
     const suggestions = [
@@ -329,6 +329,40 @@ test('Should not trigger callbacks when input does not match a suggestion but an
     Mousetrap.trigger(',');
 
     expect(multiAutoComplete.instance().inputValue).toEqual('Suggestion');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
+test('Should not trigger callbacks when input does not match case-insensitive an already added value', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[{name: 'Suggestion'}]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'suggestion';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(multiAutoComplete.instance().inputValue).toEqual('suggestion');
 
     expect(changeSpy).not.toBeCalled();
     expect(finishSpy).not.toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -300,6 +300,40 @@ test('Should trigger callbacks when input does not match a suggestion and allowA
     expect(finishSpy).toBeCalledWith();
 });
 
+test('Should not trigger callbacks when input does not match a suggestion but an already allowed value', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[{name: 'Suggestion'}]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'Suggestion';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(multiAutoComplete.instance().inputValue).toEqual('Suggestion');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
 test('Should delete last value item if backspace is pressed in empty focused input field', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -297,3 +297,81 @@ test('Should trigger callbacks when input does not match a suggestion and allowA
     expect(changeSpy).toBeCalledWith([{name: 'Suggestion'}]);
     expect(finishSpy).toBeCalledWith();
 });
+
+test('Should delete last value item if backspace is pressed in empty focused input field', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={[]}
+            value={[{name: 'Tag1'}, {name: 'Tag2'}]}
+        />
+    );
+
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('backspace');
+
+    expect(changeSpy).toBeCalledWith([{name: 'Tag1'}]);
+    expect(finishSpy).toBeCalledWith();
+});
+
+test('Should not delete last value item if backspace is pressed in filled focused input field', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={[]}
+            value={[{name: 'Tag1'}, {name: 'Tag2'}]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'Suggestion';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('backspace');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
+test('Should not delete last value item if backspace is pressed in empty non-focused input field', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    mount(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={[]}
+            value={[{name: 'Tag1'}, {name: 'Tag2'}]}
+        />
+    );
+
+    Mousetrap.trigger('backspace');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -2,7 +2,12 @@
 import React from 'react';
 import {mount, render} from 'enzyme';
 import pretty from 'pretty';
+import Mousetrap from 'mousetrap';
 import MultiAutoComplete from '../MultiAutoComplete';
+
+beforeEach(() => {
+    Mousetrap.reset();
+});
 
 test('MultiAutoComplete should render', () => {
     const suggestions = [
@@ -138,5 +143,157 @@ test('Should call the onFinish callback when an item is added', () => {
 
     multiAutoComplete.find('Suggestion button').at(0).simulate('click');
 
+    expect(finishSpy).toBeCalledWith();
+});
+
+test('Should not trigger any callbacks when input is not focused', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            displayProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'test';
+    multiAutoComplete.update();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
+test('Should trigger callbacks when input matches a suggestion and input is focused', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            displayProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'Suggestion 1';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(changeSpy).toBeCalledWith([suggestions[0]]);
+    expect(finishSpy).toBeCalledWith();
+});
+
+test('Should not trigger callbacks when input does not match a suggestion and input is focused', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            displayProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'Suggestion';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
+test('Should not trigger callbacks when input matches a suggestion and input has lost focus', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            displayProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'Suggestion 1';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+    multiAutoComplete.find('input').prop('onBlur')();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(changeSpy).not.toBeCalled();
+    expect(finishSpy).not.toBeCalled();
+});
+
+test('Should trigger callbacks when input does not match a suggestion and allowAdd is set', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+    const suggestions = [
+        {id: 1, name: 'Suggestion 1'},
+    ];
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={[]}
+        />
+    );
+
+    multiAutoComplete.instance().inputValue = 'Suggestion';
+    multiAutoComplete.update();
+    multiAutoComplete.find('input').prop('onFocus')();
+
+    Mousetrap.trigger('enter');
+    Mousetrap.trigger(',');
+
+    expect(changeSpy).toBeCalledWith([{name: 'Suggestion'}]);
     expect(finishSpy).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -60,7 +60,7 @@ test('Render the MultiAutoComplete with open suggestions list', () => {
     expect(pretty(document.body ? document.body.innerHTML : '')).toMatchSnapshot();
 });
 
-test('Clicking on a suggestion should call the onChange handler with the value of the selected Suggestion', () => {
+test('Clicking a suggestion should call onChange with value of the Suggestion and focus input afterwards', () => {
     const changeSpy = jest.fn();
 
     const suggestions = [
@@ -88,9 +88,11 @@ test('Clicking on a suggestion should call the onChange handler with the value o
     multiAutoComplete.instance().inputValue = 'test';
     multiAutoComplete.update();
 
+    multiAutoComplete.instance().inputRef = {focus: jest.fn()};
     multiAutoComplete.find('Suggestion button').at(0).simulate('click');
 
     expect(changeSpy).toHaveBeenCalledWith([...value, suggestions[0]]);
+    expect(multiAutoComplete.instance().inputRef.focus).toBeCalledWith();
 });
 
 test('Clicking on delete icon of a suggestion should call the onChange callback without the deleted Suggestion', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -38,7 +38,7 @@ exports[`MultiAutoComplete should render 1`] = `
       />
     </div>
     <input
-      class="input"
+      class="input mousetrap"
       value=""
     />
   </div>
@@ -72,7 +72,7 @@ exports[`Render the MultiAutoComplete with open suggestions list 1`] = `
       />
     </div>
     <input
-      class="input"
+      class="input mousetrap"
       value="test"
     />
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -47,7 +47,7 @@ export default class Overlay extends React.Component<Props> {
     }
 
     componentWillUnmount() {
-        Mousetrap.unbind('esc', this.close);
+        Mousetrap.unbind('esc');
     }
 
     componentDidMount() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -11,19 +11,20 @@ import PopoverPositioner from './PopoverPositioner';
 import popoverStyles from './popover.scss';
 
 type Props = {
-    open: boolean,
+    /** This element will be used to position the popover */
+    anchorElement: ElementRef<*>,
+    backdrop: boolean,
+    centerChildElement?: ElementRef<*>,
     children?: (
         setPopoverElementRef: (ref: ElementRef<*>) => void,
         style: Object,
         verticalPosition: string,
     ) => Node,
-    onClose?: () => void,
-    /** This element will be used to position the popover */
-    anchorElement: ElementRef<*>,
-    centerChildElement?: ElementRef<*>,
     horizontalOffset: number,
+    onClose?: () => void,
+    open: boolean,
+    popoverChildRef?: (ref: ?ElementRef<*>) => void,
     verticalOffset: number,
-    backdrop: boolean,
 };
 
 @observer
@@ -128,9 +129,14 @@ export default class Popover extends React.Component<Props> {
 
     handleBackdropClick = this.close;
 
-    @action setPopoverChildRef = (popoverChildRef: ElementRef<*>) => {
+    @action setPopoverChildRef = (ref: ElementRef<*>) => {
+        if (ref) {
+            this.popoverChildRef = ref;
+        }
+
+        const {popoverChildRef} = this.props;
         if (popoverChildRef) {
-            this.popoverChildRef = popoverChildRef;
+            popoverChildRef(ref);
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
@@ -144,3 +144,20 @@ test('The popover should take its dimensions from the positioner', () => {
     expect(pretty(body.innerHTML)).toMatchSnapshot();
     expect(popover.instance().dimensions.scrollTop).toBe(4);
 });
+
+test('The popover should pass its child ref to the parent', () => {
+    const popoverChildRefSpy = jest.fn();
+    const popover = mount(
+        <Popover open={true} anchorElement={getMockedAnchorEl()} popoverChildRef={popoverChildRefSpy}>
+            {
+                (setPopoverRef, styles) => (
+                    <div ref={setPopoverRef} style={styles}>
+                        <div>My item 1</div>
+                    </div>
+                )
+            }
+        </Popover>
+    );
+
+    expect(popoverChildRefSpy.mock.calls[0][0].innerHTML).toEqual('<div>My item 1</div>');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/Popover.test.js
@@ -147,7 +147,7 @@ test('The popover should take its dimensions from the positioner', () => {
 
 test('The popover should pass its child ref to the parent', () => {
     const popoverChildRefSpy = jest.fn();
-    const popover = mount(
+    mount(
         <Popover open={true} anchorElement={getMockedAnchorEl()} popoverChildRef={popoverChildRefSpy}>
             {
                 (setPopoverRef, styles) => (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -90,10 +90,12 @@ export default class SingleAutoComplete extends React.Component<Props> {
         const {inputValue} = this;
         const showSuggestionList = (!!inputValue && inputValue.length > 0) && suggestions.length > 0;
 
+        // The mousetrap class is required to allow mousetrap catch key bindings for up and down keys
         return (
             <div className={singleAutoCompleteStyles.singleAutoComplete}>
                 <Input
                     icon={LENS_ICON}
+                    inputClass="mousetrap"
                     value={inputValue}
                     loading={loading}
                     labelRef={this.setLabelRef}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -16,6 +16,7 @@ exports[`Render the SingleAutoComplete with open suggestions list 1`] = `
       />
     </div>
     <input
+      class="mousetrap"
       type="text"
       value="Test"
     />
@@ -60,6 +61,7 @@ exports[`SingleAutoComplete should render 1`] = `
       />
     </div>
     <input
+      class="mousetrap"
       type="text"
       value="Test"
     />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -122,6 +122,7 @@ export default class Selection extends React.Component<Props> {
                 resource_key: resourceKey,
                 types: {
                     auto_complete: {
+                        allow_add: allowAdd,
                         display_property: displayProperty,
                         filter_parameter: filterParameter,
                         id_property: idProperty,
@@ -143,6 +144,7 @@ export default class Selection extends React.Component<Props> {
 
         return (
             <MultiAutoComplete
+                allowAdd={allowAdd}
                 displayProperty={displayProperty}
                 filterParameter={filterParameter}
                 idProperty={idProperty}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -436,6 +436,7 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
     );
 
     expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
+        allowAdd: false,
         displayProperty: 'name',
         filterParameter: 'names',
         idProperty: 'uuid',
@@ -443,5 +444,52 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         resourceKey: 'snippets',
         searchProperties: ['name'],
         value,
+    }));
+});
+
+test('Should pass allowAdd prop to MultiAutoComplete component', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'snippets',
+        types: {
+            auto_complete: {
+                allow_add: true,
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+
+    const locale = observable.box('en');
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1, {locale})
+        )
+    );
+
+    const selection = shallow(
+        <Selection
+            dataPath=""
+            error={undefined}
+            formInspector={formInspector}
+            fieldTypeOptions={fieldTypeOptions}
+            maxOccurs={undefined}
+            minOccurs={undefined}
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            schemaPath=""
+            showAllErrors={false}
+            types={undefined}
+            value={value}
+        />
+    );
+
+    expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
+        allowAdd: true,
     }));
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -8,6 +8,7 @@ import SearchStore from '../../stores/SearchStore';
 import SelectionStore from '../../stores/SelectionStore';
 
 type Props = {|
+    allowAdd: boolean,
     displayProperty: string,
     filterParameter: string,
     idProperty: string,
@@ -21,6 +22,7 @@ type Props = {|
 @observer
 export default class MultiAutoComplete extends React.Component<Props> {
     static defaultProps = {
+        allowAdd: false,
         filterParameter: 'ids',
         idProperty: 'id',
     };
@@ -78,14 +80,18 @@ export default class MultiAutoComplete extends React.Component<Props> {
     render() {
         const {
             props: {
+                allowAdd,
                 displayProperty,
+                idProperty,
                 searchProperties,
             },
         } = this;
 
         return (
             <MultiAutoCompleteComponent
+                allowAdd={allowAdd}
                 displayProperty={displayProperty}
+                idProperty={idProperty}
                 loading={this.searchStore.loading || this.selectionStore.loading}
                 onChange={this.handleChange}
                 onSearch={this.handleSearch}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -124,6 +124,35 @@ test('Pass loading flag if only SelectionStore is loading', () => {
     expect(multiAutoComplete.find('MultiAutoComplete').prop('loading')).toEqual(true);
 });
 
+test('Pass allowAdd and idProperty prop to component', () => {
+    // $FlowFixMe
+    SearchStore.mockImplementation(function() {});
+
+    // $FlowFixMe
+    SelectionStore.mockImplementation(function() {
+        mockExtendObservable(this, {
+            items: [],
+        });
+    });
+
+    const multiAutoComplete = shallow(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={jest.fn()}
+            resourceKey="test"
+            searchProperties={[]}
+            value={undefined}
+        />
+    );
+
+    expect(multiAutoComplete.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
+        allowAdd: true,
+        idProperty: 'name',
+    }));
+});
+
 test('Render with loaded suggestions', () => {
     const suggestions = [
         {id: 7, number: '007', name: 'James Bond'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -23,7 +23,7 @@ exports[`Render in loading state 1`] = `
     class="items"
   >
     <input
-      class="input"
+      class="input mousetrap"
       value=""
     />
   </div>
@@ -68,7 +68,7 @@ exports[`Render with given value 1`] = `
       />
     </div>
     <input
-      class="input"
+      class="input mousetrap"
       value=""
     />
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -23,6 +23,7 @@ exports[`Render in loading state 1`] = `
       </div>
     </div>
     <input
+      class="mousetrap"
       type="text"
       value=""
     />
@@ -53,6 +54,7 @@ exports[`Render with given value 1`] = `
       </div>
     </div>
     <input
+      class="mousetrap"
       type="text"
       value="James Bond"
     />

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -38,6 +38,7 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
                                 'resource_key' => 'tags',
                                 'types' => [
                                     'auto_complete' => [
+                                        'allow_add' => true,
                                         'display_property' => 'name',
                                         'id_property' => 'name',
                                         'filter_parameter' => 'names',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds keyboard functionality to the auto complete components.

#### Why?

Because it is much more comfortable to work with it this way.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
