### PR TITLE
add conflicting symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "phpdocumentor/reflection-docblock": "~3.1"
     },
     "conflict": {
-        "symfony/symfony": "2.8.10 || 3.4.12",
+        "symfony/symfony": "2.8.10 || 3.4.12 || 3.4.16 || 3.4.17",
         "symfony/phpunit-bridge": "2.8.10",
         "symfony/monolog-bundle": "2.8.10",
         "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1 || 1.3.6",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR inserts conflicts for symfony/symfony because of symfony/symfony#28658 and symfony/symfony#28699.