### PR TITLE
fix error when creating male contact

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -504,13 +504,13 @@ class ContactController extends RestController implements ClassResourceInterface
 
     private function checkArguments(Request $request)
     {
-        if (null == $request->get('firstName')) {
+        if (null === $request->get('firstName')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.contact.class'), 'username');
         }
         if (null === $request->get('lastName')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.contact.class'), 'password');
         }
-        if (null == $request->get('formOfAddress')) {
+        if (null === $request->get('formOfAddress')) {
             throw new MissingArgumentException($this->container->getParameter('sulu.model.contact.class'), 'formOfAddress');
         }
     }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -564,9 +564,7 @@ class ContactControllerTest extends SuluTestCase
                     ['value' => 'Note 2'],
                 ],
                 'salutation' => 'Sehr geehrte Frau Dr Mustermann',
-                'formOfAddress' => [
-                    'id' => 0,
-                ],
+                'formOfAddress' => 0,
             ]
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #4101
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The `formOfAddress` contains an id as value, which can be of type number since #4101. The `formOfAddress` uses an ID of `0`, which makes the contact controller fail.

#### Why?

Because the `ContactController` didn't use a strict type check, so that `null` and `0` were considered equal.
