### PR TITLE
add headline param to Input field type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -56,6 +56,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
     render() {
         const {
             alignment,
+            headline,
             id,
             inputClass,
             valid,
@@ -94,6 +95,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
                 [inputStyles.disabled]: disabled,
                 [inputStyles.collapsed]: collapsed,
                 [inputStyles.hasAppendIcon]: onClearClick,
+                [inputStyles.headline]: headline,
             }
         );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/README.md
@@ -20,6 +20,17 @@ const onChange = (newValue) => {
 <Input icon="fa-key" type="password" placeholder="Password" value={state.value} onChange={onChange} />
 ```
 
+It also offers a `headline` prop, which allows to use distinguish more important fields from others.
+
+```javascript
+initialState = {value: ''};
+const onChange = (newValue) => {
+    setState({value: newValue});
+};
+
+<Input icon="fa-key" headline={true} value={state.value} onChange={onChange} />
+```
+
 When setting the `valid` prop to `false` it will mark the field as invalid. The following example shows an input field
 that needs to contain some text.
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -7,9 +7,10 @@ $inputDisabledBackgroundColor: $wildSand;
 $inputBorderWidth: 1px;
 $inputBorderRadius: 3px;
 $inputHeight: 30px;
+$inputHeadlineHeight: 40px;
 $inputColor: $black;
-$inputFontSize: 12px;
 $inputPrependWidth: 32px;
+$inputHeadlinePrependWidth: 42px;
 $iconColor: $dustyGray;
 $iconBorderPadding: 5px;
 $placeholderColor: $dustyGray;
@@ -27,6 +28,7 @@ $darkIconColor: $doveGray;
     border: $inputBorderWidth solid $inputBorderColor;
     border-radius: $inputBorderRadius;
     display: inline-flex;
+    font-size: 12px;
     align-items: center;
     height: $inputHeight;
     width: 100%;
@@ -39,14 +41,12 @@ $darkIconColor: $doveGray;
         border: none;
         border-radius: $inputBorderRadius;
         height: calc($inputHeight - 2 * $inputBorderWidth);
-        font-size: $inputFontSize;
         color: $inputColor;
         will-change: width, padding-left;
         transition: width .3s, padding-left .1s linear;
 
         &::placeholder {
             color: $placeholderColor;
-            font-size: $inputFontSize;
         }
 
         &:invalid {
@@ -123,17 +123,44 @@ $darkIconColor: $doveGray;
     &.disabled {
         background-color: $inputDisabledBackgroundColor;
     }
+
+    .prepended-container {
+        flex: 0 0 $inputPrependWidth;
+        height: calc($inputHeight - 2 * $iconBorderPadding);
+        width: $inputPrependWidth;
+    }
+
+    .icon {
+        font-size: 14px;
+    }
+
+    &.headline {
+        font-size: 18px;
+        line-height: 28px;
+        height: $inputHeadlineHeight;
+
+        input {
+            font-weight: bold;
+        }
+
+        .prepended-container {
+            flex: 0 0 $inputHeadlinePrependWidth;
+            height: calc($inputHeadlineHeight - 2 * $iconBorderPadding);
+            width: $inputHeadlinePrependWidth;
+        }
+
+        .icon {
+            font-size: 20px;
+        }
+    }
 }
 
 .prepended-container {
     position: relative;
-    flex: 0 0 $inputPrependWidth;
-    height: calc($inputHeight - 2 * $iconBorderPadding);
     box-shadow: $inputBorderWidth 0 0 $inputBorderColor;
     display: flex;
     justify-content: center;
     align-items: center;
-    width: $inputPrependWidth;
 
     &.dark {
         box-shadow: $inputBorderWidth 0 0 $darkInputBorderColor;
@@ -156,7 +183,6 @@ $darkIconColor: $doveGray;
 
 .icon {
     display: block;
-    font-size: 14px;
     flex-grow: 0;
     color: $iconColor;
     line-height: calc($inputHeight - 2 * $iconBorderPadding);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -12,6 +12,10 @@ test('Input should render', () => {
     expect(render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />)).toMatchSnapshot();
 });
 
+test('Input should render as headline', () => {
+    expect(render(<Input headline={true} onChange={jest.fn()} value="My value" />)).toMatchSnapshot();
+});
+
 test('Input should render with invalid value', () => {
     const onChange = jest.fn();
     expect(render(<Input onBlur={jest.fn()} onChange={onChange} valid={false} value="My value" />)).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -43,6 +43,17 @@ exports[`Input should render append container with icon when onClearClick callba
 </label>
 `;
 
+exports[`Input should render as headline 1`] = `
+<label
+  class="input default left headline"
+>
+  <input
+    type="text"
+    value="My value"
+  />
+</label>
+`;
+
 exports[`Input should render collapsed 1`] = `
 <label
   class="input default left collapsed"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
@@ -5,6 +5,7 @@ export type InputProps<T: ?string | ?number> = {|
     alignment: 'left' | 'center' | 'right',
     collapsed?: boolean,
     name?: string,
+    headline?: boolean,
     icon?: string,
     id?: string,
     inputClass?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Input.js
@@ -15,6 +15,9 @@ export default class Input extends React.Component<FieldTypeProps<?string>> {
             disabled,
             onChange,
             schemaOptions: {
+                headline: {
+                    value: headline,
+                } = {},
                 max_characters: {
                     value: maxCharacters,
                 } = {},
@@ -27,6 +30,10 @@ export default class Input extends React.Component<FieldTypeProps<?string>> {
             } = {},
             value,
         } = this.props;
+
+        if (headline !== undefined && typeof headline !== 'boolean') {
+            throw new Error('The "headline" schema option must be a boolean!');
+        }
 
         if (maxCharacters !== undefined && isNaN(maxCharacters)) {
             throw new Error('The "max_characters" schema option must be a number!');
@@ -43,6 +50,7 @@ export default class Input extends React.Component<FieldTypeProps<?string>> {
         return (
             <InputComponent
                 disabled={!!disabled}
+                headline={headline}
                 id={dataPath}
                 maxCharacters={maxCharacters ? parseInt(maxCharacters) : undefined}
                 maxSegments={maxSegments ? parseInt(maxSegments) : undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js
@@ -40,6 +40,25 @@ test('Pass props correctly to Input component', () => {
     expect(inputValid.find(InputComponent).prop('maxCharacters')).toBe(undefined);
     expect(inputValid.find(InputComponent).prop('valid')).toBe(true);
     expect(inputValid.find(InputComponent).prop('disabled')).toBe(true);
+    expect(inputValid.find(InputComponent).prop('headline')).toBe(undefined);
+});
+
+test('Pass headline prop correctly', () => {
+    const schemaOptions = {
+        headline: {
+            value: true,
+        },
+    };
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const inputValid = shallow(
+        <Input
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(inputValid.find(InputComponent).prop('headline')).toBe(true);
 });
 
 test('Pass props correctly including maxCharacters to Input component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -17,7 +17,7 @@ export type SchemaOption = {
     name?: string,
     infoText?: string,
     title?: string,
-    value?: ?string | number | Array<SchemaOption>,
+    value?: ?string | number | boolean | Array<SchemaOption>,
 };
 
 export type SchemaOptions = {[key: string]: SchemaOption};

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
@@ -21,7 +21,25 @@
         </section>
         <section name="contact" colspan="8">
             <properties>
-                <property name="formOfAddress" type="single_select" mandatory="true" colspan="3" spaceAfter="9">
+                <property name="firstName" type="text_line" mandatory="true" colspan="6">
+                    <meta>
+                        <title>sulu_contact.first_name</title>
+                    </meta>
+                    <params>
+                        <param name="headline" value="true"/>
+                    </params>
+                </property>
+
+                <property name="lastName" type="text_line" mandatory="true" colspan="6">
+                    <meta>
+                        <title>sulu_contact.last_name</title>
+                    </meta>
+                    <params>
+                        <param name="headline" value="true"/>
+                    </params>
+                </property>
+
+                <property name="formOfAddress" type="single_select" mandatory="true" colspan="6">
                     <meta>
                         <title>sulu_contact.form_of_address</title>
                     </meta>
@@ -42,15 +60,9 @@
                     </params>
                 </property>
 
-                <property name="firstName" type="text_line" mandatory="true" colspan="6">
+                <property name="birthday" type="date" colspan="6">
                     <meta>
-                        <title>sulu_contact.first_name</title>
-                    </meta>
-                </property>
-
-                <property name="lastName" type="text_line" mandatory="true" colspan="6">
-                    <meta>
-                        <title>sulu_contact.last_name</title>
+                        <title>sulu_contact.birthday</title>
                     </meta>
                 </property>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the handling for the `headline` param to the input field type. This will allow to have bigger input fields, e.g. for the names in the contact or the title on pages.

#### Why?

Because this way it is easier to recognize the very important fields for the content manager.