### PR TITLE
Add warning message when try to install npm dependencies using yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ jobs:
       - image: circleci/node:10.9
     steps:
       - checkout
-      # Node
+      - run:
+            name: Check error for yarn install
+            command: tests/js/check-yarn-warning.sh
       - run: npm install
       - run: npm run lint:js
       - run: npm run lint:scss

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ composer.lock
 # npm
 package-lock.json
 /node_modules
+yarn.lock
 
 # phpunit
 .phpunit

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 ## dev-develop
 
+### Add sulu preinstall script to your package.json
+
+Sulu will check if the dependencies are correctly install in a preinstall script
+add this to your project `package.json`:
+
+```diff
+     "scripts": {
++        "preinstall": "node vendor/sulu/sulu/preinstall.js",
+```
+
 ### Type information of contacts
 
 The contacts have different sub entities, which are assigned in combination with a type (e.g. phone numbers, fax number,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu.git",
     "scripts": {
+        "preinstall": "node preinstall.js",
         "lint:js": "eslint .",
         "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
         "flow": "flow",

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,0 +1,5 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+if (process.env.npm_execpath.indexOf('npm') === -1) {
+    throw new Error('\x1b[31mYou must use "npm install", yarn is not supported\x1b[0m');
+}

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/preview.scss
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/preview.scss
@@ -1,4 +1,4 @@
-@import '../../../../../AdminBundle/Resources/js/containers/Application/colors.scss';
+@import 'sulu-admin-bundle/containers/Application/colors.scss';
 
 $previewBackgroundColor: $white;
 $toolbarHeight: 60px;

--- a/tests/js/check-yarn-warning.sh
+++ b/tests/js/check-yarn-warning.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+YARN_OUTPUT="$(yarn install 2>&1)"
+
+if [[ $YARN_OUTPUT == *"You must use \"npm install\", yarn is not supported"* ]]; then
+    exit 0
+fi
+
+exit 1

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* eslint-disable import/no-nodejs-modules*/
 const path = require('path');
-const glob = require('glob');
 const webpack = require('webpack');
 const CleanObsoleteChunksPlugin = require('webpack-clean-obsolete-chunks');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
@@ -19,9 +18,15 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
         publicDir = composerConfig.extra['public-dir'];
     }
 
-    const entries = glob.sync(
-        path.resolve(__dirname, 'src/Sulu/Bundle/*/Resources/js/index.js') // eslint-disable-line no-undef
-    );
+    const entries = [];
+
+    entries.unshift('sulu-admin-bundle');
+    entries.unshift('sulu-contact-bundle');
+    entries.unshift('sulu-media-bundle');
+    entries.unshift('sulu-page-bundle');
+    entries.unshift('sulu-preview-bundle');
+    entries.unshift('sulu-security-bundle');
+
     const entriesCount = entries.length;
 
     entries.unshift('core-js/fn/array/includes');
@@ -57,7 +62,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
             rules: [
                 {
                     test: /\.js$/,
-                    exclude: /node_modules/,
+                    exclude: /node_modules\/(?!(sulu-(.*)-bundle|@ckeditor|lodash-es)\/)/,
                     use: 'babel-loader',
                 },
                 {


### PR DESCRIPTION
# ~~Fix building sulu with yarn~~

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | https://github.com/sulu/sulu-minimal/pull/154
| License | MIT

#### What's in this PR?

~~Fix building sulu with yarn.~~

Add warning message when try to install npm dependencies using yarn 

#### Why?

~~If somebody want to use yarn to build sulu he should not end up with an error.~~

We will currently not supporting yarn because of yarn is not supporting symlinks:

#### Example Usage

~~~php
yarn install
~~~

> You must use npm to install, yarn is not supported

#### TODO

 - [x] Create sulu-minimal PR where adding preinstall.js