### PR TITLE
Fixed property param default value

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -66,6 +66,16 @@ class FormXmlLoaderTest extends TestCase
             $formMetadata->getProperties()['formOfAddress']->getParameter(0)['name']
         );
         $this->assertSame(0, $formMetadata->getProperties()['formOfAddress']->getParameter(0)['value']);
+        $this->assertSame(
+            0,
+            ($formMetadata->getProperties()['formOfAddress']->getParameter(1)['value'][0]['value']),
+            'Param did not fallback to name.'
+        );
+        $this->assertSame(
+            'custom',
+            ($formMetadata->getProperties()['formOfAddress']->getParameter(1)['value'][1]['value']),
+            'Param did not use custom value.'
+        );
         $this->assertEquals('firstName', $formMetadata->getProperties()['firstName']->getName());
         $this->assertEquals('lastName', $formMetadata->getProperties()['lastName']->getName());
         $this->assertEquals('salutation', $formMetadata->getProperties()['salutation']->getName());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form.xml
@@ -11,13 +11,13 @@
             <params>
                 <param name="default_value" value="0"/>
                 <param name="values" type="collection">
-                    <param name="0" value="0">
+                    <param name="0">
                         <meta>
                             <title lang="en">Mr.</title>
                             <title lang="de">Herr</title>
                         </meta>
                     </param>
-                    <param name="1" value="1">
+                    <param name="1" value="custom">
                         <meta>
                             <title lang="en">Ms.</title>
                             <title lang="de">Frau</title>

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -345,7 +345,12 @@ class PropertiesXmlParser
                 $result['value'] = $this->loadParams('x:param', $xpath, $node);
                 break;
             default:
-                $result['value'] = $this->getValueFromXPath('@value', $xpath, $node, 'string');
+                $result['value'] = $this->getValueFromXPath('@value', $xpath, $node);
+
+                if (null === $result['value']) {
+                    $result['value'] = $result['name'];
+                }
+
                 break;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove the accidentally added default value of params value and fix single select to work without value as documented in the [sulu docs single_select](http://docs.sulu.io/en/latest/reference/content-types/single_select.html)

#### Why?

To fix that a value is `"string"` and avoid a not needed bc break as value is not mandatory in the xml scheme.

#### Example Usage

See http://docs.sulu.io/en/latest/reference/content-types/single_select.html
