### PR TITLE
Use scalar result for list builder execute

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -205,7 +205,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         $select = $this->idField->getSelect();
         $this->queryBuilder->where($select . ' IN (:ids)')->setParameter('ids', $ids);
 
-        return $this->queryBuilder->getQuery()->getArrayResult();
+        return $this->queryBuilder->getQuery()->getScalarResult();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use scalar result for list builder result.

#### Why?

E.g. when use the `uuid` type of ramsey/uuid-doctrine the uuid will be converted to a UuidInterface and would result in something like:

```
[{
  "id": {
    "factory": {
      "codec": {
        "builder": {
          "converter": {}
        }
      },
      "nodeProvider": {
        "nodeProviders": [{}, {}]
      },
      "numberConverter": {},
      "randomGenerator": {},
      "timeGenerator": {
        "nodeProvider": {
          "nodeProviders": [{}, {}]
        },
        "timeConverter": {},
        "timeProvider": {}
      },
      "uuidBuilder": {
        "converter": {}
      }
    },
    "codec": {
      "builder": {
        "converter": {}
      }
    },
    "fields": {
      "time_low": "212f4b62",
      "time_mid": "c5de",
      "time_hi_and_version": "484c",
      "clock_seq_hi_and_reserved": "86",
      "clock_seq_low": "4b",
      "node": "b2a90db79b0b"
    },
    "converter": {}
  }
}]
```

instead of:

```
[{
  "id": "212f4b62-c5de-484c-864b-b2a90db79b0b"
}]
```
