### PR TITLE
Set default locale for admin user to "en".

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -43,7 +43,7 @@ class UserBuilder extends SuluBuilder
         $password = 'admin';
         $roleName = 'User';
         $system = 'Sulu';
-        $locale = 'de';
+        $locale = 'en';
         $doctrine = $this->container->get('doctrine')->getManager();
         $userRep = $this->container->get('sulu.repository.user');
         $userLocales = $this->container->getParameter('sulu_core.locales');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

Getting the admin UI in English instead of German initially is more friendlier to international users.