### PR TITLE
Add expressions in form XMLs to conditionally display field types

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
@@ -30,6 +30,11 @@ abstract class Item
     /**
      * @var string
      */
+    protected $visibilityCondition;
+
+    /**
+     * @var string
+     */
     protected $description;
 
     /**
@@ -60,6 +65,16 @@ abstract class Item
     public function setLabel(?string $label): void
     {
         $this->label = $label;
+    }
+
+    public function getVisibilityCondition(): ?string
+    {
+        return $this->visibilityCondition;
+    }
+
+    public function setVisibilityCondition(?string $visibilityCondition): void
+    {
+        $this->visibilityCondition = $visibilityCondition;
     }
 
     public function getDescription(): ?string

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
@@ -104,6 +104,7 @@ class ResourceMetadataMapper
         }
 
         $section->setSize($property->getSize());
+        $section->setVisibilityCondition($property->getVisibilityCondition());
 
         foreach ($property->getChildren() as $component) {
             if ($component instanceof BlockMetadata) {
@@ -131,6 +132,7 @@ class ResourceMetadataMapper
         }
 
         $field->setLabel($property->getTitle($locale));
+        $field->setVisibilityCondition($property->getVisibilityCondition());
         $field->setDescription($property->getDescription($locale));
         $field->setType($property->getType());
         $field->setSize($property->getSize());

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -39,10 +39,12 @@ test('Render block with schema', () => {
                 text1: {
                     label: 'Text 1',
                     type: 'text_line',
+                    visible: true,
                 },
                 text2: {
                     label: 'Text 2',
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },
@@ -93,6 +95,7 @@ test('Render block with schema and error on fields already being modified', () =
                 text: {
                     label: 'Text',
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },
@@ -165,6 +168,7 @@ test('Render block with schema and error on fields already being modified', () =
                 text: {
                     label: 'Text',
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },
@@ -235,6 +239,7 @@ test('Should correctly pass props to the BlockCollection', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },
@@ -280,6 +285,7 @@ test('Should pass correct schemaPath to FieldRender', () => {
             form: {
                 text: {
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },
@@ -321,6 +327,7 @@ test('Should call onFinish when a field from the child renderer has finished edi
                 text: {
                     label: 'Text',
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },
@@ -361,6 +368,7 @@ test('Should call onFinish when the order of the blocks has changed', () => {
                 text: {
                     label: 'Text',
                     type: 'text_line',
+                    visible: true,
                 },
             },
         },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js
@@ -25,7 +25,7 @@ test('Should pass props correctly to Renderer', () => {
         },
     };
     const schema = {
-        text: {label: 'Label', type: 'text_line'},
+        text: {label: 'Label', type: 'text_line', visible: true},
     };
     const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -71,6 +71,10 @@ export default class Renderer extends React.Component<Props> {
     }
 
     renderItem(schemaField: SchemaEntry, schemaKey: string, schemaPath: string) {
+        if (schemaField.visible === false) {
+            return null;
+        }
+
         if (schemaField.type === 'section') {
             return this.renderSection(schemaField, schemaKey, schemaPath);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/MetadataStore.js
@@ -1,6 +1,6 @@
 // @flow
 import resourceMetadataStore from '../../../stores/ResourceMetadataStore';
-import type {Schema, SchemaTypes} from '../types';
+import type {RawSchema, SchemaTypes} from '../types';
 
 class MetadataStore {
     getSchemaTypes(resourceKey: string): Promise<SchemaTypes> {
@@ -24,7 +24,7 @@ class MetadataStore {
             });
     }
 
-    getSchema(resourceKey: string, type: ?string): Promise<Schema> {
+    getSchema(resourceKey: string, type: ?string): Promise<RawSchema> {
         return resourceMetadataStore.loadConfiguration(resourceKey)
             .then((configuration) => {
                 const typeConfiguration = this.getTypeConfiguration(configuration, type, resourceKey);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -33,7 +33,7 @@ test('Render correct label with correct field type', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{label: 'label1', type: 'text'}}
+            schema={{label: 'label1', type: 'text', visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -48,7 +48,7 @@ test('Render correct label with correct field type', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{label: 'label2', type: 'datetime'}}
+            schema={{label: 'label2', type: 'datetime', visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -67,7 +67,7 @@ test('Render field with correct values for grid', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{label: 'label1', type: 'text', size: 8, spaceAfter: 3}}
+            schema={{label: 'label1', type: 'text', size: 8, spaceAfter: 3, visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -86,7 +86,7 @@ test('Render a required field with correct field type', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{label: 'label1', required: true, type: 'text'}}
+            schema={{label: 'label1', required: true, type: 'text', visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -102,7 +102,7 @@ test('Render a field without a label', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{type: 'text'}}
+            schema={{type: 'text', visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -118,7 +118,12 @@ test('Render a field with a description', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{description: 'Small description describing the field', label: 'label1', type: 'text'}}
+            schema={{
+                description: 'Small description describing the field',
+                label: 'label1',
+                type: 'text',
+                visible: true,
+            }}
             schemaPath=""
         />
     )).toMatchSnapshot();
@@ -139,7 +144,7 @@ test('Render a field with an error', () => {
                 name="test"
                 onChange={jest.fn()}
                 onFinish={jest.fn()}
-                schema={{label: 'label1', type: 'text'}}
+                schema={{label: 'label1', type: 'text', visible: true}}
                 schemaPath=""
             />
         )
@@ -167,7 +172,7 @@ test('Render a field with a error collection', () => {
                 name="test"
                 onChange={jest.fn()}
                 onFinish={jest.fn()}
-                schema={{label: 'label1', type: 'text'}}
+                schema={{label: 'label1', type: 'text', visible: true}}
                 schemaPath=""
             />
         )
@@ -187,6 +192,7 @@ test('Pass correct props to FieldType', () => {
         minOccurs: 2,
         type: 'text_line',
         types: {},
+        visible: true,
     };
     const field = shallow(
         <Field
@@ -234,6 +240,7 @@ test('Merge with options from fieldRegistry before passing props to FieldType', 
         },
         type: 'text_line',
         types: {},
+        visible: true,
     };
     const field = shallow(
         <Field
@@ -279,7 +286,7 @@ test('Call onChange callback when value of Field changes', () => {
             name="test"
             onChange={changeSpy}
             onFinish={jest.fn()}
-            schema={{label: 'label', type: 'text'}}
+            schema={{label: 'label', type: 'text', visible: true}}
             schemaPath=""
         />
     );
@@ -304,7 +311,7 @@ test('Call onFinish callback after editing the field has finished', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={finishSpy}
-            schema={{label: 'label', type: 'text'}}
+            schema={{label: 'label', type: 'text', visible: true}}
             schemaPath="/test"
         />
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -103,6 +103,7 @@ test('Call finish handlers with dataPath and schemaPath when a section field has
     const handler2 = jest.fn();
 
     const store = new FormStore(new ResourceStore('snippet', '1'));
+    // $FlowFixMe
     store.schema = {
         highlight: {
             items: {
@@ -127,6 +128,7 @@ test('Call finish handlers with dataPath and schemaPath when a field has finishe
     const handler2 = jest.fn();
 
     const store = new FormStore(new ResourceStore('snippet', '1'));
+    // $FlowFixMe
     store.schema = {
         article: {
             type: 'text_line',
@@ -156,6 +158,7 @@ test('Call finish handlers with dataPath and schemaPath when a block field has f
     };
 
     const store = new FormStore(resourceStore);
+    // $FlowFixMe
     store.schema = {
         block: {
             type: 'block',
@@ -184,6 +187,7 @@ test('Call finish handlers with dataPath and schemaPath when a block field has f
 
 test('Should pass formInspector, schema, data and showAllErrors flag to Renderer', () => {
     const store = new FormStore(new ResourceStore('snippet', '1'));
+    // $FlowFixMe
     store.schema = {};
     store.data.title = 'Title';
     store.data.description = 'Description';
@@ -221,6 +225,7 @@ test('Should change data on store when changed', () => {
 test('Should change data on store without sections', () => {
     const submitSpy = jest.fn();
     const store = new FormStore(new ResourceStore('snippet', '1'));
+    // $FlowFixMe
     store.schema = {
         section1: {
             label: 'Section 1',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -34,10 +34,12 @@ test('Should call onFieldFinish callback when editing a field has finished', () 
         text: {
             label: 'Text',
             type: 'text_line',
+            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
+            visible: true,
         },
     };
     const fieldFinishSpy = jest.fn();
@@ -67,10 +69,68 @@ test('Should render field types based on schema', () => {
         text: {
             label: 'Text',
             type: 'text_line',
+            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
+            visible: true,
+        },
+    };
+
+    const changeSpy = jest.fn();
+
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
+
+    const renderer = render(
+        <Renderer
+            data={{}}
+            dataPath=""
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFieldFinish={jest.fn()}
+            schema={schema}
+            schemaPath=""
+        />
+    );
+
+    expect(renderer).toMatchSnapshot();
+});
+
+test('Should not render fields when the schema contains a visible flag of false', () => {
+    const schema = {
+        highlight: {
+            items: {
+                title: {
+                    type: 'text_line',
+                    visible: true,
+                },
+                url: {
+                    type: 'text_line',
+                    visible: false,
+                },
+            },
+            type: 'section',
+            visible: true,
+        },
+        highlight2: {
+            items: {
+                title: {
+                    type: 'text_line',
+                    visible: true,
+                },
+            },
+            type: 'section',
+            visible: false,
+        },
+        text: {
+            label: 'Text',
+            type: 'text_line',
+        },
+        datetime: {
+            label: 'Datetime',
+            type: 'datetime',
+            visible: false,
         },
     };
 
@@ -99,15 +159,19 @@ test('Should pass correct schemaPath to fields', () => {
             items: {
                 title: {
                     type: 'text_line',
+                    visible: true,
                 },
                 url: {
                     type: 'text_line',
+                    visible: true,
                 },
             },
             type: 'section',
+            visible: true,
         },
         article: {
             type: 'text_line',
+            visible: true,
         },
     };
 
@@ -138,10 +202,12 @@ test('Should pass name, schema and formInspector to fields', () => {
         text: {
             label: 'Text',
             type: 'text_line',
+            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
+            visible: true,
         },
     };
 
@@ -181,10 +247,12 @@ test('Should pass errors to fields that have already been modified at least once
         text: {
             label: 'Text',
             type: 'text_line',
+            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
+            visible: true,
         },
     };
 
@@ -232,10 +300,12 @@ test('Should pass all errors to fields if showAllErrors is set to true', () => {
         text: {
             label: 'Text',
             type: 'text_line',
+            visible: true,
         },
         datetime: {
             label: 'Datetime',
             type: 'datetime',
+            visible: true,
         },
     };
 
@@ -289,12 +359,15 @@ test('Should render nested sections', () => {
                 item11: {
                     label: 'Item 1.1',
                     type: 'text_line',
+                    visible: true,
                 },
                 section11: {
                     label: 'Section 1.1',
                     type: 'section',
+                    visible: true,
                 },
             },
+            visible: true,
         },
         section2: {
             label: 'Section 2',
@@ -303,8 +376,10 @@ test('Should render nested sections', () => {
                 item21: {
                     label: 'Item 2.1',
                     type: 'text_line',
+                    visible: true,
                 },
             },
+            visible: true,
         },
     };
 
@@ -335,8 +410,10 @@ test('Should render sections with size', () => {
                 item11: {
                     label: 'Item 1.1',
                     type: 'text_line',
+                    visible: true,
                 },
             },
+            visible: true,
         },
         section2: {
             label: 'Section 2',
@@ -346,8 +423,10 @@ test('Should render sections with size', () => {
                 item21: {
                     label: 'Item 2.1',
                     type: 'text_line',
+                    visible: true,
                 },
             },
+            visible: true,
         },
     };
 
@@ -377,8 +456,10 @@ test('Should render sections without label', () => {
                 item11: {
                     label: 'Item 1.1',
                     type: 'text_line',
+                    visible: true,
                 },
             },
+            visible: true,
         },
         section2: {
             label: 'Section 2',
@@ -388,8 +469,10 @@ test('Should render sections without label', () => {
                 item21: {
                     label: 'Item 2.1',
                     type: 'text_line',
+                    visible: true,
                 },
             },
+            visible: true,
         },
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Should not render fields when the schema contains a visible flag of false 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="section gridSection size size-12 space-before-0 space-after-0"
+  >
+    <div
+      class="item gridItem size size-12 space-before-0 space-after-0"
+    >
+      <div
+        class="field"
+      >
+        <input
+          type="text"
+        />
+        <label
+          class="errorLabel"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="item gridItem size size-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        Text
+      </label>
+      <input
+        type="text"
+      />
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Should render field types based on schema 1`] = `
 <div
   class="grid grid"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -8,20 +8,29 @@ export type SchemaType = {
 
 export type SchemaTypes = {[key: string]: SchemaType};
 
-export type Type = {
-    title: string,
-    form: Schema,
-};
-export type Types = {[key: string]: Type};
-
 export type Tag = {
     name: string,
     priority?: number,
 };
 
-export type SchemaEntry = {
+type BaseType = {
+    title: string,
+};
+
+export type RawType = BaseType & {
+    form: RawSchema,
+};
+
+export type RawTypes = {[key: string]: RawType};
+
+export type Type = BaseType & {
+    form: Schema,
+};
+
+export type Types = {[key: string]: Type};
+
+type BaseSchemaEntry = {
     description?: string,
-    items?: Schema,
     label?: string,
     maxOccurs?: number,
     minOccurs?: number,
@@ -31,11 +40,22 @@ export type SchemaEntry = {
     spaceAfter?: Size,
     tags?: Array<Tag>,
     type: string,
-    types?: Types,
 };
 
-export type Schema = {
-    [string]: SchemaEntry,
+export type RawSchemaEntry = BaseSchemaEntry & {
+    items?: RawSchema,
+    types?: RawTypes,
+    visibilityCondition?: string,
 };
+
+export type SchemaEntry = BaseSchemaEntry & {
+    items?: Schema,
+    types?: Types,
+    visible?: boolean,
+};
+
+export type RawSchema = {[string]: RawSchemaEntry};
+
+export type Schema = {[string]: SchemaEntry};
 
 export type FinishFieldHandler = (dataPath: string, schemaPath: string) => void;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -19,6 +19,7 @@
         "imagesloaded": "^4.1.3",
         "intl-messageformat": "^2.2.0",
         "isemail": "^3.1.2",
+        "jexl": "^1.1.4",
         "jsonpointer": "^4.0.1",
         "loglevel": "^1.4.1",
         "masonry-layout": "^4.2.0",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
@@ -122,6 +122,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Field $field1 */
         $field1 = $form->getItems()['test1'];
         $this->assertSame($field1->getName(), 'test1');
