### PR TITLE
update ckeditor to latest version

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@ckeditor/ckeditor5-alignment": "^10.0.1",
         "@ckeditor/ckeditor5-basic-styles": "^10.0.1",
-        "@ckeditor/ckeditor5-editor-classic": "^10.0.1",
+        "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
         "@ckeditor/ckeditor5-essentials": "^10.1.0",
         "@ckeditor/ckeditor5-list": "^11.0.0",
         "@ckeditor/ckeditor5-paragraph": "^10.0.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Some of the latest dependency updates broke the CKEditor. This PR updates the CKEditor itself, so that it is working again.

@chirimoya Thought about adding the table plugin as well, but we probably need a design and implement some styling on our own. If I add it now without it, it looks like this:

![screenshot from 2018-10-09 16-06-13](https://user-images.githubusercontent.com/405874/46674828-63f4d200-cbdd-11e8-8388-5af2c9ae6c07.png)
