### PR TITLE
Added support for autowire for rest helper and field descriptor factory

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/list_builder.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/list_builder.xml
@@ -10,6 +10,8 @@
             <argument type="string">%sulu.cache_dir%/field_descriptor</argument>
             <argument>%kernel.debug%</argument>
         </service>
+        <service id="Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface"
+                 alias="sulu_core.list_builder.field_descriptor_factory"/>
 
         <service id="sulu_core.list_builder.metadata.provider.chain"
                  class="Sulu\Component\Rest\ListBuilder\Metadata\Provider\ChainProvider">
@@ -37,7 +39,7 @@
             <argument>Metadata\ClassHierarchyMetadata</argument>
             <argument>%kernel.debug%</argument>
             <call method="setCache">
-                <argument type="service" id="sulu_core.list_builder.metadata.provider.general.cache" />
+                <argument type="service" id="sulu_core.list_builder.metadata.provider.general.cache"/>
             </call>
         </service>
 
@@ -68,7 +70,7 @@
             <argument>Metadata\ClassHierarchyMetadata</argument>
             <argument>%kernel.debug%</argument>
             <call method="setCache">
-                <argument type="service" id="sulu_core.list_builder.metadata.provider.doctrine.cache" />
+                <argument type="service" id="sulu_core.list_builder.metadata.provider.doctrine.cache"/>
             </call>
         </service>
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -2,37 +2,32 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_core.rest_helper.class">Sulu\Component\Rest\RestHelper</parameter>
-        <parameter key="sulu_core.doctrine_rest_helper.class">Sulu\Component\Rest\DoctrineRestHelper</parameter>
-        <parameter key="sulu_core.list_rest_helper.class">Sulu\Component\Rest\ListBuilder\ListRestHelper</parameter>
-        <parameter key="sulu_core.doctrine_list_builder_factory.class">Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactory</parameter>
-        <parameter key="sulu_core.rest.datetime_handler.class">Sulu\Component\Rest\Handler\DateHandler</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_core.rest_helper" class="%sulu_core.rest_helper.class%">
+        <service id="sulu_core.rest_helper" class="Sulu\Component\Rest\RestHelper">
             <argument type="service" id="sulu_core.list_rest_helper"/>
         </service>
+        <service id="Sulu\Component\Rest\RestHelperInterface" alias="sulu_core.rest_helper" />
 
-        <service id="sulu_core.doctrine_rest_helper" class="%sulu_core.doctrine_rest_helper.class%" public="true">
+        <service id="sulu_core.doctrine_rest_helper" class="Sulu\Component\Rest\DoctrineRestHelper" public="true">
             <argument type="service" id="sulu_core.list_rest_helper"/>
         </service>
+        <service id="Sulu\Component\Rest\DoctrineRestHelper" alias="sulu_core.doctrine_rest_helper" />
 
-        <service id="sulu_core.list_rest_helper" class="%sulu_core.list_rest_helper.class%" public="true">
+        <service id="sulu_core.list_rest_helper" class="Sulu\Component\Rest\ListBuilder\ListRestHelper" public="true">
             <argument type="service" id="request_stack"/>
         </service>
+        <service id="Sulu\Component\Rest\ListBuilder\ListRestHelperInterface" alias="sulu_core.list_rest_helper"/>
 
         <service id="sulu_core.doctrine_list_builder_factory"
-                 class="%sulu_core.doctrine_list_builder_factory.class%"
+                 class="Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactory"
                  public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%sulu_security.permissions%</argument>
         </service>
+        <service id="Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface" alias="sulu_core.doctrine_list_builder_factory"/>
 
-        <service id="sulu_core.rest.datetime_handler" class="%sulu_core.rest.datetime_handler.class%">
+        <service id="sulu_core.rest.datetime_handler" class="Sulu\Component\Rest\Handler\DateHandler">
             <tag name="jms_serializer.subscribing_handler" />
         </service>
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -11,7 +11,6 @@
         <service id="sulu_core.doctrine_rest_helper" class="Sulu\Component\Rest\DoctrineRestHelper" public="true">
             <argument type="service" id="sulu_core.list_rest_helper"/>
         </service>
-        <service id="Sulu\Component\Rest\DoctrineRestHelper" alias="sulu_core.doctrine_rest_helper" />
 
         <service id="sulu_core.list_rest_helper" class="Sulu\Component\Rest\ListBuilder\ListRestHelper" public="true">
             <argument type="service" id="request_stack"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added support for autowire for rest helper and field descriptor factory.

#### Why?

To support autowire for some sulu services

#### Example Usage

Use configured interface aliases.
