### PR TITLE
Fixed getProperties on null

### DIFF
--- a/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
+++ b/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
@@ -179,6 +179,9 @@ class ManagedStructure extends Structure
     {
         $this->init();
         $values = [];
+        if (is_null($this->structureMetadata)) {
+            return $values;
+        }
         foreach (array_keys($this->structureMetadata->getProperties()) as $childName) {
             $values[$childName] = $this->normalize($this->getProperty($childName)->getValue());
         }


### PR DESCRIPTION
Fixes a bug, where sulu backend would break, if you mess around with snippets during developement.

| Q | A
| --- | ---
| Bug fix? | Yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Contains a fix for sulu backend snippet handling.

#### Why?

Fixes a bug, where sulu backend would break, if you have added a snippet of a certain type and then remove this type (e.g.: For developement purposes)
