### PR TITLE
implemented content-locale property in user store

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -26,7 +26,7 @@ class UserStore {
         this.resetSuccess = false;
     }
 
-    @computed get locale() {
+    @computed get systemLocale() {
         return this.user ? this.user.locale : Config.fallbackLocale;
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -6,13 +6,12 @@ import initializer from '../../services/Initializer';
 import localizationStore from '../LocalizationStore';
 import type {Contact, User} from './types';
 
-const CONTENT_LOCALE_SETTING_KEY = 'sulu_admin.user.content_locale';
-
 class UserStore {
     @observable persistentSettings: Map<string, string> = new Map();
 
     @observable user: ?User = undefined;
     @observable contact: ?Contact = undefined;
+    @observable userContentLocale: ?string = undefined;
 
     @observable loggedIn: boolean = false;
     @observable loading: boolean = false;
@@ -25,6 +24,7 @@ class UserStore {
         this.loading = false;
         this.user = undefined;
         this.contact = undefined;
+        this.userContentLocale = undefined;
         this.loginError = false;
         this.resetSuccess = false;
     }
@@ -34,17 +34,15 @@ class UserStore {
     }
 
     @computed get contentLocale() {
-        const userLocale = this.getPersistentSetting(CONTENT_LOCALE_SETTING_KEY);
-
-        if (!userLocale) {
-            localizationStore.loadLocalizations().then((localizations) => {
+        if (!this.userContentLocale) {
+            localizationStore.loadLocalizations().then(action((localizations) => {
                 const defaultLocalizations = localizations.filter((localization) => localization.default);
                 const fallbackLocalization = defaultLocalizations.length ? defaultLocalizations[0] : localizations[0];
-                this.setPersistentSetting(CONTENT_LOCALE_SETTING_KEY, fallbackLocalization.locale);
-            });
+                this.userContentLocale = fallbackLocalization.locale;
+            }));
         }
 
-        return userLocale ? userLocale : Config.fallbackLocale;
+        return this.userContentLocale ? this.userContentLocale : Config.fallbackLocale;
     }
 
     @action setLoggedIn(loggedIn: boolean) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -52,7 +52,7 @@ class UserStore {
         this.user = user;
 
         // TODO this code should be adjusted/removed when a proper content-locale handling is implemented
-        // load and use first (default) localization of first webspace of user as content-locale for the user
+        // load and use first (default) localization of first webspace as content-locale for the user
         localizationStore.loadLocalizations().then(action((localizations) => {
             const defaultLocalizations = localizations.filter((localization) => localization.default);
             const fallbackLocalization = defaultLocalizations.length ? defaultLocalizations[0] : localizations[0];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -11,7 +11,7 @@ class UserStore {
 
     @observable user: ?User = undefined;
     @observable contact: ?Contact = undefined;
-    @observable userContentLocale: ?string = undefined;
+    @observable contentLocale: string = Config.fallbackLocale;
 
     @observable loggedIn: boolean = false;
     @observable loading: boolean = false;
@@ -24,25 +24,12 @@ class UserStore {
         this.loading = false;
         this.user = undefined;
         this.contact = undefined;
-        this.userContentLocale = undefined;
         this.loginError = false;
         this.resetSuccess = false;
     }
 
     @computed get systemLocale() {
         return this.user ? this.user.locale : Config.fallbackLocale;
-    }
-
-    @computed get contentLocale() {
-        if (!this.userContentLocale) {
-            localizationStore.loadLocalizations().then(action((localizations) => {
-                const defaultLocalizations = localizations.filter((localization) => localization.default);
-                const fallbackLocalization = defaultLocalizations.length ? defaultLocalizations[0] : localizations[0];
-                this.userContentLocale = fallbackLocalization.locale;
-            }));
-        }
-
-        return this.userContentLocale ? this.userContentLocale : Config.fallbackLocale;
     }
 
     @action setLoggedIn(loggedIn: boolean) {
@@ -63,6 +50,14 @@ class UserStore {
 
     @action setUser(user: User) {
         this.user = user;
+
+        // TODO this code should be adjusted/removed when a proper content-locale handling is implemented
+        // load and use first (default) localization of first webspace of user as content-locale for the user
+        localizationStore.loadLocalizations().then(action((localizations) => {
+            const defaultLocalizations = localizations.filter((localization) => localization.default);
+            const fallbackLocalization = defaultLocalizations.length ? defaultLocalizations[0] : localizations[0];
+            this.contentLocale = fallbackLocalization ? fallbackLocalization.locale : this.contentLocale;
+        }));
     }
 
     @action setContact(contact: Contact) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -48,11 +48,11 @@ test('Should return the locale of the user', () => {
         username: 'test',
     });
 
-    expect(userStore.locale).toEqual('de');
+    expect(userStore.systemLocale).toEqual('de');
 });
 
 test('Should return the fallback locale if the user has none set', () => {
-    expect(userStore.locale).toEqual('en');
+    expect(userStore.systemLocale).toEqual('en');
 });
 
 test('Should set persistent setting', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -60,17 +60,17 @@ test('Should return the fallback locale as system-locale if the user has none se
     expect(userStore.systemLocale).toEqual('en');
 });
 
-test('Should return the persisted content-locale', () => {
-    userStore.setPersistentSetting('sulu_admin.user.content_locale', 'de');
+test('Should return the user-conent-locale as content-locale', () => {
+    userStore.userContentLocale = 'de';
     expect(userStore.contentLocale).toEqual('de');
 });
 
-test('Should return the fallback locale as content-locale if no content-locale is persisted', () => {
+test('Should return the fallback-locale as content-locale if no user-content-locale is not set', () => {
     LocalizationStore.loadLocalizations.mockReturnValueOnce(new Promise((resolve) => resolve([])));
     expect(userStore.contentLocale).toEqual('en');
 });
 
-test('Should persist first default-localization of localization-store as content-locale', () => {
+test('Should set first default-localization of localization-store as user-content-locale', () => {
     const localizationsPromise = new Promise((resolve) => resolve([
         {locale: 'cz', default: false},
         {locale: 'ru', default: true},
@@ -81,11 +81,11 @@ test('Should persist first default-localization of localization-store as content
     expect(userStore.contentLocale).toEqual('en');
 
     return localizationsPromise.then(() => {
-        expect(userStore.getPersistentSetting('sulu_admin.user.content_locale')).toEqual('ru');
+        expect(userStore.userContentLocale).toEqual('ru');
     });
 });
 
-test('Should persist first localization as content-locale if store does not return a default-localization', () => {
+test('Should set first localization as user-content-locale if store does not return a default-localization', () => {
     const localizationsPromise = new Promise((resolve) => resolve([
         {locale: 'cz', default: false},
         {locale: 'ru', default: false},
@@ -96,7 +96,7 @@ test('Should persist first localization as content-locale if store does not retu
     expect(userStore.contentLocale).toEqual('en');
 
     return localizationsPromise.then(() => {
-        expect(userStore.getPersistentSetting('sulu_admin.user.content_locale')).toEqual('cz');
+        expect(userStore.userContentLocale).toEqual('cz');
     });
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/UserStore';
-import {computed} from 'mobx';
+import {observable} from 'mobx';
 import MultiMediaSelection from '../../MultiMediaSelection';
 import type {Value} from '../../MultiMediaSelection';
 
@@ -18,7 +18,7 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
 
     render() {
         const {formInspector, disabled, value} = this.props;
-        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
         return (
             <MultiMediaSelection

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import userStore from 'sulu-admin-bundle/stores/UserStore';
+import {computed} from 'mobx';
 import MultiMediaSelection from '../../MultiMediaSelection';
 import type {Value} from '../../MultiMediaSelection';
 
@@ -16,12 +18,9 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
 
     render() {
         const {formInspector, disabled, value} = this.props;
-
-        if (!formInspector || !formInspector.locale) {
-            throw new Error('The media selection needs a locale to work properly');
-        }
-
-        const {locale} = formInspector;
+        const locale = formInspector && formInspector.locale
+            ? formInspector.locale
+            : computed(() => userStore.contentLocale);
 
         return (
             <MultiMediaSelection

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -18,9 +18,7 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
 
     render() {
         const {formInspector, disabled, value} = this.props;
-        const locale = formInspector && formInspector.locale
-            ? formInspector.locale
-            : computed(() => userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         return (
             <MultiMediaSelection

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -18,9 +18,7 @@ export default class SingleMediaSelection extends React.Component<FieldTypeProps
 
     render() {
         const {formInspector, disabled, value} = this.props;
-        const locale = formInspector && formInspector.locale
-            ? formInspector.locale
-            : computed(() => userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         return (
             <SingleMediaSelectionComponent

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import userStore from 'sulu-admin-bundle/stores/UserStore';
+import {computed} from 'mobx';
 import SingleMediaSelectionComponent from '../../SingleMediaSelection';
 import type {Value} from '../../SingleMediaSelection';
 
@@ -16,12 +18,9 @@ export default class SingleMediaSelection extends React.Component<FieldTypeProps
 
     render() {
         const {formInspector, disabled, value} = this.props;
-
-        if (!formInspector || !formInspector.locale) {
-            throw new Error('The media selection needs a locale to work properly');
-        }
-
-        const {locale} = formInspector;
+        const locale = formInspector && formInspector.locale
+            ? formInspector.locale
+            : computed(() => userStore.contentLocale);
 
         return (
             <SingleMediaSelectionComponent

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/UserStore';
-import {computed} from 'mobx';
+import {observable} from 'mobx';
 import SingleMediaSelectionComponent from '../../SingleMediaSelection';
 import type {Value} from '../../SingleMediaSelection';
 
@@ -18,7 +18,7 @@ export default class SingleMediaSelection extends React.Component<FieldTypeProps
 
     render() {
         const {formInspector, disabled, value} = this.props;
-        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
         return (
             <SingleMediaSelectionComponent

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -14,9 +14,7 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
         super(props);
 
         const {formInspector, value} = this.props;
-        const locale = formInspector && formInspector.locale
-            ? formInspector.locale
-            : computed(() => userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
 
         this.mediaUploadStore = new MediaUploadStore(
             value,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import userStore from 'sulu-admin-bundle/stores/UserStore';
+import {computed} from 'mobx';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 import SingleMediaUploadComponent from '../../SingleMediaUpload';
 import type {Media} from '../../../types';
@@ -12,12 +14,9 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
         super(props);
 
         const {formInspector, value} = this.props;
-
-        if (!formInspector || !formInspector.locale) {
-            throw new Error('The single media upload needs a locale to work properly');
-        }
-
-        const {locale} = formInspector;
+        const locale = formInspector && formInspector.locale
+            ? formInspector.locale
+            : computed(() => userStore.contentLocale);
 
         this.mediaUploadStore = new MediaUploadStore(
             value,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/UserStore';
-import {computed} from 'mobx';
+import {observable} from 'mobx';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 import SingleMediaUploadComponent from '../../SingleMediaUpload';
 import type {Media} from '../../../types';
@@ -14,12 +14,9 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
         super(props);
 
         const {formInspector, value} = this.props;
-        const locale = formInspector.locale ? formInspector.locale : computed(() => userStore.contentLocale);
+        const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
-        this.mediaUploadStore = new MediaUploadStore(
-            value,
-            locale
-        );
+        this.mediaUploadStore = new MediaUploadStore(value, locale);
     }
 
     handleUploadComplete = (media: Object) => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaUpload.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import {observable} from 'mobx';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 import SingleMediaUploadComponent from '../../SingleMediaUpload';
@@ -12,12 +11,17 @@ export default class SingleMediaUpload extends React.Component<FieldTypeProps<Me
     constructor(props: FieldTypeProps<Object>) {
         super(props);
 
-        const {value} = this.props;
+        const {formInspector, value} = this.props;
+
+        if (!formInspector || !formInspector.locale) {
+            throw new Error('The single media upload needs a locale to work properly');
+        }
+
+        const {locale} = formInspector;
 
         this.mediaUploadStore = new MediaUploadStore(
             value,
-            // TODO remove 'en' and determine language to upload
-            observable.box('en')
+            locale
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -25,6 +25,10 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+jest.mock('sulu-admin-bundle/stores/UserStore', () => ({
+    contentLocale: 'userContentLocale',
+}));
+
 test('Pass correct props to MultiMediaSelection component', () => {
     const formInspector = new FormInspector(
         new FormStore(
@@ -46,21 +50,22 @@ test('Pass correct props to MultiMediaSelection component', () => {
     expect(mediaSelection.find(MultiMediaSelection).props().value).toEqual({ids: [55, 66, 77]});
 });
 
-test('Should throw an error if locale is not present in form-inspector', () => {
+test('Pass content-locale of user to MultiMediaSelection if locale is not present in form-inspector', () => {
     const formInspector = new FormInspector(
         new FormStore(
-            new ResourceStore('test', undefined, {locale: undefined})
+            new ResourceStore('test', undefined, {})
         )
     );
 
-    expect(() => shallow(
+    const mediaSelection = shallow(
         <MediaSelection
             {...fieldTypeDefaultProps}
-            disabled={true}
             formInspector={formInspector}
             value={{ids: [55, 66, 77]}}
         />
-    )).toThrowError();
+    );
+
+    expect(mediaSelection.find(MultiMediaSelection).props().locale.get()).toEqual('userContentLocale');
 });
 
 test('Should call onChange and onFinish if the selection changes', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
@@ -25,6 +25,10 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+jest.mock('sulu-admin-bundle/stores/UserStore', () => ({
+    contentLocale: 'userContentLocale',
+}));
+
 test('Pass correct props to SingleMediaSelection component', () => {
     const formInspector = new FormInspector(
         new FormStore(
@@ -46,21 +50,23 @@ test('Pass correct props to SingleMediaSelection component', () => {
     expect(mediaSelection.find(SingleMediaSelectionComponent).props().value).toEqual({id: 33});
 });
 
-test('Should throw an error if locale is not present in form-inspector', () => {
+test('Pass content-locale of user to SingleMediaSelection if locale is not present in form-inspector', () => {
     const formInspector = new FormInspector(
         new FormStore(
-            new ResourceStore('test', undefined, {locale: undefined})
+            new ResourceStore('test', undefined, {})
         )
     );
 
-    expect(() => shallow(
+    const mediaSelection = shallow(
         <SingleMediaSelection
             {...fieldTypeDefaultProps}
             disabled={true}
             formInspector={formInspector}
-            value={{id: 55}}
+            value={{id: 33}}
         />
-    )).toThrowError();
+    );
+
+    expect(mediaSelection.find(SingleMediaSelectionComponent).props().locale.get()).toEqual('userContentLocale');
 });
 
 test('Should call onChange and onFinish if the selection changes', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
@@ -4,21 +4,29 @@ import {shallow} from 'enzyme';
 import {FormInspector, FormStore} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {fieldTypeDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
+import {observable} from 'mobx';
 import SingleMediaUpload from '../../fields/SingleMediaUpload';
 import SingleMediaUploadComponent from '../../../SingleMediaUpload';
 import MediaUploadStore from '../../../../stores/MediaUploadStore';
 
-jest.mock('sulu-admin-bundle/containers', () => ({
-    FormInspector: jest.fn(),
-    FormStore: jest.fn(),
+jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions) {
+    this.locale = observableOptions.locale;
 }));
 
-jest.mock('sulu-admin-bundle/stores', () => ({
-    ResourceStore: jest.fn(),
+jest.mock('sulu-admin-bundle/containers/Form/stores/FormStore', () => jest.fn(function(resourceStore) {
+    this.locale = resourceStore.locale;
+}));
+
+jest.mock('sulu-admin-bundle/containers/Form/FormInspector', () => jest.fn(function(formStore) {
+    this.locale = formStore.locale;
 }));
 
 test('Pass correct props', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {
         collection_id: {
             value: 3,
@@ -51,7 +59,11 @@ test('Pass correct props', () => {
 });
 
 test('Pass correct skin to props', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {
         collection_id: {
             value: 2,
@@ -73,7 +85,11 @@ test('Pass correct skin to props', () => {
 });
 
 test('Throw if emptyIcon is set but not a valid value', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {
         collection_id: {
             value: 2,
@@ -95,7 +111,11 @@ test('Throw if emptyIcon is set but not a valid value', () => {
 });
 
 test('Throw if skin is set but not a valid value', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {
         collection_id: {
             value: 2,
@@ -117,7 +137,11 @@ test('Throw if skin is set but not a valid value', () => {
 });
 
 test('Throw if image_size is set but not a valid value', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {
         collection_id: {
             value: 2,
@@ -139,7 +163,11 @@ test('Throw if image_size is set but not a valid value', () => {
 });
 
 test('Throw if collectionId is not set', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {};
 
     expect(
@@ -154,7 +182,11 @@ test('Throw if collectionId is not set', () => {
 });
 
 test('Call onChange and onFinish when upload has completed', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
     const media = {name: 'test.jpg'};
@@ -181,7 +213,11 @@ test('Call onChange and onFinish when upload has completed', () => {
 });
 
 test('Create a MediaUploadStore when constructed', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const schemaOptions = {
         collection_id: {
             value: 2,
@@ -200,11 +236,15 @@ test('Create a MediaUploadStore when constructed', () => {
 });
 
 test('Create a MediaUploadStore when constructed with data', () => {
-    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')})
+        )
+    );
     const data = {
         id: 1,
+        title: 'test title',
         mimeType: 'image/jpeg',
-        title: 'test_title',
         thumbnails: {},
         url: '',
     };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js
@@ -21,6 +21,10 @@ jest.mock('sulu-admin-bundle/containers/Form/FormInspector', () => jest.fn(funct
     this.locale = formStore.locale;
 }));
 
+jest.mock('sulu-admin-bundle/stores/UserStore', () => ({
+    contentLocale: 'userContentLocale',
+}));
+
 test('Pass correct props', () => {
     const formInspector = new FormInspector(
         new FormStore(
@@ -232,7 +236,31 @@ test('Create a MediaUploadStore when constructed', () => {
     );
 
     expect(singleMediaUpload.instance().mediaUploadStore).toBeInstanceOf(MediaUploadStore);
+    expect(singleMediaUpload.instance().mediaUploadStore.locale.get()).toEqual('en');
     expect(singleMediaUpload.instance().mediaUploadStore.media).toEqual(undefined);
+});
+
+test('Create MediaUploadStore with content-locale of user if locale is not present in form-inspector', () => {
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('test', undefined, {})
+        )
+    );
+    const schemaOptions = {
+        collection_id: {
+            value: 2,
+        },
+    };
+    const singleMediaUpload = shallow(
+        <SingleMediaUpload
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(singleMediaUpload.instance().mediaUploadStore).toBeInstanceOf(MediaUploadStore);
+    expect(singleMediaUpload.instance().mediaUploadStore.locale.get()).toEqual('userContentLocale');
 });
 
 test('Create a MediaUploadStore when constructed with data', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a dummy `contentLocale` property to the `UserStore`. The `contentLocale` defines the locale in which localized content should be displayed.

The implementation in this PR returns a `contentLocale` fallback value all the time. In the future, the `contentLocale` should be updated and persisted when the user changes the displayed locale of a localized content in the UI.

#### Why?

Because we need a standardized way to access the locale in which localized content should be displayed.
