### PR TITLE
Add `setNote` and `getNote` to ContactInterface

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -482,7 +482,7 @@ class Contact extends ApiEntity implements ContactInterface, AuditableInterface
         return $this->creator;
     }
 
-    public function setNote(?string $note): self
+    public function setNote(?string $note): ContactInterface
     {
         $this->note = $note;
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
@@ -590,4 +590,8 @@ interface ContactInterface
      * @return Collection|BankAccount[]
      */
     public function getBankAccounts();
+
+    public function setNote(?string $note): self;
+
+    public function getNote(): ?string;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add `setNote` and `getNote` to ContactInterface

#### Why?

It are needed contact interface functions. Also phpstan did fail in project because of this.
