### PR TITLE
fix changing of folders in MediaSelectionOverlay

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelectionOverlay.js
@@ -107,7 +107,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
             {
                 page: this.collectionPage,
                 locale: this.locale,
-                parent: this.collectionId,
+                parentId: this.collectionId,
             }
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelectionOverlay.test.js
@@ -218,9 +218,10 @@ test('Should instantiate the needed stores when the overlay opens', () => {
     ].join(','));
 
     expect(DatagridStore.mock.calls[0][0]).toBe(collectionResourceKey);
-    expect(DatagridStore.mock.calls[1][1]).toBe('media_selection_overlay');
+    expect(DatagridStore.mock.calls[0][1]).toBe('media_selection_overlay');
     expect(DatagridStore.mock.calls[0][2].locale).toBe(locale);
     expect(DatagridStore.mock.calls[0][2].page.get()).toBe(1);
+    expect(DatagridStore.mock.calls[0][2].parentId.get()).toBe(undefined);
 });
 
 test('Should call onConfirm callback with selections from datagrid', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR changes the `parent` parameter to `parentId` in the `MediaOverlay`.

#### Why?

Because the API expects a `parentId` parameter, and this causes a bug currently. When changing the folder in the `MediaSelectionOverlay`