### PR TITLE
Add toolbar action registry for datagrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ composer.lock
 
 # npm
 package-lock.json
-/node_modules
+node_modules/
 yarn.lock
 
 # phpunit

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,25 @@
 
 ## dev-develop
 
+### Datagrid Toolbar Actions added
+
+**This change only affects you if you have used a 2.0.0 alpha release before**
+
+The datagrid will not longer add automatically toolbar actions so if you e.g.
+need a delete and add button on your datagrid you should add them to your
+toolbarActions the following way:
+
+```php
+$this->routeBuilderFactory->createDatagridRouteBuilder(...)
+    ->addToolbarActions([
+        'sulu_admin.add',
+        'sulu_admin.delete',
+    ]);
+```
+
+The functions `enableMoving` and `disableMoving` where also replaced by a
+ToolbarAction called `sulu_admin.move`.
+
 ### Add sulu preinstall script to your package.json
 
 Sulu will check if the dependencies are correctly install in a preinstall script

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilder.php
@@ -92,6 +92,24 @@ class DatagridRouteBuilder implements DatagridRouteBuilderInterface
         return $this;
     }
 
+    public function addToolbarActions(array $toolbarActions): DatagridRouteBuilderInterface
+    {
+        $oldToolbarActions = $this->route->getOption('toolbarActions');
+        $newToolbarActions = $oldToolbarActions ? array_merge($oldToolbarActions, $toolbarActions) : $toolbarActions;
+        $this->route->setOption('toolbarActions', $newToolbarActions);
+
+        return $this;
+    }
+
+    public function removeToolbarAction(string $toolbarAction): DatagridRouteBuilderInterface
+    {
+        $toolbarActions = $this->route->getOption('toolbarActions');
+        unset($toolbarActions[array_search($toolbarAction, $toolbarActions)]);
+        $this->route->setOption('toolbarActions', $toolbarActions);
+
+        return $this;
+    }
+
     public function setAddRoute(string $addRoute): DatagridRouteBuilderInterface
     {
         $this->route->setOption('addRoute', $addRoute);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilder.php
@@ -101,15 +101,6 @@ class DatagridRouteBuilder implements DatagridRouteBuilderInterface
         return $this;
     }
 