+        $this->assertSame($field1->getVisibilityCondition(), 'propertyVisibilityCondition');
         $this->assertSame($field1->getLabel(), 'Test 1');
         $this->assertSame($field1->getType(), 'text_line');
 
@@ -181,6 +182,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Field $block */
         $block = $form->getItems()['blocktest'];
         $this->assertSame($block->getName(), 'blocktest');
+        $this->assertSame($block->getVisibilityCondition(), 'blockVisibilityCondition');
         $this->assertSame($block->getLabel(), 'Block Test');
         $this->assertSame($block->getType(), 'block');
         $this->assertCount(2, $block->getTypes());
@@ -208,6 +210,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Section $section */
         $section = $form->getItems()['sectiontest'];
         $this->assertSame('sectiontest', $section->getName());
+        $this->assertSame($section->getVisibilityCondition(), 'sectionVisibilityCondition');
         $this->assertSame('Section Title', $section->getLabel());
         $this->assertCount(4, $section->getItems());
         $this->assertArrayHasKey('test1', $section->getItems());
@@ -233,6 +236,7 @@ class ResourceMetadataMapperTest extends TestCase
     private function getProperties(string $type): array
     {
         $property1 = new PropertyMetadata('test1');
+        $property1->setVisibilityCondition('propertyVisibilityCondition');
         $property1->setSpaceAfter('2');
         $property1->setRequired(false);
         $property1->setType('text_line');
@@ -302,6 +306,7 @@ class ResourceMetadataMapperTest extends TestCase
         );
 
         $block = new BlockMetadata('blocktest');
