### PR TITLE
 added and implemented loading prop for single-item-selection component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import type {Node} from 'react';
 import Icon from '../Icon';
+import Loader from '../Loader/Loader';
 import singleItemSelectionStyles from './singleItemSelection.scss';
 import type {Button} from './types';
 
@@ -11,16 +12,18 @@ type Props = {|
     disabled: boolean,
     emptyText?: string,
     leftButton: Button,
+    loading: boolean,
     onRemove?: () => void,
 |};
 
 export default class SingleItemSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
+        loading: false,
     };
 
     render() {
-        const {children, disabled, emptyText, leftButton, onRemove} = this.props;
+        const {children, disabled, emptyText, leftButton, loading, onRemove} = this.props;
         const {icon, onClick} = leftButton;
 
         const singleItemSelectionClass = classNames(
@@ -49,7 +52,7 @@ export default class SingleItemSelection extends React.Component<Props> {
                             </div>
                         }
                     </div>
-                    {onRemove &&
+                    {onRemove && !loading &&
                         <button
                             className={singleItemSelectionStyles.removeButton}
                             disabled={disabled}
@@ -58,6 +61,9 @@ export default class SingleItemSelection extends React.Component<Props> {
                         >
                             <Icon name="su-trash-alt" />
                         </button>
+                    }
+                    {loading &&
+                        <Loader className={singleItemSelectionStyles.loader} size={14} />
                     }
                 </div>
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
@@ -59,9 +59,13 @@ $singleItemSelectionBorderRadius: 3px;
 
     .remove-button {
         border: 0;
-        padding: 0 10px;
+        margin: 0 10px;
         cursor: pointer;
         background-color: transparent;
+    }
+
+    .loader {
+        margin: 0 10px;
     }
 
     &.disabled {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -23,6 +23,17 @@ test('Render in disabled state', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in loading state', () => {
+    const leftButton = {
+        icon: 'su-document',
+        onClick: jest.fn(),
+    };
+
+    expect(render(
+        <SingleItemSelection leftButton={leftButton} loading={true}>Test Item</SingleItemSelection>
+    )).toMatchSnapshot();
+});
+
 test('Render with given onRemove prop', () => {
     const leftButton = {
         icon: 'su-page',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
@@ -26,6 +26,42 @@ exports[`Render in disabled state 1`] = `
 </div>
 `;
 
+exports[`Render in loading state 1`] = `
+<div
+  class="singleItemSelection"
+>
+  <button
+    class="button"
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      Test Item
+    </div>
+    <div
+      class="spinner loader"
+      style="width:14px;height:14px"
+    >
+      <div
+        class="doubleBounce1"
+      />
+      <div
+        class="doubleBounce2"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render with emptyText if no children have been passed 1`] = `
 <div
   class="singleItemSelection"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -110,8 +110,8 @@ export default class SingleSelection extends React.Component<Props> {
             overlayTitle,
             resourceKey,
         } = this.props;
+        const {item, loading} = this.singleSelectionStore;
         const columns = displayProperties.length;
-        const item = this.singleSelectionStore.item;
 
         return (
             <Fragment>
@@ -122,6 +122,7 @@ export default class SingleSelection extends React.Component<Props> {
                         icon,
                         onClick: this.handleOverlayOpen,
                     }}
+                    loading={loading}
                     onRemove={this.singleSelectionStore.item ? this.handleRemove : undefined}
                 >
                     {item &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -5,6 +5,7 @@ import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import SingleSelectionStore from '../../../stores/SingleSelectionStore';
 import SingleDatagridOverlay from '../../../containers/SingleDatagridOverlay';
 import SingleSelection from '../SingleSelection';
+import SingleItemSelection from '../../../components/SingleItemSelection';
 
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
@@ -27,6 +28,7 @@ jest.mock('../../../stores/SingleSelectionStore', () => jest.fn(function() {
 
     mockExtendObservable(this, {
         item: undefined,
+        loading: false,
     });
 }));
 
@@ -317,4 +319,41 @@ test('Should not call the onChange callback if the component props change', () =
 
     singleSelection.setProps({emptyText: 'New Empty Text'});
     expect(changeSpy).not.toBeCalled();
+});
+
+test('Correct props should be passed to SingleItemSelection component', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            disabled={true}
+            displayProperties={[]}
+            emptyText="nothing"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={1}
+        />
+    );
+
+    expect(singleSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
+    expect(singleSelection.find(SingleItemSelection).prop('emptyText')).toEqual('nothing');
+});
+
+test('Set loading prop of SingleItemSelection component if SingleSelectionStore is loading', () => {
+    const singleSelection = shallow(
+        <SingleSelection
+            adapter="table"
+            disabled={true}
+            displayProperties={[]}
+            emptyText="nothing"
+            onChange={jest.fn()}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+            value={1}
+        />
+    );
+
+    expect(singleSelection.find(SingleItemSelection).prop('loading')).toEqual(false);
+    singleSelection.instance().singleSelectionStore.loading = true;
+    expect(singleSelection.find(SingleItemSelection).prop('loading')).toEqual(true);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -105,6 +105,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
             locale,
         } = this.props;
         const {
+            loading,
             selectedMedia,
             selectedMediaId,
         } = this.singleMediaSelectionStore;
@@ -118,6 +119,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
                         icon: 'su-image',
                         onClick: this.handleOverlayOpen,
                     }}
+                    loading={loading}
                     onRemove={selectedMedia ? this.handleRemove : undefined}
                 >
                     {selectedMedia &&

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
@@ -161,3 +161,20 @@ test('Correct props should be passed to SingleItemSelection component', () => {
 
     expect(singleMediaSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
 });
+
+test('Set loading prop of SingleItemSelection component if SingleMediaSelectionStore is loading', () => {
+    // $FlowFixMe
+    SingleMediaSelectionStore.mockImplementationOnce(function() {
+        mockExtendObservable(this, {
+            loading: false,
+        });
+    });
+
+    const singleMediaSelection = shallow(
+        <SingleMediaSelection disabled={true} locale={observable.box('en')} onChange={jest.fn()} value={undefined} />
+    );
+
+    expect(singleMediaSelection.find(SingleItemSelection).prop('loading')).toEqual(false);
+    singleMediaSelection.instance().singleMediaSelectionStore.loading = true;
+    expect(singleMediaSelection.find(SingleItemSelection).prop('loading')).toEqual(true);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR introduces a `loading` prop for the `SingleItemSelection` component. If the `loading` prop is set to true, a loading icon ist displayed on the right side of the component.

Furthermore, the PR changes the `SingleSelection` component and the `SingleMediaSelection` component to use the introduced prop.

#### Why?

Because we want to signal to the user that the selection is loading. With the current implementation, it looks like the input field is empty while the component is loading. The current behaviour can be seen at the `contact-selection` on the **Page Settings** tab.

