### PR TITLE
fix dirty state after saving empty ckeditor

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
@@ -54,7 +54,8 @@ export default class CKEditor5 extends React.Component<Props> {
                 this.editorInstance.element.classList.remove('disabled');
             }
 
-            if (this.editorInstance.getData() !== value) {
+            const editorData = this.getEditorData();
+            if (editorData !== value && !(value === '' && editorData === undefined)) {
                 this.editorInstance.setData(value);
             }
         }
@@ -130,8 +131,7 @@ export default class CKEditor5 extends React.Component<Props> {
                 if (onChange) {
                     modelDocument.on('change', () => {
                         if (modelDocument.differ.getChanges().length > 0) {
-                            const editorData = editor.getData();
-                            onChange(editorData === '<p>&nbsp;</p>' ? undefined : editorData);
+                            onChange(this.getEditorData());
                         }
                     });
                 }
@@ -145,6 +145,11 @@ export default class CKEditor5 extends React.Component<Props> {
         if (this.editorInstance) {
             this.editorInstance.destroy().then(() => this.editorInstance = null);
         }
+    }
+
+    getEditorData() {
+        const editorData = this.editorInstance.getData();
+        return editorData === '<p>&nbsp;</p>' ? undefined : editorData;
     }
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/tests/CKEditor5.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/tests/CKEditor5.test.js
@@ -31,6 +31,116 @@ test('Create a CKEditor5 instance', () => {
     expect(ClassicEditor.create).toBeCalled();
 });
 
+test('Set data on editor when value is updated', () => {
+    const editor = {
+        editing: {
+            view: {
+                document: {
+                    on: jest.fn(),
+                },
+            },
+        },
+        model: {
+            document: {
+                on: jest.fn(),
+            },
+        },
+        element: {
+            classList: {
+                add: jest.fn(),
+                remove: jest.fn(),
+            },
+        },
+        getData: jest.fn(),
+        setData: jest.fn(),
+    };
+
+    const editorPromise = Promise.resolve(editor);
+    ClassicEditor.create.mockReturnValue(editorPromise);
+
+    const ckeditor = mount(<CKEditor5 onBlur={jest.fn()} onChange={jest.fn()} value={undefined} />);
+
+    return editorPromise.then(() => {
+        ckeditor.setProps({value: '<p>Test</p>'});
+
+        expect(editor.setData).toBeCalledWith('<p>Test</p>');
+    });
+});
+
+test('Do not set data on editor when value is not changed when props change', () => {
+    const editor = {
+        editing: {
+            view: {
+                document: {
+                    on: jest.fn(),
+                },
+            },
+        },
+        model: {
+            document: {
+                on: jest.fn(),
+            },
+        },
+        element: {
+            classList: {
+                add: jest.fn(),
+                remove: jest.fn(),
+            },
+        },
+        getData: jest.fn().mockReturnValue('<p>Test</p>'),
+        setData: jest.fn(),
+    };
+
+    const editorPromise = Promise.resolve(editor);
+    ClassicEditor.create.mockReturnValue(editorPromise);
+
+    const ckeditor = mount(<CKEditor5 onBlur={jest.fn()} onChange={jest.fn()} value="<p>Test</p>" />);
+
+    return editorPromise.then(() => {
+        editor.setData.mockClear();
+        ckeditor.setProps({value: '<p>Test</p>'});
+
+        expect(editor.setData).not.toBeCalled();
+    });
+});
+
+test('Do not set data on editor when value and editorData is undefined', () => {
+    const editor = {
+        editing: {
+            view: {
+                document: {
+                    on: jest.fn(),
+                },
+            },
+        },
+        model: {
+            document: {
+                on: jest.fn(),
+            },
+        },
+        element: {
+            classList: {
+                add: jest.fn(),
+                remove: jest.fn(),
+            },
+        },
+        getData: jest.fn().mockReturnValue(),
+        setData: jest.fn(),
+    };
+
+    const editorPromise = Promise.resolve(editor);
+    ClassicEditor.create.mockReturnValue(editorPromise);
+
+    const ckeditor = mount(<CKEditor5 onBlur={jest.fn()} onChange={jest.fn()} value={undefined} />);
+
+    return editorPromise.then(() => {
+        editor.setData.mockClear();
+        ckeditor.setProps({});
+
+        expect(editor.setData).not.toBeCalled();
+    });
+});
+
 test('Set disabled class and isReadOnly property to CKEditor5', () => {
     const editor = {
         editing: {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes ----
| Related issues/PRs | #4254
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR fixes the handling of `undefined` in the ckeditor.

#### Why?

When a form included a CKEditor, which was empty and another field was changed and the form was saved, the save button stayed active, even though the form save was successful.