### PR TITLE
implemented handling of undefined-value in single-select component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -13,9 +13,9 @@ type Props = {
     selected: boolean,
     disabled: boolean,
     focus: boolean,
-    value: string | number,
+    value?: string | number,
     children: string,
-    onClick?: (value: string | number) => void,
+    onClick?: (value?: string | number) => void,
     optionRef?: (optionNode: ElementRef<'li'>, selected: boolean) => void,
     selectedVisualization: OptionSelectedVisualization,
 };
@@ -29,7 +29,7 @@ export default class Option extends React.PureComponent<Props> {
         focus: false,
         selected: false,
         selectedVisualization: 'icon',
-        value: '',
+        value: undefined,
     };
 
     item: ElementRef<'li'>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -29,7 +29,6 @@ export default class Option extends React.PureComponent<Props> {
         focus: false,
         selected: false,
         selectedVisualization: 'icon',
-        value: undefined,
     };
 
     item: ElementRef<'li'>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/README.md
@@ -3,7 +3,8 @@ The component follows the
 [recommendation of React for form components](https://facebook.github.io/react/docs/forms.html):
 The `SingleSelect` itself holds no internal state and is solely dependent on the passed properties. Moreover, it
 provides a possibility to pass a callback which gets called when the user selects an option.
-```
+
+```javascript
 const Action = SingleSelect.Action;
 const Option = SingleSelect.Option;
 const Divider = SingleSelect.Divider;
@@ -23,12 +24,12 @@ const onChange = (selectValue) => setState({selectValue});
 
 Also a lot of options are possible and correctly handled as well as neatly styled.
 
-```
+```javascript
 const Action = SingleSelect.Action;
 const Option = SingleSelect.Option;
 const Divider = SingleSelect.Divider;
 
-initialState = {selectValue: null};
+initialState = {selectValue: undefined};
 const onChange = (value) => setState({selectValue: value});
 
 <SingleSelect value={state.selectValue} onChange={onChange}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -26,7 +26,7 @@ export default class SingleSelect<T: string | number> extends React.PureComponen
                 return;
             }
 
-            if (!displayValue || this.props.value == child.props.value) {
+            if (this.props.value == child.props.value) {
                 displayValue = child.props.children;
             }
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -41,7 +41,7 @@ export default class SingleSelect<T: string | number> extends React.PureComponen
             return false;
         }
 
-        return option.props.value.toString() === value.toString() && !option.props.disabled;
+        return option.props.value === value && !option.props.disabled;
     };
 
     handleSelect = (value: T) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -3,6 +3,7 @@ import React from 'react';
 import type {Element} from 'react';
 import type {SelectProps} from '../Select';
 import Select from '../Select';
