### PR TITLE
Add history and formats tab to media form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Body.js
@@ -35,10 +35,10 @@ export default class Body extends React.PureComponent<Props> {
         return React.Children.map(originalRows, (row, index) => React.cloneElement(
             row,
             {
+                buttons: buttons,
                 ...row.props,
                 key: `body-row-${index}`,
                 rowIndex: index,
-                buttons: buttons,
                 selectMode: selectMode,
                 selectInFirstCell: this.props.selectInFirstCell,
                 onSelectionChange: this.props.onRowSelectionChange ? this.handleRowSelectionChange : undefined,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/ButtonCell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/ButtonCell.js
@@ -8,15 +8,15 @@ type Props = {
     /** A ButtonCell is always associated with a row */
     rowId: string | number,
     icon: string,
-    onClick?: (rowId: string | number) => void,
+    onClick: ?(rowId: string | number) => void,
 };
 
 export default class ButtonCell extends React.PureComponent<Props> {
     handleClick = () => {
-        const {rowId} = this.props;
+        const {rowId, onClick} = this.props;
 
-        if (this.props.onClick) {
-            this.props.onClick(rowId);
+        if (onClick) {
+            onClick(rowId);
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/Table.test.js
@@ -106,6 +106,35 @@ test('Render a table with buttons', () => {
     )).toMatchSnapshot();
 });
 
+test('Render a table with different buttons for each row', () => {
+    const buttons = [{
+        icon: 'fa-pencil',
+        onClick: jest.fn(),
+    }];
+
+    expect(render(
+        <Table buttons={buttons}>
+            <Header>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+                <HeaderCell>Column Title</HeaderCell>
+            </Header>
+            <Body>
+                <Row>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                </Row>
+                <Row buttons={[{icon: 'fa-plus', onClick: jest.fn()}]}>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                    <Cell>Column Text</Cell>
+                </Row>
+            </Body>
+        </Table>
+    )).toMatchSnapshot();
+});
+
 test('Table buttons should implement an onClick handler', () => {
     const clickSpy = jest.fn();
     const buttons = [{

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/tests/__snapshots__/Table.test.js.snap
@@ -141,6 +141,146 @@ exports[`Render a table with buttons 1`] = `
 </div>
 `;
 
+exports[`Render a table with different buttons for each row 1`] = `
+<div
+  class="tableContainer"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerButtonCell headerCell"
+        >
+          <span>
+            <span
+              aria-label="fa-pencil"
+              class="fa fa-pencil"
+            />
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            Column Title
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="buttonCell cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button>
+              <span
+                aria-label="fa-pencil"
+                class="fa fa-pencil"
+              />
+            </button>
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="buttonCell cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button>
+              <span
+                aria-label="fa-plus"
+                class="fa fa-plus"
+              />
+            </button>
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Column Text
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Render an empty table 1`] = `
 <div
   class="tableContainer"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
@@ -5,5 +5,5 @@ export type SortOrder = 'asc' | 'desc';
 
 export type ButtonConfig = {
     icon: string,
-    onClick: (string | number) => void,
+    onClick: ?(string | number) => void,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
@@ -26,6 +26,7 @@ import Overlay from './Overlay';
 import Popover from './Popover';
 import PublishIndicator from './PublishIndicator';
 import SingleSelect from './SingleSelect';
+import Table from './Table';
 import Toolbar from './Toolbar';
 import withContainerSize from './withContainerSize';
 
@@ -57,6 +58,7 @@ export {
     Popover,
     PublishIndicator,
     SingleSelect,
+    Table,
     Toolbar,
     withContainerSize,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -1,6 +1,7 @@
 // @flow
 import {action, autorun, observable, toJS, when} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import log from 'loglevel';
 import ResourceRequester from '../../services/ResourceRequester';
 import type {ObservableOptions} from './types';
 
@@ -63,6 +64,8 @@ export default class ResourceStore {
         if (locale) {
             options.locale = locale.get();
         }
+
+        log.info('ResourceStore loads "' + this.resourceKey + '" data with the ID "' + id + '"');
 
         const promise = this.idQueryParameter
             ? ResourceRequester.get(

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -85,6 +85,9 @@ class MediaAdmin extends Admin
                 ->addOption('tabTitle', 'sulu_media.information_taxonomy')
                 ->addOption('locales', $mediaLocales)
                 ->setParent('sulu_media.form'),
+            (new Route('sulu_media.form.formats', '/formats', 'sulu_media.formats'))
+                ->addOption('tabTitle', 'sulu_media.formats')
+                ->setParent('sulu_media.form'),
             (new Route('sulu_media.form.history', '/history', 'sulu_media.history'))
                 ->addOption('tabTitle', 'sulu_media.history')
                 ->setParent('sulu_media.form'),

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -85,6 +85,9 @@ class MediaAdmin extends Admin
                 ->addOption('tabTitle', 'sulu_media.information_taxonomy')
                 ->addOption('locales', $mediaLocales)
                 ->setParent('sulu_media.form'),
+            (new Route('sulu_media.form.history', '/history', 'sulu_media.history'))
+                ->addOption('tabTitle', 'sulu_media.history')
+                ->setParent('sulu_media.form'),
         ];
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/FormatController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/FormatController.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Controller;
+
+use FOS\RestBundle\Routing\ClassResourceInterface;
+use Hateoas\Representation\CollectionRepresentation;
+use Sulu\Component\Rest\RequestParametersTrait;
+use Sulu\Component\Rest\RestController;
+use Symfony\Component\HttpFoundation\Request;
+
+class FormatController extends RestController implements ClassResourceInterface
+{
+    use RequestParametersTrait;
+
+    public function cgetAction(Request $request)
+    {
+        $locale = $this->getRequestParameter($request, 'locale', true);
+
+        return $this->handleView($this->view(
+            new CollectionRepresentation(
+                array_values($this->get('sulu_media.format_manager')->getFormatDefinitions($locale)),
+                'formats'
+            )
+        ));
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Controller;
 
 use FOS\RestBundle\Routing\ClassResourceInterface;
+use FOS\RestBundle\Controller\Annotations\RouteResource;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatOptions\FormatOptionsManagerInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
@@ -20,9 +21,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Makes the image formats, with the format options available through the REST API.
+ * @RouteResource("Format")
  */
-class FormatController extends RestController implements ClassResourceInterface
+class MediaFormatController extends RestController implements ClassResourceInterface
 {
     use RequestParametersTrait;
 
@@ -40,6 +41,7 @@ class FormatController extends RestController implements ClassResourceInterface
         $formatOptions = $this->getFormatOptionsManager()->getAll($id);
         $formats = $this->getFormatManager()->getFormatDefinitions($locale, $formatOptions);
 
+        // TODO only return $formatOptions instead
         return $this->handleView($this->view($formats));
     }
 
@@ -67,6 +69,7 @@ class FormatController extends RestController implements ClassResourceInterface
         $formatOptions = $this->getFormatOptionsManager()->get($id, $key);
         $format = $this->getFormatManager()->getFormatDefinition($key, $locale, $formatOptions);
 
+        // TODO only return $formatOptions instead
         return $this->handleView($this->view($format));
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
@@ -11,8 +11,8 @@
 
 namespace Sulu\Bundle\MediaBundle\Controller;
 
-use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\Controller\Annotations\RouteResource;
+use FOS\RestBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatOptions\FormatOptionsManagerInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
@@ -39,10 +39,8 @@ class MediaFormatController extends RestController implements ClassResourceInter
     {
         $locale = $this->getRequestParameter($request, 'locale', true);
         $formatOptions = $this->getFormatOptionsManager()->getAll($id);
-        $formats = $this->getFormatManager()->getFormatDefinitions($locale, $formatOptions);
 
-        // TODO only return $formatOptions instead
-        return $this->handleView($this->view($formats));
+        return $this->handleView($this->view($formatOptions));
     }
 
     /**
@@ -67,10 +65,8 @@ class MediaFormatController extends RestController implements ClassResourceInter
         $this->get('doctrine.orm.entity_manager')->flush();
 
         $formatOptions = $this->getFormatOptionsManager()->get($id, $key);
-        $format = $this->getFormatManager()->getFormatDefinition($key, $locale, $formatOptions);
 
-        // TODO only return $formatOptions instead
-        return $this->handleView($this->view($format));
+        return $this->handleView($this->view($formatOptions));
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -95,6 +95,10 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                             'datagrid' => Collection::class,
                             'endpoint' => 'get_collections',
                         ],
+                        'formats' => [
+                            'form' => [],
+                            'endpoint' => 'get_formats',
+                        ]
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -98,7 +98,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                         'formats' => [
                             'form' => [],
                             'endpoint' => 'get_formats',
-                        ]
+                        ],
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -208,8 +208,7 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    // TODO remove $formatOptions
-    public function getFormatDefinition($formatKey, $locale = null, array $formatOptions = [])
+    public function getFormatDefinition($formatKey, $locale = null)
     {
         if (!isset($this->formats[$formatKey])) {
             throw new FormatNotFoundException($formatKey);
@@ -229,7 +228,6 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
             'key' => $format['key'],
             'title' => $title,
             'scale' => $format['scale'],
-            'options' => (!empty($formatOptions)) ? $formatOptions : null,
         ];
 
         return $formatArray;
@@ -238,16 +236,12 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
-    // TODO remove $formatOptions
-    public function getFormatDefinitions($locale = null, array $formatOptions = [])
+    public function getFormatDefinitions($locale = null)
     {
         $definitionsArray = [];
 
         foreach ($this->formats as $format) {
             $options = [];
-            if (array_key_exists($format['key'], $formatOptions)) {
-                $options = $formatOptions[$format['key']];
-            }
             $definitionsArray[$format['key']] = $this->getFormatDefinition($format['key'], $locale, $options);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -208,6 +208,7 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
+    // TODO remove $formatOptions
     public function getFormatDefinition($formatKey, $locale = null, array $formatOptions = [])
     {
         if (!isset($this->formats[$formatKey])) {
@@ -236,6 +237,7 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
     /**
      * {@inheritdoc}
      */
+    // TODO remove $formatOptions
     public function getFormatDefinitions($locale = null, array $formatOptions = [])
     {
         $definitionsArray = [];

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -225,6 +225,7 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
         }
 
         $formatArray = [
+            'internal' => $format['internal'],
             'key' => $format['key'],
             'title' => $title,
             'scale' => $format['scale'],

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -51,27 +51,23 @@ interface FormatManagerInterface
     public function getFormats($id, $fileName, $storageOptions, $version, $subVersion, $mimeType);
 
     /**
-     * Returns a definition of a format with a given key. The returned formats contain
-     * the passed format options merged into them.
+     * Returns a definition of a format with a given key.
      *
      * @param string $formatKey
      * @param string $locale
-     * @param array $formatOptions
      *
      * @return array
      */
-    public function getFormatDefinition($formatKey, $locale = null, array $formatOptions = []);
+    public function getFormatDefinition($formatKey, $locale = null);
 
     /**
-     * Returns all definitions of image formats. The returned formats contain the passed
-     * format-options merged into them.
+     * Returns all definitions of image formats.
      *
      * @param string $locale
-     * @param array $formatOptions
      *
      * @return array
      */
-    public function getFormatDefinitions($locale = null, array $formatOptions = []);
+    public function getFormatDefinitions($locale = null);
 
     /**
      * Delete the image by the given parameters.

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_api.yml
@@ -11,6 +11,10 @@ sulu_media.media_preview:
     parent: sulu_media.media
     resource: Sulu\Bundle\MediaBundle\Controller\MediaPreviewController
 
+sulu_media.format:
+    type: rest
+    resource: Sulu\Bundle\MediaBundle\Controller\FormatController
+
 sulu_media.media_format:
     type: rest
     parent: sulu_media.media

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_api.yml
@@ -11,7 +11,7 @@ sulu_media.media_preview:
     parent: sulu_media.media
     resource: Sulu\Bundle\MediaBundle\Controller\MediaPreviewController
 
-sulu_media.format:
+sulu_media.media_format:
     type: rest
     parent: sulu_media.media
-    resource: Sulu\Bundle\MediaBundle\Controller\FormatController
+    resource: Sulu\Bundle\MediaBundle\Controller\MediaFormatController

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -14,6 +14,7 @@ $downloadButtonBorderColorActive: $shakespeare;
 
 .media-card {
     width: 240px;
+    border: 1px solid $mediaCardBorderColor;
 
     &:hover,
     &.selected {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -81,7 +81,7 @@ export default class SingleMediaDropzone extends React.Component<Props> {
                 onDrop={this.handleDrop}
             >
                 {image &&
-                    <img className={singleMediaDropzoneStyles.thumbnail} src={image} />
+                    <img className={singleMediaDropzoneStyles.thumbnail} key={image} src={image} />
                 }
                 {!image && mimeType &&
                     <div className={singleMediaDropzoneStyles.mimeTypeIndicator}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
@@ -45,6 +45,19 @@ test('Render a SingleMediaDropzone while uploading', () => {
     )).toMatchSnapshot();
 });
 
+test('Render img tag with key to avoid keeping old image on new upload', () => {
+    const singleMediaDropzone = shallow(
+        <SingleMediaDropzone
+            image="http://lorempixel.com/400/400"
+            onDrop={jest.fn()}
+            progress={0}
+            uploading={false}
+        />
+    );
+
+    expect(singleMediaDropzone.find('img').key()).not.toBe(null);
+});
+
 test('Dragging a file over the area will show the upload indicator', () => {
     const singleMediaDropzone = shallow(
         <SingleMediaDropzone

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -5,10 +5,12 @@ import {MediaCardOverviewAdapter, MediaCardSelectionAdapter} from './containers/
 import {SingleMediaUpload} from './containers/Form';
 import MediaOverview from './views/MediaOverview';
 import MediaDetail from './views/MediaDetail';
+import MediaHistory from './views/MediaHistory';
 import MediaSelection from './containers/MediaSelection';
 
 viewRegistry.add('sulu_media.overview', MediaOverview);
 viewRegistry.add('sulu_media.detail', MediaDetail);
+viewRegistry.add('sulu_media.history', MediaHistory);
 
 datagridAdapterRegistry.add('media_card_overview', MediaCardOverviewAdapter);
 datagridAdapterRegistry.add('media_card_selection', MediaCardSelectionAdapter);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -6,10 +6,12 @@ import {SingleMediaUpload} from './containers/Form';
 import MediaOverview from './views/MediaOverview';
 import MediaDetail from './views/MediaDetail';
 import MediaHistory from './views/MediaHistory';
+import MediaFormats from './views/MediaFormats';
 import MediaSelection from './containers/MediaSelection';
 
 viewRegistry.add('sulu_media.overview', MediaOverview);
 viewRegistry.add('sulu_media.detail', MediaDetail);
+viewRegistry.add('sulu_media.formats', MediaFormats);
 viewRegistry.add('sulu_media.history', MediaHistory);
 
 datagridAdapterRegistry.add('media_card_overview', MediaCardOverviewAdapter);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
@@ -5,6 +5,7 @@
     "repository": "https://github.com/sulu/sulu.git",
     "dependencies": {
         "classnames": "^2.2.5",
+        "copy-to-clipboard": "^3.0.8",
         "fast-deep-equal": "^1.0.0",
         "react-clipboard.js": "^1.1.2",
         "react-dropzone": "^4.2.1",

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/FormatStore/FormatStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/FormatStore/FormatStore.js
@@ -1,0 +1,27 @@
+// @flow
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import {userStore} from 'sulu-admin-bundle/stores';
+
+class FormatStore {
+    formatPromise: Promise<Object>;
+
+    sendRequest(): Promise<Object> {
+        if (!userStore.user) {
+            throw new Error('A user must be logged in to load the webspaces with the correct locale');
+        }
+
+        if (!this.formatPromise) {
+            this.formatPromise = ResourceRequester.getList('formats', {locale: userStore.user.locale});
+        }
+
+        return this.formatPromise;
+    }
+
+    loadFormats(): Promise<Array<Object>> {
+        return this.sendRequest().then((response: Object) => {
+            return response._embedded.formats;
+        });
+    }
+}
+
+export default new FormatStore();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/FormatStore/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/FormatStore/index.js
@@ -1,0 +1,4 @@
+// @flow
+import FormatStore from './FormatStore';
+
+export default FormatStore;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/FormatStore/tests/FormatStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/FormatStore/tests/FormatStore.test.js
@@ -1,0 +1,74 @@
+// @flow
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import userStore from 'sulu-admin-bundle/stores/UserStore';
+import formatStore from '../FormatStore';
+
+jest.mock('sulu-admin-bundle/stores/UserStore', () => ({
+    user: undefined,
+}));
+
+jest.mock('sulu-admin-bundle/services', () => ({
+    ResourceRequester: {
+        getList: jest.fn().mockReturnValue({
+            then: jest.fn(),
+        }),
+    },
+}));
+
+test('Should fail if no user is logged in', () => {
+    expect(() => formatStore.loadFormats()).toThrow(/user must be logged in /);
+});
+
+test('Load localizations', () => {
+    userStore.user = {
+        id: 1,
+        locale: 'de',
+        settings: [],
+        username: 'test',
+    };
+
+    const response = {
+        _embedded: {
+            formats: [
+                {
+                    internal: false,
+                    key: '400x400',
+                    options: null,
+                    scale: {
+                        x: 400,
+                        y: 400,
+                        mode: 'outbound',
+                        retina: false,
+                        forceRatio: true,
+                    },
+                    title: 'Test EN',
+                },
+                {
+                    internal: false,
+                    key: '800x800',
+                    options: null,
+                    scale: {
+                        x: 800,
+                        y: 800,
+                        mode: 'outbound',
+                        retina: false,
+                        forceRatio: true,
+                    },
+                    title: 'Test1 EN',
+                },
+            ],
+        },
+    };
+
+    const promise = Promise.resolve(response);
+
+    ResourceRequester.getList.mockReturnValue(promise);
+
+    const formatPromise = formatStore.loadFormats();
+
+    return formatPromise.then((formats) => {
+        // check if promise has been cached
+        expect(formatStore.formatPromise).toEqual(formatPromise);
+        expect(formats).toBe(response._embedded.formats);
+    });
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -60,6 +60,10 @@ class MediaDetail extends React.Component<Props> {
         this.props.resourceStore.save();
     };
 
+    handleUploadComplete = (media: Object) => {
+        this.props.resourceStore.setMultiple(media);
+    };
+
     render() {
         return (
             <div className={mediaDetailStyles.mediaDetail}>
@@ -73,6 +77,7 @@ class MediaDetail extends React.Component<Props> {
                                     downloadable={false}
                                     imageSize="sulu-400x400-inset"
                                     mediaUploadStore={this.mediaUploadStore}
+                                    onUploadComplete={this.handleUploadComplete}
                                     uploadText={translate('sulu_media.upload_or_replace')}
                                 />
                             </Grid.Item>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -2,7 +2,7 @@
 import 'url-search-params-polyfill';
 import React from 'react';
 import {observable} from 'mobx';
-import {mount} from 'enzyme';
+import {mount, render} from 'enzyme';
 import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
 
 jest.mock('sulu-admin-bundle/containers', () => ({
@@ -73,9 +73,9 @@ test('Render a loading MediaDetail view', () => {
     const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
     resourceStore.loading = true;
 
-    expect(mount(
+    expect(render(
         <MediaDetail resourceStore={resourceStore} router={router} />
-    ).render()).toMatchSnapshot();
+    )).toMatchSnapshot();
 });
 
 test('Should change locale via locale chooser', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/__snapshots__/MediaDetail.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/__snapshots__/MediaDetail.test.js.snap
@@ -6,7 +6,7 @@ exports[`Render a loading MediaDetail view 1`] = `
 >
   <div
     class="spinner"
-    style="width: 40px; height: 40px;"
+    style="width:40px;height:40px"
   >
     <div
       class="doubleBounce1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/MediaFormats.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/MediaFormats.js
@@ -1,0 +1,122 @@
+// @flow
+import React from 'react';
+import {action, computed, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import copyToClipboard from 'copy-to-clipboard';
+import {Loader, Table} from 'sulu-admin-bundle/components';
+import {withToolbar} from 'sulu-admin-bundle/containers';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {translate} from 'sulu-admin-bundle/utils';
+import mediaFormatsStyles from './mediaFormats.scss';
+
+const COLLECTION_ROUTE = 'sulu_media.overview';
+
+type Props = ViewProps & {
+    resourceStore: ResourceStore,
+};
+
+@observer
+class MediaFormats extends React.Component<Props> {
+    @observable copySuccessThumbnailKey: ?string | number;
+
+    constructor(props: Props) {
+        super(props);
+
+        const {
+            router,
+            resourceStore,
+        } = this.props;
+
+        const locale = resourceStore.locale;
+
+        if (!locale) {
+            throw new Error('The resourceStore for the MediaFormats must have a locale');
+        }
+
+        router.bind('locale', locale);
+    }
+
+    @computed get thumbnails() {
+        return this.props.resourceStore.data.thumbnails;
+    }
+
+    handleDownloadClick = (id: string | number) => {
+        window.open(this.thumbnails[id] + '&inline=1');
+    };
+
+    @action handleCopyClick = (id: string | number) => {
+        copyToClipboard(this.thumbnails[id]);
+        this.copySuccessThumbnailKey = id;
+        setTimeout(action(() => this.copySuccessThumbnailKey = undefined), 500);
+    };
+
+    render() {
+        const {resourceStore} = this.props;
+
+        const buttons = [
+            {
+                icon: 'su-eye',
+                onClick: this.handleDownloadClick,
+            },
+            {
+                icon: 'su-copy',
+                onClick: this.handleCopyClick,
+            },
+        ];
+
+        return (
+            <div className={mediaFormatsStyles.mediaFormats}>
+                {resourceStore.loading
+                    ? <Loader />
+                    : <Table buttons={buttons}>
+                        <Table.Header>
+                            <Table.HeaderCell>{translate('sulu_media.format')}</Table.HeaderCell>
+                        </Table.Header>
+                        <Table.Body>
+                            {Object.keys(this.thumbnails).map((thumbnailKey: string) => (
+                                <Table.Row
+                                    buttons={
+                                        this.copySuccessThumbnailKey === thumbnailKey
+                                            ? [buttons[0], {icon: 'su-check', onClick: undefined}]
+                                            : buttons
+                                    }
+                                    id={thumbnailKey}
+                                    key={thumbnailKey}
+                                >
+                                    <Table.Cell>{thumbnailKey}</Table.Cell>
+                                </Table.Row>
+                            ))}
+                        </Table.Body>
+                    </Table>
+                }
+            </div>
+        );
+    }
+}
+
+export default withToolbar(MediaFormats, function() {
+    const {resourceStore, router} = this.props;
+    const {locales} = router.route.options;
+    const locale = locales
+        ? {
+            value: resourceStore.locale.get(),
+            onChange: (locale) => {
+                resourceStore.setLocale(locale);
+            },
+            options: locales.map((locale) => ({
+                value: locale,
+                label: locale,
+            })),
+        }
+        : undefined;
+
+    return {
+        locale,
+        backButton: {
+            onClick: () => {
+                router.restore(COLLECTION_ROUTE, {locale: resourceStore.locale.get()});
+            },
+        },
+    };
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/README.md
@@ -1,0 +1,7 @@
+The `MediaFormats` view is registered with the key `sulu_media.formats`. It shows a list of avaible image formats of a
+file using the `ResourceStore` it receives from the [`ResourceTabs`](#resourcetabs) view. It also allows opening the
+each image format as well as copying the URL to this image format.
+
+Option  | Description
+--------|------------------------------------------------------------------------
+locales | Defines which locales are available in the locale chooser of this form.

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/index.js
@@ -1,0 +1,4 @@
+// @flow
+import MediaFormats from './MediaFormats';
+
+export default MediaFormats;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/mediaFormats.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/mediaFormats.scss
@@ -1,0 +1,7 @@
+@import 'sulu-admin-bundle/containers/Application/variables.scss';
+
+.media-formats {
+    padding: $viewPadding;
+    max-width: $viewMaxWidth;
+    min-width: $viewMinWidth;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
@@ -26,6 +26,10 @@ jest.mock('sulu-admin-bundle/utils', () => ({
     translate: (key) => key,
 }));
 
+jest.mock('../../../stores/FormatStore', () => ({
+    loadFormats: jest.fn(),
+}));
+
 beforeEach(() => {
     jest.resetModules();
 });
@@ -49,7 +53,39 @@ test('Render a loading MediaFormats view', () => {
     )).toMatchSnapshot();
 });
 
+test('Render a loading MediaFormats view if formats have not been loaded yet', () => {
+    const MediaFormats = require('../MediaFormats').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.loading = false;
+
+    expect(render(
+        <MediaFormats resourceStore={resourceStore} router={router} />
+    )).toMatchSnapshot();
+});
+
 test('Render a MediaFormats view', () => {
+    const formatStore = require('../../../stores/FormatStore');
+    const formatPromise = Promise.resolve([
+        {
+            key: '400x400',
+            title: 'Contact',
+        },
+        {
+            key: '800x800',
+            title: 'Account',
+        },
+    ]);
+    formatStore.loadFormats.mockReturnValue(formatPromise);
+
     const MediaFormats = require('../MediaFormats').default;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
     const router = {
@@ -66,12 +102,25 @@ test('Render a MediaFormats view', () => {
         '800x800': '/media/800x800/image.jpg',
     };
 
-    expect(render(
-        <MediaFormats resourceStore={resourceStore} router={router} />
-    )).toMatchSnapshot();
+    const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />);
+
+    return formatPromise.then(() => {
+        expect(mediaFormats.render()).toMatchSnapshot();
+    });
 });
 
 test('Open the image in the given format when icon is clicked', () => {
+    const formatStore = require('../../../stores/FormatStore');
+    const formatPromise = Promise.resolve([
+        {
+            key: '400x400',
+        },
+        {
+            key: '800x800',
+        },
+    ]);
+    formatStore.loadFormats.mockReturnValue(formatPromise);
+
     window.open = jest.fn();
 
     const MediaFormats = require('../MediaFormats').default;
@@ -92,13 +141,28 @@ test('Open the image in the given format when icon is clicked', () => {
 
     const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />);
 
-    mediaFormats.find('Row').at(0).find('ButtonCell').at(0).prop('onClick')('400x400');
-    expect(window.open).toHaveBeenLastCalledWith('/media/400x400/image.jpg?v=1&inline=1');
-    mediaFormats.find('Row').at(1).find('ButtonCell').at(0).prop('onClick')('800x800');
-    expect(window.open).toHaveBeenLastCalledWith('/media/800x800/image.jpg?v=1&inline=1');
+    return formatPromise.then(() => {
+        mediaFormats.update();
+
+        mediaFormats.find('Row').at(0).find('ButtonCell').at(0).prop('onClick')('400x400');
+        expect(window.open).toHaveBeenLastCalledWith('/media/400x400/image.jpg?v=1&inline=1');
+        mediaFormats.find('Row').at(1).find('ButtonCell').at(0).prop('onClick')('800x800');
+        expect(window.open).toHaveBeenLastCalledWith('/media/800x800/image.jpg?v=1&inline=1');
+    });
 });
 
 test('Copy the image URL for the given format when icon is clicked and show a success message', () => {
+    const formatStore = require('../../../stores/FormatStore');
+    const formatPromise = Promise.resolve([
+        {
+            key: '400x400',
+        },
+        {
+            key: '800x800',
+        },
+    ]);
+    formatStore.loadFormats.mockReturnValue(formatPromise);
+
     const copyToClipboard = require('copy-to-clipboard');
     const MediaFormats = require('../MediaFormats').default;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
@@ -118,24 +182,31 @@ test('Copy the image URL for the given format when icon is clicked and show a su
 
     const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />);
 
-    mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('onClick')('400x400');
-    expect(copyToClipboard).toHaveBeenLastCalledWith('/media/400x400/image.jpg?v=1');
-    mediaFormats.update();
-    expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-check');
-    jest.runAllTimers();
-    mediaFormats.update();
-    expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-copy');
+    return formatPromise.then(() => {
+        mediaFormats.update();
 
-    mediaFormats.find('Row').at(1).find('ButtonCell').at(1).prop('onClick')('800x800');
-    expect(copyToClipboard).toHaveBeenLastCalledWith('/media/800x800/image.jpg?v=1');
-    mediaFormats.update();
-    expect(mediaFormats.find('Row').at(1).find('ButtonCell').at(1).prop('icon')).toEqual('su-check');
-    jest.runAllTimers();
-    mediaFormats.update();
-    expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-copy');
+        mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('onClick')('400x400');
+        expect(copyToClipboard).toHaveBeenLastCalledWith('/media/400x400/image.jpg?v=1');
+        mediaFormats.update();
+        expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-check');
+        jest.runAllTimers();
+        mediaFormats.update();
+        expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-copy');
+
+        mediaFormats.find('Row').at(1).find('ButtonCell').at(1).prop('onClick')('800x800');
+        expect(copyToClipboard).toHaveBeenLastCalledWith('/media/800x800/image.jpg?v=1');
+        mediaFormats.update();
+        expect(mediaFormats.find('Row').at(1).find('ButtonCell').at(1).prop('icon')).toEqual('su-check');
+        jest.runAllTimers();
+        mediaFormats.update();
+        expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-copy');
+    });
 });
 
 test('Should change locale via locale chooser', () => {
+    const formatStore = require('../../../stores/FormatStore');
+    formatStore.loadFormats.mockReturnValue(Promise.resolve());
+
     const MediaFormats = require('../MediaFormats').default;
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
@@ -159,6 +230,9 @@ test('Should change locale via locale chooser', () => {
 });
 
 test('Should show locales from router options in toolbar', () => {
+    const formatStore = require('../../../stores/FormatStore');
+    formatStore.loadFormats.mockReturnValue(Promise.resolve());
+
     const MediaFormats = require('../MediaFormats').default;
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
@@ -183,6 +257,9 @@ test('Should show locales from router options in toolbar', () => {
 });
 
 test('Should navigate to defined route on back button click', () => {
+    const formatStore = require('../../../stores/FormatStore');
+    formatStore.loadFormats.mockReturnValue(Promise.resolve());
+
     const MediaFormats = require('../MediaFormats').default;
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
@@ -1,0 +1,206 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import {observable} from 'mobx';
+import {mount, render} from 'enzyme';
+import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
+
+jest.useFakeTimers();
+
+jest.mock('copy-to-clipboard', () => jest.fn());
+
+jest.mock('sulu-admin-bundle/containers', () => ({
+    withToolbar: jest.fn((Component) => Component),
+}));
+
+jest.mock('sulu-admin-bundle/stores', () => ({
+    ResourceStore: jest.fn(function(resourceKey, id, observableOptions = {}) {
+        this.locale = observableOptions.locale;
+        this.data = {
+            thumbnails: {},
+        };
+        this.setLocale = jest.fn();
+    }),
+}));
+
+jest.mock('sulu-admin-bundle/utils', () => ({
+    translate: (key) => key,
+}));
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+test('Render a loading MediaFormats view', () => {
+    const MediaFormats = require('../MediaFormats').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.loading = true;
+
+    expect(render(
+        <MediaFormats resourceStore={resourceStore} router={router} />
+    )).toMatchSnapshot();
+});
+
+test('Render a MediaFormats view', () => {
+    const MediaFormats = require('../MediaFormats').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.data.thumbnails = {
+        '400x400': '/media/400x400/image.jpg',
+        '800x800': '/media/800x800/image.jpg',
+    };
+
+    expect(render(
+        <MediaFormats resourceStore={resourceStore} router={router} />
+    )).toMatchSnapshot();
+});
+
+test('Open the image in the given format when icon is clicked', () => {
+    window.open = jest.fn();
+
+    const MediaFormats = require('../MediaFormats').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.data.thumbnails = {
+        '400x400': '/media/400x400/image.jpg?v=1',
+        '800x800': '/media/800x800/image.jpg?v=1',
+    };
+
+    const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />);
+
+    mediaFormats.find('Row').at(0).find('ButtonCell').at(0).prop('onClick')('400x400');
+    expect(window.open).toHaveBeenLastCalledWith('/media/400x400/image.jpg?v=1&inline=1');
+    mediaFormats.find('Row').at(1).find('ButtonCell').at(0).prop('onClick')('800x800');
+    expect(window.open).toHaveBeenLastCalledWith('/media/800x800/image.jpg?v=1&inline=1');
+});
+
+test('Copy the image URL for the given format when icon is clicked and show a success message', () => {
+    const copyToClipboard = require('copy-to-clipboard');
+    const MediaFormats = require('../MediaFormats').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.data.thumbnails = {
+        '400x400': '/media/400x400/image.jpg?v=1',
+        '800x800': '/media/800x800/image.jpg?v=1',
+    };
+
+    const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />);
+
+    mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('onClick')('400x400');
+    expect(copyToClipboard).toHaveBeenLastCalledWith('/media/400x400/image.jpg?v=1');
+    mediaFormats.update();
+    expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-check');
+    jest.runAllTimers();
+    mediaFormats.update();
+    expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-copy');
+
+    mediaFormats.find('Row').at(1).find('ButtonCell').at(1).prop('onClick')('800x800');
+    expect(copyToClipboard).toHaveBeenLastCalledWith('/media/800x800/image.jpg?v=1');
+    mediaFormats.update();
+    expect(mediaFormats.find('Row').at(1).find('ButtonCell').at(1).prop('icon')).toEqual('su-check');
+    jest.runAllTimers();
+    mediaFormats.update();
+    expect(mediaFormats.find('Row').at(0).find('ButtonCell').at(1).prop('icon')).toEqual('su-copy');
+});
+
+test('Should change locale via locale chooser', () => {
+    const MediaFormats = require('../MediaFormats').default;
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaFormats);
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />).get(0);
+    resourceStore.locale.set('de');
+
+    const toolbarConfig = toolbarFunction.call(mediaFormats);
+    toolbarConfig.locale.onChange('en');
+    expect(resourceStore.setLocale).toBeCalledWith('en');
+});
+
+test('Should show locales from router options in toolbar', () => {
+    const MediaFormats = require('../MediaFormats').default;
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaFormats);
+    const resourceStore = new ResourceStore('media', 1, {locale: observable.box()});
+
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['en', 'de'],
+            },
+        },
+    };
+    const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />).get(0);
+
+    const toolbarConfig = toolbarFunction.call(mediaFormats);
+    expect(toolbarConfig.locale.options).toEqual([
+        {value: 'en', label: 'en'},
+        {value: 'de', label: 'de'},
+    ]);
+});
+
+test('Should navigate to defined route on back button click', () => {
+    const MediaFormats = require('../MediaFormats').default;
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaFormats);
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box('de')});
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const mediaFormats = mount(<MediaFormats resourceStore={resourceStore} router={router} />).get(0);
+
+    const toolbarConfig = toolbarFunction.call(mediaFormats);
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('sulu_media.overview', {locale: 'de'});
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/__snapshots__/MediaFormats.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/__snapshots__/MediaFormats.test.js.snap
@@ -1,0 +1,151 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render a MediaFormats view 1`] = `
+<div
+  class="mediaFormats"
+>
+  <div
+    class="tableContainer"
+  >
+    <table
+      class="table"
+    >
+      <thead
+        class="header"
+      >
+        <tr>
+          <th
+            class="headerButtonCell headerCell"
+          >
+            <span>
+              <span
+                aria-label="su-eye"
+                class="su-eye"
+              />
+            </span>
+          </th>
+          <th
+            class="headerButtonCell headerCell"
+          >
+            <span>
+              <span
+                aria-label="su-copy"
+                class="su-copy"
+              />
+            </span>
+          </th>
+          <th
+            class="headerCell"
+          >
+            <span>
+              sulu_media.format
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="buttonCell cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <button>
+                <span
+                  aria-label="su-eye"
+                  class="su-eye"
+                />
+              </button>
+            </div>
+          </td>
+          <td
+            class="buttonCell cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <button>
+                <span
+                  aria-label="su-copy"
+                  class="su-copy"
+                />
+              </button>
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              400x400
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="buttonCell cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <button>
+                <span
+                  aria-label="su-eye"
+                  class="su-eye"
+                />
+              </button>
+            </div>
+          </td>
+          <td
+            class="buttonCell cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <button>
+                <span
+                  aria-label="su-copy"
+                  class="su-copy"
+                />
+              </button>
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              800x800
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Render a loading MediaFormats view 1`] = `
+<div
+  class="mediaFormats"
+>
+  <div
+    class="spinner"
+    style="width:40px;height:40px"
+  >
+    <div
+      class="doubleBounce1"
+    />
+    <div
+      class="doubleBounce2"
+    />
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/__snapshots__/MediaFormats.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/__snapshots__/MediaFormats.test.js.snap
@@ -38,7 +38,14 @@ exports[`Render a MediaFormats view 1`] = `
             class="headerCell"
           >
             <span>
-              sulu_media.format
+              sulu_admin.title
+            </span>
+          </th>
+          <th
+            class="headerCell"
+          >
+            <span>
+              sulu_admin.key
             </span>
           </th>
         </tr>
@@ -73,6 +80,15 @@ exports[`Render a MediaFormats view 1`] = `
                   class="su-copy"
                 />
               </button>
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              Contact
             </div>
           </td>
           <td
@@ -122,6 +138,15 @@ exports[`Render a MediaFormats view 1`] = `
             <div
               class="cellContent"
             >
+              Account
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
               800x800
             </div>
           </td>
@@ -133,6 +158,24 @@ exports[`Render a MediaFormats view 1`] = `
 `;
 
 exports[`Render a loading MediaFormats view 1`] = `
+<div
+  class="mediaFormats"
+>
+  <div
+    class="spinner"
+    style="width:40px;height:40px"
+  >
+    <div
+      class="doubleBounce1"
+    />
+    <div
+      class="doubleBounce2"
+    />
+  </div>
+</div>
+`;
+
+exports[`Render a loading MediaFormats view if formats have not been loaded yet 1`] = `
 <div
   class="mediaFormats"
 >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/MediaHistory.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/MediaHistory.js
@@ -1,0 +1,109 @@
+// @flow
+import React from 'react';
+import {computed} from 'mobx';
+import {observer} from 'mobx-react';
+import {Loader, Table} from 'sulu-admin-bundle/components';
+import {withToolbar} from 'sulu-admin-bundle/containers';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {translate} from 'sulu-admin-bundle/utils';
+import mediaHistoryStyles from './mediaHistory.scss';
+
+const COLLECTION_ROUTE = 'sulu_media.overview';
+
+type Props = ViewProps & {
+    resourceStore: ResourceStore,
+};
+
+@observer
+class MediaHistory extends React.Component<Props> {
+    constructor(props: Props) {
+        super(props);
+
+        const {
+            router,
+            resourceStore,
+        } = this.props;
+
+        const locale = resourceStore.locale;
+
+        if (!locale) {
+            throw new Error('The resourceStore for the MediaHistory must have a locale');
+        }
+
+        router.bind('locale', locale);
+    }
+
+    @computed get versions(): Array<Object> {
+        // $FlowFixMe
+        return Object.values(this.props.resourceStore.data.versions);
+    }
+
+    handleShowClick = (id: string | number) => {
+        const version = this.versions.find((version) => version.version === id);
+        if (!version) {
+            throw new Error('Version "' + id + '" was not found. This should not happen and is likely a bug.');
+        }
+
+        window.open(version.url + '&inline=1');
+    };
+
+    render() {
+        const {resourceStore} = this.props;
+
+        const buttons = [
+            {
+                icon: 'su-eye',
+                onClick: this.handleShowClick,
+            },
+        ];
+
+        return (
+            <div className={mediaHistoryStyles.mediaHistory}>
+                {resourceStore.loading
+                    ? <Loader />
+                    : <Table buttons={buttons}>
+                        <Table.Header>
+                            <Table.HeaderCell>{translate('sulu_media.version')}</Table.HeaderCell>
+                            <Table.HeaderCell>{translate('sulu_admin.created')}</Table.HeaderCell>
+                        </Table.Header>
+                        <Table.Body>
+                            {this.versions.reverse().map((version: Object) => (
+                                <Table.Row id={version.version} key={version.version}>
+                                    <Table.Cell>{translate('sulu_media.version')} {version.version}</Table.Cell>
+                                    <Table.Cell>{(new Date(version.created)).toLocaleString()}</Table.Cell>
+                                </Table.Row>
+                            ))}
+                        </Table.Body>
+                    </Table>
+                }
+            </div>
+        );
+    }
+}
+
+export default withToolbar(MediaHistory, function() {
+    const {resourceStore, router} = this.props;
+    const {locales} = router.route.options;
+    const locale = locales
+        ? {
+            value: resourceStore.locale.get(),
+            onChange: (locale) => {
+                resourceStore.setLocale(locale);
+            },
+            options: locales.map((locale) => ({
+                value: locale,
+                label: locale,
+            })),
+        }
+        : undefined;
+
+    return {
+        locale,
+        backButton: {
+            onClick: () => {
+                router.restore(COLLECTION_ROUTE, {locale: resourceStore.locale.get()});
+            },
+        },
+    };
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/README.md
@@ -1,0 +1,7 @@
+The `MediaHistory` view is registered with the key `sulu_media.history`. It shows a list of different versions of a file
+using the `ResourceStore` it receives from the [`ResourceTabs`](#resourcetabs) view. It also allows opening the old
+versions in a new window.
+
+Option  | Description
+--------|------------------------------------------------------------------------
+locales | Defines which locales are available in the locale chooser of this form.

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/index.js
@@ -1,0 +1,4 @@
+// @flow
+import MediaHistory from './MediaHistory';
+
+export default MediaHistory;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/mediaHistory.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/mediaHistory.scss
@@ -1,0 +1,7 @@
+@import 'sulu-admin-bundle/containers/Application/variables.scss';
+
+.media-history {
+    padding: $viewPadding;
+    max-width: $viewMaxWidth;
+    min-width: $viewMinWidth;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js
@@ -1,0 +1,184 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import React from 'react';
+import {observable} from 'mobx';
+import {mount, render} from 'enzyme';
+import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
+
+jest.mock('sulu-admin-bundle/containers', () => ({
+    withToolbar: jest.fn((Component) => Component),
+}));
+
+jest.mock('sulu-admin-bundle/stores', () => ({
+    ResourceStore: jest.fn(function(resourceKey, id, observableOptions = {}) {
+        this.locale = observableOptions.locale;
+        this.data = {
+            versions: {},
+        };
+        this.setLocale = jest.fn();
+    }),
+}));
+
+jest.mock('sulu-admin-bundle/utils', () => ({
+    translate: (key) => key,
+}));
+
+beforeEach(() => {
+    jest.resetModules();
+});
+
+test('Render a loading MediaHistory view', () => {
+    const MediaHistory = require('../MediaHistory').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.loading = true;
+
+    expect(render(
+        <MediaHistory resourceStore={resourceStore} router={router} />
+    )).toMatchSnapshot();
+});
+
+test('Render a MediaHistory view', () => {
+    const MediaHistory = require('../MediaHistory').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.data.versions = {
+        1: {
+            created: '2018-10-23T10:18',
+            version: 1,
+        },
+        2: {
+            created: '2018-10-23T10:25',
+            version: 2,
+        },
+    };
+
+    expect(render(
+        <MediaHistory resourceStore={resourceStore} router={router} />
+    )).toMatchSnapshot();
+});
+
+test('Open the old media when icon is clicked', () => {
+    window.open = jest.fn();
+
+    const MediaHistory = require('../MediaHistory').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    resourceStore.data.versions = {
+        1: {
+            created: '2018-10-23T10:18',
+            url: '/media/1?v=1',
+            version: 1,
+        },
+        2: {
+            created: '2018-10-23T10:25',
+            url: '/media/1?v=2',
+            version: 2,
+        },
+    };
+
+    const mediaHistory = mount(<MediaHistory resourceStore={resourceStore} router={router} />);
+
+    mediaHistory.find('Row').at(0).find('ButtonCell').prop('onClick')(1);
+    expect(window.open).toHaveBeenLastCalledWith('/media/1?v=1&inline=1');
+    mediaHistory.find('Row').at(1).find('ButtonCell').prop('onClick')(2);
+    expect(window.open).toHaveBeenLastCalledWith('/media/1?v=2&inline=1');
+});
+
+test('Should change locale via locale chooser', () => {
+    const MediaHistory = require('../MediaHistory').default;
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaHistory);
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+
+    const router = {
+        navigate: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const mediaHistory = mount(<MediaHistory resourceStore={resourceStore} router={router} />).get(0);
+    resourceStore.locale.set('de');
+
+    const toolbarConfig = toolbarFunction.call(mediaHistory);
+    toolbarConfig.locale.onChange('en');
+    expect(resourceStore.setLocale).toBeCalledWith('en');
+});
+
+test('Should show locales from router options in toolbar', () => {
+    const MediaHistory = require('../MediaHistory').default;
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaHistory);
+    const resourceStore = new ResourceStore('media', 1, {locale: observable.box()});
+
+    const router = {
+        navigate: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['en', 'de'],
+            },
+        },
+    };
+    const mediaHistory = mount(<MediaHistory resourceStore={resourceStore} router={router} />).get(0);
+
+    const toolbarConfig = toolbarFunction.call(mediaHistory);
+    expect(toolbarConfig.locale.options).toEqual([
+        {value: 'en', label: 'en'},
+        {value: 'de', label: 'de'},
+    ]);
+});
+
+test('Should navigate to defined route on back button click', () => {
+    const MediaHistory = require('../MediaHistory').default;
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaHistory);
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box('de')});
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+    };
+    const mediaHistory = mount(<MediaHistory resourceStore={resourceStore} router={router} />).get(0);
+
+    const toolbarConfig = toolbarFunction.call(mediaHistory);
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('sulu_media.overview', {locale: 'de'});
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/__snapshots__/MediaHistory.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/__snapshots__/MediaHistory.test.js.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render a MediaHistory view 1`] = `
+<div
+  class="mediaHistory"
+>
+  <div
+    class="tableContainer"
+  >
+    <table
+      class="table"
+    >
+      <thead
+        class="header"
+      >
+        <tr>
+          <th
+            class="headerButtonCell headerCell"
+          >
+            <span>
+              <span
+                aria-label="su-eye"
+                class="su-eye"
+              />
+            </span>
+          </th>
+          <th
+            class="headerCell"
+          >
+            <span>
+              sulu_media.version
+            </span>
+          </th>
+          <th
+            class="headerCell"
+          >
+            <span>
+              sulu_admin.created
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="buttonCell cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <button>
+                <span
+                  aria-label="su-eye"
+                  class="su-eye"
+                />
+              </button>
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              sulu_media.version 2
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              10/23/2018, 10:25:00 AM
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="buttonCell cell"
+          >
+            <div
+              class="cellContent"
+            >
+              <button>
+                <span
+                  aria-label="su-eye"
+                  class="su-eye"
+                />
+              </button>
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              sulu_media.version 1
+            </div>
+          </td>
+          <td
+            class="cell"
+          >
+            <div
+              class="cellContent"
+            >
+              10/23/2018, 10:18:00 AM
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Render a loading MediaHistory view 1`] = `
+<div
+  class="mediaHistory"
+>
+  <div
+    class="spinner"
+    style="width:40px;height:40px"
+  >
+    <div
+      class="doubleBounce1"
+    />
+    <div
+      class="doubleBounce2"
+    />
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -27,5 +27,6 @@
     "sulu_media.mime_type": "MIME-Typ",
     "sulu_media.license": "Lizenz",
     "sulu_media.copyright": "Copyright Informationen",
-    "sulu_media.taxonomies": "Taxonomien"
+    "sulu_media.taxonomies": "Taxonomien",
+    "sulu_media.history": "Verlauf"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -28,5 +28,7 @@
     "sulu_media.license": "Lizenz",
     "sulu_media.copyright": "Copyright Informationen",
     "sulu_media.taxonomies": "Taxonomien",
-    "sulu_media.history": "Verlauf"
+    "sulu_media.history": "Verlauf",
+    "sulu_media.formats": "Formate",
+    "sulu_media.format": "Format"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -29,6 +29,5 @@
     "sulu_media.copyright": "Copyright Informationen",
     "sulu_media.taxonomies": "Taxonomien",
     "sulu_media.history": "Verlauf",
-    "sulu_media.formats": "Formate",
-    "sulu_media.format": "Format"
+    "sulu_media.formats": "Formate"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -27,5 +27,6 @@
     "sulu_media.mime_type": "MIME-Type",
     "sulu_media.license": "License",
     "sulu_media.copyright": "Copyright Information",
-    "sulu_media.taxonomies": "Taxonomies"
+    "sulu_media.taxonomies": "Taxonomies",
+    "sulu_media.history": "History"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -28,5 +28,7 @@
     "sulu_media.license": "License",
     "sulu_media.copyright": "Copyright Information",
     "sulu_media.taxonomies": "Taxonomies",
-    "sulu_media.history": "History"
+    "sulu_media.history": "History",
+    "sulu_media.formats": "Formats",
+    "sulu_media.format": "Format"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -29,6 +29,5 @@
     "sulu_media.copyright": "Copyright Information",
     "sulu_media.taxonomies": "Taxonomies",
     "sulu_media.history": "History",
-    "sulu_media.formats": "Formats",
-    "sulu_media.format": "Format"
+    "sulu_media.formats": "Formats"
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
+
+use Doctrine\ORM\EntityManager;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionType;
+use Sulu\Bundle\MediaBundle\Entity\File;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
+use Sulu\Bundle\MediaBundle\Entity\Media;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class FormatControllerTest extends SuluTestCase
+{
+    /**
+     * @var FormatOptions[]
+     */
+    private $formatOptions;
+
+    public function testCGet()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/api/formats?locale=de');
+
+        $response = json_decode($client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $formats = $response->_embedded->formats;
+
+        $this->assertCount(13, $formats);
+        $this->assertTrue($formats[0]->internal);
+        $this->assertEquals('sulu-400x400', $formats[0]->key);
+        $this->assertEquals('Kontaktavatar (Sulu)', $formats[0]->title);
+        $this->assertEquals(
+            [
+                'x' => 400,
+                'y' => 400,
+                'mode' => 'outbound',
+                'retina' => false,
+                'forceRatio' => true,
+            ],
+            (array) $formats[0]->scale
+        );
+    }
+
+    public function testCGetWithoutLocale()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/formats');
+
+        $this->assertHttpStatusCode(400, $client->getResponse());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
@@ -11,15 +11,8 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
-use Doctrine\ORM\EntityManager;
-use Sulu\Bundle\MediaBundle\Entity\Collection;
-use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Bundle\MediaBundle\Entity\File;
-use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
-use Sulu\Bundle\MediaBundle\Entity\Media;
-use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
-use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class FormatControllerTest extends SuluTestCase

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
@@ -22,7 +22,7 @@ use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
-class FormatControllerTest extends SuluTestCase
+class MediaFormatControllerTest extends SuluTestCase
 {
     /**
      * @var EntityManager

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaFormatControllerTest.php
@@ -122,31 +122,13 @@ class MediaFormatControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotNull($response->{'big-squared'});
-        $this->assertEquals('big-squared', $response->{'big-squared'}->key);
-        $this->assertEquals('My big squared format', $response->{'big-squared'}->title);
-        $this->assertEquals(400, $response->{'big-squared'}->scale->x);
-        $this->assertEquals(400, $response->{'big-squared'}->scale->y);
-        $this->assertEquals('outbound', $response->{'big-squared'}->scale->mode);
-        $this->assertEquals(30, $response->{'big-squared'}->options->cropX);
-        $this->assertEquals(31, $response->{'big-squared'}->options->cropY);
-        $this->assertEquals(32, $response->{'big-squared'}->options->cropHeight);
-        $this->assertEquals(33, $response->{'big-squared'}->options->cropWidth);
+        $this->assertEquals(30, $response->{'big-squared'}->cropX);
+        $this->assertEquals(31, $response->{'big-squared'}->cropY);
+        $this->assertEquals(32, $response->{'big-squared'}->cropHeight);
+        $this->assertEquals(33, $response->{'big-squared'}->cropWidth);
 
-        $this->assertNotNull($response->{'small-inset'});
-        $this->assertEquals('small-inset', $response->{'small-inset'}->key);
-        $this->assertEquals('My small inset format', $response->{'small-inset'}->title);
-        $this->assertEquals(50, $response->{'small-inset'}->scale->x);
-        $this->assertEquals(50, $response->{'small-inset'}->scale->y);
-        $this->assertEquals('inset', $response->{'small-inset'}->scale->mode);
-        $this->assertNull($response->{'small-inset'}->options);
-
-        $this->assertNotNull($response->{'one-side'});
-        $this->assertEquals('one-side', $response->{'one-side'}->key);
-        $this->assertEquals('My one sided format', $response->{'one-side'}->title);
-        $this->assertEquals(200, $response->{'one-side'}->scale->x);
-        $this->assertNull($response->{'one-side'}->scale->y);
-        $this->assertEquals('outbound', $response->{'one-side'}->scale->mode);
-        $this->assertNull($response->{'one-side'}->options);
+        $this->assertObjectNotHasAttribute('small-inset', $response);
+        $this->assertObjectNotHasAttribute('one-side', $response);
     }
 
     public function testCGetWithoutLocale()
@@ -182,15 +164,10 @@ class MediaFormatControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertHttpStatusCode(200, $client->getResponse());
 
-        $this->assertEquals('small-inset', $response->key);
-        $this->assertEquals('Mein kleines inset Format', $response->title);
-        $this->assertEquals(50, $response->scale->x);
-        $this->assertEquals(50, $response->scale->y);
-        $this->assertEquals('inset', $response->scale->mode);
-        $this->assertEquals(10, $response->options->cropX);
-        $this->assertEquals(15, $response->options->cropY);
-        $this->assertEquals(100, $response->options->cropWidth);
-        $this->assertEquals(100, $response->options->cropHeight);
+        $this->assertEquals(10, $response->cropX);
+        $this->assertEquals(15, $response->cropY);
+        $this->assertEquals(100, $response->cropWidth);
+        $this->assertEquals(100, $response->cropHeight);
 
         // Test if the options have really been persisted
 
@@ -208,10 +185,10 @@ class MediaFormatControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertNotNull($response->{'small-inset'});
-        $this->assertEquals(10, $response->{'small-inset'}->options->cropX);
-        $this->assertEquals(15, $response->{'small-inset'}->options->cropY);
-        $this->assertEquals(100, $response->{'small-inset'}->options->cropWidth);
-        $this->assertEquals(100, $response->{'small-inset'}->options->cropHeight);
+        $this->assertEquals(10, $response->{'small-inset'}->cropX);
+        $this->assertEquals(15, $response->{'small-inset'}->cropY);
+        $this->assertEquals(100, $response->{'small-inset'}->cropWidth);
+        $this->assertEquals(100, $response->{'small-inset'}->cropHeight);
     }
 
     public function testPutWithEmptyFormatOptions()
@@ -230,12 +207,7 @@ class MediaFormatControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertHttpStatusCode(200, $client->getResponse());
 
-        $this->assertEquals('big-squared', $response->key);
-        $this->assertEquals('My big squared format', $response->title);
-        $this->assertEquals(400, $response->scale->x);
-        $this->assertEquals(400, $response->scale->y);
-        $this->assertEquals('outbound', $response->scale->mode);
-        $this->assertNull($response->options);
+        $this->assertEquals([], $response);
 
         // Test if the options have really been persisted
         $client = $this->createAuthenticatedClient();
@@ -251,8 +223,7 @@ class MediaFormatControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertHttpStatusCode(200, $client->getResponse());
 
-        $this->assertNotNull($response->{'big-squared'});
-        $this->assertNull($response->{'big-squared'}->options);
+        $this->assertObjectNotHasAttribute('big-squared', $response);
     }
 
     public function testPutNotExistingFormat()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -59,6 +59,7 @@ class FormatManagerTest extends TestCase
         $this->supportedMimeTypes = ['image/*', 'video/*'];
         $this->formats = [
             '640x480' => [
+                'internal' => false,
                 'key' => '640x480',
                 'meta' => [
                     'title' => [
@@ -78,6 +79,7 @@ class FormatManagerTest extends TestCase
                 ],
             ],
             '50x50' => [
+                'internal' => true,
                 'key' => '50x50',
                 'meta' => [
                     'title' => [],
@@ -222,6 +224,7 @@ class FormatManagerTest extends TestCase
         $format = $this->formatManager->getFormatDefinition('640x480', 'en', ['my-option' => 'my-value']);
 
         $this->assertEquals('640x480', $format['key']);
+        $this->assertEquals(false, $format['internal']);
         $this->assertEquals('My image format for testing', $format['title']);
         $this->assertEquals(['x' => 640, 'y' => 480, 'mode' => 'outbound'], $format['scale']);
         $this->assertEquals(['my-option' => 'my-value'], $format['options']);
@@ -245,6 +248,7 @@ class FormatManagerTest extends TestCase
 
         $this->assertEquals(
             [
+                'internal' => false,
                 'key' => '640x480',
                 'title' => 'Mein Bildformat zum Testen',
                 'scale' => [
@@ -259,6 +263,7 @@ class FormatManagerTest extends TestCase
 
         $this->assertEquals(
             [
+                'internal' => true,
                 'key' => '50x50',
                 'title' => '50x50',
                 'scale' => [

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -227,7 +227,6 @@ class FormatManagerTest extends TestCase
         $this->assertEquals(false, $format['internal']);
         $this->assertEquals('My image format for testing', $format['title']);
         $this->assertEquals(['x' => 640, 'y' => 480, 'mode' => 'outbound'], $format['scale']);
-        $this->assertEquals(['my-option' => 'my-value'], $format['options']);
     }
 
     public function testGetFormatDefinitionNotExistingTitle()
@@ -256,7 +255,6 @@ class FormatManagerTest extends TestCase
                     'y' => 480,
                     'mode' => 'outbound',
                 ],
-                'options' => null,
             ],
             $formats['640x480']
         );
@@ -271,7 +269,6 @@ class FormatManagerTest extends TestCase
                     'y' => 480,
                     'mode' => 'outbound',
                 ],
-                'options' => null,
             ],
             $formats['50x50']
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a tab for the different version of media in the media form.

#### Why?

Because the content manager might be interested in the history of a media.