### PR TITLE
Properties are redundantly added on a document save

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Structure/ExcerptStructureExtension.php
@@ -247,6 +247,9 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
      */
     private function initProperties($locale)
     {
+        // Reset the properties before new initialization.
+        $this->properties = [];
+
         /** @var PropertyInterface $property */
         foreach ($this->getExcerptStructure($locale)->getProperties() as $property) {
             $this->properties[] = $property->getName();

--- a/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
@@ -51,7 +51,6 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
         'template',
         'changed',
         'changer',
-        'created',
         'creator',
         'created',
         'nodeType',
@@ -87,7 +86,7 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
         $this->extensionManager = $extensionManager;
         $this->languageNamespace = $languageNamespace;
 
-        $properties = array_merge($this->defaultProperties, $this->properties);
+        $properties = array_unique(array_merge($this->defaultProperties, $this->properties));
         $this->translatedProperties = new MultipleTranslatedProperties($properties, $this->languageNamespace);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

If you save a sulu document multiple properties where added that where just duplications.

#### Why?

We imported 1.500 nodes and got 7.000.000 properties.