### PR TITLE
Fix error when pressing save buttons right after each other

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -1,6 +1,6 @@
 // @flow
 import {observer} from 'mobx-react';
-import {action} from 'mobx';
+import {action, computed} from 'mobx';
 import React from 'react';
 import ToolbarComponent from '../../components/Toolbar';
 import ToolbarStore from './stores/ToolbarStore';
@@ -67,22 +67,39 @@ export default class Toolbar extends React.Component<*> {
         this.toolbarStore.errors.pop();
     };
 
-    render() {
-        const {onNavigationButtonClick, navigationOpen} = this.props;
+    @computed get disableAllButtons() {
         const loadingItems = this.toolbarStore.getItemsConfig().filter((item) => item.loading);
-        const disableAllButtons = this.toolbarStore.disableAll || loadingItems.length > 0;
+        return this.toolbarStore.disableAll || loadingItems.length > 0;
+    }
+
+    @computed get backButtonConfig() {
         const backButtonConfig = this.toolbarStore.getBackButtonConfig();
+
+        if (!backButtonConfig) {
+            return;
+        }
+
+        if (this.disableAllButtons) {
+            backButtonConfig.disabled = true;
+        }
+
+        return backButtonConfig;
+    }
+
+    @computed get itemsConfig() {
         const itemsConfig = this.toolbarStore.getItemsConfig();
 
-        if (disableAllButtons) {
-            if (backButtonConfig) {
-                backButtonConfig.disabled = true;
-            }
-
+        if (this.disableAllButtons) {
             itemsConfig.forEach((item) => {
                 item.disabled = true;
             });
         }
+
+        return itemsConfig;
+    }
+
+    render() {
+        const {onNavigationButtonClick, navigationOpen} = this.props;
 
         return (
             <ToolbarComponent>
@@ -106,13 +123,13 @@ export default class Toolbar extends React.Component<*> {
                     }
                     {this.toolbarStore.hasBackButtonConfig() &&
                     <ToolbarComponent.Button
-                        {...backButtonConfig}
+                        {...this.backButtonConfig}
                         icon="su-angle-left"
                     />
                     }
                     {this.toolbarStore.hasItemsConfig() &&
                     <ToolbarComponent.Items>
-                        {itemsConfig.map((itemConfig, index) => getItemComponentByType(itemConfig, index))}
+                        {this.itemsConfig.map((itemConfig, index) => getItemComponentByType(itemConfig, index))}
                     </ToolbarComponent.Items>
                     }
                 </ToolbarComponent.Controls>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR moves some logic from the `Toolbar::render` method into some `@computed` statements.

#### Why?

Because obervable data was altered in the `render` method, which is not a mobx `action`. This caused an error when following this sequence:

1. Open a page
2. Reload using the browser
3. Change something
4. Save the changes as draft
5. Quickly afterwards Publish the page
6. An error was shown and the entire React tree was unmounted