### PR TITLE
Better error display for dev environments

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -192,7 +192,7 @@ class PreviewRenderer implements PreviewRendererInterface
         try {
             $response = $this->handle($request);
         } catch (\Twig_Error $e) {
-            // dev/test only: display also the file and line which was causing the error 
+            // dev/test only: display also the file and line which was causing the error
             // for better debugging and faster development
             if (in_array($this->environment, ['dev', 'test'])) {
                 $e->appendMessage(' (' . $e->getFile() . ' line ' . $e->getLine() . ')');

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -192,13 +192,12 @@ class PreviewRenderer implements PreviewRendererInterface
         try {
             $response = $this->handle($request);
         } catch (\Twig_Error $e) {
-            
             // dev/test only: display also the file and line which was causing the error 
             // for better debugging and faster development
             if (in_array($this->environment, ['dev', 'test'])) {
                 $e->appendMessage(' (' . $e->getFile() . ' line ' . $e->getLine() . ')');
             }
-            
+
             throw new TwigException($e, $object, $id, $webspace, $locale);
         } catch (\InvalidArgumentException $e) {
             throw new TemplateNotFoundException($e, $object, $id, $webspace, $locale);

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -192,6 +192,13 @@ class PreviewRenderer implements PreviewRendererInterface
         try {
             $response = $this->handle($request);
         } catch (\Twig_Error $e) {
+            
+            // dev/test only: display also the file and line which was causing the error 
+            // for better debugging and faster development
+            if (in_array($this->environment, ['dev', 'test'])) {
+                $e->appendMessage(' (' . $e->getFile() . ' line ' . $e->getLine() . ')');
+            }
+            
             throw new TwigException($e, $object, $id, $webspace, $locale);
         } catch (\InvalidArgumentException $e) {
             throw new TemplateNotFoundException($e, $object, $id, $webspace, $locale);


### PR DESCRIPTION
Adding file and line numbers for the error display in dev environments to support and speed up template development.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

It adds template file path and error line number to the preview error display.

#### Why?

Otherwise it is almost impossible to swiftly find the mistake in complex templates. Often the error message only is to short.

#### Example Usage
Well, just add an error to some template and check the preview out ;)