-    public function removeToolbarAction(string $toolbarAction): DatagridRouteBuilderInterface
-    {
-        $toolbarActions = $this->route->getOption('toolbarActions');
-        unset($toolbarActions[array_search($toolbarAction, $toolbarActions)]);
-        $this->route->setOption('toolbarActions', $toolbarActions);
-
-        return $this;
-    }
-
     public function setAddRoute(string $addRoute): DatagridRouteBuilderInterface
     {
         $this->route->setOption('addRoute', $addRoute);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilderInterface.php
@@ -40,8 +40,6 @@ interface DatagridRouteBuilderInterface
      */
     public function addToolbarActions(array $toolbarActions): self;
 
-    public function removeToolbarAction(string $toolbarAction): self;
-
     public function setDefaultLocale(string $locale): self;
 
     public function setAddRoute(string $addRoute): self;
@@ -53,10 +51,6 @@ interface DatagridRouteBuilderInterface
     public function enableSearching(): self;
 
     public function disableSearching(): self;
-
-    public function enableMoving(): self;
-
-    public function disableMoving(): self;
 
     /**
      * @param string[] $routerAttributesToDatagridStore

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilderInterface.php
@@ -35,6 +35,13 @@ interface DatagridRouteBuilderInterface
      */
     public function addLocales(array $locales): self;
 
+    /**
+     * @param string[] $toolbarActions
+     */
+    public function addToolbarActions(array $toolbarActions): self;
+
+    public function removeToolbarAction(string $toolbarAction): self;
+
     public function setDefaultLocale(string $locale): self;
 
     public function setAddRoute(string $addRoute): self;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -63,7 +63,6 @@ export default class Datagrid extends React.Component<Props> {
     @observable deleting: boolean = false;
     @observable moving: boolean = false;
     @observable ordering: boolean = false;
-    @observable selectionDeleting: boolean = false;
     @observable showCopyOverlay: boolean = false;
     @observable showDeleteDialog: boolean = false;
     @observable showMoveOverlay: boolean = false;
@@ -138,10 +137,8 @@ export default class Datagrid extends React.Component<Props> {
     };
 
     @action handleSelectionDeleteDialogConfirmClick = () => {
-        this.selectionDeleting = true;
         this.props.store.deleteSelection().then(action(() => {
             this.showDeleteSelectionDialog = false;
-            this.selectionDeleting = false;
         }));
     };
 
@@ -501,7 +498,7 @@ export default class Datagrid extends React.Component<Props> {
                 </div>
                 <Dialog
                     cancelText={translate('sulu_admin.cancel')}
-                    confirmLoading={this.selectionDeleting}
+                    confirmLoading={this.props.store.deleting}
                     confirmText={translate('sulu_admin.ok')}
                     onCancel={this.handleSelectionDeleteDialogCancelClick}
                     onConfirm={this.handleSelectionDeleteDialogConfirmClick}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -59,10 +59,6 @@ export default class Datagrid extends React.Component<Props> {
     };
 
     @observable currentAdapterKey: string;
-    @observable copying: boolean = false;
-    @observable deleting: boolean = false;
-    @observable moving: boolean = false;
-    @observable ordering: boolean = false;
     @observable showCopyOverlay: boolean = false;
     @observable showDeleteDialog: boolean = false;
     @observable showMoveOverlay: boolean = false;
@@ -156,10 +152,8 @@ export default class Datagrid extends React.Component<Props> {
                 return response;
             }
 
-            this.deleting = true;
             this.props.store.delete(id).then(action(() => {
                 this.showDeleteDialog = false;
-                this.deleting = false;
             }));
 
             return response;
@@ -200,11 +194,9 @@ export default class Datagrid extends React.Component<Props> {
                 throw new Error('The moveId is not set. This should not happen and is likely a bug.');
             }
 
-            this.moving = true;
             // TODO do not hardcode "id", but use some kind of metadata instead
             this.props.store.move(this.moveId, response.parent.id).then(action(() => {
                 this.moveId = undefined;
-                this.moving = false;
                 this.showMoveOverlay = false;
             }));
 
@@ -240,10 +232,8 @@ export default class Datagrid extends React.Component<Props> {
                 return response;
             }
 
-            this.copying = true;
             // TODO do not hardcode "id", but use some kind of metadata instead
             this.props.store.copy(id, response.parent.id).then(action(() => {
-                this.copying = false;
                 this.showCopyOverlay = false;
             }));
 
@@ -279,10 +269,8 @@ export default class Datagrid extends React.Component<Props> {
                 return response;
             }
 
-            this.ordering = true;
             this.props.store.order(id, position).then(action(() => {
                 this.showOrderDialog = false;
-                this.ordering = false;
             }));
 
             return response;
@@ -498,7 +486,7 @@ export default class Datagrid extends React.Component<Props> {
                 </div>
                 <Dialog
                     cancelText={translate('sulu_admin.cancel')}
-                    confirmLoading={store.deleting}
+                    confirmLoading={store.deletingSelection}
                     confirmText={translate('sulu_admin.ok')}
                     onCancel={this.handleSelectionDeleteDialogCancelClick}
                     onConfirm={this.handleSelectionDeleteDialogConfirmClick}
@@ -510,7 +498,7 @@ export default class Datagrid extends React.Component<Props> {
                 {deletable &&
                     <Dialog
                         cancelText={translate('sulu_admin.cancel')}
-                        confirmLoading={this.deleting}
+                        confirmLoading={store.deleting}
                         confirmText={translate('sulu_admin.ok')}
                         onCancel={this.handleDeleteDialogCancelClick}
                         onConfirm={this.handleDeleteDialogConfirmClick}
@@ -525,7 +513,7 @@ export default class Datagrid extends React.Component<Props> {
                         adapter={adapters[0]}
                         allowActivateForDisabledItems={false}
                         clearSelectionOnClose={true}
-                        confirmLoading={this.moving}
+                        confirmLoading={store.movingSelection || store.moving}
                         datagridKey={store.datagridKey}
                         disabledIds={this.moveId ? [this.moveId] : []}
                         locale={store.observableOptions.locale}
@@ -542,7 +530,7 @@ export default class Datagrid extends React.Component<Props> {
                     <SingleDatagridOverlay
                         adapter={adapters[0]}
                         clearSelectionOnClose={true}
-                        confirmLoading={this.copying}
+                        confirmLoading={store.copying}
                         datagridKey={store.datagridKey}
                         locale={store.observableOptions.locale}
                         onClose={this.handleCopyOverlayClose}
@@ -557,7 +545,7 @@ export default class Datagrid extends React.Component<Props> {
                 {orderable &&
                     <Dialog
                         cancelText={translate('sulu_admin.cancel')}
-                        confirmLoading={this.ordering}
+                        confirmLoading={store.ordering}
                         confirmText={translate('sulu_admin.ok')}
                         onCancel={this.handleOrderDialogCancelClick}
                         onConfirm={this.handleOrderDialogConfirmClick}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -498,7 +498,7 @@ export default class Datagrid extends React.Component<Props> {
                 </div>
                 <Dialog
                     cancelText={translate('sulu_admin.cancel')}
-                    confirmLoading={this.props.store.deleting}
+                    confirmLoading={store.deleting}
                     confirmText={translate('sulu_admin.ok')}
                     onCancel={this.handleSelectionDeleteDialogCancelClick}
                     onConfirm={this.handleSelectionDeleteDialogConfirmClick}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -26,6 +26,7 @@ export default class DatagridStore {
     @observable selections: Array<Object> = [];
     @observable dataLoading: boolean = true;
     @observable deleting: boolean = false;
+    @observable moving: boolean = false;
     @observable schemaLoading: boolean = true;
     @observable loadingStrategy: LoadingStrategyInterface;
     @observable structureStrategy: StructureStrategyInterface;
@@ -336,9 +337,11 @@ export default class DatagridStore {
 
     @action moveSelection = (parentId: string | number) => {
         const {selectionIds} = this;
+        this.moving = true;
 
         return Promise.all(selectionIds.map((selectionId: string | number) => this.requestMove(selectionId, parentId)))
             .then(action(() => {
+                this.moving = false;
                 this.clear();
                 this.activate(parentId);
             }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -26,7 +26,11 @@ export default class DatagridStore {
     @observable selections: Array<Object> = [];
     @observable dataLoading: boolean = true;
     @observable deleting: boolean = false;
+    @observable deletingSelection: boolean = false;
     @observable moving: boolean = false;
+    @observable movingSelection: boolean = false;
+    @observable copying: boolean = false;
+    @observable ordering: boolean = false;
     @observable schemaLoading: boolean = true;
     @observable loadingStrategy: LoadingStrategyInterface;
     @observable structureStrategy: StructureStrategyInterface;
@@ -305,8 +309,11 @@ export default class DatagridStore {
     }
 
     delete = (id: string | number): Promise<Object> => {
+        this.deleting = true;
+
         return ResourceRequester.delete(this.resourceKey, id, this.queryOptions)
             .then(action(() => {
+                this.deleting = false;
                 this.deselectById(id);
                 this.remove(id);
             }));
@@ -328,8 +335,11 @@ export default class DatagridStore {
     }
 
     move = (id: string | number, parentId: string | number) => {
+        this.moving = true;
+
         return this.requestMove(id, parentId)
             .then(action(() => {
+                this.moving = false;
                 this.activate(id);
                 this.clear();
             }));
@@ -337,11 +347,11 @@ export default class DatagridStore {
 
     @action moveSelection = (parentId: string | number) => {
         const {selectionIds} = this;
-        this.moving = true;
+        this.movingSelection = true;
 
         return Promise.all(selectionIds.map((selectionId: string | number) => this.requestMove(selectionId, parentId)))
             .then(action(() => {
-                this.moving = false;
+                this.movingSelection = false;
                 this.clear();
                 this.activate(parentId);
             }));
@@ -359,8 +369,11 @@ export default class DatagridStore {
             queryOptions.locale = locale.get();
         }
 
+        this.copying = true;
+
         return ResourceRequester.postWithId(this.resourceKey, id, queryOptions)
             .then(action((response) => {
+                this.copying = false;
                 // TODO do not hardcode "id", but use some metadata instead
                 this.activate(response.id);
                 this.clear();
@@ -369,7 +382,7 @@ export default class DatagridStore {
 
     @action deleteSelection = () => {
         const deletePromises = [];
-        this.deleting = true;
+        this.deletingSelection = true;
         this.selectionIds.forEach((id) => {
             deletePromises.push(ResourceRequester.delete(this.resourceKey, id, this.queryOptions).catch((error) => {
                 if (error.status !== 404) {
@@ -381,7 +394,7 @@ export default class DatagridStore {
         return Promise.all(deletePromises).then(action(() => {
             this.selectionIds.forEach(this.remove);
             this.clearSelection();
-            this.deleting = false;
+            this.deletingSelection = false;
         }));
     };
 
@@ -503,14 +516,17 @@ export default class DatagridStore {
     }
 
     @action order(id: string | number, order: number) {
+        this.ordering = true;
+
         return ResourceRequester.postWithId(
             this.resourceKey,
             id,
             {position: order},
             {...this.queryOptions, action: 'order'}
-        ).then(() => {
+        ).then(action(() => {
+            this.ordering = false;
             this.structureStrategy.order(id, order);
-        });
+        }));
     }
 
     @action search(searchTerm: ?string) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/stores/DatagridStore.js
@@ -25,6 +25,7 @@ export default class DatagridStore {
     @observable pageCount: ?number = 0;
     @observable selections: Array<Object> = [];
     @observable dataLoading: boolean = true;
+    @observable deleting: boolean = false;
     @observable schemaLoading: boolean = true;
     @observable loadingStrategy: LoadingStrategyInterface;
     @observable structureStrategy: StructureStrategyInterface;
@@ -365,6 +366,7 @@ export default class DatagridStore {
 
     @action deleteSelection = () => {
         const deletePromises = [];
+        this.deleting = true;
         this.selectionIds.forEach((id) => {
             deletePromises.push(ResourceRequester.delete(this.resourceKey, id, this.queryOptions).catch((error) => {
                 if (error.status !== 404) {
@@ -376,6 +378,7 @@ export default class DatagridStore {
         return Promise.all(deletePromises).then(action(() => {
             this.selectionIds.forEach(this.remove);
             this.clearSelection();
+            this.deleting = false;
         }));
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/Datagrid.test.js
@@ -1,7 +1,7 @@
 // @flow
 import {mount, render, shallow} from 'enzyme';
 import React from 'react';
-import {observable} from 'mobx';
+import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import {translate} from '../../../utils/Translator';
 import SingleDatagridOverlay from '../../SingleDatagridOverlay';
 import Datagrid from '../Datagrid';
@@ -72,6 +72,11 @@ jest.mock('../stores/DatagridStore', () => jest.fn(function(resourceKey, datagri
     this.search = jest.fn();
     this.move = jest.fn();
     this.copy = jest.fn();
+
+    mockExtendObservable(this, {
+        copying: false,
+        ordering: false,
+    });
 }));
 
 jest.mock('../registries/DatagridAdapterRegistry', () => ({
@@ -526,12 +531,10 @@ test('DatagridStore should copy item when onRequestItemCopy callback is called a
 
     datagrid.find(SingleDatagridOverlay).at(1).prop('onConfirm')({id: 8});
     return requestCopyPromise.then(() => {
-        expect(datagrid.instance().copying).toEqual(true);
         expect(datagridStore.copy).toBeCalledWith(5, 8);
 
         return copyPromise.then(() => {
             datagrid.update();
-            expect(datagrid.instance().copying).toEqual(false);
             expect(datagrid.find(SingleDatagridOverlay).at(1).prop('open')).toEqual(false);
         });
     });
@@ -584,12 +587,10 @@ test('DatagridStore should move item when onRequestItemMove callback is called a
 
     datagrid.find(SingleDatagridOverlay).at(0).prop('onConfirm')({id: 8});
     return requestMovePromise.then(() => {
-        expect(datagrid.instance().moving).toEqual(true);
         expect(datagridStore.move).toBeCalledWith(5, 8);
 
         return movePromise.then(() => {
             datagrid.update();
-            expect(datagrid.instance().moving).toEqual(false);
             expect(datagrid.find(SingleDatagridOverlay).at(0).prop('open')).toEqual(false);
         });
     });
@@ -688,12 +689,10 @@ test('DatagridStore should delete item when onRequestItemDelete callback is call
 
     datagrid.find('Dialog').at(1).prop('onConfirm')();
     return requestDeletePromise.then(() => {
-        expect(datagrid.instance().deleting).toEqual(true);
         expect(datagridStore.delete).toBeCalledWith(5);
 
         return deletePromise.then(() => {
             datagrid.update();
-            expect(datagrid.instance().deleting).toEqual(false);
             expect(datagrid.find('Dialog').at(1).prop('open')).toEqual(false);
         });
     });
@@ -743,12 +742,10 @@ test('DatagridStore should order item when onRequestItemOrder callback is called
     datagrid.find('Dialog').at(2).prop('onConfirm')();
 
     return requestOrderPromise.then(() => {
-        expect(datagrid.instance().ordering).toEqual(true);
         expect(datagridStore.order).toBeCalledWith(5, 8);
 
         return orderPromise.then(() => {
             datagrid.update();
-            expect(datagrid.instance().ordering).toEqual(false);
             expect(datagrid.find('Dialog').at(2).prop('open')).toEqual(false);
         });
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -1477,7 +1477,12 @@ test('Should move all selected items to the new given parent and reload the data
         datagridStore.select({id: 1});
         datagridStore.select({id: 2});
         datagridStore.select({id: 4});
+
+        expect(datagridStore.moving).toEqual(false);
+
         const moveSelectionPromise = datagridStore.moveSelection(3);
+
+        expect(datagridStore.moving).toEqual(true);
 
         expect(ResourceRequester.postWithId)
             .toBeCalledWith('snippets', 1, {}, {action: 'move', destination: 3, locale: 'de', webspace: 'sulu'});
@@ -1487,6 +1492,7 @@ test('Should move all selected items to the new given parent and reload the data
             .toBeCalledWith('snippets', 4, {}, {action: 'move', destination: 3, locale: 'de', webspace: 'sulu'});
 
         return moveSelectionPromise.then(() => {
+            expect(datagridStore.moving).toEqual(false);
             expect(structureStrategy.clear).toBeCalledWith();
             expect(loadingStrategy.load).toHaveBeenLastCalledWith(
                 'snippets',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/stores/DatagridStore.test.js
@@ -1478,11 +1478,11 @@ test('Should move all selected items to the new given parent and reload the data
         datagridStore.select({id: 2});
         datagridStore.select({id: 4});
 
-        expect(datagridStore.moving).toEqual(false);
+        expect(datagridStore.movingSelection).toEqual(false);
 
         const moveSelectionPromise = datagridStore.moveSelection(3);
 
-        expect(datagridStore.moving).toEqual(true);
+        expect(datagridStore.movingSelection).toEqual(true);
 
         expect(ResourceRequester.postWithId)
             .toBeCalledWith('snippets', 1, {}, {action: 'move', destination: 3, locale: 'de', webspace: 'sulu'});
@@ -1492,7 +1492,7 @@ test('Should move all selected items to the new given parent and reload the data
             .toBeCalledWith('snippets', 4, {}, {action: 'move', destination: 3, locale: 'de', webspace: 'sulu'});
 
         return moveSelectionPromise.then(() => {
-            expect(datagridStore.moving).toEqual(false);
+            expect(datagridStore.movingSelection).toEqual(false);
             expect(structureStrategy.clear).toBeCalledWith();
             expect(loadingStrategy.load).toHaveBeenLastCalledWith(
                 'snippets',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Select.js
@@ -3,7 +3,7 @@ import React from 'react';
 import MultiSelectComponent from '../../../components/MultiSelect';
 import type {FieldTypeProps} from '../../../types';
 
-const MISSING_VALUES_OPTIONS = 'The "values" option has to be set for the SingleSelect FieldType';
+const MISSING_VALUES_OPTIONS = 'The "values" option has to be set for the Select FieldType';
 
 type Props = FieldTypeProps<Array<string | number>>;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -15,7 +15,10 @@ import userStore, {logoutOnUnauthorizedResponse} from './stores/UserStore';
 import {bundleReady, Config, resourceEndpointRegistry} from './services';
 import initializer from './services/Initializer';
 import ResourceTabs from './views/ResourceTabs';
-import Datagrid from './views/Datagrid';
+import Datagrid, {
+    DeleteToolbarAction as DatagridDeleteToolbarAction,
+    toolbarActionRegistry as datagridToolbarActionRegistry,
+} from './views/Datagrid';
 import CKEditor5 from './containers/TextEditor/adapters/CKEditor5';
 import {
     BoolFieldTransformer,
@@ -66,11 +69,11 @@ import {
 } from './containers/Form';
 import {textEditorRegistry} from './containers/TextEditor';
 import Form, {
-    DeleteToolbarAction,
-    SaveToolbarAction,
-    SaveWithPublishingToolbarAction,
-    toolbarActionRegistry,
-    TypeToolbarAction,
+    DeleteToolbarAction as FormDeleteToolbarAction,
+    SaveToolbarAction as FormSaveToolbarAction,
+    SaveWithPublishingToolbarAction as FormSaveWithPublishingToolbarAction,
+    toolbarActionRegistry as formToolbarActionRegistry,
+    TypeToolbarAction as FormTypeToolbarAction,
 } from './views/Form';
 import {navigationRegistry} from './containers/Navigation';
 import {smartContentConfigStore} from './containers/SmartContent';
@@ -116,7 +119,8 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         registerDatagridFieldTransformers();
         registerFieldTypes(config.fieldTypeOptions);
         registerTextEditors();
-        registerToolbarActions();
+        registerFormToolbarActions();
+        registerDatagridToolbarActions();
         registerViews();
     }
 
@@ -209,11 +213,15 @@ function registerTextEditors() {
     textEditorRegistry.add('ckeditor5', CKEditor5);
 }
 
-function registerToolbarActions() {
-    toolbarActionRegistry.add('sulu_admin.delete', DeleteToolbarAction);
-    toolbarActionRegistry.add('sulu_admin.save_with_publishing', SaveWithPublishingToolbarAction);
-    toolbarActionRegistry.add('sulu_admin.save', SaveToolbarAction);
-    toolbarActionRegistry.add('sulu_admin.type', TypeToolbarAction);
+function registerFormToolbarActions() {
+    formToolbarActionRegistry.add('sulu_admin.delete', FormDeleteToolbarAction);
+    formToolbarActionRegistry.add('sulu_admin.save_with_publishing', FormSaveWithPublishingToolbarAction);
+    formToolbarActionRegistry.add('sulu_admin.save', FormSaveToolbarAction);
+    formToolbarActionRegistry.add('sulu_admin.type', FormTypeToolbarAction);
+}
+
+function registerDatagridToolbarActions() {
+    datagridToolbarActionRegistry.add('sulu_admin.delete', DatagridDeleteToolbarAction);
 }
 
 function processConfig(config: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -16,7 +16,9 @@ import {bundleReady, Config, resourceEndpointRegistry} from './services';
 import initializer from './services/Initializer';
 import ResourceTabs from './views/ResourceTabs';
 import Datagrid, {
+    AddToolbarAction as DatagridAddToolbarAction,
     DeleteToolbarAction as DatagridDeleteToolbarAction,
+    MoveToolbarAction as DatagridMovingToolbarAction,
     toolbarActionRegistry as datagridToolbarActionRegistry,
 } from './views/Datagrid';
 import CKEditor5 from './containers/TextEditor/adapters/CKEditor5';
@@ -221,7 +223,9 @@ function registerFormToolbarActions() {
 }
 
 function registerDatagridToolbarActions() {
+    datagridToolbarActionRegistry.add('sulu_admin.add', DatagridAddToolbarAction);
     datagridToolbarActionRegistry.add('sulu_admin.delete', DatagridDeleteToolbarAction);
+    datagridToolbarActionRegistry.add('sulu_admin.move', DatagridMovingToolbarAction);
 }
 
 function processConfig(config: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -18,7 +18,7 @@ import ResourceTabs from './views/ResourceTabs';
 import Datagrid, {
     AddToolbarAction as DatagridAddToolbarAction,
     DeleteToolbarAction as DatagridDeleteToolbarAction,
-    MoveToolbarAction as DatagridMovingToolbarAction,
+    MoveToolbarAction as DatagridMoveToolbarAction,
     toolbarActionRegistry as datagridToolbarActionRegistry,
 } from './views/Datagrid';
 import CKEditor5 from './containers/TextEditor/adapters/CKEditor5';
@@ -225,7 +225,7 @@ function registerFormToolbarActions() {
 function registerDatagridToolbarActions() {
     datagridToolbarActionRegistry.add('sulu_admin.add', DatagridAddToolbarAction);
     datagridToolbarActionRegistry.add('sulu_admin.delete', DatagridDeleteToolbarAction);
-    datagridToolbarActionRegistry.add('sulu_admin.move', DatagridMovingToolbarAction);
+    datagridToolbarActionRegistry.add('sulu_admin.move', DatagridMoveToolbarAction);
 }
 
 function processConfig(config: Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -4,13 +4,14 @@ import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import type {ElementRef} from 'react';
 import React from 'react';
-import {default as DatagridContainer} from '../../containers/Datagrid';
+import equals from 'fast-deep-equal';
+import {default as DatagridContainer, DatagridStore} from '../../containers/Datagrid';
 import SingleDatagridOverlay from '../../containers/SingleDatagridOverlay';
-import DatagridStore from '../../containers/Datagrid/stores/DatagridStore';
 import {withToolbar} from '../../containers/Toolbar';
 import type {ViewProps} from '../../containers/ViewRenderer';
 import type {Route} from '../../services/Router/types';
 import {translate} from '../../utils/Translator';
+import toolbarActionRegistry from './registries/ToolbarActionRegistry';
 import datagridStyles from './datagrid.scss';
 
 const USER_SETTINGS_KEY = 'datagrid';
@@ -24,6 +25,7 @@ class Datagrid extends React.Component<ViewProps> {
     @observable deleting: boolean = false;
     @observable moving: boolean = false;
     @observable showMoveOverlay: boolean = false;
+    @observable toolbarActions = [];
 
     static getDerivedRouteAttributes(route: Route) {
         const {
@@ -119,6 +121,53 @@ class Datagrid extends React.Component<ViewProps> {
         return datagridStoreOptions;
     }
 
+    @action componentDidMount() {
+        const {router} = this.props;
+        const {
+            route: {
+                options: {
+                    locales,
+                    toolbarActions,
+                },
+            },
+        } = router;
+
+        if (!toolbarActions) {
+            return;
+        }
+
+        this.toolbarActions = toolbarActions.map((toolbarAction) => new (toolbarActionRegistry.get(toolbarAction))(
+            this.datagridStore,
+            this,
+            router,
+            locales
+        ));
+    }
+
+    componentDidUpdate(prevProps: ViewProps) {
+        const {
+            route: {
+                options: {
+                    locales,
+                },
+            },
+        } = this.props.router;
+
+        const {
+            route: {
+                options: {
+                    prevLocales,
+                },
+            },
+        } = prevProps.router;
+
+        if (!equals(locales, prevLocales)) {
+            this.toolbarActions.forEach((toolbarAction) => {
+                toolbarAction.setLocales(this.props.route.options.locales);
+            });
+        }
+    }
+
     componentWillUnmount() {
         this.datagridStore.destroy();
     }
@@ -134,6 +183,14 @@ class Datagrid extends React.Component<ViewProps> {
         } = router;
 
         router.navigate(addRoute, {locale: this.locale.get(), parentId: rowId});
+    };
+
+    handleDelete = () => {
+        if (!this.datagrid) {
+            throw new Error('Datagrid not created yet.');
+        }
+
+        this.datagrid.requestSelectionDelete();
     };
 
     handleEditClick = (rowId: string | number) => {
@@ -201,6 +258,7 @@ class Datagrid extends React.Component<ViewProps> {
                         title={translate('sulu_admin.move_items')}
                     />
                 }
+                {this.toolbarActions.map((toolbarAction) => toolbarAction.getNode())}
             </div>
         );
     }
@@ -244,25 +302,18 @@ export default withToolbar(Datagrid, function() {
         }
         : undefined;
 
-    const items = [];
+    const items = this.toolbarActions
+        .map((toolbarAction) => toolbarAction.getToolbarItemConfig())
+        .filter((item) => item !== undefined);
 
     if (addRoute) {
-        items.push({
+        items.unshift({
             icon: 'su-plus-circle',
             label: translate('sulu_admin.add'),
             onClick: this.handleItemAdd,
             type: 'button',
         });
     }
-
-    items.push({
-        disabled: this.datagridStore.selectionIds.length === 0,
-        icon: 'su-trash-alt',
-        label: translate('sulu_admin.delete'),
-        loading: this.datagridStore.selectionDeleting,
-        onClick: this.datagrid.requestSelectionDelete,
-        type: 'button',
-    });
 
     if (movable) {
         items.push({

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/index.js
@@ -2,12 +2,16 @@
 import Datagrid from './Datagrid';
 import toolbarActionRegistry from './registries/ToolbarActionRegistry';
 import AbstractToolbarAction from './toolbarActions/AbstractToolbarAction';
+import AddToolbarAction from './toolbarActions/AddToolbarAction';
 import DeleteToolbarAction from './toolbarActions/DeleteToolbarAction';
+import MoveToolbarAction from './toolbarActions/MoveToolbarAction';
 
 export default Datagrid;
 
 export {
     AbstractToolbarAction,
     toolbarActionRegistry,
+    AddToolbarAction,
     DeleteToolbarAction,
+    MoveToolbarAction,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/index.js
@@ -1,4 +1,13 @@
 // @flow
 import Datagrid from './Datagrid';
+import toolbarActionRegistry from './registries/ToolbarActionRegistry';
+import AbstractToolbarAction from './toolbarActions/AbstractToolbarAction';
+import DeleteToolbarAction from './toolbarActions/DeleteToolbarAction';
 
 export default Datagrid;
+
+export {
+    AbstractToolbarAction,
+    toolbarActionRegistry,
+    DeleteToolbarAction,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/registries/ToolbarActionRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/registries/ToolbarActionRegistry.js
@@ -1,0 +1,32 @@
+// @flow
+import AbstractToolbarAction from '../toolbarActions/AbstractToolbarAction';
+
+class ToolbarActionRegistry {
+    toolbarActions: {[name: string]: Class<AbstractToolbarAction>} = {};
+
+    constructor() {
+        this.clear();
+    }
+
+    clear() {
+        this.toolbarActions = {};
+    }
+
+    add(name: string, item: Class<AbstractToolbarAction>) {
+        if (name in this.toolbarActions) {
+            throw new Error('The key "' + name + '" has already been used for another ToolbarAction!');
+        }
+
+        this.toolbarActions[name] = item;
+    }
+
+    get(name: string) {
+        if (!(name in this.toolbarActions)) {
+            throw new Error('There is no toolbar item with key "' + name + '" registered!');
+        }
+
+        return this.toolbarActions[name];
+    }
+}
+
+export default new ToolbarActionRegistry();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -170,16 +170,19 @@ test('Should render the datagrid with a title', () => {
 
 test('Should pass correct props to move datagrid overlay', () => {
     const Datagrid = require('../Datagrid').default;
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const MoveToolbarAction = require('../toolbarActions/MoveToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.move', MoveToolbarAction);
 
     const router = {
         bind: jest.fn(),
         route: {
             options: {
                 adapters: ['table'],
-                movable: true,
                 datagridKey: 'snippets_datagrid',
                 resourceKey: 'snippets',
                 title: 'sulu_snippet.snippets',
+                toolbarActions: ['sulu_admin.move'],
             },
         },
     };
@@ -231,6 +234,10 @@ test('Should pass the onItemClick callback when an editRoute has been passed', (
 
 test('Should render the datagrid with the add icon if a addRoute has been passed', () => {
     const Datagrid = require('../Datagrid').default;
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const AddToolbarAction = require('../toolbarActions/AddToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.add', AddToolbarAction);
+
     const router = {
         bind: jest.fn(),
         route: {
@@ -239,6 +246,7 @@ test('Should render the datagrid with the add icon if a addRoute has been passed
                 addRoute: 'addRoute',
                 datagridKey: 'snippets',
                 resourceKey: 'snippets',
+                toolbarActions: ['sulu_admin.add'],
             },
         },
     };
@@ -422,6 +430,9 @@ test('Should render the add button in the toolbar only if an addRoute has been p
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const AddToolbarAction = require('../toolbarActions/AddToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.add', AddToolbarAction);
     const router = {
         bind: jest.fn(),
         route: {
@@ -430,6 +441,7 @@ test('Should render the add button in the toolbar only if an addRoute has been p
                 addRoute: 'addRoute',
                 datagridKey: 'test',
                 resourceKey: 'test',
+                toolbarActions: ['sulu_admin.add'],
             },
         },
     };
@@ -450,6 +462,9 @@ test('Should navigate when add button is clicked and locales have been passed in
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const AddToolbarAction = require('../toolbarActions/AddToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.add', AddToolbarAction);
     const router = {
         navigate: jest.fn(),
         bind: jest.fn(),
@@ -460,6 +475,7 @@ test('Should navigate when add button is clicked and locales have been passed in
                 locales: ['de', 'en'],
                 datagridKey: 'test',
                 resourceKey: 'test',
+                toolbarActions: ['sulu_admin.add'],
             },
         },
     };
@@ -481,6 +497,9 @@ test('Should navigate without locale when pencil button is clicked', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const AddToolbarAction = require('../toolbarActions/AddToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.add', AddToolbarAction);
     const router = {
         navigate: jest.fn(),
         bind: jest.fn(),
@@ -490,6 +509,7 @@ test('Should navigate without locale when pencil button is clicked', () => {
                 addRoute: 'addRoute',
                 datagridKey: 'test',
                 resourceKey: 'test',
+                toolbarActions: ['sulu_admin.add'],
             },
         },
     };
@@ -803,14 +823,17 @@ test('Should make move overlay disappear if cancel is clicked', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const MoveToolbarAction = require('../toolbarActions/MoveToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.move', MoveToolbarAction);
     const router = {
         bind: jest.fn(),
         route: {
             options: {
                 adapters: ['table'],
                 datagridKey: 'test',
-                movable: true,
                 resourceKey: 'test',
+                toolbarActions: ['sulu_admin.move'],
             },
         },
     };
@@ -839,14 +862,17 @@ test('Should move items after move overlay was confirmed', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const MoveToolbarAction = require('../toolbarActions/MoveToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.move', MoveToolbarAction);
     const router = {
         bind: jest.fn(),
         route: {
             options: {
                 adapters: ['table'],
                 datagridKey: 'test',
-                movable: true,
                 resourceKey: 'test',
+                toolbarActions: ['sulu_admin.move'],
             },
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -84,6 +84,7 @@ jest.mock(
 
         mockExtendObservable(this, {
             moving: false,
+            movingSelection: false,
         });
     })
 );
@@ -892,7 +893,7 @@ test('Should move items after move overlay was confirmed', () => {
     expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('open')).toEqual(false);
 
     getMoveItem().onClick();
-    datagridStore.moving = true;
+    datagridStore.movingSelection = true;
     datagrid.update();
     expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('open')).toEqual(true);
     datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('onConfirm')({id: 5});
@@ -903,7 +904,7 @@ test('Should move items after move overlay was confirmed', () => {
     expect(datagridStore.moveSelection).toBeCalledWith(5);
 
     return moveSelectionPromise.then(() => {
-        datagridStore.moving = false;
+        datagridStore.movingSelection = false;
         datagrid.update();
         expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('confirmLoading')).toEqual(false);
         expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('open')).toEqual(false);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -578,10 +578,14 @@ test('Should render the delete item enabled only if something is selected', () =
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const DeleteToolbarAction = require('../toolbarActions/DeleteToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.delete', DeleteToolbarAction);
     const router = {
         bind: jest.fn(),
         route: {
             options: {
+                toolbarActions: ['sulu_admin.delete'],
                 adapters: ['table'],
                 datagridKey: 'test',
                 resourceKey: 'test',
@@ -763,11 +767,15 @@ test('Should delete selected items when delete button is clicked', () => {
 
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;
+    const toolbarActionRegistry = require('../registries/ToolbarActionRegistry').default;
+    const DeleteToolbarAction = require('../toolbarActions/DeleteToolbarAction').default;
+    toolbarActionRegistry.add('sulu_admin.delete', DeleteToolbarAction);
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
     const router = {
         bind: jest.fn(),
         route: {
             options: {
+                toolbarActions: ['sulu_admin.delete'],
                 adapters: ['table'],
                 datagridKey: 'test',
                 resourceKey: 'test',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
 import {mount, render, shallow} from 'enzyme';
-import {observable} from 'mobx';
+import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import TableAdapter from '../../../containers/Datagrid/adapters/TableAdapter';
 import datagridFieldTransformRegistry from '../../../containers/Datagrid/registries/DatagridFieldTransformerRegistry';
 import StringFieldTransformer from '../../../containers/Datagrid/fieldTransformers/StringFieldTransformer';
@@ -81,6 +81,10 @@ jest.mock(
         this.clearSelection = jest.fn();
         this.remove = jest.fn();
         this.moveSelection = jest.fn();
+
+        mockExtendObservable(this, {
+            moving: false,
+        });
     })
 );
 
@@ -888,6 +892,7 @@ test('Should move items after move overlay was confirmed', () => {
     expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('open')).toEqual(false);
 
     getMoveItem().onClick();
+    datagridStore.moving = true;
     datagrid.update();
     expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('open')).toEqual(true);
     datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('onConfirm')({id: 5});
@@ -898,6 +903,7 @@ test('Should move items after move overlay was confirmed', () => {
     expect(datagridStore.moveSelection).toBeCalledWith(5);
 
     return moveSelectionPromise.then(() => {
+        datagridStore.moving = false;
         datagrid.update();
         expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('confirmLoading')).toEqual(false);
         expect(datagrid.find('SingleDatagridOverlay[title="Move items"]').prop('open')).toEqual(false);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/registries/ToolbarActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/registries/ToolbarActionRegistry.test.js
@@ -4,9 +4,6 @@ import AbstractToolbarAction from '../../toolbarActions/AbstractToolbarAction';
 
 jest.mock('../../../../services/Initializer', () => jest.fn());
 jest.mock('../../toolbarActions/DeleteToolbarAction', () => jest.fn());
-jest.mock('../../toolbarActions/SaveWithPublishingToolbarAction', () => jest.fn());
-jest.mock('../../toolbarActions/SaveToolbarAction', () => jest.fn());
-jest.mock('../../toolbarActions/TypeToolbarAction', () => jest.fn());
 
 beforeEach(() => {
     toolbarActionRegistry.clear();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/AbstractToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/AbstractToolbarAction.js
@@ -1,0 +1,32 @@
+// @flow
+import type {Node} from 'react';
+import type {ToolbarAction, ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import Router from '../../../services/Router';
+import Datagrid from '../../../views/Datagrid/Datagrid';
+import DatagridStore from '../../../containers/Datagrid/stores/DatagridStore';
+
+export default class AbstractToolbarAction implements ToolbarAction {
+    datagridStore: DatagridStore;
+    datagrid: Datagrid;
+    router: Router;
+    locales: ?Array<string>;
+
+    constructor(datagridStore: DatagridStore, datagrid: Datagrid, router: Router, locales?: Array<string>) {
+        this.datagridStore = datagridStore;
+        this.datagrid = datagrid;
+        this.router = router;
+        this.locales = locales;
+    }
+
+    setLocales(locales: Array<string>) {
+        this.locales = locales;
+    }
+
+    getNode(): Node {
+        return null;
+    }
+
+    getToolbarItemConfig(): ToolbarItemConfig {
+        throw new Error('The getToolbarItemConfig method must be implemented by the sub class!');
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/AddToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/AddToolbarAction.js
@@ -1,0 +1,15 @@
+// @flow
+import {action} from 'mobx';
+import {translate} from '../../../utils/Translator';
+import AbstractToolbarAction from './AbstractToolbarAction';
+
+export default class AddToolbarAction extends AbstractToolbarAction {
+    getToolbarItemConfig() {
+        return {
+            icon: 'su-plus-circle',
+            label: translate('sulu_admin.add'),
+            onClick: action(this.datagrid.addItem),
+            type: 'button',
+        };
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/DeleteToolbarAction.js
@@ -1,0 +1,16 @@
+// @flow
+import {translate} from '../../../utils/Translator';
+import AbstractToolbarAction from './AbstractToolbarAction';
+
+export default class DeleteToolbarAction extends AbstractToolbarAction {
+    getToolbarItemConfig() {
+        return {
+            disabled: this.datagridStore.selectionIds.length === 0,
+            icon: 'su-trash-alt',
+            label: translate('sulu_admin.delete'),
+            loading: this.datagridStore.deleting,
+            onClick: this.datagrid.handleDelete,
+            type: 'button',
+        };
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/DeleteToolbarAction.js
@@ -9,7 +9,7 @@ export default class DeleteToolbarAction extends AbstractToolbarAction {
             icon: 'su-trash-alt',
             label: translate('sulu_admin.delete'),
             loading: this.datagridStore.deleting,
-            onClick: this.datagrid.handleDelete,
+            onClick: this.datagrid.requestSelectionDelete,
             type: 'button',
         };
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/DeleteToolbarAction.js
@@ -8,7 +8,7 @@ export default class DeleteToolbarAction extends AbstractToolbarAction {
             disabled: this.datagridStore.selectionIds.length === 0,
             icon: 'su-trash-alt',
             label: translate('sulu_admin.delete'),
-            loading: this.datagridStore.deleting,
+            loading: this.datagridStore.deletingSelection,
             onClick: this.datagrid.requestSelectionDelete,
             type: 'button',
         };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/MoveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/MoveToolbarAction.js
@@ -14,7 +14,7 @@ export default class MoveToolbarAction extends AbstractToolbarAction {
                 adapter="column_list"
                 allowActivateForDisabledItems={false}
                 clearSelectionOnClose={true}
-                confirmLoading={this.datagridStore.moving}
+                confirmLoading={this.datagridStore.movingSelection}
                 datagridKey={this.datagridStore.datagridKey}
                 disabledIds={this.datagridStore.selectionIds}
                 key="sulu_admin.move"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/MoveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/MoveToolbarAction.js
@@ -1,0 +1,58 @@
+// @flow
+import {action, observable} from 'mobx';
+import React from 'react';
+import {translate} from '../../../utils/Translator';
+import SingleDatagridOverlay from '../../../containers/SingleDatagridOverlay';
+import AbstractToolbarAction from './AbstractToolbarAction';
+
+export default class MoveToolbarAction extends AbstractToolbarAction {
+    @observable showOverlay = false;
+    @observable moving = false;
+
+    getNode() {
+        return (
+            <SingleDatagridOverlay
+                adapter="column_list"
+                allowActivateForDisabledItems={false}
+                clearSelectionOnClose={true}
+                confirmLoading={this.moving}
+                datagridKey={this.datagridStore.datagridKey}
+                disabledIds={this.datagridStore.selectionIds}
+                key="sulu_admin.move"
+                locale={this.datagrid.locale}
+                onClose={this.handleClose}
+                onConfirm={this.handleConfirm}
+                open={this.showOverlay}
+                options={{includeRoot: true}}
+                reloadOnOpen={true}
+                resourceKey={this.datagridStore.resourceKey}
+                title={translate('sulu_admin.move_items')}
+            />
+        );
+    }
+
+    getToolbarItemConfig() {
+        return {
+            disabled: this.datagridStore.selectionIds.length === 0,
+            icon: 'su-arrows-alt',
+            label: translate('sulu_admin.move_selected'),
+            onClick: action(() => {
+                this.showOverlay = true;
+            }),
+            type: 'button',
+        };
+    }
+
+    @action handleClose = () => {
+        this.showOverlay = false;
+    };
+
+    @action handleConfirm = (item: Object) => {
+        this.moving = true;
+
+        this.datagridStore.moveSelection(item.id).then(action(() => {
+            this.moving = false;
+            this.showOverlay = false;
+        }));
+    };
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/MoveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/toolbarActions/MoveToolbarAction.js
@@ -7,7 +7,6 @@ import AbstractToolbarAction from './AbstractToolbarAction';
 
 export default class MoveToolbarAction extends AbstractToolbarAction {
     @observable showOverlay = false;
-    @observable moving = false;
 
     getNode() {
         return (
@@ -15,7 +14,7 @@ export default class MoveToolbarAction extends AbstractToolbarAction {
                 adapter="column_list"
                 allowActivateForDisabledItems={false}
                 clearSelectionOnClose={true}
-                confirmLoading={this.moving}
+                confirmLoading={this.datagridStore.moving}
                 datagridKey={this.datagridStore.datagridKey}
                 disabledIds={this.datagridStore.selectionIds}
                 key="sulu_admin.move"
@@ -48,10 +47,7 @@ export default class MoveToolbarAction extends AbstractToolbarAction {
     };
 
     @action handleConfirm = (item: Object) => {
-        this.moving = true;
-
         this.datagridStore.moveSelection(item.id).then(action(() => {
-            this.moving = false;
             this.showOverlay = false;
         }));
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -128,7 +128,7 @@ class Form extends React.Component<Props> {
     }
 
     @action componentDidMount() {
-        const {locales, router} = this.props;
+        const {router} = this.props;
         const {
             route: {
                 options: {
@@ -145,7 +145,7 @@ class Form extends React.Component<Props> {
             this.resourceFormStore,
             this,
             router,
-            locales
+            this.locales
         ));
 
         when(() => !this.resourceFormStore.loading, this.evaluatePreview);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/index.js
@@ -1,10 +1,20 @@
 // @flow
 import ResourceTabs from './ResourceTabs';
-import Form, {AbstractToolbarAction, toolbarActionRegistry} from './Form';
+import Form, {
+    AbstractToolbarAction as AbstractFormToolbarAction,
+    toolbarActionRegistry as formToolbarActionRegistry,
+} from './Form';
+import Datagrid, {
+    AbstractToolbarAction as AbstractDatagridToolbarAction,
+    toolbarActionRegistry as datagridToolbarActionRegistry,
+} from './Datagrid';
 
 export {
-    AbstractToolbarAction,
+    AbstractDatagridToolbarAction,
+    AbstractFormToolbarAction,
+    Datagrid,
+    datagridToolbarActionRegistry,
     Form,
+    formToolbarActionRegistry,
     ResourceTabs,
-    toolbarActionRegistry,
 };

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/DatagridRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/DatagridRouteBuilderTest.php
@@ -196,32 +196,6 @@ class DatagridRouteBuilderTest extends TestCase
         $this->assertFalse($route->getOption('searchable'));
     }
 
-    public function testBuildDatagridRouteWithMoving()
-    {
-        $route = (new DatagridRouteBuilder('sulu_role.datagrid', '/roles'))
-            ->setResourceKey('roles')
-            ->setDatagridKey('roles')
-            ->addDatagridAdapters(['tree'])
-            ->disableMoving()
-            ->enableMoving()
-            ->getRoute();
-
-        $this->assertTrue($route->getOption('movable'));
-    }
-
-    public function testBuildDatagridRouteWithoutMoving()
-    {
-        $route = (new DatagridRouteBuilder('sulu_role.datagrid', '/roles'))
-            ->setResourceKey('roles')
-            ->setDatagridKey('roles')
-            ->addDatagridAdapters(['tree'])
-            ->enableMoving()
-            ->disableMoving()
-            ->getRoute();
-
-        $this->assertFalse($route->getOption('movable'));
-    }
-
     public function testBuildDatagridWithRouterAttributesToFormStore()
     {
         $route = (new DatagridRouteBuilder('sulu_role.datagrid', '/roles'))

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/DatagridRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/DatagridRouteBuilderTest.php
@@ -271,4 +271,17 @@ class DatagridRouteBuilderTest extends TestCase
 
         $this->assertEquals('sulu_category.edit_form', $route->getOption('backRoute'));
     }
+
+    public function testBuildAddToolbarActions()
+    {
+        $route = (new DatagridRouteBuilder('sulu_role.datagrid', '/roles'))
+            ->setResourceKey('roles')
+            ->setDatagridKey('roles')
+            ->addDatagridAdapters(['tree'])
+            ->addToolbarActions(['sulu_admin.add', 'sulu_admin.move'])
+            ->addToolbarActions(['sulu_admin.delete'])
+            ->getRoute();
+
+        $this->assertEquals(['sulu_admin.add', 'sulu_admin.move', 'sulu_admin.delete'], $route->getOption('toolbarActions'));
+    }
 }

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -88,7 +88,9 @@ class CategoryAdmin extends Admin
         ];
 
         $listToolbarActions = [
+            'sulu_admin.add',
             'sulu_admin.delete',
+            'sulu_admin.move',
         ];
 
         return [
@@ -102,7 +104,6 @@ class CategoryAdmin extends Admin
                 ->setAddRoute(static::ADD_FORM_ROUTE)
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
                 ->enableSearching()
-                ->enableMoving()
                 ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/categories/:locale/add')

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -87,6 +87,10 @@ class CategoryAdmin extends Admin
             'sulu_admin.delete',
         ];
 
+        $listToolbarActions = [
+            'sulu_admin.delete',
+        ];
+
         return [
             $this->routeBuilderFactory->createDatagridRouteBuilder(static::DATAGRID_ROUTE, '/categories/:locale')
                 ->setResourceKey('categories')
@@ -99,6 +103,7 @@ class CategoryAdmin extends Admin
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
                 ->enableSearching()
                 ->enableMoving()
+                ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/categories/:locale/add')
                 ->setResourceKey('categories')

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -95,6 +95,7 @@ class ContactAdmin extends Admin
         ];
 
         $listToolbarActions = [
+            'sulu_admin.add',
             'sulu_admin.delete',
         ];
 

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -89,8 +89,12 @@ class ContactAdmin extends Admin
 
     public function getRoutes(): array
     {
-        $formToolbarActionsWithDelete = [
+        $formToolbarActions = [
             'sulu_admin.save',
+            'sulu_admin.delete',
+        ];
+
+        $listToolbarActions = [
             'sulu_admin.delete',
         ];
 
@@ -102,6 +106,7 @@ class ContactAdmin extends Admin
                 ->addDatagridAdapters(['table'])
                 ->setAddRoute(static::CONTACT_ADD_FORM_ROUTE)
                 ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
+                ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::CONTACT_ADD_FORM_ROUTE, '/contacts/add')
                 ->setResourceKey('contacts')
@@ -112,7 +117,7 @@ class ContactAdmin extends Admin
                 ->setFormKey('contact_details')
                 ->setTabTitle('sulu_admin.details')
                 ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
-                ->addToolbarActions($formToolbarActionsWithDelete)
+                ->addToolbarActions($formToolbarActions)
                 ->setParent(static::CONTACT_ADD_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::CONTACT_EDIT_FORM_ROUTE, '/contacts/:id')
@@ -124,7 +129,7 @@ class ContactAdmin extends Admin
                 ->setResourceKey('contacts')
                 ->setFormKey('contact_details')
                 ->setTabTitle('sulu_admin.details')
-                ->addToolbarActions($formToolbarActionsWithDelete)
+                ->addToolbarActions($formToolbarActions)
                 ->setParent(static::CONTACT_EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createDatagridRouteBuilder(static::ACCOUNT_DATAGRID_ROUTE, '/accounts')
@@ -134,6 +139,7 @@ class ContactAdmin extends Admin
                 ->addDatagridAdapters(['table'])
                 ->setAddRoute(static::ACCOUNT_ADD_FORM_ROUTE)
                 ->setEditRoute(static::ACCOUNT_EDIT_FORM_ROUTE)
+                ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ACCOUNT_ADD_FORM_ROUTE, '/accounts/add')
                 ->setResourceKey('accounts')
@@ -144,7 +150,7 @@ class ContactAdmin extends Admin
                 ->setFormKey('account_details')
                 ->setTabTitle('sulu_admin.details')
                 ->setEditRoute(static::ACCOUNT_EDIT_FORM_ROUTE)
-                ->addToolbarActions($formToolbarActionsWithDelete)
+                ->addToolbarActions($formToolbarActions)
                 ->setParent(static::ACCOUNT_ADD_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ACCOUNT_EDIT_FORM_ROUTE, '/accounts/:id')
@@ -156,7 +162,7 @@ class ContactAdmin extends Admin
                 ->setResourceKey('accounts')
                 ->setFormKey('account_details')
                 ->setTabTitle('sulu_admin.details')
-                ->addToolbarActions($formToolbarActionsWithDelete)
+                ->addToolbarActions($formToolbarActions)
                 ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
                 ->getRoute(),
         ];

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -243,7 +243,7 @@ export default withToolbar(MediaOverview, function() {
                 disabled: this.mediaDatagridStore.selectionIds.length === 0,
                 icon: 'su-trash-alt',
                 label: translate('sulu_admin.delete'),
-                loading: this.mediaDatagridStore.selectionDeleting,
+                loading: this.mediaDatagridStore.deleting,
                 onClick: this.mediaDatagrid.requestSelectionDelete,
                 type: 'button',
             },

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -243,7 +243,7 @@ export default withToolbar(MediaOverview, function() {
                 disabled: this.mediaDatagridStore.selectionIds.length === 0,
                 icon: 'su-trash-alt',
                 label: translate('sulu_admin.delete'),
-                loading: this.mediaDatagridStore.deleting,
+                loading: this.mediaDatagridStore.deletingSelection,
                 onClick: this.mediaDatagrid.requestSelectionDelete,
                 type: 'button',
             },

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -1,7 +1,7 @@
 // @flow
 import {bundleReady, initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
-import {toolbarActionRegistry} from 'sulu-admin-bundle/views';
+import {formToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import SearchResult from './containers/Form/fields/SearchResult';
 import PageSettingsNavigationSelect from './containers/Form/fields/PageSettingsNavigationSelect';
 import PageSettingsShadowLocaleSelect from './containers/Form/fields/PageSettingsShadowLocaleSelect';
@@ -21,7 +21,7 @@ fieldRegistry.add('search_result', SearchResult);
 fieldRegistry.add('page_settings_navigation_select', PageSettingsNavigationSelect);
 fieldRegistry.add('page_settings_shadow_locale_select', PageSettingsShadowLocaleSelect);
 
-toolbarActionRegistry.add('sulu_page.edit', EditToolbarAction);
-toolbarActionRegistry.add('sulu_page.templates', TemplateToolbarAction);
+formToolbarActionRegistry.add('sulu_page.edit', EditToolbarAction);
+formToolbarActionRegistry.add('sulu_page.templates', TemplateToolbarAction);
 
 bundleReady();

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/TemplateToolbarAction.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/TemplateToolbarAction.test.js
@@ -35,7 +35,7 @@ jest.mock('sulu-admin-bundle/services', () => ({
 
 jest.mock('sulu-admin-bundle/views', () => ({
     // $FlowFixMe
-    AbstractToolbarAction: require.requireActual('sulu-admin-bundle/views').AbstractToolbarAction,
+    AbstractFormToolbarAction: require.requireActual('sulu-admin-bundle/views').AbstractFormToolbarAction,
     Form: jest.fn(function() {
         this.submit = jest.fn();
     }),

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/EditToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/EditToolbarAction.js
@@ -4,10 +4,10 @@ import {action, observable} from 'mobx';
 import {Dialog} from 'sulu-admin-bundle/components';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
 import {translate} from 'sulu-admin-bundle/utils';
-import {AbstractToolbarAction} from 'sulu-admin-bundle/views';
+import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views';
 import CopyLocaleDialog from './CopyLocaleDialog';
 
-export default class EditToolbarAction extends AbstractToolbarAction {
+export default class EditToolbarAction extends AbstractFormToolbarAction {
     @observable showCopyLocaleDialog = false;
     @observable showDeleteDraftDialog = false;
     @observable deletingDraft = false;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -1,11 +1,11 @@
 // @flow
 import {action, computed, observable} from 'mobx';
-import {AbstractToolbarAction} from 'sulu-admin-bundle/views';
+import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views';
 import type {ToolbarItemConfig} from 'sulu-admin-bundle/types';
 import webspaceStore from '../../../stores/WebspaceStore';
 import type {Webspace} from '../../../stores/WebspaceStore/types';
 
-export default class TemplateToolbarAction extends AbstractToolbarAction {
+export default class TemplateToolbarAction extends AbstractFormToolbarAction {
     @observable webspace: ?Webspace = undefined;
 
     @computed get defaultTemplate(): ?string {

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -98,6 +98,10 @@ class SecurityAdmin extends Admin
             'sulu_admin.save',
         ];
 
+        $listToolbarActions = [
+            'sulu_admin.delete',
+        ];
+
         return [
             $this->routeBuilderFactory->createDatagridRouteBuilder(static::DATAGRID_ROUTE, '/roles')
                 ->setResourceKey('roles')
@@ -106,6 +110,7 @@ class SecurityAdmin extends Admin
                 ->addDatagridAdapters(['table'])
                 ->setAddRoute(static::ADD_FORM_ROUTE)
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
+                ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/roles/add')
                 ->setResourceKey('roles')

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -99,6 +99,7 @@ class SecurityAdmin extends Admin
         ];
 
         $listToolbarActions = [
+            'sulu_admin.add',
             'sulu_admin.delete',
         ];
 

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -114,6 +114,10 @@ class SnippetAdmin extends Admin
             'sulu_admin.delete',
         ];
 
+        $listToolbarActions = [
+            'sulu_admin.delete',
+        ];
+
         return [
             $this->routeBuilderFactory->createDatagridRouteBuilder(static::DATAGRID_ROUTE, '/snippets/:locale')
                 ->setResourceKey('snippets')
@@ -124,6 +128,7 @@ class SnippetAdmin extends Admin
                 ->setDefaultLocale($snippetLocales[0])
                 ->setAddRoute(static::ADD_FORM_ROUTE)
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
+                ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/snippets/:locale/add')
                 ->setResourceKey('snippets')

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -115,6 +115,7 @@ class SnippetAdmin extends Admin
         ];
 
         $listToolbarActions = [
+            'sulu_admin.add',
             'sulu_admin.delete',
         ];
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -77,7 +77,7 @@ class SnippetAdminTest extends TestCase
         $this->assertAttributeEquals('sulu_snippet.datagrid', 'name', $listRoute);
         $this->assertAttributeEquals([
             'title' => 'sulu_snippet.snippets',
-            'toolbarActions' => ['sulu_admin.delete'],
+            'toolbarActions' => ['sulu_admin.add', 'sulu_admin.delete'],
             'resourceKey' => 'snippets',
             'datagridKey' => 'snippets',
             'adapters' => ['table'],

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -77,6 +77,7 @@ class SnippetAdminTest extends TestCase
         $this->assertAttributeEquals('sulu_snippet.datagrid', 'name', $listRoute);
         $this->assertAttributeEquals([
             'title' => 'sulu_snippet.snippets',
+            'toolbarActions' => ['sulu_admin.delete'],
             'resourceKey' => 'snippets',
             'datagridKey' => 'snippets',
             'adapters' => ['table'],

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -70,6 +70,10 @@ class TagAdmin extends Admin
             'sulu_admin.delete',
         ];
 
+        $listToolbarActions = [
+            'sulu_admin.delete',
+        ];
+
         return [
             $this->routeBuilderFactory->createDatagridRouteBuilder(static::DATAGRID_ROUTE, '/tags')
                 ->setResourceKey('tags')
@@ -78,6 +82,7 @@ class TagAdmin extends Admin
                 ->addDatagridAdapters(['table'])
                 ->setAddRoute(static::ADD_FORM_ROUTE)
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
+                ->addToolbarActions($listToolbarActions)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/tags/add')
                 ->setResourceKey('tags')

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -71,6 +71,7 @@ class TagAdmin extends Admin
         ];
 
         $listToolbarActions = [
+            'sulu_admin.add',
             'sulu_admin.delete',
         ];
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add toolbar action registry for datagrid.

#### Why?

Also datagrids should have the possibility to have toolbar actions.

