### PR TITLE
Fix compatibility to symfony 3.4.21, 4.1.10 and 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-develop
+    * BUGFIX      #4349 [ContentBundle]         Fix compatibility to symfony 3.4.21, 4.1.10 and 4.2.2
+
 * 1.6.23 (2018-12-03)
     * FEATURE     #4236 [MediaBundle]           Added autorotation based on exif
     * HOTFIX      #4304 [DocumentManager]       Fix performance issue by removing redundant properties on Metadata

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/AbstractStructureBehaviorType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/AbstractStructureBehaviorType.php
@@ -30,7 +30,7 @@ abstract class AbstractStructureBehaviorType extends AbstractType
     {
         $builder->add('title', TextType::class);
         $builder->add('structureType', TextType::class);
-        $builder->add('structure', TextType::class, ['property_path' => 'structure.stagedData']);
+        $builder->add('structure', UnstructuredType::class, ['property_path' => 'structure.stagedData']);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, [DataNormalizer::class, 'normalize']);
     }

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/BasePageDocumentType.php
@@ -43,7 +43,7 @@ abstract class BasePageDocumentType extends AbstractStructureBehaviorType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('extensions', TextType::class, ['property_path' => 'extensionsData']);
+        $builder->add('extensions', UnstructuredType::class, ['property_path' => 'extensionsData']);
         $builder->add('resourceSegment', TextType::class);
         $builder->add(
             'navigationContexts',

--- a/src/Sulu/Bundle/ContentBundle/Form/Type/UnstructuredType.php
+++ b/src/Sulu/Bundle/ContentBundle/Form/Type/UnstructuredType.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContentBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @internal
+ */
+class UnstructuredType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'compound' => false,
+            'multiple' => true,
+        ]);
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
+++ b/src/Sulu/Bundle/SnippetBundle/Form/SnippetType.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Form;
 
 use Sulu\Bundle\ContentBundle\Form\Type\AbstractStructureBehaviorType;
+use Sulu\Bundle\ContentBundle\Form\Type\UnstructuredType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -36,7 +37,7 @@ class SnippetType extends AbstractStructureBehaviorType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
-        $builder->add('extensions', TextType::class, ['property_path' => 'extensionsData']);
+        $builder->add('extensions', UnstructuredType::class, ['property_path' => 'extensionsData']);
         $builder->add('workflowStage');
 
         // TODO: Fix the admin interface to not send this junk (not required for snippets)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix form submit of unstructured data.

#### Why?

Symfony seems since the latest release https://github.com/symfony/symfony/issues/29809 only allow scalar values be submit in the TextType.

> [structure.stagedData] This value is not valid. ({"{{ value }}":"NULL"})

I not really happy with the solution but currently seems the only working one.