### PR TITLE
handle null values in API consistently

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -257,9 +257,9 @@ class CategoryController extends RestController implements ClassResourceInterfac
      */
     protected function saveCategory(Request $request, $id = null, $patch = false)
     {
-        $mediasData = $request->get('medias', []);
+        $mediasData = $request->get('medias');
         $medias = null;
-        if (array_key_exists('ids', $mediasData)) {
+        if ($mediasData && array_key_exists('ids', $mediasData)) {
             $medias = $mediasData['ids'];
         }
 

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -1004,6 +1004,25 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertEquals('myValue', $response->meta[0]->value);
     }
 
+    public function testPostWithoutMedia()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'POST',
+            '/api/categories?locale=en',
+            [
+                'name' => 'New Category',
+                'medias' => null,
+            ]
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+        $this->assertEquals('New Category', $response->name);
+        $this->assertEquals(['ids' => []], (array) $response->medias);
+    }
+
     public function testPostWithNoLocale()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -1134,7 +1134,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Modified Category', $response->name);
-        $this->assertObjectNotHasAttribute('key', $response);
+        $this->assertNull($response->key);
         $this->assertEquals('en', $response->defaultLocale);
         $this->assertEquals(2, count($response->meta));
 
@@ -1157,7 +1157,7 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals('Modified Category', $response->name);
-        $this->assertObjectNotHasAttribute('key', $response);
+        $this->assertNull($response->key);
         $this->assertEquals(2, count($response->meta));
 
         usort(

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1909,7 +1909,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals('ExampleCompany 222', $response->name);
-        $this->assertObjectNotHasAttribute('parent', $response);
+        $this->assertNull($response->parent);
         $this->assertEquals('erika.mustermann@muster.at', $response->emails[0]->email);
         $this->assertEquals('123456789', $response->phones[0]->phone);
         $this->assertEquals('Musterstraße', $response->addresses[0]->street);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -838,7 +838,7 @@ class ContactControllerTest extends SuluTestCase
 
         $this->assertEquals('Home', $response['addresses'][0]['title']);
         $this->assertEquals(47.4049309, $response['addresses'][0]['latitude']);
-        $this->assertArrayNotHasKey('longitude', $response['addresses'][0]);
+        $this->assertNull($response['addresses'][0]['longitude']);
     }
 
     public function testPostWithoutAdditionalData()
@@ -1850,7 +1850,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('John', $response->firstName);
         $this->assertEquals('Doe', $response->lastName);
         $this->assertEquals('MSc', $response->title->title);
-        $this->assertObjectNotHasAttribute('account', $response);
+        $this->assertNull($response->account);
         $this->assertEquals('john.doe@muster.at', $response->emails[0]->email);
         $this->assertEquals('321654987', $response->phones[0]->phone);
         $this->assertEquals('Street', $response->addresses[0]->street);
@@ -1863,7 +1863,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals(1, count($response->notes));
 
         $this->assertEquals(0, $response->formOfAddress);
-        $this->assertFalse(property_exists($response, 'salutation'));
+        $this->assertNull($response->salutation);
 
         $client->request('GET', '/api/contacts/' . $response->id);
         $response = json_decode($client->getResponse()->getContent());
@@ -1871,7 +1871,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('John', $response->firstName);
         $this->assertEquals('Doe', $response->lastName);
         $this->assertEquals('MSc', $response->title->title);
-        $this->assertObjectNotHasAttribute('account', $response);
+        $this->assertNull($response->account);
         $this->assertEquals('john.doe@muster.at', $response->emails[0]->email);
         $this->assertEquals('321654987', $response->phones[0]->phone);
         $this->assertEquals('Street', $response->addresses[0]->street);
@@ -1883,7 +1883,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals(1, count($response->notes));
 
         $this->assertEquals(0, $response->formOfAddress);
-        $this->assertFalse(property_exists($response, 'salutation'));
+        $this->assertNull($response->salutation);
     }
 
     public function testPatchNotExisting()
@@ -2197,7 +2197,7 @@ class ContactControllerTest extends SuluTestCase
 
         $client->request('GET', '/api/contacts/' . $this->contact->getId());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertArrayHasKey('birthday', $response);
