### PR TITLE
Use field descriptor interface in resthelper

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -26,8 +26,8 @@ export default class Preview extends React.Component<Props> {
 
     previewStore: PreviewStore;
 
-    typeDisposer: () => void;
-    dataDisposer: () => void;
+    typeDisposer: () => mixed;
+    dataDisposer: () => mixed;
 
     constructor(props: Props) {
         super(props);

--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Rest;
 
 use Sulu\Component\Persistence\RelationTrait;
-use Sulu\Component\Rest\ListBuilder\FieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 use Sulu\Component\Rest\ListBuilder\ListRestHelper;
@@ -84,7 +83,7 @@ class RestHelper implements RestHelperInterface
     }
 
     /**
-     * @param FieldDescriptor[] $fieldDescriptors
+     * @param FieldDescriptorInterface[] $fieldDescriptors
      *
      * @return string[]
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use field descriptor interface in resthelper and fixed error with flow.

#### Why?

Avoid problems with [phpstan](https://github.com/phpstan/phpstan).

#### Example Usage

~~~php
$fieldDescriptors = $this->fieldDescriptorsFactory->getFieldDescriptorForClass(Location::class);
$this->restHelper->initializeListBuilder($this->listBuilder, $fieldDescriptors);
~~~

