### PR TITLE
extracted media-selection field-type from media-selection container

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -90,7 +90,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         $languageCode,
         $segmentKey
     ) {
-        $data = json_decode($node->getPropertyValueWithDefault($property->getName(), '{}'), true);
+        $data = json_decode($node->getPropertyValueWithDefault($property->getName(), '{"ids": []}'), true);
 
         $property->setValue($data);
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -1,0 +1,37 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import type {Value} from '../../MediaSelection/types';
+import MediaSelectionComponent from '../../MediaSelection';
+
+@observer
+export default class MediaSelection extends React.Component<FieldTypeProps<Value>> {
+    handleChange = (selectedIds: Array<number>) => {
+        const {onChange, onFinish} = this.props;
+
+        onChange({
+            ids: selectedIds,
+        });
+        onFinish();
+    };
+
+    render() {
+        const {formInspector, disabled, value} = this.props;
+
+        if (!formInspector || !formInspector.locale) {
+            throw new Error('The media selection needs a locale to work properly');
+        }
+
+        const {locale} = formInspector;
+
+        return (
+            <MediaSelectionComponent
+                disabled={!!disabled}
+                locale={locale}
+                onChange={this.handleChange}
+                value={value && value.ids ? value.ids : []}
+            />
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -7,12 +7,10 @@ import MediaSelectionComponent from '../../MediaSelection';
 
 @observer
 export default class MediaSelection extends React.Component<FieldTypeProps<Value>> {
-    handleChange = (selectedIds: Array<number>) => {
+    handleChange = (value: Value) => {
         const {onChange, onFinish} = this.props;
 
-        onChange({
-            ids: selectedIds,
-        });
+        onChange(value);
         onFinish();
     };
 
@@ -30,7 +28,7 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
                 disabled={!!disabled}
                 locale={locale}
                 onChange={this.handleChange}
-                value={value && value.ids ? value.ids : []}
+                value={value ? value : undefined}
             />
         );
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/index.js
@@ -1,6 +1,8 @@
 // @flow
 import SingleMediaUpload from './fields/SingleMediaUpload';
+import MediaSelection from './fields/MediaSelection';
 
 export {
     SingleMediaUpload,
+    MediaSelection,
 };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -45,3 +45,47 @@ test('Pass correct props to MediaSelection component', () => {
     expect(mediaSelection.find(MediaSelectionComponent).props().locale.get()).toEqual('en');
     expect(mediaSelection.find(MediaSelectionComponent).props().value).toEqual([55, 66, 77]);
 });
+
+test('Should throw an error if locale is not present in form-inspector', () => {
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: undefined })
+        )
+    );
+
+    expect(() => shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            value={{ids: [55, 66, 77]}}
+        />
+    )).toThrowError();
+});
+
+test('Should call onChange and onFinish if the selection changes', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
+
+    const mediaSelection = shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+            value={{ids: [55, 66, 77]}}
+        />
+    );
+
+    mediaSelection.find(MediaSelectionComponent).props().onChange([33, 44]);
+
+    expect(changeSpy).toBeCalledWith({ ids: [33, 44] });
+    expect(finishSpy).toBeCalled();
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -1,0 +1,47 @@
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import {fieldTypeDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
+import FormInspector from 'sulu-admin-bundle/containers/Form/FormInspector';
+import FormStore from 'sulu-admin-bundle/containers/Form/stores/FormStore';
+import ResourceStore from 'sulu-admin-bundle/stores/ResourceStore';
+import {observable} from 'mobx';
+import MediaSelection from '../../fields/MediaSelection';
+import MediaSelectionComponent from '../../../MediaSelection/MediaSelection';
+
+jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions) {
+    this.locale = observableOptions.locale;
+}));
+
+jest.mock('sulu-admin-bundle/containers/Form/stores/FormStore', () => jest.fn(function(resourceStore) {
+    this.locale = resourceStore.locale;
+}));
+
+jest.mock('sulu-admin-bundle/containers/Form/FormInspector', () => jest.fn(function(formStore) {
+    this.locale = formStore.locale;
+}));
+
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Pass correct props to MediaSelection component', () => {
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
+
+    const mediaSelection = shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            value={{ids: [55, 66, 77]}}
+        />
+    );
+
+    expect(mediaSelection.find(MediaSelectionComponent).props().disabled).toEqual(true);
+    expect(mediaSelection.find(MediaSelectionComponent).props().locale.get()).toEqual('en');
+    expect(mediaSelection.find(MediaSelectionComponent).props().value).toEqual([55, 66, 77]);
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -43,7 +43,7 @@ test('Pass correct props to MediaSelection component', () => {
 
     expect(mediaSelection.find(MediaSelectionComponent).props().disabled).toEqual(true);
     expect(mediaSelection.find(MediaSelectionComponent).props().locale.get()).toEqual('en');
-    expect(mediaSelection.find(MediaSelectionComponent).props().value).toEqual([55, 66, 77]);
+    expect(mediaSelection.find(MediaSelectionComponent).props().value).toEqual({ ids: [55, 66, 77] });
 });
 
 test('Should throw an error if locale is not present in form-inspector', () => {
@@ -84,7 +84,7 @@ test('Should call onChange and onFinish if the selection changes', () => {
         />
     );
 
-    mediaSelection.find(MediaSelectionComponent).props().onChange([33, 44]);
+    mediaSelection.find(MediaSelectionComponent).props().onChange({ ids: [33, 44] });
 
     expect(changeSpy).toBeCalledWith({ ids: [33, 44] });
     expect(finishSpy).toBeCalled();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
@@ -9,19 +9,20 @@ import type {IObservableValue} from 'mobx';
 import MediaSelectionStore from '../../stores/MediaSelectionStore';
 import MediaSelectionOverlay from './MediaSelectionOverlay';
 import MediaSelectionItem from './MediaSelectionItem';
+import type {Value} from './types';
 
 type Props = {|
     disabled: boolean,
     locale: IObservableValue<string>,
-    onChange: (selectedIds: Array<number>) => void,
-    value: Array<number>,
+    onChange: (selectedIds: Value) => void,
+    value: Value,
 |}
 
 @observer
 export default class MediaSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
-        value: [],
+        value: { ids: [] },
     };
 
     mediaSelectionStore: MediaSelectionStore;
@@ -38,21 +39,21 @@ export default class MediaSelection extends React.Component<Props> {
             value,
         } = this.props;
 
-        this.mediaSelectionStore = new MediaSelectionStore(value, locale);
+        this.mediaSelectionStore = new MediaSelectionStore(value.ids, locale);
         this.changeDisposer = autorun(() => {
             const {onChange, value} = this.props;
-            const mediaIds = this.mediaSelectionStore.selectedMediaIds;
+            const loadedMediaIds = this.mediaSelectionStore.selectedMediaIds;
 
             if (!this.changeAutorunInitialized) {
                 this.changeAutorunInitialized = true;
                 return;
             }
 
-            if (equals(toJS(value), toJS(mediaIds))) {
+            if (equals(toJS(value.ids), toJS(loadedMediaIds))) {
                 return;
             }
 
-            onChange(mediaIds);
+            onChange({ ids: loadedMediaIds });
         });
     }
 
@@ -62,13 +63,13 @@ export default class MediaSelection extends React.Component<Props> {
             value,
         } = this.props;
 
-        const newValue = toJS(value);
-        const oldValue = toJS(this.mediaSelectionStore.selectedMediaIds);
+        const newSelectedIds = toJS(value.ids);
+        const currentSelectedIds = toJS(this.mediaSelectionStore.selectedMediaIds);
 
-        newValue.sort();
-        oldValue.sort();
-        if (!equals(newValue, oldValue) && !this.mediaSelectionStore.loading) {
-            this.mediaSelectionStore.loadSelectedMedia(newValue, locale);
+        newSelectedIds.sort();
+        currentSelectedIds.sort();
+        if (!equals(newSelectedIds, currentSelectedIds) && !this.mediaSelectionStore.loading) {
+            this.mediaSelectionStore.loadSelectedMedia(newSelectedIds, locale);
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
@@ -1,34 +1,79 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, observable} from 'mobx';
+import {action, autorun, toJS, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import equals from 'fast-deep-equal';
 import {MultiItemSelection} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
+import type {IObservableValue} from 'mobx';
 import MediaSelectionStore from './stores/MediaSelectionStore';
 import MediaSelectionOverlay from './MediaSelectionOverlay';
 import MediaSelectionItem from './MediaSelectionItem';
-import type {Value} from './types';
+
+type Props = {|
+    disabled: boolean,
+    locale: IObservableValue<string>,
+    onChange: (selectedIds: Array<number>) => void,
+    value: Array<number>,
+|}
 
 @observer
-export default class MediaSelection extends React.Component<FieldTypeProps<Value>> {
+export default class MediaSelection extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+        value: [],
+    };
+
     mediaSelectionStore: MediaSelectionStore;
+    changeDisposer: () => void;
+    changeAutorunInitialized: boolean = false;
+
     @observable overlayOpen: boolean = false;
 
-    constructor(props: FieldTypeProps<Value>) {
+    constructor(props: Props) {
         super(props);
 
         const {
-            formInspector,
+            locale,
             value,
         } = this.props;
-        const selectedMediaIds = (value && value.ids) ? value.ids : null;
 
-        if (!formInspector || !formInspector.locale) {
-            throw new Error('The media selection needs a locale to work properly');
+        this.mediaSelectionStore = new MediaSelectionStore(value, locale);
+        this.changeDisposer = autorun(() => {
+            const {onChange, value} = this.props;
+            const mediaIds = this.mediaSelectionStore.selectedMediaIds;
+
+            if (!this.changeAutorunInitialized) {
+                this.changeAutorunInitialized = true;
+                return;
+            }
+
+            if (equals(toJS(value), toJS(mediaIds))) {
+                return;
+            }
+
+            onChange(mediaIds);
+        });
+    }
+
+    componentDidUpdate() {
+        const {
+            locale,
+            value,
+        } = this.props;
+
+        const newValue = toJS(value);
+        const oldValue = toJS(this.mediaSelectionStore.selectedMediaIds);
+
+        newValue.sort();
+        oldValue.sort();
+        if (!equals(newValue, oldValue) && !this.mediaSelectionStore.loading) {
+            this.mediaSelectionStore.loadSelectedMedia(newValue, locale);
         }
+    }
 
-        this.mediaSelectionStore = new MediaSelectionStore(selectedMediaIds, formInspector.locale);
+    componentWillUnmount() {
+        this.changeDisposer();
     }
 
     @action openMediaOverlay() {
@@ -37,15 +82,6 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
 
     @action closeMediaOverlay() {
         this.overlayOpen = false;
-    }
-
-    callChangeHandler() {
-        const {onChange, onFinish} = this.props;
-
-        onChange({
-            ids: this.mediaSelectionStore.selectedMediaIds,
-        });
-        onFinish();
     }
 
     getLabel(itemCount: number) {
@@ -60,12 +96,10 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
 
     handleRemove = (mediaId: number) => {
         this.mediaSelectionStore.removeById(mediaId);
-        this.callChangeHandler();
     };
 
     handleSorted = (oldItemIndex: number, newItemIndex: number) => {
         this.mediaSelectionStore.move(oldItemIndex, newItemIndex);
-        this.callChangeHandler();
     };
 
     handleOverlayOpen = () => {
@@ -78,18 +112,11 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
 
     handleOverlayConfirm = (selectedMedia: Array<Object>) => {
         selectedMedia.forEach((media) => this.mediaSelectionStore.add(media));
-        this.callChangeHandler();
         this.closeMediaOverlay();
     };
 
     render() {
-        const {formInspector, disabled} = this.props;
-
-        if (!formInspector || !formInspector.locale) {
-            throw new Error('The media selection needs a locale to work properly');
-        }
-
-        const {locale} = formInspector;
+        const {locale, disabled} = this.props;
 
         const {
             loading,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/MediaSelection.js
@@ -6,7 +6,7 @@ import equals from 'fast-deep-equal';
 import {MultiItemSelection} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import type {IObservableValue} from 'mobx';
-import MediaSelectionStore from './stores/MediaSelectionStore';
+import MediaSelectionStore from '../../stores/MediaSelectionStore';
 import MediaSelectionOverlay from './MediaSelectionOverlay';
 import MediaSelectionItem from './MediaSelectionItem';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -343,14 +343,14 @@ test('Should call the onChange handler if selection store changes', () => {
     const changeSpy = jest.fn();
 
     const mediaSelectionInstance = shallow(
-        <MediaSelection locale={observable.box('en')} onChange={changeSpy} value={[55]} />
+        <MediaSelection locale={observable.box('en')} onChange={changeSpy} value={{ ids: [55] }} />
     ).instance();
 
     mediaSelectionInstance.mediaSelectionStore.selectedMedia.push({id: 99});
-    expect(changeSpy).toBeCalledWith([55, 99]);
+    expect(changeSpy).toBeCalledWith({ ids: [55, 99] });
 
     mediaSelectionInstance.mediaSelectionStore.selectedMedia.splice(0, 1);
-    expect(changeSpy).toBeCalledWith([99]);
+    expect(changeSpy).toBeCalledWith({ ids: [99] });
 });
 
 test('Pass correct props to MultiItemSelection component', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelection/tests/MediaSelection.test.js
@@ -4,9 +4,9 @@ import pretty from 'pretty';
 import React from 'react';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import MediaSelection from '../MediaSelection';
-import MediaSelectionStore from '../stores/MediaSelectionStore';
+import MediaSelectionStore from '../../../stores/MediaSelectionStore';
 
-jest.mock('../stores/MediaSelectionStore', () => jest.fn());
+jest.mock('../../../stores/MediaSelectionStore', () => jest.fn());
 
 jest.mock('sulu-admin-bundle/containers', () => {
     return {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -2,12 +2,11 @@
 import {bundleReady} from 'sulu-admin-bundle/services';
 import {datagridAdapterRegistry, fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
 import {MediaCardOverviewAdapter, MediaCardSelectionAdapter} from './containers/Datagrid';
-import {SingleMediaUpload} from './containers/Form';
+import {MediaSelection, SingleMediaUpload} from './containers/Form';
 import MediaOverview from './views/MediaOverview';
 import MediaDetail from './views/MediaDetail';
 import MediaHistory from './views/MediaHistory';
 import MediaFormats from './views/MediaFormats';
-import MediaSelection from './containers/Form/fields/MediaSelection';
 
 viewRegistry.add('sulu_media.overview', MediaOverview);
 viewRegistry.add('sulu_media.detail', MediaDetail);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -7,7 +7,7 @@ import MediaOverview from './views/MediaOverview';
 import MediaDetail from './views/MediaDetail';
 import MediaHistory from './views/MediaHistory';
 import MediaFormats from './views/MediaFormats';
-import MediaSelection from './containers/MediaSelection';
+import MediaSelection from './containers/Form/fields/MediaSelection';
 
 viewRegistry.add('sulu_media.overview', MediaOverview);
 viewRegistry.add('sulu_media.detail', MediaDetail);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/MediaSelectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/MediaSelectionStore.js
@@ -1,9 +1,9 @@
 // @flow
 import {action, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line
-import {arrayMove} from 'sulu-admin-bundle/components';
-import {ResourceRequester} from 'sulu-admin-bundle/services';
-import type {MediaItem} from '../types';
+import {arrayMove} from 'sulu-admin-bundle/components/index';
+import {ResourceRequester} from 'sulu-admin-bundle/services/index';
+import type {MediaItem} from '../../containers/MediaSelection/types';
 
 const THUMBNAIL_SIZE = 'sulu-25x25';
 const MEDIA_RESOURCE_KEY = 'media';

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/MediaSelectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/MediaSelectionStore.js
@@ -1,8 +1,8 @@
 // @flow
 import {action, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx'; // eslint-disable-line
-import {arrayMove} from 'sulu-admin-bundle/components/index';
-import {ResourceRequester} from 'sulu-admin-bundle/services/index';
+import {arrayMove} from 'sulu-admin-bundle/components';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 import type {MediaItem} from '../../containers/MediaSelection/types';
 
 const THUMBNAIL_SIZE = 'sulu-25x25';

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/index.js
@@ -1,0 +1,4 @@
+// @flow
+import MediaSelectionStore from './MediaSelectionStore';
+
+export default MediaSelectionStore;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/tests/MediaSelectionStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaSelectionStore/tests/MediaSelectionStore.test.js
@@ -1,30 +1,27 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
-import {ResourceRequester} from 'sulu-admin-bundle/services';
-import MediaSelectionStore from '../../stores/MediaSelectionStore';
+// @flow
+import {observable, toJS} from 'mobx';
+import ResourceRequester from 'sulu-admin-bundle/services/ResourceRequester';
+import MediaSelectionStore from '../MediaSelectionStore';
 
-jest.mock('sulu-admin-bundle/services', () => ({
-    ResourceRequester: {
-        getList: jest.fn(),
-    },
+jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
+    getList: jest.fn(),
 }));
 
 test('Should not make a request if the given ids array is empty or undefined', () => {
-    const Promise = require.requireActual('promise');
+    const Promise = jest.requireActual('promise');
 
     ResourceRequester.getList.mockReturnValue(Promise.resolve());
 
-    const locale = 'en';
     const mediaIds = [];
 
-    new MediaSelectionStore(mediaIds, locale);
-    new MediaSelectionStore(null, locale);
+    new MediaSelectionStore(mediaIds, observable.box('en'));
+    new MediaSelectionStore(null, observable.box('en'));
 
     expect(ResourceRequester.getList).not.toBeCalled();
 });
 
 test('Should prepare media data and store it inside an array', () => {
-    const locale = 'en';
-    const mediaSelectionStore = new MediaSelectionStore(null, locale);
+    const mediaSelectionStore = new MediaSelectionStore(null, observable.box('en'));
 
     mediaSelectionStore.add({
         id: 1,
@@ -35,7 +32,7 @@ test('Should prepare media data and store it inside an array', () => {
     });
 
     expect(mediaSelectionStore.selectedMediaIds).toEqual([1]);
-    expect(mediaSelectionStore.selectedMedia.toJS()).toEqual([
+    expect(toJS(mediaSelectionStore.selectedMedia)).toEqual([
         {
             id: 1,
             title: 'Awesome',
@@ -45,8 +42,7 @@ test('Should prepare media data and store it inside an array', () => {
 });
 
 test('Should remove media from array', () => {
-    const locale = 'en';
-    const mediaSelectionStore = new MediaSelectionStore(null, locale);
+    const mediaSelectionStore = new MediaSelectionStore(null, observable.box('en'));
 
     mediaSelectionStore.add({
         id: 1,
@@ -66,7 +62,7 @@ test('Should remove media from array', () => {
 
     mediaSelectionStore.removeById(1);
     expect(mediaSelectionStore.selectedMediaIds).toEqual([2]);
-    expect(mediaSelectionStore.selectedMedia.toJS()).toEqual([
+    expect(toJS(mediaSelectionStore.selectedMedia)).toEqual([
         {
             id: 2,
             title: 'Awesome 2',
@@ -76,12 +72,11 @@ test('Should remove media from array', () => {
 
     mediaSelectionStore.removeById(2);
     expect(mediaSelectionStore.selectedMediaIds).toEqual([]);
-    expect(mediaSelectionStore.selectedMedia.toJS()).toEqual([]);
+    expect(toJS(mediaSelectionStore.selectedMedia)).toEqual([]);
 });
 
 test('Should move the media positions inside the array', () => {
-    const locale = 'en';
-    const mediaSelectionStore = new MediaSelectionStore(null, locale);
+    const mediaSelectionStore = new MediaSelectionStore(null, observable.box('en'));
 
     mediaSelectionStore.add({
         id: 1,
@@ -110,7 +105,7 @@ test('Should move the media positions inside the array', () => {
     expect(mediaSelectionStore.selectedMediaIds).toEqual([1, 2, 3]);
     mediaSelectionStore.move(0, 2);
     expect(mediaSelectionStore.selectedMediaIds).toEqual([2, 3, 1]);
-    expect(mediaSelectionStore.selectedMedia.toJS()).toEqual([
+    expect(toJS(mediaSelectionStore.selectedMedia)).toEqual([
         {
             id: 2,
             title: 'Awesome 2',

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/MediaSelectionContentTypeTest.php
@@ -186,7 +186,7 @@ class MediaSelectionContentTypeTest extends TestCase
                 [
                     [
                         'property',
-                        '{}',
+                        '{"ids": []}',
                         $config,
                     ],
                 ]
@@ -238,7 +238,7 @@ class MediaSelectionContentTypeTest extends TestCase
                 [
                     [
                         'property',
-                        '{}',
+                        '{"ids": []}',
                         $config,
                     ],
                 ]
@@ -291,7 +291,7 @@ class MediaSelectionContentTypeTest extends TestCase
                 [
                     [
                         'property',
-                        '{}',
+                        '{"ids": []}',
                         $config,
                     ],
                 ]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | hopefully no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR splits up the `MediaSelection` component into a field-type component and a container-component.

#### Why?

This allows to use the `MediaSelection` component outside of a form. Also, most other input-components are split into a container-component and a field-type too.