+        $this->assertNotNull($response['birthday']);
 
         $data = [
             'firstName' => 'John',
@@ -2208,7 +2208,7 @@ class ContactControllerTest extends SuluTestCase
 
         $client->request('PUT', '/api/contacts/' . $this->contact->getId(), $data);
         $response = json_decode($client->getResponse()->getContent(), true);
-        $this->assertArrayNotHasKey('birthday', $response);
+        $this->assertNull($response['birthday']);
     }
 
     public function sortAddressesPrimaryLast()

--- a/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/ContentBundle/Controller/NodeController.php
@@ -282,7 +282,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
 
         $context = new Context();
         $context->setGroups($groups);
-        $context->setSerializeNull(true);
 
         // preview needs also null value to work correctly
         $view->setContext($context);
@@ -561,7 +560,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
 
         $context = new Context();
         $context->setGroups(['defaultPage']);
-        $context->setSerializeNull(true);
 
         return $this->handleView($this->view($document)->setContext($context));
     }
@@ -593,7 +591,6 @@ class NodeController extends RestController implements ClassResourceInterface, S
 
         $context = new Context();
         $context->setGroups(['defaultPage']);
-        $context->setSerializeNull(true);
 
         return $this->handleView($this->view($document)->setContext($context));
     }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1490,7 +1490,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertEquals('/test2/test3/test5', $response['path']);
         $this->assertEquals('/test2/test3/testing5', $response['url']);
         $this->assertEquals(false, $response['publishedState']);
-        $this->assertArrayNotHasKey('published', $response);
+        $this->assertNull($response['published']);
 
         // check old node
         $client->request(

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -258,41 +258,37 @@ class SmartContentItemControllerTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
-            $result['datasource']
-        );
-        $this->assertEquals(
             [
-                ['id' => $this->johannes->getUuid(), 'title' => 'Johannes', 'publishedState' => false, 'url' => '/team/johannes'],
-                ['id' => $this->daniel->getUuid(), 'title' => 'Daniel', 'publishedState' => false, 'url' => '/team/daniel'],
-                ['id' => $this->thomas->getUuid(), 'title' => 'Thomas', 'publishedState' => false, 'url' => '/team/thomas'],
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
             ],
-            $result['_embedded']['items']
-        );
-    }
-
-    public function testGetItemsSorted()
-    {
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
-            'GET',
-            '/api/items?webspace=sulu_io&locale=en&dataSource=' . $this->team->getUuid() .
-            '&sortBy=title&sortMethod=asc&provider=pages&excluded=' . $this->team->getUuid()
-        );
-
-        $this->assertHttpStatusCode(200, $client->getResponse());
-
-        $result = json_decode($client->getResponse()->getContent(), true);
-        $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
             $result['datasource']
         );
         $this->assertEquals(
             [
-                ['id' => $this->daniel->getUuid(), 'title' => 'Daniel', 'publishedState' => false, 'url' => '/team/daniel'],
-                ['id' => $this->johannes->getUuid(), 'title' => 'Johannes', 'publishedState' => false, 'url' => '/team/johannes'],
-                ['id' => $this->thomas->getUuid(), 'title' => 'Thomas', 'publishedState' => false, 'url' => '/team/thomas'],
+                [
+                    'id' => $this->johannes->getUuid(),
+                    'title' => 'Johannes',
+                    'publishedState' => false,
+                    'url' => '/team/johannes',
+                    'published' => null,
+                ],
+                [
+                    'id' => $this->daniel->getUuid(),
+                    'title' => 'Daniel',
+                    'publishedState' => false,
+                    'url' => '/team/daniel',
+                    'published' => null,
+                ],
+                [
+                    'id' => $this->thomas->getUuid(),
+                    'title' => 'Thomas',
+                    'publishedState' => false,
+                    'url' => '/team/thomas',
+                    'published' => null,
+                ],
             ],
             $result['_embedded']['items']
         );
