### PR TITLE
Put branch alias in extra section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,8 +160,11 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true,
+        "sort-packages": true
+    },
+    "extra": {
         "branch-alias": {
+            "dev-master": "1.7-dev",
             "dev-develop": "2.0-dev"
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -164,7 +164,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7-dev",
+            "dev-master": "1.6-dev",
             "dev-develop": "2.0-dev"
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?
The docs of composer state the branch-alias settings should be placed under extra.
See https://getcomposer.org/doc/articles/aliases.md#branch-alias

#### Why?
This makes it possible to require a development version without having issues with other packages requirements

#### Example Usage

~~~bash
composer require sulu/sulu:2.0.x-dev
~~~

#### BC Breaks/Deprecations
none
