### PR TITLE
Remove unneeded sensio extra framework bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "pagerfanta/pagerfanta": "^1.0.4",
         "piwik/device-detector": "^3.7",
         "ramsey/uuid": "^3.1",
-        "sensio/framework-extra-bundle": "^5.0",
         "stof/doctrine-extensions-bundle": "^1.2.2",
         "symfony-cmf/routing-bundle": "^2.0",
         "symfony-cmf/slugifier-api": "^1.0 || ^2.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -14,7 +14,6 @@ return [
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
-    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Sulu\Bundle\CoreBundle\SuluCoreBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],

--- a/src/Sulu/Bundle/SecurityBundle/Tests/app/AppKernel.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/app/AppKernel.php
@@ -21,7 +21,6 @@ class AppKernel extends SuluTestKernel
             [
                 new \Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
                 new Symfony\Bundle\DebugBundle\DebugBundle(),
-                new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             ]
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove unneeded sensio extra framework bundle.

#### Why?

Sulu is not related on the sensio extra framework bundle and sensio extra framework bundle is also not. Most used features like route annotations are part of symfony core now also thats way its mostly not longer used in symfony 4 projects and not part of symfony standard installation.