@@ -312,13 +308,30 @@ class SmartContentItemControllerTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
+            [
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
+            ],
             $result['datasource']
         );
         $this->assertEquals(
             [
-                ['id' => $this->daniel->getUuid(), 'title' => 'Daniel', 'publishedState' => false, 'url' => '/team/daniel'],
-                ['id' => $this->thomas->getUuid(), 'title' => 'Thomas', 'publishedState' => false, 'url' => '/team/thomas'],
+                [
+                    'id' => $this->daniel->getUuid(),
+                    'title' => 'Daniel',
+                    'publishedState' => false,
+                    'url' => '/team/daniel',
+                    'published' => null,
+                ],
+                [
+                    'id' => $this->thomas->getUuid(),
+                    'title' => 'Thomas',
+                    'publishedState' => false,
+                    'url' => '/team/thomas',
+                    'published' => null,
+                ],
             ],
             $result['_embedded']['items']
         );
@@ -342,7 +355,12 @@ class SmartContentItemControllerTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
+            [
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
+            ],
             $result['datasource']
         );
         $this->assertEquals(
@@ -352,6 +370,7 @@ class SmartContentItemControllerTest extends SuluTestCase
                     'title' => 'Thomas',
                     'publishedState' => false,
                     'url' => '/team/thomas',
+                    'published' => null,
                 ],
             ],
             $result['_embedded']['items']
@@ -374,13 +393,30 @@ class SmartContentItemControllerTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
+            [
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
+            ],
             $result['datasource']
         );
         $this->assertEquals(
             [
-                ['id' => $this->daniel->getUuid(), 'title' => 'Daniel', 'publishedState' => false, 'url' => '/team/daniel'],
-                ['id' => $this->thomas->getUuid(), 'title' => 'Thomas', 'publishedState' => false, 'url' => '/team/thomas'],
+                [
+                    'id' => $this->daniel->getUuid(),
+                    'title' => 'Daniel',
+                    'publishedState' => false,
+                    'url' => '/team/daniel',
+                    'published' => null,
+                ],
+                [
+                    'id' => $this->thomas->getUuid(),
+                    'title' => 'Thomas',
+                    'publishedState' => false,
+                    'url' => '/team/thomas',
+                    'published' => null,
+                ],
             ],
             $result['_embedded']['items']
         );
@@ -400,13 +436,30 @@ class SmartContentItemControllerTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
+            [
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
+            ],
             $result['datasource']
         );
         $this->assertEquals(
             [
-                ['id' => $this->johannes->getUuid(), 'title' => 'Johannes', 'publishedState' => false, 'url' => '/team/johannes'],
-                ['id' => $this->daniel->getUuid(), 'title' => 'Daniel', 'publishedState' => false, 'url' => '/team/daniel'],
+                [
+                    'id' => $this->johannes->getUuid(),
+                    'title' => 'Johannes',
+                    'publishedState' => false,
+                    'url' => '/team/johannes',
+                    'published' => null,
+                ],
+                [
+                    'id' => $this->daniel->getUuid(),
+                    'title' => 'Daniel',
+                    'publishedState' => false,
+                    'url' => '/team/daniel',
+                    'published' => null,
+                ],
             ],
             $result['_embedded']['items']
         );
@@ -426,12 +479,23 @@ class SmartContentItemControllerTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertEquals(
-            ['id' => $this->team->getUuid(), 'title' => 'Team', 'path' => '/team'],
+            [
+                'id' => $this->team->getUuid(),
+                'title' => 'Team',
+                'path' => '/team',
+                'image' => null,
+            ],
             $result['datasource']
         );
         $this->assertEquals(
             [
-                ['id' => $this->johannes->getUuid(), 'title' => 'Johannes', 'publishedState' => false, 'url' => '/team/johannes'],
+                [
+                    'id' => $this->johannes->getUuid(),
+                    'title' => 'Johannes',
+                    'publishedState' => false,
+                    'url' => '/team/johannes',
+                    'published' => null,
+                ],
             ],
             $result['_embedded']['items']
         );

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -100,6 +100,15 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                             ObjectNotSupportedException::class => 406,
                         ],
                     ],
