### PR TITLE
hide pagination if no data is available

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/FolderAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/FolderAdapter.js
@@ -40,6 +40,24 @@ export default class FolderAdapter extends AbstractAdapter {
             pageCount,
         } = this.props;
 
+        const folderList = (
+            <FolderList onFolderClick={onItemClick}>
+                {data.map((item: Object) => (
+                    // TODO: Don't access properties like "title" directly.
+                    <FolderList.Folder
+                        id={item.id}
+                        info={FolderAdapter.getInfoText(item)}
+                        key={item.id}
+                        title={item.title}
+                    />
+                ))}
+            </FolderList>
+        );
+
+        if (page === 1 && data.length === 0) {
+            return folderList;
+        }
+
         return (
             <Pagination
                 currentLimit={limit}
@@ -49,17 +67,7 @@ export default class FolderAdapter extends AbstractAdapter {
                 onPageChange={onPageChange}
                 totalPages={pageCount}
             >
-                <FolderList onFolderClick={onItemClick}>
-                    {data.map((item: Object) => (
-                        // TODO: Don't access properties like "title" directly.
-                        <FolderList.Folder
-                            id={item.id}
-                            info={FolderAdapter.getInfoText(item)}
-                            key={item.id}
-                            title={item.title}
-                        />
-                    ))}
-                </FolderList>
+                {folderList}
             </Pagination>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/adapters/TableAdapter.js
@@ -29,6 +29,7 @@ export default class TableAdapter extends AbstractTableAdapter {
 
     render() {
         const {
+            data,
             limit,
             loading,
             onAllSelectionChange,
@@ -48,6 +49,26 @@ export default class TableAdapter extends AbstractTableAdapter {
             });
         }
 
+        const table = (
+            <Table
+                buttons={buttons}
+                onAllSelectionChange={onAllSelectionChange}
+                onRowSelectionChange={onItemSelectionChange}
+                selectMode={onItemSelectionChange ? 'multiple' : undefined}
+            >
+                <Table.Header>
+                    {this.renderHeaderCells()}
+                </Table.Header>
+                <Table.Body>
+                    {this.renderRows()}
+                </Table.Body>
+            </Table>
+        );
+
+        if (page === 1 && data.length === 0) {
+            return table;
+        }
+
         return (
             <Pagination
                 currentLimit={limit}
@@ -57,19 +78,7 @@ export default class TableAdapter extends AbstractTableAdapter {
                 onPageChange={onPageChange}
                 totalPages={pageCount}
             >
-                <Table
-                    buttons={buttons}
-                    onAllSelectionChange={onAllSelectionChange}
-                    onRowSelectionChange={onItemSelectionChange}
-                    selectMode={onItemSelectionChange ? 'multiple' : undefined}
-                >
-                    <Table.Header>
-                        {this.renderHeaderCells()}
-                    </Table.Header>
-                    <Table.Body>
-                        {this.renderRows()}
-                    </Table.Body>
-                </Table>
+                {table}
             </Pagination>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
@@ -119,6 +119,40 @@ test('Click on a Folder should call the onItemEdit callback', () => {
     expect(folderAdapter.find('FolderList').get(0).props.onFolderClick).toBe(itemClickSpy);
 });
 
+test('Pagination should not be rendered if no data is available', () => {
+    const folderAdapter = shallow(
+        <FolderAdapter
+            active={undefined}
+            activeItems={[]}
+            disabledIds={[]}
+            limit={10}
+            loading={false}
+            onAllSelectionChange={undefined}
+            onItemActivate={jest.fn()}
+            onItemAdd={undefined}
+            onItemClick={undefined}
+            onItemDeactivate={jest.fn()}
+            onItemSelectionChange={undefined}
+            onLimitChange={jest.fn()}
+            onPageChange={jest.fn()}
+            onRequestItemCopy={undefined}
+            onRequestItemDelete={jest.fn()}
+            onRequestItemMove={undefined}
+            onRequestItemOrder={undefined}
+            onSort={jest.fn()}
+            options={{}}
+            page={1}
+            pageCount={7}
+            schema={{}}
+            selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
+        />
+    );
+
+    expect(folderAdapter.find('Pagination')).toHaveLength(0);
+});
+
 test('Pagination should be passed correct props', () => {
     const pageChangeSpy = jest.fn();
     const limitChangeSpy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
@@ -784,3 +784,38 @@ test('Pagination should be passed correct props', () => {
         children: expect.anything(),
     });
 });
+
+test('Pagination should not be rendered if no data is available', () => {
+    const pageChangeSpy = jest.fn();
+    const limitChangeSpy = jest.fn();
+    const tableAdapter = shallow(
+        <TableAdapter
+            active={undefined}
+            activeItems={[]}
+            disabledIds={[]}
+            limit={10}
+            loading={false}
+            onAllSelectionChange={undefined}
+            onItemActivate={jest.fn()}
+            onItemAdd={undefined}
+            onItemClick={undefined}
+            onItemDeactivate={jest.fn()}
+            onItemSelectionChange={undefined}
+            onLimitChange={limitChangeSpy}
+            onPageChange={pageChangeSpy}
+            onRequestItemCopy={undefined}
+            onRequestItemDelete={jest.fn()}
+            onRequestItemMove={undefined}
+            onRequestItemOrder={undefined}
+            onSort={jest.fn()}
+            options={{}}
+            page={1}
+            pageCount={7}
+            schema={{}}
+            selections={[]}
+            sortColumn={undefined}
+            sortOrder={undefined}
+        />
+    );
+    expect(tableAdapter.find('Pagination')).toHaveLength(0);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR hides the pagination of the `Table` and `Folder` DatagridAdapter, if no data at all is available.

#### Why?

Because it looks strange in some situations, e.g. the `MediaSelectionOverlay`.