### PR TITLE
Fixed missing http cache parameters under dev and test env

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -80,6 +80,9 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('sulu_http_cache.cache.max_age', $config['cache']['max_age']);
+        $container->setParameter('sulu_http_cache.cache.shared_max_age', $config['cache']['shared_max_age']);
+
         if (!$this->shouldCache($container)) {
             return;
         }
@@ -102,9 +105,6 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
                 $loader->load('tags.xml');
             }
         }
-
-        $container->setParameter('sulu_http_cache.cache.max_age', $config['cache']['max_age']);
-        $container->setParameter('sulu_http_cache.cache.shared_max_age', $config['cache']['shared_max_age']);
     }
 
     /**

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -40,7 +40,6 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
     /**
      * @var ReplacerInterface
      */
-    private $replacer;
 
     /**
      * @var LoggerInterface
@@ -101,8 +100,24 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
         $this->assertTrue($this->container->has('sulu_http_cache.cache_lifetime.resolver'));
         $this->assertTrue($this->container->has('sulu_http_cache.event_subscriber.invalidation'));
         $this->assertFalse($this->container->has('sulu_http_cache.cache_manager'));
-        $this->assertTrue($this->container->hasParameter('sulu_http_cache.cache.max_age'));
-        $this->assertTrue($this->container->hasParameter('sulu_http_cache.cache.shared_max_age'));
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.shared_max_age', 240);
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.max_age', 240);
+    }
+
+    public function testConfig()
+    {
+        $config = [
+            'cache' => [
+                'max_age' => 520,
+                'shared_max_age' => 340,
+            ],
+        ];
+
+        $this->load($config);
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.max_age', 520);
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.shared_max_age', 340);
     }
 
     /**
@@ -125,11 +140,8 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
         $this->compile();
 
         $this->assertEquals($expected, $this->container->has('sulu_http_cache.cache_manager'));
-
-        if ($expected) {
-            $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.max_age', 240);
-            $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.shared_max_age', 240);
-        }
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.max_age', 240);
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.shared_max_age', 240);
     }
 
     /**
@@ -152,10 +164,7 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
         $this->compile();
 
         $this->assertEquals($expected, $this->container->has('sulu_http_cache.cache_manager'));
-
-        if ($expected) {
-            $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.max_age', 240);
-            $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.shared_max_age', 240);
-        }
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.max_age', 240);
+        $this->assertContainerBuilderHasParameter('sulu_http_cache.cache.shared_max_age', 240);
     }
 }

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -101,6 +101,8 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
         $this->assertTrue($this->container->has('sulu_http_cache.cache_lifetime.resolver'));
         $this->assertTrue($this->container->has('sulu_http_cache.event_subscriber.invalidation'));
         $this->assertFalse($this->container->has('sulu_http_cache.cache_manager'));
+        $this->assertTrue($this->container->hasParameter('sulu_http_cache.cache.max_age'));
+        $this->assertTrue($this->container->hasParameter('sulu_http_cache.cache.shared_max_age'));
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

The parameters `sulu_http_cache.cache.max_age`and `sulu_http_cache.cache.shared_max_age` are currently not available in dev and test environment because of the `shouldCache` method.

#### Why?

The parameters should always be available.

#### Example Usage

Mostly I use the following snippet in my custom static controllers:

~~~php
$response = new Response();
$response->setPublic();
$response->setMaxAge($this->getParameter('sulu_http_cache.cache.max_age'));
$response->setSharedMaxAge($this->getParameter('sulu_http_cache.cache.shared_max_age'));

$response->headers->set(
    AbstractHttpCache::HEADER_REVERSE_PROXY_TTL,
    1209600
);
~~~

#### BC Breaks/Deprecations

This PR fixed an accidently BC Break in 2.0 and make the variables again available under dev and test.

