### PR TITLE
Floating problem in forms

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Switch/switch.scss
@@ -4,6 +4,7 @@ $marginBottom: 10px;
     display: flex;
     align-items: center;
     cursor: pointer;
+    height: 30px;
 
     & > div {
         font-size: 14px;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

The main problem is, that if a form field is higher than it's next sibling, the layout can break. (Example below)
This PR sets a fixed height of 30px to the checkbox component. But this doesn't fix the problem at all. Using flex instead of float would probably solve this problem, but this needs further discussion.

#### Why?

Imagine the following template:
```xml
<section name="test">
    <meta>
        <title>Test</title>
    </meta>

    <properties>
        <property name="text1" type="text_line" colspan="6">
            <meta>
                <title>Text 1</title>
            </meta>
        </property>

        <property name="check1" type="checkbox" colspan="6">
            <meta>
                <title>Checkbox 1</title>
            </meta>
        </property>

        <property name="check2" type="checkbox" colspan="6">
            <meta>
                <title>Checkbox 2</title>
            </meta>
        </property>
    </properties>
</section>
```

The result you would expect:
![image](https://user-images.githubusercontent.com/5758674/49523800-c6e7aa00-f8aa-11e8-9b53-31b857bdc39d.png)

But this is what you get:
![image](https://user-images.githubusercontent.com/5758674/49523819-cf3fe500-f8aa-11e8-85d3-07fbd5fd00e8.png)
