### PR TITLE
remove warning for missing translations

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
@@ -25,9 +25,7 @@ exports[`Render ArrowMenu open 2`] = `
       <div class=\\"arrowMenu\\">
         <div class=\\"section\\">
           <div class=\\"title\\">Search Section</div>
-          <div class=\\"children\\">
-            <input type=\\"text\\">
-          </div>
+          <div class=\\"children\\"><input type=\\"text\\"></div>
         </div>
         <div class=\\"section\\">
           <div class=\\"title\\">Webspaces</div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
@@ -147,8 +147,10 @@ exports[`ColorPicker should render with open overlay 1`] = `
                     }
 
                     .hue-vertical {
-                      background: linear-gradient(to top, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
-                      background: -webkit-linear-gradient(to top, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
+                      background: linear-gradient(to top, #f00 0%, #ff0 17%, #0f0 33%,
+                        #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
+                      background: -webkit-linear-gradient(to top, #f00 0%, #ff0 17%,
+                        #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
                     }
                   </style>
                   <div style=\\"position: absolute; left: 69.44444444444443%;\\">
@@ -178,24 +180,19 @@ exports[`ColorPicker should render with open overlay 1`] = `
         </div>
         <div style=\\"display: flex; padding-top: 4px;\\" class=\\"flexbox-fix\\">
           <div>
-            <div style=\\"position: relative;\\">
-              <input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"22194D\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize;\\">hex</span></div>
+            <div style=\\"position: relative;\\"><input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"22194D\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize;\\">hex</span></div>
           </div>
           <div style=\\"padding-left: 6px;\\">
-            <div style=\\"position: relative;\\">
-              <input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"34\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">r</span></div>
+            <div style=\\"position: relative;\\"><input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"34\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">r</span></div>
           </div>
           <div style=\\"padding-left: 6px;\\">
-            <div style=\\"position: relative;\\">
-              <input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"25\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">g</span></div>
+            <div style=\\"position: relative;\\"><input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"25\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">g</span></div>
           </div>
           <div style=\\"padding-left: 6px;\\">
-            <div style=\\"position: relative;\\">
-              <input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"77\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">b</span></div>
+            <div style=\\"position: relative;\\"><input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"77\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">b</span></div>
           </div>
           <div style=\\"padding-left: 6px; display: none;\\">
-            <div style=\\"position: relative;\\">
-              <input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"100\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">a</span></div>
+            <div style=\\"position: relative;\\"><input style=\\"width: 80%; padding: 4px 10% 3px; box-shadow: inset 0 0 0 1px #ccc; font-size: 11px;\\" spellcheck=\\"false\\" value=\\"100\\"><span style=\\"display: block; text-align: center; font-size: 11px; color: rgb(34, 34, 34); padding-top: 3px; padding-bottom: 4px; text-transform: capitalize; cursor: ew-resize;\\">a</span></div>
           </div>
         </div>
         <div style=\\"margin: 0px -10px; padding: 10px 0px 0px 10px; border-top: 1px solid #eee; display: none; flex-wrap: wrap; position: relative;\\" class=\\"flexbox-fix\\"></div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
@@ -32,12 +32,8 @@ exports[`Should render with active 2`] = `
     <div style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\">
       <div class=\\"listContainer\\">
         <ul class=\\"list primary\\">
-          <li>
-            <button class=\\"option\\">Option1</button>
-          </li>
-          <li>
-            <button class=\\"option\\" disabled=\\"\\">Option1</button>
-          </li>
+          <li><button class=\\"option\\">Option1</button></li>
+          <li><button class=\\"option\\" disabled=\\"\\">Option1</button></li>
         </ul>
       </div>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -40,168 +40,524 @@ exports[`DatePicker should render 1`] = `
       verticalOffset={-31}
     >
       <Portal>
-        <div
-          className="container"
-        >
-          <div
-            style={
-              Object {
-                "left": "34px",
-                "maxHeight": undefined,
-                "pointerEvents": "auto",
-                "position": "fixed",
-                "top": "10px",
-              }
-            }
-          >
-            <DateTime
-              className=""
-              closeOnSelect={true}
-              closeOnTab={true}
-              dateFormat="MM/DD/YYYY"
-              defaultValue=""
-              input={true}
-              inputProps={
-                Object {
-                  "icon": "su-calendar",
-                  "placeholder": "MM/DD/YYYY",
-                  "valid": true,
-                }
-              }
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onNavigateBack={[Function]}
-              onNavigateForward={[Function]}
-              onViewModeChange={[Function]}
-              open={false}
-              renderInput={[Function]}
-              strictParsing={true}
-              timeConstraints={Object {}}
-              timeFormat={false}
-              utc={false}
-              value={null}
-            >
+        <Portal
+          containerInfo={
+            <div>
               <div
-                className="rdt"
+                class="container"
               >
                 <div
-                  key="i"
+                  style="top: 10px; position: fixed; pointer-events: auto; left: 34px;"
                 >
-                  <Input
-                    className="form-control"
-                    collapsed={false}
-                    icon="su-calendar"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onIconClick={[Function]}
-                    onKeyDown={[Function]}
-                    placeholder="MM/DD/YYYY"
-                    skin="default"
-                    type="text"
-                    valid={true}
-                    value=""
+                  <div
+                    class="rdt"
                   >
-                    <label
-                      className="input default"
+                    <div />
+                    <div
+                      class="rdtPicker"
                     >
                       <div
-                        className="prependedContainer default"
+                        class="rdtDays"
                       >
-                        <Icon
-                          className="icon default iconClickable"
-                          name="su-calendar"
-                          onClick={[Function]}
-                        >
-                          <span
-                            aria-label="su-calendar"
-                            className="icon default iconClickable su-calendar clickable"
-                            onClick={[Function]}
-                            role="button"
-                            tabIndex={0}
-                          />
-                        </Icon>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th
+                                class="rdtPrev"
+                              >
+                                <span>
+                                  ‹
+                                </span>
+                              </th>
+                              <th
+                                class="rdtSwitch"
+                                colspan="5"
+                                data-value="3"
+                              >
+                                April 2017
+                              </th>
+                              <th
+                                class="rdtNext"
+                              >
+                                <span>
+                                  ›
+                                </span>
+                              </th>
+                            </tr>
+                            <tr>
+                              <th
+                                class="dow"
+                              >
+                                Su
+                              </th>
+                              <th
+                                class="dow"
+                              >
+                                Mo
+                              </th>
+                              <th
+                                class="dow"
+                              >
+                                Tu
+                              </th>
+                              <th
+                                class="dow"
+                              >
+                                We
+                              </th>
+                              <th
+                                class="dow"
+                              >
+                                Th
+                              </th>
+                              <th
+                                class="dow"
+                              >
+                                Fr
+                              </th>
+                              <th
+                                class="dow"
+                              >
+                                Sa
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td
+                                class="rdtDay rdtOld"
+                                data-value="26"
+                              >
+                                26
+                              </td>
+                              <td
+                                class="rdtDay rdtOld"
+                                data-value="27"
+                              >
+                                27
+                              </td>
+                              <td
+                                class="rdtDay rdtOld"
+                                data-value="28"
+                              >
+                                28
+                              </td>
+                              <td
+                                class="rdtDay rdtOld"
+                                data-value="29"
+                              >
+                                29
+                              </td>
+                              <td
+                                class="rdtDay rdtOld"
+                                data-value="30"
+                              >
+                                30
+                              </td>
+                              <td
+                                class="rdtDay rdtOld"
+                                data-value="31"
+                              >
+                                31
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="1"
+                              >
+                                1
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="rdtDay"
+                                data-value="2"
+                              >
+                                2
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="3"
+                              >
+                                3
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="4"
+                              >
+                                4
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="5"
+                              >
+                                5
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="6"
+                              >
+                                6
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="7"
+                              >
+                                7
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="8"
+                              >
+                                8
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="rdtDay"
+                                data-value="9"
+                              >
+                                9
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="10"
+                              >
+                                10
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="11"
+                              >
+                                11
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="12"
+                              >
+                                12
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="13"
+                              >
+                                13
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="14"
+                              >
+                                14
+                              </td>
+                              <td
+                                class="rdtDay rdtToday"
+                                data-value="15"
+                              >
+                                15
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="rdtDay"
+                                data-value="16"
+                              >
+                                16
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="17"
+                              >
+                                17
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="18"
+                              >
+                                18
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="19"
+                              >
+                                19
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="20"
+                              >
+                                20
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="21"
+                              >
+                                21
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="22"
+                              >
+                                22
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="rdtDay"
+                                data-value="23"
+                              >
+                                23
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="24"
+                              >
+                                24
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="25"
+                              >
+                                25
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="26"
+                              >
+                                26
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="27"
+                              >
+                                27
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="28"
+                              >
+                                28
+                              </td>
+                              <td
+                                class="rdtDay"
+                                data-value="29"
+                              >
+                                29
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                class="rdtDay"
+                                data-value="30"
+                              >
+                                30
+                              </td>
+                              <td
+                                class="rdtDay rdtNew"
+                                data-value="1"
+                              >
+                                1
+                              </td>
+                              <td
+                                class="rdtDay rdtNew"
+                                data-value="2"
+                              >
+                                2
+                              </td>
+                              <td
+                                class="rdtDay rdtNew"
+                                data-value="3"
+                              >
+                                3
+                              </td>
+                              <td
+                                class="rdtDay rdtNew"
+                                data-value="4"
+                              >
+                                4
+                              </td>
+                              <td
+                                class="rdtDay rdtNew"
+                                data-value="5"
+                              >
+                                5
+                              </td>
+                              <td
+                                class="rdtDay rdtNew"
+                                data-value="6"
+                              >
+                                6
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
                       </div>
-                      <input
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+        >
+          <div
+            className="container"
+          >
+            <div
+              style={
+                Object {
+                  "left": "34px",
+                  "maxHeight": undefined,
+                  "pointerEvents": "auto",
+                  "position": "fixed",
+                  "top": "10px",
+                }
+              }
+            >
+              <DateTime
+                className=""
+                closeOnSelect={true}
+                closeOnTab={true}
+                dateFormat="MM/DD/YYYY"
+                defaultValue=""
+                input={true}
+                inputProps={
+                  Object {
+                    "icon": "su-calendar",
+                    "placeholder": "MM/DD/YYYY",
+                    "valid": true,
+                  }
+                }
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onNavigateBack={[Function]}
+                onNavigateForward={[Function]}
+                onViewModeChange={[Function]}
+                open={false}
+                renderInput={[Function]}
+                strictParsing={true}
+                timeConstraints={Object {}}
+                timeFormat={false}
+                utc={false}
+                value={null}
+              >
+                <div
+                  className="rdt"
+                >
+                  <div
+                    key="i"
+                  >
+                    <Portal
+                      containerInfo={
+                        <div>
+                          <label
+                            class="input default"
+                          >
+                            <div
+                              class="prependedContainer default"
+                            >
+                              <span
+                                aria-label="su-calendar"
+                                class="icon default iconClickable su-calendar clickable"
+                                role="button"
+                                tabindex="0"
+                              />
+                            </div>
+                            <input
+                              placeholder="MM/DD/YYYY"
+                              type="text"
+                              value=""
+                            />
+                          </label>
+                        </div>
+                      }
+                    >
+                      <Input
+                        className="form-control"
+                        collapsed={false}
+                        icon="su-calendar"
                         onBlur={[Function]}
                         onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onIconClick={[Function]}
+                        onKeyDown={[Function]}
                         placeholder="MM/DD/YYYY"
+                        skin="default"
                         type="text"
+                        valid={true}
                         value=""
-                      />
-                    </label>
-                  </Input>
-                </div>
-                <div
-                  className="rdtPicker"
-                  key="dt"
-                >
-                  <Component
-                    onClickOutside={[Function]}
-                    view="days"
-                    viewProps={
-                      Object {
-                        "addTime": [Function],
-                        "dateFormat": "MM/DD/YYYY",
-                        "handleClickOutside": [Function],
-                        "isValidDate": undefined,
-                        "localMoment": [Function],
-                        "renderDay": undefined,
-                        "renderMonth": undefined,
-                        "renderYear": undefined,
-                        "selectedDate": undefined,
-                        "setDate": [Function],
-                        "setTime": [Function],
-                        "showView": [Function],
-                        "subtractTime": [Function],
-                        "timeConstraints": Object {},
-                        "timeFormat": "",
-                        "updateOn": "days",
-                        "updateSelectedDate": [Function],
-                        "value": null,
-                        "viewDate": "2017-03-31T22:00:00.000Z",
-                      }
-                    }
+                      >
+                        <label
+                          className="input default"
+                        >
+                          <div
+                            className="prependedContainer default"
+                          >
+                            <Icon
+                              className="icon default iconClickable"
+                              name="su-calendar"
+                              onClick={[Function]}
+                            >
+                              <span
+                                aria-label="su-calendar"
+                                className="icon default iconClickable su-calendar clickable"
+                                onClick={[Function]}
+                                role="button"
+                                tabIndex={0}
+                              />
+                            </Icon>
+                          </div>
+                          <input
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            placeholder="MM/DD/YYYY"
+                            type="text"
+                            value=""
+                          />
+                        </label>
+                      </Input>
+                    </Portal>
+                  </div>
+                  <div
+                    className="rdtPicker"
+                    key="dt"
                   >
-                    <OnClickOutside(Component)
-                      addTime={[Function]}
-                      dateFormat="MM/DD/YYYY"
-                      eventTypes={
-                        Array [
-                          "mousedown",
-                          "touchstart",
-                        ]
+                    <Component
+                      onClickOutside={[Function]}
+                      view="days"
+                      viewProps={
+                        Object {
+                          "addTime": [Function],
+                          "dateFormat": "MM/DD/YYYY",
+                          "handleClickOutside": [Function],
+                          "isValidDate": undefined,
+                          "localMoment": [Function],
+                          "renderDay": undefined,
+                          "renderMonth": undefined,
+                          "renderYear": undefined,
+                          "selectedDate": undefined,
+                          "setDate": [Function],
+                          "setTime": [Function],
+                          "showView": [Function],
+                          "subtractTime": [Function],
+                          "timeConstraints": Object {},
+                          "timeFormat": "",
+                          "updateOn": "days",
+                          "updateSelectedDate": [Function],
+                          "value": null,
+                          "viewDate": "2017-03-31T22:00:00.000Z",
+                        }
                       }
-                      excludeScrollbar={false}
-                      handleClickOutside={[Function]}
-                      localMoment={[Function]}
-                      outsideClickIgnoreClass="ignore-react-onclickoutside"
-                      preventDefault={false}
-                      setDate={[Function]}
-                      setTime={[Function]}
-                      showView={[Function]}
-                      stopPropagation={false}
-                      subtractTime={[Function]}
-                      timeConstraints={Object {}}
-                      timeFormat=""
-                      updateOn="days"
-                      updateSelectedDate={[Function]}
-                      value={null}
-                      viewDate={"2017-03-31T22:00:00.000Z"}
                     >
-                      <Component
+                      <OnClickOutside(Component)
                         addTime={[Function]}
                         dateFormat="MM/DD/YYYY"
-                        disableOnClickOutside={[Function]}
-                        enableOnClickOutside={[Function]}
                         eventTypes={
                           Array [
                             "mousedown",
                             "touchstart",
                           ]
                         }
+                        excludeScrollbar={false}
                         handleClickOutside={[Function]}
                         localMoment={[Function]}
                         outsideClickIgnoreClass="ignore-react-onclickoutside"
@@ -218,465 +574,493 @@ exports[`DatePicker should render 1`] = `
                         value={null}
                         viewDate={"2017-03-31T22:00:00.000Z"}
                       >
-                        <div
-                          className="rdtDays"
+                        <Component
+                          addTime={[Function]}
+                          dateFormat="MM/DD/YYYY"
+                          disableOnClickOutside={[Function]}
+                          enableOnClickOutside={[Function]}
+                          eventTypes={
+                            Array [
+                              "mousedown",
+                              "touchstart",
+                            ]
+                          }
+                          handleClickOutside={[Function]}
+                          localMoment={[Function]}
+                          outsideClickIgnoreClass="ignore-react-onclickoutside"
+                          preventDefault={false}
+                          setDate={[Function]}
+                          setTime={[Function]}
+                          showView={[Function]}
+                          stopPropagation={false}
+                          subtractTime={[Function]}
+                          timeConstraints={Object {}}
+                          timeFormat=""
+                          updateOn="days"
+                          updateSelectedDate={[Function]}
+                          value={null}
+                          viewDate={"2017-03-31T22:00:00.000Z"}
                         >
-                          <table>
-                            <thead
-                              key="th"
-                            >
-                              <tr
-                                key="h"
+                          <div
+                            className="rdtDays"
+                          >
+                            <table>
+                              <thead
+                                key="th"
                               >
-                                <th
-                                  className="rdtPrev"
-                                  key="p"
-                                  onClick={[Function]}
+                                <tr
+                                  key="h"
                                 >
-                                  <span>
-                                    ‹
-                                  </span>
-                                </th>
-                                <th
-                                  className="rdtSwitch"
-                                  colSpan={5}
-                                  data-value={3}
-                                  key="s"
-                                  onClick={[Function]}
+                                  <th
+                                    className="rdtPrev"
+                                    key="p"
+                                    onClick={[Function]}
+                                  >
+                                    <span>
+                                      ‹
+                                    </span>
+                                  </th>
+                                  <th
+                                    className="rdtSwitch"
+                                    colSpan={5}
+                                    data-value={3}
+                                    key="s"
+                                    onClick={[Function]}
+                                  >
+                                    April 2017
+                                  </th>
+                                  <th
+                                    className="rdtNext"
+                                    key="n"
+                                    onClick={[Function]}
+                                  >
+                                    <span>
+                                      ›
+                                    </span>
+                                  </th>
+                                </tr>
+                                <tr
+                                  key="d"
                                 >
-                                  April 2017
-                                </th>
-                                <th
-                                  className="rdtNext"
-                                  key="n"
-                                  onClick={[Function]}
-                                >
-                                  <span>
-                                    ›
-                                  </span>
-                                </th>
-                              </tr>
-                              <tr
-                                key="d"
+                                  <th
+                                    className="dow"
+                                    key="Su0"
+                                  >
+                                    Su
+                                  </th>
+                                  <th
+                                    className="dow"
+                                    key="Mo1"
+                                  >
+                                    Mo
+                                  </th>
+                                  <th
+                                    className="dow"
+                                    key="Tu2"
+                                  >
+                                    Tu
+                                  </th>
+                                  <th
+                                    className="dow"
+                                    key="We3"
+                                  >
+                                    We
+                                  </th>
+                                  <th
+                                    className="dow"
+                                    key="Th4"
+                                  >
+                                    Th
+                                  </th>
+                                  <th
+                                    className="dow"
+                                    key="Fr5"
+                                  >
+                                    Fr
+                                  </th>
+                                  <th
+                                    className="dow"
+                                    key="Sa6"
+                                  >
+                                    Sa
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody
+                                key="tb"
                               >
-                                <th
-                                  className="dow"
-                                  key="Su0"
-                                >
-                                  Su
-                                </th>
-                                <th
-                                  className="dow"
-                                  key="Mo1"
-                                >
-                                  Mo
-                                </th>
-                                <th
-                                  className="dow"
-                                  key="Tu2"
-                                >
-                                  Tu
-                                </th>
-                                <th
-                                  className="dow"
-                                  key="We3"
-                                >
-                                  We
-                                </th>
-                                <th
-                                  className="dow"
-                                  key="Th4"
-                                >
-                                  Th
-                                </th>
-                                <th
-                                  className="dow"
-                                  key="Fr5"
-                                >
-                                  Fr
-                                </th>
-                                <th
-                                  className="dow"
-                                  key="Sa6"
-                                >
-                                  Sa
-                                </th>
-                              </tr>
-                            </thead>
-                            <tbody
-                              key="tb"
-                            >
-                              <tr
-                                key="4_1"
-                              >
-                                <td
-                                  className="rdtDay rdtOld"
-                                  data-value={26}
-                                  key="3_26"
-                                  onClick={[Function]}
-                                >
-                                  26
-                                </td>
-                                <td
-                                  className="rdtDay rdtOld"
-                                  data-value={27}
-                                  key="3_27"
-                                  onClick={[Function]}
-                                >
-                                  27
-                                </td>
-                                <td
-                                  className="rdtDay rdtOld"
-                                  data-value={28}
-                                  key="3_28"
-                                  onClick={[Function]}
-                                >
-                                  28
-                                </td>
-                                <td
-                                  className="rdtDay rdtOld"
-                                  data-value={29}
-                                  key="3_29"
-                                  onClick={[Function]}
-                                >
-                                  29
-                                </td>
-                                <td
-                                  className="rdtDay rdtOld"
-                                  data-value={30}
-                                  key="3_30"
-                                  onClick={[Function]}
-                                >
-                                  30
-                                </td>
-                                <td
-                                  className="rdtDay rdtOld"
-                                  data-value={31}
-                                  key="3_31"
-                                  onClick={[Function]}
-                                >
-                                  31
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={1}
+                                <tr
                                   key="4_1"
-                                  onClick={[Function]}
                                 >
-                                  1
-                                </td>
-                              </tr>
-                              <tr
-                                key="4_8"
-                              >
-                                <td
-                                  className="rdtDay"
-                                  data-value={2}
-                                  key="4_2"
-                                  onClick={[Function]}
-                                >
-                                  2
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={3}
-                                  key="4_3"
-                                  onClick={[Function]}
-                                >
-                                  3
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={4}
-                                  key="4_4"
-                                  onClick={[Function]}
-                                >
-                                  4
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={5}
-                                  key="4_5"
-                                  onClick={[Function]}
-                                >
-                                  5
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={6}
-                                  key="4_6"
-                                  onClick={[Function]}
-                                >
-                                  6
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={7}
-                                  key="4_7"
-                                  onClick={[Function]}
-                                >
-                                  7
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={8}
+                                  <td
+                                    className="rdtDay rdtOld"
+                                    data-value={26}
+                                    key="3_26"
+                                    onClick={[Function]}
+                                  >
+                                    26
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtOld"
+                                    data-value={27}
+                                    key="3_27"
+                                    onClick={[Function]}
+                                  >
+                                    27
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtOld"
+                                    data-value={28}
+                                    key="3_28"
+                                    onClick={[Function]}
+                                  >
+                                    28
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtOld"
+                                    data-value={29}
+                                    key="3_29"
+                                    onClick={[Function]}
+                                  >
+                                    29
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtOld"
+                                    data-value={30}
+                                    key="3_30"
+                                    onClick={[Function]}
+                                  >
+                                    30
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtOld"
+                                    data-value={31}
+                                    key="3_31"
+                                    onClick={[Function]}
+                                  >
+                                    31
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={1}
+                                    key="4_1"
+                                    onClick={[Function]}
+                                  >
+                                    1
+                                  </td>
+                                </tr>
+                                <tr
                                   key="4_8"
-                                  onClick={[Function]}
                                 >
-                                  8
-                                </td>
-                              </tr>
-                              <tr
-                                key="4_15"
-                              >
-                                <td
-                                  className="rdtDay"
-                                  data-value={9}
-                                  key="4_9"
-                                  onClick={[Function]}
-                                >
-                                  9
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={10}
-                                  key="4_10"
-                                  onClick={[Function]}
-                                >
-                                  10
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={11}
-                                  key="4_11"
-                                  onClick={[Function]}
-                                >
-                                  11
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={12}
-                                  key="4_12"
-                                  onClick={[Function]}
-                                >
-                                  12
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={13}
-                                  key="4_13"
-                                  onClick={[Function]}
-                                >
-                                  13
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={14}
-                                  key="4_14"
-                                  onClick={[Function]}
-                                >
-                                  14
-                                </td>
-                                <td
-                                  className="rdtDay rdtToday"
-                                  data-value={15}
+                                  <td
+                                    className="rdtDay"
+                                    data-value={2}
+                                    key="4_2"
+                                    onClick={[Function]}
+                                  >
+                                    2
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={3}
+                                    key="4_3"
+                                    onClick={[Function]}
+                                  >
+                                    3
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={4}
+                                    key="4_4"
+                                    onClick={[Function]}
+                                  >
+                                    4
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={5}
+                                    key="4_5"
+                                    onClick={[Function]}
+                                  >
+                                    5
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={6}
+                                    key="4_6"
+                                    onClick={[Function]}
+                                  >
+                                    6
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={7}
+                                    key="4_7"
+                                    onClick={[Function]}
+                                  >
+                                    7
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={8}
+                                    key="4_8"
+                                    onClick={[Function]}
+                                  >
+                                    8
+                                  </td>
+                                </tr>
+                                <tr
                                   key="4_15"
-                                  onClick={[Function]}
                                 >
-                                  15
-                                </td>
-                              </tr>
-                              <tr
-                                key="4_22"
-                              >
-                                <td
-                                  className="rdtDay"
-                                  data-value={16}
-                                  key="4_16"
-                                  onClick={[Function]}
-                                >
-                                  16
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={17}
-                                  key="4_17"
-                                  onClick={[Function]}
-                                >
-                                  17
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={18}
-                                  key="4_18"
-                                  onClick={[Function]}
-                                >
-                                  18
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={19}
-                                  key="4_19"
-                                  onClick={[Function]}
-                                >
-                                  19
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={20}
-                                  key="4_20"
-                                  onClick={[Function]}
-                                >
-                                  20
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={21}
-                                  key="4_21"
-                                  onClick={[Function]}
-                                >
-                                  21
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={22}
+                                  <td
+                                    className="rdtDay"
+                                    data-value={9}
+                                    key="4_9"
+                                    onClick={[Function]}
+                                  >
+                                    9
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={10}
+                                    key="4_10"
+                                    onClick={[Function]}
+                                  >
+                                    10
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={11}
+                                    key="4_11"
+                                    onClick={[Function]}
+                                  >
+                                    11
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={12}
+                                    key="4_12"
+                                    onClick={[Function]}
+                                  >
+                                    12
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={13}
+                                    key="4_13"
+                                    onClick={[Function]}
+                                  >
+                                    13
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={14}
+                                    key="4_14"
+                                    onClick={[Function]}
+                                  >
+                                    14
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtToday"
+                                    data-value={15}
+                                    key="4_15"
+                                    onClick={[Function]}
+                                  >
+                                    15
+                                  </td>
+                                </tr>
+                                <tr
                                   key="4_22"
-                                  onClick={[Function]}
                                 >
-                                  22
-                                </td>
-                              </tr>
-                              <tr
-                                key="4_29"
-                              >
-                                <td
-                                  className="rdtDay"
-                                  data-value={23}
-                                  key="4_23"
-                                  onClick={[Function]}
-                                >
-                                  23
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={24}
-                                  key="4_24"
-                                  onClick={[Function]}
-                                >
-                                  24
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={25}
-                                  key="4_25"
-                                  onClick={[Function]}
-                                >
-                                  25
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={26}
-                                  key="4_26"
-                                  onClick={[Function]}
-                                >
-                                  26
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={27}
-                                  key="4_27"
-                                  onClick={[Function]}
-                                >
-                                  27
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={28}
-                                  key="4_28"
-                                  onClick={[Function]}
-                                >
-                                  28
-                                </td>
-                                <td
-                                  className="rdtDay"
-                                  data-value={29}
+                                  <td
+                                    className="rdtDay"
+                                    data-value={16}
+                                    key="4_16"
+                                    onClick={[Function]}
+                                  >
+                                    16
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={17}
+                                    key="4_17"
+                                    onClick={[Function]}
+                                  >
+                                    17
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={18}
+                                    key="4_18"
+                                    onClick={[Function]}
+                                  >
+                                    18
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={19}
+                                    key="4_19"
+                                    onClick={[Function]}
+                                  >
+                                    19
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={20}
+                                    key="4_20"
+                                    onClick={[Function]}
+                                  >
+                                    20
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={21}
+                                    key="4_21"
+                                    onClick={[Function]}
+                                  >
+                                    21
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={22}
+                                    key="4_22"
+                                    onClick={[Function]}
+                                  >
+                                    22
+                                  </td>
+                                </tr>
+                                <tr
                                   key="4_29"
-                                  onClick={[Function]}
                                 >
-                                  29
-                                </td>
-                              </tr>
-                              <tr
-                                key="5_6"
-                              >
-                                <td
-                                  className="rdtDay"
-                                  data-value={30}
-                                  key="4_30"
-                                  onClick={[Function]}
-                                >
-                                  30
-                                </td>
-                                <td
-                                  className="rdtDay rdtNew"
-                                  data-value={1}
-                                  key="5_1"
-                                  onClick={[Function]}
-                                >
-                                  1
-                                </td>
-                                <td
-                                  className="rdtDay rdtNew"
-                                  data-value={2}
-                                  key="5_2"
-                                  onClick={[Function]}
-                                >
-                                  2
-                                </td>
-                                <td
-                                  className="rdtDay rdtNew"
-                                  data-value={3}
-                                  key="5_3"
-                                  onClick={[Function]}
-                                >
-                                  3
-                                </td>
-                                <td
-                                  className="rdtDay rdtNew"
-                                  data-value={4}
-                                  key="5_4"
-                                  onClick={[Function]}
-                                >
-                                  4
-                                </td>
-                                <td
-                                  className="rdtDay rdtNew"
-                                  data-value={5}
-                                  key="5_5"
-                                  onClick={[Function]}
-                                >
-                                  5
-                                </td>
-                                <td
-                                  className="rdtDay rdtNew"
-                                  data-value={6}
+                                  <td
+                                    className="rdtDay"
+                                    data-value={23}
+                                    key="4_23"
+                                    onClick={[Function]}
+                                  >
+                                    23
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={24}
+                                    key="4_24"
+                                    onClick={[Function]}
+                                  >
+                                    24
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={25}
+                                    key="4_25"
+                                    onClick={[Function]}
+                                  >
+                                    25
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={26}
+                                    key="4_26"
+                                    onClick={[Function]}
+                                  >
+                                    26
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={27}
+                                    key="4_27"
+                                    onClick={[Function]}
+                                  >
+                                    27
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={28}
+                                    key="4_28"
+                                    onClick={[Function]}
+                                  >
+                                    28
+                                  </td>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={29}
+                                    key="4_29"
+                                    onClick={[Function]}
+                                  >
+                                    29
+                                  </td>
+                                </tr>
+                                <tr
                                   key="5_6"
-                                  onClick={[Function]}
                                 >
-                                  6
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </Component>
-                    </OnClickOutside(Component)>
-                  </Component>
+                                  <td
+                                    className="rdtDay"
+                                    data-value={30}
+                                    key="4_30"
+                                    onClick={[Function]}
+                                  >
+                                    30
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtNew"
+                                    data-value={1}
+                                    key="5_1"
+                                    onClick={[Function]}
+                                  >
+                                    1
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtNew"
+                                    data-value={2}
+                                    key="5_2"
+                                    onClick={[Function]}
+                                  >
+                                    2
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtNew"
+                                    data-value={3}
+                                    key="5_3"
+                                    onClick={[Function]}
+                                  >
+                                    3
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtNew"
+                                    data-value={4}
+                                    key="5_4"
+                                    onClick={[Function]}
+                                  >
+                                    4
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtNew"
+                                    data-value={5}
+                                    key="5_5"
+                                    onClick={[Function]}
+                                  >
+                                    5
+                                  </td>
+                                  <td
+                                    className="rdtDay rdtNew"
+                                    data-value={6}
+                                    key="5_6"
+                                    onClick={[Function]}
+                                  >
+                                    6
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </Component>
+                      </OnClickOutside(Component)>
+                    </Component>
+                  </div>
                 </div>
-              </div>
-            </DateTime>
+              </DateTime>
+            </div>
           </div>
-        </div>
+        </Portal>
       </Portal>
     </Popover>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -16,10 +16,7 @@ exports[`The component should render in body when open 2`] = `
         <article>
           <div>My dialog content</div>
         </article>
-        <footer>
-          <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
-        </footer>
+        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button></footer>
       </section>
     </div>
   </div>
@@ -40,17 +37,14 @@ exports[`The component should render in body with loader instead of confirm butt
         <article>
           <div>My dialog content</div>
         </article>
-        <footer>
-          <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button>
-          <button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span>
+        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button><button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span>
             <div class=\\"loader\\">
               <div style=\\"width: 25px; height: 25px;\\" class=\\"spinner\\">
                 <div class=\\"doubleBounce1\\"></div>
                 <div class=\\"doubleBounce2\\"></div>
               </div>
             </div>
-          </button>
-        </footer>
+          </button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -86,15 +86,9 @@ exports[`Render the MultiAutoComplete with open suggestions list 2`] = `
 <div>
   <div class=\\"container\\">
     <ul style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\" class=\\"menu\\">
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button>
-      </li>
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 2</span></button>
-      </li>
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 3</span></button>
-      </li>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button></li>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 2</span></button></li>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 3</span></button></li>
     </ul>
   </div>
 </div>"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -16,9 +16,7 @@ exports[`The component should render in body when open 2`] = `
         <article>
           <p>My overlay content</p>
         </article>
-        <footer>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Apply</span></button>
-        </footer>
+        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Apply</span></button></footer>
       </section>
     </div>
   </div>
@@ -40,11 +38,7 @@ exports[`The component should render in body with actions when open 2`] = `
           <p>My overlay content</p>
         </article>
         <footer>
-          <div class=\\"actions\\">
-            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Action 1</span></button>
-            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Action 2</span></button>
-          </div>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Apply</span></button>
+          <div class=\\"actions\\"><button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Action 1</span></button><button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Action 2</span></button></div><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Apply</span></button>
         </footer>
       </section>
     </div>
@@ -66,16 +60,14 @@ exports[`The component should render in body with loader instead of confirm butt
         <article>
           <p>My overlay content</p>
         </article>
-        <footer>
-          <button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Apply</span>
+        <footer><button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Apply</span>
             <div class=\\"loader\\">
               <div style=\\"width: 25px; height: 25px;\\" class=\\"spinner\\">
                 <div class=\\"doubleBounce1\\"></div>
                 <div class=\\"doubleBounce2\\"></div>
               </div>
             </div>
-          </button>
-        </footer>
+          </button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -48,16 +48,10 @@ exports[`The component should open the popover when the display value is clicked
 <div>
   <div class=\\"container\\">
     <ul style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\" class=\\"menu\\">
-      <li>
-        <button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 1</button>
-      </li>
-      <li>
-        <button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 2</button>
-      </li>
+      <li><button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 1</button></li>
+      <li><button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 2</button></li>
       <li class=\\"divider\\"></li>
-      <li>
-        <button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 3</button>
-      </li>
+      <li><button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 3</button></li>
     </ul>
   </div>
 </div>"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -31,15 +31,9 @@ exports[`Render the SingleAutoComplete with open suggestions list 2`] = `
 <div>
   <div class=\\"container\\">
     <ul style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\" class=\\"menu\\">
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button>
-      </li>
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 2</span></button>
-      </li>
-      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\">
-        <button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 3</span></button>
-      </li>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button></li>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 2</span></button></li>
+      <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 3</span></button></li>
     </ul>
   </div>
 </div>"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -12,18 +12,10 @@ exports[`Render block with schema 1`] = `
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text 1</label>
-                <input type=\\"text\\" value=\\"Test 1\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text 1</label><input type=\\"text\\" value=\\"Test 1\\"><label class=\\"errorLabel\\"></label></div>
             </div>
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text 2</label>
-                <input type=\\"text\\" value=\\"Test 2\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text 2</label><input type=\\"text\\" value=\\"Test 2\\"><label class=\\"errorLabel\\"></label></div>
             </div>
           </div>
         </article>
@@ -38,25 +30,16 @@ exports[`Render block with schema 1`] = `
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text 1</label>
-                <input type=\\"text\\" value=\\"Test 3\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text 1</label><input type=\\"text\\" value=\\"Test 3\\"><label class=\\"errorLabel\\"></label></div>
             </div>
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text 2</label>
-                <input type=\\"text\\" value=\\"Test 4\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text 2</label><input type=\\"text\\" value=\\"Test 4\\"><label class=\\"errorLabel\\"></label></div>
             </div>
           </div>
         </article>
       </div>
     </section>
-  </div>
-  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
+  </div><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
 </section>"
 `;
 
@@ -72,11 +55,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text</label>
-                <input type=\\"text\\" value=\\"Test1\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text</label><input type=\\"text\\" value=\\"Test1\\"><label class=\\"errorLabel\\"></label></div>
             </div>
           </div>
         </article>
@@ -91,11 +70,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field error\\">
-                <label class=\\"label\\">Text</label>
-                <input class=\\"minLength\\" type=\\"text\\" value=\\"T2\\">
-                <label class=\\"errorLabel\\">sulu_admin.error_minlength</label>
-              </div>
+              <div class=\\"field error\\"><label class=\\"label\\">Text</label><input class=\\"minLength\\" type=\\"text\\" value=\\"T2\\"><label class=\\"errorLabel\\">sulu_admin.error_minlength</label></div>
             </div>
           </div>
         </article>
@@ -110,18 +85,13 @@ exports[`Render block with schema and error on fields already being modified 1`]
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text</label>
-                <input type=\\"text\\" value=\\"T3\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text</label><input type=\\"text\\" value=\\"T3\\"><label class=\\"errorLabel\\"></label></div>
             </div>
           </div>
         </article>
       </div>
     </section>
-  </div>
-  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
+  </div><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
 </section>"
 `;
 
@@ -137,11 +107,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\">
-                <label class=\\"label\\">Text</label>
-                <input type=\\"text\\" value=\\"Test1\\">
-                <label class=\\"errorLabel\\"></label>
-              </div>
+              <div class=\\"field\\"><label class=\\"label\\">Text</label><input type=\\"text\\" value=\\"Test1\\"><label class=\\"errorLabel\\"></label></div>
             </div>
           </div>
         </article>
@@ -156,11 +122,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field error\\">
-                <label class=\\"label\\">Text</label>
-                <input class=\\"minLength\\" type=\\"text\\" value=\\"T2\\">
-                <label class=\\"errorLabel\\">sulu_admin.error_minlength</label>
-              </div>
+              <div class=\\"field error\\"><label class=\\"label\\">Text</label><input class=\\"minLength\\" type=\\"text\\" value=\\"T2\\"><label class=\\"errorLabel\\">sulu_admin.error_minlength</label></div>
             </div>
           </div>
         </article>
@@ -175,17 +137,12 @@ exports[`Render block with schema and error on fields already being modified 2`]
         <article>
           <div class=\\"grid grid\\">
             <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field error\\">
-                <label class=\\"label\\">Text</label>
-                <input class=\\"minLength\\" type=\\"text\\" value=\\"T3\\">
-                <label class=\\"errorLabel\\">sulu_admin.error_minlength</label>
-              </div>
+              <div class=\\"field error\\"><label class=\\"label\\">Text</label><input class=\\"minLength\\" type=\\"text\\" value=\\"T3\\"><label class=\\"errorLabel\\">sulu_admin.error_minlength</label></div>
             </div>
           </div>
         </article>
       </div>
     </section>
-  </div>
-  <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
+  </div><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"buttonIcon su-plus\\" aria-label=\\"su-plus\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
 </section>"
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -11,24 +11,19 @@ exports[`Should render a Dialog 1`] = `
         <header></header>
         <article>
           <div class=\\"ghostDialog\\">
-            <p></p>
-            <label class=\\"label\\"></label>
+            <p></p><label class=\\"label\\"></label>
             <div class=\\"localeSelect\\">
-              <div class=\\"select\\">
-                <button class=\\"displayValue\\" type=\\"button\\">
+              <div class=\\"select\\"><button class=\\"displayValue\\" type=\\"button\\">
                   <div title=\\"en\\" aria-label=\\"en\\" class=\\"croppedText\\">
                     <div class=\\"front\\" aria-hidden=\\"true\\">e</div>
                     <div class=\\"back\\" aria-hidden=\\"true\\"><span>n</span></div>
                     <div class=\\"whole\\">en</div>
-                  </div><span class=\\"toggle su-angle-down\\" aria-label=\\"su-angle-down\\"></span></button>
-              </div>
+                  </div><span class=\\"toggle su-angle-down\\" aria-label=\\"su-angle-down\\"></span>
+                </button></div>
             </div>
           </div>
         </article>
-        <footer>
-          <button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"></span></button>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\"></span></button>
-        </footer>
+        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\"></span></button><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\"></span></button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Selection/tests/__snapshots__/Selection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Selection/tests/__snapshots__/Selection.test.js.snap
@@ -16,9 +16,7 @@ exports[`Should open an overlay 1`] = `
             </div>
           </div>
         </article>
-        <footer>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">sulu_admin.confirm</span></button>
-        </footer>
+        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">sulu_admin.confirm</span></button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -3,6 +3,7 @@ import {observer} from 'mobx-react';
 import {action, computed} from 'mobx';
 import React from 'react';
 import ToolbarComponent from '../../components/Toolbar';
+import Initializer from '../../services/Initializer';
 import ToolbarStore from './stores/ToolbarStore';
 import toolbarStorePool, {DEFAULT_STORE_KEY} from './stores/ToolbarStorePool';
 import toolbarStyles from './toolbar.scss';
@@ -100,16 +101,20 @@ export default class Toolbar extends React.Component<*> {
 
         return (
             <ToolbarComponent>
-                <ToolbarComponent.Snackbar
-                    onCloseClick={this.handleSnackbarCloseClick}
-                    type="error"
-                    visible={this.toolbarStore.errors.length > 0}
-                />
-                <ToolbarComponent.Snackbar
-                    onClick={onNavigationButtonClick}
-                    type="success"
-                    visible={this.toolbarStore.showSuccess}
-                />
+                {!!Initializer.initializedTranslationsLocale &&
+                    <ToolbarComponent.Snackbar
+                        onCloseClick={this.handleSnackbarCloseClick}
+                        type="error"
+                        visible={this.toolbarStore.errors.length > 0}
+                    />
+                }
+                {!!Initializer.initializedTranslationsLocale &&
+                    <ToolbarComponent.Snackbar
+                        onClick={onNavigationButtonClick}
+                        type="success"
+                        visible={this.toolbarStore.showSuccess}
+                    />
+                }
                 <ToolbarComponent.Controls>
                     {!!onNavigationButtonClick &&
                     <ToolbarComponent.Button

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js
@@ -16,6 +16,10 @@ jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+jest.mock('../../../services/Initializer', () => ({
+    initializedTranslationsLocale: true,
+}));
+
 beforeEach(() => {
     toolbarStoreMock = {
         errors: [],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -105,6 +105,10 @@ jest.mock('../../../utils/Translator', () => ({
     },
 }));
 
+jest.mock('../../../services/Initializer', () => ({
+    initializedTranslationsLocale: true,
+}));
+
 beforeEach(() => {
     jest.resetModules();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -5,6 +5,7 @@ import {mount, shallow} from 'enzyme';
 import {findWithToolbarFunction} from '../../../utils/TestHelper';
 import AbstractToolbarAction from '../toolbarActions/AbstractToolbarAction';
 
+jest.mock('../../../services/Initializer', () => jest.fn());
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
 jest.mock('../toolbarActions/DeleteToolbarAction', () => jest.fn());
 jest.mock('../toolbarActions/SaveWithPublishingToolbarAction', () => jest.fn());

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/registries/ToolbarActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/registries/ToolbarActionRegistry.test.js
@@ -2,6 +2,7 @@
 import toolbarActionRegistry from '../../registries/ToolbarActionRegistry';
 import AbstractToolbarAction from '../../toolbarActions/AbstractToolbarAction';
 
+jest.mock('../../../../services/Initializer', () => jest.fn());
 jest.mock('../../toolbarActions/DeleteToolbarAction', () => jest.fn());
 jest.mock('../../toolbarActions/SaveWithPublishingToolbarAction', () => jest.fn());
 jest.mock('../../toolbarActions/SaveToolbarAction', () => jest.fn());

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleDialog.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleDialog.test.js
@@ -27,7 +27,7 @@ test('Render the dialog with given props', () => {
         />
     );
 
-    expect(copyLocaleDialog.find('Portal').at(1).render()).toMatchSnapshot();
+    expect(copyLocaleDialog.find('Portal').at(2).render()).toMatchSnapshot();
 });
 
 test('Call onClose callback if cancel is clicked', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -197,23 +197,11 @@ exports[`Render a MediaCard with download list 1`] = `
 <div>
   <div class=\\"container\\">
     <ul style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\" class=\\"menu\\">
-      <li class=\\"item\\">
-        <button><span class=\\"content\\">Direct download<span class=\\"copyText\\"></span></span>
-        </button>
-      </li>
+      <li class=\\"item\\"><button><span class=\\"content\\">Direct download<span class=\\"copyText\\"></span></span></button></li>
       <li class=\\"divider\\"></li>
-      <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"content\\">300/200<span class=\\"copyText\\">Copy URL</span></span>
-        </button>
-      </li>
-      <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"content\\">600/300<span class=\\"copyText\\">Copy URL</span></span>
-        </button>
-      </li>
-      <li class=\\"item\\">
-        <button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"content\\">150/200<span class=\\"copyText\\">Copy URL</span></span>
-        </button>
-      </li>
+      <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"content\\">300/200<span class=\\"copyText\\">Copy URL</span></span></button></li>
+      <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"content\\">600/300<span class=\\"copyText\\">Copy URL</span></span></button></li>
+      <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"content\\">150/200<span class=\\"copyText\\">Copy URL</span></span></button></li>
     </ul>
   </div>
 </div>"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
@@ -3,6 +3,8 @@ import {render} from 'enzyme';
 import React from 'react';
 import MediaCardOverviewAdapter from '../../adapters/MediaCardOverviewAdapter';
 
+jest.mock('sulu-admin-bundle/services/Initializer', () => jest.fn());
+
 jest.mock('sulu-admin-bundle/utils', () => ({
     translate: function(key) {
         switch (key) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/CollectionFormOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/CollectionFormOverlay.test.js
@@ -4,6 +4,8 @@ import {shallow} from 'enzyme';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import CollectionFormOverlay from '../CollectionFormOverlay';
 
+jest.mock('sulu-admin-bundle/services/Initializer', () => jest.fn());
+
 jest.mock('sulu-admin-bundle/containers', () => ({
     FormStore: jest.fn(),
     Form: require.requireActual('sulu-admin-bundle/containers').Form,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
@@ -15,12 +15,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
               <div>
                 <div class=\\"collectionSection\\">
                   <ul class=\\"breadcrumb\\">
-                    <li>
-                      <button disabled=\\"\\" class=\\"item\\">All Media</button>
-                    </li>
+                    <li><button disabled=\\"\\" class=\\"item\\">All Media</button></li>
                   </ul>
-                  <div><span class=\\"su-plus clickable\\" aria-label=\\"su-plus\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-pen clickable\\" aria-label=\\"su-pen\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-trash-alt clickable\\" aria-label=\\"su-trash-alt\\"
-                      role=\\"button\\" tabindex=\\"0\\"></span></div>
+                  <div><span class=\\"su-plus clickable\\" aria-label=\\"su-plus\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-pen clickable\\" aria-label=\\"su-pen\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-trash-alt clickable\\" aria-label=\\"su-trash-alt\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
                 </div>
                 <div class=\\"datagrid\\">
                   <section>
@@ -45,9 +42,7 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                       </li>
                     </ul>
                     <nav class=\\"pagination\\">
-                      <div class=\\"loader\\"></div><span class=\\"display\\">Page: 2 of 3</span>
-                      <button class=\\"previous\\"><span class=\\"su-angle-left\\" aria-label=\\"su-angle-left\\"></span></button>
-                      <button class=\\"next\\"><span class=\\"su-angle-right\\" aria-label=\\"su-angle-right\\"></span></button>
+                      <div class=\\"loader\\"></div><span class=\\"display\\">Page: 2 of 3</span><button class=\\"previous\\"><span class=\\"su-angle-left\\" aria-label=\\"su-angle-left\\"></span></button><button class=\\"next\\"><span class=\\"su-angle-right\\" aria-label=\\"su-angle-right\\"></span></button>
                     </nav>
                   </section>
                 </div>
@@ -58,12 +53,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
               <div class=\\"divider\\"></div>
               <div>
                 <div class=\\"headerContainer\\">
-                  <div class=\\"toolbar\\">
-                    <label class=\\"input dark collapsed hasAppendIcon\\">
-                      <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
-                      <input type=\\"text\\" value=\\"\\">
-                    </label>
-                  </div>
+                  <div class=\\"toolbar\\"><label class=\\"input dark collapsed hasAppendIcon\\">
+                      <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div><input type=\\"text\\" value=\\"\\">
+                    </label></div>
                 </div>
                 <div class=\\"datagrid\\">
                   <section>
@@ -73,8 +65,7 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                           <div class=\\"mediaCard\\">
                             <div class=\\"header\\">
                               <div class=\\"description\\">
-                                <div class=\\"title\\">
-                                  <label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"1\\"><span></span></span>
+                                <div class=\\"title\\"><label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"1\\"><span></span></span>
                                     <div>
                                       <div class=\\"titleText\\">
                                         <div title=\\"Title 1\\" aria-label=\\"Title 1\\" class=\\"croppedText\\">
@@ -84,8 +75,7 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                                         </div>
                                       </div>
                                     </div>
-                                  </label>
-                                </div>
+                                  </label></div>
                                 <div class=\\"meta\\">
                                   <div title=\\"image/png 12.35 KB\\" aria-label=\\"image/png 12.35 KB\\" class=\\"croppedText\\">
                                     <div class=\\"front\\" aria-hidden=\\"true\\">image/png</div>
@@ -94,12 +84,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                                   </div>
                                 </div>
                               </div>
-                              <div>
-                                <button class=\\"downloadButton\\"><span class=\\"fa fa-cloud-download\\" aria-label=\\"fa-cloud-download\\"></span></button>
-                              </div>
+                              <div><button class=\\"downloadButton\\"><span class=\\"fa fa-cloud-download\\" aria-label=\\"fa-cloud-download\\"></span></button></div>
                             </div>
-                            <div class=\\"media\\">
-                              <img alt=\\"Title 1\\" src=\\"http://lorempixel.com/240/100\\">
+                            <div class=\\"media\\"><img alt=\\"Title 1\\" src=\\"http://lorempixel.com/240/100\\">
                               <div class=\\"cover\\"><span class=\\"mediaIcon su-check\\" aria-label=\\"su-check\\"></span></div>
                             </div>
                           </div>
@@ -108,8 +95,7 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                           <div class=\\"mediaCard\\">
                             <div class=\\"header\\">
                               <div class=\\"description\\">
-                                <div class=\\"title\\">
-                                  <label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"2\\"><span></span></span>
+                                <div class=\\"title\\"><label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"2\\"><span></span></span>
                                     <div>
                                       <div class=\\"titleText\\">
                                         <div title=\\"Title 2\\" aria-label=\\"Title 2\\" class=\\"croppedText\\">
@@ -119,8 +105,7 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                                         </div>
                                       </div>
                                     </div>
-                                  </label>
-                                </div>
+                                  </label></div>
                                 <div class=\\"meta\\">
                                   <div title=\\"image/jpeg 54.32 KB\\" aria-label=\\"image/jpeg 54.32 KB\\" class=\\"croppedText\\">
                                     <div class=\\"front\\" aria-hidden=\\"true\\">image/jpeg</div>
@@ -129,12 +114,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                                   </div>
                                 </div>
                               </div>
-                              <div>
-                                <button class=\\"downloadButton\\"><span class=\\"fa fa-cloud-download\\" aria-label=\\"fa-cloud-download\\"></span></button>
-                              </div>
+                              <div><button class=\\"downloadButton\\"><span class=\\"fa fa-cloud-download\\" aria-label=\\"fa-cloud-download\\"></span></button></div>
                             </div>
-                            <div class=\\"media\\">
-                              <img alt=\\"Title 2\\" src=\\"http://lorempixel.com/240/100\\">
+                            <div class=\\"media\\"><img alt=\\"Title 2\\" src=\\"http://lorempixel.com/240/100\\">
                               <div class=\\"cover\\"><span class=\\"mediaIcon su-check\\" aria-label=\\"su-check\\"></span></div>
                             </div>
                           </div>
@@ -145,16 +127,12 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
                   </section>
                 </div>
                 <div></div>
-              </div>
-              <input type=\\"file\\" style=\\"position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;\\" multiple=\\"\\" autocomplete=\\"off\\">
+              </div><input type=\\"file\\" style=\\"position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;\\" multiple=\\"\\" autocomplete=\\"off\\">
             </div>
           </div>
         </article>
         <footer>
-          <div class=\\"actions\\">
-            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Reset fields</span></button>
-          </div>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
+          <div class=\\"actions\\"><button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Reset fields</span></button></div><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -15,12 +15,9 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
               <div>
                 <div class=\\"collectionSection\\">
                   <ul class=\\"breadcrumb\\">
-                    <li>
-                      <button disabled=\\"\\" class=\\"item\\"></button>
-                    </li>
+                    <li><button disabled=\\"\\" class=\\"item\\"></button></li>
                   </ul>
-                  <div><span class=\\"su-plus clickable\\" aria-label=\\"su-plus\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-pen clickable\\" aria-label=\\"su-pen\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-trash-alt clickable\\" aria-label=\\"su-trash-alt\\"
-                      role=\\"button\\" tabindex=\\"0\\"></span></div>
+                  <div><span class=\\"su-plus clickable\\" aria-label=\\"su-plus\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-pen clickable\\" aria-label=\\"su-pen\\" role=\\"button\\" tabindex=\\"0\\"></span><span class=\\"su-trash-alt clickable\\" aria-label=\\"su-trash-alt\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
                 </div>
                 <div class=\\"datagrid\\">
                   <section>
@@ -45,9 +42,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                       </li>
                     </ul>
                     <nav class=\\"pagination\\">
-                      <div class=\\"loader\\"></div><span class=\\"display\\">Page: 2 of 3</span>
-                      <button class=\\"previous\\"><span class=\\"su-angle-left\\" aria-label=\\"su-angle-left\\"></span></button>
-                      <button class=\\"next\\"><span class=\\"su-angle-right\\" aria-label=\\"su-angle-right\\"></span></button>
+                      <div class=\\"loader\\"></div><span class=\\"display\\">Page: 2 of 3</span><button class=\\"previous\\"><span class=\\"su-angle-left\\" aria-label=\\"su-angle-left\\"></span></button><button class=\\"next\\"><span class=\\"su-angle-right\\" aria-label=\\"su-angle-right\\"></span></button>
                     </nav>
                   </section>
                 </div>
@@ -58,12 +53,9 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
               <div class=\\"divider\\"></div>
               <div>
                 <div class=\\"headerContainer\\">
-                  <div class=\\"toolbar\\">
-                    <label class=\\"input dark collapsed hasAppendIcon\\">
-                      <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
-                      <input type=\\"text\\" value=\\"\\">
-                    </label>
-                  </div>
+                  <div class=\\"toolbar\\"><label class=\\"input dark collapsed hasAppendIcon\\">
+                      <div class=\\"prependedContainer dark collapsed\\"><span class=\\"icon dark iconClickable collapsed su-search clickable\\" aria-label=\\"su-search\\" role=\\"button\\" tabindex=\\"0\\"></span></div><input type=\\"text\\" value=\\"\\">
+                    </label></div>
                 </div>
                 <div class=\\"datagrid\\">
                   <section>
@@ -73,8 +65,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                           <div class=\\"mediaCard\\">
                             <div class=\\"header\\">
                               <div class=\\"description\\">
-                                <div class=\\"title\\">
-                                  <label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"1\\"><span></span></span>
+                                <div class=\\"title\\"><label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"1\\"><span></span></span>
                                     <div>
                                       <div class=\\"titleText\\">
                                         <div title=\\"Title 1\\" aria-label=\\"Title 1\\" class=\\"croppedText\\">
@@ -84,8 +75,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                                         </div>
                                       </div>
                                     </div>
-                                  </label>
-                                </div>
+                                  </label></div>
                                 <div class=\\"meta\\">
                                   <div title=\\"image/png 12.35 KB\\" aria-label=\\"image/png 12.35 KB\\" class=\\"croppedText\\">
                                     <div class=\\"front\\" aria-hidden=\\"true\\">image/png</div>
@@ -95,8 +85,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                                 </div>
                               </div>
                             </div>
-                            <div class=\\"media\\">
-                              <img alt=\\"Title 1\\" src=\\"http://lorempixel.com/240/100\\">
+                            <div class=\\"media\\"><img alt=\\"Title 1\\" src=\\"http://lorempixel.com/240/100\\">
                               <div class=\\"cover\\"><span class=\\"mediaIcon su-check\\" aria-label=\\"su-check\\"></span></div>
                             </div>
                           </div>
@@ -105,8 +94,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                           <div class=\\"mediaCard\\">
                             <div class=\\"header\\">
                               <div class=\\"description\\">
-                                <div class=\\"title\\">
-                                  <label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"2\\"><span></span></span>
+                                <div class=\\"title\\"><label class=\\"label\\"><span class=\\"switch checkbox dark checkbox\\"><input type=\\"checkbox\\" value=\\"2\\"><span></span></span>
                                     <div>
                                       <div class=\\"titleText\\">
                                         <div title=\\"Title 2\\" aria-label=\\"Title 2\\" class=\\"croppedText\\">
@@ -116,8 +104,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                                         </div>
                                       </div>
                                     </div>
-                                  </label>
-                                </div>
+                                  </label></div>
                                 <div class=\\"meta\\">
                                   <div title=\\"image/jpeg 54.32 KB\\" aria-label=\\"image/jpeg 54.32 KB\\" class=\\"croppedText\\">
                                     <div class=\\"front\\" aria-hidden=\\"true\\">image/jpeg</div>
@@ -127,8 +114,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                                 </div>
                               </div>
                             </div>
-                            <div class=\\"media\\">
-                              <img alt=\\"Title 2\\" src=\\"http://lorempixel.com/240/100\\">
+                            <div class=\\"media\\"><img alt=\\"Title 2\\" src=\\"http://lorempixel.com/240/100\\">
                               <div class=\\"cover\\"><span class=\\"mediaIcon su-check\\" aria-label=\\"su-check\\"></span></div>
                             </div>
                           </div>
@@ -139,16 +125,12 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
                   </section>
                 </div>
                 <div></div>
-              </div>
-              <input type=\\"file\\" style=\\"position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;\\" multiple=\\"\\" autocomplete=\\"off\\">
+              </div><input type=\\"file\\" style=\\"position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;\\" multiple=\\"\\" autocomplete=\\"off\\">
             </div>
           </div>
         </article>
         <footer>
-          <div class=\\"actions\\">
-            <button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Reset fields</span></button>
-          </div>
-          <button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
+          <div class=\\"actions\\"><button class=\\"button link\\" type=\\"button\\"><span class=\\"text\\">Reset fields</span></button></div><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button>
         </footer>
       </section>
     </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -24,6 +24,10 @@ jest.mock('sulu-admin-bundle/containers/Form/stores/MetadataStore', () => ({
     getSchemaTypes: jest.fn().mockReturnValue(Promise.resolve([])),
 }));
 
+jest.mock('sulu-admin-bundle/services/Initializer', () => ({
+    initializedTranslationsLocale: true,
+}));
+
 jest.mock('sulu-admin-bundle/utils', () => ({
     translate: function(key) {
         switch (key) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

There was a warning shown, because some translations were used before they were loaded from the backend.

#### Why?

Because this has shown two non-warnings in the console.