### PR TITLE
Remove deprecation message from getcolspan on section

### DIFF
--- a/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
@@ -162,21 +162,11 @@ class PropertyMetadata extends ItemMetadata
 
     public function getColSpan(): ?int
     {
-        @trigger_error(
-            sprintf('Do not use getter "%s" from "%s"', 'getColSpan', __CLASS__),
-            E_USER_DEPRECATED
-        );
-
         return $this->colSpan;
     }
 
     public function setColSpan(int $colSpan = null): self
     {
-        @trigger_error(
-            sprintf('Do not use setter "%s" from "%s"', 'setColSpan', __CLASS__),
-            E_USER_DEPRECATED
-        );
-
         $this->colSpan = $colSpan;
 
         return $this;

--- a/src/Sulu/Component/Content/Metadata/SectionMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/SectionMetadata.php
@@ -42,11 +42,6 @@ class SectionMetadata extends ItemMetadata
 
     public function getColSpan()
     {
-        @trigger_error(
-            sprintf('Do not use getter "%s" from "%s"', 'getColSpan', __CLASS__),
-            E_USER_DEPRECATED
-        );
-
         return $this->colSpan;
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove deprecation message from getcolspan on section.

#### Why?

Sections can have colspan in sulu 2.0.