### PR TITLE
Add focus point overlay

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/tests/Block.test.js
@@ -3,6 +3,10 @@ import React from 'react';
 import {render, shallow} from 'enzyme';
 import Block from '../Block';
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: (key) => key,
+}));
+
 test('Render an expanded block', () => {
     expect(render(
         <Block expanded={true} onCollapse={jest.fn()} onExpand={jest.fn()}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
@@ -8,6 +8,10 @@ jest.mock('react-sortable-hoc', () => ({
     SortableHandle: jest.fn().mockImplementation((component) => component),
 }));
 
+jest.mock('../../../utils/Translator', () => ({
+    translate: (key) => key,
+}));
+
 test('Render collapsed sortable block', () => {
     expect(render(
         <SortableBlock

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
+import type {Node} from 'react';
 import classNames from 'classnames';
 import type {BaseItemProps} from './types';
 import baseItemStyles from './baseItem.scss';
 
 type Props = BaseItemProps & {
     className: string,
-    children: ?Element<*>,
+    children: ?Node,
 };
 
 export default class BaseItem extends React.PureComponent<Props> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
-import type {Element} from 'react';
+import type {Node} from 'react';
 import classNames from 'classnames';
 import type {BaseItemProps} from './types';
 import BaseItem from './BaseItem';
 import itemStyles from './item.scss';
 
 type Props = BaseItemProps & {
-    children?: Element<*>,
+    children?: Node,
     className?: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -61,7 +61,9 @@ export default class Overlay extends React.Component<Props> {
     }
 
     @action componentWillReceiveProps(nextProps: Props) {
-        this.openHasChanged = nextProps.open !== this.props.open;
+        if (nextProps.open !== this.props.open) {
+            this.openHasChanged = true;
+        }
     }
 
     @action componentDidUpdate(prevProps: Props) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -36,7 +36,6 @@ export default class Overlay extends React.Component<Props> {
         actions: [],
         confirmDisabled: false,
         confirmLoading: false,
-        open: false,
     };
 
     @observable visible: boolean = false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/datagridAdapterDefaultProps.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/datagridAdapterDefaultProps.js
@@ -5,7 +5,7 @@ const datagridAdapterDefaultProps = {
     activeItems: undefined,
     data: [],
     disabledIds: [],
-    limit: 0,
+    limit: 10,
     loading: false,
     onAllSelectionChange: undefined,
     // $FlowFixMe

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
@@ -1,5 +1,8 @@
 // @flow
 import React from 'react';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import {Loader} from 'sulu-admin-bundle/components';
 import type {Point} from './types';
 import ImageFocusPointCell from './ImageFocusPointCell';
 import imageFocusPointStyles from './imageFocusPoint.scss';
@@ -12,7 +15,10 @@ type Props = {|
     value: Point,
 |};
 
-export default class ImageFocusPoint extends React.PureComponent<Props> {
+@observer
+export default class ImageFocusPoint extends React.Component<Props> {
+    @observable imageDimension: ClientRect;
+
     createFocusPoints(selectedPoint: Point) {
         const points = [];
 
@@ -108,6 +114,10 @@ export default class ImageFocusPoint extends React.PureComponent<Props> {
         this.props.onChange(selectedPoint);
     };
 
+    @action handleImageLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+        this.imageDimension = event.currentTarget.getBoundingClientRect();
+    };
+
     render() {
         const {
             image,
@@ -116,10 +126,16 @@ export default class ImageFocusPoint extends React.PureComponent<Props> {
 
         return (
             <div className={imageFocusPointStyles.imageFocusPoint}>
-                <div className={imageFocusPointStyles.focusPoints}>
-                    {this.createFocusPoints(value)}
-                </div>
-                <img className={imageFocusPointStyles.image} src={image} />
+                {this.imageDimension
+                    ? <div
+                        className={imageFocusPointStyles.focusPoints}
+                        style={{height: this.imageDimension.height, width: this.imageDimension.width}}
+                    >
+                        {this.createFocusPoints(value)}
+                    </div>
+                    : <Loader />
+                }
+                <img className={imageFocusPointStyles.image} onLoad={this.handleImageLoad} src={image} />
             </div>
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
@@ -6,11 +6,11 @@ import imageFocusPointStyles from './imageFocusPoint.scss';
 
 const FOCUS_POINT_MATRIX_SIZE = 3;
 
-type Props = {
+type Props = {|
     image: string,
-    value: Point,
     onChange: (value: Point) => void,
-};
+    value: Point,
+|};
 
 export default class ImageFocusPoint extends React.PureComponent<Props> {
     createFocusPoints(selectedPoint: Point) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/imageFocusPoint.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/imageFocusPoint.scss
@@ -1,6 +1,7 @@
 .image-focus-point {
     position: relative;
     display: inline-block;
+    height: 100%;
 }
 
 .focus-points {
@@ -11,4 +12,9 @@
     height: 100%;
     display: flex;
     flex-flow: wrap;
+}
+
+.image {
+    max-width: 100%;
+    max-height: 100%;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/index.js
@@ -1,4 +1,6 @@
 // @flow
 import ImageFocusPoint from './ImageFocusPoint';
+import type {Point} from './types';
 
 export default ImageFocusPoint;
+export type {Point};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/tests/ImageFocusPoint.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/tests/ImageFocusPoint.test.js
@@ -1,105 +1,164 @@
 // @flow
-import {render, mount} from 'enzyme';
+import {mount} from 'enzyme';
 import React from 'react';
 import ImageFocusPoint from '../ImageFocusPoint';
 
-test('Should render ImageFocusPoint with focusing the top-left point', () => {
+test('Should render Loader at the beginning', () => {
     const value = {x: 0, y: 0};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    expect(imageFocusPoint.render()).toMatchSnapshot();
+});
+
+test('Should render focus point cells with correct size', () => {
+    const value = {x: 0, y: 0};
+    const imageFocusPoint = mount(
+        <ImageFocusPoint
+            image="http://lorempixel.com/300/300"
+            onChange={jest.fn()}
+            value={value}
+        />
+    );
+
+    imageFocusPoint.find('img').prop('onLoad')({
+        currentTarget: {
+            getBoundingClientRect: jest.fn().mockReturnValue({width: '300px', height: '200px'}),
+        },
+    });
+
+    expect(imageFocusPoint.render()).toMatchSnapshot();
+});
+
+test('Should render ImageFocusPoint with focusing the top-left point', () => {
+    const value = {x: 0, y: 0};
+    const imageFocusPoint = mount(
+        <ImageFocusPoint
+            image="http://lorempixel.com/300/300"
+            onChange={jest.fn()}
+            value={value}
+        />
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the top-center point', () => {
     const value = {x: 1, y: 0};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the top-right point', () => {
     const value = {x: 2, y: 0};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the center-left point', () => {
     const value = {x: 0, y: 1};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the center-center point', () => {
     const value = {x: 1, y: 1};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the center-right point', () => {
     const value = {x: 2, y: 1};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the bottom-left point', () => {
     const value = {x: 0, y: 2};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the bottom-center point', () => {
     const value = {x: 1, y: 2};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should render ImageFocusPoint with focusing the bottom-right point', () => {
     const value = {x: 2, y: 2};
-    expect(render(
+    const imageFocusPoint = mount(
         <ImageFocusPoint
             image="http://lorempixel.com/300/300"
             onChange={jest.fn()}
             value={value}
         />
-    )).toMatchSnapshot();
+    );
+
+    imageFocusPoint.find('img').simulate('load');
+    expect(imageFocusPoint.render()).toMatchSnapshot();
 });
 
 test('Should call the onClick handler when a focus point was clicked', () => {
@@ -112,6 +171,8 @@ test('Should call the onClick handler when a focus point was clicked', () => {
             value={value}
         />
     );
+
+    imageFocusPoint.find('img').simulate('load');
 
     imageFocusPoint.find('button').at(0).simulate('click');
     expect(changeSpy).toBeCalledWith({x: 0, y: 0});
@@ -132,6 +193,8 @@ test('Should disable the selected focus point button', () => {
             value={value}
         />
     );
+
+    imageFocusPoint.find('img').simulate('load');
 
     expect(imageFocusPoint.find('button').at(0).props().disabled).toBe(true);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/tests/__snapshots__/ImageFocusPoint.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/tests/__snapshots__/ImageFocusPoint.test.js.snap
@@ -6,25 +6,26 @@ exports[`Should render ImageFocusPoint with focusing the bottom-center point 1`]
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-45deg)"
+        style="transform: rotate(-45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -34,10 +35,10 @@ exports[`Should render ImageFocusPoint with focusing the bottom-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(0deg)"
+        style="transform: rotate(0deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -47,10 +48,10 @@ exports[`Should render ImageFocusPoint with focusing the bottom-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(45deg)"
+        style="transform: rotate(45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -60,10 +61,10 @@ exports[`Should render ImageFocusPoint with focusing the bottom-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-90deg)"
+        style="transform: rotate(-90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -74,14 +75,14 @@ exports[`Should render ImageFocusPoint with focusing the bottom-center point 1`]
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(90deg)"
+        style="transform: rotate(90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -103,25 +104,26 @@ exports[`Should render ImageFocusPoint with focusing the bottom-left point 1`] =
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(0deg)"
+        style="transform: rotate(0deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -131,10 +133,10 @@ exports[`Should render ImageFocusPoint with focusing the bottom-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(45deg)"
+        style="transform: rotate(45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -144,19 +146,19 @@ exports[`Should render ImageFocusPoint with focusing the bottom-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(90deg)"
+        style="transform: rotate(90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -166,7 +168,7 @@ exports[`Should render ImageFocusPoint with focusing the bottom-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
   </div>
   <img
@@ -182,29 +184,30 @@ exports[`Should render ImageFocusPoint with focusing the bottom-right point 1`] 
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-45deg)"
+        style="transform: rotate(-45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -214,10 +217,10 @@ exports[`Should render ImageFocusPoint with focusing the bottom-right point 1`] 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(0deg)"
+        style="transform: rotate(0deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -227,14 +230,14 @@ exports[`Should render ImageFocusPoint with focusing the bottom-right point 1`] 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-90deg)"
+        style="transform: rotate(-90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -245,7 +248,7 @@ exports[`Should render ImageFocusPoint with focusing the bottom-right point 1`] 
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
   </div>
   <img
@@ -261,13 +264,14 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-45deg)"
+        style="transform: rotate(-45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -277,10 +281,10 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(0deg)"
+        style="transform: rotate(0deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -290,10 +294,10 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(45deg)"
+        style="transform: rotate(45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -303,10 +307,10 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-90deg)"
+        style="transform: rotate(-90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -317,14 +321,14 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(90deg)"
+        style="transform: rotate(90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -334,10 +338,10 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(225deg)"
+        style="transform: rotate(225deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -347,10 +351,10 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(180deg)"
+        style="transform: rotate(180deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -360,10 +364,10 @@ exports[`Should render ImageFocusPoint with focusing the center-center point 1`]
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(125deg)"
+        style="transform: rotate(125deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -385,13 +389,14 @@ exports[`Should render ImageFocusPoint with focusing the center-left point 1`] =
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(0deg)"
+        style="transform: rotate(0deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -401,10 +406,10 @@ exports[`Should render ImageFocusPoint with focusing the center-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(45deg)"
+        style="transform: rotate(45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -414,19 +419,19 @@ exports[`Should render ImageFocusPoint with focusing the center-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(90deg)"
+        style="transform: rotate(90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -436,14 +441,14 @@ exports[`Should render ImageFocusPoint with focusing the center-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(180deg)"
+        style="transform: rotate(180deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -453,10 +458,10 @@ exports[`Should render ImageFocusPoint with focusing the center-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(125deg)"
+        style="transform: rotate(125deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -466,7 +471,7 @@ exports[`Should render ImageFocusPoint with focusing the center-left point 1`] =
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
   </div>
   <img
@@ -482,17 +487,18 @@ exports[`Should render ImageFocusPoint with focusing the center-right point 1`] 
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-45deg)"
+        style="transform: rotate(-45deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -502,10 +508,10 @@ exports[`Should render ImageFocusPoint with focusing the center-right point 1`] 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(0deg)"
+        style="transform: rotate(0deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -515,14 +521,14 @@ exports[`Should render ImageFocusPoint with focusing the center-right point 1`] 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-90deg)"
+        style="transform: rotate(-90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -533,18 +539,18 @@ exports[`Should render ImageFocusPoint with focusing the center-right point 1`] 
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(225deg)"
+        style="transform: rotate(225deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -554,10 +560,10 @@ exports[`Should render ImageFocusPoint with focusing the center-right point 1`] 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(180deg)"
+        style="transform: rotate(180deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -579,13 +585,14 @@ exports[`Should render ImageFocusPoint with focusing the top-center point 1`] = 
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-90deg)"
+        style="transform: rotate(-90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -596,14 +603,14 @@ exports[`Should render ImageFocusPoint with focusing the top-center point 1`] = 
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(90deg)"
+        style="transform: rotate(90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -613,10 +620,10 @@ exports[`Should render ImageFocusPoint with focusing the top-center point 1`] = 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(225deg)"
+        style="transform: rotate(225deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -626,10 +633,10 @@ exports[`Should render ImageFocusPoint with focusing the top-center point 1`] = 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(180deg)"
+        style="transform: rotate(180deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -639,10 +646,10 @@ exports[`Should render ImageFocusPoint with focusing the top-center point 1`] = 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(125deg)"
+        style="transform: rotate(125deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -652,15 +659,15 @@ exports[`Should render ImageFocusPoint with focusing the top-center point 1`] = 
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
   </div>
   <img
@@ -676,18 +683,19 @@ exports[`Should render ImageFocusPoint with focusing the top-left point 1`] = `
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(90deg)"
+        style="transform: rotate(90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -697,14 +705,14 @@ exports[`Should render ImageFocusPoint with focusing the top-left point 1`] = `
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(180deg)"
+        style="transform: rotate(180deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -714,10 +722,10 @@ exports[`Should render ImageFocusPoint with focusing the top-left point 1`] = `
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(125deg)"
+        style="transform: rotate(125deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -727,19 +735,19 @@ exports[`Should render ImageFocusPoint with focusing the top-left point 1`] = `
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
   </div>
   <img
@@ -755,17 +763,18 @@ exports[`Should render ImageFocusPoint with focusing the top-right point 1`] = `
 >
   <div
     class="focusPoints"
+    style="height: 0px; width: 0px;"
   >
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(-90deg)"
+        style="transform: rotate(-90deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -776,18 +785,18 @@ exports[`Should render ImageFocusPoint with focusing the top-right point 1`] = `
     <button
       class="imageFocusPointCell active"
       disabled=""
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(225deg)"
+        style="transform: rotate(225deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -797,10 +806,10 @@ exports[`Should render ImageFocusPoint with focusing the top-right point 1`] = `
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     >
       <div
-        style="transform:rotate(180deg)"
+        style="transform: rotate(180deg);"
       >
         <span
           aria-label="su-angle-up"
@@ -810,15 +819,117 @@ exports[`Should render ImageFocusPoint with focusing the top-right point 1`] = `
     </button>
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
     <button
       class="imageFocusPointCell"
-      style="width:33.333333333333336%;height:33.333333333333336%"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    />
+  </div>
+  <img
+    class="image"
+    src="http://lorempixel.com/300/300"
+  />
+</div>
+`;
+
+exports[`Should render Loader at the beginning 1`] = `
+<div
+  class="imageFocusPoint"
+>
+  <div
+    class="spinner"
+    style="width: 40px; height: 40px;"
+  >
+    <div
+      class="doubleBounce1"
+    />
+    <div
+      class="doubleBounce2"
+    />
+  </div>
+  <img
+    class="image"
+    src="http://lorempixel.com/300/300"
+  />
+</div>
+`;
+
+exports[`Should render focus point cells with correct size 1`] = `
+<div
+  class="imageFocusPoint"
+>
+  <div
+    class="focusPoints"
+    style="height: 200px; width: 300px;"
+  >
+    <button
+      class="imageFocusPointCell active"
+      disabled=""
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    />
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    >
+      <div
+        style="transform: rotate(90deg);"
+      >
+        <span
+          aria-label="su-angle-up"
+          class="su-angle-up"
+        />
+      </div>
+    </button>
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    />
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    >
+      <div
+        style="transform: rotate(180deg);"
+      >
+        <span
+          aria-label="su-angle-up"
+          class="su-angle-up"
+        />
+      </div>
+    </button>
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    >
+      <div
+        style="transform: rotate(125deg);"
+      >
+        <span
+          aria-label="su-angle-up"
+          class="su-angle-up"
+        />
+      </div>
+    </button>
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    />
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    />
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
+    />
+    <button
+      class="imageFocusPointCell"
+      style="width: 33.333333333333336%; height: 33.333333333333336%;"
     />
   </div>
   <img

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -11,6 +11,7 @@ import focusPointOverlayStyles from './focusPointOverlay.scss';
 
 type Props = {|
     onClose: () => void,
+    onConfirm: () => void,
     open: boolean,
     resourceStore: ResourceStore,
 |};
@@ -71,7 +72,7 @@ export default class FocusPointOverlay extends React.Component<Props> {
         this.resourceStore.save().then(() => {
             this.props.resourceStore.set('focusPointX', this.focusPointX);
             this.props.resourceStore.set('focusPointY', this.focusPointY);
-            this.props.onClose();
+            this.props.onConfirm();
         });
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -65,7 +65,7 @@ export default class FocusPointOverlay extends React.Component<Props> {
         return (
             <Overlay
                 confirmLoading={resourceStore.saving}
-                confirmText={translate('sulu_admin.confirm')}
+                confirmText={translate('sulu_admin.save')}
                 onClose={this.handleClose}
                 onConfirm={this.handleConfirm}
                 open={open}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -18,16 +18,23 @@ type Props = {|
 export default class FocusPointOverlay extends React.Component<Props> {
     @observable focusPointX: number;
     @observable focusPointY: number;
+    resourceStore: ResourceStore;
 
     constructor(props: Props) {
         super(props);
 
+        this.resourceStore = this.props.resourceStore.clone();
         this.updateFocusPoint();
     }
 
     componentDidUpdate(prevProps: Props) {
         if (!prevProps.open && this.props.open) {
+            this.resourceStore = this.props.resourceStore.clone();
             this.updateFocusPoint();
+        }
+
+        if (prevProps.open && !this.props.open) {
+            this.resourceStore.destroy();
         }
     }
 
@@ -44,12 +51,12 @@ export default class FocusPointOverlay extends React.Component<Props> {
     };
 
     handleConfirm = () => {
-        const {resourceStore} = this.props;
+        this.resourceStore.change('focusPointX', this.focusPointX);
+        this.resourceStore.change('focusPointY', this.focusPointY);
 
-        resourceStore.change('focusPointX', this.focusPointX);
-        resourceStore.change('focusPointY', this.focusPointY);
-
-        this.props.resourceStore.save().then(() => {
+        this.resourceStore.save().then(() => {
+            this.props.resourceStore.set('focusPointX', this.focusPointX);
+            this.props.resourceStore.set('focusPointY', this.focusPointY);
             this.props.onClose();
         });
     };
@@ -60,11 +67,11 @@ export default class FocusPointOverlay extends React.Component<Props> {
     };
 
     render() {
-        const {open, resourceStore} = this.props;
+        const {open} = this.props;
 
         return (
             <Overlay
-                confirmLoading={resourceStore.saving}
+                confirmLoading={this.resourceStore.saving}
                 confirmText={translate('sulu_admin.save')}
                 onClose={this.handleClose}
                 onConfirm={this.handleConfirm}
@@ -72,7 +79,7 @@ export default class FocusPointOverlay extends React.Component<Props> {
                 title={translate('sulu_media.set_focus_point')}
             >
                 <ImageFocusPoint
-                    image={resourceStore.data.url}
+                    image={this.resourceStore.data.url}
                     onChange={this.handleFocusPointChange}
                     value={{x: this.focusPointX, y: this.focusPointY}}
                 />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -1,0 +1,82 @@
+// @flow
+import React from 'react';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import {Overlay} from 'sulu-admin-bundle/components';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {translate} from 'sulu-admin-bundle/utils';
+import ImageFocusPoint from '../../components/ImageFocusPoint';
+import type {Point} from '../../components/ImageFocusPoint';
+
+type Props = {|
+    onClose: () => void,
+    open: boolean,
+    resourceStore: ResourceStore,
+|};
+
+@observer
+export default class FocusPointOverlay extends React.Component<Props> {
+    @observable focusPointX: number = 1;
+    @observable focusPointY: number = 1;
+
+    constructor(props: Props) {
+        super(props);
+
+        this.updateFocusPoint();
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (!prevProps.open && this.props.open) {
+            this.updateFocusPoint();
+        }
+    }
+
+    @action updateFocusPoint = () => {
+        const {resourceStore} = this.props;
+        const {focusPointX, focusPointY} = resourceStore.data;
+
+        this.focusPointX = focusPointX;
+        this.focusPointY = focusPointY;
+    };
+
+    handleClose = () => {
+        this.props.onClose();
+    };
+
+    handleConfirm = () => {
+        const {resourceStore} = this.props;
+
+        resourceStore.change('focusPointX', this.focusPointX);
+        resourceStore.change('focusPointY', this.focusPointY);
+
+        this.props.resourceStore.save().then(() => {
+            this.props.onClose();
+        });
+    };
+
+    @action handleFocusPointChange = (point: Point) => {
+        this.focusPointX = point.x;
+        this.focusPointY = point.y;
+    };
+
+    render() {
+        const {open, resourceStore} = this.props;
+
+        return (
+            <Overlay
+                confirmLoading={resourceStore.saving}
+                confirmText={translate('sulu_admin.confirm')}
+                onClose={this.handleClose}
+                onConfirm={this.handleConfirm}
+                open={open}
+                title={translate('sulu_media.set_focus_point')}
+            >
+                <ImageFocusPoint
+                    image={resourceStore.data.url}
+                    onChange={this.handleFocusPointChange}
+                    value={{x: this.focusPointX, y: this.focusPointY}}
+                />
+            </Overlay>
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable} from 'mobx';
+import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Overlay} from 'sulu-admin-bundle/components';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
@@ -20,6 +20,19 @@ export default class FocusPointOverlay extends React.Component<Props> {
     @observable focusPointX: number;
     @observable focusPointY: number;
     resourceStore: ResourceStore;
+
+    @computed get confirmDisabled() {
+        const {
+            resourceStore: {
+                data: {
+                    focusPointX,
+                    focusPointY,
+                },
+            },
+        } = this.props;
+
+        return this.focusPointX === focusPointX && this.focusPointY === focusPointY;
+    }
 
     constructor(props: Props) {
         super(props);
@@ -72,6 +85,7 @@ export default class FocusPointOverlay extends React.Component<Props> {
 
         return (
             <Overlay
+                confirmDisabled={this.confirmDisabled}
                 confirmLoading={this.resourceStore.saving}
                 confirmText={translate('sulu_admin.save')}
                 onClose={this.handleClose}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -7,6 +7,7 @@ import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {translate} from 'sulu-admin-bundle/utils';
 import ImageFocusPoint from '../../components/ImageFocusPoint';
 import type {Point} from '../../components/ImageFocusPoint';
+import focusPointOverlayStyles from './focusPointOverlay.scss';
 
 type Props = {|
     onClose: () => void,
@@ -76,13 +77,16 @@ export default class FocusPointOverlay extends React.Component<Props> {
                 onClose={this.handleClose}
                 onConfirm={this.handleConfirm}
                 open={open}
+                size="large"
                 title={translate('sulu_media.set_focus_point')}
             >
-                <ImageFocusPoint
-                    image={this.resourceStore.data.url}
-                    onChange={this.handleFocusPointChange}
-                    value={{x: this.focusPointX, y: this.focusPointY}}
-                />
+                <div className={focusPointOverlayStyles.focusPointContainer}>
+                    <ImageFocusPoint
+                        image={this.resourceStore.data.url}
+                        onChange={this.handleFocusPointChange}
+                        value={{x: this.focusPointX, y: this.focusPointY}}
+                    />
+                </div>
             </Overlay>
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/FocusPointOverlay.js
@@ -16,8 +16,8 @@ type Props = {|
 
 @observer
 export default class FocusPointOverlay extends React.Component<Props> {
-    @observable focusPointX: number = 1;
-    @observable focusPointY: number = 1;
+    @observable focusPointX: number;
+    @observable focusPointY: number;
 
     constructor(props: Props) {
         super(props);
@@ -33,7 +33,7 @@ export default class FocusPointOverlay extends React.Component<Props> {
 
     @action updateFocusPoint = () => {
         const {resourceStore} = this.props;
-        const {focusPointX, focusPointY} = resourceStore.data;
+        const {focusPointX = 1, focusPointY = 1} = resourceStore.data;
 
         this.focusPointX = focusPointX;
         this.focusPointY = focusPointY;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -59,9 +59,13 @@ class MediaDetail extends React.Component<Props> {
         this.form = form;
     };
 
+    @action showSuccessSnackbar() {
+        this.showSuccess.set(true);
+    }
+
     handleSubmit = () => {
         return this.props.resourceStore.save().then(action(() => {
-            this.showSuccess.set(true);
+            this.showSuccessSnackbar();
         }));
     };
 
@@ -75,6 +79,11 @@ class MediaDetail extends React.Component<Props> {
 
     @action handleFocusPointOverlayClose = () => {
         this.showFocusPointOverlay = false;
+    };
+
+    @action handleFocusPointOverlayConfirm = () => {
+        this.showFocusPointOverlay = false;
+        this.showSuccessSnackbar();
     };
 
     render() {
@@ -119,6 +128,7 @@ class MediaDetail extends React.Component<Props> {
                 }
                 <FocusPointOverlay
                     onClose={this.handleFocusPointOverlayClose}
+                    onConfirm={this.handleFocusPointOverlayConfirm}
                     open={this.showFocusPointOverlay}
                     resourceStore={resourceStore}
                 />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -1,8 +1,8 @@
 // @flow
 import React from 'react';
-import {when} from 'mobx';
+import {action, observable, when} from 'mobx';
 import {observer} from 'mobx-react';
-import {Grid, Loader} from 'sulu-admin-bundle/components';
+import {Button, Grid, Loader} from 'sulu-admin-bundle/components';
 import {Form, FormStore, withToolbar} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
@@ -10,6 +10,7 @@ import {translate} from 'sulu-admin-bundle/utils';
 import MediaUploadStore from '../../stores/MediaUploadStore';
 import SingleMediaUpload from '../../containers/SingleMediaUpload';
 import mediaDetailStyles from './mediaDetail.scss';
+import FocusPointOverlay from './FocusPointOverlay';
 
 const COLLECTION_ROUTE = 'sulu_media.overview';
 
@@ -22,6 +23,7 @@ class MediaDetail extends React.Component<Props> {
     mediaUploadStore: MediaUploadStore;
     form: ?Form;
     formStore: FormStore;
+    @observable showFocusPointOverlay: boolean = false;
 
     constructor(props: Props) {
         super(props);
@@ -64,7 +66,17 @@ class MediaDetail extends React.Component<Props> {
         this.props.resourceStore.setMultiple(media);
     };
 
+    @action handleFocusPointButtonClick = () => {
+        this.showFocusPointOverlay = true;
+    };
+
+    @action handleFocusPointOverlayClose = () => {
+        this.showFocusPointOverlay = false;
+    };
+
     render() {
+        const {resourceStore} = this.props;
+
         return (
             <div className={mediaDetailStyles.mediaDetail}>
                 {this.formStore.loading
@@ -80,6 +92,15 @@ class MediaDetail extends React.Component<Props> {
                                     onUploadComplete={this.handleUploadComplete}
                                     uploadText={translate('sulu_media.upload_or_replace')}
                                 />
+                                <div className={mediaDetailStyles.buttons}>
+                                    <Button
+                                        icon="su-focus"
+                                        onClick={this.handleFocusPointButtonClick}
+                                        skin="link"
+                                    >
+                                        {translate('sulu_media.set_focus_point')}
+                                    </Button>
+                                </div>
                             </Grid.Item>
                         </Grid.Section>
                         <Grid.Section size={8}>
@@ -93,6 +114,11 @@ class MediaDetail extends React.Component<Props> {
                         </Grid.Section>
                     </Grid>
                 }
+                <FocusPointOverlay
+                    onClose={this.handleFocusPointOverlayClose}
+                    open={this.showFocusPointOverlay}
+                    resourceStore={resourceStore}
+                />
             </div>
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -24,6 +24,7 @@ class MediaDetail extends React.Component<Props> {
     form: ?Form;
     formStore: FormStore;
     @observable showFocusPointOverlay: boolean = false;
+    showSuccess = observable.box(false);
 
     constructor(props: Props) {
         super(props);
@@ -59,7 +60,9 @@ class MediaDetail extends React.Component<Props> {
     };
 
     handleSubmit = () => {
-        this.props.resourceStore.save();
+        return this.props.resourceStore.save().then(action(() => {
+            this.showSuccess.set(true);
+        }));
     };
 
     handleUploadComplete = (media: Object) => {
@@ -125,6 +128,7 @@ class MediaDetail extends React.Component<Props> {
 }
 
 export default withToolbar(MediaDetail, function() {
+    const {showSuccess} = this;
     const {
         router,
         resourceStore,
@@ -162,5 +166,6 @@ export default withToolbar(MediaDetail, function() {
                 },
             },
         ],
+        showSuccess,
     };
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/focusPointOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/focusPointOverlay.scss
@@ -1,0 +1,8 @@
+@import 'sulu-admin-bundle/containers/Application/variables.scss';
+
+.focus-point-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: $viewPadding;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/focusPointOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/focusPointOverlay.scss
@@ -1,8 +1,10 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
+@import 'sulu-admin-bundle/components/Overlay/variables.scss';
 
 .focus-point-container {
     display: flex;
     align-items: center;
     justify-content: center;
     padding: $viewPadding;
+    height: $overlayContentMaxHeight;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/mediaDetail.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/mediaDetail.scss
@@ -13,3 +13,13 @@
 .image-section {
     margin-bottom: 30px;
 }
+
+.buttons {
+    display: flex;
+    flex-wrap: wrap;
+
+    > * {
+        flex: 1;
+        margin-top: 20px;
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
@@ -1,0 +1,100 @@
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import FocusPointOverlay from '../FocusPointOverlay';
+
+jest.mock('sulu-admin-bundle/stores', () => ({
+    ResourceStore: jest.fn(function() {
+        this.change = jest.fn();
+        this.save = jest.fn();
+    }),
+}));
+
+jest.mock('sulu-admin-bundle/utils', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Initialize with data from resourceStore when overlay opens', () => {
+    const resourceStore = new ResourceStore('media');
+    resourceStore.data = {
+        url: '/image.jpeg',
+        focusPointX: 2,
+        focusPointY: 1,
+    };
+
+    const focusPointOverlay = shallow(
+        <FocusPointOverlay
+            onClose={jest.fn()}
+            open={false}
+            resourceStore={resourceStore}
+        />
+    );
+
+    expect(focusPointOverlay.find('ImageFocusPoint').prop('image')).toEqual('/image.jpeg');
+    expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 2, y: 1});
+
+    focusPointOverlay.instance().focusPointX = 0;
+    focusPointOverlay.instance().focusPointY = 0;
+
+    focusPointOverlay.update();
+    expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 0, y: 0});
+
+    focusPointOverlay.setProps({open: true});
+    focusPointOverlay.update();
+    expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 2, y: 1});
+});
+
+test('Closing the overlay should call the onClose callback', () => {
+    const closeSpy = jest.fn();
+
+    const resourceStore = new ResourceStore('media');
+    resourceStore.data = {
+        focusPointX: 2,
+        focusPointY: 1,
+    };
+
+    const focusPointOverlay = shallow(
+        <FocusPointOverlay
+            onClose={closeSpy}
+            open={true}
+            resourceStore={resourceStore}
+        />
+    );
+
+    focusPointOverlay.find('Overlay').prop('onClose')();
+
+    expect(closeSpy).toBeCalledWith();
+});
+
+test('Should save the focus point when confirm button is clicked', () => {
+    const closeSpy = jest.fn();
+
+    const resourceStore = new ResourceStore('media');
+    resourceStore.data = {
+        focusPointX: 2,
+        focusPointY: 1,
+    };
+
+    const savePromise = Promise.resolve({});
+    resourceStore.save.mockReturnValue(savePromise);
+
+    const focusPointOverlay = shallow(
+        <FocusPointOverlay
+            onClose={closeSpy}
+            open={true}
+            resourceStore={resourceStore}
+        />
+    );
+
+    focusPointOverlay.find('ImageFocusPoint').prop('onChange')({x: 0, y: 2});
+    focusPointOverlay.find('Overlay').prop('onConfirm')();
+
+    expect(resourceStore.change).toBeCalledWith('focusPointX', 0);
+    expect(resourceStore.change).toBeCalledWith('focusPointY', 2);
+    expect(resourceStore.save).toBeCalledWith();
+
+    return savePromise.then(() => {
+        expect(closeSpy).toBeCalled();
+    });
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
@@ -15,6 +15,25 @@ jest.mock('sulu-admin-bundle/utils', () => ({
     translate: jest.fn((key) => key),
 }));
 
+test('Should select the  middle by default', () => {
+    const resourceStore = new ResourceStore('media');
+    resourceStore.data = {
+        url: '/image.jpeg',
+        focusPointX: undefined,
+        focusPointY: undefined,
+    };
+
+    const focusPointOverlay = shallow(
+        <FocusPointOverlay
+            onClose={jest.fn()}
+            open={false}
+            resourceStore={resourceStore}
+        />
+    );
+
+    expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 1, y: 1});
+});
+
 test('Initialize with data from resourceStore when overlay opens', () => {
     const resourceStore = new ResourceStore('media');
     resourceStore.data = {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
@@ -6,8 +6,10 @@ import FocusPointOverlay from '../FocusPointOverlay';
 
 jest.mock('sulu-admin-bundle/stores', () => ({
     ResourceStore: jest.fn(function() {
+        this.clone = jest.fn().mockReturnValue(this);
         this.change = jest.fn();
         this.save = jest.fn();
+        this.set = jest.fn();
     }),
 }));
 
@@ -90,6 +92,7 @@ test('Should save the focus point when confirm button is clicked', () => {
     const closeSpy = jest.fn();
 
     const resourceStore = new ResourceStore('media');
+
     resourceStore.data = {
         focusPointX: 2,
         focusPointY: 1,
@@ -109,11 +112,15 @@ test('Should save the focus point when confirm button is clicked', () => {
     focusPointOverlay.find('ImageFocusPoint').prop('onChange')({x: 0, y: 2});
     focusPointOverlay.find('Overlay').prop('onConfirm')();
 
-    expect(resourceStore.change).toBeCalledWith('focusPointX', 0);
-    expect(resourceStore.change).toBeCalledWith('focusPointY', 2);
-    expect(resourceStore.save).toBeCalledWith();
+    const clonedResourceStore = focusPointOverlay.instance().resourceStore;
+
+    expect(clonedResourceStore.change).toBeCalledWith('focusPointX', 0);
+    expect(clonedResourceStore.change).toBeCalledWith('focusPointY', 2);
+    expect(clonedResourceStore.save).toBeCalledWith();
 
     return savePromise.then(() => {
+        expect(resourceStore.set).toBeCalledWith('focusPointX', 0);
+        expect(resourceStore.set).toBeCalledWith('focusPointY', 2);
         expect(closeSpy).toBeCalled();
     });
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
@@ -109,7 +109,9 @@ test('Should save the focus point when confirm button is clicked', () => {
         />
     );
 
+    expect(focusPointOverlay.find('Overlay').prop('confirmDisabled')).toEqual(true);
     focusPointOverlay.find('ImageFocusPoint').prop('onChange')({x: 0, y: 2});
+    expect(focusPointOverlay.find('Overlay').prop('confirmDisabled')).toEqual(false);
     focusPointOverlay.find('Overlay').prop('onConfirm')();
 
     const clonedResourceStore = focusPointOverlay.instance().resourceStore;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/FocusPointOverlay.test.js
@@ -28,6 +28,7 @@ test('Should select the  middle by default', () => {
     const focusPointOverlay = shallow(
         <FocusPointOverlay
             onClose={jest.fn()}
+            onConfirm={jest.fn()}
             open={false}
             resourceStore={resourceStore}
         />
@@ -47,6 +48,7 @@ test('Initialize with data from resourceStore when overlay opens', () => {
     const focusPointOverlay = shallow(
         <FocusPointOverlay
             onClose={jest.fn()}
+            onConfirm={jest.fn()}
             open={false}
             resourceStore={resourceStore}
         />
@@ -78,6 +80,7 @@ test('Closing the overlay should call the onClose callback', () => {
     const focusPointOverlay = shallow(
         <FocusPointOverlay
             onClose={closeSpy}
+            onConfirm={jest.fn()}
             open={true}
             resourceStore={resourceStore}
         />
@@ -89,7 +92,7 @@ test('Closing the overlay should call the onClose callback', () => {
 });
 
 test('Should save the focus point when confirm button is clicked', () => {
-    const closeSpy = jest.fn();
+    const confirmSpy = jest.fn();
 
     const resourceStore = new ResourceStore('media');
 
@@ -103,7 +106,8 @@ test('Should save the focus point when confirm button is clicked', () => {
 
     const focusPointOverlay = shallow(
         <FocusPointOverlay
-            onClose={closeSpy}
+            onClose={jest.fn()}
+            onConfirm={confirmSpy}
             open={true}
             resourceStore={resourceStore}
         />
@@ -123,6 +127,6 @@ test('Should save the focus point when confirm button is clicked', () => {
     return savePromise.then(() => {
         expect(resourceStore.set).toBeCalledWith('focusPointX', 0);
         expect(resourceStore.set).toBeCalledWith('focusPointY', 2);
-        expect(closeSpy).toBeCalled();
+        expect(confirmSpy).toBeCalled();
     });
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -318,6 +318,8 @@ test('Should save form when submitted', (done) => {
     const metadataStore = require('sulu-admin-bundle/containers/Form/stores/MetadataStore');
     const Form = require('sulu-admin-bundle/containers').Form;
     const resourceStore = new ResourceStore('media', 4, {locale: observable.box()});
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaDetail);
     resourceStore.locale.set('en');
     resourceStore.data = {value: 'Value'};
     resourceStore.loading = false;
@@ -350,9 +352,14 @@ test('Should save form when submitted', (done) => {
     Promise.all([schemaTypesPromise, metadataPromise, jsonSchemaPromise]).then(() => {
         jsonSchemaPromise.then(() => {
             mediaDetail.update();
-            mediaDetail.find(Form).instance().submit();
-            expect(ResourceRequester.put).toBeCalledWith('media', 4, {value: 'Value'}, {locale: 'en'});
-            done();
+            expect(toolbarFunction.call(mediaDetail.instance()).showSuccess.get()).toEqual(false);
+
+            mediaDetail.find(Form).instance().submit().then(() => {
+                mediaDetail.update();
+                expect(ResourceRequester.put).toBeCalledWith('media', 4, {value: 'Value'}, {locale: 'en'});
+                expect(toolbarFunction.call(mediaDetail.instance()).showSuccess.get()).toEqual(true);
+                done();
+            });
         });
     });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -382,3 +382,119 @@ test('Should destroy the store on unmount', () => {
     mediaDetail.unmount();
     expect(formStore.destroy).toBeCalled();
 });
+
+test('Should open and close focus point overlay', (done) => {
+    const ResourceRequester = require('sulu-admin-bundle/services/ResourceRequester');
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
+    const MediaDetail = require('../MediaDetail').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const metadataStore = require('sulu-admin-bundle/containers/Form/stores/MetadataStore');
+    const resourceStore = new ResourceStore('media', 4, {locale: observable.box()});
+    resourceStore.loading = false;
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const metadataPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(metadataPromise);
+
+    let jsonSchemaResolve;
+    const jsonSchemaPromise = new Promise((resolve) => {
+        jsonSchemaResolve = resolve;
+    });
+
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaDetail = mount(<MediaDetail resourceStore={resourceStore} router={router} />);
+
+    Promise.all([schemaTypesPromise, metadataPromise, jsonSchemaPromise]).then(() => {
+        jsonSchemaPromise.then(() => {
+            mediaDetail.update();
+            expect(mediaDetail.find('FocusPointOverlay').prop('open')).toEqual(false);
+
+            mediaDetail.find('Button[icon="su-focus"]').prop('onClick')();
+            mediaDetail.update();
+            expect(mediaDetail.find('FocusPointOverlay').prop('open')).toEqual(true);
+
+            mediaDetail.find('FocusPointOverlay').prop('onClose')();
+            mediaDetail.update();
+            expect(mediaDetail.find('FocusPointOverlay').prop('open')).toEqual(false);
+            done();
+        });
+    });
+
+    jsonSchemaResolve({});
+});
+
+test('Should save focus point overlay', (done) => {
+    const ResourceRequester = require('sulu-admin-bundle/services/ResourceRequester');
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
+    const MediaDetail = require('../MediaDetail').default;
+    const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
+    const metadataStore = require('sulu-admin-bundle/containers/Form/stores/MetadataStore');
+    const resourceStore = new ResourceStore('media', 4, {locale: observable.box()});
+    resourceStore.loading = false;
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const metadataPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(metadataPromise);
+
+    let jsonSchemaResolve;
+    const jsonSchemaPromise = new Promise((resolve) => {
+        jsonSchemaResolve = resolve;
+    });
+
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route: {
+            options: {
+                locales: [],
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaDetail = mount(<MediaDetail resourceStore={resourceStore} router={router} />);
+
+    Promise.all([schemaTypesPromise, metadataPromise, jsonSchemaPromise]).then(() => {
+        jsonSchemaPromise.then(() => {
+            mediaDetail.update();
+            mediaDetail.find('Button[icon="su-focus"]').prop('onClick')();
+
+            mediaDetail.update();
+            expect(mediaDetail.find('FocusPointOverlay').prop('open')).toEqual(true);
+
+            mediaDetail.find('ImageFocusPoint').prop('onChange')({x: 0, y: 2});
+            mediaDetail.find('Overlay').prop('onConfirm')();
+
+            expect(ResourceRequester.put).toBeCalledWith(
+                'media',
+                4,
+                {focusPointX: 0, focusPointY: 2},
+                {locale: undefined}
+            );
+
+            setTimeout(() => {
+                mediaDetail.update();
+                expect(mediaDetail.find('FocusPointOverlay').prop('open')).toEqual(false);
+                done();
+            });
+        });
+    });
+
+    jsonSchemaResolve({});
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -450,6 +450,8 @@ test('Should save focus point overlay', (done) => {
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
     const metadataStore = require('sulu-admin-bundle/containers/Form/stores/MetadataStore');
     const resourceStore = new ResourceStore('media', 4, {locale: observable.box()});
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaDetail);
     resourceStore.loading = false;
 
     const schemaTypesPromise = Promise.resolve({});
@@ -497,6 +499,7 @@ test('Should save focus point overlay', (done) => {
 
             setTimeout(() => {
                 mediaDetail.update();
+                expect(toolbarFunction.call(mediaDetail.instance()).showSuccess.get()).toEqual(true);
                 expect(mediaDetail.find('FocusPointOverlay').prop('open')).toEqual(false);
                 done();
             });

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -32,5 +32,6 @@
     "sulu_media.history": "Verlauf",
     "sulu_media.formats": "Formate",
     "sulu_media.all_collections": "Alle Kollektionen",
-    "sulu_media.move_media": "Medien verschieben"
+    "sulu_media.move_media": "Medien verschieben",
+    "sulu_media.set_focus_point": "Fokuspunkt setzen"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -32,5 +32,6 @@
     "sulu_media.history": "History",
     "sulu_media.formats": "Formats",
     "sulu_media.all_collections": "All collections",
-    "sulu_media.move_media": "Move media"
+    "sulu_media.move_media": "Move media",
+    "sulu_media.set_focus_point": "Set focus point"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the overlay for setting the focus point of an image.

#### Why?

Because this is a feature being already available in the old UI.