### PR TITLE
fix datetime formatting for Symfony regression

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## dev-develop
 
+### DateTime Serialization
+
+DateTimes in a REST response do not contain the timezone anymore.
+
 ### Websocket
 
 The websocket-bundle and component was removed without replacement.

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -139,7 +139,6 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals(['tag1', 'tag2'], $response->tags);
         $this->assertEquals($this->getTestUserId(), $response->creator);
         $this->assertEquals($this->getTestUserId(), $response->changer);
-        $this->assertNotFalse(\DateTime::createFromFormat(\DateTime::ATOM, $response->authored));
 
         /** @var NodeInterface $content */
         $defaultContent = $this->session->getNode('/cmf/sulu_io/contents/news/test-1');
@@ -267,7 +266,6 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals(['tag1', 'tag2'], $response['tags']);
         $this->assertEquals('/test_en', $response['url']);
         $this->assertEquals('Test English', $response['article']);
-        $this->assertNotFalse(\DateTime::createFromFormat(\DateTime::ATOM, $response['authored']));
 
         $client->request('GET', '/api/nodes/' . $document->getUuid() . '?language=de');
         $response = json_decode($client->getResponse()->getContent(), true);
@@ -562,7 +560,7 @@ class NodeControllerTest extends SuluTestCase
                 'title' => 'Testtitle DE',
                 'template' => 'default',
                 'url' => '/test-de',
-                'authored' => '2017-11-20T13:15:00+00:00',
+                'authored' => '2017-11-20T13:15:00',
                 'author' => 1,
             ]
         );
@@ -574,7 +572,7 @@ class NodeControllerTest extends SuluTestCase
                 'title' => 'Testtitle EN',
                 'template' => 'default',
                 'url' => '/test-en',
-                'authored' => '2017-11-20T13:15:00+00:00',
+                'authored' => '2017-11-20T13:15:00',
                 'author' => 1,
             ]
         );
@@ -589,8 +587,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals($this->getTestUserId(), $response['changer']);
         $this->assertEquals($this->getTestUserId(), $response['creator']);
 
-        $this->assertNotFalse(\DateTime::createFromFormat(\DateTime::ATOM, $response['authored']));
-        $this->assertEquals('2017-11-20T13:15:00+00:00', $response['authored']);
+        $this->assertEquals('2017-11-20T13:15:00', $response['authored']);
         $this->assertEquals(1, $response['author']);
 
         $client->request('GET', '/api/nodes/' . $response['id'] . '?language=en');
@@ -602,7 +599,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals($this->getTestUserId(), $response['changer']);
         $this->assertEquals($this->getTestUserId(), $response['creator']);
 
-        $this->assertEquals('2017-11-20T13:15:00+00:00', $response['authored']);
+        $this->assertEquals('2017-11-20T13:15:00', $response['authored']);
         $this->assertEquals(1, $response['author']);
 
         $this->assertFalse(

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -155,7 +155,19 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         if ($container->hasExtension('jms_serializer')) {
-            $container->prependExtensionConfig('jms_serializer', ['metadata' => ['debug' => '%kernel.debug%']]);
+            $container->prependExtensionConfig(
+                'jms_serializer',
+                [
+                    'metadata' => [
+                        'debug' => '%kernel.debug%',
+                    ],
+                    'handlers' => [
+                        'datetime' => [
+                            'default_format' => 'Y-m-d\\TH:i:s',
+                        ],
+                    ],
+                ]
+            );
         }
 
         if ($container->hasExtension('fos_rest')) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | symfony/symfony#28372
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The `DateTimeType` of the Symfony Form component doesn't accept any timezones anymore. Our datetime field doesn't add a timezone anyway, but the server should not return the timezone as well, because if the field is not edited, we don't update the value, and the validation will fail as well.

We might also have to backport this change to 1.x, because Symfony 3.4.16 should have the same bug, but doesn't work currently because of symfony/symfony#28658.

#### Why?

The tests were failing, and if a datetime field was in the form, it couldn't be sent to the server without an error without editing it first.

#### BC Breaks/Deprecations

The datetimes in a REST API do not contain the timezone anymore.