### PR TITLE
Fixed hash serializer for inline serialization

### DIFF
--- a/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
+++ b/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\Hash\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\EventDispatcher\PreSerializeEvent;
 use JMS\Serializer\JsonSerializationVisitor;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Hash\HasherInterface;

--- a/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
+++ b/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
@@ -13,7 +13,8 @@ namespace Sulu\Component\Hash\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\GenericSerializationVisitor;
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
+use JMS\Serializer\JsonSerializationVisitor;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Hash\HasherInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
@@ -62,10 +63,12 @@ class HashSerializeEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$event->getVisitor() instanceof GenericSerializationVisitor) {
+        $visitor = $event->getVisitor();
+
+        if (!$visitor instanceof JsonSerializationVisitor) {
             return;
         }
 
-        $event->getVisitor()->addData('_hash', $this->hasher->hash($object));
+        $visitor->setData('_hash', $this->hasher->hash($object));
     }
 }

--- a/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
+++ b/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
@@ -13,7 +13,7 @@ namespace Sulu\Component\Hash\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\GenericSerializationVisitor;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Hash\HasherInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
@@ -64,7 +64,7 @@ class HashSerializeEventSubscriber implements EventSubscriberInterface
 
         $visitor = $event->getVisitor();
 
-        if (!$visitor instanceof JsonSerializationVisitor) {
+        if (!$visitor instanceof GenericSerializationVisitor) {
             return;
         }
 

--- a/src/Sulu/Component/Hash/Tests/Unit/Serializer/Subscriber/HashSerializeEventSubscriberTest.php
+++ b/src/Sulu/Component/Hash/Tests/Unit/Serializer/Subscriber/HashSerializeEventSubscriberTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Hash\Tests\Unit\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\GenericSerializationVisitor;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\XmlSerializationVisitor;
 use PHPUnit\Framework\TestCase;
@@ -34,7 +33,7 @@ class HashSerializeEventSubscriberTest extends TestCase
     private $hashSerializeEventSubscriber;
 
     /**
-     * @var GenericSerializationVisitor
+     * @var JsonSerializationVisitor
      */
     private $visitor;
 
@@ -57,7 +56,7 @@ class HashSerializeEventSubscriberTest extends TestCase
         $object = $this->prophesize(AuditableInterface::class);
         $this->objectEvent->getObject()->willReturn($object);
 
-        $this->visitor->addData('_hash', Argument::any())->shouldBeCalled();
+        $this->visitor->setData('_hash', Argument::any())->shouldBeCalled();
         $this->hashSerializeEventSubscriber->onPostSerialize($this->objectEvent->reveal());
     }
 
@@ -66,7 +65,7 @@ class HashSerializeEventSubscriberTest extends TestCase
         $object = new \stdClass();
         $this->objectEvent->getObject()->willReturn($object);
 
-        $this->visitor->addData('_hash', Argument::any())->shouldNotBeCalled();
+        $this->visitor->setData('_hash', Argument::any())->shouldNotBeCalled();
         $this->hashSerializeEventSubscriber->onPostSerialize($this->objectEvent->reveal());
     }
 

--- a/src/Sulu/Component/Security/Tests/Unit/Serializer/Subscriber/SecuredEntitySubscriberTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Serializer/Subscriber/SecuredEntitySubscriberTest.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Security\Tests\Unit\Serializer\Subscriber;
 
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\GenericSerializationVisitor;
+use JMS\Serializer\JsonSerializationVisitor;
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Rest\ApiWrapper;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -60,7 +60,7 @@ class SecuredEntitySubscriberTest extends TestCase
     private $user;
 
     /**
-     * @var GenericSerializationVisitor
+     * @var JsonSerializationVisitor
      */
     private $visitor;
 
@@ -78,7 +78,7 @@ class SecuredEntitySubscriberTest extends TestCase
             $this->tokenStorage->reveal()
         );
 
-        $this->visitor = $this->prophesize(GenericSerializationVisitor::class);
+        $this->visitor = $this->prophesize(JsonSerializationVisitor::class);
         $this->objectEvent = $this->prophesize(ObjectEvent::class);
         $this->objectEvent->getVisitor()->willReturn($this->visitor);
     }

--- a/src/Sulu/Component/Serializer/ArraySerializationVisitor.php
+++ b/src/Sulu/Component/Serializer/ArraySerializationVisitor.php
@@ -11,12 +11,12 @@
 
 namespace Sulu\Component\Serializer;
 
-use JMS\Serializer\GenericSerializationVisitor;
+use JMS\Serializer\JsonSerializationVisitor;
 
 /**
  * Enables serialization to an array with the JMSSerializer.
  */
-class ArraySerializationVisitor extends GenericSerializationVisitor
+class ArraySerializationVisitor extends JsonSerializationVisitor
 {
     /**
      * Returns the visited data as array.

--- a/src/Sulu/Component/Serializer/ArraySerializationVisitor.php
+++ b/src/Sulu/Component/Serializer/ArraySerializationVisitor.php
@@ -11,12 +11,12 @@
 
 namespace Sulu\Component\Serializer;
 
-use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\GenericSerializationVisitor;
 
 /**
  * Enables serialization to an array with the JMSSerializer.
  */
-class ArraySerializationVisitor extends JsonSerializationVisitor
+class ArraySerializationVisitor extends GenericSerializationVisitor
 {
     /**
      * Returns the visited data as array.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Replace deprecated `addData` function with `setData` function to avoid a serialization error when serialize [inline](https://jmsyst.com/libs/serializer/master/reference/annotations#inline). ~~Replace deprecated [GenericSerializationVisitor](https://github.com/schmittjoh/serializer/blob/1.13.0/src/JMS/Serializer/GenericSerializationVisitor.php#L11)~~

#### Why?

To fix hash serializer for inline serialization. If you have subentities which are also auditable and you try to inline them it will error with `_hash` exist instead. 

#### Example Usage

~~~php
    /**
     * @Serializer\Expose
     * @Serializer\Inline
     *
     * @ORM\OneToOne(targetEntity="App\Model\Location\LocationDimensionRestaurant", mappedBy="locationDimension", cascade={"persist", "remove"})
     */
    private $restaurant;

    /**
     * @Serializer\Expose
     * @Serializer\Inline
     *
     * @ORM\OneToOne(targetEntity="App\Model\Location\LocationDimensionBaker", mappedBy="locationDimension", cascade={"persist", "remove"})
     */
    private $baker;
~~~

