### PR TITLE
Remove the env file copy composer script

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
@@ -11,34 +11,12 @@
 
 namespace Sulu\Bundle\CoreBundle\Composer;
 
-use Composer\Script\Event;
-
 /**
  * A handler for general tasks executed with composer scripts.
  */
 class ScriptHandler
 {
     const GIT_IGNORE_FILE = '.gitignore';
-
-    const ENV_FILE = '.env';
-
-    const ENV_DIST_FILE = '.env.dist';
-
-    /**
-     * Copy the .env.dist file to .env file if not exists and generate a app secret.
-     */
-    public static function copyEnvDistFile(Event $event)
-    {
-        if (file_exists(static::ENV_FILE) || !file_exists(static::ENV_DIST_FILE)) {
-            return;
-        }
-
-        $envFile = file_get_contents(static::ENV_DIST_FILE);
-        $envFile = str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), $envFile);
-        file_put_contents(static::ENV_FILE, $envFile);
-
-        $event->getIO()->write('Please edit the created ".env" file to match your settings.');
-    }
 
     /**
      * Removes the composer.lock file from .gitignore, because we don't want the composer.lock to be included in our


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove the env file copy composer script.

#### Why?

The script was not working because post create project scripts are runned after post install scripts.

#### Example Usage

~~~php
composer create-project sulu/sulu-minimal:^2.0@dev
~~~

