### PR TITLE
Fix image formats folder path

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -54,7 +54,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                         ],
                     ],
                     'image_format_files' => [
-                        '%kernel.root_dir%/config/image-formats.xml',
+                        '%kernel.project_dir%/config/image-formats.xml',
                         __DIR__ . '/../Resources/config/image-formats.xml',
                     ],
                     'search' => ['enabled' => $container->hasExtension('massive_search')],

--- a/src/Sulu/Bundle/MediaBundle/Tests/app/config/config.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/app/config/config.yml
@@ -7,6 +7,8 @@ sulu_media:
     format_manager:
         response_headers:
             Expires: "+1 month"
+    image_format_files:
+        - "%kernel.root_dir%/config/image-formats.xml"
 
 framework:
     assets: ~


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | #3966
| License | MIT

#### What's in this PR?

Set image formats folder to project_dir/config/image-formats.xml

#### Why?

The configuration should be in the config folder not in the src folder. Its also so documented in the UPGRADE.md
