### PR TITLE
Make logger service optional

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,20 @@
 
 ## dev-develop
 
+### Logger is optional
+
+As the logger is know optional in the following services the constructor changed and logger is injected
+over the `Psr/Log/LoggerAwareTrait::setLogger`:
+
+ - `sulu.content.type.internal_links`
+ - `sulu_content.compat.structure.legacy_property_factory`
+ - `sulu_content.node_repository`
+ - `sulu_media.search.subscriber.media`
+ - `sulu_media.format_manager`
+ - `sulu_media.storage.local`
+ - `sulu_snippet.import.snippet`
+ - `sulu_website.twig.content`
+
 ### TagBundle services changed
 
 Following Services changed:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,8 +4,7 @@
 
 ### Logger is optional
 
-As the logger is know optional in the following services the constructor changed and logger is injected
-over the `Psr/Log/LoggerAwareTrait::setLogger`:
+As the logger is now optional in the following services the constructor changed:
 
  - `sulu.content.type.internal_links`
  - `sulu_content.compat.structure.legacy_property_factory`

--- a/src/Sulu/Bundle/ContentBundle/Content/InternalLinksContainer.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/InternalLinksContainer.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\ContentBundle\Content;
 
 use JMS\Serializer\Annotation\Exclude;
-use Psr\Log\LoggerInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Query\ContentQueryBuilderInterface;
 use Sulu\Component\Content\Query\ContentQueryExecutorInterface;
@@ -49,13 +48,6 @@ class InternalLinksContainer implements ArrayableInterface
      * @var array
      */
     private $params;
-
-    /**
-     * @Exclude
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
 
     /**
      * The key of the webspace.
@@ -97,7 +89,6 @@ class InternalLinksContainer implements ArrayableInterface
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $contentQueryBuilder,
         $params,
-        LoggerInterface $logger,
         $webspaceKey,
         $languageCode,
         $showDrafts
@@ -105,7 +96,6 @@ class InternalLinksContainer implements ArrayableInterface
         $this->ids = $ids;
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->contentQueryBuilder = $contentQueryBuilder;
-        $this->logger = $logger;
         $this->webspaceKey = $webspaceKey;
         $this->languageCode = $languageCode;
         $this->params = $params;

--- a/src/Sulu/Bundle/ContentBundle/Content/Types/InternalLinks.php
+++ b/src/Sulu/Bundle/ContentBundle/Content/Types/InternalLinks.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\ContentBundle\Content\Types;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
-use Psr\Log\LoggerInterface;
 use Sulu\Bundle\ContentBundle\Content\InternalLinksContainer;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -41,11 +40,6 @@ class InternalLinks extends ComplexContentType implements ContentTypeExportInter
     private $contentQueryBuilder;
 
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @var ReferenceStoreInterface
      */
     private $referenceStore;
@@ -59,13 +53,11 @@ class InternalLinks extends ComplexContentType implements ContentTypeExportInter
         ContentQueryExecutorInterface $contentQueryExecutor,
         ContentQueryBuilderInterface $contentQueryBuilder,
         ReferenceStoreInterface $referenceStore,
-        LoggerInterface $logger,
         $showDrafts
     ) {
         $this->contentQueryExecutor = $contentQueryExecutor;
         $this->contentQueryBuilder = $contentQueryBuilder;
         $this->referenceStore = $referenceStore;
-        $this->logger = $logger;
         $this->showDrafts = $showDrafts;
     }
 
@@ -156,7 +148,6 @@ class InternalLinks extends ComplexContentType implements ContentTypeExportInter
             $this->contentQueryExecutor,
             $this->contentQueryBuilder,
             array_merge($this->getDefaultParams(), $property->getParams()),
