### PR TITLE
Set service 'sulu_website.resolver.template_attribute' to public

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -156,7 +156,8 @@
         </service>
 
         <service id="sulu_website.resolver.template_attribute"
-                 class="Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolver">
+                 class="Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolver"
+                 public="true">
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Set service 'sulu_website.resolver.template_attribute' to public

#### Why?

This is used by third party bundles.