### PR TITLE
Fixed url field type initial value

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -8,6 +8,7 @@ import SingleSelect from '../SingleSelect';
 import urlStyles from './url.scss';
 
 type Props = {|
+    defaultProtocol: string,
     id?: string,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
@@ -30,6 +31,7 @@ const URL_REGEX = new RegExp(
 @observer
 export default class Url extends React.Component<Props> {
     static defaultProps = {
+        defaultProtocol: 'https://',
         protocols: ['http://', 'https://', 'ftp://', 'ftps://'],
         valid: true,
     };
@@ -153,7 +155,7 @@ export default class Url extends React.Component<Props> {
     };
 
     render() {
-        const {id, protocols, valid} = this.props;
+        const {defaultProtocol, id, protocols, valid} = this.props;
 
         const urlClass = classNames(
             urlStyles.url,
@@ -168,7 +170,7 @@ export default class Url extends React.Component<Props> {
                     <SingleSelect
                         onChange={this.handleProtocolChange}
                         skin="flat"
-                        value={this.protocol || protocols[0]}
+                        value={this.protocol || defaultProtocol}
                     >
                         {protocols.map((protocol) => (
                             <SingleSelect.Option key={protocol} value={protocol}>{protocol}</SingleSelect.Option>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -8,7 +8,7 @@ import SingleSelect from '../SingleSelect';
 import urlStyles from './url.scss';
 
 type Props = {|
-    defaultProtocol: string,
+    defaultProtocol?: string,
     id?: string,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
@@ -31,7 +31,6 @@ const URL_REGEX = new RegExp(
 @observer
 export default class Url extends React.Component<Props> {
     static defaultProps = {
-        defaultProtocol: 'https://',
         protocols: ['http://', 'https://', 'ftp://', 'ftps://'],
         valid: true,
     };
@@ -170,7 +169,7 @@ export default class Url extends React.Component<Props> {
                     <SingleSelect
                         onChange={this.handleProtocolChange}
                         skin="flat"
-                        value={this.protocol || defaultProtocol}
+                        value={this.protocol || defaultProtocol || this.protocols[0]}
                     >
                         {protocols.map((protocol) => (
                             <SingleSelect.Option key={protocol} value={protocol}>{protocol}</SingleSelect.Option>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -10,7 +10,13 @@ jest.mock('loglevel', () => ({
 
 test('Render the component with an error', () => {
     expect(render(
-        <Url defaultProtocol={'http://'} onChange={jest.fn()} protocols={['http://', 'https://']} valid={false} value={undefined} />
+        <Url
+            defaultProtocol="http://"
+            onChange={jest.fn()}
+            protocols={['http://', 'https://']}
+            valid={false}
+            value={undefined}
+        />
     )).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -10,7 +10,7 @@ jest.mock('loglevel', () => ({
 
 test('Render the component with an error', () => {
     expect(render(
-        <Url onChange={jest.fn()} protocols={['http://', 'https://']} valid={false} value={undefined} />
+        <Url defaultProtocol={'http://'} onChange={jest.fn()} protocols={['http://', 'https://']} valid={false} value={undefined} />
     )).toMatchSnapshot();
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -56,9 +56,7 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             onChange,
             schemaOptions: {
                 defaults: {
-                    value: defaults = [
-                        {name: 'scheme', value: 'https://'},
-                    ],
+                    value: defaults = [],
                 } = {},
                 schemes: {
                     value: schemes = [
@@ -72,18 +70,6 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             value,
         } = this.props;
 
-        if (!Array.isArray(defaults) || defaults.length === 0) {
-            throw new Error('The "defaults" option must contain scheme value!');
-        }
-
-        const defaultScheme = defaults.find((defaultOption) => defaultOption.name === 'scheme');
-
-        if (!defaultScheme || typeof defaultScheme.value !== 'string') {
-            throw new Error('No valid default scheme found in configuration!');
-        }
-
-        const defaultProtocol = defaultScheme.value;
-
         if (!Array.isArray(schemes) || schemes.length === 0) {
             throw new Error('The "schemes" schema option must contain some values!');
         }
@@ -96,6 +82,21 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             }
             return scheme.name;
         });
+
+        if (!Array.isArray(defaults)) {
+            throw new Error('The "defaults" schema option must be an array!');
+        }
+
+        let defaultProtocol = protocols[0];
+        const defaultScheme = defaults.find((defaultOption) => defaultOption.name === 'scheme');
+
+        if (defaultScheme && defaultScheme.value) {
+            if (typeof defaultScheme.value !== 'string') {
+                throw new Error('The "scheme" value of the "defaults" schema option must be a string!');
+            }
+
+            defaultProtocol = defaultScheme.value;
+        }
 
         return (
             <UrlComponent

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -12,11 +12,7 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             schemaOptions: {
                 defaults: {
                     value: defaults,
-                } = {
-                    value: [
-                        {name: 'scheme', value: 'https://'},
-                    ],
-                },
+                } = {},
             } = {},
             value,
         } = this.props;
@@ -30,30 +26,23 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             (defaultOption) => defaultOption.name === 'specific_part'
         );
 
-        if (!defaultSchemeOption && defaultSpecificPartOption) {
+        if (value || !defaultSpecificPartOption) {
+            return;
+        }
+
+        if (!defaultSchemeOption) {
             throw new Error('It is not allowed to set a default URL without a scheme!');
         }
 
-        if (!value) {
-            let defaultValue = undefined;
-            if (defaultSchemeOption) {
-                if (typeof defaultSchemeOption.value !== 'string') {
-                    throw new Error('The "scheme" default must be a string if set!');
-                }
-                defaultValue = defaultSchemeOption.value;
-
-                if (defaultSpecificPartOption) {
-                    if (typeof defaultSpecificPartOption.value !== 'string') {
-                        throw new Error('The "specific_part" default must be a string if set!');
-                    }
-                    defaultValue += defaultSpecificPartOption.value;
-                }
-            }
-
-            if (defaultValue) {
-                onChange(defaultValue);
-            }
+        if (typeof defaultSchemeOption.value !== 'string') {
+            throw new Error('The "scheme" default must be a string if set!');
         }
+
+        if (typeof defaultSpecificPartOption.value !== 'string') {
+            throw new Error('The "specific_part" default must be a string if set!');
+        }
+
+        onChange(defaultSchemeOption.value + defaultSpecificPartOption.value);
     }
 
     handleBlur = () => {
@@ -66,6 +55,11 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             error,
             onChange,
             schemaOptions: {
+                defaults: {
+                    value: defaults = [
+                        {name: 'scheme', value: 'https://'},
+                    ],
+                } = {},
                 schemes: {
                     value: schemes = [
                         {name: 'http://'},
@@ -77,6 +71,18 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
             } = {},
             value,
         } = this.props;
+
+        if (!Array.isArray(defaults) || defaults.length === 0) {
+            throw new Error('The "defaults" option must contain scheme value!');
+        }
+
+        const defaultScheme = defaults.find((defaultOption) => defaultOption.name === 'scheme');
+
+        if (!defaultScheme || typeof defaultScheme.value !== 'string') {
+            throw new Error('No valid default scheme found in configuration!');
+        }
+
+        const defaultProtocol = defaultScheme.value;
 
         if (!Array.isArray(schemes) || schemes.length === 0) {
             throw new Error('The "schemes" schema option must contain some values!');
@@ -93,6 +99,7 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
 
         return (
             <UrlComponent
+                defaultProtocol={defaultProtocol}
                 id={dataPath}
                 onBlur={this.handleBlur}
                 onChange={onChange}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Url.js
@@ -78,7 +78,7 @@ export default class Url extends React.Component<FieldTypeProps<?string>> {
 
         const defaultScheme = defaults.find((defaultOption) => defaultOption.name === 'scheme');
 
-        if (!defaultScheme || typeof defaultScheme.value !== 'string') {
+        if (!defaultScheme || typeof defaultScheme.value !== 'string') {
             throw new Error('No valid default scheme found in configuration!');
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -86,7 +86,7 @@ test('Pass correct default props to Url component', () => {
                 {name: 'scheme', value: 'http://'},
                 {name: 'specific_part', value: 'github.com'},
             ],
-        }
+        },
     };
     const changeSpy = jest.fn();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -76,7 +76,7 @@ test('Not call changed when only protocol is given', () => {
     );
 
     expect(url.find(UrlComponent).prop('protocols')).toEqual(['http://', 'https://', 'ftp://', 'ftps://']);
-    expect(changeSpy).not.toBeCalledWith('https://');
+    expect(changeSpy).not.toBeCalled();
 });
 
 test('Pass correct default props to Url component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -61,7 +61,7 @@ test('Pass props correctly to Url component', () => {
     expect(url.find(UrlComponent).prop('value')).toEqual('http://www.sulu.io');
 });
 
-test('Pass correct default props to Url component', () => {
+test('Not call changed when only protocol is given', () => {
     const schemaOptions = {};
     const changeSpy = jest.fn();
 
@@ -76,7 +76,32 @@ test('Pass correct default props to Url component', () => {
     );
 
     expect(url.find(UrlComponent).prop('protocols')).toEqual(['http://', 'https://', 'ftp://', 'ftps://']);
-    expect(changeSpy).toBeCalledWith('https://');
+    expect(changeSpy).not.toBeCalledWith('https://');
+});
+
+test('Pass correct default props to Url component', () => {
+    const schemaOptions = {
+        defaults: {
+            value: [
+                {name: 'scheme', value: 'http://'},
+                {name: 'specific_part', value: 'github.com'},
+            ],
+        }
+    };
+    const changeSpy = jest.fn();
+
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const url = shallow(
+        <Url
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(url.find(UrlComponent).prop('protocols')).toEqual(['http://', 'https://', 'ftp://', 'ftps://']);
+    expect(changeSpy).toBeCalledWith('http://github.com');
 });
 
 test('Throw error if only specific_part default is set', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js
@@ -62,7 +62,14 @@ test('Pass props correctly to Url component', () => {
 });
 
 test('Not call changed when only protocol is given', () => {
-    const schemaOptions = {};
+    const schemaOptions = {
+        defaults: {
+            value: [
+                {name: 'scheme', value: 'http://'},
+            ],
+        },
+    };
+
     const changeSpy = jest.fn();
 
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
@@ -76,6 +83,7 @@ test('Not call changed when only protocol is given', () => {
     );
 
     expect(url.find(UrlComponent).prop('protocols')).toEqual(['http://', 'https://', 'ftp://', 'ftps://']);
+    expect(url.find(UrlComponent).prop('defaultProtocol')).toEqual('http://');
     expect(changeSpy).not.toBeCalled();
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fixed url field type initial value.

#### Why?

It should not submit a url with just a protocol. 

#### Example Usage

1. Create a template with url field type e.g.:

~~~xml
<property name="website" type="url" colspan="4">
    <meta>
        <title>app.website</title>
    </meta>
</property>
~~~

2. try to save the template 

**before**

Value was: `https://`

**after**

Value is *empty*

