### PR TITLE
Fixed website caching by setting cache_lifetime.enhancer public

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-lifetime-enhancer.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-lifetime-enhancer.xml
@@ -3,7 +3,9 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sulu_http_cache.cache_lifetime.enhancer" class="Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer">
+        <service id="sulu_http_cache.cache_lifetime.enhancer"
+                 class="Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer"
+                 public="true">
             <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
             <argument>%sulu_http_cache.cache.max_age%</argument>
             <argument>%sulu_http_cache.cache.shared_max_age%</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR set the `sulu_http_cache.cache_lifetime.enhancer` public.

#### Why?

Without this the  `X-Reverse-Proxy-TTL` will not be set.
