### PR TITLE
fix loading in ColumnListAdapter when activating item

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -430,7 +430,7 @@ export default class Datagrid extends React.Component<Props> {
                     </div>
                 }
                 <div className={datagridStyles.datagrid}>
-                    {store.loading && !store.pageCount
+                    {store.loading && store.pageCount === 0
                         ? <Loader />
                         : <Adapter
                             active={store.active.get()}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -22,7 +22,7 @@ const USER_SETTING_LIMIT = 'limit';
 const USER_SETTING_SCHEMA = 'schema';
 
 export default class DatagridStore {
-    @observable pageCount: number = 0;
+    @observable pageCount: ?number = 0;
     @observable selections: Array<Object> = [];
     @observable dataLoading: boolean = true;
     @observable schemaLoading: boolean = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -148,6 +148,15 @@ test('Render Loader instead of Adapter if nothing was loaded yet', () => {
     expect(render(<Datagrid adapters={['table']} store={datagridStore} />)).toMatchSnapshot();
 });
 
+test('Do not render Loader instead of Adapter if no page count is given', () => {
+    const datagridStore = new DatagridStore('test', 'datagrid_test', {page: observable.box(1)});
+    // $FlowFixMe
+    datagridStore.loading = true;
+    datagridStore.pageCount = undefined;
+
+    expect(render(<Datagrid adapters={['table']} store={datagridStore} />)).toMatchSnapshot();
+});
+
 test('Render TableAdapter with correct values', () => {
     datagridAdapterRegistry.get.mockReturnValue(TableAdapter);
     mockStructureStrategyData = [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Do not render Loader instead of Adapter if no page count is given 1`] = `
+Array [
+  <div
+    class="headerContainer"
+  >
+    <div
+      class="toolbar"
+    >
+      <label
+        class="input dark left collapsed hasAppendIcon"
+      >
+        <div
+          class="prependedContainer dark collapsed"
+        >
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
+          />
+        </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+    </div>
+  </div>,
+  <div
+    class="datagrid"
+  >
+    <div>
+      Test Adapter
+    </div>
+  </div>,
+]
+`;
+
 exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
 Array [
   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/types.js
@@ -45,7 +45,7 @@ export type DatagridAdapterProps = {
     onSort: (column: string, order: SortOrder) => void,
     options: Object,
     page: ?number,
-    pageCount: number,
+    pageCount: ?number,
     schema: Schema,
     selections: Array<number | string>,
     sortColumn: ?string,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4211 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR only shows the loader if the `pageCount` of the datagrid is zero.

#### Why?

Because only then it makes sense to show the general loader. E.g. the `ColumnListAdapter` uses the `FullLoadingStrategy`, which causes the `pageCount` to be undefined, leading to a full loader on every click on an item in the Webspace overview.