### PR TITLE
Added autowire services for SecurityCheckerInterface and WebspaceManagerInterface

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -3,10 +3,8 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sulu_core.webspace.webspace_manager.class">Sulu\Component\Webspace\Manager\WebspaceManager</parameter>
         <parameter key="sulu_core.webspace.cache_class">%sulu.context%WebspaceCollectionCache</parameter>
         <parameter key="sulu_core.webspace.base_class">WebspaceCollection</parameter>
-        <parameter key="sulu_core.webspace.document_manager.webspace_initializer.class">Sulu\Component\Webspace\Document\Initializer\WebspaceInitializer</parameter>
     </parameters>
 
     <services>
@@ -31,7 +29,7 @@
 
         <service id="sulu_core.webspace.webspace_manager.url_replacer" class="Sulu\Component\Webspace\Url\Replacer"/>
 
-        <service id="sulu_core.webspace.webspace_manager" class="%sulu_core.webspace.webspace_manager.class%" public="true">
+        <service id="sulu_core.webspace.webspace_manager" class="Sulu\Component\Webspace\Manager\WebspaceManager" public="true">
             <argument type="service" id="sulu_core.webspace.loader.delegator"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager.url_replacer"/>
             <argument type="collection">
@@ -44,8 +42,9 @@
 
             <tag name="sulu.localization_provider"/>
         </service>
+        <service id="Sulu\Component\Webspace\Manager\WebspaceManagerInterface" alias="sulu_core.webspace.webspace_manager"/>
 
-        <service id="sulu_core.webspace.document_manager.webspace_initializer" class="%sulu_core.webspace.document_manager.webspace_initializer.class%">
+        <service id="sulu_core.webspace.document_manager.webspace_initializer" class="Sulu\Component\Webspace\Document\Initializer\WebspaceInitializer">
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/checker.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/checker.xml
@@ -2,19 +2,14 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_security.security_checker.class">Sulu\Component\Security\Authorization\SecurityChecker</parameter>
-        <parameter key="sulu_security.event_listener.security.class">Sulu\Bundle\SecurityBundle\EventListener\SuluSecurityListener</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_security.security_checker" class="%sulu_security.security_checker.class%" public="true">
+        <service id="sulu_security.security_checker" class="Sulu\Component\Security\Authorization\SecurityChecker" public="true">
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authorization_checker"/>
         </service>
+        <service id="Sulu\Component\Security\Authorization\SecurityCheckerInterface" alias="sulu_security.security_checker"/>
 
-        <service id="sulu_security.event_listener.security" class="%sulu_security.event_listener.security.class%">
+        <service id="sulu_security.event_listener.security" class="Sulu\Bundle\SecurityBundle\EventListener\SuluSecurityListener">
             <argument type="service" id="sulu_security.security_checker"/>
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related PRs? | #4228, #4223
| License | MIT

#### What's in this PR?

Added autowire services for SecurityCheckerInterface and WebspaceManagerInterface.

#### Why?

It allows to autowire webspace manager and security manager interface for the admin class.

#### Example Usage

```yaml
# config/services.yaml

services:
    _defaults:
        autowire: true
        autoconfigure: true
        public: false

    App\:
        resource: '../src/*'
        exclude: '../src/{Migrations,Tests,Kernel.php}'
```

```php
// src/App/AppAdmin.php

namespace App\Admin;

use Sulu\Bundle\AdminBundle\Admin\Admin;
use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;

class AppAdmin extends Admin
{
    /**
     * @var WebspaceManagerInterface
     */
    private $webspaceManager;

    /**
     * @var SecurityCheckerInterface
     */
    private $securityChecker;

    public function __construct(
        WebspaceManagerInterface $webspaceManager,
        SecurityCheckerInterface $securityChecker
    ) {
        $this->webspaceManager = $webspaceManager;
        $this->securityChecker = $securityChecker;
    }
}
```
