### PR TITLE
add missing fields to category form

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/forms/Category.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/forms/Category.xml
@@ -3,17 +3,29 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
      <properties>
-         <property name="name" type="text_line" mandatory="true" colspan="12">
+         <property name="name" type="text_line" mandatory="true">
              <meta>
                  <title lang="en">Name</title>
                  <title lang="de">Name</title>
              </meta>
          </property>
      
-         <property name="key" type="text_line" colspan="12">
+         <property name="key" type="text_line">
              <meta>
                  <title lang="en">Key</title>
                  <title lang="de">Schlüssel</title>
+             </meta>
+         </property>
+         <property name="description" type="text_editor">
+             <meta>
+                 <title lang="en">Description</title>
+                 <title lang="de">Beschreibung</title>
+             </meta>
+         </property>
+         <property name="medias" type="media_selection">
+             <meta>
+                 <title lang="en">Media</title>
+                 <title lang="de">Medien</title>
              </meta>
          </property>
      </properties>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the description and media field to the Category form.

#### Why?

Because our category entities support that. The only missing field in this form are the keywords now, which probably require a separate field type.