### PR TITLE
Added single contact selection content type

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleContactSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleContactSelection.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Content\Types;
+
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\SimpleContentType;
+
+class SingleContactSelection extends SimpleContentType
+{
+    /**
+     * @var ContactRepositoryInterface
+     */
+    protected $contactRepository;
+
+    public function __construct(ContactRepositoryInterface $contactRepository)
+    {
+        $this->contactRepository = $contactRepository;
+
+        parent::__construct('SingleContact');
+    }
+
+    public function getContentData(PropertyInterface $property): ?ContactInterface
+    {
+        $id = $property->getValue();
+
+        if (!$id) {
+            return null;
+        }
+
+        return $this->contactRepository->findById($id);
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
@@ -20,5 +20,12 @@
             <tag name="sulu.content.type" alias="contact"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false"/>
         </service>
+
+        <service id="sulu_contact.content.single_contact_selection" class="Sulu\Bundle\ContactBundle\Content\Types\SingleContactSelection">
+            <argument type="service" id="sulu.repository.contact" />
+
+            <tag name="sulu.content.type" alias="single_contact_selection"/>
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleContactSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleContactSelectionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Util;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Content\Types\SingleContactSelection;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Component\Content\Compat\Property;
+
+class SingleContactSelectionTest extends TestCase
+{
+    /**
+     * @var SingleContactSelection
+     */
+    private $singleContactSelection;
+
+    /**
+     * @var ContactRepositoryInterface
+     */
+    private $contactRepository;
+
+    /**
+     * @var NodeInterface
+     */
+    private $node;
+
+    /**
+     * @var
+     */
+    private $property;
+
+    /**
+     * @var ContactInterface
+     */
+    private $contact;
+
+    protected function setUp()
+    {
+        $this->contactRepository = $this->prophesize(ContactRepositoryInterface::class);
+        $this->contact = $this->prophesize(ContactInterface::class);
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->property = $this->prophesize(PropertyInterface::class);
+        $this->singleContactSelection = new SingleContactSelection($this->contactRepository->reveal());
+    }
+
+    public function testRead()
+    {
+        $this->node->hasProperty('contact')->willReturn(true);
+        $this->node->getPropertyValue('contact')->willReturn(1);
+
+        $this->assertEquals(
+            1,
+            $this->singleContactSelection->read(
+                $this->node->reveal(),
+                new Property('contact', [], 'single_contact_selection'),
+                'sulu',
+                'de',
+                ''
+            )
+        );
+    }
+
+    public function testWrite()
+    {
+        $this->node->setProperty('contact', 1)->shouldBeCalled();
+        $property = new Property('contact', [], 'single_contact_selection');
+        $property->setValue(1);
+
+        $this->singleContactSelection->write(
+            $this->node->reveal(),
+            $property,
+            1,
+            'sulu',
+            'de',
+            ''
+        );
+    }
+
+    public function testWriteNothing()
+    {
+        $this->node->hasProperty('contact')->shouldBeCalled();
+        $property = new Property('contact', [], 'single_contact_selection');
+        $this->node->hasProperty('contact')->willReturn(true);
+        $this->property->remove()->shouldBeCalled();
+        $this->node->getProperty('contact')->willReturn($this->property->reveal());
+
+        $this->singleContactSelection->write(
+            $this->node->reveal(),
+            $property,
+            null,
+            'sulu',
+            'de',
+            ''
+        );
+    }
+
+    public function testDefaultParams()
+    {
+        $this->assertEquals(
+            [],
+            $this->singleContactSelection->getDefaultParams(new Property('contact', [], 'single_contact_selection'))
+        );
+    }
+
+    public function testViewDataEmpty()
+    {
+        $this->assertEquals(
+            [],
+            $this->singleContactSelection->getViewData(new Property('contact', [], 'single_contact_selection'))
+        );
+    }
+
+    public function testViewData()
+    {
+        $property = new Property('contact', [], 'single_contact_selection');
+        $property->setValue(1);
+
+        $this->assertEquals(
+            [],
+            $this->singleContactSelection->getViewData($property)
+        );
+    }
+
+    public function testContentDataEmpty()
+    {
+        $this->assertNull(
+            $this->singleContactSelection->getContentData(new Property('contact', [], 'single_contact_selection'))
+        );
+    }
+
+    public function testContentData()
+    {
+        $property = new Property('contact', [], 'single_contact_selection');
+        $property->setValue(1);
+        $this->contactRepository->findById(1)->willReturn($this->contact->reveal())->shouldBeCalled();
+
+        $this->assertEquals($this->contact->reveal(), $this->singleContactSelection->getContentData($property));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related Issues | #3624 
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/393

#### What's in this PR?

Added single contact selection content type.

#### Why?

Have a single contact selection content type available.

#### Example Usage

See documentation: https://github.com/sulu/sulu-docs/pull/393

#### BC Breaks/Deprecations

none

#### To Do

- [x] Tests
- [x] Create a documentation PR
