### PR TITLE
Remove prepended fos rest zone config

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -51,22 +51,6 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
             );
         }
 
-        if ($container->hasExtension('fos_rest')) {
-            $container->prependExtensionConfig(
-                'fos_rest',
-                [
-                    'zone' => [
-                        [
-                            'path' => '^/admin/api/*',
-                        ],
-                        [
-                            'path' => '^/api/*',
-                        ],
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('jms_serializer')) {
             $container->prependExtensionConfig(
                 'jms_serializer',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | https://github.com/sulu/sulu-minimal/pull/112
| License | MIT

#### What's in this PR?

Remove prepended fos rest zone config.

#### Why?

>   Configuration path "fos_rest.zone" cannot be overwritten. You have to define all options for this path, and any of its sub-paths
  in one configuration section.

#### Example Usage

Instead configure this in your project configuration:

~~~php
fos_rest:
    zone:
        - { path: ^/admin/* }
        - { path: ^/api/* }
~~~

