### PR TITLE
Exclude shadows on ghost via toggler

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
@@ -3,6 +3,7 @@ $marginBottom: 10px;
 
 .label {
     display: flex;
+    align-items: center;
     cursor: pointer;
 
     & > div {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -20,13 +20,13 @@ export default class Dropdown extends React.Component<DropdownProps> {
         this.open = !this.open;
     };
 
-    componentWillReceiveProps = (nextProps: DropdownProps) => {
-        const {disabled} = nextProps;
+    componentDidUpdate() {
+        const {disabled} = this.props;
 
         if (disabled) {
             this.close();
         }
-    };
+    }
 
     handleButtonClick = () => {
         this.toggle();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/README.md
@@ -21,6 +21,12 @@ const Toolbar = require('./Toolbar').default;
 <Toolbar>
     <Toolbar.Controls>
         <Toolbar.Button onClick={() => null}>Test 1</Toolbar.Button>
+        <Toolbar.Toggler
+            disabled={true}
+            onClick={() => null}
+            label="Toggler"
+            value={true}
+        />
         <Toolbar.Items>
             <Toolbar.Button onClick={() => null}>Test 2</Toolbar.Button>
             <Toolbar.Dropdown
@@ -57,6 +63,11 @@ const Toolbar = require('./Toolbar').default;
 
 <Toolbar skin="dark">
     <Toolbar.Controls>
+        <Toolbar.Toggler
+            onClick={() => null}
+            label="Toggler"
+            value={false}
+        />
         <Toolbar.Button onClick={() => null}>Test 1</Toolbar.Button>
         <Toolbar.Items>
             <Toolbar.Button onClick={() => null}>Test 2</Toolbar.Button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toggler.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toggler.js
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react';
+import TogglerComponent from '../Toggler';
+import Button from './Button';
+import type {Toggler as TogglerProps} from './types';
+
+export default class Toggler extends React.Component<TogglerProps> {
+    render() {
+        const {disabled, label, onClick, skin, value} = this.props;
+
+        return (
+            <Button disabled={disabled} onClick={onClick} skin={skin}>
+                <TogglerComponent checked={value}>
+                    {label}
+                </TogglerComponent>
+            </Button>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toggler.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toggler.js
@@ -6,11 +6,11 @@ import type {Toggler as TogglerProps} from './types';
 
 export default class Toggler extends React.Component<TogglerProps> {
     render() {
-        const {disabled, label, onClick, skin, value} = this.props;
+        const {disabled, label, loading, onClick, skin, value} = this.props;
 
         return (
-            <Button disabled={disabled} onClick={onClick} skin={skin}>
-                <TogglerComponent checked={value}>
+            <Button disabled={disabled} loading={loading} onClick={onClick} skin={skin}>
+                <TogglerComponent checked={value} onChange={onClick}>
                     {label}
                 </TogglerComponent>
             </Button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Toolbar.js
@@ -8,6 +8,7 @@ import Dropdown from './Dropdown';
 import Snackbar from './Snackbar';
 import Items from './Items';
 import Icons from './Icons';
+import Toggler from './Toggler';
 import Select from './Select';
 import type {Skin} from './types';
 import toolbarStyles from './toolbar.scss';
@@ -23,17 +24,12 @@ export default class Toolbar extends React.PureComponent<Props> {
     };
 
     static Button = Button;
-
     static Controls = Controls;
-
     static Dropdown = Dropdown;
-
     static Items = Items;
-
     static Icons = Icons;
-
     static Select = Select;
-
+    static Toggler = Toggler;
     static Snackbar = Snackbar;
 
     static createChildren(children: ChildrenArray<*>, skin?: Skin) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Dropdown.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {mount, render} from 'enzyme';
 import React from 'react';
 import Dropdown from '../Dropdown';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toggler.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toggler.test.js
@@ -1,0 +1,31 @@
+// @flow
+import React from 'react';
+import {shallow, render} from 'enzyme';
+import Toggler from '../Toggler';
+
+test('Render disabled toggler', () => {
+    expect(render(
+        <Toggler disabled={true} label="Disabled Toggler" onClick={jest.fn()} value={false} />
+    )).toMatchSnapshot();
+});
+
+test('Render toggler with skin', () => {
+    expect(render(
+        <Toggler label="Dark Toggler" onClick={jest.fn()} skin="dark" value={false} />
+    )).toMatchSnapshot();
+});
+
+test('Render with active toggler', () => {
+    expect(render(
+        <Toggler label="Active Toggler" onClick={jest.fn()} value={true} />
+    )).toMatchSnapshot();
+});
+
+test('Call onClick handler when item was clicked', () => {
+    const clickSpy = jest.fn();
+    const toggler = shallow(<Toggler label="Click Toggler" onClick={clickSpy} value={false} />);
+
+    toggler.find('Button').simulate('click');
+
+    expect(clickSpy).toBeCalledWith();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toggler.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Toggler.test.js
@@ -9,6 +9,12 @@ test('Render disabled toggler', () => {
     )).toMatchSnapshot();
 });
 
+test('Render loading toggler', () => {
+    expect(render(
+        <Toggler label="Disabled Toggler" loading={true} onClick={jest.fn()} value={false} />
+    )).toMatchSnapshot();
+});
+
 test('Render toggler with skin', () => {
     expect(render(
         <Toggler label="Dark Toggler" onClick={jest.fn()} skin="dark" value={false} />
@@ -26,6 +32,15 @@ test('Call onClick handler when item was clicked', () => {
     const toggler = shallow(<Toggler label="Click Toggler" onClick={clickSpy} value={false} />);
 
     toggler.find('Button').simulate('click');
+
+    expect(clickSpy).toBeCalledWith();
+});
+
+test('Call onClick handler when toggler was changed', () => {
+    const clickSpy = jest.fn();
+    const toggler = shallow(<Toggler label="Click Toggler" onClick={clickSpy} value={false} />);
+
+    toggler.find('Toggler').simulate('change');
 
     expect(clickSpy).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toggler.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toggler.test.js.snap
@@ -27,6 +27,43 @@ exports[`Render disabled toggler 1`] = `
 </button>
 `;
 
+exports[`Render loading toggler 1`] = `
+<button
+  class="button"
+>
+  <div
+    class="spinner loader"
+    style="width:20px;height:20px"
+  >
+    <div
+      class="doubleBounce1"
+    />
+    <div
+      class="doubleBounce2"
+    />
+  </div>
+  <span
+    class="label"
+  >
+    <label
+      class="label"
+    >
+      <span
+        class="switch toggler"
+      >
+        <input
+          type="checkbox"
+        />
+        <span />
+      </span>
+      <div>
+        Disabled Toggler
+      </div>
+    </label>
+  </span>
+</button>
+`;
+
 exports[`Render toggler with skin 1`] = `
 <button
   class="button dark"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toggler.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toggler.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render disabled toggler 1`] = `
+<button
+  class="button"
+  disabled=""
+>
+  <span
+    class="label"
+  >
+    <label
+      class="label"
+    >
+      <span
+        class="switch toggler"
+      >
+        <input
+          type="checkbox"
+        />
+        <span />
+      </span>
+      <div>
+        Disabled Toggler
+      </div>
+    </label>
+  </span>
+</button>
+`;
+
+exports[`Render toggler with skin 1`] = `
+<button
+  class="button dark"
+>
+  <span
+    class="label"
+  >
+    <label
+      class="label"
+    >
+      <span
+        class="switch toggler"
+      >
+        <input
+          type="checkbox"
+        />
+        <span />
+      </span>
+      <div>
+        Dark Toggler
+      </div>
+    </label>
+  </span>
+</button>
+`;
+
+exports[`Render with active toggler 1`] = `
+<button
+  class="button"
+>
+  <span
+    class="label"
+  >
+    <label
+      class="label"
+    >
+      <span
+        class="switch toggler"
+      >
+        <input
+          checked=""
+          type="checkbox"
+        />
+        <span />
+      </span>
+      <div>
+        Active Toggler
+      </div>
+    </label>
+  </span>
+</button>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
@@ -5,11 +5,13 @@ import IconsComponent from './Icons';
 import ButtonComponent from './Button';
 import DropdownComponent from './Dropdown';
 import SelectComponent from './Select';
+import TogglerComponent from './Toggler';
 
 export type Item =
     Element<typeof ButtonComponent>
     | Element<typeof DropdownComponent>
-    | Element<typeof SelectComponent>;
+    | Element<typeof SelectComponent>
+    | Element<typeof TogglerComponent>;
 export type Group = Element<typeof ItemsComponent> | Element<typeof IconsComponent>;
 
 export type Skin = 'light' | 'dark';
@@ -17,7 +19,6 @@ export type Skin = 'light' | 'dark';
 export type Button = {
     children?: Node,
     onClick: () => ?Promise<*>,
-    // TODO rename to label?
     value?: string | number,
     icon?: string,
     size?: string,
@@ -32,6 +33,7 @@ export type Button = {
 export type Toggler = {
     disabled?: boolean,
     label: string,
+    loading?: boolean,
     onClick: () => void,
     skin?: Skin,
     value: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
@@ -17,6 +17,7 @@ export type Skin = 'light' | 'dark';
 export type Button = {
     children?: Node,
     onClick: () => ?Promise<*>,
+    // TODO rename to label?
     value?: string | number,
     icon?: string,
     size?: string,
@@ -26,6 +27,14 @@ export type Button = {
     loading?: boolean,
     primary?: boolean,
     skin?: Skin,
+};
+
+export type Toggler = {
+    disabled?: boolean,
+    label: string,
+    onClick: () => void,
+    skin?: Skin,
+    value: boolean,
 };
 
 export type DropdownOption = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -126,12 +126,16 @@ export default class DatagridStore {
         this.structureStrategy = structureStrategy;
     };
 
-    @action reset = () => {
-        const page = this.getPage();
-
+    @action clear = () => {
         if (this.structureStrategy) {
             this.structureStrategy.clear();
         }
+    };
+
+    @action reset = () => {
+        const page = this.getPage();
+
+        this.clear();
 
         this.setActive(undefined);
         this.pageCount = 0;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -873,6 +873,19 @@ test('Should reset page count and page when loading strategy changes', () => {
     datagridStore.destroy();
 });
 
+test('Should clear the StructureStrategy when the clear method is called', () => {
+    const datagridStore = new DatagridStore('snippets', {});
+
+    const structureStrategy = new StructureStrategy();
+    datagridStore.clear();
+    expect(structureStrategy.clear).not.toBeCalledWith();
+
+    datagridStore.updateStructureStrategy(structureStrategy);
+    datagridStore.clear();
+
+    expect(structureStrategy.clear).toBeCalledWith();
+});
+
 test('Should trigger a mobx autorun if activate is called with the same id', () => {
     const page = observable.box();
     const datagridStore = new DatagridStore('snippets', {page});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -12,25 +12,22 @@ const LOCALE_SELECT_SIZE = 'small';
 
 const ToolbarItemTypes = {
     Button: 'button',
-    Select: 'select',
     Dropdown: 'dropdown',
+    Select: 'select',
+    Toggler: 'toggler',
 };
 
 function getItemComponentByType(itemConfig, key) {
-    let item;
-
     switch (itemConfig.type) {
         case ToolbarItemTypes.Select:
-            item = (<ToolbarComponent.Select {...itemConfig} key={key} />);
-            break;
+            return <ToolbarComponent.Select {...itemConfig} key={key} />;
         case ToolbarItemTypes.Dropdown:
-            item = (<ToolbarComponent.Dropdown {...itemConfig} key={key} />);
-            break;
+            return <ToolbarComponent.Dropdown {...itemConfig} key={key} />;
+        case ToolbarItemTypes.Toggler:
+            return <ToolbarComponent.Toggler {...itemConfig} key={key} />;
         default:
-            item = (<ToolbarComponent.Button {...itemConfig} key={key} />);
+            return <ToolbarComponent.Button {...itemConfig} key={key} />;
     }
-
-    return item;
 }
 
 @observer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import React from 'react';
 import {render, shallow} from 'enzyme';
 import Toolbar from '../Toolbar';
@@ -34,6 +34,7 @@ beforeEach(() => {
 test('Render the items and icons from the ToolbarStore', () => {
     const storeKey = 'testStore';
 
+    // $FlowFixMe
     toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
 
     toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
@@ -75,6 +76,12 @@ test('Render the items and icons from the ToolbarStore', () => {
                     },
                 ],
             },
+            {
+                type: 'toggler',
+                label: 'Toggler',
+                onClick: () => {},
+                value: true,
+            },
         ]
     );
 
@@ -85,6 +92,7 @@ test('Render the items and icons from the ToolbarStore', () => {
 test('Render the items as disabled if one is loading', () => {
     const storeKey = 'testStore';
 
+    // $FlowFixMe
     toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
 
     toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
@@ -122,6 +130,7 @@ test('Render the items as disabled if one is loading', () => {
 test('Show success message for some time', () => {
     const storeKey = 'testStore';
 
+    // $FlowFixMe
     toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
 
     toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
@@ -142,6 +151,7 @@ test('Click on the success message should open the navigation', () => {
     const storeKey = 'testStore';
     const navigationButtonClickSpy = jest.fn();
 
+    // $FlowFixMe
     toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
 
     toolbarStoreMock.hasItemsConfig.mockReturnValue(true);
@@ -162,6 +172,7 @@ test('Click on the success message should open the navigation', () => {
 test('Remove last error if close button on snackbar is clicked', () => {
     const storeKey = 'testStore';
 
+    // $FlowFixMe
     toolbarStorePool.createStore.mockReturnValue(toolbarStoreMock);
 
     toolbarStoreMock.hasItemsConfig.mockReturnValue(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -77,6 +77,32 @@ exports[`Render the items and icons from the ToolbarStore 1`] = `
           </button>
         </div>
       </li>
+      <li>
+        <button
+          class="button light"
+        >
+          <span
+            class="label"
+          >
+            <label
+              class="label"
+            >
+              <span
+                class="switch toggler"
+              >
+                <input
+                  checked=""
+                  type="checkbox"
+                />
+                <span />
+              </span>
+              <div>
+                Toggler
+              </div>
+            </label>
+          </span>
+        </button>
+      </li>
     </ul>
   </div>
   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -1,13 +1,14 @@
 // @flow
 import type {Node} from 'react';
 import type {IObservableValue} from 'mobx';
-import type {Button, Dropdown, Select} from '../../components/Toolbar/types';
+import type {Button, Dropdown, Select, Toggler} from '../../components/Toolbar/types';
 
-export type {Button, Dropdown, Select};
+export type {Button, Dropdown, Select, Toggler};
 export type ButtonItemConfig = Button & { type: 'button' };
 export type DropdownItemConfig = Dropdown & { type: 'dropdown' };
 export type SelectItemConfig = Select & { type: 'select' };
-export type ToolbarItemConfig = ButtonItemConfig | DropdownItemConfig | SelectItemConfig;
+export type TogglerItemConfig = Toggler & { type: 'toggler'};
+export type ToolbarItemConfig = ButtonItemConfig | DropdownItemConfig | SelectItemConfig | TogglerItemConfig;
 
 export type ToolbarProps = {
     storeKey?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -12,7 +12,7 @@ export default class Router {
     @observable route: Route;
     @observable attributes: Object = {};
     @observable bindings: Map<string, IObservableValue<*>> = new Map();
-    bindingDefaults: Map<string, ?string | number> = new Map();
+    bindingDefaults: Map<string, ?string | number | boolean> = new Map();
     attributesHistory: {[string]: Array<AttributeMap>} = {};
     updateAttributesHooks: Array<UpdateAttributesHook> = [];
 
@@ -41,7 +41,7 @@ export default class Router {
         this.updateAttributesHooks.push(hook);
     }
 
-    @action bind(key: string, value: IObservableValue<*>, defaultValue: ?string | number = undefined) {
+    @action bind(key: string, value: IObservableValue<*>, defaultValue: ?string | number | boolean = undefined) {
         if (key in this.attributes) {
             // when the bound parameter is bound set the state of the passed observable to the current value once
             // required because otherwise the parameter will be overridden on the initial start of the application
@@ -78,12 +78,12 @@ export default class Router {
 
             const attributes = {};
             for (let i = 1; i < match.length; i++) {
-                attributes[names[i - 1].name] = Router.tryParseNumber(match[i]);
+                attributes[names[i - 1].name] = Router.tryParse(match[i]);
             }
 
             const search = new URLSearchParams(queryString);
             search.forEach((value, key) => {
-                attributes[key] = Router.tryParseNumber(value);
+                attributes[key] = Router.tryParse(value);
             });
 
             this.handleNavigation(name, attributes);
@@ -208,7 +208,15 @@ export default class Router {
         );
     }
 
-    static tryParseNumber(value: string) {
+    static tryParse(value: string) {
+        if (value === 'true') {
+            return true;
+        }
+
+        if (value === 'false') {
+            return false;
+        }
+
         if (isNaN(value)) {
             return value;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -220,6 +220,32 @@ test('Update observable attribute on route change', () => {
     expect(history.location.pathname).toBe('/list/de');
 });
 
+test('Update boolean observable attribute on route change', () => {
+    routeRegistry.getAll.mockReturnValue({
+        list: {
+            name: 'list',
+            view: 'list',
+            path: '/list',
+            attributeDefaults: {
+                exclude: true,
+            },
+        },
+    });
+
+    const exclude = observable.box();
+
+    const history = createHistory();
+    const router = new Router(history);
+
+    router.bind('exclude', exclude);
+
+    router.navigate('list');
+    expect(router.attributes.exclude).toBe(true);
+
+    history.push('/list?exclude=false');
+    expect(router.attributes.exclude).toBe(false);
+});
+
 test('Navigate to route using URL', () => {
     routeRegistry.getAll.mockReturnValue({
         page: {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -212,11 +212,12 @@ export default withToolbar(WebspaceOverview, function() {
     return {
         items: [
             {
-                value: translate('sulu_content.show_ghost_and_shadow'),
-                type: 'button',
+                label: translate('sulu_content.show_ghost_and_shadow'),
                 onClick: action(() => {
                     this.excludeGhostsAndShadows.set(!this.excludeGhostsAndShadows.get());
                 }),
+                type: 'toggler',
+                value: !this.excludeGhostsAndShadows.get(),
             },
         ],
         locale: {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/WebspaceOverview.js
@@ -7,6 +7,7 @@ import {Datagrid, DatagridStore, withToolbar} from 'sulu-admin-bundle/containers
 import {Loader} from 'sulu-admin-bundle/components';
 import {userStore} from 'sulu-admin-bundle/stores';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
+import {translate} from 'sulu-admin-bundle/utils';
 import WebspaceSelect from '../../components/WebspaceSelect';
 import WebspaceStore from '../../stores/WebspaceStore';
 import type {Webspace, Localization} from '../../stores/WebspaceStore/types';
@@ -24,9 +25,11 @@ class WebspaceOverview extends React.Component<ViewProps> {
     page: IObservableValue<number> = observable.box();
     locale: IObservableValue<string> = observable.box();
     webspace: IObservableValue<string> = observable.box();
+    excludeGhostsAndShadows: IObservableValue<boolean> = observable.box(false);
     datagridStore: DatagridStore;
     @observable webspaces: Array<Webspace>;
     activeDisposer: () => void;
+    excludeGhostsAndShadowsDisposer: () => void;
     webspaceDisposer: () => void;
 
     static getDerivedRouteAttributes() {
@@ -93,8 +96,12 @@ class WebspaceOverview extends React.Component<ViewProps> {
         const observableOptions = {};
         const apiOptions = {};
 
-        router.bind('page', this.page, '1');
+        router.bind('page', this.page, 1);
         observableOptions.page = this.page;
+
+        router.bind('excludeGhostsAndShadows', this.excludeGhostsAndShadows, false);
+        observableOptions['exclude-ghosts'] = this.excludeGhostsAndShadows;
+        observableOptions['exclude-shadows'] = this.excludeGhostsAndShadows;
 
         router.bind('locale', this.locale);
         observableOptions.locale = this.locale;
@@ -104,6 +111,11 @@ class WebspaceOverview extends React.Component<ViewProps> {
 
         this.datagridStore = new DatagridStore('pages', observableOptions, apiOptions);
         router.bind('active', this.datagridStore.active);
+
+        this.excludeGhostsAndShadowsDisposer = intercept(this.excludeGhostsAndShadows, '', (change) => {
+            this.datagridStore.clear();
+            return change;
+        });
 
         this.webspaceDisposer = intercept(this.webspace, '', (change) => {
             userStore.setPersistentSetting(USER_SETTING_WEBSPACE, change.newValue);
@@ -134,6 +146,7 @@ class WebspaceOverview extends React.Component<ViewProps> {
     componentWillUnmount() {
         this.datagridStore.destroy();
         this.activeDisposer();
+        this.excludeGhostsAndShadowsDisposer();
         this.webspaceDisposer();
     }
 
@@ -196,20 +209,25 @@ export default withToolbar(WebspaceOverview, function() {
         return {};
     }
 
-    const options = this.selectedWebspace.allLocalizations.map((localization) => ({
-        value: localization.localization,
-        label: localization.name,
-    }));
-
-    const locale = {
-        value: this.locale.get(),
-        onChange: action((locale) => {
-            this.locale.set(locale);
-        }),
-        options,
-    };
-
     return {
-        locale,
+        items: [
+            {
+                value: translate('sulu_content.show_ghost_and_shadow'),
+                type: 'button',
+                onClick: action(() => {
+                    this.excludeGhostsAndShadows.set(!this.excludeGhostsAndShadows.get());
+                }),
+            },
+        ],
+        locale: {
+            value: this.locale.get(),
+            onChange: action((locale) => {
+                this.locale.set(locale);
+            }),
+            options: this.selectedWebspace.allLocalizations.map((localization) => ({
+                value: localization.localization,
+                label: localization.name,
+            })),
+        },
     };
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/WebspaceOverview/tests/WebspaceOverview.test.js
@@ -189,6 +189,7 @@ test('Should change excludeGhostsAndShadows when value of toggler is changed', (
     return promise.then(() => {
         webspaceOverview.instance().webspace.set('sulu');
         webspaceOverview.update();
+
         const excludeGhostsAndShadows = webspaceOverview.instance().excludeGhostsAndShadows;
         expect(excludeGhostsAndShadows.get()).toEqual(false);
         expect(webspaceOverview.instance().datagridStore.observableOptions).toEqual(expect.objectContaining({
@@ -196,12 +197,18 @@ test('Should change excludeGhostsAndShadows when value of toggler is changed', (
             'exclude-shadows': excludeGhostsAndShadows,
         }));
 
-        const toolbarConfig = toolbarFunction.call(webspaceOverview.instance());
+        let toolbarConfig = toolbarFunction.call(webspaceOverview.instance());
+        expect(toolbarConfig.items[0].value).toEqual(true);
+
         toolbarConfig.items[0].onClick();
+        toolbarConfig = toolbarFunction.call(webspaceOverview.instance());
+        expect(toolbarConfig.items[0].value).toEqual(false);
         expect(webspaceOverview.instance().datagridStore.clear).toBeCalledWith();
         expect(webspaceOverview.instance().excludeGhostsAndShadows.get()).toEqual(true);
 
         toolbarConfig.items[0].onClick();
+        toolbarConfig = toolbarFunction.call(webspaceOverview.instance());
+        expect(toolbarConfig.items[0].value).toEqual(true);
         expect(webspaceOverview.instance().excludeGhostsAndShadows.get()).toEqual(false);
     });
 });

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
@@ -4,5 +4,6 @@
     "sulu_content.page_form_detail": "Details",
     "sulu_content.page_form_seo": "SEO",
     "sulu_content.page_form_excerpt": "Auszug & Taxonomien",
-    "sulu_content.title": "Titel"
+    "sulu_content.title": "Titel",
+    "sulu_content.show_ghost_and_shadow": "Ghost- und Shadow- Seiten anzeigen"
 }

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
@@ -4,5 +4,6 @@
     "sulu_content.page_form_detail": "Details",
     "sulu_content.page_form_seo": "SEO",
     "sulu_content.page_form_excerpt": "Excerpt & Taxonomies",
-    "sulu_content.title": "Title"
+    "sulu_content.title": "Title",
+    "sulu_content.show_ghost_and_shadow": "Show ghost and shadow pages"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a toggler in the `WebspaceOverview`, allowing the user to switch ghosts and shadow pages on and off.

#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
