### PR TITLE
implemented value prop for action component 

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Action.js
@@ -2,20 +2,22 @@
 import React from 'react';
 import actionStyles from './action.scss';
 
-type Props = {|
+type Props<T> = {|
     children: string,
-    onClick: () => void,
+    onClick: (value: T) => void,
     afterAction?: () => void,
+    value: T,
 |};
 
-export default class Action extends React.PureComponent<Props> {
+export default class Action<T> extends React.PureComponent<Props<T>> {
     handleButtonClick = () => {
         const {
             onClick,
             afterAction,
+            value,
         } = this.props;
 
-        onClick();
+        onClick(value);
 
         if (afterAction) {
             afterAction();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Action.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/Action.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {render, shallow} from 'enzyme';
 import React from 'react';
 import Action from '../Action';
@@ -17,4 +17,12 @@ test('The component should call the callbacks after a click', () => {
     action.find('button').simulate('click');
     expect(onClick).toBeCalled();
     expect(afterAction).toBeCalled();
+});
+
+test('The component should call the onClick callbacks with its value', () => {
+    const onClick = jest.fn();
+    const action = shallow(<Action onClick={onClick} value="my-value">My action</Action>);
+
+    action.find('button').simulate('click');
+    expect(onClick).toBeCalledWith('my-value');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/types.js
@@ -15,5 +15,5 @@ export type Skin = 'default' | 'flat' | 'dark';
 
 export type OptionSelectedVisualization = 'icon' | 'checkbox';
 
-export type SelectChild<T> = Element<Class<Option<T>>> | Element<Class<Select.Divider>> | Element<Class<Action>>;
+export type SelectChild<T> = Element<Class<Option<T>>> | Element<Class<Select.Divider>> | Element<Class<Action<*>>>;
 export type SelectChildren<T> = ChildrenArray<SelectChild<T>>;


### PR DESCRIPTION
…en onClick callback

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a `value` prop to the `Action` component. The given `value` is passed to the given `onClick` callback on click.

#### Why?

Because it might be useful to pass a value to the given `onClick`handler.