### PR TITLE
Hotfix - redirect pages with trailing slashes were missing query params

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProvider.php
@@ -175,13 +175,11 @@ class ContentRouteProvider implements RouteProviderInterface
                     && $this->requestAnalyzer->getResourceLocatorPrefix()
                 ) {
                     // redirect page to page without slash at the end
-                    $collection->add(
-                        'redirect_' . uniqid(),
-                        $this->getRedirectRoute(
-                            $request,
-                            $this->requestAnalyzer->getResourceLocatorPrefix() . rtrim($resourceLocator, '/')
-                        )
-                    );
+                    $url = $this->requestAnalyzer->getResourceLocatorPrefix() . rtrim($resourceLocator, '/');
+                    if ($request->getQueryString()) {
+                        $url .= '?' . $request->getQueryString();
+                    }
+                    $collection->add('redirect_' . uniqid(), $this->getRedirectRoute($request, $url));
                 } elseif (RedirectType::INTERNAL === $document->getRedirectType()) {
                     // redirect internal link
                     $redirectUrl = $this->requestAnalyzer->getResourceLocatorPrefix()

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -30,6 +30,7 @@ use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Metadata;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Portal;
@@ -727,7 +728,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCollectionTrailingSlashWithQueryParams()
     {
-        $attributes = $this->prophesize('Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes');
+        $attributes = $this->prophesize(RequestAttributes::class);
         $portal = new Portal();
         $portal->setKey('portal');
         $webspace = new Webspace();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -724,7 +724,7 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SuluWebsiteBundle:Redirect:redirect', $route->getDefaults()['_controller']);
         $this->assertEquals('de/qwertz', $route->getDefaults()['url']);
     }
-    
+
     public function testGetCollectionTrailingSlashWithQueryParams()
     {
         $attributes = $this->prophesize('Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes');
@@ -734,14 +734,14 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $webspace->setKey('webspace');
         $webspace->setTheme('theme');
         $portal->setWebspace($webspace);
-    
+
         $localization = new Localization('de');
         $this->requestAnalyzer->getPortal()->willReturn($portal);
         $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
         $this->requestAnalyzer->getResourceLocator()->willReturn('/foo/');
         $this->requestAnalyzer->getMatchType()->willReturn(RequestAnalyzerInterface::MATCH_TYPE_FULL);
         $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/de');
-        
+
         $this->resourceLocatorStrategy->loadByResourceLocator('/foo', 'webspace', 'de')->willReturn('some-uuid');
         $redirectTargetDocument = $this->prophesize(ResourceSegmentBehavior::class);
         $redirectTargetDocument->getResourceSegment()->willReturn('/foo');

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Routing/ContentRouteProviderTest.php
@@ -724,6 +724,50 @@ class ContentRouteProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SuluWebsiteBundle:Redirect:redirect', $route->getDefaults()['_controller']);
         $this->assertEquals('de/qwertz', $route->getDefaults()['url']);
     }
+    
+    public function testGetCollectionTrailingSlashWithQueryParams()
+    {
+        $attributes = $this->prophesize('Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes');
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $webspace = new Webspace();
+        $webspace->setKey('webspace');
+        $webspace->setTheme('theme');
+        $portal->setWebspace($webspace);
+    
+        $localization = new Localization('de');
+        $this->requestAnalyzer->getPortal()->willReturn($portal);
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+        $this->requestAnalyzer->getResourceLocator()->willReturn('/foo/');
+        $this->requestAnalyzer->getMatchType()->willReturn(RequestAnalyzerInterface::MATCH_TYPE_FULL);
+        $this->requestAnalyzer->getResourceLocatorPrefix()->willReturn('/de');
+        
+        $this->resourceLocatorStrategy->loadByResourceLocator('/foo', 'webspace', 'de')->willReturn('some-uuid');
+        $redirectTargetDocument = $this->prophesize(ResourceSegmentBehavior::class);
+        $redirectTargetDocument->getResourceSegment()->willReturn('/foo');
+        $document = $this->prophesize(TitleBehavior::class)
+            ->willImplement(RedirectTypeBehavior::class)
+            ->willImplement(StructureBehavior::class)
+            ->willImplement(UuidBehavior::class);
+        $document->getTitle()->willReturn('some-title');
+        $document->getRedirectType()->willReturn(RedirectType::INTERNAL);
+        $document->getRedirectTarget()->willReturn($redirectTargetDocument->reveal());
+        $document->getStructureType()->willReturn('default');
+        $document->getUuid()->willReturn('some-uuid');
+        $this->documentManager->find('some-uuid', 'de', ['load_ghost_content' => false])->willReturn($document->reveal());
+        $request = new Request(
+            [],
+            [],
+            ['_sulu' => $attributes->reveal()],
+            [],
+            [], ['REQUEST_URI' => rawurlencode('/de/foo/'), 'QUERY_STRING' => 'bar=baz']
+        );
+        $routes = $this->contentRouteProvider->getRouteCollectionForRequest($request);
+        $this->assertCount(1, $routes);
+        $route = $routes->getIterator()->current();
+        $this->assertEquals('SuluWebsiteBundle:Redirect:redirect', $route->getDefaults()['_controller']);
+        $this->assertEquals('/de/foo?bar=baz', $route->getDefaults()['url']);
+    }
 
     public function testGetCollectionTrailingSlashForHomepage()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4103 
| Related issues/PRs | n/a
| License | MIT
| Documentation PR | n/a

#### What's in this PR?

Fixes  redirects that contain query parameters.

#### To Do

- [x] Fix tests

