### PR TITLE
Added easier way to overwrite public directory and base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
         "test": "jest",
         "styleguide": "styleguidist server",
         "styleguide:build": "styleguidist build",
-        "clean": "rimraf public/build/admin",
-        "build": "npm run clean && webpack -p",
-        "watch": "npm run clean && webpack -d -w"
+        "build": "webpack -p",
+        "watch": "webpack -d -w"
     },
     "dependencies": {
         "sulu-admin-bundle": "file:src/Sulu/Bundle/AdminBundle/Resources/js",

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -35,13 +35,21 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
     public function prepend(ContainerBuilder $container)
     {
         if ($container->hasExtension('framework')) {
+            $publicDir = 'public';
+
+            $composerFile = $container->getParameter('kernel.project_dir') . '/composer.json';
+            if (file_exists($composerFile)) {
+                $composerConfig = json_decode(file_get_contents($composerFile), true);
+                $publicDir = $composerConfig['extra']['public-dir'] ?? $publicDir;
+            }
+
             $container->prependExtensionConfig(
                 'framework',
                 [
                     'assets' => [
                         'packages' => [
                             'sulu_admin' => [
-                                'json_manifest_path' => '%kernel.project_dir%/public/build/admin/manifest.json',
+                                'json_manifest_path' => '%kernel.project_dir%/' . $publicDir . '/build/admin/manifest.json',
                             ],
                         ],
                     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
 /* eslint-disable import/no-nodejs-modules*/
 const path = require('path');
 const glob = require('glob');
+const rimraf = require('rimraf');
 const webpack = require('webpack');
 const CleanObsoleteChunksPlugin = require('webpack-clean-obsolete-chunks');
 const ManifestPlugin = require('webpack-manifest-plugin');
@@ -22,103 +23,123 @@ entries.unshift('core-js/fn/symbol');
 entries.unshift('whatwg-fetch');
 entries.unshift('url-search-params-polyfill');
 
-const basePath = 'build/admin';
+module.exports = (env, argv) => { // eslint-disable-line no-undef
+    let publicDir = 'public';
+    const basePath = env && env.base_path ? env.base_path : 'build/admin';
 
-module.exports = (env, argv) => ({ // eslint-disable-line no-undef
-    entry: entries,
-    output: {
-        path: path.resolve('public'),
-        filename: basePath + '/[name].[chunkhash].js',
-    },
-    devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
-    plugins: [
-        new webpack.DefinePlugin({
-            BUNDLE_ENTRIES_COUNT: entriesCount,
-        }),
-        new MiniCssExtractPlugin({
-            filename: basePath + '/[name].[chunkhash].css',
-        }),
-        new ManifestPlugin({
-            fileName: basePath + '/manifest.json',
-        }),
-        new CleanObsoleteChunksPlugin(),
-    ],
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                exclude: /node_modules/,
-                use: 'babel-loader',
-            },
-            {
-                test: /\.css/,
-                exclude: /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    'css-loader',
-                ],
-            },
-            {
-                test: /\.(scss)$/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    {
-                        loader: 'css-loader',
-                        options: {
-                            modules: true,
-                            importLoaders: 1,
-                            camelCase: true,
-                            localIdentName: '[local]--[hash:base64:10]',
-                        },
-                    },
-                    'postcss-loader',
-                ],
-            },
-            {
-                test: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
-                use: 'raw-loader',
-            },
-            {
-                test: /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/,
-                use: [
-                    MiniCssExtractPlugin.loader,
-                    {
-                        loader: 'css-loader',
-                    },
-                    {
-                        loader: 'postcss-loader',
-                        options: styles.getPostCssConfig({
-                            themeImporter: {
-                                themePath: require.resolve('@ckeditor/ckeditor5-theme-lark'),
-                            },
-                            minify: true,
-                        }),
-                    },
-                ],
-            },
-            {
-                test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
-                exclude: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
-                use: [
-                    {
-                        loader: 'file-loader',
-                        options: {
-                            name: '/' + basePath + '/fonts/[name].[hash].[ext]',
-                        },
-                    },
-                ],
-            },
-            {
-                test: /\.(jpg|gif|png)(\?.*$|$)/,
-                use: [
-                    {
-                        loader: 'file-loader',
-                        options: {
-                            name: '/' + basePath + '/images/[name].[hash].[ext]',
-                        },
-                    },
-                ],
-            },
+    // Read public dir from composer.json:
+    const composerConfig = require(path.resolve('composer.json')); // eslint-disable-line import/no-dynamic-require
+    if (composerConfig.extra && composerConfig.extra['public-dir']) {
+        publicDir = composerConfig.extra['public-dir'];
+    }
+
+    // Remove old build files
+    if (!publicDir.startsWith('/')) {
+        rimraf.sync(path.resolve(publicDir, basePath));
+    } else {
+        console.warn([ // eslint-disable-line no-console
+            'WARN: Using absolute path for "public-dir" detected',
+            '      This can end up in accidentally remove of files outside your project dir.',
+            '      Removing old build files was skipped!',
+        ].join('\n'));
+    }
+
+    return {
+        entry: entries,
+        output: {
+            path: path.resolve(publicDir),
+            filename: basePath + '/[name].[chunkhash].js',
+        },
+        devtool: argv.mode === 'development' ? 'eval-source-map' : 'source-map',
+        plugins: [
+            new webpack.DefinePlugin({
+                BUNDLE_ENTRIES_COUNT: entriesCount,
+            }),
+            new MiniCssExtractPlugin({
+                filename: basePath + '/[name].[chunkhash].css',
+            }),
+            new ManifestPlugin({
+                fileName: basePath + '/manifest.json',
+            }),
+            new CleanObsoleteChunksPlugin(),
         ],
-    },
-});
+        module: {
+            rules: [
+                {
+                    test: /\.js$/,
+                    exclude: /node_modules/,
+                    use: 'babel-loader',
+                },
+                {
+                    test: /\.css/,
+                    exclude: /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/,
+                    use: [
+                        MiniCssExtractPlugin.loader,
+                        'css-loader',
+                    ],
+                },
+                {
+                    test: /\.(scss)$/,
+                    use: [
+                        MiniCssExtractPlugin.loader,
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                modules: true,
+                                importLoaders: 1,
+                                camelCase: true,
+                                localIdentName: '[local]--[hash:base64:10]',
+                            },
+                        },
+                        'postcss-loader',
+                    ],
+                },
+                {
+                    test: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
+                    use: 'raw-loader',
+                },
+                {
+                    test: /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/,
+                    use: [
+                        MiniCssExtractPlugin.loader,
+                        {
+                            loader: 'css-loader',
+                        },
+                        {
+                            loader: 'postcss-loader',
+                            options: styles.getPostCssConfig({
+                                themeImporter: {
+                                    themePath: require.resolve('@ckeditor/ckeditor5-theme-lark'),
+                                },
+                                minify: true,
+                            }),
+                        },
+                    ],
+                },
+                {
+                    test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
+                    exclude: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
+                    use: [
+                        {
+                            loader: 'file-loader',
+                            options: {
+                                name: '/' + basePath + '/fonts/[name].[hash].[ext]',
+                            },
+                        },
+                    ],
+                },
+                {
+                    test: /\.(jpg|gif|png)(\?.*$|$)/,
+                    use: [
+                        {
+                            loader: 'file-loader',
+                            options: {
+                                name: '/' + basePath + '/images/[name].[hash].[ext]',
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,20 +9,6 @@ const ManifestPlugin = require('webpack-manifest-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const {styles} = require('@ckeditor/ckeditor5-dev-utils'); // eslint-disable-line import/no-extraneous-dependencies
 
-const entries = glob.sync(
-    path.resolve(__dirname, 'src/Sulu/Bundle/*/Resources/js/index.js') // eslint-disable-line no-undef
-);
-const entriesCount = entries.length;
-
-entries.unshift('core-js/fn/array/includes');
-entries.unshift('core-js/fn/array/find-index');
-entries.unshift('core-js/fn/array/fill');
-entries.unshift('core-js/fn/array/from');
-entries.unshift('core-js/fn/promise');
-entries.unshift('core-js/fn/symbol');
-entries.unshift('whatwg-fetch');
-entries.unshift('url-search-params-polyfill');
-
 module.exports = (env, argv) => { // eslint-disable-line no-undef
     let publicDir = 'public';
     const basePath = env && env.base_path ? env.base_path : 'build/admin';
@@ -37,7 +23,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
             '\x1b[31mUsing absolute path for \x1b[0m"public-dir"\x1b[31m detected',
             '       This can end up in accidentally remove of files outside your project dir.',
             '       Build was cancelled!\x1b[0m',
-            ''
+            '',
         ].join('\n');
 
         throw new Error(errorMessage);
@@ -45,6 +31,20 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
 
     // Remove old build files
     rimraf.sync(path.resolve(publicDir, basePath));
+
+    const entries = glob.sync(
+        path.resolve(__dirname, 'src/Sulu/Bundle/*/Resources/js/index.js') // eslint-disable-line no-undef
+    );
+    const entriesCount = entries.length;
+
+    entries.unshift('core-js/fn/array/includes');
+    entries.unshift('core-js/fn/array/find-index');
+    entries.unshift('core-js/fn/array/fill');
+    entries.unshift('core-js/fn/array/from');
+    entries.unshift('core-js/fn/promise');
+    entries.unshift('core-js/fn/symbol');
+    entries.unshift('whatwg-fetch');
+    entries.unshift('url-search-params-polyfill');
 
     return {
         entry: entries,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,22 +27,24 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
     let publicDir = 'public';
     const basePath = env && env.base_path ? env.base_path : 'build/admin';
 
-    // Read public dir from composer.json:
     const composerConfig = require(path.resolve('composer.json')); // eslint-disable-line import/no-dynamic-require
     if (composerConfig.extra && composerConfig.extra['public-dir']) {
         publicDir = composerConfig.extra['public-dir'];
     }
 
-    // Remove old build files
-    if (!publicDir.startsWith('/')) {
-        rimraf.sync(path.resolve(publicDir, basePath));
-    } else {
-        console.warn([ // eslint-disable-line no-console
-            'WARN: Using absolute path for "public-dir" detected',
-            '      This can end up in accidentally remove of files outside your project dir.',
-            '      Removing old build files was skipped!',
-        ].join('\n'));
+    if (publicDir.startsWith('/')) {
+        const errorMessage = [
+            '\x1b[31mUsing absolute path for \x1b[0m"public-dir"\x1b[31m detected',
+            '       This can end up in accidentally remove of files outside your project dir.',
+            '       Build was cancelled!\x1b[0m',
+            ''
+        ].join('\n');
+
+        throw new Error(errorMessage);
     }
+
+    // Remove old build files
+    rimraf.sync(path.resolve(publicDir, basePath));
 
     return {
         entry: entries,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs? | https://github.com/sulu/sulu/pull/4287, https://github.com/sulu/sulu-minimal/pull/141
| License | MIT

#### What's in this PR?

The basepath where to build the js should be easy overwriteable over env variables.
And the public-dir is read from the composer.json configuration see https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-public-directory.

#### Why?

In some cases you want to change the basepath where the js is build to.

#### Example Usage

```js
const webpackConfig = require('./vendor/sulu/sulu/webpack.config.js');

module.exports = (env, argv) => {
    if (!env) {
        env = {};
    }

    env.base_path = 'admin-build';

    return webpackConfig(env, argv);
};
```

and changing public dir in symfony:

```json
{
    ...
    "extra": {
        "public-dir": "web",
        "symfony-bin-dir": "bin"
    }
}
```

See https://github.com/sulu/sulu-docs/pull/410/files

#### BC Breaks/Deprecations

None

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/410
