### PR TITLE
load full item on select in single-selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -89,7 +89,8 @@ export default class SingleSelection extends React.Component<Props> {
     };
 
     handleOverlayConfirm = (selectedItem: Object) => {
-        this.singleSelectionStore.set(selectedItem);
+        // need to load the whole item as the object returned from the overlay may not contain all displayProperties
+        this.singleSelectionStore.loadItem(selectedItem.id);
         this.closeOverlay();
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -20,7 +20,9 @@ jest.mock('../../../stores/SingleSelectionStore', () => jest.fn(function() {
     this.set = jest.fn((item) => {
         this.item = item;
     });
-    this.loadItem = jest.fn();
+    this.loadItem = jest.fn((id) => {
+        this.item = {id};
+    });
     this.clear = jest.fn();
 
     mockExtendObservable(this, {
@@ -64,6 +66,7 @@ test('Render with selected item', () => {
     expect(SingleSelectionStore).toBeCalledWith('test', 3, locale);
 
     singleSelection.instance().singleSelectionStore.item = {
+        id: 3,
         name: 'Name',
         value: 'Value',
     };
@@ -92,6 +95,7 @@ test('Render with selected item in disabled state', () => {
     );
 
     singleSelection.instance().singleSelectionStore.item = {
+        id: 3,
         name: 'Name',
         value: 'Value',
     };
@@ -208,7 +212,7 @@ test('Should call the onChange callback if a new item was selected', () => {
     expect(singleSelection.find(SingleDatagridOverlay).prop('open')).toEqual(true);
 
     singleSelection.find(SingleDatagridOverlay).prop('onConfirm')({id: 6});
-    expect(singleSelection.instance().singleSelectionStore.set).toBeCalledWith({id: 6});
+    expect(singleSelection.instance().singleSelectionStore.loadItem).toBeCalledWith(6);
     expect(changeSpy).toBeCalledWith(6);
     singleSelection.update();
     expect(singleSelection.find(SingleDatagridOverlay).prop('open')).toEqual(false);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `SingleSelection`  component to load the whole item with a separate request after it was selected in the overlay.

#### Why?

Because the item returned from the overlay may not contain all properties that are used as `displayProperties`.