### PR TITLE
fix font size in matrix items

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
@@ -61,6 +61,7 @@ $itemColorSelected: $white;
     color: $itemColor;
     cursor: pointer;
     display: inline-flex;
+    font-size: 16px;
     justify-content: center;
     margin-right: 5px;
     text-align: center;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | introduced in #4101
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the regression in the matrix items caused by the font-size set on the `body`.

#### Why?

Because the icons are too small currently.