+        $block->setVisibilityCondition('blockVisibilityCondition');
         $block->setType('block');
         $block->setTitles([
             'de' => 'Block Test',
@@ -324,6 +329,7 @@ class ResourceMetadataMapperTest extends TestCase
         $block->addComponent($component2);
 
         $section = new SectionMetadata('sectiontest');
+        $section->setVisibilityCondition('sectionVisibilityCondition');
         $section->setTitles([
             'de' => 'Section Title',
         ]);

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -76,6 +76,11 @@ abstract class ItemMetadata
     protected $label = true;
 
     /**
+     * @var string
+     */
+    protected $visibilityCondition = null;
+
+    /**
      * @param mixed $name
      */
     public function __construct($name = null)
@@ -345,5 +350,17 @@ abstract class ItemMetadata
         }
 
         return '';
+    }
+
+    public function getVisibilityCondition(): ?string
+    {
+        return $this->visibilityCondition;
+    }
+
+    public function setVisibilityCondition(?string $visibilityCondition): self
+    {
+        $this->visibilityCondition = $visibilityCondition;
+
+        return $this;
     }
 }

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -73,6 +73,7 @@
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
+        <xs:attribute type="xs:string" name="visibilityCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 
@@ -110,6 +111,7 @@
         <xs:attribute type="xs:integer" name="size" use="optional"/>
         <xs:attribute type="xs:integer" name="spaceAfter" use="optional"/>
         <xs:attribute type="xs:boolean" name="label" use="optional"/>
