### PR TITLE
Added support for list-builder configuration in project config directory

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Tests/DependencyInjection/SuluCoreExtensionTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/DependencyInjection/SuluCoreExtensionTest.php
@@ -21,7 +21,8 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
         parent::setUp();
 
         $this->container->setParameter('kernel.bundles', []);
-        $this->container->setParameter('kernel.cache_dir', __DIR__);
+        $this->container->setParameter('kernel.project_dir', dirname(__DIR__));
+        $this->container->setParameter('kernel.cache_dir', dirname(__DIR__) . '/var/cache');
         $this->container->setParameter('sulu.context', 'admin');
     }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Provider/ChainProvider.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Provider/ChainProvider.php
@@ -37,7 +37,13 @@ class ChainProvider implements ProviderInterface
         $classMetadata = new ClassMetadata($className);
 
         foreach ($this->chain as $provider) {
-            $classMetadata->merge($provider->getMetadataForClass($className));
+            $metaData = $provider->getMetadataForClass($className);
+
+            if (!$metaData) {
+                throw new \RuntimeException(sprintf('Could not find metadata for class "%s"', $className));
+            }
+
+            $classMetadata->merge($metaData);
         }
 
         return $classMetadata;

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Provider/ChainProvider.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Provider/ChainProvider.php
@@ -37,13 +37,13 @@ class ChainProvider implements ProviderInterface
         $classMetadata = new ClassMetadata($className);
 
         foreach ($this->chain as $provider) {
-            $metaData = $provider->getMetadataForClass($className);
+            $metadata = $provider->getMetadataForClass($className);
 
-            if (!$metaData) {
+            if (!$metadata) {
                 throw new \RuntimeException(sprintf('Could not find metadata for class "%s"', $className));
             }
 
-            $classMetadata->merge($metaData);
+            $classMetadata->merge($metadata);
         }
 
         return $classMetadata;

--- a/src/Sulu/Component/Rest/RestHelperInterface.php
+++ b/src/Sulu/Component/Rest/RestHelperInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\Rest;
 
-use Sulu\Component\Rest\ListBuilder\FieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 use Traversable;
 
@@ -21,7 +21,7 @@ interface RestHelperInterface
      * Initializes the given ListBuilder with the standard values from the request.
      *
      * @param ListBuilderInterface      $listBuilder      The ListBuilder to initialize
-     * @param FieldDescriptor[] $fieldDescriptors The FieldDescriptors available for this object type
+     * @param FieldDescriptorInterface[] $fieldDescriptors The FieldDescriptors available for this object type
      */
     public function initializeListBuilder(ListBuilderInterface $listBuilder, array $fieldDescriptors);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #4147
| License | MIT

#### What's in this PR?

Added support for list-builder configuration in project config directory. 

#### Why?

As the application itself is not longer a bundle we should allow to store `list-builder` configuration in project `config` directory to allow create custom entities in a project.

#### Example Usage

Create `config/list-builder/Test.xml`

~~~xml
<class xmlns="http://schemas.sulu.io/class/general"
       xmlns:orm="http://schemas.sulu.io/class/doctrine"
       xmlns:list="http://schemas.sulu.io/class/list">
    <properties>
        <property name="id" visibility="always" list:translation="app.id" searchability="yes">
            <orm:field-name>id</orm:field-name>
            <orm:entity-name>App\Entity\Test</orm:entity-name>
        </property>
    </properties>
</class>
~~~

try to load the fielddescriptors:

```php
function (FieldDescriptorFactoryInterface $fieldDescriptorsFactory) {
    $fieldDescriptors = $fieldDescriptorsFactory->getFieldDescriptorForClass(Location::class);
}
```

config folder structure will look like this in a project:

![Project Config Folder](https://user-images.githubusercontent.com/1698337/47723561-0d673a80-dc55-11e8-93aa-21b701ccf93b.png)

Additional folders in config could be `doctrine` or `serializer`?