### PR TITLE
Introduce datagridAdapterDefaultProps

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/ColumnListAdapter.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {mount, render} from 'enzyme';
+import datagridAdapterDefaultProps from '../../../../utils/TestHelper/datagridAdapterDefaultProps';
 import ColumnListAdapter from '../../adapters/ColumnListAdapter';
 
 jest.mock('../../../../utils/Translator', () => ({
@@ -105,32 +106,12 @@ test('Render different kind of data with edit button', () => {
 
     const columnListAdapter = render(
         <ColumnListAdapter
-            active={4}
+            {...datagridAdapterDefaultProps}
             activeItems={[2, 4]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
             onItemAdd={jest.fn()}
             onItemClick={jest.fn()}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -150,32 +131,10 @@ test('Render data without edit button', () => {
 
     const columnListAdapter = render(
         <ColumnListAdapter
-            active={4}
+            {...datagridAdapterDefaultProps}
             activeItems={[]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -195,32 +154,12 @@ test('Render data with selection', () => {
 
     const columnListAdapter = render(
         <ColumnListAdapter
-            active={4}
+            {...datagridAdapterDefaultProps}
             activeItems={[]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={jest.fn()}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
             selections={[1]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -248,32 +187,13 @@ test('Render data with disabled items', () => {
 
     const columnListAdapter = render(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
             disabledIds={[3]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={jest.fn()}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
             selections={[1]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -287,32 +207,11 @@ test('Render with add button in toolbar when onItemAdd callback is given', () =>
 
     const columnListAdapter = render(
         <ColumnListAdapter
-            active={4}
+            {...datagridAdapterDefaultProps}
             activeItems={[]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
             onItemAdd={jest.fn()}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -338,32 +237,11 @@ test('Render data with loading column', () => {
 
     const columnListAdapter = render(
         <ColumnListAdapter
-            active={1}
+            {...datagridAdapterDefaultProps}
             activeItems={[1]}
             data={data}
-            disabledIds={[]}
-            limit={10}
             loading={true}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -397,32 +275,10 @@ test('Execute onItemActivate callback when an item is clicked with the correct p
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
             onItemActivate={itemActivateSpy}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -445,32 +301,11 @@ test('Do not show order button if onRequestItemOrder callback is undefined', () 
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
             onRequestItemMove={jest.fn()}
             onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -499,32 +334,10 @@ test('Call onRequestItemOrder callback when an item ordering has been changed', 
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={1}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
             onRequestItemOrder={requestItemOrderSpy}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -565,32 +378,11 @@ test('Do not execute onItemActivate callback when a column is ordering', () => {
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={1}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
             onItemActivate={itemActivateSpy}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
             onRequestItemOrder={jest.fn()}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -622,32 +414,11 @@ test('Execute onItemSelectionChange callback when an item is selected', () => {
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={itemSelectionChangeSpy}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
             selections={[2]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -685,32 +456,10 @@ test('Execute onRequestItemCopy callback when an item is moved with the correct 
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
             onRequestItemCopy={copyClickSpy}
-            onRequestItemDelete={undefined}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -747,32 +496,10 @@ test('Execute onRequestItemMove callback when an item is moved with the correct 
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={undefined}
             onRequestItemMove={moveClickSpy}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -809,32 +536,10 @@ test('Execute onRequestItemDelete callback when an item is deleted with the corr
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={deleteClickSpy}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -870,32 +575,11 @@ test('Enable delete and move button if an item in this column has been activated
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1, 3]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
             onRequestItemMove={jest.fn()}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -930,32 +614,11 @@ test('Disable delete and move button if no item in this column has been activate
 
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1]}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
             onRequestItemDelete={jest.fn()}
             onRequestItemMove={jest.fn()}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -967,32 +630,8 @@ test('Disable delete and move button if no item in this column has been activate
 test('Do not show settings if no options are available', () => {
     const columnListAdapter = mount(
         <ColumnListAdapter
-            active={3}
+            {...datagridAdapterDefaultProps}
             activeItems={[1]}
-            data={[]}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={undefined}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={undefined}
-            pageCount={0}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/FolderAdapter.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {render, shallow} from 'enzyme';
+import datagridAdapterDefaultProps from '../../../../utils/TestHelper/datagridAdapterDefaultProps';
 import FolderAdapter from '../../adapters/FolderAdapter';
 
 jest.mock('../../../../utils/Translator', () => ({
@@ -32,32 +33,10 @@ test('Render a basic Folder list with data', () => {
 
     const folderAdapter = render(
         <FolderAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={2}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -88,32 +67,9 @@ test('Click on a Folder should call the onItemEdit callback', () => {
     ];
     const folderAdapter = shallow(
         <FolderAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
             onItemClick={itemClickSpy}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={3}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     expect(folderAdapter.find('FolderList').get(0).props.onFolderClick).toBe(itemClickSpy);
@@ -122,31 +78,8 @@ test('Click on a Folder should call the onItemEdit callback', () => {
 test('Pagination should not be rendered if no data is available', () => {
     const folderAdapter = shallow(
         <FolderAdapter
-            active={undefined}
-            activeItems={[]}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
+            {...datagridAdapterDefaultProps}
             page={1}
-            pageCount={7}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -158,31 +91,12 @@ test('Pagination should be passed correct props', () => {
     const limitChangeSpy = jest.fn();
     const folderAdapter = shallow(
         <FolderAdapter
-            active={undefined}
-            activeItems={[]}
-            disabledIds={[]}
+            {...datagridAdapterDefaultProps}
             limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
             onLimitChange={limitChangeSpy}
             onPageChange={pageChangeSpy}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={7}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     expect(folderAdapter.find('Pagination').get(0).props).toEqual({

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TableAdapter.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {render, shallow} from 'enzyme';
+import datagridAdapterDefaultProps from '../../../../utils/TestHelper/datagridAdapterDefaultProps';
 import TableAdapter from '../../adapters/TableAdapter';
 import StringFieldTransformer from '../../fieldTransformers/StringFieldTransformer';
 import datagridFieldTransformerRegistry from '../../registries/DatagridFieldTransformerRegistry';
@@ -55,32 +56,11 @@ test('Render data with schema', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={5}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -107,32 +87,9 @@ test('Attach onClick handler for sorting if schema says the header is sortable',
 
     const tableAdapter = shallow(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
-            data={[]}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
+            {...datagridAdapterDefaultProps}
             onSort={sortSpy}
-            options={{}}
-            page={2}
-            pageCount={5}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -181,32 +138,11 @@ test('Render data with all different visibility types schema', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={5}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -247,32 +183,13 @@ test('Render data with schema and selections', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={jest.fn()}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
             selections={[1, 3]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -308,32 +225,11 @@ test('Render data with schema in different order', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={3}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -363,32 +259,11 @@ test('Render data with schema not containing all fields', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -425,32 +300,12 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
             onItemClick={rowEditClickSpy}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -481,30 +336,11 @@ test('Render column with ascending sort icon', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
-            selections={[]}
             sortColumn="title"
             sortOrder="asc"
         />
@@ -537,30 +373,11 @@ test('Render column with descending sort icon', () => {
     };
     const tableAdapter = render(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
-            selections={[]}
             sortColumn="description"
             sortOrder="desc"
         />
@@ -599,32 +416,12 @@ test('Click on pencil should execute onItemClick callback', () => {
     };
     const tableAdapter = shallow(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
             onItemClick={rowEditClickSpy}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     const buttons = tableAdapter.find('Table').prop('buttons');
@@ -665,32 +462,12 @@ test('Click on checkbox should call onItemSelectionChange callback', () => {
     };
     const tableAdapter = shallow(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={rowSelectionChangeSpy}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={3}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -710,32 +487,10 @@ test('Click on checkbox in header should call onAllSelectionChange callback', ()
     };
     const tableAdapter = shallow(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
             onAllSelectionChange={allSelectionChangeSpy}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={3}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -747,31 +502,12 @@ test('Pagination should be passed correct props', () => {
     const limitChangeSpy = jest.fn();
     const tableAdapter = shallow(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
-            disabledIds={[]}
+            {...datagridAdapterDefaultProps}
             limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
             onLimitChange={limitChangeSpy}
             onPageChange={pageChangeSpy}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={7}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     expect(tableAdapter.find('Pagination').get(0).props).toEqual({
@@ -790,31 +526,10 @@ test('Pagination should not be rendered if no data is available', () => {
     const limitChangeSpy = jest.fn();
     const tableAdapter = shallow(
         <TableAdapter
-            active={undefined}
-            activeItems={[]}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
+            {...datagridAdapterDefaultProps}
             onLimitChange={limitChangeSpy}
             onPageChange={pageChangeSpy}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
-            pageCount={7}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     expect(tableAdapter.find('Pagination')).toHaveLength(0);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TreeTableAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/adapters/TreeTableAdapter.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {mount, render, shallow} from 'enzyme';
+import datagridAdapterDefaultProps from '../../../../utils/TestHelper/datagridAdapterDefaultProps';
 import TreeTableAdapter from '../../adapters/TreeTableAdapter';
 
 jest.mock('../../../../utils/Translator', () => ({
@@ -67,32 +68,9 @@ test('Render data with schema', () => {
     };
     const treeListAdapter = render(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={2}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -140,32 +118,12 @@ test('Render data without header', () => {
     };
     const treeListAdapter = render(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
             options={{showHeader: false}}
             page={1}
             pageCount={2}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -192,32 +150,9 @@ test('Attach onClick handler for sorting if schema says the header is sortable',
 
     const treeTableAdapter = shallow(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
-            data={[]}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
+            {...datagridAdapterDefaultProps}
             onSort={sortSpy}
-            options={{}}
-            page={2}
-            pageCount={5}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -275,32 +210,9 @@ test('Render data with two columns', () => {
     };
     const treeListAdapter = render(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={2}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -348,32 +260,10 @@ test('Render data with schema and selections', () => {
     };
     const treeListAdapter = render(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={2}
             schema={schema}
             selections={[1, 3]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -444,32 +334,11 @@ test('Execute onItemActivate respectively onItemDeactivate callback when an item
 
     const treeListAdapter = mount(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
             onItemActivate={onItemActivateSpy}
-            onItemAdd={undefined}
-            onItemClick={undefined}
             onItemDeactivate={onItemDeactivateSpy}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={1}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -511,32 +380,10 @@ test('Render data with pencil button when onItemEdit callback is passed', () => 
     };
     const treeListAdapter = render(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
             onItemClick={rowEditClickSpy}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={1}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -572,32 +419,10 @@ test('Render data with plus button when onItemAdd callback is passed', () => {
     };
     const treeListAdapter = render(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
             onItemAdd={rowAddClickSpy}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={1}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -633,32 +458,10 @@ test('Click on pencil should execute onItemClick callback', () => {
     };
     const treeListAdapter = shallow(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
             onItemClick={rowEditClickSpy}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={1}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     const buttons = treeListAdapter.find('Table').prop('buttons');
@@ -698,32 +501,10 @@ test('Click on add should execute onItemAdd callback', () => {
     const rowAddClickSpy = jest.fn();
     const treeListAdapter = shallow(
         <TreeTableAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
             onItemAdd={rowAddClickSpy}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
-            page={1}
-            pageCount={1}
             schema={schema}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     const buttons = treeListAdapter.find('Table').prop('buttons');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/datagridAdapterDefaultProps.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/datagridAdapterDefaultProps.js
@@ -1,0 +1,37 @@
+// @flow
+
+const datagridAdapterDefaultProps = {
+    active: undefined,
+    activeItems: undefined,
+    data: [],
+    disabledIds: [],
+    limit: 0,
+    loading: false,
+    onAllSelectionChange: undefined,
+    // $FlowFixMe
+    onItemActivate: jest.fn(),
+    onItemAdd: undefined,
+    onItemClick: undefined,
+    // $FlowFixMe
+    onItemDeactivate: jest.fn(),
+    onItemSelectionChange: undefined,
+    // $FlowFixMe
+    onLimitChange: jest.fn(),
+    // $FlowFixMe
+    onPageChange: jest.fn(),
+    onRequestItemCopy: undefined,
+    onRequestItemDelete: undefined,
+    onRequestItemMove: undefined,
+    onRequestItemOrder: undefined,
+    // $FlowFixMe
+    onSort: jest.fn(),
+    options: {},
+    page: undefined,
+    pageCount: undefined,
+    schema: {},
+    selections: [],
+    sortColumn: undefined,
+    sortOrder: undefined,
+};
+
+export default datagridAdapterDefaultProps;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/index.js
@@ -1,8 +1,10 @@
 // @flow
+import datagridAdapterDefaultProps from './datagridAdapterDefaultProps';
 import fieldTypeDefaultProps from './fieldTypeDefaultProps';
 import findWithHighOrderFunction from './findWithHighOrderFunction';
 
 export {
+    datagridAdapterDefaultProps,
     fieldTypeDefaultProps,
     findWithHighOrderFunction,
 };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardAdapter.test.js
@@ -1,6 +1,7 @@
 // @flow
 import {shallow, render} from 'enzyme';
 import React from 'react';
+import {datagridAdapterDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import MediaCardAdapter from '../../adapters/MediaCardAdapter';
 
 jest.mock('sulu-admin-bundle/utils', () => ({
@@ -39,33 +40,12 @@ test('Render a basic Masonry view with MediaCards', () => {
     ];
     const mediaCardAdapter = render(
         <MediaCardAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
             icon="su-pen"
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={jest.fn()}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={1}
             pageCount={7}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -98,33 +78,13 @@ test('MediaCard should call the the appropriate handler', () => {
     ];
     const mediaCardAdapter = shallow(
         <MediaCardAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
             icon="su-pen"
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
             onItemClick={mediaCardSelectionChangeSpy}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={mediaCardSelectionChangeSpy}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={3}
             pageCount={9}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 
@@ -136,33 +96,12 @@ test('InfiniteScroller should be passed correct props', () => {
     const pageChangeSpy = jest.fn();
     const tableAdapter = shallow(
         <MediaCardAdapter
-            active={undefined}
-            activeItems={[]}
-            data={[]}
-            disabledIds={[]}
+            {...datagridAdapterDefaultProps}
             icon="su-pen"
-            limit={10}
             loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
-            onItemSelectionChange={undefined}
-            onLimitChange={jest.fn()}
             onPageChange={pageChangeSpy}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={7}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
     expect(tableAdapter.find('InfiniteScroller').get(0).props).toEqual({

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Datagrid/tests/adapters/MediaCardOverviewAdapter.test.js
@@ -1,6 +1,7 @@
 // @flow
 import {render} from 'enzyme';
 import React from 'react';
+import {datagridAdapterDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import MediaCardOverviewAdapter from '../../adapters/MediaCardOverviewAdapter';
 
 jest.mock('sulu-admin-bundle/services/Initializer', () => jest.fn());
@@ -41,32 +42,11 @@ test('Render a basic Masonry view with the MediaCardOverviewAdapter', () => {
     ];
     const mediaCardAdapter = render(
         <MediaCardOverviewAdapter
-            active={undefined}
-            activeItems={[]}
+            {...datagridAdapterDefaultProps}
             data={data}
-            disabledIds={[]}
-            limit={10}
-            loading={false}
-            onAllSelectionChange={undefined}
-            onItemActivate={jest.fn()}
-            onItemAdd={undefined}
-            onItemClick={undefined}
-            onItemDeactivate={jest.fn()}
             onItemSelectionChange={jest.fn()}
-            onLimitChange={jest.fn()}
-            onPageChange={jest.fn()}
-            onRequestItemCopy={undefined}
-            onRequestItemDelete={jest.fn()}
-            onRequestItemMove={undefined}
-            onRequestItemOrder={undefined}
-            onSort={jest.fn()}
-            options={{}}
             page={2}
             pageCount={5}
-            schema={{}}
-            selections={[]}
-            sortColumn={undefined}
-            sortOrder={undefined}
         />
     );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4159 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This introduces default props for `DatagridAdapters` in the same way #4159 did for `FieldType`s.

#### Why?

Because it makes tests less tedious to write.