### PR TITLE
consolidate initial loader for Datagrids

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
@@ -131,10 +131,6 @@ export default class Pagination extends React.Component<Props> {
         const {currentInputValue} = this;
         const {children, loading, totalPages, currentLimit} = this.props;
 
-        if (loading && !totalPages) {
-            return <Loader />;
-        }
-
         return (
             <section>
                 {children}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/Pagination.test.js
@@ -31,21 +31,6 @@ test('Render pagination with loader', () => {
     )).toMatchSnapshot();
 });
 
-test('Render only loader if total is not passed initially', () => {
-    expect(render(
-        <Pagination
-            currentLimit={10}
-            currentPage={0}
-            loading={true}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            totalPages={undefined}
-        >
-            <p></p>
-        </Pagination>
-    )).toMatchSnapshot();
-});
-
 test('Render pagination with page numbers', () => {
     expect(render(
         <Pagination

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
@@ -196,20 +196,6 @@ exports[`Render disabled previous link current page is first page 1`] = `
 </section>
 `;
 
-exports[`Render only loader if total is not passed initially 1`] = `
-<div
-  class="spinner"
-  style="width:40px;height:40px"
->
-  <div
-    class="doubleBounce1"
-  />
-  <div
-    class="doubleBounce2"
-  />
-</div>
-`;
-
 exports[`Render pagination with loader 1`] = `
 <section>
   <p>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -7,6 +7,7 @@ import equal from 'fast-deep-equal';
 import ArrowMenu from '../../components/ArrowMenu';
 import Button from '../../components/Button';
 import Dialog from '../../components/Dialog';
+import Loader from '../../components/Loader';
 import SingleDatagridOverlay from '../SingleDatagridOverlay';
 import {translate} from '../../utils/Translator';
 import type {Schema, SortOrder} from './types';
@@ -429,34 +430,37 @@ export default class Datagrid extends React.Component<Props> {
                     </div>
                 }
                 <div className={datagridStyles.datagrid}>
-                    <Adapter
-                        active={store.active.get()}
-                        activeItems={store.activeItems}
-                        data={store.data}
-                        disabledIds={disabledIds}
-                        limit={store.limit.get()}
-                        loading={store.loading}
-                        onAllSelectionChange={selectable ? this.handleAllSelectionChange : undefined}
-                        onItemActivate={this.handleItemActivate}
-                        onItemAdd={onItemAdd}
-                        onItemClick={onItemClick}
-                        onItemDeactivate={this.handleItemDeactivate}
-                        onItemSelectionChange={selectable ? this.handleItemSelectionChange : undefined}
-                        onLimitChange={this.handleLimitChange}
-                        onPageChange={this.handlePageChange}
-                        onRequestItemCopy={copyable ? this.handleRequestItemCopy : undefined}
-                        onRequestItemDelete={deletable ? this.handleRequestItemDelete : undefined}
-                        onRequestItemMove={movable ? this.handleRequestItemMove : undefined}
-                        onRequestItemOrder={orderable ? this.handleRequestItemOrder : undefined}
-                        onSort={this.handleSort}
-                        options={this.currentAdapterOptions}
-                        page={store.getPage()}
-                        pageCount={store.pageCount}
-                        schema={store.userSchema}
-                        selections={store.selectionIds}
-                        sortColumn={store.sortColumn.get()}
-                        sortOrder={store.sortOrder.get()}
-                    />
+                    {store.loading && !store.pageCount
+                        ? <Loader />
+                        : <Adapter
+                            active={store.active.get()}
+                            activeItems={store.activeItems}
+                            data={store.data}
+                            disabledIds={disabledIds}
+                            limit={store.limit.get()}
+                            loading={store.loading}
+                            onAllSelectionChange={selectable ? this.handleAllSelectionChange : undefined}
+                            onItemActivate={this.handleItemActivate}
+                            onItemAdd={onItemAdd}
+                            onItemClick={onItemClick}
+                            onItemDeactivate={this.handleItemDeactivate}
+                            onItemSelectionChange={selectable ? this.handleItemSelectionChange : undefined}
+                            onLimitChange={this.handleLimitChange}
+                            onPageChange={this.handlePageChange}
+                            onRequestItemCopy={copyable ? this.handleRequestItemCopy : undefined}
+                            onRequestItemDelete={deletable ? this.handleRequestItemDelete : undefined}
+                            onRequestItemMove={movable ? this.handleRequestItemMove : undefined}
+                            onRequestItemOrder={orderable ? this.handleRequestItemOrder : undefined}
+                            onSort={this.handleSort}
+                            options={this.currentAdapterOptions}
+                            page={store.getPage()}
+                            pageCount={store.pageCount}
+                            schema={store.userSchema}
+                            selections={store.selectionIds}
+                            sortColumn={store.sortColumn.get()}
+                            sortOrder={store.sortOrder.get()}
+                        />
+                    }
                 </div>
                 {deletable &&
                     <Dialog

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -139,6 +139,15 @@ beforeEach(() => {
     datagridFieldTransformerRegistry.get.mockReturnValue(new StringFieldTransformer());
 });
 
+test('Render Loader instead of Adapter if nothing was loaded yet', () => {
+    const datagridStore = new DatagridStore('test', 'datagrid_test', {page: observable.box(1)});
+    // $FlowFixMe
+    datagridStore.loading = true;
+    datagridStore.pageCount = 0;
+
+    expect(render(<Datagrid adapters={['table']} store={datagridStore} />)).toMatchSnapshot();
+});
+
 test('Render TableAdapter with correct values', () => {
     datagridAdapterRegistry.get.mockReturnValue(TableAdapter);
     mockStructureStrategyData = [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
+Array [
+  <div
+    class="headerContainer"
+  >
+    <div
+      class="toolbar"
+    >
+      <label
+        class="input dark left collapsed hasAppendIcon"
+      >
+        <div
+          class="prependedContainer dark collapsed"
+        >
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
+          />
+        </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+    </div>
+  </div>,
+  <div
+    class="datagrid"
+  >
+    <div
+      class="spinner"
+      style="width:40px;height:40px"
+    >
+      <div
+        class="doubleBounce1"
+      />
+      <div
+        class="doubleBounce2"
+      />
+    </div>
+  </div>,
+]
+`;
+
 exports[`Render the adapter in non-searchable mode 1`] = `
 Array [
   <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | introduced in #4203 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR renders the initial loader for the `Datagrid` within the `Datagrid` container component.

#### Why?

Because this way the initial loader always looks the same, and it is handled in a central place instead of multiple times.

This also fixes a bug, in which the `TableAdapter` resp. any adapter using the `Pagination` were not showing a loader but an empty list at the beginning.