### PR TITLE
implemented valid prop in single-media-selection and single-item-selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -14,21 +14,24 @@ type Props = {|
     leftButton: Button,
     loading: boolean,
     onRemove?: () => void,
+    valid: boolean,
 |};
 
 export default class SingleItemSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         loading: false,
+        valid: true,
     };
 
     render() {
-        const {children, disabled, emptyText, leftButton, loading, onRemove} = this.props;
+        const {children, disabled, emptyText, leftButton, loading, onRemove, valid} = this.props;
         const {icon, onClick} = leftButton;
 
         const singleItemSelectionClass = classNames(
             singleItemSelectionStyles.singleItemSelection,
             {
+                [singleItemSelectionStyles.error]: !valid,
                 [singleItemSelectionStyles.disabled]: disabled,
             }
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/singleItemSelection.scss
@@ -8,6 +8,8 @@ $singleItemSelectionButtonBackgroundColor: $white;
 $singleItemSelectionButtonActiveBackgroundColor: $shakespeare;
 $singleItemSelectionEmptyColor: $silver;
 
+$singleItemSelectionErrorBorderColor: $persianRed;
+
 $singleItemSelectionDisabledColor: $gray;
 $singleItemSelectionDisabledBackgroundColor: $wildSand;
 
@@ -66,6 +68,17 @@ $singleItemSelectionBorderRadius: 3px;
 
     .loader {
         margin: 0 10px;
+    }
+
+    &.error {
+        .button {
+            border-color: $singleItemSelectionErrorBorderColor;
+        }
+
+        .item-container {
+            border-color: $singleItemSelectionErrorBorderColor;
+            border-left-color: $singleItemSelectionBorderColor;
+        }
     }
 
     &.disabled {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -34,6 +34,17 @@ test('Render in loading state', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in invalid state', () => {
+    const leftButton = {
+        icon: 'su-document',
+        onClick: jest.fn(),
+    };
+
+    expect(render(
+        <SingleItemSelection leftButton={leftButton} valid={false}>Test Item</SingleItemSelection>
+    )).toMatchSnapshot();
+});
+
 test('Render with given onRemove prop', () => {
     const leftButton = {
         icon: 'su-page',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
@@ -26,6 +26,31 @@ exports[`Render in disabled state 1`] = `
 </div>
 `;
 
+exports[`Render in invalid state 1`] = `
+<div
+  class="singleItemSelection error"
+>
+  <button
+    class="button"
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      Test Item
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render in loading state 1`] = `
 <div
   class="singleItemSelection"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -17,7 +17,7 @@ export default class SingleMediaSelection extends React.Component<FieldTypeProps
     };
 
     render() {
-        const {formInspector, disabled, value} = this.props;
+        const {formInspector, disabled, error, value} = this.props;
         const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
         return (
@@ -25,6 +25,7 @@ export default class SingleMediaSelection extends React.Component<FieldTypeProps
                 disabled={!!disabled}
                 locale={locale}
                 onChange={this.handleChange}
+                valid={!error}
                 value={value ? value : undefined}
             />
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
@@ -40,12 +40,14 @@ test('Pass correct props to SingleMediaSelection component', () => {
         <SingleMediaSelection
             {...fieldTypeDefaultProps}
             disabled={true}
+            error={{keyword: 'mandatory', parameters: {}}}
             formInspector={formInspector}
             value={{id: 33}}
         />
     );
 
     expect(mediaSelection.find(SingleMediaSelectionComponent).props().disabled).toEqual(true);
+    expect(mediaSelection.find(SingleMediaSelectionComponent).props().valid).toEqual(false);
     expect(mediaSelection.find(SingleMediaSelectionComponent).props().locale.get()).toEqual('en');
     expect(mediaSelection.find(SingleMediaSelectionComponent).props().value).toEqual({id: 33});
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -15,6 +15,7 @@ type Props = {|
     disabled: boolean,
     locale: IObservableValue<string>,
     onChange: (selectedIds: Value) => void,
+    valid: boolean,
     value: Value,
 |}
 
@@ -24,6 +25,7 @@ const THUMBNAIL_SIZE = 'sulu-25x25';
 export default class SingleMediaSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
+        valid: true,
         value: {id: undefined},
     };
 
@@ -103,6 +105,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
         const {
             disabled,
             locale,
+            valid,
         } = this.props;
         const {
             loading,
@@ -121,6 +124,7 @@ export default class SingleMediaSelection extends React.Component<Props> {
                     }}
                     loading={loading}
                     onRemove={selectedMedia ? this.handleRemove : undefined}
+                    valid={valid}
                 >
                     {selectedMedia &&
                         <div className={singleMediaSelectionStyle.mediaItem}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
@@ -156,10 +156,17 @@ test('Should not call the onChange callback if the component props change', () =
 
 test('Correct props should be passed to SingleItemSelection component', () => {
     const singleMediaSelection = shallow(
-        <SingleMediaSelection disabled={true} locale={observable.box('en')} onChange={jest.fn()} value={undefined} />
+        <SingleMediaSelection
+            disabled={true}
+            locale={observable.box('en')}
+            onChange={jest.fn()}
+            valid={false}
+            value={undefined}
+        />
     );
 
     expect(singleMediaSelection.find(SingleItemSelection).prop('disabled')).toEqual(true);
+    expect(singleMediaSelection.find(SingleItemSelection).prop('valid')).toEqual(false);
 });
 
 test('Set loading prop of SingleItemSelection component if SingleMediaSelectionStore is loading', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR implements a `valid` prop for the `SingleMediaSelection` component and the `SingleItemSelection` component. The `valid` prop works similar to the `valid` prop of other input components and can be used to signal a validation error.

#### Why?

Because we want need a way to signal to the user that the content of a `SingleMediaSelection` component is not valid.
