### PR TITLE
Set default locale for admin user to "en".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-release/1.5
+    * HOTFIX      #4241 [SecurityBundle]        Set default locale for admin user to "en"
     * HOTFIX      #4112 [SecurityBundle]        Added exception messages to user provider for enabled and locked
 
 * 1.5.18 (2018-10-05)

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -43,7 +43,7 @@ class UserBuilder extends SuluBuilder
         $password = 'admin';
         $roleName = 'User';
         $system = 'Sulu';
-        $locale = 'de';
+        $locale = 'en';
         $doctrine = $this->container->get('doctrine')->getManager();
         $userRep = $this->container->get('sulu.repository.user');
         $userLocales = $this->container->getParameter('sulu_core.locales');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set default locale for admin user to "en".

#### Why?

This is more friendlier to international users.
