### PR TITLE
Parse input value not strictly matching time format in DatePicker component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -102,6 +102,14 @@ export default class DatePicker extends React.Component<Props> {
 
     handleInputBlur = () => {
         if (this.inputChanged && typeof this.value === 'string') {
+            const fieldOptions = this.getFieldOptions(this.props.options);
+            const currentMoment = moment(this.value, this.getPlaceholder(fieldOptions));
+
+            if (currentMoment.isValid()) {
+                this.handleChange(currentMoment.toDate());
+                return;
+            }
+
             this.handleChange(undefined);
         }
     };
@@ -134,6 +142,15 @@ export default class DatePicker extends React.Component<Props> {
         return placeholderTime;
     };
 
+    getFieldOptions(options: Object) {
+        return {
+            closeOnSelect: true,
+            timeFormat: false,
+            dateFormat: moment.localeData().longDateFormat('L'),
+            ...options,
+        };
+    }
+
     renderInput = (props: Object) => {
         const handleInputChange = this.getInputChange(props);
 
@@ -156,12 +173,7 @@ export default class DatePicker extends React.Component<Props> {
     render() {
         const {disabled, options, placeholder, valid} = this.props;
 
-        const fieldOptions = {
-            closeOnSelect: true,
-            timeFormat: false,
-            dateFormat: moment.localeData().longDateFormat('L'),
-            ...options,
-        };
+        const fieldOptions = this.getFieldOptions(options);
 
         const inputProps = {
             placeholder: placeholder ? placeholder : this.getPlaceholder(fieldOptions),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -20,7 +20,6 @@ type Props = {|
     onChange: (value: ?Date) => void,
     /** Configure the datepicker to your needs, for more information have a look in the README.md */
     options: {
-        [any]: any,
         dateFormat?: ?string | boolean,
         timeFormat?: ?string | boolean,
     },
@@ -128,20 +127,20 @@ export default class DatePicker extends React.Component<Props> {
     };
 
     getDateFormat = (): string => {
-        let dateFormat = this.props.options.dateFormat;
+        const dateFormat = this.props.options.dateFormat;
 
         if ((!dateFormat && dateFormat !== false) || dateFormat === true || (!dateFormat && !this.getTimeFormat())) {
-            dateFormat = moment.localeData().longDateFormat('L');
+            return moment.localeData().longDateFormat('L') || '';
         }
 
         return dateFormat || '';
     };
 
     getTimeFormat = (): string => {
-        let timeFormat = this.props.options.timeFormat;
+        const timeFormat = this.props.options.timeFormat;
 
         if (timeFormat === true) {
-            timeFormat = moment.localeData().longDateFormat('LT');
+            return moment.localeData().longDateFormat('LT') || '';
         }
 
         return timeFormat || '';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
@@ -69,19 +69,23 @@ test('DatePicker should try to guess incomplete value using format on blur.', ()
     };
     const datePicker = mount(<DatePicker onChange={onChangeCallback} options={options} value={null} />);
 
-    const target = {
+    const eventTarget = {
         value: '9',
     };
 
-    datePicker.find('input').at(0).simulate('change', {target, currentTarget: target});
+    datePicker.find('input').at(0).simulate('change', {target: eventTarget, currentTarget: eventTarget});
     datePicker.find('input').at(0).simulate('blur');
 
     expect(onChangeCallback).toBeCalledWith(expect.any(Date));
 
     const date = onChangeCallback.mock.calls[0][0];
 
-    expect(date && date.getHours()).toBe(9);
-    expect(date && date.getMinutes()).toBe(0);
+    const expectedMoment = moment('09:00', options.timeFormat);
+    expect(expectedMoment.isValid()).toBe(true);
+
+    const expectedDate = expectedMoment.toDate();
+    expect(date && date.getHours()).toBe(expectedDate.getHours());
+    expect(date && date.getMinutes()).toBe(expectedDate.getMinutes());
 });
 
 test('DatePicker should render null value as empty string', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/tests/DatePicker.test.js
@@ -61,6 +61,29 @@ test('DatePicker should render with value', () => {
     expect(datePicker.render()).toMatchSnapshot();
 });
 
+test('DatePicker should try to guess incomplete value using format on blur.', () => {
+    const onChangeCallback = jest.fn();
+    const options = {
+        dateFormat: false,
+        timeFormat: 'HH:mm',
+    };
+    const datePicker = mount(<DatePicker onChange={onChangeCallback} options={options} value={null} />);
+
+    const target = {
+        value: '9',
+    };
+
+    datePicker.find('input').at(0).simulate('change', {target, currentTarget: target});
+    datePicker.find('input').at(0).simulate('blur');
+
+    expect(onChangeCallback).toBeCalledWith(expect.any(Date));
+
+    const date = onChangeCallback.mock.calls[0][0];
+
+    expect(date && date.getHours()).toBe(9);
+    expect(date && date.getMinutes()).toBe(0);
+});
+
 test('DatePicker should render null value as empty string', () => {
     const onChange = jest.fn();
     const datePicker = mount(<DatePicker onChange={onChange} value={null} />);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

This PR adds the functionality to the DatePicker component to enter e.g. "9" in a date picker field with format "HH:mm". Previously the DatePicker component called the onChange callback with undefined then, now it tries to parse that string.