### PR TITLE
Added a check so that properties will only be added to MultipleTransl…

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
@@ -247,6 +247,9 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
      */
     private function initProperties($locale)
     {
+        // Reset the properties before new initialization.
+        $this->properties = [];
+
         /** @var PropertyInterface $property */
         foreach ($this->getExcerptStructure($locale)->getProperties() as $property) {
             $this->properties[] = $property->getName();

--- a/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
@@ -49,8 +49,10 @@ class MultipleTranslatedProperties
         $this->languageNamespace = $languageNamespace;
         $this->properties = [];
         foreach ($names as $name) {
-            $propertyName = (!empty($namespace) ? $namespace . '-' : '') . $name;
-            $this->properties[$name] = new Property($propertyName, [], 'none', false, true);
+            if (empty($this->properties[$name])) {
+                $propertyName            = (!empty($namespace) ? $namespace.'-' : '').$name;
+                $this->properties[$name] = new Property($propertyName, [], 'none', false, true);
+            }
         }
     }
 

--- a/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
@@ -50,7 +50,7 @@ class MultipleTranslatedProperties
         $this->properties = [];
         foreach ($names as $name) {
             if (empty($this->properties[$name])) {
-                $propertyName            = (!empty($namespace) ? $namespace.'-' : '').$name;
+                $propertyName = (!empty($namespace) ? $namespace . '-' : '') . $name;
                 $this->properties[$name] = new Property($propertyName, [], 'none', false, true);
             }
         }

--- a/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/MultipleTranslatedProperties.php
@@ -49,10 +49,8 @@ class MultipleTranslatedProperties
         $this->languageNamespace = $languageNamespace;
         $this->properties = [];
         foreach ($names as $name) {
-            if (empty($this->properties[$name])) {
-                $propertyName = (!empty($namespace) ? $namespace . '-' : '') . $name;
-                $this->properties[$name] = new Property($propertyName, [], 'none', false, true);
-            }
+            $propertyName = (!empty($namespace) ? $namespace . '-' : '') . $name;
+            $this->properties[$name] = new Property($propertyName, [], 'none', false, true);
         }
     }
 

--- a/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
@@ -53,7 +53,6 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
         'changer',
         'created',
         'creator',
-        'created',
         'nodeType',
         'state',
         'shadow-on',

--- a/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
@@ -89,7 +89,7 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
         $this->extensionManager = $extensionManager;
         $this->languageNamespace = $languageNamespace;
 
-        $properties = array_merge_recursive($this->defaultProperties, $this->properties);
+        $properties = array_unique(array_merge($this->defaultProperties, $this->properties));
         $this->translatedProperties = new MultipleTranslatedProperties($properties, $this->languageNamespace);
     }
 

--- a/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
@@ -89,7 +89,7 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
         $this->extensionManager = $extensionManager;
         $this->languageNamespace = $languageNamespace;
 
-        $properties = array_merge($this->defaultProperties, $this->properties);
+        $properties = array_merge_recursive($this->defaultProperties, $this->properties);
         $this->translatedProperties = new MultipleTranslatedProperties($properties, $this->languageNamespace);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

A check that a new translatable property of a document is only added if it was not added before.

#### Why?

603 documents create 1.2 million calls to new Property() and that eats up s lot performance.

Sadly I am not 100% sure if there is any reason you created so many properties without any check. Maybe the namespace could change? I don't know and I can't really test it. But what I do is benchmark with blackfire. And after the check MultipleTranslatedProperties is not even to be seen in the blackfire tree and the same code runs 4 seconds faster.

I don't believe I should use ->getName() because it seems too much to do the same thing but by exception handling.

If it's a stupid idea sorry please delete :)

#### Example Usage

https://blackfire.io/profiles/1eb58276-921d-4e28-b548-f596dbea2267/graph
https://blackfire.io/profiles/98115b82-3381-4edc-a472-0249628a15a7/graph


