### PR TITLE
add toolbar item for draft deletion of page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -28,7 +28,6 @@ export default class Dialog extends React.Component<Props> {
     static defaultProps = {
         confirmDisabled: false,
         confirmLoading: false,
-        open: false,
     };
 
     @observable visible: boolean = false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/FormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/FormStore.js
@@ -391,6 +391,10 @@ export default class FormStore {
         this.resourceStore.set(name, value);
     }
 
+    setMultiple(data: Object) {
+        this.resourceStore.setMultiple(data);
+    }
+
     change(name: string, value: mixed) {
         this.resourceStore.change(name, value);
     }
@@ -456,6 +460,10 @@ export default class FormStore {
 
     @computed get dirty(): boolean {
         return this.resourceStore.dirty;
+    }
+
+    set dirty(dirty: boolean) {
+        this.resourceStore.dirty = dirty;
     }
 
     @action setType(type: string) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/FormStore.test.js
@@ -10,6 +10,7 @@ jest.mock('../../../../stores/ResourceStore', () => function(resourceKey, id, op
     this.save = jest.fn().mockReturnValue(Promise.resolve());
     this.delete = jest.fn().mockReturnValue(Promise.resolve());
     this.set = jest.fn();
+    this.setMultiple = jest.fn();
     this.change = jest.fn();
     this.copyFromLocale = jest.fn();
     this.data = {};
@@ -326,6 +327,14 @@ test('Read dirty flag from ResourceStore', () => {
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.dirty = true;
     const formStore = new FormStore(resourceStore);
+
+    expect(formStore.dirty).toEqual(true);
+});
+
+test('Set dirty flag from ResourceStore', () => {
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
+    const formStore = new FormStore(resourceStore);
+    formStore.dirty = true;
 
     expect(formStore.dirty).toEqual(true);
 });
@@ -791,6 +800,18 @@ test('Set should be passed to resourceStore', () => {
     formStore.set('title', 'Title');
 
     expect(formStore.resourceStore.set).toBeCalledWith('title', 'Title');
+    formStore.destroy();
+});
+
+test('SetMultiple should be passed to resourceStore', () => {
+    const formStore = new FormStore(new ResourceStore('snippets', '3'));
+    const data = {
+        title: 'Title',
+        description: 'Description',
+    };
+    formStore.setMultiple(data);
+
+    expect(formStore.resourceStore.setMultiple).toBeCalledWith(data);
     formStore.destroy();
 });
 

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
@@ -44,5 +44,8 @@
     "sulu_content.hide_in_sitemap": "In Sitemap ausblenden",
     "sulu_content.cache_clear": "Webseiten Cache löschen",
     "sulu_content.cache_clear_warning_title": "Webseiten Cache löschen?",
-    "sulu_content.cache_clear_warning_text": "Diese Operation leert den gesamten Cache für jeden Webspace. Wollen Sie wirklich fortfahren?"
+    "sulu_content.cache_clear_warning_text": "Diese Operation leert den gesamten Cache für jeden Webspace. Wollen Sie wirklich fortfahren?",
+    "sulu_content.delete_draft": "Entwurf löschen",
+    "sulu_content.delete_draft_warning_title": "Entwurf löschen?",
+    "sulu_content.delete_draft_warning_text": "Soll der Entwurf wirklich gelöscht werden? Alle Daten gehen dadurch verloren. Die veröffentlichte Seite bleibt unverändert bestehen."
 }

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
@@ -44,5 +44,8 @@
     "sulu_content.hide_in_sitemap": "Hide in sitemap",
     "sulu_content.cache_clear": "Clear website cache",
     "sulu_content.cache_clear_warning_title": "Clear website cache?",
-    "sulu_content.cache_clear_warning_text": "This operation will clear the entire cache for all webspaces. Do you really wish to proceed?"
+    "sulu_content.cache_clear_warning_text": "This operation will clear the entire cache for all webspaces. Do you really wish to proceed?",
+    "sulu_content.delete_draft": "Delete draft",
+    "sulu_content.delete_draft_warning_title": "Delete Draft?",
+    "sulu_content.delete_draft_warning_text": "Do you really want to delete the draft? All data will be lost. The published page will not be changed."
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | --
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to delete a draft via the `edit` menu in the toolbar.

#### Why?

Because it already existed in the old UI.