### PR TITLE
Rename category_list to category_selection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,26 @@
 
 ## dev-develop
 
+### Change category_list to category_selection
+
+The `category_list` content and field type was changed to `category_selection`
+
+**Before**
+
+```xml
+<property name="yourname" type="category_list">
+    <!-- ... --->
+</property>
+```
+
+**After**
+
+```xml
+<property name="yourname" type="category_selection">
+    <!-- ... --->
+</property>
+```
+
 ### Metadata refactoring
 
 **This change only affects you if you have used a 2.0.0 alpha release before**

--- a/src/Sulu/Bundle/CategoryBundle/Content/Types/CategorySelection.php
+++ b/src/Sulu/Bundle/CategoryBundle/Content/Types/CategorySelection.php
@@ -17,10 +17,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
 
-/**
- * Content Type for the CategoryList, uses the CategoryManager-Service and the Datagrid from Husky.
- */
-class CategoryList extends ComplexContentType implements ContentTypeExportInterface
+class CategorySelection extends ComplexContentType implements ContentTypeExportInterface
 {
     /**
      * Responsible for persisting the categories in the database.

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -105,7 +105,7 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
                     ],
                     'field_type_options' => [
                         'selection' => [
-                            'category_list' => [
+                            'category_selection' => [
                                 'default_type' => 'datagrid',
                                 'resource_key' => 'categories',
                                 'types' => [

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -5,7 +5,6 @@
     <parameters>
         <parameter key="sulu_category.admin.class">Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin</parameter>
         <parameter key="sulu_category.category_manager.class">Sulu\Bundle\CategoryBundle\Category\CategoryManager</parameter>
-        <parameter key="sulu_category.content.type.category_list.class">Sulu\Bundle\CategoryBundle\Content\Types\CategoryList</parameter>
         <parameter key="sulu_category.category_request_handler.class">Sulu\Component\Category\Request\CategoryRequestHandler</parameter>
         <parameter key="sulu_category.twig_extension.class">Sulu\Bundle\CategoryBundle\Twig\CategoryTwigExtension</parameter>
     </parameters>
@@ -25,8 +24,8 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
-        <service id="sulu_category.content.type.category_list" class="%sulu_category.content.type.category_list.class%">
-            <tag name="sulu.content.type" alias="category_list"/>
+        <service id="sulu_category.content.type.category_selection" class="Sulu\Bundle\CategoryBundle\Content\Types\CategorySelection">
+            <tag name="sulu.content.type" alias="category_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
             <argument type="service" id="sulu_category.category_manager"/>
         </service>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Content/Types/CategorySelectionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Content/Types/CategorySelectionTest.php
@@ -9,17 +9,18 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\CategoryBundle\Content\Types;
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Content\Types;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
+use Sulu\Bundle\CategoryBundle\Content\Types\CategorySelection;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\StructureInterface;
 
-class CategoryListTest extends TestCase
+class CategorySelectionTest extends TestCase
 {
     public function testGetContentData()
     {
@@ -43,7 +44,7 @@ class CategoryListTest extends TestCase
         $categoryManager->findByIds([1, 2])->willReturn([$entity1, $entity2]);
         $categoryManager->getApiObjects([$entity1, $entity2], 'de')->willReturn([$category1, $category2]);
 
-        $categoryList = new CategoryList($categoryManager->reveal(), '');
+        $categoryList = new CategorySelection($categoryManager->reveal());
 
         $result = $categoryList->getContentData($property->reveal());
 
@@ -58,7 +59,7 @@ class CategoryListTest extends TestCase
         $categoryManager = $this->prophesize(CategoryManagerInterface::class);
         $categoryManager->findByIds(Argument::any())->shouldNotBeCalled();
 
-        $categoryList = new CategoryList($categoryManager->reveal(), '');
+        $categoryList = new CategorySelection($categoryManager->reveal());
 
         $result = $categoryList->getContentData($property->reveal());
 

--- a/src/Sulu/Bundle/ContentBundle/Content/templates/excerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Content/templates/excerpt.xml
@@ -39,7 +39,7 @@
             <tag name="sulu.search.field"/>
         </property>
 
-        <property name="categories" type="category_list">
+        <property name="categories" type="category_selection">
             <meta>
                 <title lang="de">Kategorien</title>
                 <title lang="en">Categories</title>

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/forms/PageExcerpt.xml
@@ -21,7 +21,7 @@
                 <title>sulu_admin.description</title>
             </meta>
         </property>
-        <property name="categories" type="category_list">
+        <property name="categories" type="category_selection">
             <meta>
                 <title>sulu_category.categories</title>
             </meta>

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
@@ -63,7 +63,7 @@ class ContentTypesDumpCommandTest extends SuluTestCase
         $this->assertContains('time', $output);
         $this->assertContains('url', $output);
         $this->assertContains('audience_targeting_groups', $output);
-        $this->assertContains('category_list', $output);
+        $this->assertContains('category_selection', $output);
         $this->assertContains('contact', $output);
         $this->assertContains('smart_content', $output);
         $this->assertContains('teaser_selection', $output);

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Export/WebspaceExportTest.php
@@ -473,7 +473,7 @@ class WebspaceExportTest extends SuluTestCase
                     ),
                     'categories' => $this->createItemArray(
                         'categories',
-                        'category_list',
+                        'category_selection',
                         false,
                         !empty($extensionData['excerpt']['categories']) ? json_encode(
                             $extensionData['excerpt']['categories']

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/forms/Media.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/forms/Media.xml
@@ -39,7 +39,7 @@
                 <title>sulu_media.taxonomies</title>
             </meta>
             <properties>
-                <property name="categories" type="category_list">
+                <property name="categories" type="category_selection">
                     <meta>
                         <title>sulu_category.categories</title>
                     </meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | parts of #3624 
| License | MIT

#### What's in this PR?

Rename category_list to category_selection.

#### Why?

Normalize content and field type names see #3624 .

#### Example Usage

```xml
<property name="yourname" type="category_selection">
    <!-- ... --->
</property>
```

#### BC Breaks/Deprecations

See UPGRAD.md

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/419
- [x] Add breaking changes to UPGRADE.md
