### PR TITLE
Allow to nest sections in forms

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/Form/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/Form/FormMetadataProvider.php
@@ -274,6 +274,8 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
                 $item = $this->mapBlock($component, $locale);
             } elseif ($component instanceof PropertyMetadata) {
                 $item = $this->mapProperty($component, $locale);
+            } elseif ($component instanceof SectionMetadata) {
+                $item = $this->mapSection($component, $locale);
             } else {
                 throw new \Exception('Unsupported property given "' . get_class($property) . '"');
             }
@@ -382,17 +384,22 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
     }
 
     /**
-     * @param PropertyMetadata[] $propertyMetadata
+     * @param ItemMetadata[] $itemsMetadata
      */
-    private function mapSchema(array $propertyMetadata): Schema
+    private function mapSchema(array $itemsMetadata): Schema
     {
-        $schemaProperties = array_filter(array_map(function(PropertyMetadata $propertyMetadata) {
-            if (!$propertyMetadata->isRequired()) {
+        $schemaProperties = array_filter(array_map(function(ItemMetadata $itemMetadata) {
+            if ($itemMetadata instanceof SectionMetadata) {
+                // TODO get required fields from sections as well
                 return;
             }
 
-            return new Property($propertyMetadata->getName(), $propertyMetadata->isRequired());
-        }, $propertyMetadata));
+            if (!$itemMetadata->isRequired()) {
+                return;
+            }
+
+            return new Property($itemMetadata->getName(), $itemMetadata->isRequired());
+        }, $itemsMetadata));
 
         return new Schema($schemaProperties);
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/Form/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/Form/FormMetadataProvider.php
@@ -388,10 +388,17 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
      */
     private function mapSchema(array $itemsMetadata): Schema
     {
-        $schemaProperties = array_filter(array_map(function(ItemMetadata $itemMetadata) {
+        return new Schema($this->mapSchemaProperties($itemsMetadata));
+    }
+
+    /**
+     * @param ItemMetadata[] $itemsMetadata
+     */
+    private function mapSchemaProperties(array $itemsMetadata)
+    {
+        return array_filter(array_map(function(ItemMetadata $itemMetadata) {
             if ($itemMetadata instanceof SectionMetadata) {
-                // TODO get required fields from sections as well
-                return;
+                return $this->mapSchemaProperties($itemMetadata->getChildren());
             }
 
             if (!$itemMetadata->isRequired()) {
@@ -400,8 +407,6 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
 
             return new Property($itemMetadata->getName(), $itemMetadata->isRequired());
         }, $itemsMetadata));
-
-        return new Schema($schemaProperties);
     }
 
     private function getConfigCache(string $key, string $locale): ConfigCache

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_nested_sections.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_nested_sections.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>form_with_nested_sections</key>
+
+    <properties>
+        <section name="test1" colspan="4">
+            <properties>
+                <property name="test11" type="text_line" />
+            </properties>
+        </section>
+        <section name="test2" colspan="8">
+            <properties>
+                <property name="test21" type="text_line" />
+                <section name="test22">
+                    <properties>
+                        <property name="test221" type="text_line" />
+                    </properties>
+                </section>
+            </properties>
+        </section>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_schema.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_schema.xml
@@ -30,5 +30,12 @@
     <properties>
         <property name="first" type="text_line" colspan="6" mandatory="true"/>
         <property name="second" type="text_line" colspan="6"/>
+
+        <section name="test">
+            <properties>
+                <property name="third" type="text_line" mandatory="true" />
+                <property name="fourth" type="text_line" />
+            </properties>
+        </section>
     </properties>
 </form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
@@ -33,6 +33,7 @@ class FormMetadataProviderTest extends KernelTestCase
         $schema = $form->getSchema()->toJsonSchema();
         $this->assertCount(1, array_keys($schema));
         $this->assertCount(2, $schema['allOf']);
+        $this->assertEquals(['first', 'third'], $schema['allOf'][0]['required']);
     }
 
     public function testGetMetadataWithEvaluations()
@@ -98,7 +99,7 @@ class FormMetadataProviderTest extends KernelTestCase
 
         $section1 = $form->getItems()['test1'];
         $section2 = $form->getItems()['test2'];
-        $section22 =$section2->getItems()['test22'];
+        $section22 = $section2->getItems()['test22'];
 
         $this->assertInstanceOf(Section::class, $section1);
         $this->assertInstanceOf(Section::class, $section2);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Functional\Metadata\Form;
 
 use Sulu\Bundle\AdminBundle\Metadata\Form\FormMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\Form\Section;
 use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
 
 class FormMetadataProviderTest extends KernelTestCase
@@ -89,5 +90,22 @@ class FormMetadataProviderTest extends KernelTestCase
 
         $schema = $form->getSchema()->toJsonSchema();
         $this->assertCount(2, $schema['allOf']);
+    }
+
+    public function testGetMetadataWithNestedSections()
+    {
+        $form = $this->formMetadataProvider->getMetadata('form_with_nested_sections', 'en');
+
+        $section1 = $form->getItems()['test1'];
+        $section2 = $form->getItems()['test2'];
+        $section22 =$section2->getItems()['test22'];
+
+        $this->assertInstanceOf(Section::class, $section1);
+        $this->assertInstanceOf(Section::class, $section2);
+        $this->assertInstanceOf(Section::class, $section22);
+
+        $this->assertEquals('test11', $section1->getItems()['test11']->getName());
+        $this->assertEquals('test21', $section2->getItems()['test21']->getName());
+        $this->assertEquals('test221', $section22->getItems()['test221']->getName());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -209,7 +209,7 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertInstanceOf(FormMetadata::class, $formMetadata);
 
-        $this->assertCount(2, $formMetadata->getProperties());
+        $this->assertCount(4, $formMetadata->getProperties());
 
         $this->assertEquals('first', $formMetadata->getProperties()['first']->getName());
         $this->assertEquals('second', $formMetadata->getProperties()['second']->getName());

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/form-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/form-1.0.xsd
@@ -18,7 +18,7 @@
     <xs:complexType name="formType">
         <xs:all>
             <xs:element type="xs:string" name="key" minOccurs="1" maxOccurs="1"/>
-            <xs:element type="rootPropertiesType" name="properties" minOccurs="1" maxOccurs="1"/>
+            <xs:element type="propertiesType" name="properties" minOccurs="1" maxOccurs="1"/>
             <xs:element type="schemaType" name="schema" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attributeGroup ref="defaultAttributes"/>

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -10,7 +10,7 @@
     -->
     <xs:import namespace='http://www.w3.org/XML/1998/namespace' schemaLocation='xml.xsd'/>
 
-    <xs:element name="properties" type="rootPropertiesType"/>
+    <xs:element name="properties" type="propertiesType"/>
 
     <!--
     Attribute group for attributes that are allowed for all elements
@@ -55,7 +55,7 @@
         </xs:simpleContent>
     </xs:complexType>
 
-    <xs:complexType name="rootPropertiesType">
+    <xs:complexType name="propertiesType">
         <xs:choice minOccurs="1" maxOccurs="unbounded">
             <xs:element type="propertyType" name="property" minOccurs="1" maxOccurs="unbounded"/>
             <xs:element type="blockType" name="block" minOccurs="0" maxOccurs="unbounded"/>
@@ -75,14 +75,6 @@
         <xs:attribute type="xs:integer" name="colspan" use="optional"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
-        <xs:attributeGroup ref="defaultAttributes"/>
-    </xs:complexType>
-
-    <xs:complexType name="propertiesType">
-        <xs:choice minOccurs="1" maxOccurs="unbounded">
-            <xs:element type="propertyType" name="property"/>
-            <xs:element type="blockType" name="block"/>
-        </xs:choice>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd
@@ -26,7 +26,7 @@
             <xs:element type="cacheLifetimeType" name="cacheLifetime" minOccurs="1" maxOccurs="1"/>
             <xs:element type="areasType" name="areas"/>
             <xs:element type="schemaType" name="schema" minOccurs="1" maxOccurs="1"/>
-            <xs:element type="rootPropertiesType" name="properties" minOccurs="1" maxOccurs="1"/>
+            <xs:element type="propertiesType" name="properties" minOccurs="1" maxOccurs="1"/>
 
             <xs:element name="meta">
                 <xs:complexType>

--- a/src/Sulu/Component/Content/Metadata/PropertiesMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/PropertiesMetadata.php
@@ -92,10 +92,18 @@ abstract class PropertiesMetadata extends ItemMetadata
      */
     public function burnProperties()
     {
+        $this->properties = $this->removeSectionProperties($this->children);
+    }
+
+    /**
+     * @param ItemMetadata[] $children
+     */
+    private function removeSectionProperties(array $children)
+    {
         $properties = [];
-        foreach ($this->children as $child) {
+        foreach ($children as $child) {
             if ($child instanceof SectionMetadata) {
-                $properties = array_merge($properties, $child->getChildren());
+                $properties = array_merge($properties, $this->removeSectionProperties($child->getChildren()));
 
                 continue;
             }
@@ -103,7 +111,7 @@ abstract class PropertiesMetadata extends ItemMetadata
             $properties[$child->getName()] = $child;
         }
 
-        $this->properties = $properties;
+        return $properties;
     }
 
     /**

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -165,6 +165,13 @@ class StructureXmlLoaderTest extends TestCase
         $this->assertCount(1, $result->getProperty('block1')->getComponents());
     }
 
+    public function testLoadNestedSections()
+    {
+        $result = $this->load('template_with_nested_sections.xml');
+
+        $this->assertEquals(['title', 'test21', 'test221'], array_keys($result->getProperties()));
+    }
+
     public function testLoadInvalidIgnore()
     {
         $this->contentTypeManager->has('text_line')->willReturn(true);

--- a/tests/Resources/DataFixtures/Page/template_with_nested_sections.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_nested_sections.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default</key>
+
+    <view>templates/pages/default</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Default</title>
+        <title lang="de">Standard</title>
+    </meta>
+
+    <properties>
+        <section name="test1" colspan="4">
+            <properties>
+                <property name="title" type="text_line" />
+                <property name="title" type="text_line">
+                    <tag name="sulu.rlp" />
+                </property>
+            </properties>
+        </section>
+        <section name="test2" colspan="8">
+            <properties>
+                <property name="test21" type="text_line" />
+                <section name="test22">
+                    <properties>
+                        <property name="test221" type="text_line" />
+                    </properties>
+                </section>
+            </properties>
+        </section>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to nest sections within each other.

#### Why?

Because it is IMO an intuitive behavior. And we need that in the contact form, because we have sections splitting the screen vertically, and in the right section we want to have a few section headlines.

#### Example Usage

Put e.g. the following part in a page template.

~~~xml
        <section name="test2" colspan="9">
            <properties>
                <property name="article" type="text_editor">
                    <meta>
                        <title lang="en">Article</title>
                        <title lang="de">Artikel</title>
                    </meta>
                </property>
                <section name="test3">
                    <meta>
                        <title>Test</title>
                    </meta>
                    <properties>
                        <property name="test" type="text_area" />
                    </properties>
                </section>
            </properties>
        </section>
~~~
