### PR TITLE
Add apiOptions-option to form-view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -67,6 +67,7 @@ class Form extends React.Component<Props> {
                 options: {
                     idQueryParameter,
                     resourceKey,
+                    apiOptions,
                     routerAttributesToFormStore,
                 },
             },
@@ -80,15 +81,12 @@ class Form extends React.Component<Props> {
             );
         }
 
-        const formStoreOptions = routerAttributesToFormStore
-            ? routerAttributesToFormStore.reduce(
-                (options: Object, routerAttribute: string) => {
-                    options[routerAttribute] = attributes[routerAttribute];
-                    return options;
-                },
-                {}
-            )
-            : {};
+        const formStoreOptions = apiOptions ? apiOptions : {};
+        if (routerAttributesToFormStore) {
+            routerAttributesToFormStore.forEach((routerAttribute) => {
+                formStoreOptions[routerAttribute] = attributes[routerAttribute];
+            });
+        }
 
         if (this.hasOwnResourceStore) {
             let locale = resourceStore.locale;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/README.md
@@ -4,6 +4,8 @@ should be shown in the toolbar and an instance of the `ResourceStore`, which all
 
 | Option                      | Description                                                                           |
 |-----------------------------|---------------------------------------------------------------------------------------|
+| apiOptions                  | Object that contains attributes that are passed to the `FormStore`. The attributes    |
+|                             | will be appended to the requests sent from the `FormStore`                            |
 | backRoute                   | The route to which the user will be navigate when the back button is clicked.         |
 | editRoute                   | The optional route to which the user will be redirected after the form is saved.      |
 | idQueryParameter            | If used the data will be loaded initially from the API by appending this parameter    |
@@ -13,7 +15,7 @@ should be shown in the toolbar and an instance of the `ResourceStore`, which all
 | resourceStore               | The store which allows to save and load data from the given type of resources         |
 | resourceKey                 | Can be set to use another resourceStore than the one being already passed, e.g. for   |
 |                             | forms depending on both stores.                                                       |
-| routerAttributesToFormStore | Defines which attributes from the [`Router`](#router) are passed to the FormStore.    |
+| routerAttributesToFormStore | Defines which attributes from the [`Router`](#router) are passed to the `FormStore`.  |
 |                             | They will be appended with the same name as in the router to the requests sent from   |
 |                             | the `FormStore`, e.g. for saving the form.                                            |
 | toolbarAction               | Defines which items registered in the `ToolbarActionRegistry` should be shown in this |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -941,6 +941,119 @@ test('Should save form when submitted with mapped router attributes', (done) => 
     jsonSchemaResolve({});
 });
 
+test('Should save form when submitted with given apiOptions', (done) => {
+    const ResourceRequester = require('../../../services/ResourceRequester');
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const metadataStore = require('../../../containers/Form/stores/MetadataStore');
+    const resourceStore = new ResourceStore('snippets', 8, {locale: observable.box()});
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const schemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+
+    let jsonSchemaResolve;
+    const jsonSchemaPromise = new Promise((resolve) => {
+        jsonSchemaResolve = resolve;
+    });
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+
+    const route = {
+        options: {
+            locales: [],
+            apiOptions: {apiKey: 'api-option-value'},
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+        attributes: {
+            id: 8,
+        },
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    resourceStore.locale.set('en');
+    resourceStore.data = {value: 'Value'};
+    resourceStore.loading = false;
+    resourceStore.destroy = jest.fn();
+
+    Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
+        jsonSchemaPromise.then(() => {
+            form.find('Form').at(1).instance().submit();
+            expect(resourceStore.destroy).not.toBeCalled();
+            expect(ResourceRequester.put)
+                .toBeCalledWith('snippets', 8, {value: 'Value'}, {locale: 'en', apiKey: 'api-option-value'});
+            done();
+        });
+    });
+
+    jsonSchemaResolve({});
+});
+
+test('Should save form when submitted with mapped router attributes and given apiOptions', (done) => {
+    const ResourceRequester = require('../../../services/ResourceRequester');
+    ResourceRequester.put.mockReturnValue(Promise.resolve({}));
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const metadataStore = require('../../../containers/Form/stores/MetadataStore');
+    const resourceStore = new ResourceStore('snippets', 8, {locale: observable.box()});
+
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const schemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+
+    let jsonSchemaResolve;
+    const jsonSchemaPromise = new Promise((resolve) => {
+        jsonSchemaResolve = resolve;
+    });
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+
+    const route = {
+        options: {
+            locales: [],
+            apiOptions: {apiKey: 'api-option-value'},
+            routerAttributesToFormStore: ['parentId'],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+        attributes: {
+            id: 8,
+            parentId: 3,
+        },
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    resourceStore.locale.set('en');
+    resourceStore.data = {value: 'Value'};
+    resourceStore.loading = false;
+    resourceStore.destroy = jest.fn();
+
+    Promise.all([schemaTypesPromise, schemaPromise, jsonSchemaPromise]).then(() => {
+        jsonSchemaPromise.then(() => {
+            form.find('Form').at(1).instance().submit();
+            expect(resourceStore.destroy).not.toBeCalled();
+            expect(ResourceRequester.put).toBeCalledWith(
+                'snippets', 8, {value: 'Value'}, {locale: 'en', apiKey: 'api-option-value', parentId: 3}
+            );
+            done();
+        });
+    });
+
+    jsonSchemaResolve({});
+});
+
 test('Should set showSuccess flag after form submission', (done) => {
     const ResourceRequester = require('../../../services/ResourceRequester');
     ResourceRequester.put.mockReturnValue(Promise.resolve({}));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR add an `apiOptions` option to the `Form` view that allows to set attributes which are then passed to the `FormStore`. The attributes are passed to the `FormStore` analog to the attributes specified in the `routerAttributesToFormStore` option.

#### Why?

Because it might be useful to define some data in the route definition that is sent to the server when the `Form` is saved.

#### Example Usage

~~~php
$route = new Route('sulu_category.add_form', '/categories/:locale/add', 'sulu_admin.resource_tabs');
$route->addOption('resourceKey', 'categories')
$route->addOption('toolbarActions', $formToolbarActions)
$route->addOption('apiOptions', ['apiKey' => 'value-that-is-sent-as-query-param'])
~~~
