### PR TITLE
allow to delete content of properties in excerpt

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
@@ -118,7 +118,7 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
         foreach ($excerptStructure->getProperties() as $property) {
             $contentType = $this->contentTypeManager->get($property->getContentTypeName());
 
-            if (isset($data[$property->getName()])) {
+            if (array_key_exists($property->getName(), $data)) {
                 $property->setValue($data[$property->getName()]);
                 $contentType->write(
                     $node,

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/ExcerptControllerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Controller/ExcerptControllerTest.php
@@ -52,6 +52,28 @@ class ExcerptControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('published', $response);
     }
 
+    public function testPutWithNullValues()
+    {
+        $client = $this->createAuthenticatedClient();
+        $webspaceUuid = $this->session->getNode('/cmf/sulu_io/contents')->getIdentifier();
+
+        $client->request('PUT', '/api/page-excerpts/' . $webspaceUuid . '?locale=en&webspace=sulu_io', [
+            'title' => 'Excerpt Title',
+        ]);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+        $this->assertEquals('Excerpt Title', $response->title);
+
+        $client->request('PUT', '/api/page-excerpts/' . $webspaceUuid . '?locale=en&webspace=sulu_io', [
+            'title' => null,
+        ]);
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+        $this->assertEquals('', $response->title);
+    }
+
     public function testPutAndGetPublished()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to have `null` as a value in the `ExcerptExtension`.

#### Why?

Because it was not possible to remove e.g. the value of the title field in the excerpt tab. It just appeared again after saving.