### PR TITLE
Added "datagrid_overlay" type to single_contact/single_account selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -63,7 +63,28 @@ export default class Selection extends React.Component<Props> {
     }
 
     @computed get type() {
-        return this.props.fieldTypeOptions.default_type;
+        const defaultType = this.props.fieldTypeOptions.default_type;
+        if (typeof defaultType !== 'string') {
+            throw new Error('The "default_type" field-type option must be a string!');
+        }
+
+        const {schemaOptions} = this.props;
+
+        if (!schemaOptions) {
+            return defaultType;
+        }
+
+        const {
+            type: {
+                value: type = defaultType,
+            } = {},
+        } = schemaOptions;
+
+        if (typeof type !== 'string') {
+            throw new Error('The "type" schema option must be a string!');
+        }
+
+        return type;
     }
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -30,7 +30,28 @@ export default class SingleSelection extends React.Component<Props>
     };
 
     @computed get type() {
-        return this.props.fieldTypeOptions.default_type;
+        const defaultType = this.props.fieldTypeOptions.default_type;
+        if (typeof defaultType !== 'string') {
+            throw new Error('The "default_type" field-type option must be a string!');
+        }
+
+        const {schemaOptions} = this.props;
+
+        if (!schemaOptions) {
+            return defaultType;
+        }
+
+        const {
+            type: {
+                value: type = defaultType,
+            } = {},
+        } = schemaOptions;
+
+        if (typeof type !== 'string') {
+            throw new Error('The "type" schema option must be a string!');
+        }
+
+        return type;
     }
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -96,6 +96,70 @@ test('Should pass props correctly to selection component', () => {
     }));
 });
 
+test('Should pass props with schema-options type correctly to selection component', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'snippets',
+        types: {
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['id', 'title'],
+                icon: '',
+                label: 'sulu_snippet.selection_label',
+                overlay_title: 'sulu_snippet.selection_overlay_title',
+            },
+            auto_complete: {
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+
+    const schemaOptions = {
+        type: {
+            name: 'type',
+            value: 'datagrid_overlay',
+        },
+    };
+
+    const locale = observable.box('en');
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1, {locale})
+        )
+    );
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            onFinish={jest.fn()}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    );
+
+    expect(translate).toBeCalledWith('sulu_snippet.selection_label', {count: 3});
+
+    expect(selection.find('MultiSelection').props()).toEqual(expect.objectContaining({
+        adapter: 'table',
+        disabled: true,
+        displayProperties: ['id', 'title'],
+        label: 'sulu_snippet.selection_label',
+        locale,
+        resourceKey: 'snippets',
+        overlayTitle: 'sulu_snippet.selection_overlay_title',
+        value,
+    }));
+});
+
 test('Should pass id of form as disabledId to overlay type to avoid assigning something to itself', () => {
     const fieldTypeOptions = {
         default_type: 'datagrid_overlay',
@@ -404,6 +468,152 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         searchProperties: ['name'],
         value,
     }));
