### PR TITLE
Introduce IntlMessageFormat for better translations

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -106,7 +106,7 @@ export default class Selection extends React.Component<Props> {
                 displayProperties={displayProperties}
                 disabledIds={resourceKey === formInspector.resourceKey && formInspector.id ? [formInspector.id] : []}
                 icon={icon}
-                label={translate(label)}
+                label={translate(label, {count: value ? value.length : 0})}
                 locale={formInspector.locale}
                 onChange={onChange}
                 resourceKey={resourceKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -2,11 +2,12 @@
 import React from 'react';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
+import {translate} from '../../../../utils/Translator';
+import ResourceStore from '../../../../stores/ResourceStore';
 import Datagrid from '../../../Datagrid';
 import Selection from '../../fields/Selection';
 import FormInspector from '../../FormInspector';
 import FormStore from '../../stores/FormStore';
-import ResourceStore from '../../../../stores/ResourceStore';
 
 jest.mock('../../../Datagrid', () => jest.fn(() => null));
 
@@ -40,9 +41,7 @@ jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey
 }));
 
 jest.mock('../../../../utils/Translator', () => ({
-    translate: jest.fn(function(key) {
-        return key;
-    }),
+    translate: jest.fn((key) => key),
 }));
 
 test('Should pass props correctly to selection component', () => {
@@ -87,6 +86,8 @@ test('Should pass props correctly to selection component', () => {
             value={value}
         />
     );
+
+    expect(translate).toBeCalledWith('sulu_snippet.selection_label', {count: 3});
 
     expect(selection.find('Selection').props()).toEqual(expect.objectContaining({
         adapter: 'table',
@@ -141,6 +142,7 @@ test('Should pass empty array if value is not given to overlay type', () => {
         types: {
             overlay: {
                 adapter: 'column_list',
+                label: 'sulu_content.selection_label',
             },
         },
     };
@@ -163,6 +165,7 @@ test('Should pass empty array if value is not given to overlay type', () => {
         />
     );
 
+    expect(translate).toBeCalledWith('sulu_content.selection_label', {count: 0});
     expect(selection.find('Selection').props()).toEqual(expect.objectContaining({
         adapter: 'column_list',
         onChange: changeSpy,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Selection/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Selection/Selection.js
@@ -105,7 +105,7 @@ export default class Selection extends React.Component<Props> {
         return (
             <Fragment>
                 <MultiItemSelection
-                    label={label && items.length + ' ' + label}
+                    label={label}
                     leftButton={{
                         icon,
                         onClick: this.handleOverlayOpen,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Selection/tests/__snapshots__/Selection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Selection/tests/__snapshots__/Selection.test.js.snap
@@ -97,7 +97,7 @@ Array [
       <div
         class="label"
       >
-        0 Select Snippets
+        Select Snippets
       </div>
     </div>
     <ul

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -17,6 +17,7 @@
         "font-awesome": "^4.7.0",
         "history": "^4.6.3",
         "imagesloaded": "^4.1.3",
+        "intl-messageformat": "^2.2.0",
         "isemail": "^3.1.2",
         "jsonpointer": "^4.0.1",
         "loglevel": "^1.4.1",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Translator/Translator.js
@@ -1,24 +1,29 @@
 // @flow
 import log from 'loglevel';
+import IntlMessageFormat from 'intl-messageformat';
 import type {TranslationMap} from './types';
 
-let translationMap: ?TranslationMap;
+let translationMap;
 
 function setTranslations(translations: TranslationMap) {
-    translationMap = translations;
+    translationMap = Object.keys(translations).reduce((messages, translationKey) => {
+        // TODO add locale for correct translation of numbers, dates, ...
+        messages[translationKey] = new IntlMessageFormat(translations[translationKey]);
+        return messages;
+    }, {});
 }
 
 function clearTranslations() {
     translationMap = null;
 }
 
-function translate(key: string) {
+function translate(key: string, parameters: ?Object) {
     if (!translationMap || !(key in translationMap)) {
         log.warn('The translation key "' + key + '" has not been translated. The key itself will be returned instead.');
         return key;
     }
 
-    return translationMap[key];
+    return translationMap[key].format(parameters);
 }
 
 export {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Translator/tests/Translator.test.js
@@ -17,6 +17,15 @@ test('Translator should translate translations', () => {
     expect(translate('delete')).toBe('Delete');
 });
 
+test('Translator should use the IntlMessageFormat for translation', () => {
+    setTranslations({
+        'apple_count': 'You have {numApples, plural, =0 {no apples} =1 {one apple} other {# apples}}.',
+    });
+    expect(translate('apple_count', {numApples: 0})).toEqual('You have no apples.');
+    expect(translate('apple_count', {numApples: 1})).toEqual('You have one apple.');
+    expect(translate('apple_count', {numApples: 4})).toEqual('You have 4 apples.');
+});
+
 test('Translator should return key when translating non-existing keys and log a warning', () => {
     expect(translate('not-existing')).toBe('not-existing');
     expect(log.warn).toBeCalled();

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
@@ -1,5 +1,5 @@
 {
-    "sulu_content.selection_label": "Seite(n) ausgewählt",
+    "sulu_content.selection_label": "{count} {count, plural, =1 {Seite} other {Seiten}} ausgewählt",
     "sulu_content.selection_overlay_title": "Seiten auswählen",
     "sulu_content.page_form_detail": "Details",
     "sulu_content.page_form_seo": "SEO",

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
@@ -1,5 +1,5 @@
 {
-    "sulu_content.selection_label": "page(s) selected",
+    "sulu_content.selection_label": "{count} {count, plural, =1 {page} other {pages}} selected",
     "sulu_content.selection_overlay_title": "Choose pages",
     "sulu_content.page_form_detail": "Details",
     "sulu_content.page_form_seo": "SEO",

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
@@ -1,6 +1,6 @@
 {
     "sulu_snippet.selection_overlay_title": "Schnipsel auswählen",
-    "sulu_snippet.selection_label": "Schnipsel ausgewählt",
+    "sulu_snippet.selection_label": "{count} Schnipsel ausgewählt",
     "sulu_snippet.snippets": "Schnipsel",
     "sulu_snippet.details": "Details",
     "sulu_snippet.taxonomies": "Taxonomien",

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
@@ -1,6 +1,6 @@
 {
     "sulu_snippet.selection_overlay_title": "Choose snippets",
-    "sulu_snippet.selection_label": "snippet(s) selected",
+    "sulu_snippet.selection_label": "{count} {count, plural, =1 {snippet} other {snippets}} selected",
     "sulu_snippet.snippets": "Snippets",
     "sulu_snippet.details": "Details",
     "sulu_snippet.taxonomies": "Taxonomies",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | --
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces the [IntlMessageFormat](https://github.com/yahoo/intl-messageformat) component to allow for better translations, especially for introducing placeholders and allow to consider plurals in translations.

#### Why?

Because we don't want to write texts like `4 page(s)` and sometimes the word order is different among languages.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
