### PR TITLE
fix default value of 0 for SingleSelect

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -21,7 +21,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
             } = {},
         } = schemaOptions;
 
-        if (defaultValue === undefined) {
+        if (defaultValue === undefined || defaultValue === null) {
             return;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -21,7 +21,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
             } = {},
         } = schemaOptions;
 
-        if (!defaultValue) {
+        if (defaultValue === undefined) {
             return;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -134,6 +134,38 @@ test('Should call onFinish callback on every onChange', () => {
     expect(finishSpy).toBeCalledWith();
 });
 
+test('Set default value of null should not call onChange', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            value: null,
+        },
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    shallow(
+        <SingleSelect
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).not.toBeCalled();
+});
+
 test('Set default value if no value is passed', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const changeSpy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -166,6 +166,38 @@ test('Set default value if no value is passed', () => {
     expect(changeSpy).toBeCalledWith('mr');
 });
 
+test('Set default value to a number of 0 should work', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            value: 0,
+        },
+        values: {
+            value: [
+                {
+                    value: 0,
+                    title: 'Mister',
+                },
+                {
+                    value: 1,
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    shallow(
+        <SingleSelect
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).toBeCalledWith(0);
+});
+
 test('Throw error if no schemaOptions are passed', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     expect(() => shallow(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -17,7 +17,7 @@ export type SchemaOption = {
     name?: string,
     infoText?: string,
     title?: string,
-    value?: string | number | Array<SchemaOption>,
+    value?: ?string | number | Array<SchemaOption>,
 };
 
 export type SchemaOptions = {[key: string]: SchemaOption};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes setting a default value of 0 to the SingleSelect field.

#### Why?

Because of a wrong check it was not recognized correctly.