### PR TITLE
Rename tag_list to tag_selection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,27 @@
 
 ## dev-develop
 
+
+### Change tag_list to tag_selection
+
+The tag_list content and field type was changed to `tag_selection`
+
+**Before**
+
+```xml
+<property name="yourname" type="tag_list">
+    <!-- ... --->
+</property>
+```
+
+**After**
+
+```xml
+<property name="yourname" type="tag_selection">
+    <!-- ... --->
+</property>
+```
+
 ### Change category_list to category_selection
 
 The `category_list` content and field type was changed to `category_selection`

--- a/src/Sulu/Bundle/ContentBundle/Content/templates/excerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Content/templates/excerpt.xml
@@ -55,7 +55,7 @@
             </meta>
         </property>
 
-        <property name="tags" type="tag_list">
+        <property name="tags" type="tag_selection">
             <meta>
                 <title lang="de">Tags</title>
                 <title lang="en">Tags</title>

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
@@ -26,7 +26,7 @@
                 <title>sulu_category.categories</title>
             </meta>
         </property>
-        <property name="tags" type="tag_list">
+        <property name="tags" type="tag_selection">
             <meta>
                 <title>sulu_tag.tags</title>
             </meta>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Application/config/templates/pages/default.xml
@@ -17,7 +17,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
-        <property name="tags" type="tag_list"/>
+        <property name="tags" type="tag_selection"/>
         <property name="url" type="resource_locator" mandatory="false">
             <tag name="sulu.rlp"/>
         </property>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Application/config/templates/pages/html5.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Application/config/templates/pages/html5.xml
@@ -13,7 +13,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
-        <property name="tags" type="tag_list"/>
+        <property name="tags" type="tag_selection"/>
         <property name="url" type="resource_locator" mandatory="false">
             <tag name="sulu.rlp"/>
         </property>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Application/config/templates/pages/invalidhtml.xml
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Application/config/templates/pages/invalidhtml.xml
@@ -13,7 +13,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" priority="1"/>
         </property>
-        <property name="tags" type="tag_list"/>
+        <property name="tags" type="tag_selection"/>
         <property name="url" type="resource_locator" mandatory="false">
             <tag name="sulu.rlp"/>
         </property>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
@@ -71,6 +71,6 @@ class ContentTypesDumpCommandTest extends SuluTestCase
         $this->assertContains('media_selection', $output);
         $this->assertContains('route', $output);
         $this->assertContains('snippet', $output);
-        $this->assertContains('tag_list', $output);
+        $this->assertContains('tag_selection', $output);
     }
 }

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
@@ -481,7 +481,7 @@ class WebspaceExportTest extends SuluTestCase
                     ),
                     'tags' => $this->createItemArray(
                         'tags',
-                        'tag_list',
+                        'tag_selection',
                         false,
                         !empty($extensionData['excerpt']['tags']) ? json_encode($extensionData['excerpt']['tags']) : ''
                     ),

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/forms/Media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/forms/Media.xml
@@ -44,7 +44,7 @@
                         <title>sulu_category.categories</title>
                     </meta>
                 </property>
-                <property name="tags" type="tag_list">
+                <property name="tags" type="tag_selection">
                     <meta>
                         <title>sulu_tag.tags</title>
                     </meta>

--- a/src/Sulu/Bundle/TagBundle/Content/Types/TagSelection.php
+++ b/src/Sulu/Bundle/TagBundle/Content/Types/TagSelection.php
@@ -17,10 +17,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
 
-/**
- * Content Type for the TagList, uses the TagManager-Service and the AutoCompleteList from Husky.
- */
-class TagList extends ComplexContentType implements ContentTypeExportInterface
+class TagSelection extends ComplexContentType implements ContentTypeExportInterface
 {
     /**
      * Responsible for saving the tags in the database.

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -38,7 +38,7 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
                     ],
                     'field_type_options' => [
                         'selection' => [
-                            'tag_list' => [
+                            'tag_selection' => [
                                 'default_type' => 'auto_complete',
                                 'resource_key' => 'tags',
                                 'types' => [

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -6,7 +6,6 @@
         <parameter key="sulu_tag.admin.class">Sulu\Bundle\TagBundle\Admin\TagAdmin</parameter>
         <parameter key="sulu_tag.tag_manager.class">Sulu\Bundle\TagBundle\Tag\TagManager</parameter>
         <parameter key="sulu_tag.tag_repository.class">Sulu\Bundle\TagBundle\Entity\TagRepository</parameter>
-        <parameter key="sulu_tag.content.type.tag_list.class">Sulu\Bundle\TagBundle\Content\Types\TagList</parameter>
         <parameter key="sulu_tag.tag_request_handler.class">Sulu\Component\Tag\Request\TagRequestHandler</parameter>
         <parameter key="sulu_tag.twig_extension.class">Sulu\Bundle\TagBundle\Twig\TagTwigExtension</parameter>
         <parameter key="sulu_tag.entity.tag">SuluTagBundle:Tag</parameter>
@@ -29,8 +28,8 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%sulu.model.tag.class%</argument>
         </service>
-        <service id="sulu_tag.content.type.tag_list" class="%sulu_tag.content.type.tag_list.class%">
-            <tag name="sulu.content.type" alias="tag_list"/>
+        <service id="sulu_tag.content.type.tag_selection" class="Sulu\Bundle\TagBundle\Content\Types\TagSelection">
+            <tag name="sulu.content.type" alias="tag_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
             <argument type="service" id="sulu_tag.tag_manager"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | part of #3624 
| License | MIT

#### What's in this PR?

Rename tag_list to tag_selection.

#### Why?

See #3624

#### Example Usage

~~~php
<property name="tags" type="tag_selection">
    <!-- ... --->
</property>
~~~

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/418
- [x] Add breaking changes to UPGRADE.md