+                    'serializer' => [
+                        'serialize_null' => true,
+                    ],
+                    'view' => [
+                        'formats' => [
+                            'json' => true,
+                            'csv' => true,
+                        ],
+                    ],
                 ]
             );
         }
@@ -168,10 +177,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                     ],
                 ]
             );
-        }
-
-        if ($container->hasExtension('fos_rest')) {
-            $container->prependExtensionConfig('fos_rest', ['view' => ['formats' => ['json' => true, 'csv' => true]]]);
         }
 
         if ($container->hasExtension('massive_build')) {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
@@ -138,15 +138,15 @@ class FormatControllerTest extends SuluTestCase
         $this->assertEquals(50, $response->{'small-inset'}->scale->x);
         $this->assertEquals(50, $response->{'small-inset'}->scale->y);
         $this->assertEquals('inset', $response->{'small-inset'}->scale->mode);
-        $this->assertObjectNotHasAttribute('options', $response->{'small-inset'});
+        $this->assertNull($response->{'small-inset'}->options);
 
         $this->assertNotNull($response->{'one-side'});
         $this->assertEquals('one-side', $response->{'one-side'}->key);
         $this->assertEquals('My one sided format', $response->{'one-side'}->title);
         $this->assertEquals(200, $response->{'one-side'}->scale->x);
-        $this->assertObjectNotHasAttribute('y', $response->{'one-side'}->scale);
+        $this->assertNull($response->{'one-side'}->scale->y);
         $this->assertEquals('outbound', $response->{'one-side'}->scale->mode);
-        $this->assertObjectNotHasAttribute('options', $response->{'one-side'});
+        $this->assertNull($response->{'one-side'}->options);
     }
 
     public function testCGetWithoutLocale()
@@ -235,7 +235,7 @@ class FormatControllerTest extends SuluTestCase
         $this->assertEquals(400, $response->scale->x);
         $this->assertEquals(400, $response->scale->y);
         $this->assertEquals('outbound', $response->scale->mode);
-        $this->assertObjectNotHasAttribute('options', $response);
+        $this->assertNull($response->options);
 
         // Test if the options have really been persisted
         $client = $this->createAuthenticatedClient();
@@ -252,7 +252,7 @@ class FormatControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotNull($response->{'big-squared'});
-        $this->assertObjectNotHasAttribute('options', $response->{'big-squared'});
+        $this->assertNull($response->{'big-squared'}->options);
     }
 
     public function testPutNotExistingFormat()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -463,7 +463,7 @@ class MediaControllerTest extends SuluTestCase
         $this->assertNotNull($response['type']['id']);
         $this->assertEquals('image', $response['type']['name']);
         $this->assertEquals('en-gb', $response['locale']);
-        $this->assertArrayNotHasKey('fallbackLocale', $response);
+        $this->assertNull($response['fallbackLocale']);
         $this->assertEquals('photo.jpeg', $response['name']);
         $this->assertEquals($this->mediaDefaultTitle, $response['title']);
         $this->assertEquals('2', $response['downloadCounter']);

--- a/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
@@ -144,7 +144,6 @@ class SearchController
         $view = View::create($representation);
         $context = new Context();
         $context->enableMaxDepth();
-        $context->setSerializeNull(true);
         $view->setContext($context);
 
         return $this->viewHandler->handle($view);

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\SnippetBundle\Controller;
 
-use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\Get;
 use FOS\RestBundle\Controller\Annotations\Post;
 use FOS\RestBundle\Routing\ClassResourceInterface;
@@ -484,10 +483,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
 
     private function handleView($document)
     {
-        $context = new Context();
-        $context->setSerializeNull(true);
-
-        $view = View::create($document)->setContext($context);
+        $view = View::create($document);
 
         return $this->viewHandler->handle($view);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4190 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to send `null` as a valid value for `medias` to the category API. Before it resulted in a 500, because an `array_key_exists` call was made with `null` as argument.

#### Why?

Because the new Admin will send `null` to the API, if the field hasn't been touched. And it seems like this should be valid anyway (and especially we should not return 500s from the server).

Can be tested if the `licence` and `description` field of a media has not been set yet.