### PR TITLE
 adjusted selection components to not fire change-handler while selection-store is loading

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -42,11 +42,11 @@ export default class MultiSelection extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const {onChange, locale, resourceKey, value} = this.props;
+        const {locale, resourceKey, value} = this.props;
 
         this.selectionStore = new MultiSelectionStore(resourceKey, value, locale);
         this.changeDisposer = autorun(() => {
-            const {value} = this.props;
+            const {onChange, value} = this.props;
             const itemIds = this.selectionStore.items.map((item) => item.id);
 
             if (!this.changeAutorunInitialized) {
@@ -54,7 +54,7 @@ export default class MultiSelection extends React.Component<Props> {
                 return;
             }
 
-            if (equals(toJS(value), toJS(itemIds))) {
+            if (equals(toJS(value), toJS(itemIds)) || this.selectionStore.loading) {
                 return;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -63,13 +63,13 @@ export default class MultiSelection extends React.Component<Props> {
     }
 
     componentDidUpdate() {
-        const newValue = toJS(this.props.value);
-        const oldValue = toJS(this.selectionStore.items.map((item) => item.id));
+        const newIds = toJS(this.props.value);
+        const loadedIds = toJS(this.selectionStore.items.map((item) => item.id));
 
-        newValue.sort();
-        oldValue.sort();
-        if (!equals(newValue, oldValue) && !this.selectionStore.loading) {
-            this.selectionStore.loadItems(newValue);
+        newIds.sort();
+        loadedIds.sort();
+        if (!equals(newIds, loadedIds) && !this.selectionStore.loading) {
+            this.selectionStore.loadItems(newIds);
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -68,7 +68,7 @@ export default class MultiSelection extends React.Component<Props> {
 
         newIds.sort();
         loadedIds.sort();
-        if (!equals(newIds, loadedIds) && !this.selectionStore.loading) {
+        if (!equals(newIds, loadedIds)) {
             this.selectionStore.loadItems(newIds);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, autorun, observable, toJS} from 'mobx';
+import {action, autorun, observable, toJS, untracked} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
@@ -46,7 +46,7 @@ export default class MultiSelection extends React.Component<Props> {
 
         this.selectionStore = new MultiSelectionStore(resourceKey, value, locale);
         this.changeDisposer = autorun(() => {
-            const {onChange, value} = this.props;
+            const {onChange, value} = untracked(() => this.props);
             const itemIds = this.selectionStore.items.map((item) => item.id);
 
             if (!this.changeAutorunInitialized) {
@@ -54,7 +54,7 @@ export default class MultiSelection extends React.Component<Props> {
                 return;
             }
 
-            if (equals(toJS(value), toJS(itemIds)) || this.selectionStore.loading) {
+            if (equals(toJS(value), toJS(itemIds))) {
                 return;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, autorun, observable, toJS} from 'mobx';
+import {action, autorun, observable, toJS, untracked} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import SingleItemSelection from '../../components/SingleItemSelection';
@@ -43,7 +43,7 @@ export default class SingleSelection extends React.Component<Props> {
 
         this.singleSelectionStore = new SingleSelectionStore(resourceKey, value, locale);
         this.changeDisposer = autorun(() => {
-            const {onChange, value} = this.props;
+            const {onChange, value} = untracked(() => this.props);
             const itemId = this.singleSelectionStore.item ? this.singleSelectionStore.item.id : undefined;
 
             if (!this.changeAutorunInitialized) {
@@ -51,7 +51,7 @@ export default class SingleSelection extends React.Component<Props> {
                 return;
             }
 
-            if (value === itemId || this.singleSelectionStore.loading) {
+            if (value === itemId) {
                 return;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, autorun, observable} from 'mobx';
+import {action, autorun, observable, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import SingleItemSelection from '../../components/SingleItemSelection';
@@ -64,10 +64,12 @@ export default class SingleSelection extends React.Component<Props> {
         this.changeDisposer();
     }
 
-    componentDidUpdate(prevProps: Props) {
-        const newValue = this.props.value;
-        if (prevProps.value !== newValue) {
-            this.singleSelectionStore.loadItem(newValue);
+    componentDidUpdate() {
+        const newId = toJS(this.props.value);
+        const loadedId = this.singleSelectionStore.item ? this.singleSelectionStore.item.id : undefined;
+
+        if (loadedId !== newId && !this.singleSelectionStore.loading) {
+            this.singleSelectionStore.loadItem(newId);
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -67,7 +67,7 @@ export default class SingleSelection extends React.Component<Props> {
         const newId = toJS(this.props.value);
         const loadedId = this.singleSelectionStore.item ? this.singleSelectionStore.item.id : undefined;
 
-        if (loadedId !== newId && !this.singleSelectionStore.loading) {
+        if (loadedId !== newId) {
             this.singleSelectionStore.loadItem(newId);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -39,20 +39,19 @@ export default class SingleSelection extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const {onChange, locale, resourceKey, value} = this.props;
+        const {locale, resourceKey, value} = this.props;
 
         this.singleSelectionStore = new SingleSelectionStore(resourceKey, value, locale);
         this.changeDisposer = autorun(() => {
-            const {value} = this.props;
-            const {item} = this.singleSelectionStore;
-            const itemId = item ? item.id : undefined;
+            const {onChange, value} = this.props;
+            const itemId = this.singleSelectionStore.item ? this.singleSelectionStore.item.id : undefined;
 
             if (!this.changeAutorunInitialized) {
                 this.changeAutorunInitialized = true;
                 return;
             }
 
-            if (value === itemId) {
+            if (value === itemId || this.singleSelectionStore.loading) {
                 return;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -272,3 +272,45 @@ test('Should remove an item when the remove button is clicked', () => {
     singleSelection.find('SingleItemSelection').prop('onRemove')();
     expect(singleSelection.instance().singleSelectionStore.clear).toBeCalledWith();
 });
+
+test('Should call the onChange callback if the value of the selection-store changes', () => {
+    const changeSpy = jest.fn();
+
+    const singleSelection = mount(
+        <SingleSelection
+            adapter="table"
+            disabledIds={[]}
+            displayProperties={[]}
+            emptyText="Nothing"
+            icon="su-test"
+            onChange={changeSpy}
+            overlayTitle="Test"
+            resourceKey="test"
+            value={3}
+        />
+    );
+
+    singleSelection.instance().singleSelectionStore.item = {id: 6};
+    expect(changeSpy).toBeCalledWith(6);
+});
+
+test('Should not call the onChange callback if the component props change', () => {
+    const changeSpy = jest.fn();
+
+    const singleSelection = mount(
+        <SingleSelection
+            adapter="table"
+            disabledIds={[]}
+            displayProperties={[]}
+            emptyText="Nothing"
+            icon="su-test"
+            onChange={changeSpy}
+            overlayTitle="Test"
+            resourceKey="test"
+            value={3}
+        />
+    );
+
+    singleSelection.setProps({emptyText: 'New Empty Text'});
+    expect(changeSpy).not.toBeCalled();
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -68,7 +68,7 @@ export default class MultiMediaSelection extends React.Component<Props> {
 
         newSelectedIds.sort();
         loadedSelectedIds.sort();
-        if (!equals(newSelectedIds, loadedSelectedIds) && !this.mediaSelectionStore.loading) {
+        if (!equals(newSelectedIds, loadedSelectedIds)) {
             this.mediaSelectionStore.loadSelectedMedia(newSelectedIds, locale);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -49,7 +49,7 @@ export default class MultiMediaSelection extends React.Component<Props> {
                 return;
             }
 
-            if (equals(toJS(value.ids), toJS(loadedMediaIds))) {
+            if (equals(toJS(value.ids), toJS(loadedMediaIds)) || this.mediaSelectionStore.loading) {
                 return;
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, autorun, toJS, observable} from 'mobx';
+import {action, autorun, toJS, observable, untracked} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import {MultiItemSelection} from 'sulu-admin-bundle/components';
@@ -41,7 +41,7 @@ export default class MultiMediaSelection extends React.Component<Props> {
 
         this.mediaSelectionStore = new MultiMediaSelectionStore(value.ids, locale);
         this.changeDisposer = autorun(() => {
-            const {onChange, value} = this.props;
+            const {onChange, value} = untracked(() => this.props);
             const loadedMediaIds = this.mediaSelectionStore.selectedMediaIds;
 
             if (!this.changeAutorunInitialized) {
@@ -49,7 +49,7 @@ export default class MultiMediaSelection extends React.Component<Props> {
                 return;
             }
 
-            if (equals(toJS(value.ids), toJS(loadedMediaIds)) || this.mediaSelectionStore.loading) {
+            if (equals(toJS(value.ids), toJS(loadedMediaIds))) {
                 return;
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js
@@ -17,6 +17,7 @@ jest.mock('../../MultiMediaSelectionOverlay', () => jest.fn(function() {
 jest.mock('../../../stores/MultiMediaSelectionStore', () => jest.fn(function() {
     this.selectedMedia = [];
     this.selectedMediaIds = [];
+    this.loadSelectedMedia = jest.fn();
 }));
 
 test('Render a MultiMediaSelection field', () => {
@@ -195,6 +196,17 @@ test('Should call the onChange handler if selection store changes', () => {
 
     mediaSelectionInstance.mediaSelectionStore.selectedMedia.splice(0, 1);
     expect(changeSpy).toBeCalledWith({ids: [99]});
+});
+
+test('Should not call the onChange callback if the component props change', () => {
+    const changeSpy = jest.fn();
+
+    const mediaSelection = shallow(
+        <MultiMediaSelection locale={observable.box('en')} onChange={changeSpy} value={{ids: [55]}} />
+    );
+
+    mediaSelection.setProps({disabled: true});
+    expect(changeSpy).not.toBeCalled();
 });
 
 test('Pass correct props to MultiItemSelection component', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -36,11 +36,11 @@ export default class SingleMediaSelection extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const {onChange, locale, value} = this.props;
+        const {locale, value} = this.props;
 
         this.singleMediaSelectionStore = new SingleMediaSelectionStore(value.id, locale);
         this.changeDisposer = autorun(() => {
-            const {value} = this.props;
+            const {onChange, value} = this.props;
             const loadedMediaId = this.singleMediaSelectionStore.selectedMediaId;
 
             if (!this.changeAutorunInitialized) {
@@ -48,7 +48,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
                 return;
             }
 
-            if (value.id === loadedMediaId) {
+            if (value.id === loadedMediaId || this.singleMediaSelectionStore.loading) {
                 return;
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -65,7 +65,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
         const newSelectedId = toJS(value.id);
         const loadedSelectedId = toJS(this.singleMediaSelectionStore.selectedMediaId);
 
-        if (loadedSelectedId !== newSelectedId && !this.singleMediaSelectionStore.loading) {
+        if (loadedSelectedId !== newSelectedId) {
             this.singleMediaSelectionStore.loadSelectedMedia(newSelectedId, locale);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -2,7 +2,7 @@
 import React, {Fragment} from 'react';
 import {observer} from 'mobx-react';
 import type {IObservableValue} from 'mobx';
-import {action, autorun, observable, toJS} from 'mobx';
+import {action, autorun, observable, toJS, untracked} from 'mobx';
 import SingleItemSelection from 'sulu-admin-bundle/components/SingleItemSelection';
 import {translate} from 'sulu-admin-bundle/utils/Translator';
 import SingleMediaSelectionStore from '../../stores/SingleMediaSelectionStore';
@@ -40,7 +40,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
 
         this.singleMediaSelectionStore = new SingleMediaSelectionStore(value.id, locale);
         this.changeDisposer = autorun(() => {
-            const {onChange, value} = this.props;
+            const {onChange, value} = untracked(() => this.props);
             const loadedMediaId = this.singleMediaSelectionStore.selectedMediaId;
 
             if (!this.changeAutorunInitialized) {
@@ -48,7 +48,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
                 return;
             }
 
-            if (value.id === loadedMediaId || this.singleMediaSelectionStore.loading) {
+            if (value.id === loadedMediaId) {
                 return;
             }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -65,7 +65,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
         const newSelectedId = toJS(value.id);
         const loadedSelectedId = toJS(this.singleMediaSelectionStore.selectedMediaId);
 
-        if (loadedSelectedId !== newSelectedId) {
+        if (loadedSelectedId !== newSelectedId && !this.singleMediaSelectionStore.loading) {
             this.singleMediaSelectionStore.loadSelectedMedia(newSelectedId, locale);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
@@ -138,6 +138,22 @@ test('Should call given onChange handler if value of selection store changes', (
     expect(changeSpy).toBeCalledWith({id: 77});
 });
 
+test('Should not call the onChange callback if the component props change', () => {
+    // $FlowFixMe
+    SingleMediaSelectionStore.mockImplementationOnce(function() {
+        this.loadSelectedMedia = jest.fn();
+    });
+
+    const changeSpy = jest.fn();
+
+    const singleMediaSelection = shallow(
+        <SingleMediaSelection locale={observable.box('en')} onChange={changeSpy} value={{id: 5}} />
+    );
+
+    singleMediaSelection.setProps({disabled: true});
+    expect(changeSpy).not.toBeCalled();
+});
+
 test('Correct props should be passed to SingleItemSelection component', () => {
     const singleMediaSelection = shallow(
         <SingleMediaSelection disabled={true} locale={observable.box('en')} onChange={jest.fn()} value={undefined} />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MultiMediaSelectionStore/MultiMediaSelectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MultiMediaSelectionStore/MultiMediaSelectionStore.js
@@ -37,24 +37,21 @@ export default class MultiMediaSelectionStore {
         return this.selectedMedia.map((media) => media.id);
     }
 
-    loadSelectedMedia = (selectedMediaIds: Array<number>, locale: IObservableValue<string>) => {
+    @action loadSelectedMedia = (selectedMediaIds: Array<number>, locale: IObservableValue<string>) => {
+        if (!selectedMediaIds || selectedMediaIds.length === 0) {
+            this.selectedMedia = [];
+            return;
+        }
+
         this.setLoading(true);
         return ResourceRequester.getList(MEDIA_RESOURCE_KEY, {
             locale: locale.get(),
             ids: selectedMediaIds.join(','),
             limit: undefined, // TODO: Should be replaced by pagination
             page: 1,
-        }).then((data) => {
-            const {
-                _embedded: {
-                    media,
-                },
-            } = data;
-
-            media.forEach((mediaItem) => {
-                this.add(mediaItem);
-            });
+        }).then(action((data) => {
+            this.selectedMedia = data._embedded[MEDIA_RESOURCE_KEY];
             this.setLoading(false);
-        });
+        }));
     };
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the selection components to not fire the given change-handler while their selection-store is loading.

#### Why?

The current implementation calls the given change handler two times when a selection component is created with an initial value. This is because the selection-store needs to load the data asynchronously and the change handler is fired automatically when the data is loaded.

The behaviour described above can be reproduced with the `contact-selection` on the *Page Settings* tab.