### PR TITLE
Added autoconfigure for sulu admin class

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -11,6 +11,10 @@
 
 namespace Sulu\Bundle\AdminBundle\DependencyInjection;
 
+use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass;
+use Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RemoveForeignContextServicesPass;
+use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -96,6 +100,10 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->registerForAutoconfiguration(Admin::class)
+                  ->addTag(AddAdminPass::ADMIN_TAG)
+                  ->addTag(RemoveForeignContextServicesPass::SULU_CONTEXT_TAG, ['context' => SuluKernel::CONTEXT_ADMIN]);
 
         $this->loadFieldTypeOptions(
             $config['field_type_options'],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added autoconfigure for sulu admin class.

#### Why?

When use autoconfigure in your project sulu should autoconfigure the admin class.

#### Example Usage

1. Create AppAdmin

~~~php
<?php

namespace App\Admin;

use Sulu\Bundle\AdminBundle\Admin\Admin;

class AppAdmin extends Admin
{

}
~~~

2. Activate autoconfigure in your `config/services.yaml`

~~~php
services:
    _defaults:
        autowire: true
        autoconfigure: true
        public: false

    App\:
        resource: '../src/*'
        exclude: '../src/{Entity,Migrations,Tests,Kernel.php}'

    App\Controller\:
        resource: '../src/Controller'
        tags: ['controller.service_arguments']
~~~

