### PR TITLE
Do not display empty text while loading in SingleItemSelection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/SingleItemSelection.js
@@ -51,7 +51,7 @@ export default class SingleItemSelection extends React.Component<Props> {
                         {children
                             ? children
                             : <div className={singleItemSelectionStyles.empty}>
-                                {emptyText}
+                                {loading ? '…' : emptyText}
                             </div>
                         }
                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/SingleItemSelection.test.js
@@ -34,6 +34,17 @@ test('Render in loading state', () => {
     )).toMatchSnapshot();
 });
 
+test('Render in loading state with no children', () => {
+    const leftButton = {
+        icon: 'su-document',
+        onClick: jest.fn(),
+    };
+
+    expect(render(
+        <SingleItemSelection leftButton={leftButton} loading={true} />
+    )).toMatchSnapshot();
+});
+
 test('Render in invalid state', () => {
     const leftButton = {
         icon: 'su-document',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleItemSelection/tests/__snapshots__/SingleItemSelection.test.js.snap
@@ -87,6 +87,46 @@ exports[`Render in loading state 1`] = `
 </div>
 `;
 
+exports[`Render in loading state with no children 1`] = `
+<div
+  class="singleItemSelection"
+>
+  <button
+    class="button"
+    type="button"
+  >
+    <span
+      aria-label="su-document"
+      class="su-document"
+    />
+  </button>
+  <div
+    class="itemContainer"
+  >
+    <div
+      class="item"
+    >
+      <div
+        class="empty"
+      >
+        …
+      </div>
+    </div>
+    <div
+      class="spinner loader"
+      style="width:14px;height:14px"
+    >
+      <div
+        class="doubleBounce1"
+      />
+      <div
+        class="doubleBounce2"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Render with emptyText if no children have been passed 1`] = `
 <div
   class="singleItemSelection"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Do not display empty text while loading in SingleItemSelection.
Display three dots instead.

#### Why?

Do not display empty text while loading, this could mislead some users.