+});
+
+test('Should pass props with schema-options type correctly to MultiAutoComplete component', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'datagrid_overlay',
+        resource_key: 'snippets',
+        types: {
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['id', 'title'],
+                icon: '',
+                label: 'sulu_snippet.selection_label',
+                overlay_title: 'sulu_snippet.selection_overlay_title',
+            },
+            auto_complete: {
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+
+    const locale = observable.box('en');
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1, {locale})
+        )
+    );
+
+    const schemaOptions = {
+        type: {
+            name: 'type',
+            value: 'auto_complete',
+        },
+    };
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    );
+
+    expect(selection.find('MultiAutoComplete').props()).toEqual(expect.objectContaining({
+        allowAdd: false,
+        disabled: true,
+        displayProperty: 'name',
+        filterParameter: 'names',
+        idProperty: 'uuid',
+        locale,
+        resourceKey: 'snippets',
+        searchProperties: ['name'],
+        value,
+    }));
+});
+
+test('Throw an error if a none string was passed to schema-options', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'datagrid_overlay',
+        resource_key: 'snippets',
+        types: {
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['id', 'title'],
+                icon: '',
+                label: 'sulu_snippet.selection_label',
+                overlay_title: 'sulu_snippet.selection_overlay_title',
+            },
+        },
+    };
+
+    const locale = observable.box('en');
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1, {locale})
+        )
+    );
+
+    const schemaOptions = {
+        type: {
+            name: 'type',
+            value: true,
+        },
+    };
+
+    expect(
+        () => shallow(
+            <Selection
+                {...fieldTypeDefaultProps}
+                disabled={true}
+                fieldTypeOptions={fieldTypeOptions}
+                formInspector={formInspector}
+                schemaOptions={schemaOptions}
+                value={value}
+            />
+        )
+    ).toThrow(/"type"/);
+});
+
+test('Throw an error if a none string was passed to field-type-options', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: true,
+        resource_key: 'snippets',
+        types: {
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['id', 'title'],
+                icon: '',
+                label: 'sulu_snippet.selection_label',
+                overlay_title: 'sulu_snippet.selection_overlay_title',
+            },
+        },
+    };
+
+    const locale = observable.box('en');
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1, {locale})
+        )
+    );
+
+    expect(
+        () => shallow(
+            <Selection
+                {...fieldTypeDefaultProps}
+                disabled={true}
+                fieldTypeOptions={fieldTypeOptions}
+                formInspector={formInspector}
+                value={value}
+            />
+        )
+    ).toThrow(/"default_type"/);
 });
 
 test('Should pass allowAdd prop to MultiAutoComplete component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -70,6 +70,57 @@ test('Pass correct props to SingleAutoComplete', () => {
     }));
 });
 