+import {translate} from '../../utils/Translator';
 
 type Props<T: string | number> = SelectProps & {
     onChange?: (value: T) => void,
@@ -19,7 +20,7 @@ export default class SingleSelect<T: string | number> extends React.PureComponen
     static Divider = Select.Divider;
 
     get displayValue(): string {
-        let displayValue = '';
+        let displayValue = translate('sulu_admin.please_choose');
 
         React.Children.forEach(this.props.children, (child: any) => {
             if (child.type !== SingleSelect.Option) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/tests/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/tests/SingleSelect.test.js
@@ -8,6 +8,9 @@ const Option = SingleSelect.Option;
 const Divider = SingleSelect.Divider;
 
 jest.mock('../../Select');
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
 
 test('The component should render a generic select', () => {
     const select = shallow(
@@ -33,7 +36,7 @@ test('The component should render a select with dark skin', () => {
     expect(select.render()).toMatchSnapshot();
 });
 
-test('The component should return an empty string as default displayValue if no valueless option is present', () => {
+test('The component should return the default displayValue if no valueless option is present', () => {
     const select = shallow(
         <SingleSelect>
             <Option value="option-1">Option 1</Option>
@@ -43,7 +46,7 @@ test('The component should return an empty string as default displayValue if no 
         </SingleSelect>
     );
     const displayValue = select.find(Select).props().displayValue;
-    expect(displayValue).toBe('');
+    expect(displayValue).toBe('sulu_admin.please_choose');
 });
 
 test('The component should return the content of the last valueless option as default displayValue', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/tests/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/tests/SingleSelect.test.js
@@ -5,7 +5,7 @@ import Select from '../../Select';
 import SingleSelect from '../../SingleSelect';
 
 const Option = SingleSelect.Option;
-const Divider = SingleSelect.Option;
+const Divider = SingleSelect.Divider;
 
 jest.mock('../../Select');
 
@@ -33,7 +33,7 @@ test('The component should render a select with dark skin', () => {
     expect(select.render()).toMatchSnapshot();
 });
 
-test('The component should return the first option as default display value', () => {
+test('The component should return an empty string as default displayValue if no valueless option is present', () => {
     const select = shallow(
         <SingleSelect>
             <Option value="option-1">Option 1</Option>
@@ -43,7 +43,36 @@ test('The component should return the first option as default display value', ()
         </SingleSelect>
     );
     const displayValue = select.find(Select).props().displayValue;
-    expect(displayValue).toBe('Option 1');
+    expect(displayValue).toBe('');
+});
+
+test('The component should return the content of the last valueless option as default displayValue', () => {
+    const select = shallow(
+        <SingleSelect>
+            <Option value="option-1">Option 1</Option>
+            <Option>Option without value 1</Option>
+            <Option>Option without value 2</Option>
+            <Option value="option-2">Option 2</Option>
+            <Divider />
+            <Option value="option-3">Option 3</Option>
+        </SingleSelect>
+    );
+    const displayValue = select.find(Select).props().displayValue;
+    expect(displayValue).toBe('Option without value 2');
+});
+
+test('The component should return undefined as value if a valueless option is selected', () => {
+    const select = shallow(
+        <SingleSelect>
+            <Option value="option-1">Option 1</Option>
+            <Option>Option without value 1</Option>
+            <Option value="option-2">Option 2</Option>
+            <Divider />
+            <Option value="option-3">Option 3</Option>
+        </SingleSelect>
+    );
+    const value = select.find(Select).props().value;
+    expect(value).toBe(undefined);
 });
 
 test('The component should return the correct displayValue', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -164,7 +164,11 @@ export default class Url extends React.Component<Props> {
         return (
             <div className={urlClass}>
                 <div className={urlStyles.protocols}>
-                    <SingleSelect onChange={this.handleProtocolChange} skin="flat" value={this.protocol}>
+                    <SingleSelect
+                        onChange={this.handleProtocolChange}
+                        skin="flat"
+                        value={this.protocol || protocols[0]}
+                    >
                         {protocols.map((protocol) => (
                             <SingleSelect.Option key={protocol} value={protocol}>{protocol}</SingleSelect.Option>
                         ))}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -36,7 +36,6 @@ test('Set the correct values for protocol and path when updating', () => {
 test('Should log a warning if a not available protocol has been given', () => {
     const url = shallow(<Url onChange={jest.fn()} protocols={['http://']} value="https://www.sulu.io" />);
 
-    expect(url.find('SingleSelect').prop('value')).toEqual(undefined);
     expect(url.find('input').prop('value')).toEqual('https://www.sulu.io');
     expect(log.warn).toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -89,7 +89,7 @@ export default class DatagridStore {
     }
 
     static setLimitSetting(resourceKey: string, userSettingsKey: string, value: *) {
-        const key = [USER_SETTING_PREFIX, resourceKey, userSettingsKey, USER_SETTING_SORT_ORDER].join('.');
+        const key = [USER_SETTING_PREFIX, resourceKey, userSettingsKey, USER_SETTING_LIMIT].join('.');
 
         userStore.setPersistentSetting(key, value);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
@@ -97,28 +97,28 @@ exports[`Render with all fields 1`] = `
                     type="button"
                   >
                     <div
-                      aria-label="sulu_admin.any_category_description"
+                      aria-label="sulu_admin.please_choose"
                       class="croppedText"
-                      title="sulu_admin.any_category_description"
+                      title="sulu_admin.please_choose"
                     >
                       <div
                         aria-hidden="true"
                         class="front"
                       >
-                        sulu_admin.any_cat
+                        sulu_admin.p
                       </div>
                       <div
                         aria-hidden="true"
                         class="back"
                       >
                         <span>
-                          egory_description
+                          lease_choose
                         </span>
                       </div>
                       <div
                         class="whole"
                       >
-                        sulu_admin.any_category_description
+                        sulu_admin.please_choose
                       </div>
                     </div>
                     <span
@@ -158,28 +158,28 @@ exports[`Render with all fields 1`] = `
                     type="button"
                   >
                     <div
-                      aria-label="sulu_admin.any_tag_description"
+                      aria-label="sulu_admin.please_choose"
                       class="croppedText"
-                      title="sulu_admin.any_tag_description"
+                      title="sulu_admin.please_choose"
                     >
                       <div
                         aria-hidden="true"
                         class="front"
                       >
-                        sulu_admin.any_
+                        sulu_admin.p
                       </div>
                       <div
                         aria-hidden="true"
                         class="back"
                       >
                         <span>
-                          tag_description
+                          lease_choose
                         </span>
                       </div>
                       <div
                         class="whole"
                       >
-                        sulu_admin.any_tag_description
+                        sulu_admin.please_choose
                       </div>
                     </div>
                     <span
@@ -233,6 +233,31 @@ exports[`Render with all fields 1`] = `
                     class="displayValue default"
                     type="button"
                   >
+                    <div
+                      aria-label="sulu_admin.please_choose"
+                      class="croppedText"
+                      title="sulu_admin.please_choose"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="front"
+                      >
+                        sulu_admin.p
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="back"
+                      >
+                        <span>
+                          lease_choose
+                        </span>
+                      </div>
+                      <div
+                        class="whole"
+                      >
+                        sulu_admin.please_choose
+                      </div>
+                    </div>
                     <span
                       aria-label="su-angle-down"
                       class="su-angle-down toggle"
@@ -251,28 +276,28 @@ exports[`Render with all fields 1`] = `
                     type="button"
                   >
                     <div
-                      aria-label="sulu_admin.ascending"
+                      aria-label="sulu_admin.please_choose"
                       class="croppedText"
-                      title="sulu_admin.ascending"
+                      title="sulu_admin.please_choose"
                     >
                       <div
                         aria-hidden="true"
                         class="front"
                       >
-                        sulu_admin
+                        sulu_admin.p
                       </div>
                       <div
                         aria-hidden="true"
                         class="back"
                       >
                         <span>
-                          .ascending
+                          lease_choose
                         </span>
                       </div>
                       <div
                         class="whole"
                       >
-                        sulu_admin.ascending
+                        sulu_admin.please_choose
                       </div>
                     </div>
                     <span
@@ -300,6 +325,31 @@ exports[`Render with all fields 1`] = `
                   class="displayValue default"
                   type="button"
                 >
+                  <div
+                    aria-label="sulu_admin.please_choose"
+                    class="croppedText"
+                    title="sulu_admin.please_choose"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="front"
+                    >
+                      sulu_admin.p
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="back"
+                    >
+                      <span>
+                        lease_choose
+                      </span>
+                    </div>
+                    <div
+                      class="whole"
+                    >
+                      sulu_admin.please_choose
+                    </div>
+                  </div>
                   <span
                     aria-label="su-angle-down"
                     class="su-angle-down toggle"

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -87,6 +87,7 @@
     "sulu_admin.deactivate_all": "Alle deaktivieren",
     "sulu_admin.all_selected": "Alle ausgewählt",
     "sulu_admin.none_selected": "Keine ausgewählt",
+    "sulu_admin.please_choose": "Bitte auswählen",
     "sulu_admin.column_options": "Spalten Optionen",
     "sulu_admin.changelog_line_changer": "Letzte Änderung {changer, select, undefined{} other{von {changer}}} am {changed}",
     "sulu_admin.changelog_line_creator": "Erstellt {creator, select, undefined{} other{von {creator}}} am {created}",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -87,6 +87,7 @@
     "sulu_admin.deactivate_all": "Deactivate all",
     "sulu_admin.all_selected": "All selected",
     "sulu_admin.none_selected": "None selected",
+    "sulu_admin.please_choose": "Please choose",
     "sulu_admin.column_options": "Column options",
     "sulu_admin.changelog_line_changer": "Last change {changer, select, undefined{} other{from {changer}}} at {changed}",
     "sulu_admin.changelog_line_creator": "Created {creator, select, undefined{} other{by {creator}}} at {created}",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the single-select component to not show any value, if nothing is selected. Furthermore, this PR implements the support for options with the value undefined. An option with the value undefined can be used to reset the current selection.

#### Why?

We need to display select-components that do not have a value initially. In these cases it is misleading, if the component contains the value of the first option.

#### To Do

- [x] do not display value of first option if nothing is selected
- [x] allow option with undefined value-property 
- [x] adjust and create tests
