### PR TITLE
only check for reserved and required keyword in StructureXmlLoader

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -51,9 +51,7 @@ class FormXmlLoader extends AbstractLoader
             $type,
             '/x:properties/x:*',
             $tags,
-            $xpath,
-            null,
-            false
+            $xpath
         );
 
         foreach ($properties as $property) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Check for reserved keyword in right loader instead of passing that information to the `PropertiesXmlLoader`.

#### Why?

Nicer design.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