+test('Pass correct props with schema-options type to SingleAutoComplete', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const value = {
+        test: 'value',
+    };
+
+    const fieldTypeOptions = {
+        default_type: 'datagrid_overlay',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['name'],
+                empty_text: 'sulu_contact.nothing',
+                icon: 'su-account',
+                overlay_title: 'sulu_contact.overlay_title',
+            },
+        },
+    };
+
+    const schemaOptions = {
+        type: {
+            name: 'type',
+            value: 'auto_complete',
+        },
+    };
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    );
+
+    expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
+        disabled: true,
+        displayProperty: 'name',
+        resourceKey: 'accounts',
+        searchProperties: ['name', 'number'],
+        value,
+    }));
+});
+
 test('Call onChange and onFinish when SingleAutoComplete changes', () => {
     const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
     const changeSpy = jest.fn();
@@ -164,6 +215,123 @@ test('Pass correct props to SingleItemSelection', () => {
         resourceKey: 'accounts',
         value,
     }));
+});
+
+test('Pass correct props with schema-options type to SingleItemSelection', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const value = 3;
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['name'],
+                empty_text: 'sulu_contact.nothing',
+                icon: 'su-account',
+                overlay_title: 'sulu_contact.overlay_title',
+            },
+        },
+    };
+
+    const schemaOptions = {
+        type: {
+            name: 'type',
+            value: 'datagrid_overlay',
+        },
+    };
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    );
+
+    expect(singleSelection.find(SingleSelectionComponent).props()).toEqual(expect.objectContaining({
+        adapter: 'table',
+        disabled: true,
+        disabledIds: [],
+        displayProperties: ['name'],
+        emptyText: 'sulu_contact.nothing',
+        icon: 'su-account',
+        overlayTitle: 'sulu_contact.overlay_title',
+        resourceKey: 'accounts',
+        value,
+    }));
+});
+
+test('Throw an error if a none string was passed to schema-options', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const value = 3;
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+        },
+    };
+
+    const schemaOptions = {
+        type: {
+            name: 'type',
+            value: true,
+        },
+    };
+
+    expect(
+        () => shallow(
+            <SingleSelection
+                {...fieldTypeDefaultProps}
+                disabled={true}
+                fieldTypeOptions={fieldTypeOptions}
+                formInspector={formInspector}
+                schemaOptions={schemaOptions}
+                value={value}
+            />
+        )
+    ).toThrow(/"type"/);
+});
+
+test('Throw an error if a none string was passed to field-type-options', () => {
+    const formInspector = new FormInspector(new FormStore(new ResourceStore('test')));
+    const value = 3;
+
+    const fieldTypeOptions = {
+        default_type: true,
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+        },
+    };
+
+    expect(
+        () => shallow(
+            <SingleSelection
+                {...fieldTypeDefaultProps}
+                disabled={true}
+                fieldTypeOptions={fieldTypeOptions}
+                formInspector={formInspector}
+                value={value}
+            />
+        )
+    ).toThrow(/"default_type"/);
 });
 
 test('Pass correct locale and disabledIds to SingleItemSelection', () => {

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -98,6 +98,13 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                                         'display_property' => 'name',
                                         'search_properties' => ['number', 'name'],
                                     ],
+                                    'datagrid_overlay' => [
+                                        'adapter' => 'table',
+                                        'display_properties' => ['number', 'name'],
+                                        'empty_text' => 'sulu_contact.no_account_selected',
+                                        'icon' => 'su-add',
+                                        'overlay_title' => 'sulu_contact.single_account_selection_overlay_title',
+                                    ],
                                 ],
                             ],
                             'single_contact_selection' => [
@@ -109,7 +116,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                                         'display_properties' => ['fullName'],
                                         'empty_text' => 'sulu_contact.no_contact_selected',
                                         'icon' => 'su-user',
-                                        'overlay_title' => 'sulu_contact.single_selection_overlay_title',
+                                        'overlay_title' => 'sulu_contact.single_contact_selection_overlay_title',
                                     ],
                                 ],
                             ],

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -100,9 +100,9 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                                     ],
                                     'datagrid_overlay' => [
                                         'adapter' => 'table',
-                                        'display_properties' => ['number', 'name'],
+                                        'display_properties' => ['name'],
                                         'empty_text' => 'sulu_contact.no_account_selected',
-                                        'icon' => 'su-add',
+                                        'icon' => 'su-house',
                                         'overlay_title' => 'sulu_contact.single_account_selection_overlay_title',
                                     ],
                                 ],

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -42,6 +42,6 @@
     "sulu_contact.upload_logo_info_text": "Bild ablegen oder klicken um das Logo zu ändern",
     "sulu_contact.no_contact_selected": "Kein Kontakt ausgewählt",
     "sulu_contact.single_contact_selection_overlay_title": "Kontakt auswählen",
-    "sulu_contact.no_accounnt_selected": "Keine Organisation ausgewählt",
+    "sulu_contact.no_account_selected": "Keine Organisation ausgewählt",
     "sulu_contact.single_account_selection_overlay_title": "Organisation auswählen"
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -41,5 +41,7 @@
     "sulu_contact.upload_avatar_info_text": "Bild ablegen oder klicken um den Avatar zu ändern",
     "sulu_contact.upload_logo_info_text": "Bild ablegen oder klicken um das Logo zu ändern",
     "sulu_contact.no_contact_selected": "Kein Kontakt ausgewählt",
-    "sulu_contact.single_selection_overlay_title": "Kontakt auswählen"
+    "sulu_contact.single_contact_selection_overlay_title": "Kontakt auswählen",
+    "sulu_contact.no_accounnt_selected": "Keine Organisation ausgewählt",
+    "sulu_contact.single_account_selection_overlay_title": "Organisation auswählen"
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
@@ -41,5 +41,7 @@
     "sulu_contact.upload_avatar_info_text": "Drop image or click to change avatar",
     "sulu_contact.upload_logo_info_text": "Drop image or click to change logo",
     "sulu_contact.no_contact_selected": "No contact selected",
-    "sulu_contact.single_selection_overlay_title": "Choose contact"
+    "sulu_contact.single_contact_selection_overlay_title": "Choose contact",
+    "sulu_contact.no_account_selected": "No account selected",
+    "sulu_contact.single_account_selection_overlay_title": "Choose account"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a second type of single selection for account.

#### To Do

- [x] Allow setting the type over params