### PR TITLE
Store value of MediaSelection field-type to ResourceStore in correct order 

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -63,11 +63,9 @@ export default class MultiMediaSelection extends React.Component<Props> {
             value,
         } = this.props;
 
-        const newSelectedIds = toJS(value.ids);
-        const loadedSelectedIds = toJS(this.mediaSelectionStore.selectedMediaIds);
+        const newSelectedIds = toJS(value.ids).concat().sort();
+        const loadedSelectedIds = toJS(this.mediaSelectionStore.selectedMediaIds).concat().sort();
 
-        newSelectedIds.sort();
-        loadedSelectedIds.sort();
         if (!equals(newSelectedIds, loadedSelectedIds)) {
             this.mediaSelectionStore.loadSelectedMedia(newSelectedIds, locale);
         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -42,11 +42,11 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
     }
 
     @action componentDidUpdate() {
-        const newExcludedIdString = this.props.excludedIds.sort().join(',');
+        const newExcludedIdString = this.props.excludedIds.concat().sort().join(',');
 
         if (this.excludedIdString.get() !== newExcludedIdString) {
             this.mediaDatagridStore.clear();
-            this.excludedIdString.set(this.props.excludedIds.sort().join(','));
+            this.excludedIdString.set(this.props.excludedIds.concat().sort().join(','));
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `MultiMediaSelection` component and the `MultiMediaSelectionOverlay` component to sort copies of arrays instead of the original arrays to preserve the user-sorting.

Furthermore, this PR replaces the `autorun` of the `MultiMediaSelection` that is used to track changes in the `MultiMediaSelectionOverlay` with a `reaction` that allows for finer grained state-dependencies. This prevents a superfluous call of the change-handler of the `MultiMediaSelection`.

#### Why?

The `MultiMediaSelection` component allows the user to sort the selected medias in the frontend.  In the current implementation, changing the order of the frontend fires the `componentDidUpdate` method of the `MultiMediaSelection` component, a rerender of the `MultiMediaSelection` component and therefore a rerender of the `MultiMediaSelectionOverlay` component.

Furthermore, the `componentDidUpdate` method of the `MultiMediaSelection` component and the rerender of the `MultiMediaSelectionOverlay` component call sort on the `selectedMedia` array of the `MultiMediaSelectionStore`. 

The change of this array then fires the `change-autorun` of the `MultiMediaSelection` component which sets the alphabetically sorted value (instead of the user-sorted value) to the `MediaSelection` field type. Therefore, it was not possible to change the order of the selected medias in the frontend.
