### PR TITLE
Add app version from composer.json to admin navigation

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -120,6 +120,11 @@ class AdminController
     private $suluVersion;
 
     /**
+     * @var string|null
+     */
+    private $appVersion;
+
+    /**
      * @var array
      */
     private $locales;
@@ -161,6 +166,7 @@ class AdminController
         DataProviderPoolInterface $dataProviderPool,
         string $environment,
         string $suluVersion,
+        ?string $appVersion,
         array $locales,
         array $translations,
         string $fallbackLocale,
@@ -183,6 +189,7 @@ class AdminController
         $this->dataProviderPool = $dataProviderPool;
         $this->environment = $environment;
         $this->suluVersion = $suluVersion;
+        $this->appVersion = $appVersion;
         $this->locales = $locales;
         $this->translations = $translations;
         $this->fallbackLocale = $fallbackLocale;
@@ -211,6 +218,7 @@ class AdminController
                 'fallback_locale' => $this->fallbackLocale,
                 'endpoints' => $endpoints,
                 'sulu_version' => $this->suluVersion,
+                'app_version' => $this->appVersion,
             ]
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="sulu_content.smart_content.data_provider_pool" />
             <argument>%kernel.environment%</argument>
             <argument>%sulu.version%</argument>
+            <argument>%app.version%</argument>
             <argument>%sulu_core.locales%</argument>
             <argument>%sulu_core.translations%</argument>
             <argument>%sulu_core.fallback_locale%</argument>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -146,13 +146,13 @@ export default class Application extends React.Component<Props> {
                     <div className={rootClass}>
                         <nav className={applicationStyles.navigation}>
                             <Navigation
+                                appVersion={appVersion}
                                 onLogout={this.handleLogout}
                                 onNavigate={this.handleNavigate}
                                 onPinToggle={this.handlePinToggle}
                                 pinned={this.navigationPinned}
                                 router={router}
                                 suluVersion={suluVersion}
-                                appVersion={appVersion}
                             />
                         </nav>
                         <div className={contentClass}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -21,6 +21,7 @@ const NAVIGATION_PINNED_SETTING_KEY = 'sulu_admin.application.navigation_pinned'
 type Props = {
     router: Router,
     suluVersion: string,
+    appVersion: string,
 };
 
 type NavigationState = 'pinned' | 'hidden' | 'visible';
@@ -105,7 +106,7 @@ export default class Application extends React.Component<Props> {
     };
 
     render() {
-        const {router, suluVersion} = this.props;
+        const {router, suluVersion, appVersion} = this.props;
         const {loggedIn} = userStore;
 
         const rootClass = classNames(
@@ -151,6 +152,7 @@ export default class Application extends React.Component<Props> {
                                 pinned={this.navigationPinned}
                                 router={router}
                                 suluVersion={suluVersion}
+                                appVersion={appVersion}
                             />
                         </nav>
                         <div className={contentClass}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -19,9 +19,9 @@ import applicationStyles from './application.scss';
 const NAVIGATION_PINNED_SETTING_KEY = 'sulu_admin.application.navigation_pinned';
 
 type Props = {
+    appVersion: ?string,
     router: Router,
     suluVersion: string,
-    appVersion: string,
 };
 
 type NavigationState = 'pinned' | 'hidden' | 'visible';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/Application.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/Application.test.js
@@ -91,7 +91,7 @@ test('Application should render login with loader', () => {
     mockUserStoreLoggedIn.mockReturnValue(false);
 
     const router = new Router({});
-    const application = mount(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const application = mount(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
     expect(application.render()).toMatchSnapshot();
 });
 
@@ -102,14 +102,14 @@ test('Application should render login when user is not logged in', () => {
     mockUserStoreLoggedIn.mockReturnValue(false);
 
     const router = new Router({});
-    const application = mount(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const application = mount(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
 
     expect(application.render()).toMatchSnapshot();
 });
 
 test('Application should not fail if current route does not exist', () => {
     const router = new Router({});
-    const view = render(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const view = render(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
 
     expect(view).toMatchSnapshot();
 });
@@ -127,7 +127,25 @@ test('Application should render based on current route', () => {
         parent: null,
     };
 
-    const view = render(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const view = render(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
+
+    expect(view).toMatchSnapshot();
+});
+
+test('Application should render based on current route with app version', () => {
+    const router = new Router({});
+    router.route = {
+        name: 'test',
+        view: 'test',
+        attributeDefaults: {},
+        rerenderAttributes: [],
+        path: '/webspaces',
+        children: [],
+        options: {},
+        parent: null,
+    };
+
+    const view = render(<Application appVersion="666" router={router} suluVersion="2.0.0-RC1" />);
 
     expect(view).toMatchSnapshot();
 });
@@ -145,7 +163,7 @@ test('Application should render opened navigation', () => {
         parent: null,
     };
 
-    const view = mount(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const view = mount(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
     view.find('Button[icon="su-bars"]').simulate('click');
 
     expect(view).toMatchSnapshot();
@@ -164,7 +182,7 @@ test('Application should render pinned navigation', () => {
         parent: null,
     };
 
-    const view = mount(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const view = mount(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
     view.find('Button[icon="su-bars"]').simulate('click');
     view.find('button.pin').simulate('click');
 
@@ -186,7 +204,7 @@ test('Application should render pinned navigation from beginning', () => {
 
     mockUserStoreGetPersistentSetting.mockReturnValueOnce(true);
 
-    const view = mount(<Application router={router} suluVersion="2.0.0-RC1" />);
+    const view = mount(<Application appVersion={null} router={router} suluVersion="2.0.0-RC1" />);
     expect(view.find('Button[icon="su-bars"]')).toHaveLength(0);
     expect(view.find('Button[icon="su-sulu"]')).toHaveLength(0);
     expect(view.find('button.pin')).toHaveLength(1);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -327,6 +327,177 @@ exports[`Application should render based on current route 1`] = `
 </div>
 `;
 
+exports[`Application should render based on current route with app version 1`] = `
+<div
+  class="root visible"
+>
+  <nav
+    class="navigation"
+  >
+    <div
+      class="navigation"
+    >
+      <div
+        class="header"
+      >
+        <div
+          class="headerContent"
+        >
+          <span
+            aria-label="su-sulu"
+            class="su-sulu headerIcon"
+          />
+          <span
+            class="headerTitle"
+          >
+            Sulu
+          </span>
+        </div>
+      </div>
+      <div
+        class="user"
+      >
+        <div
+          class="userContent"
+        >
+          <div
+            class="noUserImage"
+          >
+            <span
+              aria-label="fa-user"
+              class="fa fa-user"
+            />
+          </div>
+          <div
+            class="userProfile"
+          >
+            <span>
+              Hikaru Sulu
+            </span>
+            <button>
+              <span
+                aria-label="su-exit"
+                class="su-exit"
+              />
+              Log out
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="items"
+      />
+      <div
+        class="footer"
+      >
+        <button
+          class="button icon pin"
+          type="button"
+        >
+          <span
+            aria-label="fa-thumb-tack"
+            class="fa fa-thumb-tack buttonIcon pinIcon"
+          />
+        </button>
+        <div
+          class="versions"
+        >
+          <div>
+            Sulu (666)
+          </div>
+          <div>
+            Sulu (
+            <a
+              href="https://github.com/sulu/sulu/releases"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              2.0.0-RC1
+            </a>
+            )
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="content"
+  >
+    <main
+      class="main"
+    >
+      <header
+        class="header"
+      >
+        <nav
+          class="toolbar light"
+        >
+          <div
+            class="snackbar error"
+          >
+            <span
+              aria-label="su-exclamation-triangle"
+              class="su-exclamation-triangle icon"
+            />
+            <div
+              class="text"
+            >
+              <strong>
+                sulu_admin.error
+              </strong>
+              <button
+                class="closeButton"
+              >
+                sulu_admin.close
+                <span
+                  aria-label="su-times"
+                  class="su-times closeButtonIcon"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="snackbar success clickable"
+          >
+            <span
+              aria-label="su-check"
+              class="su-check icon"
+            />
+          </div>
+          <div
+            class="controls light grow"
+          >
+            <button
+              class="button light primary"
+            >
+              <span
+                aria-label="su-bars"
+                class="su-bars icon"
+              />
+            </button>
+          </div>
+          <div
+            class="controls light"
+          />
+        </nav>
+      </header>
+      <div
+        class="viewContainer"
+      >
+        <div>
+          <h1>
+            Test
+          </h1>
+          <h2>
+            test
+          </h2>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`Application should render login when user is not logged in 1`] = `
 <div
   class="login"
@@ -493,6 +664,7 @@ exports[`Application should render login with loader 1`] = `
 
 exports[`Application should render opened navigation 1`] = `
 <Application
+  appVersion={null}
   router={
     Object {
       "route": Object {
@@ -516,6 +688,7 @@ exports[`Application should render opened navigation 1`] = `
       className="navigation"
     >
       <Navigation
+        appVersion={null}
         onLogout={[Function]}
         onNavigate={[Function]}
         onPinToggle={[Function]}
@@ -537,6 +710,7 @@ exports[`Application should render opened navigation 1`] = `
         suluVersion="2.0.0-RC1"
       >
         <Navigation
+          appVersion={null}
           onLogoutClick={[Function]}
           onPinToggle={[Function]}
           onProfileClick={[Function]}
@@ -857,6 +1031,7 @@ exports[`Application should render opened navigation 1`] = `
 
 exports[`Application should render pinned navigation 1`] = `
 <Application
+  appVersion={null}
   router={
     Object {
       "route": Object {
@@ -880,6 +1055,7 @@ exports[`Application should render pinned navigation 1`] = `
       className="navigation"
     >
       <Navigation
+        appVersion={null}
         onLogout={[Function]}
         onNavigate={[Function]}
         onPinToggle={[Function]}
@@ -901,6 +1077,7 @@ exports[`Application should render pinned navigation 1`] = `
         suluVersion="2.0.0-RC1"
       >
         <Navigation
+          appVersion={null}
           onLogoutClick={[Function]}
           onPinToggle={[Function]}
           onProfileClick={[Function]}
@@ -1185,6 +1362,7 @@ exports[`Application should render pinned navigation 1`] = `
 
 exports[`Application should render pinned navigation from beginning 1`] = `
 <Application
+  appVersion={null}
   router={
     Object {
       "route": Object {
@@ -1208,6 +1386,7 @@ exports[`Application should render pinned navigation from beginning 1`] = `
       className="navigation"
     >
       <Navigation
+        appVersion={null}
         onLogout={[Function]}
         onNavigate={[Function]}
         onPinToggle={[Function]}
@@ -1229,6 +1408,7 @@ exports[`Application should render pinned navigation from beginning 1`] = `
         suluVersion="2.0.0-RC1"
       >
         <Navigation
+          appVersion={null}
           onLogoutClick={[Function]}
           onPinToggle={[Function]}
           onProfileClick={[Function]}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -9,12 +9,12 @@ import navigationRegistry from './registries/NavigationRegistry';
 import type {NavigationItem} from './types';
 
 type Props = {
+    appVersion: ?string,
     pinned: boolean,
     router: Router,
     onNavigate: (route: string) => void,
     onLogout: () => void,
     onPinToggle: () => void,
-    appVersion: string,
     suluVersion: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -14,6 +14,7 @@ type Props = {
     onNavigate: (route: string) => void,
     onLogout: () => void,
     onPinToggle: () => void,
+    appVersion: string,
     suluVersion: string,
 };
 
@@ -65,10 +66,12 @@ export default class Navigation extends React.Component<Props> {
 
     render() {
         const {suluVersion} = this.props;
+        const {appVersion} = this.props;
         const navigationItems = navigationRegistry.getAll();
 
         return (
             <NavigationComponent
+                appVersion={appVersion}
                 onLogoutClick={this.props.onLogout}
                 onPinToggle={this.handlePinToggle}
                 onProfileClick={this.handleProfileEditClick}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
@@ -69,6 +69,7 @@ test('Should render navigation', () => {
 
     const navigation = render(
         <Navigation
+            appVersion="666"
             onLogout={jest.fn()}
             onNavigate={jest.fn()}
             onPinToggle={jest.fn()}
@@ -80,6 +81,35 @@ test('Should render navigation', () => {
 
     expect(navigation).toMatchSnapshot();
 });
+
+test('Should render navigation without appVersion', () => {
+    const router = new Router({});
+    router.route = {
+        name: 'sulu_admin.form_tab',
+        view: 'form_tab',
+        attributeDefaults: {},
+        children: [],
+        options: {},
+        parent: undefined,
+        path: '/form',
+        rerenderAttributes: [],
+    };
+
+    const navigation = render(
+        <Navigation
+            appVersion={null}
+            onLogout={jest.fn()}
+            onNavigate={jest.fn()}
+            onPinToggle={jest.fn()}
+            pinned={false}
+            router={router}
+            suluVersion="2.0.0-RC1"
+        />
+    );
+
+    expect(navigation).toMatchSnapshot();
+});
+
 
 test('Should call the navigation callback, pin callback and router navigate', () => {
     const router = new Router({});
@@ -98,6 +128,7 @@ test('Should call the navigation callback, pin callback and router navigate', ()
 
     const navigation = mount(
         <Navigation
+            appVersion={null}
             onLogout={jest.fn()}
             onNavigate={handleNavigate}
             onPinToggle={handlePin}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
@@ -110,7 +110,6 @@ test('Should render navigation without appVersion', () => {
     expect(navigation).toMatchSnapshot();
 });
 
-
 test('Should call the navigation callback, pin callback and router navigate', () => {
     const router = new Router({});
     router.route = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -132,6 +132,156 @@ exports[`Should render navigation 1`] = `
       class="versions"
     >
       <div>
+        Sulu (666)
+      </div>
+      <div>
+        Sulu (
+        <a
+          href="https://github.com/sulu/sulu/releases"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          2.0.0-RC1
+        </a>
+        )
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Should render navigation without appVersion 1`] = `
+<div
+  class="navigation"
+>
+  <div
+    class="header"
+  >
+    <div
+      class="headerContent"
+    >
+      <span
+        aria-label="su-sulu"
+        class="su-sulu headerIcon"
+      />
+      <span
+        class="headerTitle"
+      >
+        Sulu
+      </span>
+    </div>
+  </div>
+  <div
+    class="user"
+  >
+    <div
+      class="userContent"
+    >
+      <div
+        class="noUserImage"
+      >
+        <span
+          aria-label="fa-user"
+          class="fa fa-user"
+        />
+      </div>
+      <div
+        class="userProfile"
+      >
+        <span />
+        <button>
+          <span
+            aria-label="su-exit"
+            class="su-exit"
+          />
+          Log out
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="items"
+  >
+    <div
+      class="item active"
+    >
+      <div
+        class="title"
+        role="button"
+      >
+        <span
+          aria-label="su-options"
+          class="su-options"
+        />
+      </div>
+    </div>
+    <div
+      class="item"
+    >
+      <div
+        class="title"
+        role="button"
+      >
+        <span
+          aria-label="su-article"
+          class="su-article"
+        />
+      </div>
+    </div>
+    <div
+      class="item active"
+    >
+      <div
+        class="title"
+        role="button"
+      >
+        <span
+          aria-label="su-options"
+          class="su-options"
+        />
+      </div>
+      <div>
+        <div
+          class="item active"
+        >
+          <div
+            class="title"
+            role="button"
+          />
+        </div>
+        <div
+          class="item"
+        >
+          <div
+            class="title"
+            role="button"
+          />
+        </div>
+      </div>
+      <span
+        aria-label="su-angle-down"
+        class="su-angle-down clickable childrenIndicator"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+  </div>
+  <div
+    class="footer"
+  >
+    <button
+      class="button icon pin"
+      type="button"
+    >
+      <span
+        aria-label="fa-thumb-tack"
+        class="fa fa-thumb-tack buttonIcon pinIcon"
+      />
+    </button>
+    <div
+      class="versions"
+    >
+      <div>
         Sulu (
         <a
           href="https://github.com/sulu/sulu/releases"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -197,7 +197,7 @@ function startApplication() {
         throw new Error('DOM element with ID "id" was not found!');
     }
 
-    render(<Application router={router} suluVersion={Config.suluVersion} />, applicationElement);
+    render(<Application appVersion={Config.appVersion} router={router} suluVersion={Config.suluVersion} />, applicationElement);
 }
 
 startApplication();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -197,7 +197,10 @@ function startApplication() {
         throw new Error('DOM element with ID "id" was not found!');
     }
 
-    render(<Application appVersion={Config.appVersion} router={router} suluVersion={Config.suluVersion} />, applicationElement);
+    render(
+        <Application appVersion={Config.appVersion} router={router} suluVersion={Config.suluVersion} />,
+        applicationElement
+    );
 }
 
 startApplication();

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -15,7 +15,8 @@
                 translations: {{ translations|json_encode }},
                 fallbackLocale: '{{ fallback_locale }}',
                 endpoints: {{ endpoints|json_encode }},
-                suluVersion: '{{ sulu_version }}'
+                suluVersion: '{{ sulu_version }}',
+                appVersion: '{{ app_version }}'
             });
             {% endautoescape %}
         </script>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -135,6 +135,11 @@ class AdminControllerTest extends TestCase
     private $suluVersion = '2.0.0-RC1';
 
     /**
+     * @var string
+     */
+    private $appVersion = '666';
+
+    /**
      * @var array
      */
     private $locales = ['de', 'en'];
@@ -205,6 +210,7 @@ class AdminControllerTest extends TestCase
             $this->dataProviderPool->reveal(),
             $this->environment,
             $this->suluVersion,
+            $this->appVersion,
             $this->locales,
             $this->translations,
             $this->fallbackLocale,

--- a/src/Sulu/Component/Util/SuluVersionPass.php
+++ b/src/Sulu/Component/Util/SuluVersionPass.php
@@ -67,7 +67,7 @@ class SuluVersionPass implements CompilerPassInterface
      */
     private function getAppVersion($dir)
     {
-        $version = '_._._';
+        $version = null;
 
         /** @var SplFileInfo $composerFile */
         $composerFile = new SplFileInfo($dir . '/composer.json', '', '');
@@ -77,7 +77,7 @@ class SuluVersionPass implements CompilerPassInterface
 
         $composerJson = json_decode($composerFile->getContents(), true);
         if (!array_key_exists('version', $composerJson)) {
-            return;
+            return $version;
         }
 
         return $composerJson['version'];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

I add app version to navigation bar.

#### Why?

Now you see your composer version in backend.

