### PR TITLE
fix positioning of locale chooser

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
@@ -20,7 +20,7 @@ exports[`Render ArrowMenu open 2`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <div class=\\"arrowMenuContainer\\" style=\\"top: 20px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <div class=\\"arrowMenuContainer\\" style=\\"top: 20px; left: 10px; position: fixed; pointer-events: auto;\\">
       <div class=\\"arrow top right\\"></div>
       <div class=\\"arrowMenu\\">
         <div class=\\"section\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
@@ -111,7 +111,7 @@ exports[`ColorPicker should render with open overlay 1`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <div style=\\"top: 10px; position: fixed; pointer-events: auto; left: 35px;\\">
+    <div style=\\"top: 10px; left: 35px; position: fixed; pointer-events: auto;\\">
       <div style=\\"width: 200px; padding: 10px 10px 0px; box-sizing: initial; background: rgb(255, 255, 255); border-radius: 4px; box-shadow: 0 0 0 1px rgba(0,0,0,.15), 0 8px 16px rgba(0,0,0,.15);\\" class=\\"sketch-picker \\">
         <div style=\\"width: 100%; padding-bottom: 75%; position: relative; overflow: hidden;\\">
           <div style=\\"position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px;\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
@@ -29,7 +29,7 @@ exports[`Should render with active 2`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <div style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <div style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <div class=\\"listContainer\\">
         <ul class=\\"list primary\\">
           <li><button class=\\"option\\">Option1</button></li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/__snapshots__/DatePicker.test.js.snap
@@ -47,7 +47,7 @@ exports[`DatePicker should render 1`] = `
                 class="container"
               >
                 <div
-                  style="top: 10px; position: fixed; pointer-events: auto; left: 34px;"
+                  style="top: 10px; left: 34px; position: fixed; pointer-events: auto;"
                 >
                   <div
                     class="rdt"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -85,7 +85,7 @@ exports[`Render the MultiAutoComplete with open suggestions list 2`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button></li>
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 2</span></button></li>
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 3</span></button></li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/PopoverPositioner.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/PopoverPositioner.js
@@ -136,7 +136,6 @@ export default class PopoverPositioner {
             newDimensions.left = anchorLeft + anchorWidth - popoverWidth;
         }
 
-        newDimensions.left = Math.min(windowWidth - popoverWidth - PADDING_TO_WINDOW, newDimensions.left);
         return newDimensions;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/PopoverPositioner.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/PopoverPositioner.test.js
@@ -101,7 +101,7 @@ test('The positioner should return the correct dimensions when the popover overf
             anchorLeft: 2000,
             centerChildOffsetTop: 100,
         }))
-    )).toEqual({top: 302, left: 1310, height: 500, scrollTop: 0});
+    )).toEqual({top: 302, left: 1900, height: 500, scrollTop: 0});
 });
 
 test('The positioner should return the correct dimensions when the popover undercuts the min height at the bottom 2',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -47,7 +47,7 @@ exports[`The component should open the popover when the display value is clicked
 </div>
 <div>
   <div class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li><button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 1</button></li>
       <li><button class=\\"option icon\\" style=\\"min-width: 210px;\\">Option 2</button></li>
       <li class=\\"divider\\"></li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -30,7 +30,7 @@ exports[`Render the SingleAutoComplete with open suggestions list 2`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 1</span></button></li>
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 2</span></button></li>
       <li class=\\"suggestionItem\\" style=\\"min-width: -10px;\\"><button class=\\"suggestion\\"><span class=\\"column\\">Suggestion 3</span></button></li>

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/components/WebspaceSelect/tests/__snapshots__/WebspaceSelect.test.js.snap
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/components/WebspaceSelect/tests/__snapshots__/WebspaceSelect.test.js.snap
@@ -56,7 +56,7 @@ exports[`Render WebspaceSelect opened 2`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <div class=\\"arrowMenuContainer\\" style=\\"top: 20px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <div class=\\"arrowMenuContainer\\" style=\\"top: 20px; left: 10px; position: fixed; pointer-events: auto;\\">
       <div class=\\"arrow top right\\"></div>
       <div class=\\"arrowMenu\\">
         <div class=\\"section\\">

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -196,7 +196,7 @@ exports[`Render a MediaCard with download list 1`] = `
 </div>
 <div>
   <div class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; position: fixed; pointer-events: auto; left: 10px;\\">
+    <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
       <li class=\\"item\\"><button><span class=\\"content\\">Direct download<span class=\\"copyText\\"></span></span></button></li>
       <li class=\\"divider\\"></li>
       <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"content\\">300/200<span class=\\"copyText\\">Copy URL</span></span></button></li>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | introduced in #4170 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This avoids setting a minimum padding from the right side of the window.

#### Why?

This caused a wrong positioning of the dropdown of the locale chooser:

![screenshot from 2018-10-10 11-09-11](https://user-images.githubusercontent.com/405874/46725799-3b241980-cc7d-11e8-90cd-5e10e2bf95b9.png)