### PR TITLE
implemented disabled property for sulu field-type components

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -10,6 +10,7 @@ import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {
+    disabled?: boolean,
     maxOccurs?: ?number,
     minOccurs?: ?number,
     onChange: (value: Array<BlockEntry>) => void,
@@ -133,7 +134,7 @@ export default class BlockCollection extends React.Component<Props> {
     }
 
     render() {
-        const {renderBlockContent, types, value} = this.props;
+        const {disabled, renderBlockContent, types, value} = this.props;
 
         const identifiedValues = value.map((block) => {
             if (!block.__id) {
@@ -146,6 +147,7 @@ export default class BlockCollection extends React.Component<Props> {
         return (
             <section className={blockCollectionStyles.blockCollection}>
                 <SortableBlocks
+                    disabled={disabled}
                     expandedBlocks={this.expandedBlocks}
                     lockAxis="y"
                     onCollapse={this.handleCollapse}
@@ -159,7 +161,7 @@ export default class BlockCollection extends React.Component<Props> {
                     value={identifiedValues}
                 />
                 <Button
-                    disabled={this.hasMaximumReached()}
+                    disabled={disabled || this.hasMaximumReached()}
                     icon="su-plus"
                     onClick={this.handleAddBlock}
                     skin="secondary"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -9,8 +9,8 @@ import SortableBlocks from './SortableBlocks';
 import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
-type Props = {
-    disabled?: boolean,
+type Props = {|
+    disabled: boolean,
     maxOccurs?: ?number,
     minOccurs?: ?number,
     onChange: (value: Array<BlockEntry>) => void,
@@ -18,13 +18,14 @@ type Props = {
     renderBlockContent: RenderBlockContentCallback,
     types?: {[key: string]: string},
     value: Array<BlockEntry>,
-};
+|};
 
 @observer
 export default class BlockCollection extends React.Component<Props> {
     static idCounter = 0;
 
     static defaultProps = {
+        disabled: false,
         value: [],
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -5,7 +5,7 @@ import {observer} from 'mobx-react';
 import {arrayMove} from 'react-sortable-hoc';
 import {translate} from '../../utils/Translator';
 import Button from '../Button';
-import SortableBlocks from './SortableBlocks';
+import SortableBlockList from './SortableBlockList';
 import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
@@ -147,7 +147,7 @@ export default class BlockCollection extends React.Component<Props> {
 
         return (
             <section className={blockCollectionStyles.blockCollection}>
-                <SortableBlocks
+                <SortableBlockList
                     disabled={disabled}
                     expandedBlocks={this.expandedBlocks}
                     lockAxis="y"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -21,7 +21,7 @@ type Props = {|
 |};
 
 @observer
-class SortableBlocks extends React.Component<Props> {
+class SortableBlockList extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -82,4 +82,4 @@ class SortableBlocks extends React.Component<Props> {
     }
 }
 
-export default SortableContainer(SortableBlocks);
+export default SortableContainer(SortableBlockList);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlocks.js
@@ -7,8 +7,8 @@ import SortableBlock from './SortableBlock';
 import sortableBlockListStyles from './sortableBlockList.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
-type Props = {
-    disabled?: boolean,
+type Props = {|
+    disabled: boolean,
     blockTypes: Array<string>,
     expandedBlocks: Array<boolean>,
     onExpand: (index: number) => void,
@@ -18,10 +18,14 @@ type Props = {
     renderBlockContent: RenderBlockContentCallback,
     types?: {[key: string]: string},
     value: Array<BlockEntry>,
-};
+|};
 
 @observer
 class SortableBlocks extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     handleExpand = (index: number) => {
         const {onExpand} = this.props;
         onExpand(index);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlocks.js
@@ -2,11 +2,13 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import {SortableContainer} from 'react-sortable-hoc';
+import classNames from 'classnames';
 import SortableBlock from './SortableBlock';
 import sortableBlockListStyles from './sortableBlockList.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {
+    disabled?: boolean,
     blockTypes: Array<string>,
     expandedBlocks: Array<boolean>,
     onExpand: (index: number) => void,
@@ -44,14 +46,21 @@ class SortableBlocks extends React.Component<Props> {
     };
 
     render() {
-        const {expandedBlocks, onRemove, renderBlockContent, types, value} = this.props;
+        const {disabled, expandedBlocks, onRemove, renderBlockContent, types, value} = this.props;
+
+        const sortableBlockListClass = classNames(
+            sortableBlockListStyles.sortableBlockList,
+            {
+                [sortableBlockListStyles.disabled]: disabled,
+            }
+        );
 
         return (
-            <div className={sortableBlockListStyles.sortableBlockList}>
+            <div className={sortableBlockListClass}>
                 {value && value.map((block, index) => (
                     <SortableBlock
                         activeType={block.type}
-                        expanded={expandedBlocks[index]}
+                        expanded={!disabled && expandedBlocks[index]}
                         index={index}
                         key={block.__id}
                         onCollapse={this.handleCollapse}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/sortableBlockList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/sortableBlockList.scss
@@ -4,4 +4,9 @@
     & > * {
         margin-bottom: 20px;
     }
+
+    &.disabled {
+        opacity: .5;
+        pointer-events: none;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {observable} from 'mobx';
 import {mount, render, shallow} from 'enzyme';
 import BlockCollection from '../BlockCollection';
-import SortableContainer from '../SortableBlocks';
+import SortableBlockList from '../SortableBlockList';
 
 beforeEach(() => {
     BlockCollection.idCounter = 0;
@@ -199,7 +199,7 @@ test('Should allow to reorder blocks by using drag and drop', () => {
 
     expect(blockCollection.instance().expandedBlocks.toJS()).toEqual([true, false, false]);
 
-    blockCollection.find(SortableContainer).prop('onSortEnd')({newIndex: 2, oldIndex: 0});
+    blockCollection.find(SortableBlockList).prop('onSortEnd')({newIndex: 2, oldIndex: 0});
     expect(changeSpy).toBeCalledWith([
         expect.objectContaining({content: 'Test 2'}),
         expect.objectContaining({content: 'Test 3'}),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -32,6 +32,17 @@ test('Should render a block list', () => {
     )).toMatchSnapshot();
 });
 
+test('Should render a disabled block list', () => {
+    expect(render(
+        <BlockCollection
+            disabled={true}
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Should render a fully filled block list without add button if maxOccurs is reached', () => {
     expect(render(
         <BlockCollection

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -59,6 +59,66 @@ exports[`Should render a block list 1`] = `
 </section>
 `;
 
+exports[`Should render a disabled block list 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList disabled"
+  >
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article />
+      </div>
+    </section>
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article />
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    disabled=""
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      Add block
+    </span>
+  </button>
+</section>
+`;
+
 exports[`Should render a fully filled block list without add button if maxOccurs is reached 1`] = `
 <section
   class="blockCollection"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
@@ -14,13 +14,16 @@ import UnderlinePlugin from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import TablePlugin from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbarPlugin from '@ckeditor/ckeditor5-table/src/tabletoolbar';
 import './ckeditor5.scss';
+import type {TextEditorProps} from '../../containers/TextEditor/types';
 
-type Props = {|
-    onBlur: () => void,
-    onChange: (value: ?string) => void,
-    value: ?string,
-|};
+type Props = TextEditorProps;
 
+/**
+ * React component that renders a classic ck-editor.
+ *
+ * Implementation is based upon the official ck-editor component:
+ * https://github.com/ckeditor/ckeditor5-react/blob/089e28eafa64baf273c5e3690b08c1f8ee5ebbe5/src/ckeditor.jsx
+ */
 export default class CKEditor5 extends React.Component<Props> {
     containerRef: ?ElementRef<'div'>;
     editorInstance: any;
@@ -39,14 +42,20 @@ export default class CKEditor5 extends React.Component<Props> {
         this.containerRef = containerRef;
     };
 
-    shouldComponentUpdate() {
-        return false;
-    }
-
     componentDidUpdate() {
-        const {value} = this.props;
-        if (this.editorInstance && value) {
-            this.editorInstance.setData(value);
+        if (this.editorInstance) {
+            const {value, disabled} = this.props;
+
+            this.editorInstance.isReadOnly = disabled;
+            if (disabled) {
+                this.editorInstance.element.classList.add('disabled');
+            } else {
+                this.editorInstance.element.classList.remove('disabled');
+            }
+
+            if (this.editorInstance.getData() !== value) {
+                this.editorInstance.setData(value);
+            }
         }
     }
 
@@ -94,7 +103,7 @@ export default class CKEditor5 extends React.Component<Props> {
 
                 this.editorInstance.setData(this.props.value);
 
-                const {onBlur, onChange} = this.props;
+                const {disabled, onBlur, onChange} = this.props;
                 const {
                     model: {
                         document: modelDocument,
@@ -105,6 +114,11 @@ export default class CKEditor5 extends React.Component<Props> {
                         },
                     },
                 } = this.editorInstance;
+
+                this.editorInstance.isReadOnly = disabled;
+                if (disabled) {
+                    this.editorInstance.element.classList.add('disabled');
+                }
 
                 if (onBlur) {
                     viewDocument.on('blur', () => {
@@ -128,7 +142,7 @@ export default class CKEditor5 extends React.Component<Props> {
 
     componentWillUnmount() {
         if (this.editorInstance) {
-            this.editorInstance.destroy();
+            this.editorInstance.destroy().then(() => this.editorInstance = null);
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
@@ -29,6 +29,7 @@ export default class CKEditor5 extends React.Component<Props> {
     editorInstance: any;
 
     static defaultProps = {
+        disabled: false,
         value: '',
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/ckeditor5.scss
@@ -72,21 +72,28 @@ $textEditorPanelBackground: $white;
         }
     }
 
-    .ck.ck-toolbar__separator {
-        background: none;
-        width: $textEditorButtonMinSize;
-    }
+    .ck.ck-editor {
+        .ck.ck-toolbar__separator {
+            background: none;
+            width: $textEditorButtonMinSize;
+        }
 
-    .ck.ck-content {
-        border-radius: $textEditorBorderRadius !important;
-        border-color: $textEditorBackgroundColor !important;
-    }
+        .ck.ck-content {
+            border-radius: $textEditorBorderRadius !important;
+            border-color: $textEditorBackgroundColor !important;
+        }
 
-    .ck-widget.table {
-        width: 100%;
-
-        table {
+        .ck-widget.table {
             width: 100%;
+
+            table {
+                width: 100%;
+            }
+        }
+
+        &.disabled {
+            opacity: .5;
+            pointer-events: none;
         }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/tests/CKEditor5.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/tests/CKEditor5.test.js
@@ -31,6 +31,41 @@ test('Create a CKEditor5 instance', () => {
     expect(ClassicEditor.create).toBeCalled();
 });
 
+test('Set disabled class and isReadOnly property to CKEditor5', () => {
+    const editor = {
+        editing: {
+            view: {
+                document: {
+                    on: jest.fn(),
+                },
+            },
+        },
+        model: {
+            document: {
+                on: jest.fn(),
+            },
+        },
+        element: {
+            classList: {
+                add: jest.fn(),
+            },
+        },
+        isReadOnly: false,
+        setData: jest.fn(),
+    };
+
+    const editorPromise = Promise.resolve(editor);
+    ClassicEditor.create.mockReturnValue(editorPromise);
+
+    mount(<CKEditor5 disabled={true} onBlur={jest.fn()} onChange={jest.fn()} value={undefined} />);
+
+    return editorPromise.then(() => {
+        expect(ClassicEditor.create).toBeCalled();
+        expect(editor.element.classList.add).toBeCalledWith('disabled');
+        expect(editor.isReadOnly).toEqual(true);
+    });
+});
+
 test('Call onChange prop when something changed', () => {
     const changeSpy = jest.fn();
     const editor = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Item.js
@@ -4,16 +4,18 @@ import classNames from 'classnames';
 import Icon from '../Icon';
 import matrixStyles from './matrix.scss';
 
-type Props = {
+type Props = {|
+    disabled: boolean,
     icon: string,
     name: string,
     onChange?: (name: string, value: boolean) => void,
     title?: string,
     value: boolean,
-};
+|};
 
 export default class Item extends React.PureComponent<Props> {
     static defaultProps = {
+        disabled: false,
         value: false,
     };
 
@@ -33,6 +35,7 @@ export default class Item extends React.PureComponent<Props> {
 
     render() {
         const {
+            disabled,
             icon,
             name,
             title,
@@ -42,13 +45,14 @@ export default class Item extends React.PureComponent<Props> {
             matrixStyles.item,
             {
                 [matrixStyles.selected]: value,
+                [matrixStyles.disabled]: disabled,
             }
         );
 
         const itemTitle = title ? title : name.charAt(0).toUpperCase() + name.slice(1);
 
         return (
-            <div className={itemClass} onClick={this.handleClick} title={itemTitle}>
+            <div className={itemClass} onClick={!disabled ? this.handleClick : undefined} title={itemTitle}>
                 <Icon name={icon} />
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
@@ -1,6 +1,7 @@
 // @flow
 import type {ChildrenArray, Element} from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import Row from './Row';
 import Item from './Item';
 import type {MatrixValues} from './types';
@@ -52,10 +53,18 @@ export default class Matrix extends React.PureComponent<Props> {
     render() {
         const {
             children,
+            disabled,
         } = this.props;
 
+        const matrixClass = classNames(
+            matrixStyles.matrix,
+            {
+                [matrixStyles.disabled]: disabled,
+            }
+        );
+
         return (
-            <div className={matrixStyles.matrix}>
+            <div className={matrixClass}>
                 {this.cloneRows(children)}
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
@@ -6,14 +6,16 @@ import Item from './Item';
 import type {MatrixValues} from './types';
 import matrixStyles from './matrix.scss';
 
-type Props = {
+type Props = {|
     children: ChildrenArray<Element<typeof Row>>,
+    disabled: boolean,
     onChange: (value: MatrixValues) => void,
     values: MatrixValues,
-};
+|};
 
 export default class Matrix extends React.PureComponent<Props> {
     static defaultProps = {
+        disabled: false,
         values: {},
     };
 
@@ -34,11 +36,12 @@ export default class Matrix extends React.PureComponent<Props> {
     };
 
     cloneRows = (originalRows: ChildrenArray<Element<typeof Row>>) => {
-        const values = this.props.values;
+        const {disabled, values} = this.props;
         return React.Children.map(originalRows, (row, index) => React.cloneElement(
             row,
             {
                 ...row.props,
+                disabled: disabled,
                 key: `matrix-row-${index}`,
                 onChange: this.handleChange,
                 values: values[row.props.name],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
@@ -8,17 +8,19 @@ import Item from './Item';
 import matrixStyles from './matrix.scss';
 import type {MatrixRowValue} from './types';
 
-type Props = {
+type Props = {|
     children: ChildrenArray<Element<typeof Item>>,
+    disabled: boolean,
     name: string,
     onChange?: (name: string, value: {[string]: boolean}) => void,
     title?: string,
     values: MatrixRowValue,
-};
+|};
 
 @observer
 export default class Row extends React.Component<Props> {
     static defaultProps = {
+        disabled: false,
         values: {},
     };
 
@@ -51,11 +53,12 @@ export default class Row extends React.Component<Props> {
     };
 
     cloneItems = (originalItems: ChildrenArray<Element<typeof Item>>) => {
-        const values = this.props.values;
+        const {disabled, values} = this.props;
         return React.Children.map(originalItems, (item, index) => React.cloneElement(
             item,
             {
                 ...item.props,
+                disabled: disabled,
                 key: `matrix-item-${index}`,
                 onChange: this.handleChange,
                 value: values[item.props.name],
@@ -92,6 +95,7 @@ export default class Row extends React.Component<Props> {
 
     render() {
         const {
+            disabled,
             children,
             name,
             title,
@@ -102,7 +106,7 @@ export default class Row extends React.Component<Props> {
                 <div>{title ? title : name}</div>
                 <div>
                     {this.cloneItems(children)}
-                    {this.renderAllButton()}
+                    {!disabled && this.renderAllButton()}
                 </div>
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
@@ -17,6 +17,10 @@ $itemBackgroundColorDisabledSelected: $silver;
     background: $white;
     border-radius: 3px;
     margin-top: 10px;
+
+    &.disabled {
+        opacity: .5;
+    }
 }
 
 .row {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
@@ -8,6 +8,11 @@ $itemBorderColor: $shakespeare;
 $itemBackgroundColorSelected: $shakespeare;
 $itemColorSelected: $white;
 
+$itemColorDisabled: $silver;
+$itemBorderColorDisabled: $silver;
+$itemColorDisabledSelected: $white;
+$itemBackgroundColorDisabledSelected: $silver;
+
 .matrix {
     background: $white;
     border-radius: 3px;
@@ -71,5 +76,16 @@ $itemColorSelected: $white;
     &.selected {
         background-color: $itemBackgroundColorSelected;
         color: $itemColorSelected;
+    }
+
+    &.disabled {
+        cursor: default;
+        color: $itemColorDisabled;
+        border-color: $itemBorderColorDisabled;
+    }
+
+    &.selected.disabled {
+        background-color: $itemBackgroundColorDisabledSelected;
+        color: $itemColorDisabledSelected;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/Matrix.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/Matrix.test.js
@@ -26,7 +26,7 @@ test('Render the Matrix component', () => {
     const handleChange = jest.fn();
 
     expect(render(
-        <Matrix onChange={handleChange} title="Global">
+        <Matrix onChange={handleChange}>
             <Row name="global.articles" title="articles">
                 <Item icon="su-pen" name="view" />
                 <Item icon="su-plus" name="edit" />
@@ -61,7 +61,42 @@ test('Render the Matrix component with values', () => {
     };
 
     expect(render(
-        <Matrix onChange={handleChange} title="Global" values={values}>
+        <Matrix onChange={handleChange} values={values}>
+            <Row name="global.articles" title="articles">
+                <Item icon="su-pen" name="view" />
+                <Item icon="su-plus" name="edit" />
+                <Item icon="su-trash-alt" name="delete" />
+            </Row>
+            <Row name="global.redirects" title="redirects">
+                <Item icon="su-pen" name="view" />
+            </Row>
+            <Row name="global.settings" title="settings">
+                <Item icon="su-pen" name="view" />
+                <Item icon="su-plus" name="edit" />
+            </Row>
+        </Matrix>
+    )).toMatchSnapshot();
+});
+
+test('Render the Matrix component with values in disabled state', () => {
+    const handleChange = jest.fn();
+    const values = {
+        'global.articles': {
+            'view': true,
+            'edit': true,
+            'delete': false,
+        },
+        'global.redirects': {
+            'view': true,
+        },
+        'global.settings': {
+            'view': true,
+            'edit': false,
+        },
+    };
+
+    expect(render(
+        <Matrix disabled={true} onChange={handleChange} values={values}>
             <Row name="global.articles" title="articles">
                 <Item icon="su-pen" name="view" />
                 <Item icon="su-plus" name="edit" />
@@ -96,7 +131,7 @@ test('Changing a value should call onChange ', () => {
     };
 
     const matrix = mount(
-        <Matrix onChange={handleChange} title="Global" values={values}>
+        <Matrix onChange={handleChange} values={values}>
             <Row name="global.articles" title="articles">
                 <Item icon="su-pen" name="view" />
                 <Item icon="su-plus" name="edit" />
@@ -149,7 +184,7 @@ test('Deactivate all button should call onChange', () => {
     };
 
     const matrix = mount(
-        <Matrix onChange={handleChange} title="Global" values={values}>
+        <Matrix onChange={handleChange} values={values}>
             <Row name="global.articles" title="articles">
                 <Item icon="su-pen" name="view" />
                 <Item icon="su-plus" name="edit" />
@@ -202,7 +237,7 @@ test('Activate all button should call onChange', () => {
     };
 
     const matrix = mount(
-        <Matrix onChange={handleChange} title="Global" values={values}>
+        <Matrix onChange={handleChange} values={values}>
             <Row name="global.articles" title="articles">
                 <Item icon="su-pen" name="view" />
                 <Item icon="su-plus" name="edit" />
@@ -251,7 +286,7 @@ test('Activate all button should call onChange with all values, even when the va
     };
 
     const matrix = mount(
-        <Matrix onChange={handleChange} title="Global" values={values}>
+        <Matrix onChange={handleChange} values={values}>
             <Row name="global.articles" title="articles">
                 <Item icon="su-pen" name="view" />
                 <Item icon="su-plus" name="edit" />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
@@ -208,7 +208,7 @@ exports[`Render the Matrix component with values 1`] = `
 
 exports[`Render the Matrix component with values in disabled state 1`] = `
 <div
-  class="matrix"
+  class="matrix disabled"
 >
   <div
     class="row"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
@@ -205,3 +205,91 @@ exports[`Render the Matrix component with values 1`] = `
   </div>
 </div>
 `;
+
+exports[`Render the Matrix component with values in disabled state 1`] = `
+<div
+  class="matrix"
+>
+  <div
+    class="row"
+  >
+    <div>
+      articles
+    </div>
+    <div>
+      <div
+        class="item selected disabled"
+        title="View"
+      >
+        <span
+          aria-label="su-pen"
+          class="su-pen"
+        />
+      </div>
+      <div
+        class="item selected disabled"
+        title="Edit"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus"
+        />
+      </div>
+      <div
+        class="item disabled"
+        title="Delete"
+      >
+        <span
+          aria-label="su-trash-alt"
+          class="su-trash-alt"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="row"
+  >
+    <div>
+      redirects
+    </div>
+    <div>
+      <div
+        class="item selected disabled"
+        title="View"
+      >
+        <span
+          aria-label="su-pen"
+          class="su-pen"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="row"
+  >
+    <div>
+      settings
+    </div>
+    <div>
+      <div
+        class="item selected disabled"
+        title="View"
+      >
+        <span
+          aria-label="su-pen"
+          class="su-pen"
+        />
+      </div>
+      <div
+        class="item disabled"
+        title="Edit"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/Item.js
@@ -1,27 +1,40 @@
 // @flow
 import React from 'react';
+import classNames from 'classnames';
 import Icon from '../../components/Icon';
 import itemStyles from './item.scss';
 
-type Props = {
+type Props = {|
     children: string,
+    disabled: boolean,
     onDelete: (value: Object) => void,
     value: Object,
-};
+|};
 
 export default class Item extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     handleDelete = () => {
         const {onDelete, value} = this.props;
         onDelete(value);
     };
 
     render() {
-        const {children} = this.props;
+        const {children, disabled} = this.props;
+
+        const itemClass = classNames(
+            itemStyles.item,
+            {
+                [itemStyles.disabled]: disabled,
+            }
+        );
 
         return (
-            <div className={itemStyles.item}>
+            <div className={itemClass}>
                 {children}
-                <Icon className={itemStyles.icon} name="su-times" onClick={this.handleDelete} />
+                {!disabled && <Icon className={itemStyles.icon} name="su-times" onClick={this.handleDelete} />}
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -12,8 +12,9 @@ import AutoCompletePopover from '../AutoCompletePopover';
 import Item from './Item';
 import multiAutoCompleteStyles from './multiAutoComplete.scss';
 
-type Props = {
+type Props = {|
     allowAdd: boolean,
+    disabled: boolean,
     displayProperty: string,
     id?: string,
     idProperty: string,
@@ -24,7 +25,7 @@ type Props = {
     searchProperties: Array<string>,
     suggestions: Array<Object>,
     value: Array<Object>,
-};
+|};
 
 const DEBOUNCE_TIME = 300;
 
@@ -32,6 +33,7 @@ const DEBOUNCE_TIME = 300;
 export default class MultiAutoComplete extends React.Component<Props> {
     static defaultProps = {
         allowAdd: false,
+        disabled: false,
         idProperty: 'id',
         loading: false,
     };
@@ -145,6 +147,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
 
     render() {
         const {
+            disabled,
             displayProperty,
             id,
             idProperty,
@@ -156,6 +159,13 @@ export default class MultiAutoComplete extends React.Component<Props> {
 
         const showSuggestionList = (!!this.inputValue && this.inputValue.length > 0) && suggestions.length > 0;
 
+        const multiAutoCompleteClass = classNames(
+            multiAutoCompleteStyles.multiAutoComplete,
+            {
+                [multiAutoCompleteStyles.disabled]: disabled,
+            }
+        );
+
         const inputClass = classNames(
             multiAutoCompleteStyles.input,
             'mousetrap' // required to allow mousetrap to catch key binding within input
@@ -163,7 +173,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
 
         return (
             <Fragment>
-                <label className={multiAutoCompleteStyles.multiAutoComplete} ref={this.setLabelRef}>
+                <label className={multiAutoCompleteClass} ref={this.setLabelRef}>
                     <div className={multiAutoCompleteStyles.icon}>
                         {loading
                             ? <Loader size={20} />
@@ -173,6 +183,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
                     <div className={multiAutoCompleteStyles.items}>
                         {value.map((item) => (
                             <Item
+                                disabled={disabled}
                                 key={item[idProperty]}
                                 onDelete={this.handleDelete}
                                 value={item}
@@ -182,6 +193,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
                         ))}
                         <input
                             className={inputClass}
+                            disabled={disabled}
                             id={id}
                             onBlur={this.handleInputBlur}
                             onChange={this.handleInputChange}
@@ -196,7 +208,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
                     idProperty={idProperty}
                     minWidth={this.popoverMinWidth}
                     onSelect={this.handleSelect}
-                    open={showSuggestionList}
+                    open={!disabled && showSuggestionList}
                     query={this.inputValue}
                     searchProperties={searchProperties}
                     suggestions={suggestions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/item.scss
@@ -1,6 +1,7 @@
 @import '../../containers/Application/colors.scss';
 
 $itemBackgroundColor: $wildSand;
+$itemDisabledBackgroundColor: $silver;
 
 .item {
     background-color: $itemBackgroundColor;
@@ -11,8 +12,12 @@ $itemBackgroundColor: $wildSand;
     margin: 5px 10px 5px 0;
     padding: 0 10px;
     white-space: nowrap;
-}
 
-.icon {
-    margin-left: 10px;
+    .icon {
+        margin-left: 10px;
+    }
+
+    &.disabled {
+        background-color: $itemDisabledBackgroundColor;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/multiAutoComplete.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/multiAutoComplete.scss
@@ -4,35 +4,48 @@ $multiAutoCompleteBackgroundColor: $white;
 $multiAutoCompleteBorderColor: $silver;
 $multiAutoCompleteIconColor: $dustyGray;
 
+$multiAutoCompleteDisabledColor: $gray;
+$multiAutoCompleteDisabledBackgroundColor: $wildSand;
+
 .multi-auto-complete {
     background-color: $multiAutoCompleteBackgroundColor;
     border: 1px solid $multiAutoCompleteBorderColor;
     border-radius: 3px;
     display: flex;
     align-items: center;
-}
 
-.input {
-    border: none;
-    font-size: 12px;
-    flex-grow: 1;
-    height: 28px;
-}
+    .input {
+        border: none;
+        font-size: 12px;
+        flex-grow: 1;
+        height: 28px;
+    }
 
-.icon {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: calc(100% - 10px);
-    flex: 0 0 32px;
-    margin-right: 10px;
-    font-size: 16px;
-    color: $multiAutoCompleteIconColor;
-    border-right: 1px solid $multiAutoCompleteBorderColor;
-}
+    .icon {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: calc(100% - 10px);
+        flex: 0 0 32px;
+        margin-right: 10px;
+        font-size: 16px;
+        color: $multiAutoCompleteIconColor;
+        border-right: 1px solid $multiAutoCompleteBorderColor;
+    }
 
-.items {
-    display: flex;
-    flex-wrap: wrap;
-    flex-grow: 1;
+    .items {
+        display: flex;
+        flex-wrap: wrap;
+        flex-grow: 1;
+    }
+
+    &.disabled {
+        color: $multiAutoCompleteDisabledColor;
+        background-color: $multiAutoCompleteDisabledBackgroundColor;
+
+        .input {
+            color: $multiAutoCompleteDisabledColor;
+            background-color: $multiAutoCompleteDisabledBackgroundColor;
+        }
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/Item.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/Item.test.js
@@ -7,6 +7,10 @@ test('Should render item with children', () => {
     expect(render(<Item onDelete={jest.fn()} value={{}}>Name</Item>)).toMatchSnapshot();
 });
 
+test('Should render item without icon in disabled state', () => {
+    expect(render(<Item disabled={true} onDelete={jest.fn()} value={{}}>Name</Item>)).toMatchSnapshot();
+});
+
 test('Should call onDelete callback when the times icon is clicked', () => {
     const deleteSpy = jest.fn();
     const value = {name: 'Test'};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -34,6 +34,32 @@ test('MultiAutoComplete should render', () => {
     )).toMatchSnapshot();
 });
 
+test('MultiAutoComplete should render in disabled state', () => {
+    const suggestions = [
+        {name: 'Suggestion 1'},
+        {name: 'Suggestion 2'},
+        {name: 'Suggestion 3'},
+    ];
+
+    const value = [
+        {id: 1, name: 'Test'},
+        {id: 2, name: 'Test 2'},
+    ];
+
+    expect(render(
+        <MultiAutoComplete
+            disabled={true}
+            displayProperty="name"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={value}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render the MultiAutoComplete with open suggestions list', () => {
     const suggestions = [
         {id: 1, name: 'Suggestion 1'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/Item.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/Item.test.js.snap
@@ -13,3 +13,11 @@ exports[`Should render item with children 1`] = `
   />
 </div>
 `;
+
+exports[`Should render item without icon in disabled state 1`] = `
+<div
+  class="item disabled"
+>
+  Name
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -45,6 +45,40 @@ exports[`MultiAutoComplete should render 1`] = `
 </label>
 `;
 
+exports[`MultiAutoComplete should render in disabled state 1`] = `
+<label
+  class="multiAutoComplete disabled"
+>
+  <div
+    class="icon"
+  >
+    <span
+      aria-label="su-search"
+      class="su-search"
+    />
+  </div>
+  <div
+    class="items"
+  >
+    <div
+      class="item disabled"
+    >
+      Test
+    </div>
+    <div
+      class="item disabled"
+    >
+      Test 2
+    </div>
+    <input
+      class="input mousetrap"
+      disabled=""
+      value=""
+    />
+  </div>
+</label>
+`;
+
 exports[`Render the MultiAutoComplete with open suggestions list 1`] = `
 <label
   class="multiAutoComplete"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Button.js
@@ -3,10 +3,9 @@ import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import buttonStyles from './button.scss';
+import type {Button as ButtonConfig} from './types';
 
-type Props = {
-    icon: string,
-    onClick: () => void,
+type Props = ButtonConfig & {
     location: 'left' | 'right',
 };
 
@@ -17,6 +16,7 @@ export default class Button extends React.PureComponent<Props> {
 
     render() {
         const {
+            disabled,
             icon,
             location,
         } = this.props;
@@ -28,6 +28,7 @@ export default class Button extends React.PureComponent<Props> {
         return (
             <button
                 className={buttonClass}
+                disabled={disabled}
                 onClick={this.handleClick}
                 type="button"
             >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/Button.js
@@ -5,11 +5,16 @@ import Icon from '../Icon';
 import buttonStyles from './button.scss';
 import type {Button as ButtonConfig} from './types';
 
-type Props = ButtonConfig & {
+type Props = {|
+    ...ButtonConfig,
     location: 'left' | 'right',
-};
+|};
 
 export default class Button extends React.PureComponent<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     handleClick = () => {
         this.props.onClick();
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
@@ -2,12 +2,14 @@
 import React, {Fragment} from 'react';
 import type {ChildrenArray, Element} from 'react';
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
+import classNames from 'classnames';
 import type {Button} from './types';
 import Header from './Header';
 import Item from './Item';
 import multiItemSelectionStyles from './multiItemSelection.scss';
 
-type Props<T> = {
+type Props<T> = {|
+    disabled?: boolean,
     children?: ChildrenArray<Element<typeof Item>>,
     label?: string,
     onItemRemove?: (itemid: T) => void,
@@ -16,7 +18,7 @@ type Props<T> = {
     rightButton?: Button,
     loading: boolean,
     sortable: boolean,
-};
+|};
 
 export default class MultiItemSelection<T> extends React.PureComponent<Props<T>> {
     static defaultProps = {
@@ -88,6 +90,7 @@ export default class MultiItemSelection<T> extends React.PureComponent<Props<T>>
 
     render() {
         const {
+            disabled,
             children,
             label,
             leftButton,
@@ -97,14 +100,21 @@ export default class MultiItemSelection<T> extends React.PureComponent<Props<T>>
         const emptyList = !React.Children.count(children);
         const List = this.createList();
 
+        const multiItemSelectionClass = classNames(
+            multiItemSelectionStyles.multiItemSelectionClass,
+            {
+                [multiItemSelectionStyles.disabled]: disabled,
+            }
+        );
+
         return (
-            <Fragment>
+            <div className={multiItemSelectionClass}>
                 <Header
                     emptyList={emptyList}
                     label={label}
-                    leftButton={leftButton}
+                    leftButton={leftButton ? {disabled, ...leftButton} : undefined}
                     loading={loading}
-                    rightButton={rightButton}
+                    rightButton={rightButton ? {disabled, ...rightButton} : undefined}
                 />
                 <List
                     axis="y"
@@ -115,7 +125,7 @@ export default class MultiItemSelection<T> extends React.PureComponent<Props<T>>
                 >
                     {children}
                 </List>
-            </Fragment>
+            </div>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {Fragment} from 'react';
+import React from 'react';
 import type {ChildrenArray, Element} from 'react';
 import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 import classNames from 'classnames';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/MultiItemSelection.js
@@ -9,7 +9,7 @@ import Item from './Item';
 import multiItemSelectionStyles from './multiItemSelection.scss';
 
 type Props<T> = {|
-    disabled?: boolean,
+    disabled: boolean,
     children?: ChildrenArray<Element<typeof Item>>,
     label?: string,
     onItemRemove?: (itemid: T) => void,
@@ -22,6 +22,7 @@ type Props<T> = {|
 
 export default class MultiItemSelection<T> extends React.PureComponent<Props<T>> {
     static defaultProps = {
+        disabled: false,
         loading: false,
         sortable: true,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/multiItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/multiItemSelection.scss
@@ -4,6 +4,13 @@ $listElementBackgroundColor: $white;
 $listElementBorderBottomColor: $silver;
 $listElementDragBoxShadowColor: rgba($black, .1);
 
+.multiItemSelectionClass {
+    &.disabled {
+        opacity: .5;
+        pointer-events: none;
+    }
+}
+
 .list {
     margin: 0;
     padding: 0;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/MultiItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/MultiItemSelection.test.js
@@ -32,6 +32,31 @@ test('Render an MultiItemSelection with children', () => {
     )).toMatchSnapshot();
 });
 
+test('Render a disabled MultiItemSelection with children', () => {
+    expect(render(
+        <MultiItemSelection disabled={true} label="I am disabled">
+            <MultiItemSelection.Item
+                id="1"
+                index={1}
+            >
+                Child 1
+            </MultiItemSelection.Item>
+            <MultiItemSelection.Item
+                id="2"
+                index={2}
+            >
+                Child 2
+            </MultiItemSelection.Item>
+            <MultiItemSelection.Item
+                id="3"
+                index={3}
+            >
+                Child 3
+            </MultiItemSelection.Item>
+        </MultiItemSelection>
+    )).toMatchSnapshot();
+});
+
 test('Render a not sortable MultiItemSelection with children', () => {
     expect(render(
         <MultiItemSelection label="I have children" sortable={false}>
@@ -58,7 +83,7 @@ test('Render a not sortable MultiItemSelection with children', () => {
 });
 
 test('Render an MultiItemSelection while loading', () => {
-    expect(render(<MultiItemSelection label="I have children" loading={true} />)).toMatchSnapshot();
+    expect(render(<MultiItemSelection label="I am loading" loading={true} />)).toMatchSnapshot();
 });
 
 test('Clicking the left and right button inside the header should call the right handler', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/tests/__snapshots__/MultiItemSelection.test.js.snap
@@ -2,36 +2,222 @@
 
 exports[`Clicking the left and right button inside the header should call the right handler 1`] = `
 <div
-  class="header"
+  class="multiItemSelectionClass"
 >
-  <button
-    class="button left"
-    type="button"
-  >
-    <span
-      aria-label="su-plus"
-      class="su-plus"
-    />
-  </button>
   <div
-    class="label"
+    class="header"
   >
-    I have handler
+    <button
+      class="button left"
+      type="button"
+    >
+      <span
+        aria-label="su-plus"
+        class="su-plus"
+      />
+    </button>
+    <div
+      class="label"
+    >
+      I have handler
+    </div>
+    <button
+      class="button right"
+      type="button"
+    >
+      <span
+        aria-label="fa-gear"
+        class="fa fa-gear"
+      />
+    </button>
   </div>
-  <button
-    class="button right"
-    type="button"
+  <ul
+    class="list"
   >
-    <span
-      aria-label="fa-gear"
-      class="fa fa-gear"
-    />
-  </button>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            1
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 1
+        </div>
+      </div>
+    </li>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            2
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 2
+        </div>
+      </div>
+    </li>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            3
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 3
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Render a disabled MultiItemSelection with children 1`] = `
+<div
+  class="multiItemSelectionClass disabled"
+>
+  <div
+    class="header"
+  >
+    <div
+      class="label"
+    >
+      I am disabled
+    </div>
+  </div>
+  <ul
+    class="list"
+  >
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            1
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 1
+        </div>
+      </div>
+    </li>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            2
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 2
+        </div>
+      </div>
+    </li>
+    <li
+      class="listElement"
+    >
+      <div
+        class="item"
+      >
+        <span
+          class="dragHandle sortable"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more"
+          />
+          <span
+            class="index"
+          >
+            3
+          </span>
+        </span>
+        <div
+          class="content"
+        >
+          Child 3
+        </div>
+      </div>
+    </li>
+  </ul>
 </div>
 `;
 
 exports[`Render a not sortable MultiItemSelection with children 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header"
   >
@@ -40,7 +226,7 @@ Array [
     >
       I have children
     </div>
-  </div>,
+  </div>
   <ul
     class="list"
   >
@@ -110,19 +296,21 @@ Array [
         </div>
       </div>
     </li>
-  </ul>,
-]
+  </ul>
+</div>
 `;
 
 exports[`Render an MultiItemSelection while loading 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header emptyList"
   >
     <div
       class="label"
     >
-      I have children
+      I am loading
       <div
         class="loader"
       >
@@ -139,15 +327,17 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
+  </div>
   <ul
     class="list"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`Render an MultiItemSelection with children 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header"
   >
@@ -156,7 +346,7 @@ Array [
     >
       I have children
     </div>
-  </div>,
+  </div>
   <ul
     class="list"
   >
@@ -238,12 +428,14 @@ Array [
         </div>
       </div>
     </li>
-  </ul>,
-]
+  </ul>
+</div>
 `;
 
 exports[`Render an empty MultiItemSelection 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header emptyList"
   >
@@ -252,9 +444,9 @@ Array [
     >
       I am empty
     </div>
-  </div>,
+  </div>
   <ul
     class="list"
-  />,
-]
+  />
+</div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/types.js
@@ -1,5 +1,6 @@
 // @flow
 export type Button = {
+    disabled?: boolean,
     icon: string,
     onClick: () => void,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/types.js
@@ -1,6 +1,6 @@
 // @flow
-export type Button = {
+export type Button = {|
     disabled?: boolean,
     icon: string,
     onClick: () => void,
-};
+|};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -78,11 +78,12 @@ export default class MultiSelect<T: string | number> extends React.PureComponent
     };
 
     render() {
-        const {children, icon, skin} = this.props;
+        const {children, disabled, icon, skin} = this.props;
 
         return (
             <Select
                 closeOnSelect={false}
+                disabled={disabled}
                 displayValue={this.displayValue}
                 icon={icon}
                 isOptionSelected={this.isOptionSelected}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/tests/MultiSelect.test.js
@@ -30,6 +30,23 @@ test('The component should render a generic select', () => {
     expect(select.getElement().type).toBe(Select);
 });
 
+test('The component should pass the disabled value to the select component', () => {
+    const onChange = jest.fn();
+    const select = shallow(
+        <MultiSelect
+            allSelectedText="All selected"
+            disabled={true}
+            noneSelectedText="None selected"
+            onChange={onChange}
+        >
+            <Option value="option-1">Option 1</Option>
+            <Option value="option-2">Option 2</Option>
+        </MultiSelect>
+    );
+
+    expect(select.find(Select).props().disabled).toBe(true);
+});
+
 test('The component should pass the correct display value if nothing is selected', () => {
     const onChange = jest.fn();
     const select = shallow(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
@@ -8,6 +8,7 @@ import Grid from '../Grid';
 import passwordConfirmationStyles from './passwordConfirmation.scss';
 
 type Props = {|
+    disabled?: boolean,
     onChange: (value: ?string) => void,
     valid: boolean,
 |};
@@ -72,10 +73,13 @@ export default class PasswordConfirmation extends React.Component<Props> {
     }, 500);
 
     render() {
+        const {disabled} = this.props;
+
         return (
             <Grid className={passwordConfirmationStyles.grid}>
                 <Grid.Item size={6}>
                     <Input
+                        disabled={disabled}
                         icon={LOCK_ICON}
                         onChange={this.handleFirstChange}
                         type={INPUT_TYPE}
@@ -85,6 +89,7 @@ export default class PasswordConfirmation extends React.Component<Props> {
                 </Grid.Item>
                 <Grid.Item className={passwordConfirmationStyles.item} size={6}>
                     <Input
+                        disabled={disabled}
                         icon={LOCK_ICON}
                         onChange={this.handleSecondChange}
                         type={INPUT_TYPE}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
@@ -8,7 +8,7 @@ import Grid from '../Grid';
 import passwordConfirmationStyles from './passwordConfirmation.scss';
 
 type Props = {|
-    disabled?: boolean,
+    disabled: boolean,
     onChange: (value: ?string) => void,
     valid: boolean,
 |};
@@ -19,6 +19,7 @@ const INPUT_TYPE = 'password';
 @observer
 export default class PasswordConfirmation extends React.Component<Props> {
     static defaultProps = {
+        disabled: false,
         valid: true,
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/PasswordConfirmation.test.js
@@ -7,6 +7,11 @@ import PasswordConfirmation from '../PasswordConfirmation';
 jest.mock('debounce', () => jest.fn((value) => value));
 
 test('Should render two password fields and add a debounced function', () => {
+    expect(render(<PasswordConfirmation disabled={true} onChange={jest.fn()} />)).toMatchSnapshot();
+    expect(debounce).toBeCalledWith(expect.any(Function), 500);
+});
+
+test('Should render disabled input-components when disabled', () => {
     expect(render(<PasswordConfirmation onChange={jest.fn()} />)).toMatchSnapshot();
     expect(debounce).toBeCalledWith(expect.any(Function), 500);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/__snapshots__/PasswordConfirmation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/__snapshots__/PasswordConfirmation.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should render two password fields and add a debounced function 1`] = `
+exports[`Should render disabled input-components when disabled 1`] = `
 <div
   class="grid grid"
 >
@@ -39,6 +39,55 @@ exports[`Should render two password fields and add a debounced function 1`] = `
         />
       </div>
       <input
+        type="password"
+        value=""
+      />
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Should render two password fields and add a debounced function 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="item size size-6 space-before-0 space-after-0"
+  >
+    <label
+      class="input default left disabled"
+    >
+      <div
+        class="prependedContainer default"
+      >
+        <span
+          aria-label="su-lock"
+          class="su-lock icon default"
+        />
+      </div>
+      <input
+        disabled=""
+        type="password"
+        value=""
+      />
+    </label>
+  </div>
+  <div
+    class="item item size size-6 space-before-0 space-after-0"
+  >
+    <label
+      class="input default left disabled"
+    >
+      <div
+        class="prependedContainer default"
+      >
+        <span
+          aria-label="su-lock"
+          class="su-lock icon default"
+        />
+      </div>
+      <input
+        disabled=""
         type="password"
         value=""
       />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -96,7 +96,7 @@ export default class SingleAutoComplete extends React.Component<Props> {
             suggestions,
         } = this.props;
         const {inputValue} = this;
-        const showSuggestionList = !disabled && (!!inputValue && inputValue.length > 0) && suggestions.length > 0;
+        const showSuggestionList = (!!inputValue && inputValue.length > 0) && suggestions.length > 0;
 
         // The mousetrap class is required to allow mousetrap catch key bindings for up and down keys
         return (
@@ -117,7 +117,7 @@ export default class SingleAutoComplete extends React.Component<Props> {
                     anchorElement={this.labelRef}
                     minWidth={this.popoverMinWidth}
                     onSelect={this.handleSelect}
-                    open={showSuggestionList}
+                    open={!disabled && showSuggestionList}
                     query={inputValue}
                     searchProperties={searchProperties}
                     suggestions={suggestions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -12,6 +12,7 @@ const LENS_ICON = 'su-search';
 const DEBOUNCE_TIME = 300;
 
 type Props = {|
+    disabled: boolean,
     displayProperty: string,
     id?: string,
     loading?: boolean,
@@ -27,6 +28,10 @@ type Props = {|
 
 @observer
 export default class SingleAutoComplete extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     @observable labelRef: ElementRef<'label'>;
 
     @observable inputValue: ?string = this.props.value ? this.props.value[this.props.displayProperty] : undefined;
@@ -82,6 +87,7 @@ export default class SingleAutoComplete extends React.Component<Props> {
 
     render() {
         const {
+            disabled,
             id,
             loading,
             onFinish,
@@ -90,12 +96,13 @@ export default class SingleAutoComplete extends React.Component<Props> {
             suggestions,
         } = this.props;
         const {inputValue} = this;
-        const showSuggestionList = (!!inputValue && inputValue.length > 0) && suggestions.length > 0;
+        const showSuggestionList = !disabled && (!!inputValue && inputValue.length > 0) && suggestions.length > 0;
 
         // The mousetrap class is required to allow mousetrap catch key bindings for up and down keys
         return (
             <div className={singleAutoCompleteStyles.singleAutoComplete}>
                 <Input
+                    disabled={disabled}
                     icon={LENS_ICON}
                     id={id}
                     inputClass="mousetrap"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -24,6 +24,27 @@ test('SingleAutoComplete should render', () => {
     )).toMatchSnapshot();
 });
 
+test('SingleAutoComplete should render in disabled state', () => {
+    const suggestions = [
+        {name: 'Suggestion 1'},
+        {name: 'Suggestion 2'},
+        {name: 'Suggestion 3'},
+    ];
+
+    expect(render(
+        <SingleAutoComplete
+            disabled={true}
+            displayProperty="name"
+            onChange={jest.fn()}
+            onFinish={jest.fn()}
+            onSearch={jest.fn()}
+            searchProperties={['name']}
+            suggestions={suggestions}
+            value={{name: 'Test'}}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render the SingleAutoComplete with open suggestions list', () => {
     const suggestions = [
         {id: 1, name: 'Suggestion 1'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -62,3 +62,28 @@ exports[`SingleAutoComplete should render 1`] = `
   </label>
 </div>
 `;
+
+exports[`SingleAutoComplete should render in disabled state 1`] = `
+<div
+  class="singleAutoComplete"
+>
+  <label
+    class="input default left disabled"
+  >
+    <div
+      class="prependedContainer default"
+    >
+      <span
+        aria-label="su-search"
+        class="su-search icon default"
+      />
+    </div>
+    <input
+      class="mousetrap"
+      disabled=""
+      type="text"
+      value="Test"
+    />
+  </label>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import classNames from 'classnames';
 import type {Node} from 'react';
 import Icon from '../Icon';
 import singleItemSelectionStyles from './singleItemSelection.scss';
@@ -7,19 +8,36 @@ import type {Button} from './types';
 
 type Props = {|
     children?: Node,
+    disabled: boolean,
     emptyText?: string,
     leftButton: Button,
     onRemove?: () => void,
 |};
 
 export default class SingleItemSelection extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     render() {
-        const {children, emptyText, leftButton, onRemove} = this.props;
+        const {children, disabled, emptyText, leftButton, onRemove} = this.props;
         const {icon, onClick} = leftButton;
 
+        const singleItemSelectionClass = classNames(
+            singleItemSelectionStyles.singleItemSelection,
+            {
+                [singleItemSelectionStyles.disabled]: disabled,
+            }
+        );
+
         return (
-            <div className={singleItemSelectionStyles.singleItemSelection}>
-                <button className={singleItemSelectionStyles.button} onClick={onClick} type="button">
+            <div className={singleItemSelectionClass}>
+                <button
+                    className={singleItemSelectionStyles.button}
+                    disabled={disabled}
+                    onClick={onClick}
+                    type="button"
+                >
                     <Icon name={icon} />
                 </button>
                 <div className={singleItemSelectionStyles.itemContainer}>
@@ -32,7 +50,12 @@ export default class SingleItemSelection extends React.Component<Props> {
                         }
                     </div>
                     {onRemove &&
-                        <button className={singleItemSelectionStyles.removeButton} onClick={onRemove} type="button">
+                        <button
+                            className={singleItemSelectionStyles.removeButton}
+                            disabled={disabled}
+                            onClick={onRemove}
+                            type="button"
+                        >
                             <Icon name="su-trash-alt" />
                         </button>
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
@@ -2,11 +2,14 @@
 
 $singleItemSelectionBackgroundColor: $white;
 $singleItemSelectionBorderColor: $silver;
-$singleItemSelectionButtonColor: $scorpion;
+$singleItemSelectionButtonColor: $dustyGray;
 $singleItemSelectionButtonActiveColor: $white;
 $singleItemSelectionButtonBackgroundColor: $white;
 $singleItemSelectionButtonActiveBackgroundColor: $shakespeare;
 $singleItemSelectionEmptyColor: $silver;
+
+$singleItemSelectionDisabledColor: $gray;
+$singleItemSelectionDisabledBackgroundColor: $wildSand;
 
 $singleItemSelectionBorderRadius: 3px;
 
@@ -16,48 +19,68 @@ $singleItemSelectionBorderRadius: 3px;
     background-color: $singleItemSelectionBackgroundColor;
     height: 30px;
     overflow: hidden;
-}
 
-.button {
-    height: 100%;
-    width: 28px;
-    background-color: $singleItemSelectionButtonBackgroundColor;
-    color: $singleItemSelectionButtonColor;
-    border: 1px solid $singleItemSelectionBorderColor;
-    border-right: none;
-    border-radius: $singleItemSelectionBorderRadius 0 0 $singleItemSelectionBorderRadius;
-    cursor: pointer;
-    font-size: 14px;
+    .button {
+        height: 100%;
+        width: 28px;
+        background-color: $singleItemSelectionButtonBackgroundColor;
+        color: $singleItemSelectionButtonColor;
+        border: 1px solid $singleItemSelectionBorderColor;
+        border-right: none;
+        border-radius: $singleItemSelectionBorderRadius 0 0 $singleItemSelectionBorderRadius;
+        cursor: pointer;
+        font-size: 14px;
 
-    &:hover {
-        background-color: $singleItemSelectionButtonActiveBackgroundColor;
-        border-color: $singleItemSelectionButtonActiveBackgroundColor;
-        color: $singleItemSelectionButtonActiveColor;
+        &:hover {
+            background-color: $singleItemSelectionButtonActiveBackgroundColor;
+            border-color: $singleItemSelectionButtonActiveBackgroundColor;
+            color: $singleItemSelectionButtonActiveColor;
+        }
     }
-}
 
-.item-container {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    flex-grow: 1;
-    padding-left: 10px;
-    font-size: 12px;
-    border: 1px solid $singleItemSelectionBorderColor;
-    border-radius: 0 $singleItemSelectionBorderRadius $singleItemSelectionBorderRadius 0;
-}
+    .item-container {
+        display: flex;
+        align-items: center;
+        height: 100%;
+        flex-grow: 1;
+        padding-left: 10px;
+        font-size: 12px;
+        border: 1px solid $singleItemSelectionBorderColor;
+        border-radius: 0 $singleItemSelectionBorderRadius $singleItemSelectionBorderRadius 0;
 
-.item {
-    flex-grow: 1;
-}
+        .item {
+            flex-grow: 1;
+        }
 
-.empty {
-    color: $singleItemSelectionEmptyColor;
-}
+        .empty {
+            color: $singleItemSelectionEmptyColor;
+        }
+    }
 
-.remove-button {
-    border: 0;
-    padding: 0 10px;
-    cursor: pointer;
-    background-color: transparent;
+    .remove-button {
+        border: 0;
+        padding: 0 10px;
+        cursor: pointer;
+        background-color: transparent;
+    }
+
+    &.disabled {
+        background-color: $singleItemSelectionDisabledBackgroundColor;
+        color: $singleItemSelectionDisabledColor;
+
+        .button {
+            cursor: default;
+            background-color: $singleItemSelectionDisabledBackgroundColor;
+
+            &:hover {
+                background-color: $singleItemSelectionDisabledBackgroundColor;
+                border-color: $singleItemSelectionBorderColor;
+                color: $singleItemSelectionButtonColor;
+            }
+        }
+
+        .remove-button {
+            display: none;
+        }
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -12,6 +12,17 @@ test('Render with given children prop', () => {
     expect(render(<SingleItemSelection leftButton={leftButton}>Test Item</SingleItemSelection>)).toMatchSnapshot();
 });
 
+test('Render in disabled state', () => {
+    const leftButton = {
+        icon: 'su-document',
+        onClick: jest.fn(),
+    };
+
+    expect(render(
+        <SingleItemSelection disabled={true} leftButton={leftButton}>Test Item</SingleItemSelection>
+    )).toMatchSnapshot();
+});
+
 test('Render with given onRemove prop', () => {
     const leftButton = {
         icon: 'su-page',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<div
+  class="singleItemSelection disabled"
+>
+  <button
+    class="button"
+    disabled=""
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      Test Item
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render with emptyText if no children have been passed 1`] = `
 <div
   class="singleItemSelection"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -4,6 +4,7 @@ import {observable, action, computed} from 'mobx';
 import React, {Fragment} from 'react';
 import type {Node} from 'react';
 import equal from 'fast-deep-equal';
+import classNames from 'classnames';
 import ArrowMenu from '../../components/ArrowMenu';
 import Button from '../../components/Button';
 import Dialog from '../../components/Dialog';
@@ -24,6 +25,7 @@ type Props = {|
     allowActivateForDisabledItems: boolean,
     copyable: boolean,
     deletable: boolean,
+    disabled: boolean,
     disabledIds: Array<string | number>,
     header?: Node,
     movable: boolean,
@@ -41,6 +43,7 @@ export default class Datagrid extends React.Component<Props> {
         allowActivateForDisabledItems: true,
         copyable: true,
         deletable: true,
+        disabled: false,
         disabledIds: [],
         movable: true,
         orderable: true,
@@ -418,6 +421,7 @@ export default class Datagrid extends React.Component<Props> {
             adapters,
             copyable,
             deletable,
+            disabled,
             disabledIds,
             header,
             movable,
@@ -429,6 +433,13 @@ export default class Datagrid extends React.Component<Props> {
             store,
         } = this.props;
         const Adapter = this.currentAdapter;
+
+        const datagridClass = classNames(
+            datagridStyles.datagrid,
+            {
+                [datagridStyles.disabled]: disabled,
+            }
+        );
 
         return (
             <Fragment>
@@ -448,7 +459,7 @@ export default class Datagrid extends React.Component<Props> {
                         </div>
                     </div>
                 }
-                <div className={datagridStyles.datagrid}>
+                <div className={datagridClass}>
                     {store.loading && store.pageCount === 0
                         ? <Loader />
                         : <Adapter

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
@@ -5,6 +5,11 @@ $datagridHeaderMarginBottom: 40px;
     display: flex;
     flex-direction: column;
     height: 100%;
+
+    &.disabled {
+        opacity: .5;
+        pointer-events: none;
+    }
 }
 
 .header-container {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -239,6 +239,13 @@ test('Render the adapter in non-searchable mode', () => {
     ).toMatchSnapshot();
 });
 
+test('Render the adapter in disabled state', () => {
+    const datagridStore = new DatagridStore('test', 'datagrid_test', {page: observable.box(1)});
+    expect(
+        render(<Datagrid adapters={['test']} disabled={true} header={<h1>Title</h1>} store={datagridStore} />)
+    ).toMatchSnapshot();
+});
+
 test('Pass the ids to be disabled to the adapter', () => {
     const disabledIds = [1, 3];
     const datagridStore = new DatagridStore('test', 'datagrid_test', {page: observable.box(1)});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -84,6 +84,47 @@ Array [
 ]
 `;
 
+exports[`Render the adapter in disabled state 1`] = `
+Array [
+  <div
+    class="headerContainer"
+  >
+    <h1>
+      Title
+    </h1>
+    <div
+      class="toolbar"
+    >
+      <label
+        class="input dark left collapsed hasAppendIcon"
+      >
+        <div
+          class="prependedContainer dark collapsed"
+        >
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
+          />
+        </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+    </div>
+  </div>,
+  <div
+    class="datagrid disabled"
+  >
+    <div>
+      Test Adapter
+    </div>
+  </div>,
+]
+`;
+
 exports[`Render the adapter in non-searchable mode 1`] = `
 Array [
   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -60,7 +60,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
     };
 
     render() {
-        const {maxOccurs, minOccurs, onChange, types, value} = this.props;
+        const {disabled, maxOccurs, minOccurs, onChange, types, value} = this.props;
 
         if (!types) {
             throw new Error(MISSING_BLOCK_ERROR_MESSAGE);
@@ -73,6 +73,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
 
         return (
             <BlockCollection
+                disabled={!!disabled}
                 maxOccurs={maxOccurs}
                 minOccurs={minOccurs}
                 onChange={onChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -229,6 +229,7 @@ test('Should correctly pass props to the BlockCollection', () => {
     const fieldBlocks = shallow(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             label="Test"
             maxOccurs={2}
@@ -240,6 +241,7 @@ test('Should correctly pass props to the BlockCollection', () => {
     );
 
     expect(fieldBlocks.find('BlockCollection').props()).toEqual(expect.objectContaining({
+        disabled: true,
         maxOccurs: 2,
         minOccurs: 1,
         onChange: changeSpy,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -278,8 +278,8 @@ test('Should pass correct schemaPath to FieldRender', () => {
         />
     );
 
-    fieldBlocks.find('SortableBlocks').prop('onExpand')(0);
-    fieldBlocks.find('SortableBlocks').prop('onExpand')(1);
+    fieldBlocks.find('SortableBlockList').prop('onExpand')(0);
+    fieldBlocks.find('SortableBlockList').prop('onExpand')(1);
     fieldBlocks.update();
 
     expect(fieldBlocks.find('FieldRenderer').at(0).prop('schemaPath')).toEqual('/types/default/form');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/PasswordConfirmation.js
@@ -12,8 +12,8 @@ export default class PasswordConfirmation extends React.Component<FieldTypeProps
     };
 
     render() {
-        const {error} = this.props;
+        const {disabled, error} = this.props;
 
-        return <PasswordConfirmationComponent onChange={this.handleChange} valid={!error} />;
+        return <PasswordConfirmationComponent disabled={!!disabled} onChange={this.handleChange} valid={!error} />;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -128,6 +128,7 @@ export default class Selection extends React.Component<Props> {
     renderAutoComplete() {
         const {
             dataPath,
+            disabled,
             fieldTypeOptions: {
                 resource_key: resourceKey,
                 types: {
@@ -155,6 +156,7 @@ export default class Selection extends React.Component<Props> {
         return (
             <MultiAutoComplete
                 allowAdd={allowAdd}
+                disabled={!!disabled}
                 displayProperty={displayProperty}
                 filterParameter={filterParameter}
                 id={dataPath}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -82,6 +82,7 @@ export default class Selection extends React.Component<Props> {
 
     renderDatagridOverlay() {
         const {
+            disabled,
             formInspector,
             fieldTypeOptions: {
                 resource_key: resourceKey,
@@ -105,6 +106,7 @@ export default class Selection extends React.Component<Props> {
         return (
             <MultiSelectionComponent
                 adapter={adapter}
+                disabled={!!disabled}
                 disabledIds={resourceKey === formInspector.resourceKey && formInspector.id ? [formInspector.id] : []}
                 displayProperties={displayProperties}
                 icon={icon}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -184,6 +184,7 @@ export default class Selection extends React.Component<Props> {
         }
 
         const {
+            disabled,
             fieldTypeOptions: {
                 types: {
                     datagrid: {
@@ -199,7 +200,7 @@ export default class Selection extends React.Component<Props> {
 
         return (
             <div className={selectionStyles.datagrid}>
-                <Datagrid adapters={[adapter]} searchable={false} store={this.datagridStore} />
+                <Datagrid adapters={[adapter]} disabled={!!disabled} searchable={false} store={this.datagridStore} />
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -45,6 +45,7 @@ export default class SingleSelection extends React.Component<Props>
 
     renderDatagridOverlay() {
         const {
+            disabled,
             formInspector,
             fieldTypeOptions: {
                 resource_key: resourceKey,
@@ -73,6 +74,7 @@ export default class SingleSelection extends React.Component<Props>
         return (
             <SingleSelectionComponent
                 adapter={adapter}
+                disabled={!!disabled}
                 disabledIds={isSameEndpoint && formInspector.id ? [formInspector.id] : []}
                 displayProperties={displayProperties}
                 emptyText={translate(emptyText)}
@@ -88,6 +90,7 @@ export default class SingleSelection extends React.Component<Props>
 
     renderAutoComplete() {
         const {
+            disabled,
             dataPath,
             fieldTypeOptions,
             value,
@@ -118,6 +121,7 @@ export default class SingleSelection extends React.Component<Props>
 
         return (
             <SingleAutoComplete
+                disabled={!!disabled}
                 displayProperty={displayProperty}
                 id={dataPath}
                 onChange={this.handleChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -95,6 +95,7 @@ export default class SmartContent extends React.Component<Props> {
 
     render() {
         const {
+            disabled,
             label,
             schemaOptions: {
                 present_as: {
@@ -124,6 +125,7 @@ export default class SmartContent extends React.Component<Props> {
 
         return (
             <SmartContentComponent
+                disabled={!!disabled}
                 fieldLabel={label}
                 presentations={presentations}
                 store={this.smartContentStore}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/TextEditor.js
@@ -5,11 +5,12 @@ import type {FieldTypeProps} from '../../../types';
 
 export default class TextEditor extends React.Component<FieldTypeProps<?string>> {
     render() {
-        const {onChange, onFinish, value} = this.props;
+        const {disabled, onChange, onFinish, value} = this.props;
 
         return (
             <TextEditorContainer
                 adapter="ckeditor5"
+                disabled={!!disabled}
                 onBlur={onFinish}
                 onChange={onChange}
                 value={value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -178,7 +178,7 @@ test('Call finish handlers with dataPath and schemaPath when a block field has f
     const form = mount(<Form onSubmit={jest.fn()} store={store} />);
     form.instance().formInspector.addFinishFieldHandler(handler1);
     form.instance().formInspector.addFinishFieldHandler(handler2);
-    form.find('SortableBlocks').prop('onExpand')(0);
+    form.find('SortableBlockList').prop('onExpand')(0);
     form.update();
     form.find('SortableBlock Field').at(0).instance().handleFinish();
     expect(handler1).toHaveBeenLastCalledWith('/block/0/text', '/block/types/default/form/text');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/PasswordConfirmation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/PasswordConfirmation.test.js
@@ -34,6 +34,7 @@ test('Pass props correctly to PasswordConfirmation component', () => {
     const passwordConfirmation = shallow(
         <PasswordConfirmation
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             onChange={changeSpy}
             onFinish={finishSpy}
@@ -41,6 +42,7 @@ test('Pass props correctly to PasswordConfirmation component', () => {
     );
 
     expect(passwordConfirmation.find(PasswordConfirmationComponent).prop('valid')).toBe(true);
+    expect(passwordConfirmation.find(PasswordConfirmationComponent).prop('disabled')).toBe(true);
 
     passwordConfirmation.find(PasswordConfirmationComponent).simulate('change', 'value');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -382,6 +382,7 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
     const selection = shallow(
         <Selection
             {...fieldTypeDefaultProps}
+            disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             value={value}
@@ -390,6 +391,7 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
 
     expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
         allowAdd: false,
+        disabled: true,
         displayProperty: 'name',
         filterParameter: 'names',
         idProperty: 'uuid',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -74,6 +74,7 @@ test('Should pass props correctly to selection component', () => {
     const selection = shallow(
         <Selection
             {...fieldTypeDefaultProps}
+            disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             onFinish={jest.fn()}
@@ -85,6 +86,7 @@ test('Should pass props correctly to selection component', () => {
 
     expect(selection.find('MultiSelection').props()).toEqual(expect.objectContaining({
         adapter: 'table',
+        disabled: true,
         displayProperties: ['id', 'title'],
         label: 'sulu_snippet.selection_label',
         locale,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -266,6 +266,7 @@ test('Should pass props correctly to datagrid component', () => {
     const selection = shallow(
         <Selection
             {...fieldTypeDefaultProps}
+            disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             value={value}
@@ -276,6 +277,7 @@ test('Should pass props correctly to datagrid component', () => {
     expect(selection.instance().datagridStore.initialSelectionIds).toEqual(value);
     expect(selection.find(Datagrid).props()).toEqual(expect.objectContaining({
         adapters: ['table'],
+        disabled: true,
         searchable: false,
     }));
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -54,6 +54,7 @@ test('Pass correct props to SingleAutoComplete', () => {
     const singleSelection = shallow(
         <SingleSelection
             {...fieldTypeDefaultProps}
+            disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             value={value}
@@ -61,6 +62,7 @@ test('Pass correct props to SingleAutoComplete', () => {
     );
 
     expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
+        disabled: true,
         displayProperty: 'name',
         resourceKey: 'accounts',
         searchProperties: ['name', 'number'],
@@ -144,6 +146,7 @@ test('Pass correct props to SingleItemSelection', () => {
     const singleSelection = shallow(
         <SingleSelection
             {...fieldTypeDefaultProps}
+            disabled={true}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             value={value}
@@ -152,6 +155,7 @@ test('Pass correct props to SingleItemSelection', () => {
 
     expect(singleSelection.find(SingleSelectionComponent).props()).toEqual(expect.objectContaining({
         adapter: 'table',
+        disabled: true,
         disabledIds: [],
         displayProperties: ['name'],
         emptyText: 'sulu_contact.nothing',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -124,6 +124,7 @@ test('Pass correct props to SmartContent component', () => {
     const smartContent = shallow(
         <SmartContent
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             label="Test"
             schemaOptions={schemaOptions}
@@ -135,6 +136,7 @@ test('Pass correct props to SmartContent component', () => {
         {name: 'two', value: 'Two column'},
     ]);
     expect(smartContent.find('SmartContent').prop('fieldLabel')).toEqual('Test');
+    expect(smartContent.find('SmartContent').prop('disabled')).toEqual(true);
 });
 
 test('Should not call the onChange and onFinish callbacks if SmartContentStore is still loading', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js
@@ -19,6 +19,7 @@ test('Pass props correctly to TextEditor', () => {
     const textEditor = shallow(
         <TextEditor
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             onChange={changeSpy}
             onFinish={finishSpy}
@@ -31,5 +32,6 @@ test('Pass props correctly to TextEditor', () => {
         onBlur: finishSpy,
         onChange: changeSpy,
         value: 'xyz',
+        disabled: true,
     }));
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -10,6 +10,7 @@ import MultiSelectionStore from '../../stores/MultiSelectionStore';
 
 type Props = {|
     allowAdd: boolean,
+    disabled: boolean,
     displayProperty: string,
     filterParameter: string,
     id?: string,
@@ -25,6 +26,7 @@ type Props = {|
 export default class MultiAutoComplete extends React.Component<Props> {
     static defaultProps = {
         allowAdd: false,
+        disabled: false,
         filterParameter: 'ids',
         idProperty: 'id',
     };
@@ -91,6 +93,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
         const {
             props: {
                 allowAdd,
+                disabled,
                 displayProperty,
                 id,
                 idProperty,
@@ -101,6 +104,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
         return (
             <MultiAutoCompleteComponent
                 allowAdd={allowAdd}
+                disabled={disabled}
                 displayProperty={displayProperty}
                 id={id}
                 idProperty={idProperty}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -228,6 +228,42 @@ test('Render with given value', () => {
     expect(multiAutoComplete.render()).toMatchSnapshot();
 });
 
+test('Render in disabled state', () => {
+    // $FlowFixMe
+    SearchStore.mockImplementation(function() {
+        this.searchResults = [];
+        this.loading = false;
+    });
+
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementation(function() {
+        this.set = jest.fn();
+        this.loading = false;
+        mockExtendObservable(this, {
+            items: [],
+        });
+    });
+
+    const multiAutoComplete = mount(
+        <MultiAutoComplete
+            disabled={true}
+            displayProperty="name"
+            onChange={jest.fn()}
+            resourceKey="test"
+            searchProperties={[]}
+            value={[1, 2]}
+        />
+    );
+
+    expect(MultiSelectionStore).toBeCalledWith('test', [1, 2], undefined, 'ids');
+    multiAutoComplete.instance().selectionStore.items = [
+        {id: 1, name: 'James Bond', number: '007'},
+        {id: 2, name: 'John Doe', number: '005'},
+    ];
+
+    expect(multiAutoComplete.render()).toMatchSnapshot();
+});
+
 test('Do not load items if passed value has not changed', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<label
+  class="multiAutoComplete disabled"
+>
+  <div
+    class="icon"
+  >
+    <span
+      aria-label="su-search"
+      class="su-search"
+    />
+  </div>
+  <div
+    class="items"
+  >
+    <div
+      class="item disabled"
+    >
+      James Bond
+    </div>
+    <div
+      class="item disabled"
+    >
+      John Doe
+    </div>
+    <input
+      class="input mousetrap"
+      disabled=""
+      value=""
+    />
+  </div>
+</label>
+`;
+
 exports[`Render in loading state 1`] = `
 <label
   class="multiAutoComplete"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/MultiSelect.js
@@ -8,6 +8,7 @@ import Loader from '../../components/Loader';
 type Props<T: string | number> = {|
     apiOptions: Object,
     allSelectedText?: string,
+    disabled: boolean,
     displayProperty: string,
     idProperty: string,
     noneSelectedText?: string,
@@ -20,6 +21,7 @@ type Props<T: string | number> = {|
 export default class MultiSelect<T: string | number> extends React.Component<Props<T>> {
     static defaultProps = {
         apiOptions: {},
+        disabled: false,
         idProperty: 'id',
         values: [],
     };
@@ -57,6 +59,7 @@ export default class MultiSelect<T: string | number> extends React.Component<Pro
     render() {
         const {
             allSelectedText,
+            disabled,
             noneSelectedText,
             displayProperty,
             idProperty,
@@ -70,6 +73,7 @@ export default class MultiSelect<T: string | number> extends React.Component<Pro
         return (
             <MultiSelectComponent
                 allSelectedText={allSelectedText}
+                disabled={disabled}
                 noneSelectedText={noneSelectedText}
                 onChange={this.handleChange}
                 values={values}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/tests/MultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/tests/MultiSelect.test.js
@@ -28,6 +28,38 @@ test('Render in loading state', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in disabled state', () => {
+    // $FlowFixMe
+    ResourceListStore.mockImplementation(function() {
+        this.loading = false;
+        this.data = [
+            {
+                'id': 2,
+                'name': 'Test ABC',
+                'someOtherProperty': 'No no',
+            },
+            {
+                'id': 5,
+                'name': 'Test DEF',
+                'someOtherProperty': 'YES YES',
+            },
+        ];
+    });
+
+    const multiSelect = mount(
+        <MultiSelect
+            disabled={true}
+            displayProperty="name"
+            onChange={jest.fn()}
+            resourceKey="test"
+            values={undefined}
+        />
+    );
+
+    expect(ResourceListStore).toBeCalledWith('test', {});
+    expect(multiSelect.render()).toMatchSnapshot();
+});
+
 test('Render with data', () => {
     // $FlowFixMe
     ResourceListStore.mockImplementation(function() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/tests/__snapshots__/MultiSelect.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/tests/__snapshots__/MultiSelect.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<div
+  class="select"
+>
+  <button
+    class="displayValue default"
+    disabled=""
+    type="button"
+  >
+    <div
+      aria-label="sulu_admin.none_selected"
+      class="croppedText"
+      title="sulu_admin.none_selected"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        sulu_admin.n
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          one_selected
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        sulu_admin.none_selected
+      </div>
+    </div>
+    <span
+      aria-label="su-angle-down"
+      class="su-angle-down toggle"
+    />
+  </button>
+</div>
+`;
+
 exports[`Render in loading state 1`] = `
 <div
   class="spinner"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -11,6 +11,7 @@ import multiSelectionStyles from './multiSelection.scss';
 
 type Props = {|
     adapter: string,
+    disabled: boolean,
     disabledIds: Array<string | number>,
     displayProperties: Array<string>,
     onChange: (selectedIds: Array<string | number>) => void,
@@ -25,6 +26,7 @@ type Props = {|
 @observer
 export default class MultiSelection extends React.Component<Props> {
     static defaultProps = {
+        disabled: false,
         disabledIds: [],
         displayProperties: [],
         icon: 'su-plus',
@@ -105,13 +107,25 @@ export default class MultiSelection extends React.Component<Props> {
     };
 
     render() {
-        const {adapter, disabledIds, displayProperties, icon, label, locale, resourceKey, overlayTitle} = this.props;
+        const {
+            adapter,
+            disabled,
+            disabledIds,
+            displayProperties,
+            icon,
+            label,
+            locale,
+            resourceKey,
+            overlayTitle,
+        } = this.props;
+
         const {items, loading} = this.selectionStore;
         const columns = displayProperties.length;
 
         return (
             <Fragment>
                 <MultiItemSelection
+                    disabled={disabled}
                     label={label}
                     leftButton={{
                         icon,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -44,6 +44,18 @@ test('Show with default plus icon', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in disabled state', () => {
+    expect(render(
+        <MultiSelection
+            adapter="table"
+            disabled={true}
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+        />
+    )).toMatchSnapshot();
+});
+
 test('Show with passed label', () => {
     expect(render(
         <MultiSelection
@@ -131,6 +143,22 @@ test('Should open an overlay', () => {
 
     const body = document.body;
     expect(pretty(body ? body.innerHTML : null)).toMatchSnapshot();
+});
+
+test('Should not open an overlay on icon-click when disabled', () => {
+    const selection = mount(
+        <MultiSelection
+            adapter="table"
+            disabled={true}
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+        />
+    );
+
+    selection.find('Button[icon="su-plus"]').simulate('click');
+    selection.update();
+    expect(selection.find('MultiDatagridOverlay').prop('open')).toEqual(false);
 });
 
 test('Should close an overlay using the close button', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<div
+  class="multiItemSelectionClass disabled"
+>
+  <div
+    class="header emptyList"
+  >
+    <button
+      class="button left"
+      disabled=""
+      type="button"
+    >
+      <span
+        aria-label="su-plus"
+        class="su-plus"
+      />
+    </button>
+    <div
+      class="label"
+    />
+  </div>
+  <ul
+    class="list"
+  />
+</div>
+`;
+
 exports[`Should open an overlay 1`] = `
 "<div>
   <div class=\\"backdrop visible fixed\\"></div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -26,7 +26,9 @@ exports[`Should open an overlay 1`] = `
 `;
 
 exports[`Show with default plus icon 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header emptyList"
   >
@@ -42,15 +44,17 @@ Array [
     <div
       class="label"
     />
-  </div>,
+  </div>
   <ul
     class="list"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`Show with passed icon 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header emptyList"
   >
@@ -66,15 +70,17 @@ Array [
     <div
       class="label"
     />
-  </div>,
+  </div>
   <ul
     class="list"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`Show with passed label 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header emptyList"
   >
@@ -92,15 +98,17 @@ Array [
     >
       Select Snippets
     </div>
-  </div>,
+  </div>
   <ul
     class="list"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`Show with passed values as items in right locale 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header"
   >
@@ -116,7 +124,7 @@ Array [
     <div
       class="label"
     />
-  </div>,
+  </div>
   <ul
     class="list"
   >
@@ -264,6 +272,6 @@ Array [
         </button>
       </div>
     </li>
-  </ul>,
-]
+  </ul>
+</div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
@@ -5,6 +5,7 @@ import SingleAutoCompleteComponent from '../../components/SingleAutoComplete';
 import SearchStore from '../../stores/SearchStore';
 
 type Props = {|
+    disabled: boolean,
     displayProperty: string,
     id?: string,
     searchProperties: Array<string>,
@@ -15,6 +16,10 @@ type Props = {|
 
 @observer
 export default class SingleAutoComplete extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     searchStore: SearchStore;
 
     constructor(props: Props) {
@@ -36,16 +41,17 @@ export default class SingleAutoComplete extends React.Component<Props> {
 
     render() {
         const {
-            props: {
-                displayProperty,
-                id,
-                searchProperties,
-                value,
-            },
-        } = this;
+            disabled,
+            displayProperty,
+            id,
+            searchProperties,
+            value,
+
+        } = this.props;
 
         return (
             <SingleAutoCompleteComponent
+                disabled={disabled}
                 displayProperty={displayProperty}
                 id={id}
                 loading={this.searchStore.loading}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -74,6 +74,25 @@ test('Render with given value', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in disabled state', () => {
+    // $FlowFixMe
+    SearchStore.mockImplementation(function() {
+        this.searchResults = [];
+        this.loading = true;
+    });
+
+    expect(render(
+        <SingleAutoComplete
+            disabled={true}
+            displayProperty="name"
+            onChange={jest.fn()}
+            resourceKey="test"
+            searchProperties={[]}
+            value={{name: 'James Bond', number: '007'}}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Search using store when new search value is retrieved from SingleAutoComplete component', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<div
+  class="singleAutoComplete"
+>
+  <label
+    class="input default left disabled"
+  >
+    <div
+      class="prependedContainer default"
+    >
+      <div
+        class="spinner"
+        style="width:20px;height:20px"
+      >
+        <div
+          class="doubleBounce1"
+        />
+        <div
+          class="doubleBounce2"
+        />
+      </div>
+    </div>
+    <input
+      class="mousetrap"
+      disabled=""
+      type="text"
+      value="James Bond"
+    />
+  </label>
+</div>
+`;
+
 exports[`Render in loading state 1`] = `
 <div
   class="singleAutoComplete"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -10,6 +10,7 @@ import singleSelectionStyles from './singleSelection.scss';
 
 type Props = {|
     adapter: string,
+    disabled: boolean,
     disabledIds: Array<string | number>,
     displayProperties: Array<string>,
     emptyText: string,
@@ -24,6 +25,7 @@ type Props = {|
 @observer
 export default class SingleSelection extends React.Component<Props> {
     static defaultProps = {
+        disabled: false,
         disabledIds: [],
         icon: 'su-plus',
     };
@@ -97,6 +99,7 @@ export default class SingleSelection extends React.Component<Props> {
     render() {
         const {
             adapter,
+            disabled,
             disabledIds,
             displayProperties,
             emptyText,
@@ -111,6 +114,7 @@ export default class SingleSelection extends React.Component<Props> {
         return (
             <Fragment>
                 <SingleItemSelection
+                    disabled={disabled}
                     emptyText={emptyText}
                     leftButton={{
                         icon,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -73,6 +73,33 @@ test('Render with selected item', () => {
     expect(singleSelection.render()).toMatchSnapshot();
 });
 
+test('Render with selected item in disabled state', () => {
+    const locale = observable.box('en');
+    const singleSelection = mount(
+        <SingleSelection
+            adapter="table"
+            disabled={true}
+            disabledIds={[]}
+            displayProperties={['name', 'value']}
+            emptyText="Nothing"
+            icon="su-test"
+            locale={locale}
+            onChange={jest.fn()}
+            overlayTitle="Test"
+            resourceKey="test"
+            value={3}
+        />
+    );
+
+    singleSelection.instance().singleSelectionStore.item = {
+        name: 'Name',
+        value: 'Value',
+    };
+    singleSelection.update();
+
+    expect(singleSelection.render()).toMatchSnapshot();
+});
+
 test('Pass resourceKey and locale to SingleDatagridOverlay', () => {
     const locale = observable.box('en');
     const singleSelection = shallow(
@@ -132,6 +159,29 @@ test('Should open and close an overlay', () => {
     expect(singleSelection.find(SingleDatagridOverlay).prop('open')).toEqual(true);
 
     singleSelection.find(SingleDatagridOverlay).prop('onClose')();
+    singleSelection.update();
+    expect(singleSelection.find(SingleDatagridOverlay).prop('open')).toEqual(false);
+});
+
+test('Should not open an overlay on button-click when disabled', () => {
+    const singleSelection = mount(
+        <SingleSelection
+            adapter="table"
+            disabled={true}
+            disabledIds={[]}
+            displayProperties={[]}
+            emptyText="Nothing"
+            icon="su-test"
+            onChange={jest.fn()}
+            overlayTitle="Test"
+            resourceKey="test"
+            value={3}
+        />
+    );
+
+    expect(singleSelection.find(SingleDatagridOverlay).prop('open')).toEqual(false);
+
+    singleSelection.find('.button').simulate('click');
     singleSelection.update();
     expect(singleSelection.find(SingleDatagridOverlay).prop('open')).toEqual(false);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/__snapshots__/SingleSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/__snapshots__/SingleSelection.test.js.snap
@@ -47,6 +47,55 @@ exports[`Render with selected item 1`] = `
 </div>
 `;
 
+exports[`Render with selected item in disabled state 1`] = `
+<div
+  class="singleItemSelection disabled"
+>
+  <button
+    class="button"
+    disabled=""
+    type="button"
+  >
+    <span
+      aria-label="su-test"
+      class="su-test"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      <div>
+        <span
+          class="itemColumn"
+          style="width: 50%;"
+        >
+          Name
+        </span>
+        <span
+          class="itemColumn"
+          style="width: 50%;"
+        >
+          Value
+        </span>
+      </div>
+    </div>
+    <button
+      class="removeButton"
+      disabled=""
+      type="button"
+    >
+      <span
+        aria-label="su-trash-alt"
+        class="su-trash-alt"
+      />
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Show with passed emptyText and icon 1`] = `
 Array [
   <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
@@ -11,7 +11,7 @@ import SmartContentItem from './SmartContentItem';
 import type {Presentation, SmartContentConfig} from './types';
 
 type Props = {|
-    disabled?: boolean,
+    disabled: boolean,
     fieldLabel: string,
     presentations: Array<Presentation>,
     store: SmartContentStore,
@@ -20,6 +20,7 @@ type Props = {|
 @observer
 export default class SmartContent extends React.Component<Props> {
     static defaultProps = {
+        disabled: false,
         presentations: [],
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
@@ -10,11 +10,12 @@ import FilterOverlay from './FilterOverlay';
 import SmartContentItem from './SmartContentItem';
 import type {Presentation, SmartContentConfig} from './types';
 
-type Props = {
+type Props = {|
+    disabled?: boolean,
     fieldLabel: string,
     presentations: Array<Presentation>,
     store: SmartContentStore,
-};
+|};
 
 @observer
 export default class SmartContent extends React.Component<Props> {
@@ -102,7 +103,7 @@ export default class SmartContent extends React.Component<Props> {
     };
 
     render() {
-        const {fieldLabel, store} = this.props;
+        const {disabled, fieldLabel, store} = this.props;
 
         const presentations = this.props.presentations.reduce((presentations, presentation) => {
             presentations[presentation.name] = presentation.value;
@@ -112,6 +113,7 @@ export default class SmartContent extends React.Component<Props> {
         return (
             <Fragment>
                 <MultiItemSelection
+                    disabled={disabled}
                     label={translate('sulu_admin.smart_content_label', {count: store.items.length})}
                     leftButton={{
                         icon: 'fa-filter',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
@@ -28,7 +28,7 @@ test('Pass correct sections prop', () => {
     });
 
     const smartContentStore = new SmartContentStore('content');
-    const smartContent = shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    const smartContent = shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContent.find('FilterOverlay').prop('sections'))
         .toEqual(['tags', 'audienceTargeting', 'limit']);
@@ -45,7 +45,7 @@ test('Disable sorting on MultiItemSelection', () => {
     });
 
     const smartContentStore = new SmartContentStore('content');
-    const smartContent = shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    const smartContent = shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContent.find('MultiItemSelection').prop('sortable')).toEqual(false);
 });
@@ -68,7 +68,7 @@ test('Pass correct sections prop with other values', () => {
 
     const smartContentStore = new SmartContentStore('content');
     const smartContent = shallow(
-        <SmartContent fieldLabel="Test" presentations={presentations} provider="content" store={smartContentStore} />
+        <SmartContent fieldLabel="Test" presentations={presentations} store={smartContentStore} />
     );
 
     expect(smartContent.find('FilterOverlay').prop('sections'))
@@ -91,7 +91,7 @@ test('Open and closes the FilterOverlay when the icon is clicked', () => {
         presentAs: true,
         limit: false,
     });
-    const smartContent = shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    const smartContent = shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContent.find('FilterOverlay').prop('open')).toEqual(false);
 
@@ -112,7 +112,7 @@ test('Show items in a SmartContentItem', () => {
         {title: 'About us'},
     ];
 
-    const smartContent = shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    const smartContent = shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContent.find('SmartContentItem')).toHaveLength(2);
     expect(smartContent.find('SmartContentItem').at(0).prop('item')).toEqual({title: 'Homepage'});
@@ -123,7 +123,7 @@ test('Pass the loading prop to the MultiItemSelection if items are still loading
     const smartContentStore = new SmartContentStore('content');
     smartContentStore.itemsLoading = true;
 
-    const smartContent = shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    const smartContent = shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContent.find('MultiItemSelection').prop('loading')).toEqual(true);
 });
@@ -133,7 +133,7 @@ test('Pass the loading prop to the MultiItemSelection if datagrid or categories 
     // $FlowFixMe
     smartContentStore.loading = true;
 
-    const smartContent = shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    const smartContent = shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContent.find('MultiItemSelection').prop('loading')).toEqual(true);
 });
@@ -151,7 +151,7 @@ test('Set all defaults on the SmartContentStore', () => {
     });
 
     const smartContentStore = new SmartContentStore('content');
-    shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContentStore.dataSource).toEqual(undefined);
     expect(smartContentStore.includeSubElements).toEqual(false);
@@ -179,7 +179,7 @@ test('Set no defaults on the SmartContentStore', () => {
     });
 
     const smartContentStore = new SmartContentStore('content');
-    shallow(<SmartContent fieldLabel="Test" provider="content" store={smartContentStore} />);
+    shallow(<SmartContent fieldLabel="Test" store={smartContentStore} />);
 
     expect(smartContentStore.dataSource).toEqual(undefined);
     expect(smartContentStore.includeSubElements).toEqual(undefined);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
@@ -50,6 +50,22 @@ test('Disable sorting on MultiItemSelection', () => {
     expect(smartContent.find('MultiItemSelection').prop('sortable')).toEqual(false);
 });
 
+test('Pass correct props to MultiItemSelection component', () => {
+    smartContentConfigStore.getConfig.mockReturnValue({
+        tags: true,
+        categories: false,
+        audienceTargeting: true,
+        sorting: [],
+        presentAs: false,
+        limit: true,
+    });
+
+    const smartContentStore = new SmartContentStore('content');
+    const smartContent = shallow(<SmartContent disabled={true} fieldLabel="Test" store={smartContentStore} />);
+
+    expect(smartContent.find('MultiItemSelection').prop('disabled')).toEqual(true);
+});
+
 test('Pass correct sections prop with other values', () => {
     smartContentConfigStore.getConfig.mockReturnValue({
         datasourceResourceKey: 'pages',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/TextEditor.js
@@ -1,16 +1,18 @@
 // @flow
 import React from 'react';
 import textEditorRegistry from './registries/TextEditorRegistry';
+import type {TextEditorProps} from './types';
 
-type Props = {
+type Props = {|
+    ...TextEditorProps,
     adapter: string,
-    disabled?: boolean,
-    onBlur: () => void,
-    onChange: (value: ?string) => void,
-    value: ?string,
-};
+|};
 
 export default class TextEditor extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     render() {
         const {
             adapter,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/TextEditor.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/TextEditor.js
@@ -4,6 +4,7 @@ import textEditorRegistry from './registries/TextEditorRegistry';
 
 type Props = {
     adapter: string,
+    disabled?: boolean,
     onBlur: () => void,
     onChange: (value: ?string) => void,
     value: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/TextEditor.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/TextEditor.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {render, shallow} from 'enzyme';
+import {render, shallow, mount} from 'enzyme';
 import TextEditor from '../TextEditor';
 import textEditorRegistry from '../registries/TextEditorRegistry';
 
@@ -10,9 +10,26 @@ jest.mock('../registries/TextEditorRegistry', () => ({
 
 test('Render the TextEditor', () => {
     textEditorRegistry.get.mockReturnValue(() => (<textarea />));
+
     expect(
         render(<TextEditor adapter="test" onBlur={jest.fn()} onChange={jest.fn()} value={undefined} />)
     ).toMatchSnapshot();
+});
+
+test('Pass correct props to the given adapter', () => {
+    class TestAdapter extends React.Component<{}> {
+        render() {
+            return null;
+        }
+    }
+    textEditorRegistry.get.mockReturnValue(TestAdapter);
+
+    const textEditor = mount(
+        <TextEditor adapter="test" disabled={true} onBlur={jest.fn()} onChange={jest.fn()} value="testValue" />
+    );
+
+    expect(textEditor.find('TestAdapter').prop('value')).toEqual('testValue');
+    expect(textEditor.find('TestAdapter').prop('disabled')).toEqual(true);
 });
 
 test('Throw an exception if a not existing adapter is used', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/types.js
@@ -1,6 +1,6 @@
 // @flow
 export type TextEditorProps = {|
-    disabled?: boolean,
+    disabled: boolean,
     onBlur: () => void,
     onChange: (value: ?string) => void,
     value: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/types.js
@@ -1,5 +1,6 @@
 // @flow
 export type TextEditorProps = {|
+    disabled?: boolean,
     onBlur: () => void,
     onChange: (value: ?string) => void,
     value: ?string,

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
@@ -18,12 +18,12 @@
                 <title>sulu_admin.description</title>
             </meta>
         </property>
-        <property name="categories" type="category_list" disabledCondition="title == 'test'">
+        <property name="categories" type="category_list">
             <meta>
                 <title>sulu_category.categories</title>
             </meta>
         </property>
-        <property name="tags" type="tag_list" disabledCondition="title == 'test'">
+        <property name="tags" type="tag_list">
             <meta>
                 <title>sulu_tag.tags</title>
             </meta>

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <form xmlns="http://schemas.sulu.io/template/template"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
     <properties>
         <property name="title" type="text_line">
             <meta>
@@ -18,12 +18,12 @@
                 <title>sulu_admin.description</title>
             </meta>
         </property>
-        <property name="categories" type="category_list">
+        <property name="categories" type="category_list" disabledCondition="title == 'test'">
             <meta>
                 <title>sulu_category.categories</title>
             </meta>
         </property>
-        <property name="tags" type="tag_list">
+        <property name="tags" type="tag_list" disabledCondition="title == 'test'">
             <meta>
                 <title>sulu_tag.tags</title>
             </meta>

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/fields/PageSettingsNavigationSelect.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/fields/PageSettingsNavigationSelect.js
@@ -27,9 +27,7 @@ export default class PageSettingsNavigationSelect extends React.Component<FieldT
     };
 
     render() {
-        const {
-            value,
-        } = this.props;
+        const {disabled, value} = this.props;
 
         if (!this.webspace) {
             return null;
@@ -38,6 +36,7 @@ export default class PageSettingsNavigationSelect extends React.Component<FieldT
         return (
             <MultiSelect
                 allSelectedText={translate('sulu_content.all_navigations')}
+                disabled={!!disabled}
                 noneSelectedText={translate('sulu_content.no_navigation')}
                 onChange={this.handleChange}
                 values={value || []}

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/fields/PageSettingsShadowLocaleSelect.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/fields/PageSettingsShadowLocaleSelect.js
@@ -13,7 +13,7 @@ export default class PageSettingsShadowLocaleSelect extends React.Component<Fiel
     };
 
     render() {
-        const {formInspector, value} = this.props;
+        const {disabled, formInspector, value} = this.props;
         const contentLocales = toJS(formInspector.getValueByPath('/contentLocales'));
         const locale = formInspector.locale;
 
@@ -22,7 +22,7 @@ export default class PageSettingsShadowLocaleSelect extends React.Component<Fiel
         }
 
         return (
-            <SingleSelect onChange={this.handleChange} value={value}>
+            <SingleSelect disabled={!!disabled} onChange={this.handleChange} value={value}>
                 {contentLocales
                     .filter((contentLocale) => locale && contentLocale !== locale.get())
                     .map((contentLocale) => {

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/tests/fields/PageSettingsNavigationSelect.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/tests/fields/PageSettingsNavigationSelect.test.js
@@ -42,6 +42,7 @@ test('Pass correct props to MultiSelect', () => {
     const pageSettingsNavigationSelect = shallow(
         <PageSettingsNavigationSelect
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             value={['footer']}
         />
@@ -50,6 +51,7 @@ test('Pass correct props to MultiSelect', () => {
     expect(webspaceStore.loadWebspace).toBeCalledWith('sulu_io');
 
     return webspacePromise.then(() => {
+        expect(pageSettingsNavigationSelect.find('MultiSelect').prop('disabled')).toEqual(true);
         expect(pageSettingsNavigationSelect.find('MultiSelect').prop('values')).toEqual(['footer']);
         expect(pageSettingsNavigationSelect.find('Option').at(0).prop('children')).toEqual('Main Navigation');
         expect(pageSettingsNavigationSelect.find('Option').at(0).prop('value')).toEqual('main');

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/tests/fields/PageSettingsShadowLocaleSelect.test.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/containers/Form/tests/fields/PageSettingsShadowLocaleSelect.test.js
@@ -40,11 +40,13 @@ test('Pass correct props to SingleSelect', () => {
     const pageSettingsShadowSelect = shallow(
         <PageSettingsShadowLocaleSelect
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             value="de"
         />
     );
 
+    expect(pageSettingsShadowSelect.find('SingleSelect').prop('disabled')).toEqual(true);
     expect(pageSettingsShadowSelect.find('SingleSelect').prop('value')).toEqual('de');
     expect(pageSettingsShadowSelect.find('Option').at(0).prop('children')).toEqual('de');
     expect(pageSettingsShadowSelect.find('Option').at(0).prop('value')).toEqual('de');

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -11,6 +11,7 @@ import singleMediaDropzoneStyles from './singleMediaDropzone.scss';
 const UPLOAD_ICON = 'fa-cloud-upload';
 
 type Props = {|
+    disabled: boolean,
     emptyIcon: string,
     image: ?string,
     mimeType: ?string,
@@ -24,6 +25,7 @@ type Props = {|
 @observer
 export default class SingleMediaDropzone extends React.Component<Props> {
     static defaultProps = {
+        disabled: false,
         emptyIcon: 'su-image',
         mimeType: '',
         progress: 0,
@@ -54,6 +56,7 @@ export default class SingleMediaDropzone extends React.Component<Props> {
 
     render() {
         const {
+            disabled,
             emptyIcon,
             image,
             mimeType,
@@ -68,6 +71,7 @@ export default class SingleMediaDropzone extends React.Component<Props> {
             singleMediaDropzoneStyles[skin],
             {
                 [singleMediaDropzoneStyles.showUploadIndicator]: this.uploadIndicatorVisibility,
+                [singleMediaDropzoneStyles.disabled]: disabled,
             }
         );
 
@@ -75,6 +79,7 @@ export default class SingleMediaDropzone extends React.Component<Props> {
             <Dropzone
                 className={mediaContainerClass}
                 disableClick={uploading}
+                disabled={disabled}
                 multiple={false}
                 onDragEnter={this.handleDragEnter}
                 onDragLeave={this.handleDragLeave}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -35,6 +35,15 @@ $emptyColor: $alto;
         padding-top: 100%;
     }
 
+    &.disabled {
+        opacity: .5;
+        cursor: default;
+
+        .upload-indicator {
+            opacity: 0;
+        }
+    }
+
     @media (max-width: $mediaContainerBreakpoint) {
         width: 100%;
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
@@ -22,6 +22,18 @@ test('Render a SingleMediaDropzone with the passed empty icon', () => {
     expect(render(<SingleMediaDropzone emptyIcon="su-user" image={undefined} onDrop={jest.fn()} />)).toMatchSnapshot();
 });
 
+test('Render a SingleMediaDropzone in disabled state', () => {
+    expect(render(
+        <SingleMediaDropzone
+            disabled={true}
+            image="http://lorempixel.com/400/400"
+            onDrop={jest.fn()}
+            progress={0}
+            uploading={false}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render a SingleMediaDropzone with the round skin', () => {
     expect(render(
         <SingleMediaDropzone

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
@@ -32,6 +32,39 @@ exports[`Render a SingleMediaDropzone 1`] = `
 </div>
 `;
 
+exports[`Render a SingleMediaDropzone in disabled state 1`] = `
+<div
+  aria-disabled="true"
+  class="mediaContainer default disabled"
+  style="position:relative"
+>
+  <img
+    class="thumbnail"
+    src="http://lorempixel.com/400/400"
+  />
+  <div
+    class="uploadIndicatorContainer"
+  >
+    <div
+      class="uploadIndicator"
+    >
+      <div>
+        <span
+          aria-label="fa-cloud-upload"
+          class="fa fa-cloud-upload uploadIcon"
+        />
+      </div>
+    </div>
+  </div>
+  <input
+    autocomplete="off"
+    disabled=""
+    style="position:absolute;top:0;right:0;bottom:0;left:0;opacity:0.00001;pointer-events:none"
+    type="file"
+  />
+</div>
+`;
+
 exports[`Render a SingleMediaDropzone while uploading 1`] = `
 <div
   aria-disabled="false"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -30,6 +30,7 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
 
     render() {
         const {
+            disabled,
             schemaOptions: {
                 collection_id: {
                     value: collectionId,
@@ -66,6 +67,7 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
         return (
             <SingleMediaUploadComponent
                 collectionId={collectionId}
+                disabled={!!disabled}
                 emptyIcon={emptyIcon}
                 imageSize={imageSize}
                 mediaUploadStore={this.mediaUploadStore}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
@@ -37,6 +37,7 @@ test('Pass correct props', () => {
     const singleMediaUpload = shallow(
         <SingleMediaUpload
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             schemaOptions={schemaOptions}
         />
@@ -46,6 +47,7 @@ test('Pass correct props', () => {
     expect(singleMediaUpload.prop('emptyIcon')).toEqual('su-icon');
     expect(singleMediaUpload.prop('imageSize')).toEqual('sulu-400x400-inset');
     expect(singleMediaUpload.prop('uploadText')).toEqual('Drag and drop');
+    expect(singleMediaUpload.prop('disabled')).toEqual(true);
 });
 
 test('Pass correct skin to props', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
@@ -83,7 +83,7 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
     };
 
     render() {
-        const {formInspector} = this.props;
+        const {formInspector, disabled} = this.props;
 
         if (!formInspector || !formInspector.locale) {
             throw new Error('The media selection needs a locale to work properly');
@@ -101,6 +101,7 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
         return (
             <Fragment>
                 <MultiItemSelection
+                    disabled={!!disabled}
                     label={label}
                     leftButton={{
                         icon: 'su-image',

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -361,3 +361,18 @@ test('Should add the selected medias to the selection store on confirm', () => {
     expect(finishSpy).toBeCalled();
     expect(mediaSelectionInstance.overlayOpen).toBe(false);
 });
+
+test('Pass correct props to MultiItemSelection component', () => {
+    MediaSelectionStore.mockImplementation(function() {
+        this.selectedMedia = [];
+        this.selectedMediaIds = [];
+    });
+
+    const formInspector = {
+        locale: observable.box('de'),
+    };
+
+    const mediaSelection = mount(<MediaSelection disabled={true} formInspector={formInspector} />);
+
+    expect(mediaSelection.find('MultiItemSelection').prop('disabled')).toEqual(true);
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/__snapshots__/MediaSelection.test.js.snap
@@ -147,7 +147,9 @@ exports[`Clicking on the "add media" button should open up an overlay 1`] = `
 `;
 
 exports[`Render a MediaSelection field 1`] = `
-Array [
+<div
+  class="multiItemSelectionClass"
+>
   <div
     class="header"
   >
@@ -165,7 +167,7 @@ Array [
     >
       3 media elements selected
     </div>
-  </div>,
+  </div>
   <ul
     class="list"
   >
@@ -310,6 +312,6 @@ Array [
         </button>
       </div>
     </li>
-  </ul>,
-]
+  </ul>
+</div>
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -10,6 +10,7 @@ import singleMediaUploadStyles from './singleMediaUpload.scss';
 
 type Props = {|
     collectionId?: number,
+    disabled: boolean,
     deletable: boolean,
     downloadable: boolean,
     emptyIcon?: string,
@@ -24,6 +25,7 @@ type Props = {|
 export default class SingleMediaUpload extends React.Component<Props> {
     static defaultProps = {
         deletable: true,
+        disabled: false,
         downloadable: true,
         imageSize: 'sulu-400x400',
         skin: 'default',
@@ -92,8 +94,9 @@ export default class SingleMediaUpload extends React.Component<Props> {
 
     render() {
         const {
-            downloadable,
             deletable,
+            disabled,
+            downloadable,
             emptyIcon,
             mediaUploadStore,
             imageSize,
@@ -110,6 +113,7 @@ export default class SingleMediaUpload extends React.Component<Props> {
         return (
             <Fragment>
                 <SingleMediaDropzone
+                    disabled={disabled}
                     emptyIcon={emptyIcon}
                     image={mediaUploadStore.getThumbnail(imageSize)}
                     mimeType={mimeType}
@@ -119,7 +123,7 @@ export default class SingleMediaUpload extends React.Component<Props> {
                     uploading={uploading}
                     uploadText={uploadText}
                 />
-                {mediaUploadStore.id &&
+                {mediaUploadStore.id && !disabled &&
                     <div className={singleMediaUploadStyles.buttons}>
                         {downloadable &&
                             <Button

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js
@@ -30,6 +30,22 @@ test('Render a SingleMediaUpload', () => {
     ).toMatchSnapshot();
 });
 
+test('Render a SingleMediaUpload in disabled state', () => {
+    const mediaUploadStore = new MediaUploadStore(
+        {id: 1, mimeType: 'image/jpeg', thumbnails: {}, url: ''},
+        observable.box('en')
+    );
+
+    expect(render(
+        <SingleMediaUpload
+            collectionId={5}
+            disabled={true}
+            mediaUploadStore={mediaUploadStore}
+            uploadText="Upload media"
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render a SingleMediaUpload with an empty icon if no image is passed', () => {
     const mediaUploadStore = new MediaUploadStore(
         undefined,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/__snapshots__/SingleMediaUpload.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/__snapshots__/SingleMediaUpload.test.js.snap
@@ -71,6 +71,44 @@ Array [
 ]
 `;
 
+exports[`Render a SingleMediaUpload in disabled state 1`] = `
+<div
+  aria-disabled="true"
+  class="mediaContainer default disabled"
+  style="position:relative"
+>
+  <img
+    class="thumbnail"
+    src="sulu-400x400"
+  />
+  <div
+    class="uploadIndicatorContainer"
+  >
+    <div
+      class="uploadIndicator"
+    >
+      <div>
+        <span
+          aria-label="fa-cloud-upload"
+          class="fa fa-cloud-upload uploadIcon"
+        />
+        <div
+          class="uploadInfoText"
+        >
+          Upload media
+        </div>
+      </div>
+    </div>
+  </div>
+  <input
+    autocomplete="off"
+    disabled=""
+    style="position:absolute;top:0;right:0;bottom:0;left:0;opacity:0.00001;pointer-events:none"
+    type="file"
+  />
+</div>
+`;
+
 exports[`Render a SingleMediaUpload with a different image size 1`] = `
 Array [
   <div

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/Role.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/Role.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <form xmlns="http://schemas.sulu.io/template/template"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
     <properties>
         <property name="name" type="text_line" mandatory="true">
             <meta>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/Permissions.js
@@ -28,14 +28,19 @@ export default class Permissions extends React.Component<Props> {
     };
 
     render() {
-        const {value} = this.props;
+        const {disabled, value} = this.props;
 
         if (!this.system) {
             return null;
         }
 
         return (
-            <PermissionsContainer onChange={this.handleChange} system={this.system} value={value ? value : []} />
+            <PermissionsContainer
+                disabled={!!disabled}
+                onChange={this.handleChange}
+                system={this.system}
+                value={value ? value : []}
+            />
         );
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RoleAssignments.js
@@ -13,10 +13,10 @@ export default class RoleAssignments extends React.Component<Props> {
     };
 
     render() {
-        const {value} = this.props;
+        const {disabled, value} = this.props;
 
         return (
-            <RoleAssignmentsContainer onChange={this.handleChange} value={value ? value : []} />
+            <RoleAssignmentsContainer disabled={!!disabled} onChange={this.handleChange} value={value ? value : []} />
         );
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/Permissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/Permissions.test.js
@@ -35,12 +35,14 @@ test('Pass props correctly to Permissions', () => {
     const permissions = shallow(
         <Permissions
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
         />
     );
 
     expect(permissions.prop('system')).toEqual('Sulu');
     expect(permissions.prop('value')).toEqual([]);
+    expect(permissions.prop('disabled')).toEqual(true);
 });
 
 test('Pass props with value correctly to Permissions', () => {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RoleAssignments.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RoleAssignments.test.js
@@ -62,10 +62,12 @@ test('Pass props with value correctly to RoleAssignments', () => {
     const roleAssignments = shallow(
         <RoleAssignments
             {...fieldTypeDefaultProps}
+            disabled={true}
             formInspector={formInspector}
             value={value}
         />
     );
 
+    expect(roleAssignments.prop('disabled')).toEqual(true);
     expect(roleAssignments.prop('value')).toEqual(value);
 });

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
@@ -11,6 +11,7 @@ import permissionsStyle from './permissions.scss';
 
 type Props = {|
     contextPermissions: Array<ContextPermission>,
+    disabled: boolean,
     onChange: (value: Array<ContextPermission>) => void,
     securityContexts: SecurityContexts,
     subTitle?: string,
@@ -19,6 +20,10 @@ type Props = {|
 
 @observer
 export default class PermissionMatrix extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     getIcon = (action: string) => {
         switch (action) {
             case 'view':
@@ -92,7 +97,7 @@ export default class PermissionMatrix extends React.Component<Props> {
     }
 
     render() {
-        const {title, subTitle, securityContexts} = this.props;
+        const {disabled, title, subTitle, securityContexts} = this.props;
         const matrixValues = {};
         const matrixRows = [];
 
@@ -112,6 +117,7 @@ export default class PermissionMatrix extends React.Component<Props> {
                     <h3>{subTitle}</h3>
                 }
                 <Matrix
+                    disabled={disabled}
                     onChange={this.handleMatrixChange}
                     values={matrixValues}
                 >

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
@@ -11,14 +11,19 @@ import type {ContextPermission} from './types';
 import permissionsStyle from './permissions.scss';
 import PermissionMatrix from './PermissionMatrix';
 
-type Props = {
+type Props = {|
+    disabled: boolean,
     system: string,
     onChange: (value: Array<ContextPermission>) => void,
     value: Array<ContextPermission>,
-};
+|};
 
 @observer
 export default class Permissions extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     static webspacePlaceholder = '#webspace#';
 
     systemDisposer: () => void;
@@ -165,6 +170,7 @@ export default class Permissions extends React.Component<Props> {
                 <div className={permissionsStyle.selectContainer}>
                     <MultiSelect
                         apiOptions={{checkForPermissions: 0, locale: userStore.user.locale}}
+                        disabled={this.props.disabled}
                         displayProperty="name"
                         idProperty="key"
                         onChange={this.handleWebspaceChange}
@@ -177,6 +183,7 @@ export default class Permissions extends React.Component<Props> {
                         return (
                             <PermissionMatrix
                                 contextPermissions={this.props.value}
+                                disabled={this.props.disabled}
                                 key={matrixIndex}
                                 onChange={this.handleChange}
                                 securityContexts={this.getWebspaceSecurityContexts(webspace)}
@@ -190,7 +197,7 @@ export default class Permissions extends React.Component<Props> {
     }
 
     renderMatrixes(): Array<*> {
-        const {value} = this.props;
+        const {disabled, value} = this.props;
 
         return Object.keys(this.securityContextGroups).sort().map((securityContextGroupKey, matrixIndex) => {
             // ignore webspace group here
@@ -205,6 +212,7 @@ export default class Permissions extends React.Component<Props> {
             return (
                 <PermissionMatrix
                     contextPermissions={value}
+                    disabled={disabled}
                     key={matrixIndex}
                     onChange={this.handleChange}
                     securityContexts={securityContexts}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js
@@ -48,6 +48,45 @@ test('Render with minimal', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in disabled state', () => {
+    const contextPermissions: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.contact.people',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+        {
+            id: 2,
+            context: 'sulu.contact.organizations',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+    ];
+
+    const securityContexts: SecurityContexts = {
+        'sulu.contact.people': ['view', 'add', 'edit', 'delete'],
+        'sulu.contact.organizations': ['view', 'add', 'edit', 'delete'],
+    };
+
+    expect(render(
+        <PermissionMatrix
+            contextPermissions={contextPermissions}
+            disabled={true}
+            onChange={jest.fn()}
+            securityContexts={securityContexts}
+        />
+    )).toMatchSnapshot();
+});
+
 test('Render with title', () => {
     const contextPermissions: Array<ContextPermission> = [
         {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js
@@ -80,6 +80,55 @@ test('Render with minimal', () => {
     });
 });
 
+test('Render in disabled state', () => {
+    const value: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.contact.people',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+        {
+            id: 2,
+            context: 'sulu.contact.organizations',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+    ];
+
+    const securityContextGroups: SecurityContextGroups = {
+        'Contacts': {
+            'sulu.contact.people': ['view', 'add', 'edit', 'delete'],
+            'sulu.contact.organizations': ['view', 'add', 'edit', 'delete'],
+        },
+    };
+    const promise = Promise.resolve(securityContextGroups);
+    securityContextStore.loadSecurityContextGroups.mockReturnValue(promise);
+
+    const permissions = mount(
+        <Permissions
+            disabled={true}
+            onChange={jest.fn()}
+            system="Sulu"
+            value={value}
+        />
+    );
+
+    return promise.then(() => {
+        expect(securityContextStore.loadSecurityContextGroups).toBeCalledWith('Sulu');
+        permissions.update();
+        expect(permissions.render()).toMatchSnapshot();
+    });
+});
+
 test('Should trigger onChange correctly', () => {
     const value: Array<ContextPermission> = [
         {
@@ -776,6 +825,30 @@ test('Should trigger a mobx autorun if the prop system changes', () => {
         expect(securityContextStore.loadSecurityContextGroups).toHaveBeenCalledWith('Sulu');
         expect(securityContextStore.loadSecurityContextGroups).toHaveBeenCalledWith('Other-System');
         expect(securityContextStore.loadSecurityContextGroups).toHaveBeenCalledTimes(2);
+    });
+});
+
+test('Pass disabled state to MultiSelect', () => {
+    const securityContextGroups: SecurityContextGroups = {
+        'Webspaces': {
+            'sulu.webspaces.#webspace#': ['view'],
+        },
+    };
+    const promise = Promise.resolve(securityContextGroups);
+    securityContextStore.loadSecurityContextGroups.mockReturnValue(promise);
+
+    const permissions = mount(
+        <Permissions
+            disabled={true}
+            onChange={jest.fn()}
+            system="Sulu"
+            value={[]}
+        />
+    );
+
+    return promise.then(() => {
+        permissions.update();
+        expect(permissions.find(MultiSelect).prop('disabled')).toEqual(true);
     });
 });
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
@@ -5,7 +5,7 @@ exports[`Render in disabled state 1`] = `
   class="matrixContainer"
 >
   <div
-    class="matrix"
+    class="matrix disabled"
   >
     <div
       class="row"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
@@ -1,5 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<div
+  class="matrixContainer"
+>
+  <div
+    class="matrix"
+  >
+    <div
+      class="row"
+    >
+      <div>
+        people
+      </div>
+      <div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.view"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div>
+        organizations
+      </div>
+      <div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.view"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render with minimal 1`] = `
 <div
   class="matrixContainer"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
@@ -1,5 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render in disabled state 1`] = `
+<div
+  class="matrixContainer"
+>
+  <h2>
+    Contacts
+  </h2>
+  <div
+    class="matrix"
+  >
+    <div
+      class="row"
+    >
+      <div>
+        people
+      </div>
+      <div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.view"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="row"
+    >
+      <div>
+        organizations
+      </div>
+      <div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.view"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="sulu_security.delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render with empty webspace section 1`] = `
 <h2>
   Webspaces

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
@@ -8,7 +8,7 @@ exports[`Render in disabled state 1`] = `
     Contacts
   </h2>
   <div
-    class="matrix"
+    class="matrix disabled"
   >
     <div
       class="row"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
@@ -5,14 +5,19 @@ import {MultiSelect} from 'sulu-admin-bundle/components';
 import type {Localization} from 'sulu-admin-bundle/stores';
 import roleAssignmentStyle from './roleAssignment.scss';
 
-type Props = {
+type Props = {|
+    disabled: boolean,
     localizations: Array<Localization>,
     onChange: (value: Object) => void,
     value: Object,
-};
+|};
 
 @observer
 export default class RoleAssignment extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     handleChange = (newLocalizations: Array<string>) => {
         const newValue = {...this.props.value};
         newValue.locales = newLocalizations;
@@ -21,7 +26,7 @@ export default class RoleAssignment extends React.Component<Props> {
     };
 
     render() {
-        const {localizations, value} = this.props;
+        const {disabled, localizations, value} = this.props;
 
         return (
             <div className={roleAssignmentStyle.roleAssignmentContainer}>
@@ -29,6 +34,7 @@ export default class RoleAssignment extends React.Component<Props> {
                 <div>{value.role.system}</div>
                 <div>
                     <MultiSelect
+                        disabled={disabled}
                         onChange={this.handleChange}
                         values={value.locales}
                     >

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import {MultiSelect} from 'sulu-admin-bundle/components';
 import type {Localization} from 'sulu-admin-bundle/stores';
+import classNames from 'classnames';
 import roleAssignmentStyle from './roleAssignment.scss';
 
 type Props = {|
@@ -28,8 +29,15 @@ export default class RoleAssignment extends React.Component<Props> {
     render() {
         const {disabled, localizations, value} = this.props;
 
+        const roleAssignmentContainerClass = classNames(
+            roleAssignmentStyle.roleAssignmentContainer,
+            {
+                [roleAssignmentStyle.disabled]: disabled,
+            }
+        );
+
         return (
-            <div className={roleAssignmentStyle.roleAssignmentContainer}>
+            <div className={roleAssignmentContainerClass}>
                 <div>{value.role.name}</div>
                 <div>{value.role.system}</div>
                 <div>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
@@ -10,12 +10,17 @@ import RoleAssignment from './RoleAssignment';
 import roleAssignmentsStyle from './roleAssignments.scss';
 
 type Props = {|
+    disabled: boolean,
     onChange: (value: Array<Object>) => void,
     value: Array<Object>,
 |};
 
 @observer
 export default class RoleAssignments extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
     @observable localizations: ?Array<Localization>;
 
     componentDidMount() {
@@ -75,7 +80,7 @@ export default class RoleAssignments extends React.Component<Props> {
     };
 
     render() {
-        const {value} = this.props;
+        const {disabled, value} = this.props;
         const localizations = this.localizations;
 
         if (!localizations) {
@@ -86,6 +91,7 @@ export default class RoleAssignments extends React.Component<Props> {
             <Grid>
                 <Grid.Item size={6}>
                     <MultiSelect
+                        disabled={disabled}
                         displayProperty="name"
                         onChange={this.handleRoleChange}
                         resourceKey="roles"
@@ -98,6 +104,7 @@ export default class RoleAssignments extends React.Component<Props> {
                             {value.map((userRole, key) => {
                                 return (
                                     <RoleAssignment
+                                        disabled={disabled}
                                         key={key}
                                         localizations={localizations}
                                         onChange={this.handleRoleAssignmentChange}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignment.scss
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignment.scss
@@ -18,4 +18,8 @@ $roleAssignmentBackgroundColor: $white;
         align-self: center;
         width: 33.33%;
     }
+
+    &.disabled {
+        opacity: .5;
+    }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js
@@ -50,6 +50,48 @@ test('Render component', () => {
     )).toMatchSnapshot();
 });
 
+test('Render component in disabled state', () => {
+    const value = {
+        id: 1,
+        role: {
+            id: 5,
+            name: 'Role Name 5',
+            system: 'Sulu',
+        },
+        locales: ['de'],
+    };
+
+    const localizations: Array<Localization> = [
+        {
+            country: '',
+            default: '1',
+            language: 'en',
+            locale: 'en',
+            localization: 'en',
+            shadow: '',
+            xDefault: '',
+        },
+        {
+            country: '',
+            default: '0',
+            language: 'de',
+            locale: 'de',
+            localization: 'de',
+            shadow: '',
+            xDefault: '',
+        },
+    ];
+
+    expect(render(
+        <RoleAssignment
+            disabled={true}
+            localizations={localizations}
+            onChange={jest.fn()}
+            value={value}
+        />
+    )).toMatchSnapshot();
+});
+
 test('The component should trigger the change callback', () => {
     const value = {
         id: 1,

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignments.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignments.test.js
@@ -142,6 +142,66 @@ test('Render component', () => {
     });
 });
 
+test('Render component in disabled state', () => {
+    const value: Array<Object> = [
+        {
+            id: 1,
+            role: {
+                id: 5,
+                name: 'Role Name 5',
+                system: 'Sulu',
+            },
+            locales: ['de', 'en'],
+        },
+        {
+            id: 2,
+            role: {
+                id: 23,
+                name: 'Role Name 23',
+                system: 'Sulu',
+            },
+            locales: ['de'],
+        },
+    ];
+
+    const localizations: Array<Localization> = [
+        {
+            country: '',
+            default: '1',
+            language: 'en',
+            locale: 'en',
+            localization: 'en',
+            shadow: '',
+            xDefault: '',
+        },
+        {
+            country: '',
+            default: '0',
+            language: 'de',
+            locale: 'de',
+            localization: 'de',
+            shadow: '',
+            xDefault: '',
+        },
+    ];
+    const promise = Promise.resolve(localizations);
+    localizationStore.loadLocalizations.mockReturnValueOnce(promise);
+
+    const roleAssignments = mount(
+        <RoleAssignments
+            disabled={true}
+            onChange={jest.fn()}
+            value={value}
+        />
+    );
+
+    return promise.then(() => {
+        expect(localizationStore.loadLocalizations).toBeCalled();
+        roleAssignments.update();
+        expect(roleAssignments.render()).toMatchSnapshot();
+    });
+});
+
 test('Should trigger onChange correctly when MultiSelect for roles changes', () => {
     const value: Array<Object> = [
         {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
@@ -52,3 +52,57 @@ exports[`Render component 1`] = `
   </div>
 </div>
 `;
+
+exports[`Render component in disabled state 1`] = `
+<div
+  class="roleAssignmentContainer"
+>
+  <div>
+    Role Name 5
+  </div>
+  <div>
+    Sulu
+  </div>
+  <div>
+    <div
+      class="select"
+    >
+      <button
+        class="displayValue default"
+        disabled=""
+        type="button"
+      >
+        <div
+          aria-label="de"
+          class="croppedText"
+          title="de"
+        >
+          <div
+            aria-hidden="true"
+            class="front"
+          >
+            d
+          </div>
+          <div
+            aria-hidden="true"
+            class="back"
+          >
+            <span>
+              e
+            </span>
+          </div>
+          <div
+            class="whole"
+          >
+            de
+          </div>
+        </div>
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down toggle"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
@@ -55,7 +55,7 @@ exports[`Render component 1`] = `
 
 exports[`Render component in disabled state 1`] = `
 <div
-  class="roleAssignmentContainer"
+  class="roleAssignmentContainer disabled"
 >
   <div>
     Role Name 5

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
@@ -211,7 +211,7 @@ exports[`Render component in disabled state 1`] = `
       class="roleAssignmentsContainer"
     >
       <div
-        class="roleAssignmentContainer"
+        class="roleAssignmentContainer disabled"
       >
         <div>
           Role Name 5
@@ -262,7 +262,7 @@ exports[`Render component in disabled state 1`] = `
         </div>
       </div>
       <div
-        class="roleAssignmentContainer"
+        class="roleAssignmentContainer disabled"
       >
         <div>
           Role Name 23

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
@@ -157,6 +157,166 @@ exports[`Render component 1`] = `
 </div>
 `;
 
+exports[`Render component in disabled state 1`] = `
+<div
+  class="grid"
+>
+  <div
+    class="item size size-6 space-before-0 space-after-0"
+  >
+    <div
+      class="select"
+    >
+      <button
+        class="displayValue default"
+        disabled=""
+        type="button"
+      >
+        <div
+          aria-label="Role Name 5, Role Name 23"
+          class="croppedText"
+          title="Role Name 5, Role Name 23"
+        >
+          <div
+            aria-hidden="true"
+            class="front"
+          >
+            Role Name 5, 
+          </div>
+          <div
+            aria-hidden="true"
+            class="back"
+          >
+            <span>
+              Role Name 23
+            </span>
+          </div>
+          <div
+            class="whole"
+          >
+            Role Name 5, Role Name 23
+          </div>
+        </div>
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down toggle"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="item size size-12 space-before-0 space-after-0"
+  >
+    <div
+      class="roleAssignmentsContainer"
+    >
+      <div
+        class="roleAssignmentContainer"
+      >
+        <div>
+          Role Name 5
+        </div>
+        <div>
+          Sulu
+        </div>
+        <div>
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue default"
+              disabled=""
+              type="button"
+            >
+              <div
+                aria-label="sulu_admin.all_selected"
+                class="croppedText"
+                title="sulu_admin.all_selected"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  sulu_admin.a
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    ll_selected
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  sulu_admin.all_selected
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="roleAssignmentContainer"
+      >
+        <div>
+          Role Name 23
+        </div>
+        <div>
+          Sulu
+        </div>
+        <div>
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue default"
+              disabled=""
+              type="button"
+            >
+              <div
+                aria-label="de"
+                class="croppedText"
+                title="de"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  d
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  de
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render component without data 1`] = `
 <div
   class="grid"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #3248 
| License | MIT

#### What's in this PR?

This PR implements a disabled property for all components that are used by field-type components.. Field-type components are the building blocks of forms and can be used inside of XML templates.

#### Why?

Our XML form templates already allow to set a disabledCondition on a property. To make use of this feature, we need to signify to the user that a field-type component is disabled.