-            $this->logger,
             $property->getStructure()->getWebspaceKey(),
             $property->getStructure()->getLanguageCode(),
             $this->showDrafts

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -12,9 +12,6 @@
 namespace Sulu\Bundle\ContentBundle\Repository;
 
 use PHPCR\RepositoryException;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Sulu\Bundle\AdminBundle\UserManager\UserManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\InternalLinksContainer;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -86,11 +83,6 @@ class NodeRepository implements NodeRepositoryInterface
      */
     private $tokenStorage;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
     public function __construct(
         ContentMapperInterface $mapper,
         SessionManagerInterface $sessionManager,
@@ -99,8 +91,7 @@ class NodeRepository implements NodeRepositoryInterface
         ContentQueryBuilderInterface $queryBuilder,
         ContentQueryExecutorInterface $queryExecutor,
         AccessControlManagerInterface $accessControlManager,
-        TokenStorageInterface $tokenStorage = null,
-        LoggerInterface $logger = null
+        TokenStorageInterface $tokenStorage = null
     ) {
         $this->mapper = $mapper;
         $this->sessionManager = $sessionManager;
@@ -110,7 +101,6 @@ class NodeRepository implements NodeRepositoryInterface
         $this->queryExecutor = $queryExecutor;
         $this->accessControlManager = $accessControlManager;
         $this->tokenStorage = $tokenStorage;
-        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -12,7 +12,8 @@
 namespace Sulu\Bundle\ContentBundle\Repository;
 
 use PHPCR\RepositoryException;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\AdminBundle\UserManager\UserManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\InternalLinksContainer;
 use Sulu\Component\Content\Compat\StructureInterface;
@@ -37,6 +38,8 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class NodeRepository implements NodeRepositoryInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var ContentMapperInterface
      */
@@ -84,11 +87,6 @@ class NodeRepository implements NodeRepositoryInterface
      */
     private $tokenStorage;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
     public function __construct(
         ContentMapperInterface $mapper,
         SessionManagerInterface $sessionManager,
@@ -97,8 +95,7 @@ class NodeRepository implements NodeRepositoryInterface
         ContentQueryBuilderInterface $queryBuilder,
         ContentQueryExecutorInterface $queryExecutor,
         AccessControlManagerInterface $accessControlManager,
-        TokenStorageInterface $tokenStorage = null,
-        LoggerInterface $logger
+        TokenStorageInterface $tokenStorage = null
     ) {
         $this->mapper = $mapper;
         $this->sessionManager = $sessionManager;
@@ -108,7 +105,7 @@ class NodeRepository implements NodeRepositoryInterface
         $this->queryExecutor = $queryExecutor;
         $this->accessControlManager = $accessControlManager;
         $this->tokenStorage = $tokenStorage;
-        $this->logger = $logger;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -308,7 +305,6 @@ class NodeRepository implements NodeRepositoryInterface
                 $this->queryExecutor,
                 $this->queryBuilder,
                 [],
-                $this->logger,
                 $webspaceKey,
                 $languageCode,
                 true

--- a/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/ContentBundle/Repository/NodeRepository.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContentBundle\Repository;
 
 use PHPCR\RepositoryException;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\AdminBundle\UserManager\UserManagerInterface;
 use Sulu\Bundle\ContentBundle\Content\InternalLinksContainer;
@@ -38,8 +39,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class NodeRepository implements NodeRepositoryInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * @var ContentMapperInterface
      */
@@ -87,6 +86,11 @@ class NodeRepository implements NodeRepositoryInterface
      */
     private $tokenStorage;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function __construct(
         ContentMapperInterface $mapper,
         SessionManagerInterface $sessionManager,
@@ -95,7 +99,8 @@ class NodeRepository implements NodeRepositoryInterface
         ContentQueryBuilderInterface $queryBuilder,
         ContentQueryExecutorInterface $queryExecutor,
         AccessControlManagerInterface $accessControlManager,
-        TokenStorageInterface $tokenStorage = null
+        TokenStorageInterface $tokenStorage = null,
+        LoggerInterface $logger = null
     ) {
         $this->mapper = $mapper;
         $this->sessionManager = $sessionManager;
@@ -105,7 +110,7 @@ class NodeRepository implements NodeRepositoryInterface
         $this->queryExecutor = $queryExecutor;
         $this->accessControlManager = $accessControlManager;
         $this->tokenStorage = $tokenStorage;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/content_types.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/content_types.xml
@@ -19,7 +19,6 @@
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_content.smart_content.data_provider.content.query_builder"/>
             <argument type="service" id="sulu_content.reference_store.content"/>
-            <argument type="service" id="logger"/>
             <argument>%sulu_document_manager.show_drafts%</argument>
             <tag name="sulu.content.type" alias="internal_links"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/export.xml
@@ -34,8 +34,10 @@
             <argument type="service" id="sulu.content.structure_manager" />
             <argument type="service" id="sulu_content.extension.manager" />
             <argument type="service" id="sulu_content.import.manager" />
-            <argument type="service" id="logger" />
             <argument type="service" id="sulu_content.import.webspace.xliff12" />
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
         </service>
 
         <service id="sulu_content.import.webspace.xliff12" class="Sulu\Component\Import\Format\Xliff12">

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/export.xml
@@ -35,9 +35,7 @@
             <argument type="service" id="sulu_content.extension.manager" />
             <argument type="service" id="sulu_content.import.manager" />
             <argument type="service" id="sulu_content.import.webspace.xliff12" />
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <argument type="service" id="logger" on-invalid="null"/>
         </service>
 
         <service id="sulu_content.import.webspace.xliff12" class="Sulu\Component\Import\Format\Xliff12">

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -54,10 +54,7 @@
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_security.access_control_manager"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
-
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <argument type="service" id="logger" on-invalid="null"/>
         </service>
 
         <!-- resource locator -->

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -54,7 +54,10 @@
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_security.access_control_manager"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
-            <argument type="service" id="logger"/>
+
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
         </service>
 
         <!-- resource locator -->

--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -54,7 +54,6 @@
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_security.access_control_manager"/>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
-            <argument type="service" id="logger" on-invalid="null"/>
         </service>
 
         <!-- resource locator -->

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/InternalLinksContainerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/InternalLinksContainerTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\ContentBundle\Tests\Unit\Content;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 use Sulu\Bundle\ContentBundle\Content\InternalLinksContainer;
 use Sulu\Component\Content\Query\ContentQueryBuilder;
 use Sulu\Component\Content\Query\ContentQueryExecutor;
@@ -47,7 +46,6 @@ class InternalLinksContainerTest extends TestCase
             $this->executor->reveal(),
             $this->builder->reveal(),
             [],
-            new NullLogger(),
             'default',
             'en',
             true
@@ -68,7 +66,6 @@ class InternalLinksContainerTest extends TestCase
             $this->executor->reveal(),
             $this->builder->reveal(),
             [],
-            new NullLogger(),
             'default',
             'en',
             false
@@ -93,7 +90,6 @@ class InternalLinksContainerTest extends TestCase
             $this->executor->reveal(),
             $this->builder->reveal(),
             [],
-            new NullLogger(),
             'default',
             'en',
             false

--- a/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/InternalLinksTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Unit/Content/Types/InternalLinksTest.php
@@ -64,7 +64,6 @@ class InternalLinksTest extends TestCase
         $internalLinks = new InternalLinks(
             $this->contentQueryExecutor->reveal(),
             $this->contentQueryBuilder->reveal(), $this->referenceStore->reveal(),
-            $this->logger->reveal(),
             false
         );
 
@@ -93,7 +92,6 @@ class InternalLinksTest extends TestCase
         $internalLinks = new InternalLinks(
             $this->contentQueryExecutor->reveal(),
             $this->contentQueryBuilder->reveal(), $this->referenceStore->reveal(),
-            $this->logger->reveal(),
             false
         );
 
@@ -117,7 +115,6 @@ class InternalLinksTest extends TestCase
             $this->contentQueryExecutor->reveal(),
             $this->contentQueryBuilder->reveal(),
             $this->referenceStore->reveal(),
-            $this->logger->reveal(),
             false
         );
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/core.xml
@@ -7,7 +7,7 @@
         <!-- Core -->
         <service id="sulu_document_manager.event_dispatcher.debug" class="Sulu\Component\DocumentManager\EventDispatcher\DebugEventDispatcher" public="false">
             <argument type="service" id="debug.stopwatch" />
-            <argument type="service" id="logger" />
+            <argument type="service" id="logger" on-invalid="null" />
             <tag name="monolog.logger" channel="sulu_document_manager" />
         </service>
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\FormatManager;
 
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MediaBundle\Media\FormatManager;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
@@ -30,10 +31,8 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Sulu format manager for media.
  */
-class FormatManager implements FormatManagerInterface, LoggerAwareInterface
+class FormatManager implements FormatManagerInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * The repository for communication with the database.
      *
@@ -77,6 +76,11 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
     private $supportedMimeTypes;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param MediaRepositoryInterface $mediaRepository
      * @param FormatCacheInterface $formatCache
      * @param ImageConverterInterface $converter
@@ -84,6 +88,7 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
      * @param array $responseHeaders
      * @param array $formats
      * @param array $supportedMimeTypes
+     * @param LoggerInterface $logger
      */
     public function __construct(
         MediaRepositoryInterface $mediaRepository,
@@ -92,7 +97,8 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
         $saveImage,
         $responseHeaders,
         $formats,
-        array $supportedMimeTypes
+        array $supportedMimeTypes,
+        LoggerInterface $logger = null
     ) {
         $this->mediaRepository = $mediaRepository;
         $this->formatCache = $formatCache;
@@ -102,7 +108,7 @@ class FormatManager implements FormatManagerInterface, LoggerAwareInterface
         $this->fileSystem = new Filesystem();
         $this->formats = $formats;
         $this->supportedMimeTypes = $supportedMimeTypes;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Media\Storage;
 
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -19,8 +20,6 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class LocalStorage implements StorageInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * @var string
      */
@@ -36,15 +35,21 @@ class LocalStorage implements StorageInterface
      */
     private $filesystem;
 
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     public function __construct(
         string $uploadPath,
         string $segments,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        LoggerInterface $logger = null
     ) {
         $this->uploadPath = $uploadPath;
         $this->segments = $segments;
         $this->filesystem = $filesystem;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Storage;
 
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -11,15 +11,16 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Storage;
 
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Tests\Logger;
 
 class LocalStorage implements StorageInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var string
      */
@@ -35,21 +36,15 @@ class LocalStorage implements StorageInterface
      */
     private $filesystem;
 
-    /**
-     * @var NullLogger|Logger
-     */
-    protected $logger;
-
     public function __construct(
         string $uploadPath,
         string $segments,
-        Filesystem $filesystem,
-        LoggerInterface $logger = null
+        Filesystem $filesystem
     ) {
         $this->uploadPath = $uploadPath;
         $this->segments = $segments;
         $this->filesystem = $filesystem;
-        $this->logger = $logger ?: new NullLogger();
+        $this->logger = new NullLogger();
     }
 
     public function save(string $tempPath, string $fileName, array $storageOptions = []): array

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/ffmpeg.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/ffmpeg.xml
@@ -12,7 +12,7 @@
                 <argument key="timeout">%sulu_media.ffmpeg.binary_timeout%</argument>
                 <argument key="ffmpeg.threads">%sulu_media.ffmpeg.threads_count%</argument>
             </argument>
-            <argument id="logger" type="service"/>
+            <argument id="logger" type="service" on-invalid="null"/>
         </service>
 
         <service id="sulu_media.ffprobe" class="FFMpeg\FFProbe" lazy="true">
@@ -21,7 +21,7 @@
                 <argument key="ffmpeg.binaries">%sulu_media.ffmpeg.binary%</argument>
                 <argument key="ffprobe.binaries">%sulu_media.ffmpeg.binary%</argument>
             </argument>
-            <argument id="logger" type="service"/>
+            <argument id="logger" type="service" on-invalid="null"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
@@ -20,10 +20,13 @@
         <service id="sulu_media.search.subscriber.media" class="%sulu_media.search.subscriber.media.class%" >
             <argument type="service" id="sulu_media.media_manager" />
             <argument type="service" id="massive_search.factory" />
-            <argument type="service" id="logger" />
             <argument>%sulu_media.format_manager.mime_types%</argument>
             <argument>%sulu_media.search.default_image_format%</argument>
             <tag name="kernel.event_subscriber" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
@@ -22,11 +22,9 @@
             <argument type="service" id="massive_search.factory" />
             <argument>%sulu_media.format_manager.mime_types%</argument>
             <argument>%sulu_media.search.default_image_format%</argument>
-            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="logger" on-invalid="null"/>
 
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -163,9 +163,7 @@
             <argument type="string">%sulu_media.format_manager.response_headers%</argument>
             <argument>%sulu_media.image.formats%</argument>
             <argument>%sulu_media.format_manager.mime_types%</argument>
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <argument type="service" id="logger" on-invalid="null"/>
         </service>
 
         <service id="sulu_media.type.media_selection" class="%sulu_media.media_selection.class%">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -164,7 +164,7 @@
             <argument>%sulu_media.image.formats%</argument>
             <argument>%sulu_media.format_manager.mime_types%</argument>
             <call method="setLogger">
-                <argument type="service" id="logger"/>
+                <argument type="service" id="logger" on-invalid="ignore"/>
             </call>
         </service>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_local.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_local.xml
@@ -8,7 +8,10 @@
             <argument>%sulu_media.media.storage.local.path%</argument>
             <argument>%sulu_media.media.storage.local.segments%</argument>
             <argument type="service" id="sulu_media.storage.local.file_system"/>
-            <argument type="service" id="logger"/>
+
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_local.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_local.xml
@@ -8,10 +8,7 @@
             <argument>%sulu_media.media.storage.local.path%</argument>
             <argument>%sulu_media.media.storage.local.segments%</argument>
             <argument type="service" id="sulu_media.storage.local.file_system"/>
-
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <argument type="service" id="logger" on-invalid="null"/>
         </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
@@ -28,8 +28,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class MediaSearchSubscriber implements EventSubscriberInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * @var MediaManagerInterface
      */
@@ -53,6 +51,11 @@ class MediaSearchSubscriber implements EventSubscriberInterface
     protected $thumbnailMimeTypes;
 
     /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
      * @param MediaManagerInterface $mediaManager
      * @param Factory               $factory      Massive search factory
      * @param LoggerInterface       $logger
@@ -63,13 +66,14 @@ class MediaSearchSubscriber implements EventSubscriberInterface
         MediaManagerInterface $mediaManager,
         Factory $factory,
         $thumbnailMimeTypes,
-        $searchImageFormat
+        $searchImageFormat,
+        LoggerInterface $logger = null
     ) {
         $this->mediaManager = $mediaManager;
         $this->factory = $factory;
         $this->searchImageFormat = $searchImageFormat;
         $this->thumbnailMimeTypes = $thumbnailMimeTypes;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\MediaBundle\Search\Subscriber;
 use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
 use Massive\Bundle\SearchBundle\Search\Factory;
 use Massive\Bundle\SearchBundle\Search\SearchEvents;
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Api\Media;

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
@@ -14,7 +14,9 @@ namespace Sulu\Bundle\MediaBundle\Search\Subscriber;
 use Massive\Bundle\SearchBundle\Search\Event\PreIndexEvent;
 use Massive\Bundle\SearchBundle\Search\Factory;
 use Massive\Bundle\SearchBundle\Search\SearchEvents;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
@@ -26,6 +28,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class MediaSearchSubscriber implements EventSubscriberInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var MediaManagerInterface
      */
@@ -44,11 +48,6 @@ class MediaSearchSubscriber implements EventSubscriberInterface
     protected $factory;
 
     /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
      * @var array
      */
     protected $thumbnailMimeTypes;
@@ -63,7 +62,6 @@ class MediaSearchSubscriber implements EventSubscriberInterface
     public function __construct(
         MediaManagerInterface $mediaManager,
         Factory $factory,
-        LoggerInterface $logger,
         $thumbnailMimeTypes,
         $searchImageFormat
     ) {
@@ -71,7 +69,7 @@ class MediaSearchSubscriber implements EventSubscriberInterface
         $this->factory = $factory;
         $this->searchImageFormat = $searchImageFormat;
         $this->thumbnailMimeTypes = $thumbnailMimeTypes;
-        $this->logger = $logger;
+        $this->logger = new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
@@ -63,7 +63,8 @@ class MediaSearchSubscriberTest extends TestCase
             $this->mediaManager->reveal(),
             $this->factory->reveal(),
             ['image/jpeg'],
-            'test_format'
+            'test_format',
+            $this->logger->reveal()
         );
 
         $this->indexMetadata = $this->prophesize(IndexMetadata::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
@@ -62,7 +62,6 @@ class MediaSearchSubscriberTest extends TestCase
         $this->subscriber = new MediaSearchSubscriber(
             $this->mediaManager->reveal(),
             $this->factory->reveal(),
-            $this->logger->reveal(),
             ['image/jpeg'],
             'test_format'
         );

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/import.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/import.xml
@@ -11,10 +11,7 @@
             <argument type="service" id="sulu_content.import.manager" />
             <argument type="service" id="sulu_content.compat.structure.legacy_property_factory" />
             <argument type="service" id="sulu_snippet.import.webspace.xliff12" />
-
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <argument type="service" id="logger" on-invalid="null"/>
         </service>
 
         <service id="sulu_snippet.import.webspace.xliff12" class="Sulu\Component\Import\Format\Xliff12">

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/import.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/import.xml
@@ -10,8 +10,11 @@
             <argument type="service" id="sulu_document_manager.document_registry" />
             <argument type="service" id="sulu_content.import.manager" />
             <argument type="service" id="sulu_content.compat.structure.legacy_property_factory" />
-            <argument type="service" id="logger" />
             <argument type="service" id="sulu_snippet.import.webspace.xliff12" />
+
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
         </service>
 
         <service id="sulu_snippet.import.webspace.xliff12" class="Sulu\Component\Import\Format\Xliff12">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -108,10 +108,7 @@
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
-
-            <call method="setLogger">
-                <argument type="service" id="logger" on-invalid="ignore"/>
-            </call>
+            <argument type="service" id="logger" on-invalid="null"/>
         </service>
         <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
             <argument type="service" id="sulu_website.twig.content"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -108,7 +108,10 @@
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
-            <argument type="service" id="logger"/>
+
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
         </service>
         <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
             <argument type="service" id="sulu_website.twig.content"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -103,6 +103,11 @@ class ContentTwigExtensionTest extends TestCase
      */
     private $logger;
 
+    /**
+     * @var ContentTwigExtension
+     */
+    private $extension;
+
     protected function setUp()
     {
         parent::setUp();
@@ -149,6 +154,13 @@ class ContentTwigExtensionTest extends TestCase
             $this->contentTypeManager->reveal(),
             $this->extensionManager->reveal()
         );
+
+        $this->extension = new ContentTwigExtension(
+            $this->contentMapper->reveal(),
+            $this->structureResolver,
+            $this->sessionManager->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
     }
 
     public function testLoad()
@@ -158,15 +170,7 @@ class ContentTwigExtensionTest extends TestCase
             ->load('123-123-123', 'sulu_test', 'en_us')
             ->willReturn(new TestStructure('123-123-123', 'test', 1));
 
-        $extension = new ContentTwigExtension(
-            $this->contentMapper->reveal(),
-            $this->structureResolver,
-            $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal(),
-            $this->logger->reveal()
-        );
-
-        $result = $extension->load('123-123-123');
+        $result = $this->extension->load('123-123-123');
 
         // uuid
         $this->assertEquals('123-123-123', $result['uuid']);
@@ -187,15 +191,7 @@ class ContentTwigExtensionTest extends TestCase
             ->load(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $extension = new ContentTwigExtension(
-            $this->contentMapper->reveal(),
-            $this->structureResolver,
-            $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal(),
-            $this->logger->reveal()
-        );
-
-        $this->assertNull($extension->load(null));
+        $this->assertNull($this->extension->load(null));
     }
 
     public function testLoadNotExistingDocument()
@@ -208,15 +204,7 @@ class ContentTwigExtensionTest extends TestCase
             ->load(Argument::cetera())
             ->willThrow($documentNotFoundException->reveal());
 
-        $extension = new ContentTwigExtension(
-            $this->contentMapper->reveal(),
-            $this->structureResolver,
-            $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal(),
-            $this->logger->reveal()
-        );
-
-        $this->assertNull($extension->load('999-999-999'));
+        $this->assertNull($this->extension->load('999-999-999'));
     }
 
     public function testLoadParent()
@@ -226,15 +214,7 @@ class ContentTwigExtensionTest extends TestCase
             ->load('321-321-321', 'sulu_test', 'en_us')
             ->willReturn(new TestStructure('321-321-321', 'test', 1));
 
-        $extension = new ContentTwigExtension(
-            $this->contentMapper->reveal(),
-            $this->structureResolver,
-            $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal(),
-            $this->logger->reveal()
-        );
-
-        $result = $extension->loadParent('123-123-123');
+        $result = $this->extension->loadParent('123-123-123');
 
         // uuid
         $this->assertEquals('321-321-321', $result['uuid']);
@@ -255,14 +235,6 @@ class ContentTwigExtensionTest extends TestCase
             'Parent for "321-321-321" not found (perhaps it is the startpage?)'
         );
 
-        $extension = new ContentTwigExtension(
-            $this->contentMapper->reveal(),
-            $this->structureResolver,
-            $this->sessionManager->reveal(),
-            $this->requestAnalyzer->reveal(),
-            $this->logger->reveal()
-        );
-
-        $extension->loadParent('321-321-321');
+        $this->extension->loadParent('321-321-321');
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
@@ -25,8 +26,6 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
  */
 class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensionInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * @var ContentMapperInterface
      */
@@ -48,19 +47,25 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
     private $sessionManager;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Constructor.
      */
     public function __construct(
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver,
         SessionManagerInterface $sessionManager,
-        RequestAnalyzerInterface $requestAnalyzer
+        RequestAnalyzerInterface $requestAnalyzer,
+        LoggerInterface $logger = null
     ) {
         $this->contentMapper = $contentMapper;
         $this->structureResolver = $structureResolver;
         $this->sessionManager = $sessionManager;
         $this->requestAnalyzer = $requestAnalyzer;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -11,7 +11,8 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
@@ -24,6 +25,8 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
  */
 class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensionInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var ContentMapperInterface
      */
@@ -45,25 +48,19 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
     private $sessionManager;
 
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * Constructor.
      */
     public function __construct(
         ContentMapperInterface $contentMapper,
         StructureResolverInterface $structureResolver,
         SessionManagerInterface $sessionManager,
-        RequestAnalyzerInterface $requestAnalyzer,
-        LoggerInterface $logger
+        RequestAnalyzerInterface $requestAnalyzer
     ) {
         $this->contentMapper = $contentMapper;
         $this->structureResolver = $structureResolver;
         $this->sessionManager = $sessionManager;
         $this->requestAnalyzer = $requestAnalyzer;
-        $this->logger = $logger;
+        $this->logger = new NullLogger();
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Content\Import;
 
 use PHPCR\NodeInterface;
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\ContentBundle\Document\BasePageDocument;

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Content\Import;
 
 use PHPCR\NodeInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
@@ -39,8 +40,6 @@ use Symfony\Component\Console\Output\NullOutput;
  */
 class WebspaceImport extends Import implements WebspaceImportInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * @var DocumentManagerInterface
      */
@@ -72,6 +71,11 @@ class WebspaceImport extends Import implements WebspaceImportInterface
     protected $rlpStrategy;
 
     /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
      * @var array
      */
     protected static $excludedSettings = [
@@ -93,7 +97,8 @@ class WebspaceImport extends Import implements WebspaceImportInterface
         StructureManagerInterface $structureManager,
         ExtensionManagerInterface $extensionManager,
         ImportManagerInterface $importManager,
-        FormatImportInterface $xliff12
+        FormatImportInterface $xliff12,
+        LoggerInterface $logger = null
     ) {
         parent::__construct($importManager, $legacyPropertyFactory, ['1.2.xliff' => $xliff12]);
 
@@ -103,7 +108,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
         $this->rlpStrategy = $rlpStrategy;
         $this->structureManager = $structureManager;
         $this->extensionManager = $extensionManager;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -12,7 +12,8 @@
 namespace Sulu\Component\Content\Import;
 
 use PHPCR\NodeInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\ContentBundle\Document\BasePageDocument;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -38,6 +39,8 @@ use Symfony\Component\Console\Output\NullOutput;
  */
 class WebspaceImport extends Import implements WebspaceImportInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var DocumentManagerInterface
      */
@@ -69,11 +72,6 @@ class WebspaceImport extends Import implements WebspaceImportInterface
     protected $rlpStrategy;
 
     /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
      * @var array
      */
     protected static $excludedSettings = [
@@ -95,7 +93,6 @@ class WebspaceImport extends Import implements WebspaceImportInterface
         StructureManagerInterface $structureManager,
         ExtensionManagerInterface $extensionManager,
         ImportManagerInterface $importManager,
-        LoggerInterface $logger,
         FormatImportInterface $xliff12
     ) {
         parent::__construct($importManager, $legacyPropertyFactory, ['1.2.xliff' => $xliff12]);
@@ -106,7 +103,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
         $this->rlpStrategy = $rlpStrategy;
         $this->structureManager = $structureManager;
         $this->extensionManager = $extensionManager;
-        $this->logger = $logger;
+        $this->logger = new NullLogger();
     }
 
     /**

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\DocumentManager\EventDispatcher;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -37,10 +38,10 @@ class DebugEventDispatcher extends EventDispatcher
      */
     public function __construct(
         Stopwatch $stopwatch,
-        LoggerInterface $logger
+        LoggerInterface $logger = null
     ) {
         $this->stopwatch = $stopwatch;
-        $this->logger = $logger;
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Component/Snippet/Import/SnippetImport.php
+++ b/src/Sulu/Component/Snippet/Import/SnippetImport.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Snippet\Import;
 
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Component\Content\Compat\Structure;
@@ -34,8 +35,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SnippetImport extends Import implements SnippetImportInterface
 {
-    use LoggerAwareTrait;
-
     /**
      * @var DocumentManagerInterface
      */
@@ -51,20 +50,26 @@ class SnippetImport extends Import implements SnippetImportInterface
      */
     protected $documentRegistry;
 
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
     public function __construct(
         DocumentManager $documentManager,
         StructureManagerInterface $structureManager,
         DocumentRegistry $documentRegistry,
         ImportManagerInterface $importManager,
         LegacyPropertyFactory $legacyPropertyFactory,
-        FormatImportInterface $xliff12
+        FormatImportInterface $xliff12,
+        LoggerInterface $logger = null
     ) {
         parent::__construct($importManager, $legacyPropertyFactory, ['1.2.xliff' => $xliff12]);
 
         $this->documentManager = $documentManager;
         $this->documentRegistry = $documentRegistry;
         $this->structureManager = $structureManager;
-        $this->logger = new NullLogger();
+        $this->logger = $logger ?: new NullLogger();
     }
 
     /**

--- a/src/Sulu/Component/Snippet/Import/SnippetImport.php
+++ b/src/Sulu/Component/Snippet/Import/SnippetImport.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Snippet\Import;
 
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;

--- a/src/Sulu/Component/Snippet/Import/SnippetImport.php
+++ b/src/Sulu/Component/Snippet/Import/SnippetImport.php
@@ -11,7 +11,8 @@
 
 namespace Sulu\Component\Snippet\Import;
 
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
@@ -33,10 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SnippetImport extends Import implements SnippetImportInterface
 {
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    use LoggerAwareTrait;
 
     /**
      * @var DocumentManagerInterface
@@ -59,7 +57,6 @@ class SnippetImport extends Import implements SnippetImportInterface
         DocumentRegistry $documentRegistry,
         ImportManagerInterface $importManager,
         LegacyPropertyFactory $legacyPropertyFactory,
-        LoggerInterface $logger,
         FormatImportInterface $xliff12
     ) {
         parent::__construct($importManager, $legacyPropertyFactory, ['1.2.xliff' => $xliff12]);
@@ -67,7 +64,7 @@ class SnippetImport extends Import implements SnippetImportInterface
         $this->documentManager = $documentManager;
         $this->documentRegistry = $documentRegistry;
         $this->structureManager = $structureManager;
-        $this->logger = $logger;
+        $this->logger = new NullLogger();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes constructors changed
| Deprecations? | no
| License | MIT

#### What's in this PR?

Make logger service optional and use `PSR\Log\NullLogger` when not available.

#### Why?

Currently sulu container does not build without monolog bundle installed. So in many cases like in bundles which does not need monolog need to require monolog for there tests:

e.g.:

 - [Community Bundle](https://github.com/sulu/SuluCommunityBundle/blob/8c67eb0fc4970064b36c4a3b827c17bd7fce4187/composer.json#L35)
 -  [SuluFormBundle](https://github.com/sulu/SuluFormBundle/blob/7bc6e35d6d3619f3d0de9249ed3bbbb52f367122/composer.json#L15)
 - [SuluArticleBundle](https://github.com/sulu/SuluArticleBundle/blob/5f6b4e90821f71da9179aeb7ca642d88fba1bce1/composer.json#L18)

#### To Do

- [x] Add breaking changes to UPGRADE.md
