### PR TITLE
use reference-store in single-contact-selection content-type to invalidate cache

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleContactSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleContactSelection.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContactBundle\Content\Types;
 
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepositoryInterface;
+use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\SimpleContentType;
 
@@ -23,9 +24,17 @@ class SingleContactSelection extends SimpleContentType
      */
     protected $contactRepository;
 
-    public function __construct(ContactRepositoryInterface $contactRepository)
-    {
+    /**
+     * @var ReferenceStoreInterface
+     */
+    private $contactReferenceStore;
+
+    public function __construct(
+        ContactRepositoryInterface $contactRepository,
+        ReferenceStoreInterface $contactReferenceStore
+    ) {
         $this->contactRepository = $contactRepository;
+        $this->contactReferenceStore = $contactReferenceStore;
 
         parent::__construct('SingleContact');
     }
@@ -39,5 +48,18 @@ class SingleContactSelection extends SimpleContentType
         }
 
         return $this->contactRepository->findById($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preResolve(PropertyInterface $property)
+    {
+        $id = $property->getValue();
+        if (!$id) {
+            return;
+        }
+
+        $this->contactReferenceStore->add($id);
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
@@ -23,6 +23,7 @@
 
         <service id="sulu_contact.content.single_contact_selection" class="Sulu\Bundle\ContactBundle\Content\Types\SingleContactSelection">
             <argument type="service" id="sulu.repository.contact" />
+            <argument type="service" id="sulu_contact.reference_store.contact" />
 
             <tag name="sulu.content.type" alias="single_contact_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the single-contact-selection content-type to use the reference store to invalidate cache entires if the contact value changes

