### PR TITLE
Add support for different request format for webspace templates

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,45 @@
 
 ## dev-develop
 
+### Webspace template file extension removed
+
+Sulu supports now also different format for static webspace templates like search and error.
+The following need to be changed in your webspace configuration:
+
+**Before**
+
+```xml
+<templates>
+	<template type="search">templates/search.html.twig</template>
+	<template type="error">templates/error.html.twig</template>
+</templates>
+```
+
+**After**
+
+```xml
+<templates>
+	<template type="search">templates/search</template>
+	<template type="error">templates/error</template>
+</templates>
+```
+
+If you have custom webspaces template you also need to change how you get to the template:
+
+The format is optional and will fallback to html if not given.
+
+**Before**
+
+```xml
+$webspace->getTemplate('search');
+```
+
+**After**
+
+```xml
+$webspace->getTemplate('search', $request->getRequestFormat());
+```
+
 ### SuluKernel::construct changed
 
 The `suluContext` is optional now to support extending from Symfony `KernelTestCase` of Symfony:

--- a/config/webspaces/sulu-test.xml
+++ b/config/webspaces/sulu-test.xml
@@ -16,8 +16,8 @@
     </default-templates>
 
     <templates>
-        <template type="search">templates/search.html.twig</template>
-        <template type="error">templates/error.html.twig</template>
+        <template type="search">templates/search</template>
+        <template type="error">templates/error</template>
     </templates>
 
     <navigation>

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -106,13 +106,13 @@ class WebsiteSearchController
             throw new NotFoundHttpException();
         }
 
-        return $this->twig->renderResponse(
+        return new Response($this->twig->render(
             $template,
             $this->parameterResolver->resolve(
                 ['query' => $query, 'hits' => $hits],
                 $this->requestAnalyzer
             )
-        );
+        ));
     }
 
     /**

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -15,9 +15,9 @@ use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
 use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * This controller handles the search for the website.
@@ -42,26 +42,26 @@ class WebsiteSearchController
     private $parameterResolver;
 
     /**
-     * @var EngineInterface
+     * @var \Twig_Environment
      */
-    private $engine;
+    private $twig;
 
     /**
      * @param SearchManagerInterface $searchManager
      * @param RequestAnalyzerInterface $requestAnalyzer
      * @param ParameterResolverInterface $parameterResolver
-     * @param EngineInterface $engine
+     * @param \Twig_Environment $twig
      */
     public function __construct(
         SearchManagerInterface $searchManager,
         RequestAnalyzerInterface $requestAnalyzer,
         ParameterResolverInterface $parameterResolver,
-        EngineInterface $engine
+        \Twig_Environment $twig
     ) {
         $this->searchManager = $searchManager;
         $this->requestAnalyzer = $requestAnalyzer;
         $this->parameterResolver = $parameterResolver;
-        $this->engine = $engine;
+        $this->twig = $twig;
     }
 
     /**
@@ -100,8 +100,14 @@ class WebsiteSearchController
             ->index('page_' . $webspace->getKey() . '_published')
             ->execute();
 
-        return $this->engine->renderResponse(
-            $webspace->getTemplate('search'),
+        $template = $webspace->getTemplate('search', $request->getRequestFormat());
+
+        if (!$this->twig->getLoader()->exists($template)) {
+            throw new NotFoundHttpException();
+        }
+
+        return $this->twig->renderResponse(
+            $template,
             $this->parameterResolver->resolve(
                 ['query' => $query, 'hits' => $hits],
                 $this->requestAnalyzer

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/routing_website.xml
@@ -3,7 +3,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="sulu_search.website_search" path="/search">
+    <route id="sulu_search.website_search" path="/search.{_format}">
         <default key="_controller">sulu_search.controller.website_search:queryAction</default>
+        <default key="_format">html</default>
     </route>
 </routes>

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -26,7 +26,7 @@
             <argument type="service" id="massive_search.search_manager"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.resolver.parameter"/>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="twig"/>
             <tag name="sulu.context" context="website"/>
         </service>
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -61,7 +61,7 @@ class WebsiteSearchControllerTest extends TestCase
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
         $this->twig = $this->prophesize(\Twig_Environment::class);
-        $this->twigLoader = $this->prophesize(\Twig_LoaderInterface::class);
+        $this->twigLoader = $this->prophesize(\Twig_Loader_Filesystem::class);
         $this->twig->getLoader()->willReturn($this->twigLoader->reveal());
 
         $this->websiteSearchController = new WebsiteSearchController(

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
@@ -81,15 +81,15 @@ class ExceptionController
         $code = $exception->getStatusCode();
         $template = null;
         if ($webspace = $this->requestAnalyzer->getWebspace()) {
-            $template = $webspace->getTemplate('error-' . $code);
+            $template = $webspace->getTemplate('error-' . $code, $request->getRequestFormat());
 
             if (null === $template) {
-                $template = $webspace->getTemplate('error');
+                $template = $webspace->getTemplate('error', $request->getRequestFormat());
             }
         }
 
         $showException = $request->attributes->get('showException', $this->debug);
-        if ($showException || 'html' !== $request->getRequestFormat() || null === $template) {
+        if ($showException || null === $template || !$this->twig->getLoader()->exists($template)) {
             return $this->exceptionController->showAction($request, $exception, $logger);
         }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
@@ -39,6 +39,11 @@ class ExceptionControllerTest extends TestCase
     private $twig;
 
     /**
+     * @var \Twig_LoaderInterface
+     */
+    private $twigLoader;
+
+    /**
      * @var \Twig_ExistsLoaderInterface
      */
     private $loader;
