### PR TITLE
Set a timeout when purging caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * BUGFIX      #4121 [HttpCache]             Set a timeout when purging caches
     * BUGFIX      #4109 [ContentBundle]         Remove validation-state from rendered link
 
 * 1.6.21 (2018-07-18)

--- a/src/Sulu/Component/HttpCache/ProxyClient/Symfony.php
+++ b/src/Sulu/Component/HttpCache/ProxyClient/Symfony.php
@@ -124,7 +124,12 @@ class Symfony implements ProxyClientInterface, PurgeInterface
         $promises = [];
         $collection = new ExceptionCollection();
         foreach ($requests as $request) {
-            $promises[] = $promise = $this->client->sendAsync($request);
+            $promises[] = $promise = $this->client->sendAsync(
+                $request,
+                [
+                    'connect_timeout' => 5,
+                ]
+            );
             $promise->then(
                 function (ResponseInterface $res) {
                 },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?
Set a timeout when purging caches

#### Why?
The default behavior is to wait indefinitely (see [guzzle documentation](http://docs.guzzlephp.org/en/stable/request-options.html#connect-timeout)), which
may result in a very long request once the caches need to be cleared, but a long responding host is set in the config (see [example configuration](https://github.com/sulu/sulu-minimal/blob/7887ff338657fa5148c56153030d835d0da02c49/app/Resources/webspaces/example.com.xml#L43))
