### PR TITLE
Rename logs folder to match symfony 4 var/log folder

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## dev-develop
 
+### Log Folder changes
+
+To match the symfony 4 folder structure the logs are now written into **`var/log`** instead of var/logs.
+
 ### Form visibilityCondition
 
 **This change only affects you if you have used a 2.0.0 alpha release before**

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -149,7 +149,7 @@ abstract class SuluKernel extends Kernel
     {
         return $this->getProjectDir() . DIRECTORY_SEPARATOR
             . 'var' . DIRECTORY_SEPARATOR
-            . 'logs' . DIRECTORY_SEPARATOR
+            . 'log' . DIRECTORY_SEPARATOR
             . $this->context;
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| License | MIT

#### What's in this PR?

Rename logs folder to match symfony 4 var/log folder.

#### Why?

Symfony renamed the var/logs folder to [var/log](https://github.com/symfony/demo/blob/4c100346da85aa94a61b77aedd90c30aa9c626ac/src/Kernel.php#L34).

I did see this because of the symfony 4 deployer script: https://github.com/deployphp/deployer/blob/master/recipe/symfony4.php#L12

#### To Do

- [x] Add breaking changes to UPGRADE.md
