### PR TITLE
Add disabledCondition to dynamically change disabled state of form types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## dev-develop
+
+### Form visibilityCondition
+
+**This change only affects you if you have used a 2.0.0 alpha release before**
+
+The `visibilityCondition` on the Form XML has been renamed to `visibleCondition`.
+
 ## 2.0.0-alpha4
 
 ### MediaController

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
@@ -30,7 +30,7 @@ abstract class Item
     /**
      * @var string
      */
-    protected $visibilityCondition;
+    protected $visibleCondition;
 
     /**
      * @var string
@@ -67,14 +67,14 @@ abstract class Item
         $this->label = $label;
     }
 
-    public function getVisibilityCondition(): ?string
+    public function getVisibleCondition(): ?string
     {
-        return $this->visibilityCondition;
+        return $this->visibleCondition;
     }
 
-    public function setVisibilityCondition(?string $visibilityCondition): void
+    public function setVisibleCondition(?string $visibleCondition): void
     {
-        $this->visibilityCondition = $visibilityCondition;
+        $this->visibleCondition = $visibleCondition;
     }
 
     public function getDescription(): ?string

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Item.php
@@ -30,6 +30,11 @@ abstract class Item
     /**
      * @var string
      */
+    protected $disabledCondition;
+
+    /**
+     * @var string
+     */
     protected $visibleCondition;
 
     /**
@@ -65,6 +70,16 @@ abstract class Item
     public function setLabel(?string $label): void
     {
         $this->label = $label;
+    }
+
+    public function getDisabledCondition(): ?string
+    {
+        return $this->disabledCondition;
+    }
+
+    public function setDisabledCondition(?string $disabledCondition): void
+    {
+        $this->disabledCondition = $disabledCondition;
     }
 
     public function getVisibleCondition(): ?string

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
@@ -105,7 +105,7 @@ class ResourceMetadataMapper
         }
 
         $section->setSize($property->getSize());
-        $section->setVisibilityCondition($property->getVisibilityCondition());
+        $section->setVisibleCondition($property->getVisibleCondition());
 
         foreach ($property->getChildren() as $component) {
             if ($component instanceof BlockMetadata) {
@@ -133,7 +133,7 @@ class ResourceMetadataMapper
         }
 
         $field->setLabel($property->getTitle($locale));
-        $field->setVisibilityCondition($property->getVisibilityCondition());
+        $field->setVisibleCondition($property->getVisibleCondition());
         $field->setDescription($property->getDescription($locale));
         $field->setType($property->getType());
         $field->setSize($property->getSize());

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/ResourceMetadataMapper.php
@@ -105,6 +105,7 @@ class ResourceMetadataMapper
         }
 
         $section->setSize($property->getSize());
+        $section->setDisabledCondition($property->getDisabledCondition());
         $section->setVisibleCondition($property->getVisibleCondition());
 
         foreach ($property->getChildren() as $component) {
@@ -133,6 +134,7 @@ class ResourceMetadataMapper
         }
 
         $field->setLabel($property->getTitle($locale));
+        $field->setDisabledCondition($property->getDisabledCondition());
         $field->setVisibleCondition($property->getVisibleCondition());
         $field->setDescription($property->getDescription($locale));
         $field->setType($property->getType());

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -74,7 +74,18 @@ export default class Field extends React.Component<Props> {
 
     render() {
         const {dataPath, error, value, formInspector, schema, schemaPath, showAllErrors, name} = this.props;
-        const {description, label, maxOccurs, minOccurs, options: schemaOptions, required, type, types} = schema;
+        const {
+            description,
+            disabled,
+            label,
+            maxOccurs,
+            minOccurs,
+            options: schemaOptions,
+            required,
+            type,
+            types,
+        } = schema;
+
         let FieldType;
 
         try {
@@ -112,6 +123,7 @@ export default class Field extends React.Component<Props> {
             >
                 <FieldType
                     dataPath={dataPath}
+                    disabled={disabled}
                     error={error}
                     fieldTypeOptions={fieldTypeOptions}
                     formInspector={formInspector}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -28,7 +28,11 @@ export default class Field extends React.Component<Props> {
     };
 
     handleChange = (value: *) => {
-        const {name, onChange} = this.props;
+        const {name, onChange, schema} = this.props;
+
+        if (schema.disabled) {
+            return;
+        }
 
         onChange(name, value);
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -232,6 +232,51 @@ test('Pass correct props to FieldType', () => {
 
     expect(field.find('Text').props()).toEqual(expect.objectContaining({
         dataPath: '/block/0/text',
+        disabled: undefined,
+        formInspector,
+        label: 'Text',
+        maxOccurs: 4,
+        minOccurs: 2,
+        schemaPath: '/text',
+        showAllErrors: true,
+        types: {},
+        value: 'test',
+    }));
+});
+
+test('Pass disabled flag to disabled FieldType', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="date" />;
+    });
+
+    const schema = {
+        disabled: true,
+        label: 'Text',
+        maxOccurs: 4,
+        minOccurs: 2,
+        type: 'text_line',
+        types: {},
+        visible: true,
+    };
+    const field = shallow(
+        <Field
+            dataPath="/block/0/text"
+            formInspector={formInspector}
+            name="text"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            schema={schema}
+            schemaPath="/text"
+            showAllErrors={true}
+            value="test"
+        />
+    );
+
+    expect(field.find('Text').props()).toEqual(expect.objectContaining({
+        dataPath: '/block/0/text',
+        disabled: true,
         formInspector,
         label: 'Text',
         maxOccurs: 4,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -318,6 +318,31 @@ test('Call onChange callback when value of Field changes', () => {
     expect(changeSpy).toBeCalledWith('test', 'test value');
 });
 
+test('Do not call onChange callback when value of disabled Field changes', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
+
+    fieldRegistry.get.mockReturnValue(function Text() {
+        return <input type="text" />;
+    });
+
+    const changeSpy = jest.fn();
+    const field = shallow(
+        <Field
+            dataPath=""
+            formInspector={formInspector}
+            name="test"
+            onChange={changeSpy}
+            onFinish={jest.fn()}
+            schema={{label: 'label', type: 'text', disabled: true}}
+            schemaPath=""
+        />
+    );
+
+    field.find('Text').simulate('change', 'test value');
+
+    expect(changeSpy).not.toBeCalled();
+});
+
 test('Call onFinish callback after editing the field has finished', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('snippets')));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
@@ -65,14 +65,14 @@ test('Create data object for schema', () => {
     }, 0);
 });
 
-test('Evaluate all visibilityConditions for schema', (done) => {
+test('Evaluate all visibleConditions for schema', (done) => {
     const metadata = {
         item1: {
             type: 'text_line',
         },
         item2: {
             type: 'text_line',
-            visibilityCondition: 'item1 == "item2"',
+            visibleCondition: 'item1 == "item2"',
         },
         section: {
             items: {
@@ -81,11 +81,11 @@ test('Evaluate all visibilityConditions for schema', (done) => {
                 },
                 item32: {
                     type: 'text_line',
-                    visibilityCondition: 'item1 == "item32"',
+                    visibleCondition: 'item1 == "item32"',
                 },
             },
             type: 'section',
-            visibilityCondition: 'item1 == "section"',
+            visibleCondition: 'item1 == "section"',
         },
         block: {
             types: {
@@ -93,7 +93,7 @@ test('Evaluate all visibilityConditions for schema', (done) => {
                     form: {
                         item41: {
                             type: 'text_line',
-                            visibilityCondition: 'item1 == "item41"',
+                            visibleCondition: 'item1 == "item41"',
                         },
                         item42: {
                             type: 'text_line',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
@@ -65,13 +65,14 @@ test('Create data object for schema', () => {
     }, 0);
 });
 
-test('Evaluate all visibleConditions for schema', (done) => {
+test('Evaluate all disabledConditions and visibleConditions for schema', (done) => {
     const metadata = {
         item1: {
             type: 'text_line',
         },
         item2: {
             type: 'text_line',
+            disabledCondition: 'item1 != "item2"',
             visibleCondition: 'item1 == "item2"',
         },
         section: {
@@ -81,10 +82,12 @@ test('Evaluate all visibleConditions for schema', (done) => {
                 },
                 item32: {
                     type: 'text_line',
+                    disabledCondition: 'item1 != "item32"',
                     visibleCondition: 'item1 == "item32"',
                 },
             },
             type: 'section',
+            disabledCondition: 'item1 != "section"',
             visibleCondition: 'item1 == "section"',
         },
         block: {
@@ -93,6 +96,7 @@ test('Evaluate all visibleConditions for schema', (done) => {
                     form: {
                         item41: {
                             type: 'text_line',
+                            disabledCondition: 'item1 != "item41"',
                             visibleCondition: 'item1 == "item41"',
                         },
                         item42: {
@@ -123,12 +127,17 @@ test('Evaluate all visibleConditions for schema', (done) => {
             throw new Error('Block types should be defined!');
         }
 
+        expect(formStore.schema.item2.disabled).toEqual(true);
         expect(formStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems.item32.disabled).toEqual(true);
         expect(sectionItems.item32.visible).toEqual(false);
+        expect(formStore.schema.section.disabled).toEqual(true);
         expect(formStore.schema.section.visible).toEqual(false);
+        expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
         expect(blockTypes.text_line.form.item41.visible).toEqual(false);
 
         resourceStore.data = {item1: 'item2'};
+        expect(formStore.schema.item2.disabled).toEqual(true);
         expect(formStore.schema.item2.visible).toEqual(false);
 
         formStore.finishField('/item1').then(() => {
@@ -141,9 +150,13 @@ test('Evaluate all visibleConditions for schema', (done) => {
                 throw new Error('Block types should be defined!');
             }
 
+            expect(formStore.schema.item2.disabled).toEqual(false);
             expect(formStore.schema.item2.visible).toEqual(true);
+            expect(sectionItems.item32.disabled).toEqual(true);
             expect(sectionItems.item32.visible).toEqual(false);
+            expect(formStore.schema.section.disabled).toEqual(true);
             expect(formStore.schema.section.visible).toEqual(false);
+            expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
             expect(blockTypes.text_line.form.item41.visible).toEqual(false);
 
             resourceStore.data = {item1: 'item32'};
@@ -157,9 +170,13 @@ test('Evaluate all visibleConditions for schema', (done) => {
                     throw new Error('Block types should be defined!');
                 }
 
+                expect(formStore.schema.item2.disabled).toEqual(true);
                 expect(formStore.schema.item2.visible).toEqual(false);
+                expect(sectionItems.item32.disabled).toEqual(false);
                 expect(sectionItems.item32.visible).toEqual(true);
+                expect(formStore.schema.section.disabled).toEqual(true);
                 expect(formStore.schema.section.visible).toEqual(false);
+                expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
                 expect(blockTypes.text_line.form.item41.visible).toEqual(false);
 
                 resourceStore.data = {item1: 'section'};
@@ -173,9 +190,13 @@ test('Evaluate all visibleConditions for schema', (done) => {
                         throw new Error('Block types should be defined!');
                     }
 
+                    expect(formStore.schema.item2.disabled).toEqual(true);
                     expect(formStore.schema.item2.visible).toEqual(false);
+                    expect(sectionItems.item32.disabled).toEqual(true);
                     expect(sectionItems.item32.visible).toEqual(false);
+                    expect(formStore.schema.section.disabled).toEqual(false);
                     expect(formStore.schema.section.visible).toEqual(true);
+                    expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
                     expect(blockTypes.text_line.form.item41.visible).toEqual(false);
 
                     resourceStore.data = {item1: 'item41'};
@@ -189,9 +210,13 @@ test('Evaluate all visibleConditions for schema', (done) => {
                             throw new Error('Block types should be defined!');
                         }
 
+                        expect(formStore.schema.item2.disabled).toEqual(true);
                         expect(formStore.schema.item2.visible).toEqual(false);
+                        expect(sectionItems.item32.disabled).toEqual(true);
                         expect(sectionItems.item32.visible).toEqual(false);
+                        expect(formStore.schema.section.disabled).toEqual(true);
                         expect(formStore.schema.section.visible).toEqual(false);
+                        expect(blockTypes.text_line.form.item41.disabled).toEqual(false);
                         expect(blockTypes.text_line.form.item41.visible).toEqual(true);
 
                         formStore.destroy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -45,7 +45,7 @@ type BaseSchemaEntry = {
 export type RawSchemaEntry = BaseSchemaEntry & {
     items?: RawSchema,
     types?: RawTypes,
-    visibilityCondition?: string,
+    visibleCondition?: string,
 };
 
 export type SchemaEntry = BaseSchemaEntry & {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -43,12 +43,14 @@ type BaseSchemaEntry = {
 };
 
 export type RawSchemaEntry = BaseSchemaEntry & {
+    disabledCondition?: string,
     items?: RawSchema,
     types?: RawTypes,
     visibleCondition?: string,
 };
 
 export type SchemaEntry = BaseSchemaEntry & {
+    disabled?: boolean,
     items?: Schema,
     types?: Types,
     visible?: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -24,6 +24,7 @@ export type SchemaOptions = {[key: string]: SchemaOption};
 
 export type FieldTypeProps<T> = {|
     dataPath: string,
+    disabled: ?boolean,
     error: ?Error | ErrorCollection,
     fieldTypeOptions: Object,
     formInspector: FormInspector,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/fieldTypeDefaultProps.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/fieldTypeDefaultProps.js
@@ -2,6 +2,7 @@
 
 const fieldTypeDefaultProps = {
     dataPath: '/',
+    disabled: undefined,
     error: undefined,
     fieldTypeOptions: {},
     label: '',

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -69,6 +69,54 @@ class FormXmlLoaderTest extends TestCase
         $this->assertNull($formMetadata->getSchema());
     }
 
+    public function testLoadFormWithEvaluations()
+    {
+        /** @var FormMetadata $formMetadata */
+        $formMetadata = $this->loader->load(
+            __DIR__ . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'form_with_evaluations.xml'
+        );
+
+        $this->assertInstanceOf(FormMetadata::class, $formMetadata);
+
+        $this->assertCount(5, $formMetadata->getProperties());
+
+        $this->assertEquals(
+            'lastName == \'section_property\'',
+            $formMetadata->getProperties()['formOfAddress']->getDisabledCondition()
+        );
+        $this->assertEquals(
+            'firstName == \'section_property\'',
+            $formMetadata->getProperties()['formOfAddress']->getVisibleCondition()
+        );
+
+        $this->assertEquals(
+            'lastName == \'block\'',
+            $formMetadata->getProperties()['block']->getDisabledCondition()
+        );
+        $this->assertEquals(
+            'firstName == \'block\'',
+            $formMetadata->getProperties()['block']->getVisibleCondition()
+        );
+
+        $this->assertEquals(
+            'lastName == \'block_property\'',
+            $formMetadata->getProperties()['block']->getComponents()[0]->getChild('name')->getDisabledCondition()
+        );
+        $this->assertEquals(
+            'firstName == \'block_property\'',
+            $formMetadata->getProperties()['block']->getComponents()[0]->getChild('name')->getVisibleCondition()
+        );
+
+        $this->assertEquals(
+            'lastName == \'property\'',
+            $formMetadata->getProperties()['salutation']->getDisabledCondition()
+        );
+        $this->assertEquals(
+            'firstName == \'property\'',
+            $formMetadata->getProperties()['salutation']->getVisibleCondition()
+        );
+    }
+
     public function testLoadFormWithSchema()
     {
         /** @var FormMetadata $formMetadata */

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_with_evaluations.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form_with_evaluations.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
+    <properties>
+        <section
+            name="highlight"
+            disabledCondition="lastName == 'section'"
+            visibleCondition="firstName == 'section'"
+        >
+            <properties>
+                <property
+                    name="formOfAddress"
+                    type="single_select"
+                    mandatory="true"
+                    colspan="3"
+                    spaceAfter="9"
+                    disabledCondition="lastName == 'section_property'"
+                    visibleCondition="firstName == 'section_property'"
+                >
+                    <meta>
+                        <title lang="en">Salutation</title>
+                        <title lang="de">Anrede</title>
+                    </meta>
+                    <params>
+                        <param name="default_value" value="0"/>
+                        <param name="values" type="collection">
+                            <param name="0" value="0">
+                                <meta>
+                                    <title lang="en">Mr.</title>
+                                    <title lang="de">Herr</title>
+                                </meta>
+                            </param>
+                            <param name="1" value="1">
+                                <meta>
+                                    <title lang="en">Ms.</title>
+                                    <title lang="de">Frau</title>
+                                </meta>
+                            </param>
+                        </param>
+                    </params>
+                </property>
+            </properties>
+        </section>
+
+        <block
+            name="block"
+            default-type="test"
+            disabledCondition="lastName == 'block'"
+            visibleCondition="firstName == 'block'"
+        >
+            <meta>
+                <title lang="de">Block-DE</title>
+                <title lang="en">Block-EN</title>
+
+                <info_text lang="de">Block-Info-DE</info_text>
+                <info_text lang="en">Block-Info-EN</info_text>
+            </meta>
+            <types>
+                <type name="test">
+                    <properties>
+                        <property
+                            name="name"
+                            type="text_line"
+                            disabledCondition="lastName == 'block_property'"
+                            visibleCondition="firstName == 'block_property'"
+                        />
+                    </properties>
+                </type>
+            </types>
+        </block>
+
+        <property name="firstName" type="text_line" mandatory="true" colspan="6">
+            <meta>
+                <title lang="en">First Name</title>
+                <title lang="de">Vorname</title>
+            </meta>
+        </property>
+
+        <property name="lastName" type="text_line" mandatory="true" colspan="6">
+            <meta>
+                <title lang="en">Last Name</title>
+                <title lang="de">Nachname</title>
+            </meta>
+        </property>
+
+        <property
+            name="salutation"
+            type="text_line"
+            disabledCondition="lastName == 'property'"
+            visibleCondition="firstName == 'property'"
+        >
+            <meta>
+                <title lang="en">Salutation</title>
+                <title lang="de">Anrede</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
@@ -121,7 +121,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Field $field1 */
         $field1 = $form->getItems()['test1'];
         $this->assertSame($field1->getName(), 'test1');
-        $this->assertSame($field1->getVisibilityCondition(), 'propertyVisibilityCondition');
+        $this->assertSame($field1->getVisibleCondition(), 'propertyVisibleCondition');
         $this->assertSame($field1->getLabel(), 'Test 1');
         $this->assertSame($field1->getType(), 'text_line');
 
@@ -181,7 +181,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Field $block */
         $block = $form->getItems()['blocktest'];
         $this->assertSame($block->getName(), 'blocktest');
-        $this->assertSame($block->getVisibilityCondition(), 'blockVisibilityCondition');
+        $this->assertSame($block->getVisibleCondition(), 'blockVisibleCondition');
         $this->assertSame($block->getLabel(), 'Block Test');
         $this->assertSame($block->getType(), 'block');
         $this->assertCount(2, $block->getTypes());
@@ -209,7 +209,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Section $section */
         $section = $form->getItems()['sectiontest'];
         $this->assertSame('sectiontest', $section->getName());
-        $this->assertSame($section->getVisibilityCondition(), 'sectionVisibilityCondition');
+        $this->assertSame($section->getVisibleCondition(), 'sectionVisibleCondition');
         $this->assertSame('Section Title', $section->getLabel());
         $this->assertCount(4, $section->getItems());
         $this->assertArrayHasKey('test1', $section->getItems());
@@ -235,7 +235,7 @@ class ResourceMetadataMapperTest extends TestCase
     private function getProperties(string $type): array
     {
         $property1 = new PropertyMetadata('test1');
-        $property1->setVisibilityCondition('propertyVisibilityCondition');
+        $property1->setVisibleCondition('propertyVisibleCondition');
         $property1->setSpaceAfter('2');
         $property1->setRequired(false);
         $property1->setType('text_line');
@@ -305,7 +305,7 @@ class ResourceMetadataMapperTest extends TestCase
         );
 
         $block = new BlockMetadata('blocktest');
-        $block->setVisibilityCondition('blockVisibilityCondition');
+        $block->setVisibleCondition('blockVisibleCondition');
         $block->setType('block');
         $block->setTitles([
             'de' => 'Block Test',
@@ -328,7 +328,7 @@ class ResourceMetadataMapperTest extends TestCase
         $block->addComponent($component2);
 
         $section = new SectionMetadata('sectiontest');
-        $section->setVisibilityCondition('sectionVisibilityCondition');
+        $section->setVisibleCondition('sectionVisibleCondition');
         $section->setTitles([
             'de' => 'Section Title',
         ]);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/ResourceMetadata/ResourceMetadataMapperTest.php
@@ -121,6 +121,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Field $field1 */
         $field1 = $form->getItems()['test1'];
         $this->assertSame($field1->getName(), 'test1');
+        $this->assertSame($field1->getDisabledCondition(), 'propertyDisabledCondition');
         $this->assertSame($field1->getVisibleCondition(), 'propertyVisibleCondition');
         $this->assertSame($field1->getLabel(), 'Test 1');
         $this->assertSame($field1->getType(), 'text_line');
@@ -181,6 +182,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Field $block */
         $block = $form->getItems()['blocktest'];
         $this->assertSame($block->getName(), 'blocktest');
+        $this->assertSame($block->getDisabledCondition(), 'blockDisabledCondition');
         $this->assertSame($block->getVisibleCondition(), 'blockVisibleCondition');
         $this->assertSame($block->getLabel(), 'Block Test');
         $this->assertSame($block->getType(), 'block');
@@ -209,6 +211,7 @@ class ResourceMetadataMapperTest extends TestCase
         /** @var Section $section */
         $section = $form->getItems()['sectiontest'];
         $this->assertSame('sectiontest', $section->getName());
+        $this->assertSame($section->getDisabledCondition(), 'sectionDisabledCondition');
         $this->assertSame($section->getVisibleCondition(), 'sectionVisibleCondition');
         $this->assertSame('Section Title', $section->getLabel());
         $this->assertCount(4, $section->getItems());
@@ -235,6 +238,7 @@ class ResourceMetadataMapperTest extends TestCase
     private function getProperties(string $type): array
     {
         $property1 = new PropertyMetadata('test1');
+        $property1->setDisabledCondition('propertyDisabledCondition');
         $property1->setVisibleCondition('propertyVisibleCondition');
         $property1->setSpaceAfter('2');
         $property1->setRequired(false);
@@ -305,6 +309,7 @@ class ResourceMetadataMapperTest extends TestCase
         );
 
         $block = new BlockMetadata('blocktest');
+        $block->setDisabledCondition('blockDisabledCondition');
         $block->setVisibleCondition('blockVisibleCondition');
         $block->setType('block');
         $block->setTitles([
@@ -328,6 +333,7 @@ class ResourceMetadataMapperTest extends TestCase
         $block->addComponent($component2);
 
         $section = new SectionMetadata('sectiontest');
+        $section->setDisabledCondition('sectionDisabledCondition');
         $section->setVisibleCondition('sectionVisibleCondition');
         $section->setTitles([
             'de' => 'Section Title',

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageSettings.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageSettings.xml
@@ -67,19 +67,19 @@
                         </param>
                     </params>
                 </property>
-                <property name="title" type="text_line" visibilityCondition="nodeType != 1">
+                <property name="title" type="text_line" visibleCondition="nodeType != 1">
                     <meta>
                         <title lang="en">Link title</title>
                         <title lang="de">Link Titel</title>
                     </meta>
                 </property>
-                <property name="internal_link" type="single_internal_link" visibilityCondition="nodeType == 2">
+                <property name="internal_link" type="single_internal_link" visibleCondition="nodeType == 2">
                     <meta>
                         <title lang="en">Linked Content</title>
                         <title lang="de">Verlinkter Inhalt</title>
                     </meta>
                 </property>
-                <property name="external" type="url" visibilityCondition="nodeType == 4">
+                <property name="external" type="url" visibleCondition="nodeType == 4">
                     <meta>
                         <title lang="en">URL</title>
                         <title lang="de">URL</title>

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -78,7 +78,7 @@ abstract class ItemMetadata
     /**
      * @var string
      */
-    protected $visibilityCondition = null;
+    protected $visibleCondition = null;
 
     /**
      * @param mixed $name
@@ -352,14 +352,14 @@ abstract class ItemMetadata
         return '';
     }
 
-    public function getVisibilityCondition(): ?string
+    public function getVisibleCondition(): ?string
     {
-        return $this->visibilityCondition;
+        return $this->visibleCondition;
     }
 
-    public function setVisibilityCondition(?string $visibilityCondition): self
+    public function setVisibleCondition(?string $visibleCondition): self
     {
-        $this->visibilityCondition = $visibilityCondition;
+        $this->visibleCondition = $visibleCondition;
 
         return $this;
     }

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -78,6 +78,11 @@ abstract class ItemMetadata
     /**
      * @var string
      */
+    protected $disabledCondition = null;
+
+    /**
+     * @var string
+     */
     protected $visibleCondition = null;
 
     /**
@@ -350,6 +355,18 @@ abstract class ItemMetadata
         }
 
         return '';
+    }
+
+    public function getDisabledCondition(): ?string
+    {
+        return $this->disabledCondition;
+    }
+
+    public function setDisabledCondition(?string $disabledCondition): self
+    {
+        $this->disabledCondition = $disabledCondition;
+
+        return $this;
     }
 
     public function getVisibleCondition(): ?string

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -73,6 +73,7 @@
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
+        <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
@@ -111,6 +112,7 @@
         <xs:attribute type="xs:integer" name="size" use="optional"/>
         <xs:attribute type="xs:integer" name="spaceAfter" use="optional"/>
         <xs:attribute type="xs:boolean" name="label" use="optional"/>
+        <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
@@ -130,6 +132,7 @@
         <xs:attribute type="xs:positiveInteger" name="maxOccurs" use="optional"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
+        <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -73,7 +73,7 @@
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
-        <xs:attribute type="xs:string" name="visibilityCondition" use="optional"/>
+        <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 
@@ -111,7 +111,7 @@
         <xs:attribute type="xs:integer" name="size" use="optional"/>
         <xs:attribute type="xs:integer" name="spaceAfter" use="optional"/>
         <xs:attribute type="xs:boolean" name="label" use="optional"/>
-        <xs:attribute type="xs:string" name="visibilityCondition" use="optional"/>
+        <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 
@@ -130,7 +130,7 @@
         <xs:attribute type="xs:positiveInteger" name="maxOccurs" use="optional"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
-        <xs:attribute type="xs:string" name="visibilityCondition" use="optional"/>
+        <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -89,7 +89,7 @@ class PropertiesXmlParser
                 'size',
                 'spaceAfter',
                 'label',
-                'visibilityCondition',
+                'visibleCondition',
             ]
         );
 
@@ -145,7 +145,7 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'default-type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass', 'visibilityCondition']
+            ['name', 'default-type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass', 'visibleCondition']
         );
 
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
@@ -166,7 +166,7 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'colspan', 'cssClass', 'visibilityCondition']
+            ['name', 'colspan', 'cssClass', 'visibleCondition']
         );
 
         $result['type'] = 'section';
@@ -349,8 +349,8 @@ class PropertiesXmlParser
             $section->setDescriptions($data['meta']['info_text']);
         }
 
-        if (isset($data['visibilityCondition'])) {
-            $section->setVisibilityCondition($data['visibilityCondition']);
+        if (isset($data['visibleCondition'])) {
+            $section->setVisibleCondition($data['visibleCondition']);
         }
 
         foreach ($data['properties'] as $name => $property) {
@@ -366,8 +366,8 @@ class PropertiesXmlParser
         $blockProperty->setName($propertyName);
         $blockProperty->defaultComponentName = $data['default-type'];
 
-        if (isset($data['visibilityCondition'])) {
-            $blockProperty->setVisibilityCondition($data['visibilityCondition']);
+        if (isset($data['visibleCondition'])) {
+            $blockProperty->setVisibleCondition($data['visibleCondition']);
         }
 
         if (isset($data['meta']['title'])) {
@@ -417,7 +417,7 @@ class PropertiesXmlParser
         $property->setMinOccurs(null !== $data['minOccurs'] ? intval($data['minOccurs']) : null);
         $property->setMaxOccurs(null !== $data['maxOccurs'] ? intval($data['maxOccurs']) : null);
         $property->setLabel(array_key_exists('label', $data) ? $data['label'] : null);
-        $property->setVisibilityCondition(array_key_exists('visibilityCondition', $data) ? $data['visibilityCondition'] : null);
+        $property->setVisibleCondition(array_key_exists('visibleCondition', $data) ? $data['visibleCondition'] : null);
         $property->setParameters($data['params']);
         $property->setOnInvalid(array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);
         $this->mapMeta($property, $data['meta']);

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -89,6 +89,7 @@ class PropertiesXmlParser
                 'size',
                 'spaceAfter',
                 'label',
+                'disabledCondition',
                 'visibleCondition',
             ]
         );
@@ -145,7 +146,16 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'default-type', 'minOccurs', 'maxOccurs', 'colspan', 'cssClass', 'visibleCondition']
+            [
+                'name',
+                'default-type',
+                'minOccurs',
+                'maxOccurs',
+                'colspan',
+                'cssClass',
+                'disabledCondition',
+                'visibleCondition',
+            ]
         );
 
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
@@ -166,7 +176,7 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'colspan', 'cssClass', 'visibleCondition']
+            ['name', 'colspan', 'cssClass', 'disabledCondition', 'visibleCondition']
         );
 
         $result['type'] = 'section';
@@ -349,6 +359,10 @@ class PropertiesXmlParser
             $section->setDescriptions($data['meta']['info_text']);
         }
 
+        if (isset($data['disabledCondition'])) {
+            $section->setDisabledCondition($data['disabledCondition']);
+        }
+
         if (isset($data['visibleCondition'])) {
             $section->setVisibleCondition($data['visibleCondition']);
         }
@@ -365,6 +379,10 @@ class PropertiesXmlParser
         $blockProperty = new BlockMetadata();
         $blockProperty->setName($propertyName);
         $blockProperty->defaultComponentName = $data['default-type'];
+
+        if (isset($data['disabledCondition'])) {
+            $blockProperty->setDisabledCondition($data['disabledCondition']);
+        }
 
         if (isset($data['visibleCondition'])) {
             $blockProperty->setVisibleCondition($data['visibleCondition']);
@@ -417,7 +435,12 @@ class PropertiesXmlParser
         $property->setMinOccurs(null !== $data['minOccurs'] ? intval($data['minOccurs']) : null);
         $property->setMaxOccurs(null !== $data['maxOccurs'] ? intval($data['maxOccurs']) : null);
         $property->setLabel(array_key_exists('label', $data) ? $data['label'] : null);
-        $property->setVisibleCondition(array_key_exists('visibleCondition', $data) ? $data['visibleCondition'] : null);
+        $property->setDisabledCondition(
+            array_key_exists('disabledCondition', $data) ? $data['disabledCondition'] : null
+        );
+        $property->setVisibleCondition(
+            array_key_exists('visibleCondition', $data) ? $data['visibleCondition'] : null
+        );
         $property->setParameters($data['params']);
         $property->setOnInvalid(array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);
         $this->mapMeta($property, $data['meta']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4192 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the `disabledCondition` to the form XML, which should allow to disabled certain fields on certain conditions. This is similar to the already existing `visibilityCondition`, which is renamed to `visibleCondition` to better match the other name.

#### Why?

Because we need to deactivate the shadow button in #4192 on pages, which are already the target of other locales.

#### BC Breaks/Deprecations

`visibilityCondition` is renamed to `visibleCondition` in the form xml.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Add test in `FormXmlLoaderTest` to check if `disabledCondition` and `visibleConditon` is correctly rendered
