### PR TITLE
Remove tolowercase from default snippet manager

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/DefaultSnippetManager.php
@@ -59,7 +59,7 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
         $this->documentManager = $documentManager;
         $this->webspaceManager = $webspaceManager;
         $this->registry = $registry;
-        $this->areas = new FrozenParameterBag(array_change_key_case($areas));
+        $this->areas = new FrozenParameterBag($areas);
     }
 
     /**
@@ -158,8 +158,7 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
      */
     public function loadIdentifier($webspaceKey, $type)
     {
-        // TODO remove strtolower as soon as lowest Symfony version is 3.4
-        $area = $this->areas->get(strtolower($type));
+        $area = $this->areas->get($type);
 
         return $this->settingsManager->loadString($webspaceKey, 'snippets-' . $area['key']);
     }
@@ -174,8 +173,7 @@ class DefaultSnippetManager implements DefaultSnippetManagerInterface
      */
     private function checkTemplate($document, $type)
     {
-        // TODO remove strtolower as soon as lowest Symfony version is 3.4
-        $area = $this->areas->get(strtolower($type));
+        $area = $this->areas->get($type);
 
         return $document->getStructureType() === $area['template'];
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove tolowercase from default snippet manager.

#### Why?

Was introduced because of a strange behaviour in <3.4 symfony versions where `get` method did strtolower but the array wasn't set strtolower:
See https://github.com/symfony/symfony/pull/24065#issuecomment-326638713