### PR TITLE
Allow empty image formats configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * ENHANCEMENT #4319 [MediaBundle]           Added possibility to have a image format configuration file without formats
+
 * 1.5.19 (2018-12-03)
     * HOTFIX      #4304 [DocumentManager]       Fix performance issue by removing redundant properties on Metadata
     * HOTFIX      #4263 [Content]               Fix param default value

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/schema/formats/formats-1.1.xsd
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/schema/formats/formats-1.1.xsd
@@ -6,7 +6,7 @@
 
     <xs:complexType name="formatsType">
         <xs:sequence>
-            <xs:element name="format" type="formatType" maxOccurs="unbounded"/>
+            <xs:element name="format" type="formatType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetTypesController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetTypesController.php
@@ -68,11 +68,13 @@ class SnippetTypesController extends Controller implements ClassResourceInterfac
                 $template['defaultTitle'] = $default ? $default->getTitle() : null;
             }
 
-            $templates[] = $template;
+            $templates[$type->getKey()] = $template;
         }
 
+        ksort($templates);
+
         $data = [
-            '_embedded' => $templates,
+            '_embedded' => array_values($templates),
             'total' => count($templates),
         ];
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related PRs | sulu/sulu-minimal#143
| License | MIT

#### What's in this PR?

Allow empty image formats configuration.

#### Why?

To provide an example image-formats.xml

#### Example Usage

~~~php
<?xml version="1.0" encoding="UTF-8"?>
<formats xmlns="http://schemas.sulu.io/media/formats"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">

    <!-- Fixed width and dynamic height
    <format key="300x">
        <scale x="300"/>
    </format>
    -->
</formats>

~~~

