### PR TITLE
Fix TreeTable view for pages

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/structureStrategies/TreeStructureStrategy.js
@@ -103,7 +103,9 @@ export default class TreeStructureStrategy implements StructureStrategyInterface
         if (item._embedded && Object.keys(item._embedded).length > 0) {
             const resourceKey = Object.keys(item._embedded)[0];
             const childItems = item._embedded[resourceKey];
-            childItems.forEach((childItem) => this.addItem(childItem, item.id));
+            if (childItems) {
+                childItems.forEach((childItem) => this.addItem(childItem, item.id));
+            }
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/TreeStructureStrategy.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/structureStrategies/TreeStructureStrategy.test.js
@@ -130,6 +130,9 @@ test('Should recursively add the items with data and children', () => {
     const child2 = {
         id: 2,
         hasChildren: false,
+        _embedded: {
+            nodes: null,
+        },
     };
     const child3 = {
         id: 3,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4083
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a check if a item in a `TreeStructure` has children.

#### Why?

Because in #4083 we added the possibility to return `null` instead of an empty array, to differ whether there are no children or the children only haven't been loaded.