### PR TITLE
Fix loading of environment specific configurations

### DIFF
--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -83,7 +83,7 @@ abstract class SuluKernel extends Kernel
         $confDir = $this->getProjectDir() . '/config';
 
         $this->load($loader, $confDir . '/{packages}/*');
-        $this->load($loader, $confDir . '/{packages}/' . $this->environment . '/**/*');
+        $this->load($loader, $confDir . '/{packages}/' . $this->environment . '/*');
         $this->load($loader, $confDir . '/{services}');
         $this->load($loader, $confDir . '/{services}_' . $this->environment);
     }
@@ -96,7 +96,7 @@ abstract class SuluKernel extends Kernel
         $confDir = $this->getProjectDir() . '/config';
 
         $this->import($routes, $confDir . '/{routes}/*');
-        $this->import($routes, $confDir . '/{routes}/' . $this->environment . '/**/*');
+        $this->import($routes, $confDir . '/{routes}/' . $this->environment . '/*');
         $this->import($routes, $confDir . '/{routes}');
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove the `/**/` from the current environment glob loaders to avoid problems with the normal glob function.

#### Why?

Currently no configurations under the environment folder e.g. `/config/packages/dev/web_profiler.yaml` is loaded.

#### Example Usage

Create a environment specific configuration in `/config/packages/<environment>/<yourfile>.yaml`
