### PR TITLE
Add cache clear button to the WebspaceOverview

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,6 +64,7 @@
         "comma-spacing": "error",
         "key-spacing": "error",
         "no-alert": "error",
+        "no-unused-vars": ["error", {"ignoreRestSiblings": true}],
         "padded-blocks": [
             "error",
             "never"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,10 +47,6 @@
             "error",
             "single"
         ],
-        "semi": [
-            "error",
-            "always"
-        ],
         "comma-dangle": [
             "error",
             {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,13 @@
 
 ## dev-develop
 
+### Toolbar Button label configuration
+
+**This change only affects you if you have used a 2.0.0 alpha release before**
+
+The name of the property to configure the text shown on a button in the toolbar has been change from `value` to `label`
+in order to be more consistent.
+
 ### Multiple Select renamed
 
 The multiple select content type was renamed to `select` to be equal to the other content types.

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -238,6 +238,11 @@ class AdminController
                 'user' => $user,
                 'contact' => $contact,
             ],
+            'sulu_content' => [
+                'routes' => [
+                    'clearCache' => $this->urlGenerator->generate('sulu_website.cache.remove'),
+                ],
+            ],
             'sulu_preview' => [
                 'routes' => [
                     'start' => $this->urlGenerator->generate('sulu_preview.start'),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Button.js
@@ -32,16 +32,16 @@ export default class Button extends React.PureComponent<ButtonProps> {
 
     render() {
         const {
-            icon,
-            size,
-            skin,
-            value,
             active,
-            primary,
-            loading,
             disabled,
+            label,
+            loading,
             hasOptions,
+            icon,
+            primary,
+            size,
             showText,
+            skin,
         } = this.props;
         const buttonClass = classNames(
             buttonStyles.button,
@@ -52,7 +52,7 @@ export default class Button extends React.PureComponent<ButtonProps> {
                 [buttonStyles.primary]: primary,
             }
         );
-        const buttonContent = this.props.children || value;
+        const buttonContent = this.props.children || label;
 
         return (
             <button
@@ -60,7 +60,7 @@ export default class Button extends React.PureComponent<ButtonProps> {
                 disabled={disabled}
                 onClick={this.handleOnClick}
                 ref={this.setButtonRef}
-                value={value}
+                value={label}
             >
                 {loading &&
                     <Loader className={buttonStyles.loader} size={LOADER_SIZE} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -84,11 +84,11 @@ export default class Dropdown extends React.Component<DropdownProps> {
                     disabled={disabled || allChildrenDisabled}
                     hasOptions={true}
                     icon={icon}
+                    label={showText ? label : undefined}
                     loading={loading}
                     onClick={this.handleButtonClick}
                     size={size}
                     skin={skin}
-                    value={showText ? label : undefined}
                 />
                 <Popover
                     anchorElement={this.buttonRef}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
@@ -91,11 +91,11 @@ export default class Select extends React.Component<SelectProps> {
                     disabled={disabled}
                     hasOptions={true}
                     icon={icon}
+                    label={showText ? buttonValue : undefined}
                     loading={loading}
                     onClick={this.handleButtonClick}
                     size={size}
                     skin={skin}
-                    value={showText ? buttonValue : undefined}
                 />
 
                 <Popover

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Button.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {mount, render, shallow} from 'enzyme';
 import React from 'react';
 import Button from '../Button';
@@ -12,7 +12,7 @@ test('Render loading button', () => {
 });
 
 test('Render button with value', () => {
-    expect(render(<Button value="Click" />)).toMatchSnapshot();
+    expect(render(<Button label="Click" />)).toMatchSnapshot();
 });
 
 test('Render button without text', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Select.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/Select.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {mount, render} from 'enzyme';
 import React from 'react';
 import Select from '../Select';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/types.js
@@ -16,11 +16,11 @@ export type Group = Element<typeof ItemsComponent> | Element<typeof IconsCompone
 
 export type Skin = 'light' | 'dark';
 
-export type Button = {
+export type Button = {|
     buttonRef?: (ref: ElementRef<'button'>) => void,
     children?: Node,
     onClick: () => ?Promise<*>,
-    value?: string | number,
+    label?: string | number,
     icon?: string,
     showText?: boolean,
     size?: string,
@@ -30,32 +30,32 @@ export type Button = {
     loading?: boolean,
     primary?: boolean,
     skin?: Skin,
-};
+|};
 
-export type Toggler = {
+export type Toggler = {|
     disabled?: boolean,
     label: string,
     loading?: boolean,
     onClick: () => void,
     skin?: Skin,
     value: boolean,
-};
+|};
 
-export type DropdownOption = {
+export type DropdownOption = {|
     label: string | number,
     onClick?: () => void,
     disabled?: boolean,
     skin?: Skin,
-};
+|};
 
-export type SelectOption = {
+export type SelectOption = {|
     label: string | number,
     value: string | number,
     disabled?: boolean,
     skin?: Skin,
-};
+|};
 
-export type Dropdown = {
+export type Dropdown = {|
     options: Array<DropdownOption>,
     label?: string | number,
     icon?: string,
@@ -64,9 +64,9 @@ export type Dropdown = {
     disabled?: boolean,
     loading?: boolean,
     skin?: Skin,
-};
+|};
 
-export type Select = {
+export type Select = {|
     value: string | number,
     options: Array<SelectOption>,
     onChange: (optionValue: string | number) => void,
@@ -78,4 +78,4 @@ export type Select = {
     disabled?: boolean,
     loading?: boolean,
     skin?: Skin,
-};
+|};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContentItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContentItem.js
@@ -10,7 +10,7 @@ type Props = {|
 export default class SmartContentItem extends React.Component<Props> {
     render() {
         const {
-            id, // eslint-disable-line no-unused-vars
+            id,
             image,
             title,
             publishedState,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -21,13 +21,17 @@ const ToolbarItemTypes = {
 function getItemComponentByType(itemConfig, key) {
     switch (itemConfig.type) {
         case ToolbarItemTypes.Select:
-            return <ToolbarComponent.Select {...itemConfig} key={key} />;
+            const {type: selectType, ...selectConfig} = itemConfig;
+            return <ToolbarComponent.Select {...selectConfig} key={key} />;
         case ToolbarItemTypes.Dropdown:
-            return <ToolbarComponent.Dropdown {...itemConfig} key={key} />;
+            const {type: dropdownType, ...dropdownConfig} = itemConfig;
+            return <ToolbarComponent.Dropdown {...dropdownConfig} key={key} />;
         case ToolbarItemTypes.Toggler:
-            return <ToolbarComponent.Toggler {...itemConfig} key={key} />;
+            const {type: togglerType, ...togglerConfig} = itemConfig;
+            return <ToolbarComponent.Toggler {...togglerConfig} key={key} />;
         default:
-            return <ToolbarComponent.Button {...itemConfig} key={key} />;
+            const {type: buttonType, ...buttonConfig} = itemConfig;
+            return <ToolbarComponent.Button {...buttonConfig} key={key} />;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -49,11 +49,17 @@ exports[`Render the items and icons from the ToolbarStore 1`] = `
           <button
             class="button light"
             disabled=""
+            value="Delete"
           >
             <span
               aria-label="fa-trash-o"
               class="fa fa-trash-o icon"
             />
+            <span
+              class="label"
+            >
+              Delete
+            </span>
           </button>
         </li>
         <li>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/stores/ToolbarStore.test.js
@@ -19,10 +19,10 @@ test('Set toolbar items and let mobx react', () => {
     toolbarStore.setConfig({
         items: [
             {
-                type: 'button',
-                value: 'Test',
                 icon: 'test',
+                label: 'Test',
                 onClick: () => {},
+                type: 'button',
             },
         ],
         errors,
@@ -40,7 +40,7 @@ test('Set toolbar items and let mobx react', () => {
 
     expect(isObservable(toolbarStore.config.items)).toBe(true);
     expect(toolbarConfigItems).toHaveLength(1);
-    expect(buttonConfig.value).toBe('Test');
+    expect(buttonConfig.label).toBe('Test');
     expect(buttonConfig.icon).toBe('test');
     expect(toolbarStore.errors).toEqual(errors);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -4,10 +4,26 @@ import type {IObservableValue} from 'mobx';
 import type {Button, Dropdown, Select, Toggler} from '../../components/Toolbar/types';
 
 export type {Button, Dropdown, Select, Toggler};
-export type ButtonItemConfig = Button & { type: 'button' };
-export type DropdownItemConfig = Dropdown & { type: 'dropdown' };
-export type SelectItemConfig = Select & { type: 'select' };
-export type TogglerItemConfig = Toggler & { type: 'toggler'};
+
+export type ButtonItemConfig = {|
+    ...Button,
+    type: 'button',
+|};
+
+export type DropdownItemConfig = {|
+    ...Dropdown,
+    type: 'dropdown',
+|};
+
+export type SelectItemConfig = {|
+    ...Select,
+    type: 'select',
+|};
+
+export type TogglerItemConfig = {|
+    ...Toggler,
+    type: 'toggler',
+|};
 export type ToolbarItemConfig = ButtonItemConfig | DropdownItemConfig | SelectItemConfig | TogglerItemConfig;
 
 export type ToolbarProps = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -198,31 +198,31 @@ export default withToolbar(Datagrid, function() {
 
     if (addRoute) {
         items.push({
-            type: 'button',
-            value: translate('sulu_admin.add'),
             icon: 'su-plus-circle',
+            label: translate('sulu_admin.add'),
             onClick: this.handleItemAdd,
+            type: 'button',
         });
     }
 
     items.push({
-        type: 'button',
-        value: translate('sulu_admin.delete'),
-        icon: 'su-trash-alt',
         disabled: this.datagridStore.selectionIds.length === 0,
+        icon: 'su-trash-alt',
+        label: translate('sulu_admin.delete'),
         loading: this.datagridStore.selectionDeleting,
         onClick: this.datagrid.requestSelectionDelete,
+        type: 'button',
     });
 
     if (movable) {
         items.push({
-            type: 'button',
-            value: translate('sulu_admin.move_selected'),
-            icon: 'su-arrows-alt',
             disabled: this.datagridStore.selectionIds.length === 0,
+            icon: 'su-arrows-alt',
+            label: translate('sulu_admin.move_selected'),
             onClick: action(() => {
                 this.showMoveOverlay = true;
             }),
+            type: 'button',
         });
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -335,7 +335,7 @@ test('Should render the add button in the toolbar only if an addRoute has been p
     expect(toolbarConfig.items).toEqual(
         expect.arrayContaining(
             [
-                expect.objectContaining({icon: 'su-plus-circle', value: 'Add'}),
+                expect.objectContaining({icon: 'su-plus-circle', label: 'Add'}),
             ]
         )
     );
@@ -483,12 +483,12 @@ test('Should render the delete item enabled only if something is selected', () =
 
     let toolbarConfig, item;
     toolbarConfig = toolbarFunction.call(datagrid.instance());
-    item = toolbarConfig.items.find((item) => item.value === 'Delete');
+    item = toolbarConfig.items.find((item) => item.label === 'Delete');
     expect(item.disabled).toBe(true);
 
     datagridStore.selectionIds.push(1);
     toolbarConfig = toolbarFunction.call(datagrid.instance());
-    item = toolbarConfig.items.find((item) => item.value === 'Delete');
+    item = toolbarConfig.items.find((item) => item.label === 'Delete');
     expect(item.disabled).toBe(false);
 });
 
@@ -585,7 +585,7 @@ test('Should not pass the locale observable to the DatagridStore if no locales a
 
 test('Should delete selected items when delete button is clicked', () => {
     function getDeleteItem() {
-        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.value === 'Delete');
+        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.label === 'Delete');
     }
 
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
@@ -615,7 +615,7 @@ test('Should delete selected items when delete button is clicked', () => {
 
 test('Should make move overlay disappear if cancel is clicked', () => {
     function getMoveItem() {
-        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.value === 'Move selected');
+        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.label === 'Move selected');
     }
 
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
@@ -650,7 +650,7 @@ test('Should make move overlay disappear if cancel is clicked', () => {
 
 test('Should move items after move overlay was confirmed', () => {
     function getMoveItem() {
-        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.value === 'Move selected');
+        return toolbarFunction.call(datagrid.instance()).items.find((item) => item.label === 'Move selected');
     }
 
     const withToolbar = require('../../../containers/Toolbar/withToolbar');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -71,8 +71,8 @@ test('Return item config with correct disabled, loading, icon, type and value an
     expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         disabled: false,
         icon: 'su-trash-alt',
+        label: 'sulu_admin.delete',
         type: 'button',
-        value: 'sulu_admin.delete',
     }));
 
     const element = shallow(deleteToolbarAction.getNode());

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
@@ -54,10 +54,10 @@ test('Return item config with correct disabled, loading, icon, type and value', 
 
     expect(saveToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         disabled: true,
+        label: 'sulu_admin.save',
         loading: false,
         icon: 'su-save',
         type: 'button',
-        value: 'sulu_admin.save',
     }));
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -29,11 +29,11 @@ export default class DeleteToolbarAction extends AbstractToolbarAction {
         return {
             disabled: !this.formStore.id,
             icon: 'su-trash-alt',
+            label: translate('sulu_admin.delete'),
             onClick: action(() => {
                 this.showDialog = true;
             }),
             type: 'button',
-            value: translate('sulu_admin.delete'),
         };
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
@@ -5,14 +5,14 @@ import {translate} from '../../../utils/Translator';
 export default class SaveToolbarAction extends AbstractToolbarAction {
     getToolbarItemConfig() {
         return {
-            type: 'button',
-            value: translate('sulu_admin.save'),
-            icon: 'su-save',
             disabled: !this.formStore.dirty,
+            icon: 'su-save',
+            label: translate('sulu_admin.save'),
             loading: this.formStore.saving,
             onClick: () => {
                 this.form.submit();
             },
+            type: 'button',
         };
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -234,6 +234,7 @@ class AdminControllerTest extends TestCase
         $this->urlGenerator->generate('sulu_preview.update-context')->willReturn('/preview/update-context');
         $this->urlGenerator->generate('sulu_preview.stop')->willReturn('/preview/stop');
         $this->urlGenerator->generate('cget_contexts')->willReturn('/security/contexts');
+        $this->urlGenerator->generate('sulu_website.cache.remove')->willReturn('/admin/website/cache');
 
         $this->resourceMetadataPool->getAllResourceMetadata('en')->willReturn(
             [$resourceMetadata1->reveal(), $resourceMetadata2->reveal()]

--- a/src/Sulu/Bundle/ContentBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/js/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {bundleReady} from 'sulu-admin-bundle/services';
+import {bundleReady, initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
 import {toolbarActionRegistry} from 'sulu-admin-bundle/views';
 import SearchResult from './containers/Form/fields/SearchResult';
@@ -8,6 +8,10 @@ import PageSettingsShadowLocaleSelect from './containers/Form/fields/PageSetting
 import EditToolbarAction from './views/Form/toolbarActions/EditToolbarAction';
 import PageTabs from './views/PageTabs';
 import WebspaceOverview from './views/WebspaceOverview';
+
+initializer.addUpdateConfigHook('sulu_content', (config: Object) => {
+    WebspaceOverview.clearCacheEndpoint = config.routes.clearCache;
+});
 
 viewRegistry.add('sulu_content.page_tabs', PageTabs);
 viewRegistry.add('sulu_content.webspace_overview', WebspaceOverview);

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.de.json
@@ -41,5 +41,8 @@
     "sulu_content.canonical_url": "Canonical URL  (Canonical tag)",
     "sulu_content.no_index": "no-index (Seite wird nicht von Suchmaschinen indiziert)",
     "sulu_content.no_follow": "no-follow (Links auf der Seite wird von Suchmaschinen nicht gefolgt)",
-    "sulu_content.hide_in_sitemap": "In Sitemap ausblenden"
+    "sulu_content.hide_in_sitemap": "In Sitemap ausblenden",
+    "sulu_content.cache_clear": "Webseiten Cache löschen",
+    "sulu_content.cache_clear_warning_title": "Websiten Cache löschen?",
+    "sulu_content.cache_clear_warning_text": "Diese Operation leert den gesamten Cache für jeden Webspace. Wollen Sie wirklich fortfahren?"
 }

--- a/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContentBundle/Resources/translations/admin.en.json
@@ -41,5 +41,8 @@
     "sulu_content.canonical_url": "Canonical URL  (Canonical tag)",
     "sulu_content.no_index": "no-index (page will not be indexed by search engines)",
     "sulu_content.no_follow": "no-follow (links on this page will not be followed by the search engine)",
-    "sulu_content.hide_in_sitemap": "Hide in sitemap"
+    "sulu_content.hide_in_sitemap": "Hide in sitemap",
+    "sulu_content.cache_clear": "Clear website cache",
+    "sulu_content.cache_clear_warning_title": "Clear website cache?",
+    "sulu_content.cache_clear_warning_text": "This operation will clear the entire cache for all webspaces. Do you really wish to proceed?"
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/MediaDetail.js
@@ -168,14 +168,14 @@ export default withToolbar(MediaDetail, function() {
         },
         items: [
             {
-                type: 'button',
-                value: translate('sulu_admin.save'),
-                icon: 'su-save',
                 disabled: !resourceStore.dirty,
+                icon: 'su-save',
+                label: translate('sulu_admin.save'),
                 loading: resourceStore.saving,
                 onClick: () => {
                     this.form.submit();
                 },
+                type: 'button',
             },
         ],
         showSuccess,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetail/tests/MediaDetail.test.js
@@ -285,7 +285,7 @@ test('Should initialize the ResourceStore with a schema', () => {
 
 test('Should render save button disabled only if form is not dirty', () => {
     function getSaveItem() {
-        return toolbarFunction.call(form).items.find((item) => item.value === 'Save');
+        return toolbarFunction.call(form).items.find((item) => item.label === 'Save');
     }
 
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -239,19 +239,19 @@ export default withToolbar(MediaOverview, function() {
             {
                 disabled: this.mediaDatagridStore.selectionIds.length === 0,
                 icon: 'su-trash-alt',
+                label: translate('sulu_admin.delete'),
                 loading: this.mediaDatagridStore.selectionDeleting,
                 onClick: this.mediaDatagrid.requestSelectionDelete,
                 type: 'button',
-                value: translate('sulu_admin.delete'),
             },
             {
                 disabled: this.mediaDatagridStore.selectionIds.length === 0,
                 icon: 'su-arrows-alt',
+                label: translate('sulu_admin.move_selected'),
                 onClick: action(() => {
                     this.showMediaMoveOverlay = true;
                 }),
                 type: 'button',
-                value: translate('sulu_admin.move_selected'),
             },
         ],
     };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -288,7 +288,7 @@ test('The collectionId should be update along with the content when a collection
 
 test('Should delete selected items when delete button is clicked', () => {
     function getDeleteItem() {
-        return toolbarFunction.call(mediaOverview.instance()).items.find((item) => item.value === 'sulu_admin.delete');
+        return toolbarFunction.call(mediaOverview.instance()).items.find((item) => item.label === 'sulu_admin.delete');
     }
 
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
@@ -337,7 +337,7 @@ test('Move overlay button should be disabled if nothing is selected', () => {
     mediaOverview.locale.set('de');
 
     expect(toolbarFunction.call(mediaOverview).items[1].disabled).toEqual(true);
-    expect(toolbarFunction.call(mediaOverview).items[1].value).toEqual('sulu_admin.move_selected');
+    expect(toolbarFunction.call(mediaOverview).items[1].label).toEqual('sulu_admin.move_selected');
 
     mediaOverview.mediaDatagridStore.selectionIds.push(8);
     expect(toolbarFunction.call(mediaOverview).items[1].disabled).toEqual(false);
@@ -367,7 +367,7 @@ test('Move overlay should disappear when overlay is closed', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaOverview.instance());
 
-    expect(toolbarConfig.items[1].value).toEqual('sulu_admin.move_selected');
+    expect(toolbarConfig.items[1].label).toEqual('sulu_admin.move_selected');
     toolbarConfig.items[1].onClick();
     mediaOverview.update();
     expect(mediaOverview.find(SingleDatagridOverlay).at(1).prop('resourceKey')).toEqual('collections');
@@ -404,7 +404,7 @@ test('Media should be moved when overlay is confirmed', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaOverview.instance());
 
-    expect(toolbarConfig.items[1].value).toEqual('sulu_admin.move_selected');
+    expect(toolbarConfig.items[1].label).toEqual('sulu_admin.move_selected');
     toolbarConfig.items[1].onClick();
     mediaOverview.update();
     expect(mediaOverview.find(SingleDatagridOverlay).at(1).prop('resourceKey')).toEqual('collections');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a new button to the `WebspaceOverview` allowing to clear the cache for all websites.

#### Why?

Because it was already possible in the old UI, and there are cases which cannot be handled by the automatic cache invalidation.