+        <xs:attribute type="xs:string" name="visibilityCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 
@@ -128,6 +130,7 @@
         <xs:attribute type="xs:positiveInteger" name="maxOccurs" use="optional"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
+        <xs:attribute type="xs:string" name="visibilityCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -76,7 +76,18 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass', 'size', 'spaceAfter', 'label']
+            [
+                'name',
+                'type',
+                'minOccurs',
+                'maxOccurs',
+                'colspan',
+                'cssClass',
+                'size',
+                'spaceAfter',
+                'label',
+                'visibilityCondition',
+            ]
         );
 
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
@@ -131,7 +142,7 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'default-type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass']
+            ['name', 'default-type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass', 'visibilityCondition']
         );
 
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
@@ -152,7 +163,7 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'colspan', 'cssClass']
+            ['name', 'colspan', 'cssClass', 'visibilityCondition']
         );
 
         $result['type'] = 'section';
@@ -356,11 +367,17 @@ class PropertiesXmlParser
         $section = new SectionMetadata();
         $section->setName($propertyName);
         $section->setSize($data['colspan']);
+
         if (isset($data['meta']['title'])) {
             $section->setTitles($data['meta']['title']);
         }
+
         if (isset($data['meta']['info_text'])) {
             $section->setDescriptions($data['meta']['info_text']);
+        }
+
+        if (isset($data['visibilityCondition'])) {
+            $section->setVisibilityCondition($data['visibilityCondition']);
         }
 
         foreach ($data['properties'] as $name => $property) {
@@ -376,9 +393,14 @@ class PropertiesXmlParser
         $blockProperty->setName($propertyName);
         $blockProperty->defaultComponentName = $data['default-type'];
 
+        if (isset($data['visibilityCondition'])) {
+            $blockProperty->setVisibilityCondition($data['visibilityCondition']);
+        }
+
         if (isset($data['meta']['title'])) {
             $blockProperty->setTitles($data['meta']['title']);
         }
+
         if (isset($data['meta']['info_text'])) {
             $blockProperty->setDescriptions($data['meta']['info_text']);
         }
@@ -422,6 +444,7 @@ class PropertiesXmlParser
         $property->setMinOccurs(null !== $data['minOccurs'] ? intval($data['minOccurs']) : null);
         $property->setMaxOccurs(null !== $data['maxOccurs'] ? intval($data['maxOccurs']) : null);
         $property->setLabel(array_key_exists('label', $data) ? $data['label'] : null);
+        $property->setVisibilityCondition(array_key_exists('visibilityCondition', $data) ? $data['visibilityCondition'] : null);
         $property->setParameters($data['params']);
         $property->setOnInvalid(array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);
         $this->mapMeta($property, $data['meta']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will allow to define expressions using the [JEXL expression language](https://github.com/TomFrost/Jexl), which define whether or not a specific field should be displayed.

#### Why?

Because we need this functionality in the page settings. Depending on whether the page is a normal content page, an internal link or an external link different fields have to be shown.

And in addition to that this is also a powerful feature, which can be useful in other forms as well.

#### Example

Only show the url field if the title has a value of "URL":

```xml
<properties>                                                                                                                                                                                           
    <property name="title" type="text_line" mandatory="true" />                                                                                                                                                                                                                                                                                                     
    <property name="url" type="resource_locator" mandatory="true" visibilityCondition="title == 'URL'" />
</properties>
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md