### PR TITLE
implement deleting of media in datagrid

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -52,11 +52,13 @@ export default class Datagrid extends React.Component<Props> {
     @observable copying: boolean = false;
     @observable deleting: boolean = false;
     @observable moving: boolean = false;
+    @observable ordering: boolean = false;
+    @observable selectionDeleting: boolean = false;
     @observable showCopyOverlay: boolean = false;
     @observable showDeleteDialog: boolean = false;
     @observable showMoveOverlay: boolean = false;
+    @observable showDeleteSelectionDialog: boolean = false;
     @observable showOrderDialog: boolean = false;
-    @observable ordering: boolean = false;
     @observable adapterOptionsOpen: boolean = false;
     @observable columnOptionsOpen: boolean = false;
     resolveCopy: ?({copied: boolean, parent?: ?Object}) => void;
@@ -118,6 +120,23 @@ export default class Datagrid extends React.Component<Props> {
         if (!(this.props.store.structureStrategy instanceof this.currentAdapter.StructureStrategy)) {
             this.props.store.updateStructureStrategy(new this.currentAdapter.StructureStrategy());
         }
+    };
+
+    /** @public */
+    @action requestSelectionDelete = () => {
+        this.showDeleteSelectionDialog = true;
+    };
+
+    @action handleSelectionDeleteDialogConfirmClick = () => {
+        this.selectionDeleting = true;
+        this.props.store.deleteSelection().then(action(() => {
+            this.showDeleteSelectionDialog = false;
+            this.selectionDeleting = false;
+        }));
+    };
+
+    @action handleSelectionDeleteDialogCancelClick = () => {
+        this.showDeleteSelectionDialog = false;
     };
 
     @action handleRequestItemDelete = (id: string | number) => {
@@ -229,7 +248,7 @@ export default class Datagrid extends React.Component<Props> {
 
     @action handleCopyOverlayConfirmClick = (parent: Object) => {
         if (!this.resolveCopy) {
-            throw new Error('The resolveCopy deletion is not set. This should not happen, and is likely a bug.');
+            throw new Error('The resolveCopy function is not set. This should not happen, and is likely a bug.');
         }
 
         this.resolveCopy({copied: true, parent});
@@ -237,7 +256,7 @@ export default class Datagrid extends React.Component<Props> {
 
     @action handleCopyOverlayClose = () => {
         if (!this.resolveCopy) {
-            throw new Error('The resolveCopy deletion is not set. This should not happen, and is likely a bug.');
+            throw new Error('The resolveCopy function is not set. This should not happen, and is likely a bug.');
         }
 
         this.resolveCopy({copied: false});
@@ -462,6 +481,17 @@ export default class Datagrid extends React.Component<Props> {
                         />
                     }
                 </div>
+                <Dialog
+                    cancelText={translate('sulu_admin.cancel')}
+                    confirmLoading={this.selectionDeleting}
+                    confirmText={translate('sulu_admin.ok')}
+                    onCancel={this.handleSelectionDeleteDialogCancelClick}
+                    onConfirm={this.handleSelectionDeleteDialogConfirmClick}
+                    open={this.showDeleteSelectionDialog}
+                    title={translate('sulu_admin.delete_warning_title')}
+                >
+                    {translate('sulu_admin.delete_selection_warning_text', {count: store.selections.length})}
+                </Dialog>
                 {deletable &&
                     <Dialog
                         cancelText={translate('sulu_admin.cancel')}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -349,17 +349,17 @@ export default class DatagridStore {
     @action deleteSelection = () => {
         const deletePromises = [];
         this.selectionIds.forEach((id) => {
-            deletePromises.push(this.delete(id).catch((error) => {
+            deletePromises.push(ResourceRequester.delete(this.resourceKey, id, this.queryOptions).catch((error) => {
                 if (error.status !== 404) {
                     return Promise.reject(error);
                 }
             }));
         });
 
-        return Promise.all(deletePromises).then(() => {
+        return Promise.all(deletePromises).then(action(() => {
             this.selectionIds.forEach(this.remove);
             this.clearSelection();
-        });
+        }));
     };
 
     remove = (identifier: string | number): void => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -576,46 +576,11 @@ test('Should delete selected items when delete button is clicked', () => {
     const datagrid = mount(<Datagrid router={router} />);
     const datagridStore = datagrid.instance().datagridStore;
     datagridStore.selectionIds.push(1, 4, 6);
-    datagridStore.deleteSelection.mockReturnValue(Promise.resolve());
 
-    expect(getDeleteItem().loading).toBe(false);
-    const clickPromise = getDeleteItem().onClick();
-    expect(getDeleteItem().loading).toBe(true);
+    datagrid.update();
+    expect(datagrid.find('Dialog').at(0).prop('open')).toEqual(false);
 
-    return clickPromise.then(() => {
-        expect(datagridStore.deleteSelection).toBeCalledWith();
-        expect(getDeleteItem().loading).toBe(false);
-    });
-});
-
-test('Should crash when deleting selected items returns a rejected promise', () => {
-    function getDeleteItem() {
-        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.value === 'Delete');
-    }
-
-    const withToolbar = require('../../../containers/Toolbar/withToolbar');
-    const Datagrid = require('../Datagrid').default;
-    const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
-    const router = {
-        bind: jest.fn(),
-        route: {
-            options: {
-                resourceKey: 'test',
-                adapters: ['table'],
-            },
-        },
-    };
-
-    const datagrid = mount(<Datagrid router={router} />);
-    const datagridStore = datagrid.instance().datagridStore;
-    datagridStore.selectionIds.push(1, 4, 6);
-    datagridStore.deleteSelection.mockReturnValue(Promise.reject());
-
-    expect(getDeleteItem().loading).toBe(false);
-    const clickPromise = getDeleteItem().onClick();
-    expect(getDeleteItem().loading).toBe(true);
-
-    return clickPromise.catch(() => {
-        expect(getDeleteItem().loading).toBe(false);
-    });
+    getDeleteItem().onClick();
+    datagrid.update();
+    expect(datagrid.find('Dialog').at(0).prop('open')).toEqual(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -52,6 +52,7 @@
     "sulu_admin.authored": "Verfasst am",
     "sulu_admin.delete_warning_title": "Löschen?",
     "sulu_admin.delete_warning_text": "Diese Operation löscht Daten und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
+    "sulu_admin.delete_selection_warning_text": "Diese Operation löscht {count} {count, plural, =1 {Datensatz} other {Datensätze}} und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
     "sulu_admin.ghost_dialog_title": "Sprachvariante kopieren?",
     "sulu_admin.ghost_dialog_description": "Diese Seite existiert nicht in dieser Sprache. Wollen Sie den Inhalt aus einer anderen Sprache kopieren?",
     "sulu_admin.choose_language": "Sprache wählen",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -52,6 +52,7 @@
     "sulu_admin.authored": "Authored on",
     "sulu_admin.delete_warning_title": "Delete?",
     "sulu_admin.delete_warning_text": "This operation deletes data and cannot be undone. Do you really wish to proceed?",
+    "sulu_admin.delete_selection_warning_text": "This operation deletes {count} {count, plural, =1 {row} other {rows}} and cannot be undone. Do you really wish to proceed?",
     "sulu_admin.ghost_dialog_title": "Copy language?",
     "sulu_admin.ghost_dialog_description": "This page does not exist in this language. Do you want to copy content from another language?",
     "sulu_admin.choose_language": "Choose language",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -52,7 +52,7 @@
     "sulu_admin.authored": "Authored on",
     "sulu_admin.delete_warning_title": "Delete?",
     "sulu_admin.delete_warning_text": "This operation deletes data and cannot be undone. Do you really wish to proceed?",
-    "sulu_admin.delete_selection_warning_text": "This operation deletes {count} {count, plural, =1 {row} other {rows}} and cannot be undone. Do you really wish to proceed?",
+    "sulu_admin.delete_selection_warning_text": "This operation deletes {count} {count, plural, =1 {item} other {items}} and cannot be undone. Do you really wish to proceed?",
     "sulu_admin.ghost_dialog_title": "Copy language?",
     "sulu_admin.ghost_dialog_description": "This page does not exist in this language. Do you want to copy content from another language?",
     "sulu_admin.choose_language": "Choose language",

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -1,31 +1,32 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import {when} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
 import {Divider} from 'sulu-admin-bundle/components';
-import {DatagridStore} from 'sulu-admin-bundle/containers';
+import {Datagrid, DatagridStore} from 'sulu-admin-bundle/containers';
 import CollectionStore from '../../stores/CollectionStore';
 import MultiMediaDropzone from '../MultiMediaDropzone';
 import type {OverlayType} from './types';
 import CollectionSection from './CollectionSection';
 import MediaSection from './MediaSection';
 
-type Props = {
+type Props = {|
     locale: IObservableValue<string>,
     mediaDatagridAdapters: Array<string>,
+    mediaDatagridRef?: (?ElementRef<typeof Datagrid>) => void,
     mediaDatagridStore: DatagridStore,
     collectionDatagridStore: DatagridStore,
     collectionStore: CollectionStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
     overlayType: OverlayType,
-};
+|};
 
 @observer
 export default class MediaCollection extends React.Component<Props> {
     static defaultProps = {
-        mediaViews: [],
         overlayType: 'overlay',
     };
 
@@ -47,18 +48,19 @@ export default class MediaCollection extends React.Component<Props> {
         mediaDatagridStore.reload();
         when(
             () => !mediaDatagridStore.loading,
-            (): void => media.forEach((mediaItem) => mediaDatagridStore.select(mediaItem.id))
+            (): void => media.forEach((mediaItem) => mediaDatagridStore.select(mediaItem))
         );
     };
 
     render() {
         const {
+            collectionDatagridStore,
+            collectionStore,
             locale,
             overlayType,
-            collectionStore,
-            mediaDatagridStore,
             mediaDatagridAdapters,
-            collectionDatagridStore,
+            mediaDatagridRef,
+            mediaDatagridStore,
         } = this.props;
 
         return (
@@ -79,6 +81,7 @@ export default class MediaCollection extends React.Component<Props> {
                     <MediaSection
                         adapters={mediaDatagridAdapters}
                         datagridStore={mediaDatagridStore}
+                        mediaDatagridRef={mediaDatagridRef}
                         onMediaClick={this.handleMediaClick}
                     />
                 </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaSection.js
@@ -1,12 +1,14 @@
 //@flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import {Datagrid, DatagridStore} from 'sulu-admin-bundle/containers';
 
-type Props = {
+type Props = {|
     adapters: Array<string>,
     datagridStore: DatagridStore,
+    mediaDatagridRef?: (?ElementRef<typeof Datagrid>) => void,
     onMediaClick: (mediaId: string | number) => void,
-};
+|};
 
 export default class MediaSection extends React.PureComponent<Props> {
     handleMediaClick = (mediaId: string | number) => {
@@ -17,12 +19,14 @@ export default class MediaSection extends React.PureComponent<Props> {
         const {
             adapters,
             datagridStore,
+            mediaDatagridRef,
         } = this.props;
 
         return (
             <Datagrid
                 adapters={adapters}
                 onItemClick={this.handleMediaClick}
+                ref={mediaDatagridRef}
                 store={datagridStore}
             />
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -1,10 +1,12 @@
 // @flow
 import React from 'react';
+import type {ElementRef} from 'react';
 import {action, autorun, observable} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import {observer} from 'mobx-react';
-import {withToolbar, DatagridStore} from 'sulu-admin-bundle/containers';
+import {Datagrid, DatagridStore, withToolbar} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
+import {translate} from 'sulu-admin-bundle/utils';
 import MediaCollection from '../../containers/MediaCollection';
 import CollectionStore from '../../stores/CollectionStore';
 import mediaOverviewStyles from './mediaOverview.scss';
@@ -26,6 +28,7 @@ class MediaOverview extends React.Component<ViewProps> {
     @observable mediaDatagridStore: DatagridStore;
     @observable collectionDatagridStore: DatagridStore;
     @observable collectionStore: CollectionStore;
+    mediaDatagrid: ?ElementRef<typeof Datagrid>;
     disposer: () => void;
 
     static getDerivedRouteAttributes() {
@@ -139,6 +142,10 @@ class MediaOverview extends React.Component<ViewProps> {
         );
     };
 
+    setMediaDatagridRef = (mediaDatagrid) => {
+        this.mediaDatagrid = mediaDatagrid;
+    };
+
     render() {
         return (
             <div className={mediaOverviewStyles.mediaOverview}>
@@ -147,6 +154,7 @@ class MediaOverview extends React.Component<ViewProps> {
                     collectionStore={this.collectionStore}
                     locale={this.locale}
                     mediaDatagridAdapters={['media_card_overview', 'table']}
+                    mediaDatagridRef={this.setMediaDatagridRef}
                     mediaDatagridStore={this.mediaDatagridStore}
                     onCollectionNavigate={this.handleCollectionNavigate}
                     onMediaNavigate={this.handleMediaNavigate}
@@ -199,6 +207,15 @@ export default withToolbar(MediaOverview, function() {
                 },
             }
             : undefined,
-        items: [],
+        items: [
+            {
+                type: 'button',
+                value: translate('sulu_admin.delete'),
+                icon: 'su-trash-alt',
+                disabled: this.mediaDatagridStore.selectionIds.length === 0,
+                loading: this.mediaDatagridStore.selectionDeleting,
+                onClick: this.mediaDatagrid.requestSelectionDelete,
+            },
+        ],
     };
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -129,8 +129,8 @@ jest.mock('sulu-admin-bundle/utils', () => ({
                 return 'of';
             case 'sulu_admin.object':
                 return 'Object';
-            case 'sulu_admin.objects':
-                return 'Objects';
+            case 'sulu_admin.delete':
+                return 'Delete';
         }
     },
 }));
@@ -309,4 +309,33 @@ test('The collectionId should be update along with the content when a collection
     expect(mediaOverview.instance().mediaDatagridStore.clearData).toBeCalled();
     expect(mediaOverview.instance().collectionDatagridStore.clearSelection).toBeCalled();
     expect(mediaOverview.instance().collectionDatagridStore.clearData).toBeCalled();
+});
+
+test('Should delete selected items when delete button is clicked', () => {
+    function getDeleteItem() {
+        return toolbarFunction.call(mediaOverview.instance()).items.find((item) => item.value === 'Delete');
+    }
+
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+
+            },
+        },
+    };
+
+    const mediaOverview = mount(<MediaOverview router={router} />);
+    const mediaDatagridStore = mediaOverview.instance().mediaDatagridStore;
+    mediaDatagridStore.selectionIds.push(1, 4, 6);
+
+    mediaOverview.update();
+    expect(mediaOverview.find('Dialog').at(4).prop('open')).toEqual(false);
+
+    getDeleteItem().onClick();
+    mediaOverview.update();
+    expect(mediaOverview.find('Dialog').at(4).prop('open')).toEqual(true);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds deleting of media to our feature set. In addition to that it cleaned up the existing code for the Datagrid view, and introduced a dialog, which has to be confirmed before deleting.

#### Why?

Because sometimes people want to delete medias :smiley: 