### PR TITLE
refactored select components to use exact object types

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Menu/Divider.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Menu/Divider.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import dividerStyles from './divider.scss';
 
-export default class Divider extends React.PureComponent<{}> {
+export default class Divider extends React.PureComponent<{||}> {
     render() {
         return <li className={dividerStyles.divider} />;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiSelect/MultiSelect.js
@@ -5,12 +5,13 @@ import type {SelectProps} from '../Select';
 import Select from '../Select';
 import {translate} from '../../utils/Translator';
 
-type Props<T: string | number> = SelectProps & {
+type Props<T: string | number> = {|
+    ...SelectProps<T>,
     allSelectedText?: string,
     noneSelectedText?: string,
     values: Array<T>,
     onChange: (values: Array<T>) => void,
-};
+|};
 
 export default class MultiSelect<T: string | number> extends React.PureComponent<Props<T>> {
     static defaultProps = {
@@ -64,7 +65,9 @@ export default class MultiSelect<T: string | number> extends React.PureComponent
         return this.props.values.includes(option.props.value);
     };
 
-    handleSelect = (value: T) => {
+    // TODO: Remove explicit type annotation when flow bug is fixed
+    // https://github.com/facebook/flow/issues/6978
+    handleSelect: (value: T) => void = (value: T) => {
         const newValues = [...this.props.values];
         const index = newValues.indexOf(value);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -2,11 +2,11 @@
 import React from 'react';
 import actionStyles from './action.scss';
 
-type Props = {
+type Props = {|
     children: string,
     onClick: () => void,
     afterAction?: () => void,
-};
+|};
 
 export default class Action extends React.PureComponent<Props> {
     handleButtonClick = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -8,21 +8,21 @@ import Checkbox from '../Checkbox';
 import type {OptionSelectedVisualization} from './types';
 import optionStyles from './option.scss';
 
-type Props = {
+type Props<T> = {
     anchorWidth: number,
     selected: boolean,
     disabled: boolean,
     focus: boolean,
-    value?: string | number,
+    value?: T,
     children: string,
-    onClick?: (value?: string | number) => void,
+    onClick?: (value: ?T) => void,
     optionRef?: (optionNode: ElementRef<'li'>, selected: boolean) => void,
     selectedVisualization: OptionSelectedVisualization,
 };
 
 const ANCHOR_WIDTH_DIFFERENCE = 10;
 
-export default class Option extends React.PureComponent<Props> {
+export default class Option<T> extends React.PureComponent<Props<T>> {
     static defaultProps = {
         anchorWidth: 0,
         disabled: false,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Option.js
@@ -8,17 +8,17 @@ import Checkbox from '../Checkbox';
 import type {OptionSelectedVisualization} from './types';
 import optionStyles from './option.scss';
 
-type Props<T> = {
+type Props<T> = {|
     anchorWidth: number,
     selected: boolean,
     disabled: boolean,
     focus: boolean,
-    value?: T,
+    value: T,
     children: string,
-    onClick?: (value: ?T) => void,
+    onClick?: (value: T) => void,
     optionRef?: (optionNode: ElementRef<'li'>, selected: boolean) => void,
     selectedVisualization: OptionSelectedVisualization,
-};
+|};
 
 const ANCHOR_WIDTH_DIFFERENCE = 10;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -16,7 +16,7 @@ const VERTICAL_OFFSET = 2;
 
 type Props<T> = {|
     ...SelectProps<T>,
-    onSelect: (value: ?T) => void,
+    onSelect: (value: T) => void,
     displayValue: string,
     closeOnSelect: boolean,
     isOptionSelected: (option: Element<typeof Option>) => boolean,
@@ -96,7 +96,7 @@ export default class Select<T> extends React.Component<Props<T>> {
         });
     }
 
-    handleOptionClick = (value: ?T) => {
+    handleOptionClick = (value: T) => {
         this.props.onSelect(value);
 
         if (this.props.closeOnSelect) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -14,13 +14,14 @@ import selectStyles from './select.scss';
 const HORIZONTAL_OFFSET = -20;
 const VERTICAL_OFFSET = 2;
 
-type Props<T> = SelectProps & {
-    onSelect: (values: T) => void,
+type Props<T> = {|
+    ...SelectProps<T>,
+    onSelect: (value: ?T) => void,
     displayValue: string,
     closeOnSelect: boolean,
     isOptionSelected: (option: Element<typeof Option>) => boolean,
     selectedVisualization?: OptionSelectedVisualization,
-};
+|};
 
 @observer
 export default class Select<T> extends React.Component<Props<T>> {
@@ -80,7 +81,7 @@ export default class Select<T> extends React.Component<Props<T>> {
         });
     }
 
-    cloneChildren(): SelectChildren {
+    cloneChildren(): SelectChildren<T> {
         return React.Children.map(this.props.children, (child: any) => {
             switch (child.type) {
                 case Option:
@@ -95,7 +96,7 @@ export default class Select<T> extends React.Component<Props<T>> {
         });
     }
 
-    handleOptionClick = (value: T) => {
+    handleOptionClick = (value: ?T) => {
         this.props.onSelect(value);
 
         if (this.props.closeOnSelect) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/types.js
@@ -4,16 +4,16 @@ import Select from './Select';
 import Action from './Action';
 import Option from './Option';
 
-export type SelectProps = {
-    children: SelectChildren,
+export type SelectProps<T> = {|
+    children: SelectChildren<T>,
     disabled: boolean,
     icon?: string,
     skin: Skin,
-}
+|}
 
 export type Skin = 'default' | 'flat' | 'dark';
 
 export type OptionSelectedVisualization = 'icon' | 'checkbox';
 
-export type SelectChild = Element<typeof Option> | Element<typeof Select.Divider> | Element<typeof Action>;
-export type SelectChildren = ChildrenArray<SelectChild>;
+export type SelectChild<T> = Element<Class<Option<T>>> | Element<Class<Select.Divider>> | Element<Class<Action>>;
+export type SelectChildren<T> = ChildrenArray<SelectChild<T>>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -5,7 +5,7 @@ import type {SelectProps} from '../Select';
 import Select from '../Select';
 import {translate} from '../../utils/Translator';
 
-type Props<T: string | number> = {|
+type Props<T> = {|
     ...SelectProps<T>,
     onChange?: (value: T) => void,
     value: ?T,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleSelect/SingleSelect.js
@@ -5,10 +5,11 @@ import type {SelectProps} from '../Select';
 import Select from '../Select';
 import {translate} from '../../utils/Translator';
 
-type Props<T: string | number> = SelectProps & {
+type Props<T: string | number> = {|
+    ...SelectProps<T>,
     onChange?: (value: T) => void,
     value: ?T,
-};
+|};
 
 export default class SingleSelect<T: string | number> extends React.PureComponent<Props<T>> {
     static defaultProps = {
@@ -17,7 +18,9 @@ export default class SingleSelect<T: string | number> extends React.PureComponen
     };
 
     static Action = Select.Action;
+
     static Option = Select.Option;
+
     static Divider = Select.Divider;
 
     get displayValue(): string {
@@ -46,7 +49,9 @@ export default class SingleSelect<T: string | number> extends React.PureComponen
         return option.props.value === value && !option.props.disabled;
     };
 
-    handleSelect = (value: T) => {
+    // TODO: Remove explicit type annotation when flow bug is fixed
+    // https://github.com/facebook/flow/issues/6978
+    handleSelect: (value: T) => void = (value: T) => {
         if (this.props.onChange) {
             this.props.onChange(value);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/MultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelect/MultiSelect.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type {Element} from 'react';
 import {observer} from 'mobx-react';
 import MultiSelectComponent from '../../components/MultiSelect';
 import ResourceListStore from '../../stores/ResourceListStore';
@@ -26,8 +27,6 @@ export default class MultiSelect<T: string | number> extends React.Component<Pro
         values: [],
     };
 
-    handleChange: (Array<T>) => void;
-
     resourceListStore: ResourceListStore;
 
     constructor(props: Props<T>) {
@@ -39,22 +38,22 @@ export default class MultiSelect<T: string | number> extends React.Component<Pro
         } = this.props;
 
         this.resourceListStore = new ResourceListStore(resourceKey, apiOptions);
-
-        // TODO: Can be moved to the correct place when flow bug is fixed
-        // https://github.com/facebook/flow/issues/6978
-        this.handleChange = (values: Array<T>) => {
-            const {
-                onChange,
-                idProperty,
-            } = this.props;
-
-            const valueObjects = this.resourceListStore.data.filter((dataValue) => {
-                return values.includes(dataValue[idProperty]);
-            });
-
-            onChange(values, valueObjects);
-        };
     }
+
+    // TODO: Remove explicit type annotation when flow bug is fixed
+    // https://github.com/facebook/flow/issues/6978
+    handleChange: (Array<T>) => void = (values: Array<T>) => {
+        const {
+            onChange,
+            idProperty,
+        } = this.props;
+
+        const valueObjects = this.resourceListStore.data.filter((dataValue) => {
+            return values.includes(dataValue[idProperty]);
+        });
+
+        onChange(values, valueObjects);
+    };
 
     render() {
         const {
@@ -78,11 +77,11 @@ export default class MultiSelect<T: string | number> extends React.Component<Pro
                 onChange={this.handleChange}
                 values={values}
             >
-                {this.resourceListStore.data.map((object, index) => (
+                {this.resourceListStore.data.map((object, index) => ((
                     <MultiSelectComponent.Option key={index} value={object[idProperty]}>
                         {object[displayProperty]}
                     </MultiSelectComponent.Option>
-                ))}
+                ): Element<typeof MultiSelectComponent.Option>))}
             </MultiSelectComponent>
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR refactors the already implemented select components to use props with exact object types.

#### Why?

Exact object types provide a better type safety and allow for better static code checking.

#### Discussion Points

The implementation of the `Option` component allows for not setting the `value` prop. This is desired behaviour that allows to implement valueless-options that can be used to reset the value of a single-selection.

Unfortunately, the `SingleSelect` component and `MultiSelect` component are incompatible with these valueless-options as they do not expect undefined values in their `handleSelect()` methods. These inconsistencies were not detected by flow until now, because we were not using exact object types.

How should we handle these cases?