### PR TITLE
Fix preview renderer preview attribute and xml http request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
         java -jar downloads/jackrabbit-standalone-$JACKRABBIT_VERSION.jar > /dev/null &
     fi
   # the content tests are intensive and there are memory leaks, this is more pronounced with the Jackalope DBAL PHPCR implementation.
-  - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - composer self-update
   - if [[ $SYMFONY__PHPCR__TRANSPORT = jackrabbit ]]; then composer require jackalope/jackalope-jackrabbit:~1.2  --no-update --no-interaction ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * HOTFIX      #4146 [PreviewBundle]         Fixed preview render preview attribute and XmlHttpRequest state
     * BUGFIX      #4121 [HttpCache]             Set a timeout when purging caches
     * BUGFIX      #4109 [ContentBundle]         Remove validation-state from rendered link
 

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -158,6 +158,9 @@ class PreviewRenderer implements PreviewRendererInterface
         }
 
         $attributes = $this->routeDefaultsProvider->getByEntity(get_class($object), $id, $locale, $object);
+        $attributes['object'] = $object;
+        $attributes['preview'] = true;
+        $attributes['partial'] = $partial;
 
         // get server parameters
         $server = $this->createServerAttributes($portalInformation, $currentRequest);
@@ -261,6 +264,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $server['SERVER_PORT'] = $port;
         $server['HTTP_HOST'] = $httpHost;
         $server['REQUEST_URI'] = $prefixPath . '/_sulu_preview';
+        unset($server['X-Requested-With']);
 
         return $server;
     }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -264,7 +264,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $server['SERVER_PORT'] = $port;
         $server['HTTP_HOST'] = $httpHost;
         $server['REQUEST_URI'] = $prefixPath . '/_sulu_preview';
-        unset($server['X-Requested-With']);
+        unset($server['HTTP_X_REQUESTED_WITH']); // subrequest should not be detected as ajax
 
         return $server;
     }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -158,7 +158,6 @@ class PreviewRenderer implements PreviewRendererInterface
         }
 
         $attributes = $this->routeDefaultsProvider->getByEntity(get_class($object), $id, $locale, $object);
-        $attributes['object'] = $object;
         $attributes['preview'] = true;
         $attributes['partial'] = $partial;
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -571,6 +571,7 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
             'X-Forwarded-Host' => 'forwarded.sulu.io',
             'X-Forwarded-Proto' => 'https',
             'X-Forwarded-Port' => 8081,
+            'HTTP_X_REQUESTED_WITH' => 'XmlHttpRequest',
             'HTTP_USER_AGENT' => 'Sulu/Preview',
             'HTTP_ACCEPT_LANGUAGE' => 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7',
         ];
@@ -580,6 +581,11 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
                 function (Request $request) use ($server) {
                     foreach ($server as $key => $expectedValue) {
                         $value = $request->server->get($key);
+
+                        if ('HTTP_X_REQUESTED_WITH' === $key) {
+                            $expectedValue = null;
+                        }
+
                         $this->assertEquals(
                             $expectedValue,
                             $value,
@@ -591,6 +597,9 @@ class PreviewRendererTest extends \PHPUnit_Framework_TestCase
                             )
                         );
                     }
+
+                    $this->assertTrue($request->attributes->get('preview'));
+                    $this->assertTrue($request->attributes->get('partial'));
 
                     // Assert equals will throw exception so also true can be returned.
                     return true;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4135
| License | MIT

#### What's in this PR?

Remove the server variable which symfony use the indicate xmlhttprequest and set preview and the other attirbutes correctly.

#### Why?

XMLHttpRequest was true which shouldn't and preview was not longer set.