@@ -89,7 +94,7 @@ class ExceptionControllerTest extends TestCase
         $exception = FlattenException::create(new \Exception(), 400);
 
         $webspace = new Webspace();
-        $webspace->addTemplate('error-400', 'error400.html.twig');
+        $webspace->addTemplate('error-400', 'error400');
         $webspace->setTheme('test');
 
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
@@ -97,7 +102,7 @@ class ExceptionControllerTest extends TestCase
         $this->twig->render(Argument::containingString($expectExceptionFormat), Argument::any())->shouldBeCalled();
         $this->loader->exists(Argument::any())->willReturn($templateAvailable);
 
-        if ('html' === $retrievedFormat) {
+        if ($templateAvailable) {
             $this->parameterResolver->resolve(Argument::cetera())->shouldBeCalled()->willReturn([]);
         } else {
             $this->parameterResolver->resolve(Argument::cetera())->shouldNotBeCalled();
@@ -114,26 +119,26 @@ class ExceptionControllerTest extends TestCase
         return [
             [
                 [
-                    'error-404' => 'error404.html.twig',
+                    'error-404' => 'error404',
                 ],
                 404,
-                'error404.html.twig',
+                'error404',
             ],
             [
                 [
-                    'error-404' => 'error404.html.twig',
-                    'error-500' => 'error500.html.twig',
+                    'error-404' => 'error404',
+                    'error-500' => 'error500',
                 ],
                 500,
-                'error500.html.twig',
+                'error500',
             ],
             [
                 [
-                    'error-404' => 'error404.html.twig',
-                    'error' => 'error.html.twig',
+                    'error-404' => 'error404',
+                    'error' => 'error',
                 ],
                 400,
-                'error.html.twig',
+                'error',
             ],
         ];
     }
@@ -154,7 +159,7 @@ class ExceptionControllerTest extends TestCase
 
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
-        $this->twig->render($expectedTemplate, Argument::any())->shouldBeCalled();
+        $this->twig->render($expectedTemplate . '.html.twig', Argument::any())->shouldBeCalled();
         $this->loader->exists(Argument::any())->willReturn(true);
 
         $this->parameterResolver->resolve(Argument::cetera())->willReturn([]);

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -243,7 +243,7 @@ class WebspaceTest extends TestCase
         $webspace = new Webspace();
         $webspace->addTemplate('error-404', 'template404');
 
-        $this->assertEquals('template404', $webspace->getTemplate('error-404'));
+        $this->assertEquals('template404.html.twig', $webspace->getTemplate('error-404'));
         $this->assertEquals($templates, $webspace->getTemplates());
         $data = $webspace->toArray();
         $this->assertEquals($templates, $data['templates']);
@@ -257,8 +257,8 @@ class WebspaceTest extends TestCase
         $webspace->addTemplate('error', 'template');
         $webspace->addTemplate('error-404', 'template404');
 
-        $this->assertEquals('template404', $webspace->getTemplate('error-404'));
-        $this->assertEquals('template', $webspace->getTemplate('error'));
+        $this->assertEquals('template404.html.twig', $webspace->getTemplate('error-404'));
+        $this->assertEquals('template.html.twig', $webspace->getTemplate('error'));
         $this->assertEquals($templates, $webspace->getTemplates());
         $data = $webspace->toArray();
         $this->assertEquals($templates, $data['templates']);
@@ -277,5 +277,18 @@ class WebspaceTest extends TestCase
         $this->assertNull($webspace->getDefaultTemplate('other-type'));
         $data = $webspace->toArray();
         $this->assertEquals($defaultTemplates, $data['defaultTemplates']);
+    }
+
+    public function testGetTemplateFormat()
+    {
+        $templates = ['error' => 'template'];
+
+        $webspace = new Webspace();
+        $webspace->addTemplate('error', 'template');
+
+        $this->assertEquals('template.json.twig', $webspace->getTemplate('error', 'json'));
+        $this->assertEquals($templates, $webspace->getTemplates());
+        $data = $webspace->toArray();
+        $this->assertEquals($templates, $data['templates']);
     }
 }

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -462,13 +462,14 @@ class Webspace implements ArrayableInterface
      * Returns a template for the given type.
      *
      * @param string $type
+     * @param string $format
      *
      * @return string|null
      */
-    public function getTemplate($type)
+    public function getTemplate($type, $format = 'html')
     {
         if (array_key_exists($type, $this->templates)) {
-            return $this->templates[$type];
+            return $this->templates[$type] . '.' . $format . '.twig';
         }
 
         return;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Related PRs | https://github.com/sulu/sulu-minimal/pull/148
| License | MIT

#### What's in this PR?

Add support for different request format for webspace templates.

#### Why?

Page and other templates allow to render the view in different formats. Search for example can now with this change be allowed to have a `/search.json?q=query` so its easier to create a live search.

#### Example Usage

~~~php
    <templates>
        <template type="search">templates/search</template>
        <template type="error">templates/error</template>
    </templates>
~~~

Create a `search/search.json.twig` and access http://127.0.0.1:8000/search.json?q=query

#### BC Breaks/Deprecations

See UPGRADE.md

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
