### PR TITLE
Change ContentTypeManager::getAll to return only aliases instead of instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - DATABASE_CHARSET=UTF8
         - DATABASE_COLLATE=
         # restart jackrabbit after each suite see: https://github.com/sulu-io/sulu/issues/2137
-        - TEST_FLAGS="--jackrabbit-restart"
+        - TEST_FLAGS="--jackrabbit-restart --flags=\"--testdox\""
 
 before_script:
   - if [ ! -d downloads ]; then mkdir downloads; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - DATABASE_CHARSET=UTF8
         - DATABASE_COLLATE=
         # restart jackrabbit after each suite see: https://github.com/sulu-io/sulu/issues/2137
-        - TEST_FLAGS="--jackrabbit-restart --flags=\"--testdox\""
+        - TEST_FLAGS="--jackrabbit-restart"
 
 before_script:
   - if [ ! -d downloads ]; then mkdir downloads; fi

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,7 @@ The websocket-bundle and component was removed without replacement.
 To register a `sulu_preview.object_provider` you have to change your tag definition:
 
 Before:
+
 ```xml
 <tag name="sulu_preview.object_provider" class="Sulu\Bundle\ArticleBundle\Document\ArticleDocument"/>
 ```
@@ -22,6 +23,12 @@ After:
 ```
 
 Additionally the rdfa properties are obsolete and they can be removed from your twig templates.
+
+### Content Type Manager
+
+The `ContentTypeManagerInterface::getAll` function will not longer return instances of the content types.
+Instead it will return a list of the content types aliases for performance reasons.
+Use the `ContentTypeManagerInterface::get($alias)` to get the service instance of the content type.
 
 ### Default folder changed
 

--- a/src/Sulu/Bundle/ContentBundle/Command/ContentTypesDumpCommand.php
+++ b/src/Sulu/Bundle/ContentBundle/Command/ContentTypesDumpCommand.php
@@ -11,10 +11,10 @@
 
 namespace Sulu\Bundle\ContentBundle\Command;
 
-use Sulu\Component\Content\ContentTypeManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -28,7 +28,9 @@ class ContentTypesDumpCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this->setName('sulu:content:types:dump')
-            ->setDescription('Dumps all ContentTypes registered in the system');
+            ->setDescription('Dumps all ContentTypes registered in the system')->setDefinition([
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
+            ]);
     }
 
     /**
@@ -36,15 +38,15 @@ class ContentTypesDumpCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var ContentTypeManagerInterface $contentTypeManager */
-        $contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');
+        $command = $this->getApplication()->find('debug:container');
 
-        $table = new Table($output);
-        $table->setHeaders(['Alias', 'Service ID']);
+        $arguments = [
+            'command' => 'debug:container',
+            '--tag' => 'sulu.content.type',
+            '--show-private' => true,
+            '--format' => $input->getOption('format'),
+        ];
 
-        foreach ($contentTypeManager->getAll() as $alias => $service) {
-            $table->addRow([$alias, $service['id']]);
-        }
-        $table->render();
+        return $command->run(new ArrayInput($arguments), $output);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
@@ -13,7 +13,8 @@ namespace Sulu\Bundle\ContentBundle\Tests\Functional\Command;
 
 use Sulu\Bundle\ContentBundle\Command\ContentTypesDumpCommand;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Symfony\Component\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ContentTypesDumpCommandTest extends SuluTestCase
@@ -27,6 +28,10 @@ class ContentTypesDumpCommandTest extends SuluTestCase
     {
         $application = new Application($this->getContainer()->get('kernel'));
 
+        $debugContainerCommand = new ContainerDebugCommand();
+        $debugContainerCommand->setApplication($application);
+        $application->add($debugContainerCommand);
+
         $command = new ContentTypesDumpCommand();
         $command->setApplication($application);
         $command->setContainer($this->getContainer());
@@ -39,8 +44,33 @@ class ContentTypesDumpCommandTest extends SuluTestCase
 
         $output = $this->tester->getDisplay();
 
-        $this->assertContains('text_line', $output);
+        $this->assertContains('block', $output);
+        $this->assertContains('checkbox', $output);
+        $this->assertContains('color', $output);
+        $this->assertContains('date', $output);
+        $this->assertContains('email', $output);
+        $this->assertContains('internal_link', $output);
+        $this->assertContains('multiple_select', $output);
+        $this->assertContains('number', $output);
+        $this->assertContains('password', $output);
+        $this->assertContains('phone', $output);
+        $this->assertContains('resource_locator', $output);
+        $this->assertContains('single_internal_link', $output);
+        $this->assertContains('single_select', $output);
         $this->assertContains('text_area', $output);
         $this->assertContains('text_editor', $output);
+        $this->assertContains('text_line', $output);
+        $this->assertContains('time', $output);
+        $this->assertContains('url', $output);
+        $this->assertContains('audience_targeting_groups', $output);
+        $this->assertContains('category_list', $output);
+        $this->assertContains('contact', $output);
+        $this->assertContains('smart_content', $output);
+        $this->assertContains('teaser_selection', $output);
+        $this->assertContains('location', $output);
+        $this->assertContains('media_selection', $output);
+        $this->assertContains('route', $output);
+        $this->assertContains('snippet', $output);
+        $this->assertContains('tag_list', $output);
     }
 }

--- a/src/Sulu/Component/Content/ContentTypeManager.php
+++ b/src/Sulu/Component/Content/ContentTypeManager.php
@@ -77,13 +77,8 @@ class ContentTypeManager implements ContentTypeManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getAll()
+    public function getAll(): array
     {
-        $result = [];
-        foreach ($this->aliasServiceIdMap as $alias => $id) {
-            $result[$alias] = ['instance' => $this->get($alias), 'id' => $id];
-        }
-
-        return $result;
+        return array_keys($this->aliasServiceIdMap);
     }
 }

--- a/src/Sulu/Component/Content/ContentTypeManagerInterface.php
+++ b/src/Sulu/Component/Content/ContentTypeManagerInterface.php
@@ -35,9 +35,9 @@ interface ContentTypeManagerInterface
     public function has($contentTypeName);
 
     /**
-     * returns all content types.
+     * returns all content type aliases.
      *
-     * @return ContentTypeInterface[]
+     * @return string[]
      */
-    public function getAll();
+    public function getAll(): array;
 }

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -184,7 +184,7 @@ class StructureXmlLoader extends AbstractLoader
             throw new \InvalidArgumentException(sprintf(
                 'Content type with alias "%s" has not been registered. Known content types are: "%s"',
                 $propertyType,
-                implode('", "', array_keys($this->contentTypeManager->getAll() ?: []))
+                implode('", "', $this->contentTypeManager->getAll())
             ));
         });
 

--- a/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ContentTypeManagerTest.php
@@ -59,4 +59,15 @@ class ContentTypeManagerTest extends TestCase
         $res = $this->manager->has($alias);
         $this->assertEquals($expected, $res);
     }
+
+    public function testAll()
+    {
+        $this->assertEquals(
+            [
+                'content_1.alias',
+                'content_2.alias',
+            ],
+            $this->manager->getAll()
+        );
+    }
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/XmlLoaderTest.php
@@ -147,7 +147,7 @@ class XmlLoaderTest extends TestCase
         $this->contentTypeManager->has('text_line')->willReturn(true);
         $this->contentTypeManager->has('resource_locator')->willReturn(true);
         $this->contentTypeManager->has('test')->willReturn(false);
-        $this->contentTypeManager->getAll()->willReturn(['text_line' => [], 'resource_locator' => []]);
+        $this->contentTypeManager->getAll()->willReturn(['text_line', 'resource_locator']);
         $this->load('template_without_invalid_ignore.xml');
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Fixed Issues | parts of #4008
| Deprecations? | no
| License | MIT

#### What's in this PR?

Change `ContentTypeManager::getAll`to return only aliases instead of instances.

#### Why?

To avoid that any service initialized all content types when its not needed and avoid false error messages when unregistered content types are used.

#### Example Usage

~~~php
foreach ($contentTypeManager->getAll() as $alias) {
      $contentType = $contentTypeManager->get($alias);

      // ...
}
~~~

#### BC Breaks/Deprecations

See UPGRADE.md

#### To Do

- [x] Add breaking changes to UPGRADE.md
