### PR TITLE
Added exception messages to user provider for enabled and locked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
         java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
     fi
   # the content tests are intensive and there are memory leaks, this is more pronounced with the Jackalope DBAL PHPCR implementation.
-  - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - composer self-update
   - if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then composer require jackalope/jackalope-jackrabbit:~1.2  --no-update --no-interaction ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * HOTFIX      #4112 [SecurityBundle]        Added exception messages to user provider for enabled and locked
+
 * 1.5.18 (2018-10-05)
     * HOTFIX      #4092 [TestBundle]            Fixed firewall in test website kernel for community bundle
 

--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -64,11 +64,11 @@ class UserProvider implements UserProviderInterface
             $user = $this->userRepository->findUserByIdentifier($username);
 
             if (!$user->getEnabled()) {
-                throw new DisabledException();
+                throw new DisabledException('User is not enabled yet.');
             }
 
             if ($user->getLocked()) {
-                throw new LockedException();
+                throw new LockedException('User is locked.');
             }
 
             foreach ($user->getRoleObjects() as $role) {
@@ -101,11 +101,11 @@ class UserProvider implements UserProviderInterface
         $user = $this->userRepository->findUserWithSecurityById($user->getId());
 
         if (!$user->getEnabled()) {
-            throw new DisabledException();
+            throw new DisabledException('User is not enabled yet.');
         }
 
         if ($user->getLocked()) {
-            throw new LockedException();
+            throw new LockedException('User is locked.');
         }
 
         return $user;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added exception messages to user provider for enabled and locked.

#### Why?

Easier to implement a better output for the community bundle if a user is not yet enabled.