### PR TITLE
Fix kernel name

### DIFF
--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -51,6 +51,7 @@ abstract class SuluKernel extends Kernel
      */
     public function __construct($environment, $debug, $suluContext)
     {
+        $this->name = $suluContext;
         $this->context = $suluContext;
         $this->reversedContext = self::CONTEXT_ADMIN === $this->context ? self::CONTEXT_WEBSITE : self::CONTEXT_ADMIN;
         parent::__construct($environment, $debug);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | ---
| License | MIT
| Documentation PR | --

#### What's in this PR?

Set the kernel name to avoid duplicate names.

#### Why?

For example opcache crashes.