### PR TITLE
Added multi select field type

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,28 @@
 
 ## dev-develop
 
+### Multiple Select renamed
+
+The multiple select content type was renamed to `select` to be equal to the other content types.
+
+**Before**
+
+```xml
+<property name="yourname" type="multiple_select">
+    <!-- ... -->
+</property>
+```
+
+**After**
+
+```xml
+<property name="yourname" type="select">
+    <!-- ... -->
+</property>
+```
+
+Also the service was renamed from `sulu.content.type.multiple_select` to `sulu.content.type.select`.
+
 ### Collection Controller
 
 The `include-root` option of this Controller was renamed to `includeRoot` to be more consistent. The `RootCollection`

--- a/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Option.php
+++ b/src/Sulu/Bundle/AdminBundle/ResourceMetadata/Form/Option.php
@@ -38,12 +38,18 @@ class Option
      */
     protected $infoText;
 
-    public function getName(): ?string
+    /**
+     * @return null|string|int|float
+     */
+    public function getName()
     {
         return $this->name;
     }
 
-    public function setName(string $name = null): void
+    /**
+     * @param null|string|int|float $name
+     */
+    public function setName($name = null): void
     {
         $this->name = $name;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -78,11 +78,12 @@ export default class MultiSelect<T: string | number> extends React.PureComponent
     };
 
     render() {
-        const {children, icon, skin} = this.props;
+        const {children, disabled, icon, skin} = this.props;
 
         return (
             <Select
                 closeOnSelect={false}
+                disabled={disabled}
                 displayValue={this.displayValue}
                 icon={icon}
                 isOptionSelected={this.isOptionSelected}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react';
+import MultiSelectComponent from '../../../components/MultiSelect';
+import type {FieldTypeProps} from '../../../types';
+
+const MISSING_VALUES_OPTIONS = 'The "values" option has to be set for the SingleSelect FieldType';
+
+type Props = FieldTypeProps<Array<string | number>>;
+
+export default class Select extends React.Component<Props> {
+    handleChange = (value: Array<string | number>) => {
+        const {onChange, onFinish} = this.props;
+
+        onChange(value);
+        onFinish();
+    };
+
+    render() {
+        const {schemaOptions, disabled, value} = this.props;
+        if (!schemaOptions) {
+            throw new Error(MISSING_VALUES_OPTIONS);
+        }
+
+        const {values} = schemaOptions;
+
+        if (!Array.isArray(values.value)) {
+            throw new Error(MISSING_VALUES_OPTIONS);
+        }
+
+        return (
+            <MultiSelectComponent disabled={!!disabled} onChange={this.handleChange} values={value || []}>
+                {values.value.map(({value, title}) => {
+                    if (typeof value !== 'string' && typeof value !== 'number') {
+                        throw new Error('The children of "values" must only contain values of type string or number!');
+                    }
+
+                    return (
+                        <MultiSelectComponent.Option key={value} value={value}>
+                            {title}
+                        </MultiSelectComponent.Option>
+                    );
+                })}
+            </MultiSelectComponent>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -8,6 +8,38 @@ const MISSING_VALUES_OPTIONS = 'The "values" option has to be set for the Single
 type Props = FieldTypeProps<Array<string | number>>;
 
 export default class Select extends React.Component<Props> {
+    constructor(props: FieldTypeProps<Array<string | number>>) {
+        super(props);
+
+        const {onChange, schemaOptions, value} = this.props;
+
+        if (!schemaOptions) {
+            return;
+        }
+
+        let {
+            default_value: {
+                value: defaultValue,
+            } = {},
+        } = schemaOptions;
+
+        if (defaultValue === undefined || defaultValue === null) {
+            return;
+        }
+
+        if (typeof defaultValue === 'number' || typeof defaultValue === 'string') {
+            defaultValue = [defaultValue];
+        }
+
+        if (!Array.isArray(defaultValue)) {
+            throw new Error('The "default_value" schema option must be an array!');
+        }
+
+        if (value === undefined) {
+            onChange(defaultValue);
+        }
+    }
+
     handleChange = (value: Array<string | number>) => {
         const {onChange, onFinish} = this.props;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -17,21 +17,21 @@ export default class Select extends React.Component<Props> {
             return;
         }
 
-        let {
+        const {
             default_values: {
-                value: defaultValues,
+                value: defaultOptions,
             } = {},
         } = schemaOptions;
 
-        if (defaultValues === undefined || defaultValues === null) {
+        if (defaultOptions === undefined || defaultOptions === null) {
             return;
         }
 
-        if (!Array.isArray(defaultValues)) {
+        if (!Array.isArray(defaultOptions)) {
             throw new Error('The "default_values" schema option must be an array!');
         }
 
-        defaultValues = defaultValues.map(({value, name}) => {
+        const defaultValues = defaultOptions.map(({value, name}) => {
             const defaultValue = value === undefined || value === null ? name : value;
 
             if (typeof defaultValue !== 'number' && typeof defaultValue !== 'string') {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -31,9 +31,7 @@ export default class Select extends React.Component<Props> {
             throw new Error('The "default_values" schema option must be an array!');
         }
 
-        const defaultValues = defaultOptions.map(({value, name}) => {
-            const defaultValue = value === undefined || value === null ? name : value;
-
+        const defaultValues = defaultOptions.map(({name: defaultValue}) => {
             if (typeof defaultValue !== 'number' && typeof defaultValue !== 'string') {
                 throw new Error('A single schema option of "default_values" must be a string or number');
             }
@@ -67,9 +65,7 @@ export default class Select extends React.Component<Props> {
 
         return (
             <MultiSelectComponent disabled={!!disabled} onChange={this.handleChange} values={value || []}>
-                {values.value.map(({name, value, title}) => {
-                    value = value === undefined || value === null ? name : value;
-
+                {values.value.map(({name: value, title}) => {
                     if (typeof value !== 'string' && typeof value !== 'number') {
                         throw new Error('The children of "values" must only contain values of type string or number!');
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -18,25 +18,31 @@ export default class Select extends React.Component<Props> {
         }
 
         let {
-            default_value: {
-                value: defaultValue,
+            default_values: {
+                value: defaultValues,
             } = {},
         } = schemaOptions;
 
-        if (defaultValue === undefined || defaultValue === null) {
+        if (defaultValues === undefined || defaultValues === null) {
             return;
         }
 
-        if (typeof defaultValue === 'number' || typeof defaultValue === 'string') {
-            defaultValue = [defaultValue];
+        if (!Array.isArray(defaultValues)) {
+            throw new Error('The "default_values" schema option must be an array!');
         }
 
-        if (!Array.isArray(defaultValue)) {
-            throw new Error('The "default_value" schema option must be an array!');
-        }
+        defaultValues = defaultValues.map(({value, name}) => {
+            const defaultValue = value === undefined || value === null ? name : value;
+
+            if (typeof defaultValue !== 'number' && typeof defaultValue !== 'string') {
+                throw new Error('A single schema option of "default_values" must be a string or number');
+            }
+
+            return defaultValue;
+        });
 
         if (value === undefined) {
-            onChange(defaultValue);
+            onChange(defaultValues);
         }
     }
 
@@ -61,7 +67,9 @@ export default class Select extends React.Component<Props> {
 
         return (
             <MultiSelectComponent disabled={!!disabled} onChange={this.handleChange} values={value || []}>
-                {values.value.map(({value, title}) => {
+                {values.value.map(({name, value, title}) => {
+                    value = value === undefined || value === null ? name : value;
+
                     if (typeof value !== 'string' && typeof value !== 'number') {
                         throw new Error('The children of "values" must only contain values of type string or number!');
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -17,9 +17,17 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
 
         const {
             default_value: {
+                name: defaultName,
+            } = {},
+        } = schemaOptions;
+
+        let {
+            default_value: {
                 value: defaultValue,
             } = {},
         } = schemaOptions;
+
+        defaultValue = defaultValue === undefined || defaultValue === null ? defaultName : defaultValue;
 
         if (defaultValue === undefined || defaultValue === null) {
             return;
@@ -55,7 +63,9 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
 
         return (
             <SingleSelectComponent disabled={!!disabled} onChange={this.handleChange} value={value}>
-                {values.value.map(({value, title}) => {
+                {values.value.map(({value, name, title}) => {
+                    value = value === undefined || value === null ? name : value;
+
                     if (typeof value !== 'string' && typeof value !== 'number') {
                         throw new Error('The children of "values" must only contain values of type string or number!');
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -17,7 +17,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
 
         const {
             default_value: {
-                name: defaultValue,
+                value: defaultValue,
             } = {},
         } = schemaOptions;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -17,17 +17,9 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
 
         const {
             default_value: {
-                name: defaultName,
+                name: defaultValue,
             } = {},
         } = schemaOptions;
-
-        let {
-            default_value: {
-                value: defaultValue,
-            } = {},
-        } = schemaOptions;
-
-        defaultValue = defaultValue === undefined || defaultValue === null ? defaultName : defaultValue;
 
         if (defaultValue === undefined || defaultValue === null) {
             return;
@@ -63,9 +55,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
 
         return (
             <SingleSelectComponent disabled={!!disabled} onChange={this.handleChange} value={value}>
-                {values.value.map(({value, name, title}) => {
-                    value = value === undefined || value === null ? name : value;
-
+                {values.value.map(({name: value, title}) => {
                     if (typeof value !== 'string' && typeof value !== 'number') {
                         throw new Error('The children of "values" must only contain values of type string or number!');
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -110,15 +110,19 @@ export default class SmartContent extends React.Component<Props> {
         }
 
         const presentations = schemaPresentations.map((presentation) => {
-            if (typeof presentation.name !== 'string' || typeof presentation.title !== 'string') {
-                throw new Error(
-                    'Every presentation in the "present_as" schemaOption must contain a string value and a string name'
-                );
+            const {name, title} = presentation;
+
+            if (!name) {
+                throw new Error('Every presentation in the "present_as" schema Option must contain a name');
+            }
+
+            if (!title) {
+                throw new Error('Every presentation in the "present_as" schema Option must contain a title');
             }
 
             return {
-                name: presentation.name,
-                value: presentation.title,
+                name: name.toString(),
+                value: title.toString(),
             };
         });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -15,6 +15,7 @@ import Number from './fields/Number';
 import PasswordConfirmation from './fields/PasswordConfirmation';
 import Phone from './fields/Phone';
 import SingleSelect from './fields/SingleSelect';
+import Select from './fields/Select';
 import ResourceLocator from './fields/ResourceLocator';
 import Renderer from './Renderer';
 import SmartContent from './fields/SmartContent';
@@ -34,6 +35,7 @@ export {
     Input,
     FormInspector,
     FormStore,
+    Select,
     Number,
     PasswordConfirmation,
     Phone,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -1,0 +1,285 @@
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
+import ResourceStore from '../../../../stores/ResourceStore';
+import FormInspector from '../../FormInspector';
+import FormStore from '../../stores/FormStore';
+import Select from '../../fields/Select';
+
+jest.mock('../../../../stores/ResourceStore', () => jest.fn());
+jest.mock('../../stores/FormStore', () => jest.fn());
+jest.mock('../../FormInspector', () => jest.fn());
+
+test('Pass props correctly to Select', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const schemaOptions = {
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    const select = shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={['test']}
+        />
+    );
+
+    expect(select.prop('values')).toEqual(['test']);
+    expect(select.prop('disabled')).toBe(true);
+    expect(select.find('Option').at(0).props()).toEqual(expect.objectContaining({
+        value: 'mr',
+        children: 'Mister',
+    }));
+    expect(select.find('Option').at(1).props()).toEqual(expect.objectContaining({
+        value: 'ms',
+        children: 'Miss',
+    }));
+});
+
+test('Should throw an exception if defaultValue is of wrong type', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const schemaOptions = {
+        default_value: {
+            value: {},
+        },
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+
+    expect(() => shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    )).toThrow(/"default_value"/);
+});
+
+test('Should throw an exception if value is of wrong type', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const schemaOptions = {
+        values: {
+            value: [
+                {
+                    value: [],
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+
+    expect(() => shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    )).toThrow(/"values"/);
+});
+
+test('Should call onFinish callback on every onChange', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const finishSpy = jest.fn();
+    const schemaOptions = {
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+
+    const select = shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onFinish={finishSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    select.simulate('change');
+
+    expect(finishSpy).toBeCalledWith();
+});
+
+test('Set default value of null should not call onChange', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            value: null,
+        },
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).not.toBeCalled();
+});
+
+test('Set default value if no value is passed', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            value: ['mr'],
+        },
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'ms',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).toBeCalledWith(['mr']);
+});
+
+test('Set default value to a string "mr" should work', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            value: 'mr',
+        },
+        values: {
+            value: [
+                {
+                    value: 'mr',
+                    title: 'Mister',
+                },
+                {
+                    value: 'mrs',
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).toBeCalledWith(['mr']);
+});
+
+test('Set default value to a number of 0 should work', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        default_value: {
+            value: 0,
+        },
+        values: {
+            value: [
+                {
+                    value: 0,
+                    title: 'Mister',
+                },
+                {
+                    value: 1,
+                    title: 'Miss',
+                },
+            ],
+        },
+    };
+    shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(changeSpy).toBeCalledWith([0]);
+});
+
+test('Throw error if no schemaOptions are passed', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    expect(() => shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+        />)
+    ) .toThrow(/"values"/);
+});
+
+test('Throw error if no value option is passed', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    expect(() => shallow(
+        <Select
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+        />)
+    ).toThrow(/"values"/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -111,11 +111,11 @@ test('Should call onFinish callback on every onChange', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -205,16 +205,16 @@ test('Set default value to a number of 0 should work', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
         default_values: {
-            value: [{value: 0}],
+            value: [{name: 0}],
         },
         values: {
             value: [
                 {
-                    value: 0,
+                    name: 0,
                     title: 'Mister',
                 },
                 {
-                    value: 1,
+                    name: 1,
                     title: 'Miss',
                 },
             ],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -40,11 +40,11 @@ test('Pass props correctly to Select', () => {
     expect(select.prop('values')).toEqual(['test']);
     expect(select.prop('disabled')).toBe(true);
     expect(select.find('Option').at(0).props()).toEqual(expect.objectContaining({
-        name: 'mr',
+        value: 'mr',
         children: 'Mister',
     }));
     expect(select.find('Option').at(1).props()).toEqual(expect.objectContaining({
-        name: 'ms',
+        value: 'ms',
         children: 'Miss',
     }));
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js
@@ -17,11 +17,11 @@ test('Pass props correctly to Select', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -40,11 +40,11 @@ test('Pass props correctly to Select', () => {
     expect(select.prop('values')).toEqual(['test']);
     expect(select.prop('disabled')).toBe(true);
     expect(select.find('Option').at(0).props()).toEqual(expect.objectContaining({
-        value: 'mr',
+        name: 'mr',
         children: 'Mister',
     }));
     expect(select.find('Option').at(1).props()).toEqual(expect.objectContaining({
-        value: 'ms',
+        name: 'ms',
         children: 'Miss',
     }));
 });
@@ -52,17 +52,17 @@ test('Pass props correctly to Select', () => {
 test('Should throw an exception if defaultValue is of wrong type', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const schemaOptions = {
-        default_value: {
+        default_values: {
             value: {},
         },
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -73,9 +73,9 @@ test('Should throw an exception if defaultValue is of wrong type', () => {
         <Select
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={schemaOptions}
+            schemaOptions={(schemaOptions: any)}
         />
-    )).toThrow(/"default_value"/);
+    )).toThrow(/"default_values"/);
 });
 
 test('Should throw an exception if value is of wrong type', () => {
@@ -84,11 +84,11 @@ test('Should throw an exception if value is of wrong type', () => {
         values: {
             value: [
                 {
-                    value: [],
+                    name: [],
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -99,7 +99,7 @@ test('Should throw an exception if value is of wrong type', () => {
         <Select
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={schemaOptions}
+            schemaOptions={(schemaOptions: any)}
         />
     )).toThrow(/"values"/);
 });
@@ -140,17 +140,17 @@ test('Set default value of null should not call onChange', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const changeSpy = jest.fn();
     const schemaOptions = {
-        default_value: {
-            value: null,
+        default_values: {
+            name: null,
         },
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -161,7 +161,7 @@ test('Set default value of null should not call onChange', () => {
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
             onChange={changeSpy}
-            schemaOptions={schemaOptions}
+            schemaOptions={(schemaOptions: any)}
         />
     );
 
@@ -172,49 +172,17 @@ test('Set default value if no value is passed', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const changeSpy = jest.fn();
     const schemaOptions = {
-        default_value: {
-            value: ['mr'],
+        default_values: {
+            value: [{name: 'mr'}],
         },
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
-                    title: 'Miss',
-                },
-            ],
-        },
-    };
-    shallow(
-        <Select
-            {...fieldTypeDefaultProps}
-            formInspector={formInspector}
-            onChange={changeSpy}
-            schemaOptions={schemaOptions}
-        />
-    );
-
-    expect(changeSpy).toBeCalledWith(['mr']);
-});
-
-test('Set default value to a string "mr" should work', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
-    const changeSpy = jest.fn();
-    const schemaOptions = {
-        default_value: {
-            value: 'mr',
-        },
-        values: {
-            value: [
-                {
-                    value: 'mr',
-                    title: 'Mister',
-                },
-                {
-                    value: 'mrs',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -236,8 +204,8 @@ test('Set default value to a number of 0 should work', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const changeSpy = jest.fn();
     const schemaOptions = {
-        default_value: {
-            value: 0,
+        default_values: {
+            value: [{value: 0}],
         },
         values: {
             value: [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -17,11 +17,11 @@ test('Pass props correctly to SingleSelect', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -58,11 +58,11 @@ test('Should throw an exception if defaultValue is of wrong type', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -84,11 +84,11 @@ test('Should throw an exception if value is of wrong type', () => {
         values: {
             value: [
                 {
-                    value: [],
+                    name: [],
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -99,7 +99,7 @@ test('Should throw an exception if value is of wrong type', () => {
         <SingleSelect
             {...fieldTypeDefaultProps}
             formInspector={formInspector}
-            schemaOptions={schemaOptions}
+            schemaOptions={(schemaOptions: any)}
         />
     )).toThrow(/"values"/);
 });
@@ -111,11 +111,11 @@ test('Should call onFinish callback on every onChange', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -146,11 +146,11 @@ test('Set default value of null should not call onChange', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -178,11 +178,11 @@ test('Set default value if no value is passed', () => {
         values: {
             value: [
                 {
-                    value: 'mr',
+                    name: 'mr',
                     title: 'Mister',
                 },
                 {
-                    value: 'ms',
+                    name: 'ms',
                     title: 'Miss',
                 },
             ],
@@ -210,11 +210,11 @@ test('Set default value to a number of 0 should work', () => {
         values: {
             value: [
                 {
-                    value: 0,
+                    name: 0,
                     title: 'Mister',
                 },
                 {
-                    value: 1,
+                    name: 1,
                     title: 'Miss',
                 },
             ],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -41,6 +41,7 @@ import {
     Email,
     fieldRegistry,
     Input,
+    Select,
     Number,
     PasswordConfirmation,
     Phone,
@@ -132,6 +133,7 @@ function registerFieldTypes(fieldTypeOptions) {
     fieldRegistry.add('date', DatePicker, {dateFormat: true, timeFormat: false});
     fieldRegistry.add('datetime', DatePicker, {dateFormat: true, timeFormat: true});
     fieldRegistry.add('email', Email);
+    fieldRegistry.add('select', Select);
     fieldRegistry.add('number', Number);
     fieldRegistry.add('password_confirmation', PasswordConfirmation);
     fieldRegistry.add('phone', Phone);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -14,7 +14,7 @@ export type Error = BlockError | PropertyError;
 export type ErrorCollection = {[key: string]: Error};
 
 export type SchemaOption = {
-    name?: string,
+    name?: string | number,
     infoText?: string,
     title?: string,
     value?: ?string | number | Array<SchemaOption>,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -66,6 +66,14 @@ class FormXmlLoaderTest extends TestCase
             $formMetadata->getProperties()['formOfAddress']->getParameter(0)['name']
         );
         $this->assertSame(0, $formMetadata->getProperties()['formOfAddress']->getParameter(0)['value']);
+        $this->assertSame(
+            0,
+            ($formMetadata->getProperties()['formOfAddress']->getParameter(1)['value'][0]['name'])
+        );
+        $this->assertSame(
+            1,
+            ($formMetadata->getProperties()['formOfAddress']->getParameter(1)['value'][1]['name'])
+        );
         $this->assertEquals('firstName', $formMetadata->getProperties()['firstName']->getName());
         $this->assertEquals('lastName', $formMetadata->getProperties()['lastName']->getName());
         $this->assertEquals('salutation', $formMetadata->getProperties()['salutation']->getName());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/data/form.xml
@@ -11,13 +11,13 @@
             <params>
                 <param name="default_value" value="0"/>
                 <param name="values" type="collection">
-                    <param name="0" value="0">
+                    <param name="0">
                         <meta>
                             <title lang="en">Mr.</title>
                             <title lang="de">Herr</title>
                         </meta>
                     </param>
-                    <param name="1" value="1">
+                    <param name="1">
                         <meta>
                             <title lang="en">Ms.</title>
                             <title lang="de">Frau</title>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/Contact.xml
@@ -28,12 +28,12 @@
                     <params>
                         <param name="default_value" value="0"/>
                         <param name="values" type="collection">
-                            <param name="0" value="0">
+                            <param name="0">
                                 <meta>
                                     <title>sulu_contact.male_form_of_address</title>
                                 </meta>
                             </param>
-                            <param name="1" value="1">
+                            <param name="1">
                                 <meta>
                                     <title>sulu_contact.female_form_of_address</title>
                                 </meta>

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/Select.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/Select.php
@@ -19,7 +19,7 @@ use Sulu\Component\Content\SimpleContentType;
 /**
  * ContentType for a multiple select. Currently only support for checkboxes.
  */
-class MultipleSelect extends SimpleContentType
+class Select extends SimpleContentType
 {
     public function __construct()
     {

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/content_types.xml
@@ -64,8 +64,8 @@
             <tag name="sulu.content.type" alias="checkbox"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
-        <service id="sulu.content.type.multiple_select" class="Sulu\Bundle\ContentBundle\Content\Types\MultipleSelect">
-            <tag name="sulu.content.type" alias="multiple_select"/>
+        <service id="sulu.content.type.select" class="Sulu\Bundle\ContentBundle\Content\Types\Select">
+            <tag name="sulu.content.type" alias="select"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
         <service id="sulu.content.type.single_select" class="Sulu\Bundle\ContentBundle\Content\Types\SingleSelect">

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
@@ -50,7 +50,7 @@ class ContentTypesDumpCommandTest extends SuluTestCase
         $this->assertContains('date', $output);
         $this->assertContains('email', $output);
         $this->assertContains('internal_link', $output);
-        $this->assertContains('multiple_select', $output);
+        $this->assertContains('select', $output);
         $this->assertContains('number', $output);
         $this->assertContains('password', $output);
         $this->assertContains('phone', $output);

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -108,7 +108,14 @@ abstract class ItemMetadata
         return $this[$name] = $value;
     }
 
-    public function setName(string $name): self
+    /**
+     * Set the name of the metadata property which can also be a int or float value.
+     *
+     * @param string|int|float $name
+     *
+     * @return self
+     */
+    public function setName($name): self
     {
         $this->name = $name;
 
@@ -248,7 +255,7 @@ abstract class ItemMetadata
     /**
      * Return the name of this item.
      *
-     * @return string
+     * @return string|int|float
      */
     public function getName()
     {

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -19,7 +19,7 @@ abstract class ItemMetadata
     /**
      * Name of this item.
      *
-     * @var string
+     * @var string|int|float
      */
     protected $name;
 

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -345,7 +345,7 @@ class PropertiesXmlParser
                 $result['value'] = $this->loadParams('x:param', $xpath, $node);
                 break;
             default:
-                $result['value'] = $this->getValueFromXPath('@value', $xpath, $node, 'string');
+                $result['value'] = $this->getValueFromXPath('@value', $xpath, $node);
                 break;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed Issues | fixed #4142
| Related PRs? | needs #4263
| Docs PRs? | https://github.com/sulu/sulu-docs/pull/402
| License | MIT

#### What's in this PR?

Implement multi select field type.

#### Why?

Needed for selecting multiple items instead of single items.

#### Example Usage

~~~xml
<property name="select" type="select">
    <meta>
        <title lang="en">Multiple Select</title>
        <title lang="de">Multiple Select</title>
    </meta>

    <params>
        <param name="default_values" type="collection">
            <param name="0"/>
            <param name="1"/>
        </param>

        <param name="values" type="collection">
            <param name="0">
                <meta>
                    <title lang="en">Option 1</title>
                    <title lang="de">Option 1</title>
                </meta>
            </param>

            <param name="1">
                <meta>
                    <title lang="en">Option 2</title>
                    <title lang="de">Option 2</title>
                </meta>
            </param>

            <param name="2">
                <meta>
                    <title lang="en">Option 3</title>
                    <title lang="de">Option 3</title>
                </meta>
            </param>
        </param>
    </params>
</property>
~~~
