### PR TITLE
Added root kernel path to be available as document data fixtures paths

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -113,9 +114,18 @@ EOT
 
         $candidatePaths = [];
         if (!$paths) {
+            $directories = array_map(
+                function (BundleInterface $bundle) {
+                    return $bundle->getPath();
+                },
+                $this->kernel->getBundles()
+            );
+
+            $directories[] = $this->kernel->getRootDir();
             $paths = [];
-            foreach ($this->kernel->getBundles() as $bundle) {
-                $candidatePath = $bundle->getPath() . '/DataFixtures/Document';
+
+            foreach ($directories as $directory) {
+                $candidatePath = $directory . '/DataFixtures/Document';
                 $candidatePaths[] = $candidatePath;
                 if (file_exists($candidatePath)) {
                     $paths[] = $candidatePath;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added root kernel path to be available as document data fixtures paths.

#### Why?

As the src folder is not longer a bundle we need to add `src/DataFixtures/Document` as data fixture folder. 

#### Example Usage

~~~php
<?php

// src/DataFixtures/Document/PageFixture.php

namespace App\DataFixtures\Document;

use Sulu\Bundle\DocumentManagerBundle\DataFixtures\DocumentFixtureInterface;
use Sulu\Component\DocumentManager\DocumentManager;

class PageFixture implements DocumentFixtureInterface
{
    public function getOrder()
    {
        return 10;
    }

    public function load(DocumentManager $documentManager)
    {
        // ...
    }
}
~~~
