### PR TITLE
Get media file extension based on mimetype

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -151,7 +151,7 @@ class ImagineImageConverter implements ImageConverterInterface
 
         $imagineOptions = $format['options'];
 
-        $imageExtension = $this->getImageExtension($fileVersion->getName());
+        $imageExtension = $this->getImageExtension($fileVersion->getMimeType());
 
         return $image->get(
             $imageExtension,
@@ -384,34 +384,23 @@ class ImagineImageConverter implements ImageConverterInterface
     }
 
     /**
-     * Maps the given file type to a new extension.
+     * Maps the image extension to a new extension.
      *
-     * @param string $fileName
+     * @param string $mimeType
      *
      * @return string
      */
-    private function getImageExtension($fileName)
+    private function getImageExtension($mimeType)
     {
-        $pathInfo = pathinfo($fileName);
-        $extension = null;
-        if (isset($pathInfo['extension'])) {
-            $extension = $pathInfo['extension'];
-        }
-
-        switch ($extension) {
-            case 'png':
-            case 'gif':
-            case 'jpeg':
-                // do nothing
-                break;
-            case 'svg':
-                $extension = 'png';
-                break;
+        switch ($mimeType) {
+            case 'image/gif':
+                return 'gif';
+            case 'image/png':
+                return 'png';
+            case 'image/svg+xml':
+                return 'png';
             default:
-                $extension = 'jpg';
-                break;
+                return 'jpg';
         }
-
-        return $extension;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
@@ -157,6 +157,7 @@ class ImagineImageConverterTest extends TestCase
         $fileVersion->setName('test.svg');
         $fileVersion->setVersion(1);
         $fileVersion->setStorageOptions('{}');
+        $fileVersion->setMimeType('image/svg+xml');
 
         $this->storage->loadAsString('test.svg', 1, '{}')->willReturn('image-content');
         $this->mediaImageExtractor->extract('image-content')->willReturn('image-content');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Get media file extension based on it's mimetype.

#### Why?

Images without extension in filename will not get the correct extension.
