### PR TITLE
Added .env file generation

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
@@ -11,12 +11,34 @@
 
 namespace Sulu\Bundle\CoreBundle\Composer;
 
+use Composer\Script\Event;
+
 /**
  * A handler for general tasks executed with composer scripts.
  */
 class ScriptHandler
 {
     const GIT_IGNORE_FILE = '.gitignore';
+
+    const ENV_FILE = '.env';
+
+    const ENV_DIST_FILE = '.env.dist';
+
+    /**
+     * Copy the .env.dist file to .env file if not exists and generate a app secret.
+     */
+    public static function copyEnvDistFile(Event $event)
+    {
+        if (file_exists(static::ENV_FILE) || !file_exists(static::ENV_DIST_FILE)) {
+            return;
+        }
+
+        $envFile = file_get_contents(static::ENV_DIST_FILE);
+        $envFile = str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), $envFile);
+        file_put_contents(static::ENV_FILE, $envFile);
+
+        $event->getIO()->write('Please edit the created ".env" file to match your settings.');
+    }
 
     /**
      * Removes the composer.lock file from .gitignore, because we don't want the composer.lock to be included in our


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Related PRs | https://github.com/sulu/sulu-minimal/pull/98

#### What's in this PR?

As we currently don't support symfony flex we need manually create the .env file.

#### Why?

Else composer create-project will fail with an error that the consoles don't work.

#### Example Usage

~~~json
"post-create-project-cmd": [
    "Sulu\\Bundle\\CoreBundle\\Composer\\ScriptHandler::copyEnvDistFile"
]
~~~

