### PR TITLE
fix route navigation after deleting a media collection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
@@ -35,6 +35,7 @@ $itemHeight: 40px;
     }
 
     .children {
+        font-size: 16px;
         font-weight: normal;
         width: 25px;
     }

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/components/WebspaceSelect/webspaceSelect.scss
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/components/WebspaceSelect/webspaceSelect.scss
@@ -27,6 +27,7 @@ $buttonColor: $silver;
 
 .button-value {
     padding: 0 15px;
+    font-size: 16px;
     flex-grow: 1;
     text-align: left;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -114,7 +114,7 @@ export default class CollectionSection extends React.Component<Props> {
 
         const parentCollectionId = data._embedded && data._embedded.parent && data._embedded.parent.id
             ? data._embedded.parent.id
-            : null;
+            : undefined;
 
         resourceStore.delete()
             .then(() => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -110,19 +110,16 @@ export default class CollectionSection extends React.Component<Props> {
 
     handleRemoveCollectionConfirm = () => {
         const {resourceStore} = this.props;
+        const {data} = resourceStore;
+
+        const parentCollectionId = data._embedded && data._embedded.parent && data._embedded.parent.id
+            ? data._embedded.parent.id
+            : null;
 
         resourceStore.delete()
             .then(() => {
-                const {
-                    data,
-                } = resourceStore;
-
                 this.closeCollectionOperationOverlay();
-                this.props.onCollectionNavigate(
-                    data._embedded && data._embedded.parent && data._embedded.parent.id
-                        ? data._embedded.parent.id
-                        : null
-                );
+                this.props.onCollectionNavigate(parentCollectionId);
             });
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/collectionSection.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/collectionSection.scss
@@ -16,6 +16,7 @@
 
 .icons {
     display: none;
+    font-size: 16px;
     margin: 0 10px 30px 20px;
 }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -454,7 +454,7 @@ test('Confirming the delete dialog should delete the item', () => {
 
     return promise.then(() => {
         collectionStore.resourceStore.deleting = false;
-        expect(collectionNavigateSpy).toBeCalledWith(null);
+        expect(collectionNavigateSpy).toBeCalledWith(undefined);
         mediaCollection.update();
         expect(mediaCollection.find('CollectionSection > div > Dialog').prop('open')).toEqual(false);
         expect(mediaCollection.find('CollectionSection > div > Dialog').prop('confirmLoading')).toEqual(false);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -485,7 +485,11 @@ test('Confirming the delete dialog should delete the item and navigate to its pa
     );
     const CollectionStore = require('../../../stores/CollectionStore').default;
     const collectionStore = new CollectionStore(1, locale);
-    collectionStore.resourceStore.delete = jest.fn().mockReturnValue(promise);
+    collectionStore.resourceStore.delete = jest.fn().mockImplementationOnce(() => {
+        collectionStore.resourceStore.data = {};
+        return promise;
+    });
+
     collectionStore.resourceStore.data = {
         id: 1,
         _embedded: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the navigation to the parent collection if a collection is deleted.