### PR TITLE
Added dimension properties to video media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * FEATURE    #4357  [MediaBundle]           Added dimension properties to video media
+
 * 1.6.24 (2019-01-09)
     * BUGFIX      #4349 [ContentBundle]         Fix compatibility to symfony 3.4.21, 4.1.10 and 4.2.2
     * ENHANCEMENT #4319 [MediaBundle]           Added possibility to have a image format configuration file without formats

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -307,12 +307,24 @@ class MediaManager implements MediaManagerInterface
         $properties = [];
 
         try {
-            // if the file is a video we add the duration
+            // if the file is a video we add the properties related to it
             if (fnmatch('video/*', $mimeType)) {
+                // Duration
                 $properties['duration'] = $this->ffprobe->format($uploadedFile->getPathname())->get('duration');
+
+                // Dimensions
+                try {
+                    $dimensions = $this->ffprobe->streams( $uploadedFile->getPathname() )->videos()->first()->getDimensions();
+                    $properties['width'] = $dimensions->getWidth();
+                    $properties['height'] = $dimensions->getHeight();
+                } catch (InvalidArgumentException $e) {
+                    // Exception is thrown if the video stream could not be obtained
+                } catch (RuntimeException $e) {
+                    // Exception is thrown if the dimension could not be extracted
+                }
             }
         } catch (ExecutableNotFoundException $e) {
-            // Exception is thrown if ffmpeg is not installed -> duration is not set
+            // Exception is thrown if ffmpeg is not installed -> video properties are not set
         }
 
         return $properties;

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -314,7 +314,7 @@ class MediaManager implements MediaManagerInterface
 
                 // Dimensions
                 try {
-                    $dimensions = $this->ffprobe->streams( $uploadedFile->getPathname() )->videos()->first()->getDimensions();
+                    $dimensions = $this->ffprobe->streams($uploadedFile->getPathname())->videos()->first()->getDimensions();
                     $properties['width'] = $dimensions->getWidth();
                     $properties['height'] = $dimensions->getHeight();
                 } catch (InvalidArgumentException $e) {


### PR DESCRIPTION
Updated MediaBundle's MediaManager to get the video dimensions when ffprobe is available.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| Related issues/PRs | <not-created>
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

The MediaManager in the MediaBundle allows videos to be uploaded and processed with ffmpeg and ffprobe but the dimension informations are not saved. This PR adds, when available, the width and height of the video files to the media file properties.

#### Why?

It is useful to have the video dimensions available in Twig. It could for instance be used when we want to have a cover video while keeping the video's aspect ratio.

#### Example Usage

~~~twig
{# Provided you have a media_selection field called 'video' #}
<video width="{{ content.video[0].properties.width }}" height="{{ content.video[0].properties.height }}">
    <source src={{ content.video[0].url }}" type="{{ content.video[0].mimeType }}">
</video>
~~~

#### BC Breaks/Deprecations

N/A

#### To Do

- [ ] Create a documentation PR
- [x] Add changes to CHANGELOG.md
