### PR TITLE
Show titleProperty in ResourceTabs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,14 @@ public function __construct($environment, $debug, $suluContext) {}
 public function __construct($environment, $debug, $suluContext = self::CONTEXT_ADMIN) {}
 ```
 
+### Styling of View components
+
+**This change only affects you if you have used a 2.0.0 alpha release before**
+
+The React components registered as views in the `ViewRegistry` had to add the padding using the
+`$viewPadding` scss variable on their own. That is not neccessary anymore, since it is added in a
+central place.
+
 ### Renamed ContentBundle to PageBundle
 
 Following things have changed:

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilder.php
@@ -48,6 +48,13 @@ class ResourceTabRouteBuilder implements ResourceTabRouteBuilderInterface
         return $this;
     }
 
+    public function setTitleProperty(string $titleProperty): ResourceTabRouteBuilderInterface
+    {
+        $this->route->setOption('titleProperty', $titleProperty);
+
+        return $this;
+    }
+
     public function getRoute(): Route
     {
         if (!$this->route->getOption('resourceKey')) {

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilderInterface.php
@@ -22,5 +22,7 @@ interface ResourceTabRouteBuilderInterface
 
     public function setBackRoute(string $backRoute): self;
 
+    public function setTitleProperty(string $titleProperty): self;
+
     public function getRoute(): Route;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -38,6 +38,7 @@
 .view-container {
     overflow-y: auto;
     height: calc(100% - $toolbarHeight);
+    padding: $viewPadding;
 }
 
 .main {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/Datagrid.js
@@ -449,7 +449,7 @@ export default class Datagrid extends React.Component<Props> {
         );
 
         return (
-            <Fragment>
+            <div className={datagridStyles.datagridContainer}>
                 {(header || searchable || adapters.length > 1) &&
                     <div className={datagridStyles.headerContainer}>
                         {header}
@@ -568,7 +568,7 @@ export default class Datagrid extends React.Component<Props> {
                         {translate('sulu_admin.order_warning_text')}
                     </Dialog>
                 }
-            </Fragment>
+            </div>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/datagrid.scss
@@ -1,10 +1,16 @@
 $datagridToolbarHeight: 30px;
 $datagridHeaderMarginBottom: 40px;
 
-.datagrid {
+.datagrid-container {
     display: flex;
     flex-direction: column;
     height: 100%;
+}
+
+.datagrid {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
 
     &.disabled {
         opacity: .5;
@@ -14,6 +20,7 @@ $datagridHeaderMarginBottom: 40px;
 
 .header-container {
     display: flex;
+    flex-grow: 0;
     margin-bottom: $datagridHeaderMarginBottom;
     align-items: center;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Do not render Loader instead of Adapter if no page count is given 1`] = `
-Array [
+<div
+  class="datagridContainer"
+>
   <div
     class="headerContainer"
   >
@@ -27,19 +29,21 @@ Array [
         />
       </label>
     </div>
-  </div>,
+  </div>
   <div
     class="datagrid"
   >
     <div>
       Test Adapter
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
-Array [
+<div
+  class="datagridContainer"
+>
   <div
     class="headerContainer"
   >
@@ -65,7 +69,7 @@ Array [
         />
       </label>
     </div>
-  </div>,
+  </div>
   <div
     class="datagrid"
   >
@@ -80,12 +84,14 @@ Array [
         class="doubleBounce2"
       />
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Render the adapter in disabled state 1`] = `
-Array [
+<div
+  class="datagridContainer"
+>
   <div
     class="headerContainer"
   >
@@ -114,19 +120,21 @@ Array [
         />
       </label>
     </div>
-  </div>,
+  </div>
   <div
     class="datagrid disabled"
   >
     <div>
       Test Adapter
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Render the adapter in non-searchable mode 1`] = `
-Array [
+<div
+  class="datagridContainer"
+>
   <div
     class="headerContainer"
   >
@@ -136,13 +144,13 @@ Array [
     <div
       class="toolbar"
     />
-  </div>,
+  </div>
   <div
     class="datagrid"
   >
     <div>
       Test Adapter
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -136,7 +136,7 @@ class Datagrid extends React.Component<ViewProps> {
         } = this.props.router;
 
         return (
-            <div className={datagridStyles.datagrid}>
+            <div>
                 <DatagridContainer
                     adapters={adapters}
                     header={title && <h1 className={datagridStyles.header}>{translate(title)}</h1>}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/datagrid.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/datagrid.scss
@@ -1,9 +1,3 @@
-@import '../../containers/Application/variables.scss';
-
-.datagrid {
-    margin: $viewPadding;
-}
-
 .header {
     margin: 0;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/__snapshots__/Datagrid.test.js.snap
@@ -1,510 +1,514 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should render the datagrid with a title 1`] = `
-<div
-  class="datagrid"
->
+<div>
   <div
-    class="headerContainer"
+    class="datagridContainer"
   >
-    <h1
-      class="header"
-    >
-      Snippets
-    </h1>
     <div
-      class="toolbar"
+      class="headerContainer"
     >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <h1
+        class="header"
       >
-        <div
-          class="prependedContainer dark collapsed"
+        Snippets
+      </h1>
+      <div
+        class="toolbar"
+      >
+        <label
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            type="text"
+            value=""
           />
+        </label>
+        <div>
+          <button
+            class="button icon"
+            type="button"
+          >
+            <span
+              aria-label="su-sort"
+              class="su-sort buttonIcon"
+            />
+            <span
+              aria-label="su-angle-down"
+              class="su-angle-down dropdownIcon"
+            />
+          </button>
         </div>
-        <input
-          type="text"
-          value=""
-        />
-      </label>
-      <div>
-        <button
-          class="button icon"
-          type="button"
-        >
-          <span
-            aria-label="su-sort"
-            class="su-sort buttonIcon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
       </div>
     </div>
-  </div>
-  <div
-    class="datagrid"
-  >
-    <section>
-      <div
-        class="tableContainer"
-      >
-        <table
-          class="table"
+    <div
+      class="datagrid"
+    >
+      <section>
+        <div
+          class="tableContainer"
         >
-          <thead
-            class="header"
+          <table
+            class="table"
           >
-            <tr>
-              <th
-                class="headerCell"
-              >
-                <span>
-                  <label
-                    class="label"
-                  >
-                    <span
-                      class="switch checkbox light"
-                    >
-                      <input
-                        type="checkbox"
-                      />
-                      <span />
-                    </span>
-                  </label>
-                </span>
-              </th>
-              <th
-                class="headerCell clickable"
-              >
-                <button>
-                  Description
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              class="row"
+            <thead
+              class="header"
             >
-              <td
-                class="cell small"
-              >
-                <div
-                  class="cellContent"
-                >
-                  <label
-                    class="label"
-                  >
-                    <span
-                      class="switch checkbox dark"
-                    >
-                      <input
-                        type="checkbox"
-                        value="1"
-                      />
-                      <span />
-                    </span>
-                  </label>
-                </div>
-              </td>
-              <td
-                class="cell"
-              >
-                <div
-                  class="cellContent"
-                >
-                  Description 1
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="row"
-            >
-              <td
-                class="cell small"
-              >
-                <div
-                  class="cellContent"
-                >
-                  <label
-                    class="label"
-                  >
-                    <span
-                      class="switch checkbox dark"
-                    >
-                      <input
-                        type="checkbox"
-                        value="2"
-                      />
-                      <span />
-                    </span>
-                  </label>
-                </div>
-              </td>
-              <td
-                class="cell"
-              >
-                <div
-                  class="cellContent"
-                >
-                  Description 2
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <nav
-        class="pagination"
-      >
-        <span
-          class="display"
-        >
-          :
-        </span>
-        <span>
-          <div
-            class="select"
-          >
-            <button
-              class="displayValue dark"
-              type="button"
-            >
-              <div
-                aria-label="10"
-                class="croppedText"
-                title="10"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  1
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
+              <tr>
+                <th
+                  class="headerCell"
                 >
                   <span>
-                    0
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox light"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <span />
+                      </span>
+                    </label>
                   </span>
-                </div>
-                <div
-                  class="whole"
+                </th>
+                <th
+                  class="headerCell clickable"
                 >
-                  10
-                </div>
-              </div>
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down toggle"
-              />
-            </button>
-          </div>
-        </span>
-        <div
-          class="loader"
-        />
-        <span>
-          Page:
-        </span>
-        <span
-          class="inputContainer"
+                  <button>
+                    Description
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="row"
+              >
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="1"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 1
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="row"
+              >
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="2"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 2
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <nav
+          class="pagination"
         >
-          <label
-            class="input dark center"
+          <span
+            class="display"
           >
-            <input
-              inputmode="numeric"
-              type="text"
-              value="1"
+            :
+          </span>
+          <span>
+            <div
+              class="select"
+            >
+              <button
+                class="displayValue dark"
+                type="button"
+              >
+                <div
+                  aria-label="10"
+                  class="croppedText"
+                  title="10"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    1
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      0
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    10
+                  </div>
+                </div>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </span>
+          <div
+            class="loader"
+          />
+          <span>
+            Page:
+          </span>
+          <span
+            class="inputContainer"
+          >
+            <label
+              class="input dark center"
+            >
+              <input
+                inputmode="numeric"
+                type="text"
+                value="1"
+              />
+            </label>
+          </span>
+          <span
+            class="display"
+          >
+            of 3
+          </span>
+          <button
+            class="previous"
+          >
+            <span
+              aria-label="su-angle-left"
+              class="su-angle-left"
             />
-          </label>
-        </span>
-        <span
-          class="display"
-        >
-          of 3
-        </span>
-        <button
-          class="previous"
-        >
-          <span
-            aria-label="su-angle-left"
-            class="su-angle-left"
-          />
-        </button>
-        <button
-          class="next"
-        >
-          <span
-            aria-label="su-angle-right"
-            class="su-angle-right"
-          />
-        </button>
-      </nav>
-    </section>
+          </button>
+          <button
+            class="next"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </button>
+        </nav>
+      </section>
+    </div>
   </div>
 </div>
 `;
 
 exports[`Should render the datagrid with the correct resourceKey 1`] = `
-<div
-  class="datagrid"
->
+<div>
   <div
-    class="headerContainer"
+    class="datagridContainer"
   >
     <div
-      class="toolbar"
+      class="headerContainer"
     >
-      <label
-        class="input dark left collapsed hasAppendIcon"
+      <div
+        class="toolbar"
       >
-        <div
-          class="prependedContainer dark collapsed"
+        <label
+          class="input dark left collapsed hasAppendIcon"
         >
-          <span
-            aria-label="su-search"
-            class="su-search clickable icon dark iconClickable collapsed"
-            role="button"
-            tabindex="0"
+          <div
+            class="prependedContainer dark collapsed"
+          >
+            <span
+              aria-label="su-search"
+              class="su-search clickable icon dark iconClickable collapsed"
+              role="button"
+              tabindex="0"
+            />
+          </div>
+          <input
+            type="text"
+            value=""
           />
+        </label>
+        <div>
+          <button
+            class="button icon"
+            type="button"
+          >
+            <span
+              aria-label="su-sort"
+              class="su-sort buttonIcon"
+            />
+            <span
+              aria-label="su-angle-down"
+              class="su-angle-down dropdownIcon"
+            />
+          </button>
         </div>
-        <input
-          type="text"
-          value=""
-        />
-      </label>
-      <div>
-        <button
-          class="button icon"
-          type="button"
-        >
-          <span
-            aria-label="su-sort"
-            class="su-sort buttonIcon"
-          />
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
       </div>
     </div>
-  </div>
-  <div
-    class="datagrid"
-  >
-    <section>
-      <div
-        class="tableContainer"
-      >
-        <table
-          class="table"
+    <div
+      class="datagrid"
+    >
+      <section>
+        <div
+          class="tableContainer"
         >
-          <thead
-            class="header"
+          <table
+            class="table"
           >
-            <tr>
-              <th
-                class="headerCell"
-              >
-                <span>
-                  <label
-                    class="label"
-                  >
-                    <span
-                      class="switch checkbox light"
-                    >
-                      <input
-                        type="checkbox"
-                      />
-                      <span />
-                    </span>
-                  </label>
-                </span>
-              </th>
-              <th
-                class="headerCell clickable"
-              >
-                <button>
-                  Description
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              class="row"
+            <thead
+              class="header"
             >
-              <td
-                class="cell small"
-              >
-                <div
-                  class="cellContent"
-                >
-                  <label
-                    class="label"
-                  >
-                    <span
-                      class="switch checkbox dark"
-                    >
-                      <input
-                        type="checkbox"
-                        value="1"
-                      />
-                      <span />
-                    </span>
-                  </label>
-                </div>
-              </td>
-              <td
-                class="cell"
-              >
-                <div
-                  class="cellContent"
-                >
-                  Description 1
-                </div>
-              </td>
-            </tr>
-            <tr
-              class="row"
-            >
-              <td
-                class="cell small"
-              >
-                <div
-                  class="cellContent"
-                >
-                  <label
-                    class="label"
-                  >
-                    <span
-                      class="switch checkbox dark"
-                    >
-                      <input
-                        type="checkbox"
-                        value="2"
-                      />
-                      <span />
-                    </span>
-                  </label>
-                </div>
-              </td>
-              <td
-                class="cell"
-              >
-                <div
-                  class="cellContent"
-                >
-                  Description 2
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <nav
-        class="pagination"
-      >
-        <span
-          class="display"
-        >
-          :
-        </span>
-        <span>
-          <div
-            class="select"
-          >
-            <button
-              class="displayValue dark"
-              type="button"
-            >
-              <div
-                aria-label="10"
-                class="croppedText"
-                title="10"
-              >
-                <div
-                  aria-hidden="true"
-                  class="front"
-                >
-                  1
-                </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
+              <tr>
+                <th
+                  class="headerCell"
                 >
                   <span>
-                    0
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox light"
+                      >
+                        <input
+                          type="checkbox"
+                        />
+                        <span />
+                      </span>
+                    </label>
                   </span>
-                </div>
-                <div
-                  class="whole"
+                </th>
+                <th
+                  class="headerCell clickable"
                 >
-                  10
-                </div>
-              </div>
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down toggle"
-              />
-            </button>
-          </div>
-        </span>
-        <div
-          class="loader"
-        />
-        <span>
-          Page:
-        </span>
-        <span
-          class="inputContainer"
+                  <button>
+                    Description
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="row"
+              >
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="1"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 1
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="row"
+              >
+                <td
+                  class="cell small"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    <label
+                      class="label"
+                    >
+                      <span
+                        class="switch checkbox dark"
+                      >
+                        <input
+                          type="checkbox"
+                          value="2"
+                        />
+                        <span />
+                      </span>
+                    </label>
+                  </div>
+                </td>
+                <td
+                  class="cell"
+                >
+                  <div
+                    class="cellContent"
+                  >
+                    Description 2
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <nav
+          class="pagination"
         >
-          <label
-            class="input dark center"
+          <span
+            class="display"
           >
-            <input
-              inputmode="numeric"
-              type="text"
-              value="1"
+            :
+          </span>
+          <span>
+            <div
+              class="select"
+            >
+              <button
+                class="displayValue dark"
+                type="button"
+              >
+                <div
+                  aria-label="10"
+                  class="croppedText"
+                  title="10"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    1
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      0
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    10
+                  </div>
+                </div>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </span>
+          <div
+            class="loader"
+          />
+          <span>
+            Page:
+          </span>
+          <span
+            class="inputContainer"
+          >
+            <label
+              class="input dark center"
+            >
+              <input
+                inputmode="numeric"
+                type="text"
+                value="1"
+              />
+            </label>
+          </span>
+          <span
+            class="display"
+          >
+            of 3
+          </span>
+          <button
+            class="previous"
+          >
+            <span
+              aria-label="su-angle-left"
+              class="su-angle-left"
             />
-          </label>
-        </span>
-        <span
-          class="display"
-        >
-          of 3
-        </span>
-        <button
-          class="previous"
-        >
-          <span
-            aria-label="su-angle-left"
-            class="su-angle-left"
-          />
-        </button>
-        <button
-          class="next"
-        >
-          <span
-            aria-label="su-angle-right"
-            class="su-angle-right"
-          />
-        </button>
-      </nav>
-    </section>
+          </button>
+          <button
+            class="next"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </button>
+        </nav>
+      </section>
+    </div>
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/form.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/form.scss
@@ -1,7 +1,6 @@
 @import '../../containers/Application/variables.scss';
 
 .form {
-    padding: $viewPadding;
     max-width: $viewMaxWidth;
     min-width: $viewMinWidth;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -12,6 +12,7 @@ import resourceTabsStyles from './resourceTabs.scss';
 
 type Props = ViewProps & {
     locales?: Array<string>,
+    titleProperty?: string,
 };
 
 @observer
@@ -70,6 +71,19 @@ export default class ResourceTabs extends React.Component<Props> {
         } = this.props;
 
         return routeLocales ? routeLocales : propsLocales;
+    }
+
+    @computed get title() {
+        const {
+            route: {
+                options: {
+                    titleProperty: routeTitleProperty,
+                },
+            },
+            titleProperty,
+        } = this.props;
+
+        return this.resourceStore.data[titleProperty || routeTitleProperty];
     }
 
     @computed get visibleTabRoutes(): Array<Object> {
@@ -190,6 +204,7 @@ export default class ResourceTabs extends React.Component<Props> {
                             );
                         })}
                     </Tabs>
+                    {selectedRouteIndex !== 0 && <h2>{this.title}</h2>}
                     {ChildComponent}
                 </Fragment>
             )

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -194,17 +194,19 @@ export default class ResourceTabs extends React.Component<Props> {
         return this.resourceStore.initialized
             ? (
                 <Fragment>
-                    <Tabs onSelect={this.handleSelect} selectedIndex={selectedRouteIndex}>
-                        {this.visibleTabRoutes.map((tabRoute) => {
-                            const tabTitle = tabRoute.options.tabTitle;
-                            return (
-                                <Tabs.Tab key={tabRoute.name}>
-                                    {tabTitle ? translate(tabTitle) : tabRoute.name}
-                                </Tabs.Tab>
-                            );
-                        })}
-                    </Tabs>
-                    {selectedRouteIndex !== 0 && <h2>{this.title}</h2>}
+                    <div className={resourceTabsStyles.tabsContainer}>
+                        <Tabs onSelect={this.handleSelect} selectedIndex={selectedRouteIndex}>
+                            {this.visibleTabRoutes.map((tabRoute) => {
+                                const tabTitle = tabRoute.options.tabTitle;
+                                return (
+                                    <Tabs.Tab key={tabRoute.name}>
+                                        {tabTitle ? translate(tabTitle) : tabRoute.name}
+                                    </Tabs.Tab>
+                                );
+                            })}
+                        </Tabs>
+                    </div>
+                    {selectedRouteIndex !== 0 && <h1>{this.title}</h1>}
                     {ChildComponent}
                 </Fragment>
             )

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -183,13 +183,15 @@ export default class ResourceTabs extends React.Component<Props> {
     };
 
     render() {
-        const {children} = this.props;
+        const {children, route} = this.props;
 
         const ChildComponent = children ? children({locales: this.locales, resourceStore: this.resourceStore}) : null;
 
         const selectedRouteIndex = ChildComponent
             ? this.visibleTabRoutes.findIndex((childRoute) => childRoute === ChildComponent.props.route)
             : undefined;
+
+        const selectedRoute = selectedRouteIndex !== undefined ? this.visibleTabRoutes[selectedRouteIndex] : undefined;
 
         return this.resourceStore.initialized
             ? (
@@ -206,7 +208,9 @@ export default class ResourceTabs extends React.Component<Props> {
                             })}
                         </Tabs>
                     </div>
-                    {selectedRouteIndex !== 0 && <h1>{this.title}</h1>}
+                    {route.children[0] !== selectedRoute && this.title &&
+                        <h1>{this.title}</h1>
+                    }
                     {ChildComponent}
                 </Fragment>
             )

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/resourceTabs.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/resourceTabs.scss
@@ -1,6 +1,11 @@
 @import '../../components/Toolbar/variables.scss';
 @import '../../components/Tabs/variables.scss';
+@import '../../containers/Application/variables.scss';
 
 .loader {
     margin-top: calc($toolbarHeight + $tabMenuHeight);
+}
+
+.tabs-container {
+    margin: -$viewPadding -$viewPadding $viewPadding;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -65,6 +65,43 @@ test('Should render the tab title from the ResourceStore as configured in the ro
     expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value1');
 });
 
+test('Should not render the tab title from the ResourceStore if no titleProperty is set', () => {
+    const route = {
+        options: {
+            resourceKey: 'test',
+        },
+        children: [
+            {
+                name: 'Tab 1',
+                options: {
+                    tabTitle: 'tabTitle1',
+                },
+            },
+            {
+                name: 'Tab 2',
+                options: {
+                    tabTitle: 'tabTitle2',
+                },
+            },
+        ],
+    };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route: route.children[1],
+    };
+
+    const Child = () => (<h1>Child</h1>);
+
+    const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => (<Child />)}</ResourceTabs>);
+
+    resourceTabs.instance().resourceStore.data = {test1: 'value1'};
+    resourceTabs.update();
+
+    expect(resourceTabs.find('ResourceTabs > h1')).toHaveLength(0);
+});
+
 test('Should render the tab title from the resourceStore as configured in the props', () => {
     const route = {
         options: {
@@ -147,6 +184,51 @@ test('Should not render the tab title on the first tab', () => {
     setTimeout(() => {
         resourceTabs.update();
         expect(resourceTabs.find('ResourceTabs > h1')).toHaveLength(0);
+    });
+});
+
+test('Should render the tab title on the first visible tab if the first tab is not visible', (done) => {
+    const route = {
+        options: {
+            resourceKey: 'test',
+            titleProperty: 'test1',
+        },
+        children: [
+            {
+                name: 'Tab 1',
+                options: {
+                    tabCondition: 'test == 1',
+                    tabTitle: 'tabTitle1',
+                },
+            },
+            {
+                name: 'Tab 2',
+                options: {
+                    tabTitle: 'tabTitle2',
+                },
+            },
+        ],
+    };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route: route.children[1],
+    };
+
+    const Child = () => (<h1>Child</h1>);
+
+    const resourceTabs = mount(
+        <ResourceTabs route={route} router={router}>
+            {() => (<Child route={route.children[1]} />)}
+        </ResourceTabs>
+    );
+
+    resourceTabs.instance().resourceStore.data = {test1: 'value1'};
+    setTimeout(() => {
+        resourceTabs.update();
+        expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value1');
+        done();
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -62,7 +62,7 @@ test('Should render the tab title from the ResourceStore as configured in the ro
     resourceTabs.instance().resourceStore.data = {test1: 'value1'};
     resourceTabs.update();
 
-    expect(resourceTabs.find('ResourceTabs > h2').text()).toEqual('value1');
+    expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value1');
 });
 
 test('Should render the tab title from the resourceStore as configured in the props', () => {
@@ -104,7 +104,7 @@ test('Should render the tab title from the resourceStore as configured in the pr
     resourceTabs.instance().resourceStore.data = {test1: 'value1', test2: 'value2'};
     resourceTabs.update();
 
-    expect(resourceTabs.find('ResourceTabs > h2').text()).toEqual('value2');
+    expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value2');
 });
 
 test('Should not render the tab title on the first tab', () => {
@@ -146,7 +146,7 @@ test('Should not render the tab title on the first tab', () => {
     resourceTabs.instance().resourceStore.data = {test1: 'value1', test2: 'value2'};
     setTimeout(() => {
         resourceTabs.update();
-        expect(resourceTabs.find('ResourceTabs > h2')).toHaveLength(0);
+        expect(resourceTabs.find('ResourceTabs > h1')).toHaveLength(0);
     });
 });
 
@@ -183,8 +183,8 @@ test('Should render the child components after the tabs', (done) => {
 
     setTimeout(() => {
         expect(resourceTabs.find('Loader')).toHaveLength(0);
-        expect(resourceTabs.find('ResourceTabs > Tabs').render()).toMatchSnapshot();
-        expect(resourceTabs.find('ResourceTabs > Child').render()).toMatchSnapshot();
+        expect(resourceTabs.find('ResourceTabs Tabs').render()).toMatchSnapshot();
+        expect(resourceTabs.find('ResourceTabs Child').render()).toMatchSnapshot();
         done();
     });
 });
@@ -267,8 +267,8 @@ test('Should mark the currently active child route as selected tab', (done) => {
     );
 
     setTimeout(() => {
-        expect(resourceTabs.find('ResourceTabs > Tabs').render()).toMatchSnapshot();
-        expect(resourceTabs.find('ResourceTabs > Child').render()).toMatchSnapshot();
+        expect(resourceTabs.find('ResourceTabs Tabs').render()).toMatchSnapshot();
+        expect(resourceTabs.find('ResourceTabs Child').render()).toMatchSnapshot();
         done();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -27,6 +27,129 @@ jest.mock('../../../stores/ResourceStore', () => jest.fn(function() {
     mockExtendObservable(this, {data: {}});
 }));
 
+test('Should render the tab title from the ResourceStore as configured in the route', () => {
+    const route = {
+        options: {
+            resourceKey: 'test',
+            titleProperty: 'test1',
+        },
+        children: [
+            {
+                name: 'Tab 1',
+                options: {
+                    tabTitle: 'tabTitle1',
+                },
+            },
+            {
+                name: 'Tab 2',
+                options: {
+                    tabTitle: 'tabTitle2',
+                },
+            },
+        ],
+    };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route: route.children[1],
+    };
+
+    const Child = () => (<h1>Child</h1>);
+
+    const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => (<Child />)}</ResourceTabs>);
+
+    resourceTabs.instance().resourceStore.data = {test1: 'value1'};
+    resourceTabs.update();
+
+    expect(resourceTabs.find('ResourceTabs > h2').text()).toEqual('value1');
+});
+
+test('Should render the tab title from the resourceStore as configured in the props', () => {
+    const route = {
+        options: {
+            resourceKey: 'test',
+            titleProperty: 'test1',
+        },
+        children: [
+            {
+                name: 'Tab 1',
+                options: {
+                    tabTitle: 'tabTitle1',
+                },
+            },
+            {
+                name: 'Tab 2',
+                options: {
+                    tabTitle: 'tabTitle2',
+                },
+            },
+        ],
+    };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route: route.children[1],
+    };
+
+    const Child = () => (<h1>Child</h1>);
+
+    const resourceTabs = mount(
+        <ResourceTabs route={route} router={router} titleProperty="test2">
+            {() => (<Child />)}
+        </ResourceTabs>
+    );
+
+    resourceTabs.instance().resourceStore.data = {test1: 'value1', test2: 'value2'};
+    resourceTabs.update();
+
+    expect(resourceTabs.find('ResourceTabs > h2').text()).toEqual('value2');
+});
+
+test('Should not render the tab title on the first tab', () => {
+    const route = {
+        options: {
+            resourceKey: 'test',
+            titleProperty: 'test1',
+        },
+        children: [
+            {
+                name: 'Tab 1',
+                options: {
+                    tabTitle: 'tabTitle1',
+                },
+            },
+            {
+                name: 'Tab 2',
+                options: {
+                    tabTitle: 'tabTitle2',
+                },
+            },
+        ],
+    };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route: route.children[0],
+    };
+
+    const Child = () => (<h1>Child</h1>);
+
+    const resourceTabs = mount(
+        <ResourceTabs route={route} router={router} titleProperty="test2">
+            {() => (<Child route={route.children[0]} />)}
+        </ResourceTabs>
+    );
+
+    resourceTabs.instance().resourceStore.data = {test1: 'value1', test2: 'value2'};
+    setTimeout(() => {
+        resourceTabs.update();
+        expect(resourceTabs.find('ResourceTabs > h2')).toHaveLength(0);
+    });
+});
+
 test('Should render the child components after the tabs', (done) => {
     const route = {
         options: {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ResourceTabRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ResourceTabRouteBuilderTest.php
@@ -41,11 +41,13 @@ class ResourceTabRouteBuilderTest extends TestCase
                 '/categories/add',
                 'categories',
                 'sulu_category.datagrid',
+                'title',
             ],
             [
                 'sulu_tag.edit_form',
                 '/tags/:id',
                 'tags',
+                null,
                 null,
             ],
         ];
@@ -58,7 +60,8 @@ class ResourceTabRouteBuilderTest extends TestCase
         string $name,
         string $path,
         string $resourceKey,
-        ?string $backRoute
+        ?string $backRoute,
+        ?string $titleProperty
     ) {
         $routeBuilder = (new ResourceTabRouteBuilder($name, $path))
             ->setResourceKey($resourceKey);
@@ -67,12 +70,17 @@ class ResourceTabRouteBuilderTest extends TestCase
             $routeBuilder->setBackRoute($backRoute);
         }
 
+        if ($titleProperty) {
+            $routeBuilder->setTitleProperty($titleProperty);
+        }
+
         $route = $routeBuilder->getRoute();
 
         $this->assertEquals($name, $route->getName());
         $this->assertEquals($path, $route->getPath());
         $this->assertEquals($resourceKey, $route->getOption('resourceKey'));
         $this->assertEquals($backRoute, $route->getOption('backRoute'));
+        $this->assertEquals($titleProperty, $route->getOption('titleProperty'));
         $this->assertEquals('sulu_admin.resource_tabs', $route->getView());
     }
 

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -117,6 +117,7 @@ class CategoryAdmin extends Admin
                 ->setResourceKey('categories')
                 ->addLocales($locales)
                 ->setBackRoute(static::DATAGRID_ROUTE)
+                ->setTitleProperty('name')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_category.edit_form.details', '/details')
                 ->setResourceKey('categories')

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -117,6 +117,7 @@ class ContactAdmin extends Admin
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::CONTACT_EDIT_FORM_ROUTE, '/contacts/:id')
                 ->setResourceKey('contacts')
                 ->setBackRoute(static::CONTACT_DATAGRID_ROUTE)
+                ->setTitleProperty('fullName')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_contact.contact_edit_form.details', '/details')
                 ->setResourceKey('contacts')
@@ -147,6 +148,7 @@ class ContactAdmin extends Admin
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ACCOUNT_EDIT_FORM_ROUTE, '/accounts/:id')
                 ->setResourceKey('accounts')
                 ->setBackRoute(static::ACCOUNT_DATAGRID_ROUTE)
+                ->setTitleProperty('name')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_contact.account_edit_form.details', '/details')
                 ->setResourceKey('accounts')

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -102,6 +102,7 @@ class MediaAdmin extends Admin
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/media/:locale/:id')
                 ->setResourceKey('media')
                 ->addLocales($mediaLocales)
+                ->setTitleProperty('title')
                 ->getRoute(),
             (new Route(static::EDIT_FORM_DETAILS_ROUTE, '/details', 'sulu_media.details'))
                 ->setOption('tabTitle', 'sulu_media.information_taxonomy')

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -69,163 +69,167 @@ exports[`Render the MediaCollection 1`] = `
       </div>
     </div>
     <div
-      class="datagrid"
+      class="datagridContainer"
     >
-      <section>
-        <ul
-          class="folderList"
-        >
-          <li>
-            <div
-              class="folder"
-              role="button"
-              tabindex="0"
-            >
-              <div
-                class="iconContainer"
-              >
-                <span
-                  aria-label="su-folder"
-                  class="su-folder"
-                />
-              </div>
-              <div
-                class="description"
-              >
-                <h5
-                  class="title"
-                >
-                  Title 1
-                </h5>
-                <div
-                  class="info"
-                >
-                  1 Object
-                </div>
-              </div>
-            </div>
-          </li>
-          <li>
-            <div
-              class="folder"
-              role="button"
-              tabindex="0"
-            >
-              <div
-                class="iconContainer"
-              >
-                <span
-                  aria-label="su-folder"
-                  class="su-folder"
-                />
-              </div>
-              <div
-                class="description"
-              >
-                <h5
-                  class="title"
-                >
-                  Title 2
-                </h5>
-                <div
-                  class="info"
-                >
-                  0 Objects
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-        <nav
-          class="pagination"
-        >
-          <span
-            class="display"
+      <div
+        class="datagrid"
+      >
+        <section>
+          <ul
+            class="folderList"
           >
-            :
-          </span>
-          <span>
-            <div
-              class="select"
-            >
-              <button
-                class="displayValue dark"
-                type="button"
+            <li>
+              <div
+                class="folder"
+                role="button"
+                tabindex="0"
               >
                 <div
-                  aria-label="10"
-                  class="croppedText"
-                  title="10"
+                  class="iconContainer"
                 >
-                  <div
-                    aria-hidden="true"
-                    class="front"
+                  <span
+                    aria-label="su-folder"
+                    class="su-folder"
+                  />
+                </div>
+                <div
+                  class="description"
+                >
+                  <h5
+                    class="title"
                   >
-                    1
-                  </div>
+                    Title 1
+                  </h5>
                   <div
-                    aria-hidden="true"
-                    class="back"
+                    class="info"
                   >
-                    <span>
-                      0
-                    </span>
-                  </div>
-                  <div
-                    class="whole"
-                  >
-                    10
+                    1 Object
                   </div>
                 </div>
-                <span
-                  aria-label="su-angle-down"
-                  class="su-angle-down toggle"
-                />
-              </button>
-            </div>
-          </span>
-          <div
-            class="loader"
-          />
-          <span>
-            Page:
-          </span>
-          <span
-            class="inputContainer"
+              </div>
+            </li>
+            <li>
+              <div
+                class="folder"
+                role="button"
+                tabindex="0"
+              >
+                <div
+                  class="iconContainer"
+                >
+                  <span
+                    aria-label="su-folder"
+                    class="su-folder"
+                  />
+                </div>
+                <div
+                  class="description"
+                >
+                  <h5
+                    class="title"
+                  >
+                    Title 2
+                  </h5>
+                  <div
+                    class="info"
+                  >
+                    0 Objects
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <nav
+            class="pagination"
           >
-            <label
-              class="input dark center"
+            <span
+              class="display"
             >
-              <input
-                inputmode="numeric"
-                type="text"
-                value="1"
+              :
+            </span>
+            <span>
+              <div
+                class="select"
+              >
+                <button
+                  class="displayValue dark"
+                  type="button"
+                >
+                  <div
+                    aria-label="10"
+                    class="croppedText"
+                    title="10"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="front"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="back"
+                    >
+                      <span>
+                        0
+                      </span>
+                    </div>
+                    <div
+                      class="whole"
+                    >
+                      10
+                    </div>
+                  </div>
+                  <span
+                    aria-label="su-angle-down"
+                    class="su-angle-down toggle"
+                  />
+                </button>
+              </div>
+            </span>
+            <div
+              class="loader"
+            />
+            <span>
+              Page:
+            </span>
+            <span
+              class="inputContainer"
+            >
+              <label
+                class="input dark center"
+              >
+                <input
+                  inputmode="numeric"
+                  type="text"
+                  value="1"
+                />
+              </label>
+            </span>
+            <span
+              class="display"
+            >
+              of 3
+            </span>
+            <button
+              class="previous"
+            >
+              <span
+                aria-label="su-angle-left"
+                class="su-angle-left"
               />
-            </label>
-          </span>
-          <span
-            class="display"
-          >
-            of 3
-          </span>
-          <button
-            class="previous"
-          >
-            <span
-              aria-label="su-angle-left"
-              class="su-angle-left"
-            />
-          </button>
-          <button
-            class="next"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </button>
-        </nav>
-      </section>
+            </button>
+            <button
+              class="next"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right"
+              />
+            </button>
+          </nav>
+        </section>
+      </div>
     </div>
   </div>
   <div
@@ -233,283 +237,287 @@ exports[`Render the MediaCollection 1`] = `
   />
   <div>
     <div
-      class="headerContainer"
+      class="datagridContainer"
     >
       <div
-        class="toolbar"
+        class="headerContainer"
       >
-        <label
-          class="input dark left collapsed hasAppendIcon"
-        >
-          <div
-            class="prependedContainer dark collapsed"
-          >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <input
-            type="text"
-            value=""
-          />
-        </label>
-      </div>
-    </div>
-    <div
-      class="datagrid"
-    >
-      <section>
-        <div>
-          <div
-            class="masonry"
-          >
-            <li
-              style="margin-bottom:30px"
-            >
-              <div
-                class="mediaCard"
-              >
-                <div
-                  class="header"
-                >
-                  <div
-                    class="description"
-                  >
-                    <div
-                      class="title"
-                    >
-                      <label
-                        class="label"
-                      >
-                        <span
-                          class="switch checkbox dark checkbox"
-                        >
-                          <input
-                            type="checkbox"
-                            value="1"
-                          />
-                          <span />
-                        </span>
-                        <div>
-                          <div
-                            class="titleText"
-                          >
-                            <div
-                              aria-label="Title 1"
-                              class="croppedText"
-                              title="Title 1"
-                            >
-                              <div
-                                aria-hidden="true"
-                                class="front"
-                              >
-                                Titl
-                              </div>
-                              <div
-                                aria-hidden="true"
-                                class="back"
-                              >
-                                <span>
-                                  e 1
-                                </span>
-                              </div>
-                              <div
-                                class="whole"
-                              >
-                                Title 1
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                    <div
-                      class="meta"
-                    >
-                      <div
-                        aria-label="image/png 12.35 KB"
-                        class="croppedText"
-                        title="image/png 12.35 KB"
-                      >
-                        <div
-                          aria-hidden="true"
-                          class="front"
-                        >
-                          image/png
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="back"
-                        >
-                          <span>
-                             12.35 KB
-                          </span>
-                        </div>
-                        <div
-                          class="whole"
-                        >
-                          image/png 12.35 KB
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <button
-                      class="downloadButton"
-                    >
-                      <span
-                        aria-label="fa-cloud-download"
-                        class="fa fa-cloud-download"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="media"
-                >
-                  <img
-                    alt="Title 1"
-                    src="http://lorempixel.com/240/100"
-                  />
-                  <div
-                    class="cover"
-                  >
-                    <span
-                      aria-label="su-pen"
-                      class="su-pen mediaIcon"
-                    />
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              style="margin-bottom:30px"
-            >
-              <div
-                class="mediaCard"
-              >
-                <div
-                  class="header"
-                >
-                  <div
-                    class="description"
-                  >
-                    <div
-                      class="title"
-                    >
-                      <label
-                        class="label"
-                      >
-                        <span
-                          class="switch checkbox dark checkbox"
-                        >
-                          <input
-                            type="checkbox"
-                            value="2"
-                          />
-                          <span />
-                        </span>
-                        <div>
-                          <div
-                            class="titleText"
-                          >
-                            <div
-                              aria-label="Title 1"
-                              class="croppedText"
-                              title="Title 1"
-                            >
-                              <div
-                                aria-hidden="true"
-                                class="front"
-                              >
-                                Titl
-                              </div>
-                              <div
-                                aria-hidden="true"
-                                class="back"
-                              >
-                                <span>
-                                  e 1
-                                </span>
-                              </div>
-                              <div
-                                class="whole"
-                              >
-                                Title 1
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                    <div
-                      class="meta"
-                    >
-                      <div
-                        aria-label="image/jpeg 54.32 KB"
-                        class="croppedText"
-                        title="image/jpeg 54.32 KB"
-                      >
-                        <div
-                          aria-hidden="true"
-                          class="front"
-                        >
-                          image/jpeg
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="back"
-                        >
-                          <span>
-                             54.32 KB
-                          </span>
-                        </div>
-                        <div
-                          class="whole"
-                        >
-                          image/jpeg 54.32 KB
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <button
-                      class="downloadButton"
-                    >
-                      <span
-                        aria-label="fa-cloud-download"
-                        class="fa fa-cloud-download"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="media"
-                >
-                  <img
-                    alt="Title 1"
-                    src="http://lorempixel.com/240/100"
-                  />
-                  <div
-                    class="cover"
-                  >
-                    <span
-                      aria-label="su-pen"
-                      class="su-pen mediaIcon"
-                    />
-                  </div>
-                </div>
-              </div>
-            </li>
-          </div>
-        </div>
         <div
-          class="indicator"
-        />
-      </section>
+          class="toolbar"
+        >
+          <label
+            class="input dark left collapsed hasAppendIcon"
+          >
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
+            />
+          </label>
+        </div>
+      </div>
+      <div
+        class="datagrid"
+      >
+        <section>
+          <div>
+            <div
+              class="masonry"
+            >
+              <li
+                style="margin-bottom:30px"
+              >
+                <div
+                  class="mediaCard"
+                >
+                  <div
+                    class="header"
+                  >
+                    <div
+                      class="description"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          class="label"
+                        >
+                          <span
+                            class="switch checkbox dark checkbox"
+                          >
+                            <input
+                              type="checkbox"
+                              value="1"
+                            />
+                            <span />
+                          </span>
+                          <div>
+                            <div
+                              class="titleText"
+                            >
+                              <div
+                                aria-label="Title 1"
+                                class="croppedText"
+                                title="Title 1"
+                              >
+                                <div
+                                  aria-hidden="true"
+                                  class="front"
+                                >
+                                  Titl
+                                </div>
+                                <div
+                                  aria-hidden="true"
+                                  class="back"
+                                >
+                                  <span>
+                                    e 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="whole"
+                                >
+                                  Title 1
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <div
+                        class="meta"
+                      >
+                        <div
+                          aria-label="image/png 12.35 KB"
+                          class="croppedText"
+                          title="image/png 12.35 KB"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="front"
+                          >
+                            image/png
+                          </div>
+                          <div
+                            aria-hidden="true"
+                            class="back"
+                          >
+                            <span>
+                               12.35 KB
+                            </span>
+                          </div>
+                          <div
+                            class="whole"
+                          >
+                            image/png 12.35 KB
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <button
+                        class="downloadButton"
+                      >
+                        <span
+                          aria-label="fa-cloud-download"
+                          class="fa fa-cloud-download"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="media"
+                  >
+                    <img
+                      alt="Title 1"
+                      src="http://lorempixel.com/240/100"
+                    />
+                    <div
+                      class="cover"
+                    >
+                      <span
+                        aria-label="su-pen"
+                        class="su-pen mediaIcon"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li
+                style="margin-bottom:30px"
+              >
+                <div
+                  class="mediaCard"
+                >
+                  <div
+                    class="header"
+                  >
+                    <div
+                      class="description"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          class="label"
+                        >
+                          <span
+                            class="switch checkbox dark checkbox"
+                          >
+                            <input
+                              type="checkbox"
+                              value="2"
+                            />
+                            <span />
+                          </span>
+                          <div>
+                            <div
+                              class="titleText"
+                            >
+                              <div
+                                aria-label="Title 1"
+                                class="croppedText"
+                                title="Title 1"
+                              >
+                                <div
+                                  aria-hidden="true"
+                                  class="front"
+                                >
+                                  Titl
+                                </div>
+                                <div
+                                  aria-hidden="true"
+                                  class="back"
+                                >
+                                  <span>
+                                    e 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="whole"
+                                >
+                                  Title 1
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <div
+                        class="meta"
+                      >
+                        <div
+                          aria-label="image/jpeg 54.32 KB"
+                          class="croppedText"
+                          title="image/jpeg 54.32 KB"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="front"
+                          >
+                            image/jpeg
+                          </div>
+                          <div
+                            aria-hidden="true"
+                            class="back"
+                          >
+                            <span>
+                               54.32 KB
+                            </span>
+                          </div>
+                          <div
+                            class="whole"
+                          >
+                            image/jpeg 54.32 KB
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <button
+                        class="downloadButton"
+                      >
+                        <span
+                          aria-label="fa-cloud-download"
+                          class="fa fa-cloud-download"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="media"
+                  >
+                    <img
+                      alt="Title 1"
+                      src="http://lorempixel.com/240/100"
+                    />
+                    <div
+                      class="cover"
+                    >
+                      <span
+                        aria-label="su-pen"
+                        class="su-pen mediaIcon"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </div>
+          </div>
+          <div
+            class="indicator"
+          />
+        </section>
+      </div>
     </div>
   </div>
   <input
@@ -568,163 +576,167 @@ exports[`Render the MediaCollection for all media 1`] = `
       </div>
     </div>
     <div
-      class="datagrid"
+      class="datagridContainer"
     >
-      <section>
-        <ul
-          class="folderList"
-        >
-          <li>
-            <div
-              class="folder"
-              role="button"
-              tabindex="0"
-            >
-              <div
-                class="iconContainer"
-              >
-                <span
-                  aria-label="su-folder"
-                  class="su-folder"
-                />
-              </div>
-              <div
-                class="description"
-              >
-                <h5
-                  class="title"
-                >
-                  Title 1
-                </h5>
-                <div
-                  class="info"
-                >
-                  1 Object
-                </div>
-              </div>
-            </div>
-          </li>
-          <li>
-            <div
-              class="folder"
-              role="button"
-              tabindex="0"
-            >
-              <div
-                class="iconContainer"
-              >
-                <span
-                  aria-label="su-folder"
-                  class="su-folder"
-                />
-              </div>
-              <div
-                class="description"
-              >
-                <h5
-                  class="title"
-                >
-                  Title 2
-                </h5>
-                <div
-                  class="info"
-                >
-                  0 Objects
-                </div>
-              </div>
-            </div>
-          </li>
-        </ul>
-        <nav
-          class="pagination"
-        >
-          <span
-            class="display"
+      <div
+        class="datagrid"
+      >
+        <section>
+          <ul
+            class="folderList"
           >
-            :
-          </span>
-          <span>
-            <div
-              class="select"
-            >
-              <button
-                class="displayValue dark"
-                type="button"
+            <li>
+              <div
+                class="folder"
+                role="button"
+                tabindex="0"
               >
                 <div
-                  aria-label="10"
-                  class="croppedText"
-                  title="10"
+                  class="iconContainer"
                 >
-                  <div
-                    aria-hidden="true"
-                    class="front"
+                  <span
+                    aria-label="su-folder"
+                    class="su-folder"
+                  />
+                </div>
+                <div
+                  class="description"
+                >
+                  <h5
+                    class="title"
                   >
-                    1
-                  </div>
+                    Title 1
+                  </h5>
                   <div
-                    aria-hidden="true"
-                    class="back"
+                    class="info"
                   >
-                    <span>
-                      0
-                    </span>
-                  </div>
-                  <div
-                    class="whole"
-                  >
-                    10
+                    1 Object
                   </div>
                 </div>
-                <span
-                  aria-label="su-angle-down"
-                  class="su-angle-down toggle"
-                />
-              </button>
-            </div>
-          </span>
-          <div
-            class="loader"
-          />
-          <span>
-            Page:
-          </span>
-          <span
-            class="inputContainer"
+              </div>
+            </li>
+            <li>
+              <div
+                class="folder"
+                role="button"
+                tabindex="0"
+              >
+                <div
+                  class="iconContainer"
+                >
+                  <span
+                    aria-label="su-folder"
+                    class="su-folder"
+                  />
+                </div>
+                <div
+                  class="description"
+                >
+                  <h5
+                    class="title"
+                  >
+                    Title 2
+                  </h5>
+                  <div
+                    class="info"
+                  >
+                    0 Objects
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <nav
+            class="pagination"
           >
-            <label
-              class="input dark center"
+            <span
+              class="display"
             >
-              <input
-                inputmode="numeric"
-                type="text"
-                value="1"
+              :
+            </span>
+            <span>
+              <div
+                class="select"
+              >
+                <button
+                  class="displayValue dark"
+                  type="button"
+                >
+                  <div
+                    aria-label="10"
+                    class="croppedText"
+                    title="10"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="front"
+                    >
+                      1
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="back"
+                    >
+                      <span>
+                        0
+                      </span>
+                    </div>
+                    <div
+                      class="whole"
+                    >
+                      10
+                    </div>
+                  </div>
+                  <span
+                    aria-label="su-angle-down"
+                    class="su-angle-down toggle"
+                  />
+                </button>
+              </div>
+            </span>
+            <div
+              class="loader"
+            />
+            <span>
+              Page:
+            </span>
+            <span
+              class="inputContainer"
+            >
+              <label
+                class="input dark center"
+              >
+                <input
+                  inputmode="numeric"
+                  type="text"
+                  value="1"
+                />
+              </label>
+            </span>
+            <span
+              class="display"
+            >
+              of 3
+            </span>
+            <button
+              class="previous"
+            >
+              <span
+                aria-label="su-angle-left"
+                class="su-angle-left"
               />
-            </label>
-          </span>
-          <span
-            class="display"
-          >
-            of 3
-          </span>
-          <button
-            class="previous"
-          >
-            <span
-              aria-label="su-angle-left"
-              class="su-angle-left"
-            />
-          </button>
-          <button
-            class="next"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </button>
-        </nav>
-      </section>
+            </button>
+            <button
+              class="next"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right"
+              />
+            </button>
+          </nav>
+        </section>
+      </div>
     </div>
   </div>
   <div
@@ -732,283 +744,287 @@ exports[`Render the MediaCollection for all media 1`] = `
   />
   <div>
     <div
-      class="headerContainer"
+      class="datagridContainer"
     >
       <div
-        class="toolbar"
+        class="headerContainer"
       >
-        <label
-          class="input dark left collapsed hasAppendIcon"
-        >
-          <div
-            class="prependedContainer dark collapsed"
-          >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <input
-            type="text"
-            value=""
-          />
-        </label>
-      </div>
-    </div>
-    <div
-      class="datagrid"
-    >
-      <section>
-        <div>
-          <div
-            class="masonry"
-          >
-            <li
-              style="margin-bottom:30px"
-            >
-              <div
-                class="mediaCard"
-              >
-                <div
-                  class="header"
-                >
-                  <div
-                    class="description"
-                  >
-                    <div
-                      class="title"
-                    >
-                      <label
-                        class="label"
-                      >
-                        <span
-                          class="switch checkbox dark checkbox"
-                        >
-                          <input
-                            type="checkbox"
-                            value="1"
-                          />
-                          <span />
-                        </span>
-                        <div>
-                          <div
-                            class="titleText"
-                          >
-                            <div
-                              aria-label="Title 1"
-                              class="croppedText"
-                              title="Title 1"
-                            >
-                              <div
-                                aria-hidden="true"
-                                class="front"
-                              >
-                                Titl
-                              </div>
-                              <div
-                                aria-hidden="true"
-                                class="back"
-                              >
-                                <span>
-                                  e 1
-                                </span>
-                              </div>
-                              <div
-                                class="whole"
-                              >
-                                Title 1
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                    <div
-                      class="meta"
-                    >
-                      <div
-                        aria-label="image/png 12.35 KB"
-                        class="croppedText"
-                        title="image/png 12.35 KB"
-                      >
-                        <div
-                          aria-hidden="true"
-                          class="front"
-                        >
-                          image/png
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="back"
-                        >
-                          <span>
-                             12.35 KB
-                          </span>
-                        </div>
-                        <div
-                          class="whole"
-                        >
-                          image/png 12.35 KB
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <button
-                      class="downloadButton"
-                    >
-                      <span
-                        aria-label="fa-cloud-download"
-                        class="fa fa-cloud-download"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="media"
-                >
-                  <img
-                    alt="Title 1"
-                    src="http://lorempixel.com/240/100"
-                  />
-                  <div
-                    class="cover"
-                  >
-                    <span
-                      aria-label="su-pen"
-                      class="su-pen mediaIcon"
-                    />
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li
-              style="margin-bottom:30px"
-            >
-              <div
-                class="mediaCard"
-              >
-                <div
-                  class="header"
-                >
-                  <div
-                    class="description"
-                  >
-                    <div
-                      class="title"
-                    >
-                      <label
-                        class="label"
-                      >
-                        <span
-                          class="switch checkbox dark checkbox"
-                        >
-                          <input
-                            type="checkbox"
-                            value="2"
-                          />
-                          <span />
-                        </span>
-                        <div>
-                          <div
-                            class="titleText"
-                          >
-                            <div
-                              aria-label="Title 1"
-                              class="croppedText"
-                              title="Title 1"
-                            >
-                              <div
-                                aria-hidden="true"
-                                class="front"
-                              >
-                                Titl
-                              </div>
-                              <div
-                                aria-hidden="true"
-                                class="back"
-                              >
-                                <span>
-                                  e 1
-                                </span>
-                              </div>
-                              <div
-                                class="whole"
-                              >
-                                Title 1
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                    <div
-                      class="meta"
-                    >
-                      <div
-                        aria-label="image/jpeg 54.32 KB"
-                        class="croppedText"
-                        title="image/jpeg 54.32 KB"
-                      >
-                        <div
-                          aria-hidden="true"
-                          class="front"
-                        >
-                          image/jpeg
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="back"
-                        >
-                          <span>
-                             54.32 KB
-                          </span>
-                        </div>
-                        <div
-                          class="whole"
-                        >
-                          image/jpeg 54.32 KB
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <button
-                      class="downloadButton"
-                    >
-                      <span
-                        aria-label="fa-cloud-download"
-                        class="fa fa-cloud-download"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="media"
-                >
-                  <img
-                    alt="Title 1"
-                    src="http://lorempixel.com/240/100"
-                  />
-                  <div
-                    class="cover"
-                  >
-                    <span
-                      aria-label="su-pen"
-                      class="su-pen mediaIcon"
-                    />
-                  </div>
-                </div>
-              </div>
-            </li>
-          </div>
-        </div>
         <div
-          class="indicator"
-        />
-      </section>
+          class="toolbar"
+        >
+          <label
+            class="input dark left collapsed hasAppendIcon"
+          >
+            <div
+              class="prependedContainer dark collapsed"
+            >
+              <span
+                aria-label="su-search"
+                class="su-search clickable icon dark iconClickable collapsed"
+                role="button"
+                tabindex="0"
+              />
+            </div>
+            <input
+              type="text"
+              value=""
+            />
+          </label>
+        </div>
+      </div>
+      <div
+        class="datagrid"
+      >
+        <section>
+          <div>
+            <div
+              class="masonry"
+            >
+              <li
+                style="margin-bottom:30px"
+              >
+                <div
+                  class="mediaCard"
+                >
+                  <div
+                    class="header"
+                  >
+                    <div
+                      class="description"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          class="label"
+                        >
+                          <span
+                            class="switch checkbox dark checkbox"
+                          >
+                            <input
+                              type="checkbox"
+                              value="1"
+                            />
+                            <span />
+                          </span>
+                          <div>
+                            <div
+                              class="titleText"
+                            >
+                              <div
+                                aria-label="Title 1"
+                                class="croppedText"
+                                title="Title 1"
+                              >
+                                <div
+                                  aria-hidden="true"
+                                  class="front"
+                                >
+                                  Titl
+                                </div>
+                                <div
+                                  aria-hidden="true"
+                                  class="back"
+                                >
+                                  <span>
+                                    e 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="whole"
+                                >
+                                  Title 1
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <div
+                        class="meta"
+                      >
+                        <div
+                          aria-label="image/png 12.35 KB"
+                          class="croppedText"
+                          title="image/png 12.35 KB"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="front"
+                          >
+                            image/png
+                          </div>
+                          <div
+                            aria-hidden="true"
+                            class="back"
+                          >
+                            <span>
+                               12.35 KB
+                            </span>
+                          </div>
+                          <div
+                            class="whole"
+                          >
+                            image/png 12.35 KB
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <button
+                        class="downloadButton"
+                      >
+                        <span
+                          aria-label="fa-cloud-download"
+                          class="fa fa-cloud-download"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="media"
+                  >
+                    <img
+                      alt="Title 1"
+                      src="http://lorempixel.com/240/100"
+                    />
+                    <div
+                      class="cover"
+                    >
+                      <span
+                        aria-label="su-pen"
+                        class="su-pen mediaIcon"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li
+                style="margin-bottom:30px"
+              >
+                <div
+                  class="mediaCard"
+                >
+                  <div
+                    class="header"
+                  >
+                    <div
+                      class="description"
+                    >
+                      <div
+                        class="title"
+                      >
+                        <label
+                          class="label"
+                        >
+                          <span
+                            class="switch checkbox dark checkbox"
+                          >
+                            <input
+                              type="checkbox"
+                              value="2"
+                            />
+                            <span />
+                          </span>
+                          <div>
+                            <div
+                              class="titleText"
+                            >
+                              <div
+                                aria-label="Title 1"
+                                class="croppedText"
+                                title="Title 1"
+                              >
+                                <div
+                                  aria-hidden="true"
+                                  class="front"
+                                >
+                                  Titl
+                                </div>
+                                <div
+                                  aria-hidden="true"
+                                  class="back"
+                                >
+                                  <span>
+                                    e 1
+                                  </span>
+                                </div>
+                                <div
+                                  class="whole"
+                                >
+                                  Title 1
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      </div>
+                      <div
+                        class="meta"
+                      >
+                        <div
+                          aria-label="image/jpeg 54.32 KB"
+                          class="croppedText"
+                          title="image/jpeg 54.32 KB"
+                        >
+                          <div
+                            aria-hidden="true"
+                            class="front"
+                          >
+                            image/jpeg
+                          </div>
+                          <div
+                            aria-hidden="true"
+                            class="back"
+                          >
+                            <span>
+                               54.32 KB
+                            </span>
+                          </div>
+                          <div
+                            class="whole"
+                          >
+                            image/jpeg 54.32 KB
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <button
+                        class="downloadButton"
+                      >
+                        <span
+                          aria-label="fa-cloud-download"
+                          class="fa fa-cloud-download"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="media"
+                  >
+                    <img
+                      alt="Title 1"
+                      src="http://lorempixel.com/240/100"
+                    />
+                    <div
+                      class="cover"
+                    >
+                      <span
+                        aria-label="su-pen"
+                        class="su-pen mediaIcon"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </div>
+          </div>
+          <div
+            class="indicator"
+          />
+        </section>
+      </div>
     </div>
   </div>
   <input

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -99,163 +99,167 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
                 </div>
               </div>
               <div
-                class="datagrid"
+                class="datagridContainer"
               >
-                <section>
-                  <ul
-                    class="folderList"
-                  >
-                    <li>
-                      <div
-                        class="folder"
-                        role="button"
-                        tabindex="0"
-                      >
-                        <div
-                          class="iconContainer"
-                        >
-                          <span
-                            aria-label="su-folder"
-                            class="su-folder"
-                          />
-                        </div>
-                        <div
-                          class="description"
-                        >
-                          <h5
-                            class="title"
-                          >
-                            Title 1
-                          </h5>
-                          <div
-                            class="info"
-                          >
-                            1 sulu_admin.object
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                    <li>
-                      <div
-                        class="folder"
-                        role="button"
-                        tabindex="0"
-                      >
-                        <div
-                          class="iconContainer"
-                        >
-                          <span
-                            aria-label="su-folder"
-                            class="su-folder"
-                          />
-                        </div>
-                        <div
-                          class="description"
-                        >
-                          <h5
-                            class="title"
-                          >
-                            Title 2
-                          </h5>
-                          <div
-                            class="info"
-                          >
-                            0 sulu_admin.objects
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                  </ul>
-                  <nav
-                    class="pagination"
-                  >
-                    <span
-                      class="display"
+                <div
+                  class="datagrid"
+                >
+                  <section>
+                    <ul
+                      class="folderList"
                     >
-                      sulu_admin.per_page:
-                    </span>
-                    <span>
-                      <div
-                        class="select"
-                      >
-                        <button
-                          class="displayValue dark"
-                          type="button"
+                      <li>
+                        <div
+                          class="folder"
+                          role="button"
+                          tabindex="0"
                         >
                           <div
-                            aria-label="10"
-                            class="croppedText"
-                            title="10"
+                            class="iconContainer"
                           >
-                            <div
-                              aria-hidden="true"
-                              class="front"
+                            <span
+                              aria-label="su-folder"
+                              class="su-folder"
+                            />
+                          </div>
+                          <div
+                            class="description"
+                          >
+                            <h5
+                              class="title"
                             >
-                              1
-                            </div>
+                              Title 1
+                            </h5>
                             <div
-                              aria-hidden="true"
-                              class="back"
+                              class="info"
                             >
-                              <span>
-                                0
-                              </span>
-                            </div>
-                            <div
-                              class="whole"
-                            >
-                              10
+                              1 sulu_admin.object
                             </div>
                           </div>
-                          <span
-                            aria-label="su-angle-down"
-                            class="su-angle-down toggle"
-                          />
-                        </button>
-                      </div>
-                    </span>
-                    <div
-                      class="loader"
-                    />
-                    <span>
-                      sulu_admin.page:
-                    </span>
-                    <span
-                      class="inputContainer"
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          class="folder"
+                          role="button"
+                          tabindex="0"
+                        >
+                          <div
+                            class="iconContainer"
+                          >
+                            <span
+                              aria-label="su-folder"
+                              class="su-folder"
+                            />
+                          </div>
+                          <div
+                            class="description"
+                          >
+                            <h5
+                              class="title"
+                            >
+                              Title 2
+                            </h5>
+                            <div
+                              class="info"
+                            >
+                              0 sulu_admin.objects
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                    </ul>
+                    <nav
+                      class="pagination"
                     >
-                      <label
-                        class="input dark center"
+                      <span
+                        class="display"
                       >
-                        <input
-                          inputmode="numeric"
-                          type="text"
-                          value="2"
+                        sulu_admin.per_page:
+                      </span>
+                      <span>
+                        <div
+                          class="select"
+                        >
+                          <button
+                            class="displayValue dark"
+                            type="button"
+                          >
+                            <div
+                              aria-label="10"
+                              class="croppedText"
+                              title="10"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="front"
+                              >
+                                1
+                              </div>
+                              <div
+                                aria-hidden="true"
+                                class="back"
+                              >
+                                <span>
+                                  0
+                                </span>
+                              </div>
+                              <div
+                                class="whole"
+                              >
+                                10
+                              </div>
+                            </div>
+                            <span
+                              aria-label="su-angle-down"
+                              class="su-angle-down toggle"
+                            />
+                          </button>
+                        </div>
+                      </span>
+                      <div
+                        class="loader"
+                      />
+                      <span>
+                        sulu_admin.page:
+                      </span>
+                      <span
+                        class="inputContainer"
+                      >
+                        <label
+                          class="input dark center"
+                        >
+                          <input
+                            inputmode="numeric"
+                            type="text"
+                            value="2"
+                          />
+                        </label>
+                      </span>
+                      <span
+                        class="display"
+                      >
+                        sulu_admin.of 3
+                      </span>
+                      <button
+                        class="previous"
+                      >
+                        <span
+                          aria-label="su-angle-left"
+                          class="su-angle-left"
                         />
-                      </label>
-                    </span>
-                    <span
-                      class="display"
-                    >
-                      sulu_admin.of 3
-                    </span>
-                    <button
-                      class="previous"
-                    >
-                      <span
-                        aria-label="su-angle-left"
-                        class="su-angle-left"
-                      />
-                    </button>
-                    <button
-                      class="next"
-                    >
-                      <span
-                        aria-label="su-angle-right"
-                        class="su-angle-right"
-                      />
-                    </button>
-                  </nav>
-                </section>
+                      </button>
+                      <button
+                        class="next"
+                      >
+                        <span
+                          aria-label="su-angle-right"
+                          class="su-angle-right"
+                        />
+                      </button>
+                    </nav>
+                  </section>
+                </div>
               </div>
             </div>
             <div
@@ -263,285 +267,289 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
             />
             <div>
               <div
-                class="headerContainer"
+                class="datagridContainer"
               >
                 <div
-                  class="toolbar"
+                  class="headerContainer"
                 >
-                  <label
-                    class="input dark left collapsed hasAppendIcon"
-                  >
-                    <div
-                      class="prependedContainer dark collapsed"
-                    >
-                      <span
-                        aria-label="su-search"
-                        class="su-search clickable icon dark iconClickable collapsed"
-                        role="button"
-                        tabindex="0"
-                      />
-                    </div>
-                    <input
-                      placeholder="sulu_admin.datagrid_search_placeholder"
-                      type="text"
-                      value=""
-                    />
-                  </label>
-                </div>
-              </div>
-              <div
-                class="datagrid"
-              >
-                <section>
-                  <div>
-                    <div
-                      class="masonry"
-                      style="position: relative; height: 0px;"
-                    >
-                      <li
-                        style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
-                      >
-                        <div
-                          class="mediaCard"
-                        >
-                          <div
-                            class="header"
-                          >
-                            <div
-                              class="description"
-                            >
-                              <div
-                                class="title"
-                              >
-                                <label
-                                  class="label"
-                                >
-                                  <span
-                                    class="switch checkbox dark checkbox"
-                                  >
-                                    <input
-                                      type="checkbox"
-                                      value="1"
-                                    />
-                                    <span />
-                                  </span>
-                                  <div>
-                                    <div
-                                      class="titleText"
-                                    >
-                                      <div
-                                        aria-label="Title 1"
-                                        class="croppedText"
-                                        title="Title 1"
-                                      >
-                                        <div
-                                          aria-hidden="true"
-                                          class="front"
-                                        >
-                                          Titl
-                                        </div>
-                                        <div
-                                          aria-hidden="true"
-                                          class="back"
-                                        >
-                                          <span>
-                                            e 1
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="whole"
-                                        >
-                                          Title 1
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </label>
-                              </div>
-                              <div
-                                class="meta"
-                              >
-                                <div
-                                  aria-label="image/png 12.35 KB"
-                                  class="croppedText"
-                                  title="image/png 12.35 KB"
-                                >
-                                  <div
-                                    aria-hidden="true"
-                                    class="front"
-                                  >
-                                    image/png
-                                  </div>
-                                  <div
-                                    aria-hidden="true"
-                                    class="back"
-                                  >
-                                    <span>
-                                       12.35 KB
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="whole"
-                                  >
-                                    image/png 12.35 KB
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <button
-                                class="downloadButton"
-                              >
-                                <span
-                                  aria-label="fa-cloud-download"
-                                  class="fa fa-cloud-download"
-                                />
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="media"
-                          >
-                            <img
-                              alt="Title 1"
-                              src="http://lorempixel.com/240/100"
-                            />
-                            <div
-                              class="cover"
-                            >
-                              <span
-                                aria-label="su-check"
-                                class="su-check mediaIcon"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
-                      >
-                        <div
-                          class="mediaCard"
-                        >
-                          <div
-                            class="header"
-                          >
-                            <div
-                              class="description"
-                            >
-                              <div
-                                class="title"
-                              >
-                                <label
-                                  class="label"
-                                >
-                                  <span
-                                    class="switch checkbox dark checkbox"
-                                  >
-                                    <input
-                                      type="checkbox"
-                                      value="2"
-                                    />
-                                    <span />
-                                  </span>
-                                  <div>
-                                    <div
-                                      class="titleText"
-                                    >
-                                      <div
-                                        aria-label="Title 2"
-                                        class="croppedText"
-                                        title="Title 2"
-                                      >
-                                        <div
-                                          aria-hidden="true"
-                                          class="front"
-                                        >
-                                          Titl
-                                        </div>
-                                        <div
-                                          aria-hidden="true"
-                                          class="back"
-                                        >
-                                          <span>
-                                            e 2
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="whole"
-                                        >
-                                          Title 2
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </label>
-                              </div>
-                              <div
-                                class="meta"
-                              >
-                                <div
-                                  aria-label="image/jpeg 54.32 KB"
-                                  class="croppedText"
-                                  title="image/jpeg 54.32 KB"
-                                >
-                                  <div
-                                    aria-hidden="true"
-                                    class="front"
-                                  >
-                                    image/jpeg
-                                  </div>
-                                  <div
-                                    aria-hidden="true"
-                                    class="back"
-                                  >
-                                    <span>
-                                       54.32 KB
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="whole"
-                                  >
-                                    image/jpeg 54.32 KB
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <button
-                                class="downloadButton"
-                              >
-                                <span
-                                  aria-label="fa-cloud-download"
-                                  class="fa fa-cloud-download"
-                                />
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="media"
-                          >
-                            <img
-                              alt="Title 2"
-                              src="http://lorempixel.com/240/100"
-                            />
-                            <div
-                              class="cover"
-                            >
-                              <span
-                                aria-label="su-check"
-                                class="su-check mediaIcon"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                    </div>
-                  </div>
                   <div
-                    class="indicator"
-                  />
-                </section>
+                    class="toolbar"
+                  >
+                    <label
+                      class="input dark left collapsed hasAppendIcon"
+                    >
+                      <div
+                        class="prependedContainer dark collapsed"
+                      >
+                        <span
+                          aria-label="su-search"
+                          class="su-search clickable icon dark iconClickable collapsed"
+                          role="button"
+                          tabindex="0"
+                        />
+                      </div>
+                      <input
+                        placeholder="sulu_admin.datagrid_search_placeholder"
+                        type="text"
+                        value=""
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="datagrid"
+                >
+                  <section>
+                    <div>
+                      <div
+                        class="masonry"
+                        style="position: relative; height: 0px;"
+                      >
+                        <li
+                          style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
+                        >
+                          <div
+                            class="mediaCard"
+                          >
+                            <div
+                              class="header"
+                            >
+                              <div
+                                class="description"
+                              >
+                                <div
+                                  class="title"
+                                >
+                                  <label
+                                    class="label"
+                                  >
+                                    <span
+                                      class="switch checkbox dark checkbox"
+                                    >
+                                      <input
+                                        type="checkbox"
+                                        value="1"
+                                      />
+                                      <span />
+                                    </span>
+                                    <div>
+                                      <div
+                                        class="titleText"
+                                      >
+                                        <div
+                                          aria-label="Title 1"
+                                          class="croppedText"
+                                          title="Title 1"
+                                        >
+                                          <div
+                                            aria-hidden="true"
+                                            class="front"
+                                          >
+                                            Titl
+                                          </div>
+                                          <div
+                                            aria-hidden="true"
+                                            class="back"
+                                          >
+                                            <span>
+                                              e 1
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="whole"
+                                          >
+                                            Title 1
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </label>
+                                </div>
+                                <div
+                                  class="meta"
+                                >
+                                  <div
+                                    aria-label="image/png 12.35 KB"
+                                    class="croppedText"
+                                    title="image/png 12.35 KB"
+                                  >
+                                    <div
+                                      aria-hidden="true"
+                                      class="front"
+                                    >
+                                      image/png
+                                    </div>
+                                    <div
+                                      aria-hidden="true"
+                                      class="back"
+                                    >
+                                      <span>
+                                         12.35 KB
+                                      </span>
+                                    </div>
+                                    <div
+                                      class="whole"
+                                    >
+                                      image/png 12.35 KB
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <button
+                                  class="downloadButton"
+                                >
+                                  <span
+                                    aria-label="fa-cloud-download"
+                                    class="fa fa-cloud-download"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="media"
+                            >
+                              <img
+                                alt="Title 1"
+                                src="http://lorempixel.com/240/100"
+                              />
+                              <div
+                                class="cover"
+                              >
+                                <span
+                                  aria-label="su-check"
+                                  class="su-check mediaIcon"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
+                        >
+                          <div
+                            class="mediaCard"
+                          >
+                            <div
+                              class="header"
+                            >
+                              <div
+                                class="description"
+                              >
+                                <div
+                                  class="title"
+                                >
+                                  <label
+                                    class="label"
+                                  >
+                                    <span
+                                      class="switch checkbox dark checkbox"
+                                    >
+                                      <input
+                                        type="checkbox"
+                                        value="2"
+                                      />
+                                      <span />
+                                    </span>
+                                    <div>
+                                      <div
+                                        class="titleText"
+                                      >
+                                        <div
+                                          aria-label="Title 2"
+                                          class="croppedText"
+                                          title="Title 2"
+                                        >
+                                          <div
+                                            aria-hidden="true"
+                                            class="front"
+                                          >
+                                            Titl
+                                          </div>
+                                          <div
+                                            aria-hidden="true"
+                                            class="back"
+                                          >
+                                            <span>
+                                              e 2
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="whole"
+                                          >
+                                            Title 2
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </label>
+                                </div>
+                                <div
+                                  class="meta"
+                                >
+                                  <div
+                                    aria-label="image/jpeg 54.32 KB"
+                                    class="croppedText"
+                                    title="image/jpeg 54.32 KB"
+                                  >
+                                    <div
+                                      aria-hidden="true"
+                                      class="front"
+                                    >
+                                      image/jpeg
+                                    </div>
+                                    <div
+                                      aria-hidden="true"
+                                      class="back"
+                                    >
+                                      <span>
+                                         54.32 KB
+                                      </span>
+                                    </div>
+                                    <div
+                                      class="whole"
+                                    >
+                                      image/jpeg 54.32 KB
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <button
+                                  class="downloadButton"
+                                >
+                                  <span
+                                    aria-label="fa-cloud-download"
+                                    class="fa fa-cloud-download"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="media"
+                            >
+                              <img
+                                alt="Title 2"
+                                src="http://lorempixel.com/240/100"
+                              />
+                              <div
+                                class="cover"
+                              >
+                                <span
+                                  aria-label="su-check"
+                                  class="su-check mediaIcon"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </div>
+                    </div>
+                    <div
+                      class="indicator"
+                    />
+                  </section>
+                </div>
               </div>
             </div>
             <input
@@ -684,163 +692,167 @@ exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
                 </div>
               </div>
               <div
-                class="datagrid"
+                class="datagridContainer"
               >
-                <section>
-                  <ul
-                    class="folderList"
-                  >
-                    <li>
-                      <div
-                        class="folder"
-                        role="button"
-                        tabindex="0"
-                      >
-                        <div
-                          class="iconContainer"
-                        >
-                          <span
-                            aria-label="su-folder"
-                            class="su-folder"
-                          />
-                        </div>
-                        <div
-                          class="description"
-                        >
-                          <h5
-                            class="title"
-                          >
-                            Title 1
-                          </h5>
-                          <div
-                            class="info"
-                          >
-                            1 sulu_admin.object
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                    <li>
-                      <div
-                        class="folder"
-                        role="button"
-                        tabindex="0"
-                      >
-                        <div
-                          class="iconContainer"
-                        >
-                          <span
-                            aria-label="su-folder"
-                            class="su-folder"
-                          />
-                        </div>
-                        <div
-                          class="description"
-                        >
-                          <h5
-                            class="title"
-                          >
-                            Title 2
-                          </h5>
-                          <div
-                            class="info"
-                          >
-                            0 sulu_admin.objects
-                          </div>
-                        </div>
-                      </div>
-                    </li>
-                  </ul>
-                  <nav
-                    class="pagination"
-                  >
-                    <span
-                      class="display"
+                <div
+                  class="datagrid"
+                >
+                  <section>
+                    <ul
+                      class="folderList"
                     >
-                      sulu_admin.per_page:
-                    </span>
-                    <span>
-                      <div
-                        class="select"
-                      >
-                        <button
-                          class="displayValue dark"
-                          type="button"
+                      <li>
+                        <div
+                          class="folder"
+                          role="button"
+                          tabindex="0"
                         >
                           <div
-                            aria-label="10"
-                            class="croppedText"
-                            title="10"
+                            class="iconContainer"
                           >
-                            <div
-                              aria-hidden="true"
-                              class="front"
+                            <span
+                              aria-label="su-folder"
+                              class="su-folder"
+                            />
+                          </div>
+                          <div
+                            class="description"
+                          >
+                            <h5
+                              class="title"
                             >
-                              1
-                            </div>
+                              Title 1
+                            </h5>
                             <div
-                              aria-hidden="true"
-                              class="back"
+                              class="info"
                             >
-                              <span>
-                                0
-                              </span>
-                            </div>
-                            <div
-                              class="whole"
-                            >
-                              10
+                              1 sulu_admin.object
                             </div>
                           </div>
-                          <span
-                            aria-label="su-angle-down"
-                            class="su-angle-down toggle"
-                          />
-                        </button>
-                      </div>
-                    </span>
-                    <div
-                      class="loader"
-                    />
-                    <span>
-                      sulu_admin.page:
-                    </span>
-                    <span
-                      class="inputContainer"
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          class="folder"
+                          role="button"
+                          tabindex="0"
+                        >
+                          <div
+                            class="iconContainer"
+                          >
+                            <span
+                              aria-label="su-folder"
+                              class="su-folder"
+                            />
+                          </div>
+                          <div
+                            class="description"
+                          >
+                            <h5
+                              class="title"
+                            >
+                              Title 2
+                            </h5>
+                            <div
+                              class="info"
+                            >
+                              0 sulu_admin.objects
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                    </ul>
+                    <nav
+                      class="pagination"
                     >
-                      <label
-                        class="input dark center"
+                      <span
+                        class="display"
                       >
-                        <input
-                          inputmode="numeric"
-                          type="text"
-                          value="2"
+                        sulu_admin.per_page:
+                      </span>
+                      <span>
+                        <div
+                          class="select"
+                        >
+                          <button
+                            class="displayValue dark"
+                            type="button"
+                          >
+                            <div
+                              aria-label="10"
+                              class="croppedText"
+                              title="10"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="front"
+                              >
+                                1
+                              </div>
+                              <div
+                                aria-hidden="true"
+                                class="back"
+                              >
+                                <span>
+                                  0
+                                </span>
+                              </div>
+                              <div
+                                class="whole"
+                              >
+                                10
+                              </div>
+                            </div>
+                            <span
+                              aria-label="su-angle-down"
+                              class="su-angle-down toggle"
+                            />
+                          </button>
+                        </div>
+                      </span>
+                      <div
+                        class="loader"
+                      />
+                      <span>
+                        sulu_admin.page:
+                      </span>
+                      <span
+                        class="inputContainer"
+                      >
+                        <label
+                          class="input dark center"
+                        >
+                          <input
+                            inputmode="numeric"
+                            type="text"
+                            value="2"
+                          />
+                        </label>
+                      </span>
+                      <span
+                        class="display"
+                      >
+                        sulu_admin.of 3
+                      </span>
+                      <button
+                        class="previous"
+                      >
+                        <span
+                          aria-label="su-angle-left"
+                          class="su-angle-left"
                         />
-                      </label>
-                    </span>
-                    <span
-                      class="display"
-                    >
-                      sulu_admin.of 3
-                    </span>
-                    <button
-                      class="previous"
-                    >
-                      <span
-                        aria-label="su-angle-left"
-                        class="su-angle-left"
-                      />
-                    </button>
-                    <button
-                      class="next"
-                    >
-                      <span
-                        aria-label="su-angle-right"
-                        class="su-angle-right"
-                      />
-                    </button>
-                  </nav>
-                </section>
+                      </button>
+                      <button
+                        class="next"
+                      >
+                        <span
+                          aria-label="su-angle-right"
+                          class="su-angle-right"
+                        />
+                      </button>
+                    </nav>
+                  </section>
+                </div>
               </div>
             </div>
             <div
@@ -848,285 +860,289 @@ exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
             />
             <div>
               <div
-                class="headerContainer"
+                class="datagridContainer"
               >
                 <div
-                  class="toolbar"
+                  class="headerContainer"
                 >
-                  <label
-                    class="input dark left collapsed hasAppendIcon"
-                  >
-                    <div
-                      class="prependedContainer dark collapsed"
-                    >
-                      <span
-                        aria-label="su-search"
-                        class="su-search clickable icon dark iconClickable collapsed"
-                        role="button"
-                        tabindex="0"
-                      />
-                    </div>
-                    <input
-                      placeholder="sulu_admin.datagrid_search_placeholder"
-                      type="text"
-                      value=""
-                    />
-                  </label>
-                </div>
-              </div>
-              <div
-                class="datagrid"
-              >
-                <section>
-                  <div>
-                    <div
-                      class="masonry"
-                      style="position: relative; height: 0px;"
-                    >
-                      <li
-                        style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
-                      >
-                        <div
-                          class="mediaCard"
-                        >
-                          <div
-                            class="header"
-                          >
-                            <div
-                              class="description"
-                            >
-                              <div
-                                class="title"
-                              >
-                                <label
-                                  class="label"
-                                >
-                                  <span
-                                    class="switch checkbox dark checkbox"
-                                  >
-                                    <input
-                                      type="checkbox"
-                                      value="1"
-                                    />
-                                    <span />
-                                  </span>
-                                  <div>
-                                    <div
-                                      class="titleText"
-                                    >
-                                      <div
-                                        aria-label="Title 1"
-                                        class="croppedText"
-                                        title="Title 1"
-                                      >
-                                        <div
-                                          aria-hidden="true"
-                                          class="front"
-                                        >
-                                          Titl
-                                        </div>
-                                        <div
-                                          aria-hidden="true"
-                                          class="back"
-                                        >
-                                          <span>
-                                            e 1
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="whole"
-                                        >
-                                          Title 1
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </label>
-                              </div>
-                              <div
-                                class="meta"
-                              >
-                                <div
-                                  aria-label="image/png 12.35 KB"
-                                  class="croppedText"
-                                  title="image/png 12.35 KB"
-                                >
-                                  <div
-                                    aria-hidden="true"
-                                    class="front"
-                                  >
-                                    image/png
-                                  </div>
-                                  <div
-                                    aria-hidden="true"
-                                    class="back"
-                                  >
-                                    <span>
-                                       12.35 KB
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="whole"
-                                  >
-                                    image/png 12.35 KB
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <button
-                                class="downloadButton"
-                              >
-                                <span
-                                  aria-label="fa-cloud-download"
-                                  class="fa fa-cloud-download"
-                                />
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="media"
-                          >
-                            <img
-                              alt="Title 1"
-                              src="http://lorempixel.com/240/100"
-                            />
-                            <div
-                              class="cover"
-                            >
-                              <span
-                                aria-label="su-check"
-                                class="su-check mediaIcon"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                      <li
-                        style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
-                      >
-                        <div
-                          class="mediaCard"
-                        >
-                          <div
-                            class="header"
-                          >
-                            <div
-                              class="description"
-                            >
-                              <div
-                                class="title"
-                              >
-                                <label
-                                  class="label"
-                                >
-                                  <span
-                                    class="switch checkbox dark checkbox"
-                                  >
-                                    <input
-                                      type="checkbox"
-                                      value="2"
-                                    />
-                                    <span />
-                                  </span>
-                                  <div>
-                                    <div
-                                      class="titleText"
-                                    >
-                                      <div
-                                        aria-label="Title 2"
-                                        class="croppedText"
-                                        title="Title 2"
-                                      >
-                                        <div
-                                          aria-hidden="true"
-                                          class="front"
-                                        >
-                                          Titl
-                                        </div>
-                                        <div
-                                          aria-hidden="true"
-                                          class="back"
-                                        >
-                                          <span>
-                                            e 2
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="whole"
-                                        >
-                                          Title 2
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </label>
-                              </div>
-                              <div
-                                class="meta"
-                              >
-                                <div
-                                  aria-label="image/jpeg 54.32 KB"
-                                  class="croppedText"
-                                  title="image/jpeg 54.32 KB"
-                                >
-                                  <div
-                                    aria-hidden="true"
-                                    class="front"
-                                  >
-                                    image/jpeg
-                                  </div>
-                                  <div
-                                    aria-hidden="true"
-                                    class="back"
-                                  >
-                                    <span>
-                                       54.32 KB
-                                    </span>
-                                  </div>
-                                  <div
-                                    class="whole"
-                                  >
-                                    image/jpeg 54.32 KB
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <button
-                                class="downloadButton"
-                              >
-                                <span
-                                  aria-label="fa-cloud-download"
-                                  class="fa fa-cloud-download"
-                                />
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="media"
-                          >
-                            <img
-                              alt="Title 2"
-                              src="http://lorempixel.com/240/100"
-                            />
-                            <div
-                              class="cover"
-                            >
-                              <span
-                                aria-label="su-check"
-                                class="su-check mediaIcon"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                    </div>
-                  </div>
                   <div
-                    class="indicator"
-                  />
-                </section>
+                    class="toolbar"
+                  >
+                    <label
+                      class="input dark left collapsed hasAppendIcon"
+                    >
+                      <div
+                        class="prependedContainer dark collapsed"
+                      >
+                        <span
+                          aria-label="su-search"
+                          class="su-search clickable icon dark iconClickable collapsed"
+                          role="button"
+                          tabindex="0"
+                        />
+                      </div>
+                      <input
+                        placeholder="sulu_admin.datagrid_search_placeholder"
+                        type="text"
+                        value=""
+                      />
+                    </label>
+                  </div>
+                </div>
+                <div
+                  class="datagrid"
+                >
+                  <section>
+                    <div>
+                      <div
+                        class="masonry"
+                        style="position: relative; height: 0px;"
+                      >
+                        <li
+                          style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
+                        >
+                          <div
+                            class="mediaCard"
+                          >
+                            <div
+                              class="header"
+                            >
+                              <div
+                                class="description"
+                              >
+                                <div
+                                  class="title"
+                                >
+                                  <label
+                                    class="label"
+                                  >
+                                    <span
+                                      class="switch checkbox dark checkbox"
+                                    >
+                                      <input
+                                        type="checkbox"
+                                        value="1"
+                                      />
+                                      <span />
+                                    </span>
+                                    <div>
+                                      <div
+                                        class="titleText"
+                                      >
+                                        <div
+                                          aria-label="Title 1"
+                                          class="croppedText"
+                                          title="Title 1"
+                                        >
+                                          <div
+                                            aria-hidden="true"
+                                            class="front"
+                                          >
+                                            Titl
+                                          </div>
+                                          <div
+                                            aria-hidden="true"
+                                            class="back"
+                                          >
+                                            <span>
+                                              e 1
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="whole"
+                                          >
+                                            Title 1
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </label>
+                                </div>
+                                <div
+                                  class="meta"
+                                >
+                                  <div
+                                    aria-label="image/png 12.35 KB"
+                                    class="croppedText"
+                                    title="image/png 12.35 KB"
+                                  >
+                                    <div
+                                      aria-hidden="true"
+                                      class="front"
+                                    >
+                                      image/png
+                                    </div>
+                                    <div
+                                      aria-hidden="true"
+                                      class="back"
+                                    >
+                                      <span>
+                                         12.35 KB
+                                      </span>
+                                    </div>
+                                    <div
+                                      class="whole"
+                                    >
+                                      image/png 12.35 KB
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <button
+                                  class="downloadButton"
+                                >
+                                  <span
+                                    aria-label="fa-cloud-download"
+                                    class="fa fa-cloud-download"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="media"
+                            >
+                              <img
+                                alt="Title 1"
+                                src="http://lorempixel.com/240/100"
+                              />
+                              <div
+                                class="cover"
+                              >
+                                <span
+                                  aria-label="su-check"
+                                  class="su-check mediaIcon"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                        <li
+                          style="margin-bottom: 30px; position: absolute; left: 0px; top: 0px;"
+                        >
+                          <div
+                            class="mediaCard"
+                          >
+                            <div
+                              class="header"
+                            >
+                              <div
+                                class="description"
+                              >
+                                <div
+                                  class="title"
+                                >
+                                  <label
+                                    class="label"
+                                  >
+                                    <span
+                                      class="switch checkbox dark checkbox"
+                                    >
+                                      <input
+                                        type="checkbox"
+                                        value="2"
+                                      />
+                                      <span />
+                                    </span>
+                                    <div>
+                                      <div
+                                        class="titleText"
+                                      >
+                                        <div
+                                          aria-label="Title 2"
+                                          class="croppedText"
+                                          title="Title 2"
+                                        >
+                                          <div
+                                            aria-hidden="true"
+                                            class="front"
+                                          >
+                                            Titl
+                                          </div>
+                                          <div
+                                            aria-hidden="true"
+                                            class="back"
+                                          >
+                                            <span>
+                                              e 2
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="whole"
+                                          >
+                                            Title 2
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </label>
+                                </div>
+                                <div
+                                  class="meta"
+                                >
+                                  <div
+                                    aria-label="image/jpeg 54.32 KB"
+                                    class="croppedText"
+                                    title="image/jpeg 54.32 KB"
+                                  >
+                                    <div
+                                      aria-hidden="true"
+                                      class="front"
+                                    >
+                                      image/jpeg
+                                    </div>
+                                    <div
+                                      aria-hidden="true"
+                                      class="back"
+                                    >
+                                      <span>
+                                         54.32 KB
+                                      </span>
+                                    </div>
+                                    <div
+                                      class="whole"
+                                    >
+                                      image/jpeg 54.32 KB
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <button
+                                  class="downloadButton"
+                                >
+                                  <span
+                                    aria-label="fa-cloud-download"
+                                    class="fa fa-cloud-download"
+                                  />
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="media"
+                            >
+                              <img
+                                alt="Title 2"
+                                src="http://lorempixel.com/240/100"
+                              />
+                              <div
+                                class="cover"
+                              >
+                                <span
+                                  aria-label="su-check"
+                                  class="su-check mediaIcon"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </li>
+                      </div>
+                    </div>
+                    <div
+                      class="indicator"
+                    />
+                  </section>
+                </div>
               </div>
             </div>
             <input

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/mediaDetails.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/mediaDetails.scss
@@ -1,7 +1,6 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .media-detail {
-    padding: $viewPadding;
     max-width: $viewMaxWidth;
     min-width: $viewMinWidth;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/mediaFormats.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/mediaFormats.scss
@@ -1,7 +1,6 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .media-formats {
-    padding: $viewPadding;
     max-width: $viewMaxWidth;
     min-width: $viewMinWidth;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/mediaHistory.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/mediaHistory.scss
@@ -1,7 +1,6 @@
 @import 'sulu-admin-bundle/containers/Application/variables.scss';
 
 .media-history {
-    padding: $viewPadding;
     max-width: $viewMaxWidth;
     min-width: $viewMinWidth;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/mediaOverview.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/mediaOverview.scss
@@ -2,7 +2,6 @@
 @import 'sulu-admin-bundle/components/Toolbar/variables.scss';
 
 .mediaOverview {
-    padding: $viewPadding $viewPadding 30px;
     min-height: calc(100vh - $toolbarHeight);
     display: flex;
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -81,163 +81,167 @@ exports[`Render a simple MediaOverview 1`] = `
         </div>
       </div>
       <div
-        class="datagrid"
+        class="datagridContainer"
       >
-        <section>
-          <ul
-            class="folderList"
-          >
-            <li>
-              <div
-                class="folder"
-                role="button"
-                tabindex="0"
-              >
-                <div
-                  class="iconContainer"
-                >
-                  <span
-                    aria-label="su-folder"
-                    class="su-folder"
-                  />
-                </div>
-                <div
-                  class="description"
-                >
-                  <h5
-                    class="title"
-                  >
-                    Title 1
-                  </h5>
-                  <div
-                    class="info"
-                  >
-                    1 sulu_admin.object
-                  </div>
-                </div>
-              </div>
-            </li>
-            <li>
-              <div
-                class="folder"
-                role="button"
-                tabindex="0"
-              >
-                <div
-                  class="iconContainer"
-                >
-                  <span
-                    aria-label="su-folder"
-                    class="su-folder"
-                  />
-                </div>
-                <div
-                  class="description"
-                >
-                  <h5
-                    class="title"
-                  >
-                    Title 2
-                  </h5>
-                  <div
-                    class="info"
-                  >
-                    0 sulu_admin.objects
-                  </div>
-                </div>
-              </div>
-            </li>
-          </ul>
-          <nav
-            class="pagination"
-          >
-            <span
-              class="display"
+        <div
+          class="datagrid"
+        >
+          <section>
+            <ul
+              class="folderList"
             >
-              sulu_admin.per_page:
-            </span>
-            <span>
-              <div
-                class="select"
-              >
-                <button
-                  class="displayValue dark"
-                  type="button"
+              <li>
+                <div
+                  class="folder"
+                  role="button"
+                  tabindex="0"
                 >
                   <div
-                    aria-label="10"
-                    class="croppedText"
-                    title="10"
+                    class="iconContainer"
                   >
-                    <div
-                      aria-hidden="true"
-                      class="front"
+                    <span
+                      aria-label="su-folder"
+                      class="su-folder"
+                    />
+                  </div>
+                  <div
+                    class="description"
+                  >
+                    <h5
+                      class="title"
                     >
-                      1
-                    </div>
+                      Title 1
+                    </h5>
                     <div
-                      aria-hidden="true"
-                      class="back"
+                      class="info"
                     >
-                      <span>
-                        0
-                      </span>
-                    </div>
-                    <div
-                      class="whole"
-                    >
-                      10
+                      1 sulu_admin.object
                     </div>
                   </div>
-                  <span
-                    aria-label="su-angle-down"
-                    class="su-angle-down toggle"
-                  />
-                </button>
-              </div>
-            </span>
-            <div
-              class="loader"
-            />
-            <span>
-              sulu_admin.page:
-            </span>
-            <span
-              class="inputContainer"
+                </div>
+              </li>
+              <li>
+                <div
+                  class="folder"
+                  role="button"
+                  tabindex="0"
+                >
+                  <div
+                    class="iconContainer"
+                  >
+                    <span
+                      aria-label="su-folder"
+                      class="su-folder"
+                    />
+                  </div>
+                  <div
+                    class="description"
+                  >
+                    <h5
+                      class="title"
+                    >
+                      Title 2
+                    </h5>
+                    <div
+                      class="info"
+                    >
+                      0 sulu_admin.objects
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+            <nav
+              class="pagination"
             >
-              <label
-                class="input dark center"
+              <span
+                class="display"
               >
-                <input
-                  inputmode="numeric"
-                  type="text"
-                  value="1"
+                sulu_admin.per_page:
+              </span>
+              <span>
+                <div
+                  class="select"
+                >
+                  <button
+                    class="displayValue dark"
+                    type="button"
+                  >
+                    <div
+                      aria-label="10"
+                      class="croppedText"
+                      title="10"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="front"
+                      >
+                        1
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="back"
+                      >
+                        <span>
+                          0
+                        </span>
+                      </div>
+                      <div
+                        class="whole"
+                      >
+                        10
+                      </div>
+                    </div>
+                    <span
+                      aria-label="su-angle-down"
+                      class="su-angle-down toggle"
+                    />
+                  </button>
+                </div>
+              </span>
+              <div
+                class="loader"
+              />
+              <span>
+                sulu_admin.page:
+              </span>
+              <span
+                class="inputContainer"
+              >
+                <label
+                  class="input dark center"
+                >
+                  <input
+                    inputmode="numeric"
+                    type="text"
+                    value="1"
+                  />
+                </label>
+              </span>
+              <span
+                class="display"
+              >
+                sulu_admin.of 3
+              </span>
+              <button
+                class="previous"
+              >
+                <span
+                  aria-label="su-angle-left"
+                  class="su-angle-left"
                 />
-              </label>
-            </span>
-            <span
-              class="display"
-            >
-              sulu_admin.of 3
-            </span>
-            <button
-              class="previous"
-            >
-              <span
-                aria-label="su-angle-left"
-                class="su-angle-left"
-              />
-            </button>
-            <button
-              class="next"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right"
-              />
-            </button>
-          </nav>
-        </section>
+              </button>
+              <button
+                class="next"
+              >
+                <span
+                  aria-label="su-angle-right"
+                  class="su-angle-right"
+                />
+              </button>
+            </nav>
+          </section>
+        </div>
       </div>
     </div>
     <div
@@ -245,312 +249,316 @@ exports[`Render a simple MediaOverview 1`] = `
     />
     <div>
       <div
-        class="headerContainer"
+        class="datagridContainer"
       >
         <div
-          class="toolbar"
+          class="headerContainer"
         >
-          <label
-            class="input dark left collapsed hasAppendIcon"
+          <div
+            class="toolbar"
           >
-            <div
-              class="prependedContainer dark collapsed"
+            <label
+              class="input dark left collapsed hasAppendIcon"
             >
-              <span
-                aria-label="su-search"
-                class="su-search clickable icon dark iconClickable collapsed"
-                role="button"
-                tabindex="0"
+              <div
+                class="prependedContainer dark collapsed"
+              >
+                <span
+                  aria-label="su-search"
+                  class="su-search clickable icon dark iconClickable collapsed"
+                  role="button"
+                  tabindex="0"
+                />
+              </div>
+              <input
+                placeholder="sulu_admin.datagrid_search_placeholder"
+                type="text"
+                value=""
               />
+            </label>
+            <div>
+              <button
+                class="button icon active button"
+                type="button"
+              >
+                <span
+                  class="text"
+                >
+                  <span
+                    aria-label="su-th-large"
+                    class="su-th-large"
+                  />
+                </span>
+              </button>
+              <button
+                class="button icon button"
+                type="button"
+              >
+                <span
+                  class="text"
+                >
+                  <span
+                    aria-label="su-align-justify"
+                    class="su-align-justify"
+                  />
+                </span>
+              </button>
             </div>
-            <input
-              placeholder="sulu_admin.datagrid_search_placeholder"
-              type="text"
-              value=""
-            />
-          </label>
-          <div>
-            <button
-              class="button icon active button"
-              type="button"
-            >
-              <span
-                class="text"
-              >
-                <span
-                  aria-label="su-th-large"
-                  class="su-th-large"
-                />
-              </span>
-            </button>
-            <button
-              class="button icon button"
-              type="button"
-            >
-              <span
-                class="text"
-              >
-                <span
-                  aria-label="su-align-justify"
-                  class="su-align-justify"
-                />
-              </span>
-            </button>
           </div>
         </div>
-      </div>
-      <div
-        class="datagrid"
-      >
-        <section>
-          <div>
-            <div
-              class="masonry"
-            >
-              <li
-                style="margin-bottom:30px"
+        <div
+          class="datagrid"
+        >
+          <section>
+            <div>
+              <div
+                class="masonry"
               >
-                <div
-                  class="mediaCard"
+                <li
+                  style="margin-bottom:30px"
                 >
                   <div
-                    class="header"
+                    class="mediaCard"
                   >
                     <div
-                      class="description"
+                      class="header"
                     >
                       <div
-                        class="title"
+                        class="description"
                       >
-                        <label
-                          class="label"
+                        <div
+                          class="title"
                         >
-                          <span
-                            class="switch checkbox dark checkbox"
+                          <label
+                            class="label"
                           >
-                            <input
-                              type="checkbox"
-                              value="1"
-                            />
-                            <span />
-                          </span>
-                          <div>
-                            <div
-                              class="titleText"
+                            <span
+                              class="switch checkbox dark checkbox"
                             >
+                              <input
+                                type="checkbox"
+                                value="1"
+                              />
+                              <span />
+                            </span>
+                            <div>
                               <div
-                                aria-label="Title 1"
-                                class="croppedText"
-                                title="Title 1"
+                                class="titleText"
                               >
                                 <div
-                                  aria-hidden="true"
-                                  class="front"
+                                  aria-label="Title 1"
+                                  class="croppedText"
+                                  title="Title 1"
                                 >
-                                  Titl
-                                </div>
-                                <div
-                                  aria-hidden="true"
-                                  class="back"
-                                >
-                                  <span>
-                                    e 1
-                                  </span>
-                                </div>
-                                <div
-                                  class="whole"
-                                >
-                                  Title 1
+                                  <div
+                                    aria-hidden="true"
+                                    class="front"
+                                  >
+                                    Titl
+                                  </div>
+                                  <div
+                                    aria-hidden="true"
+                                    class="back"
+                                  >
+                                    <span>
+                                      e 1
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="whole"
+                                  >
+                                    Title 1
+                                  </div>
                                 </div>
                               </div>
                             </div>
-                          </div>
-                        </label>
-                      </div>
-                      <div
-                        class="meta"
-                      >
+                          </label>
+                        </div>
                         <div
-                          aria-label="image/png 12.35 KB"
-                          class="croppedText"
-                          title="image/png 12.35 KB"
+                          class="meta"
                         >
                           <div
-                            aria-hidden="true"
-                            class="front"
+                            aria-label="image/png 12.35 KB"
+                            class="croppedText"
+                            title="image/png 12.35 KB"
                           >
-                            image/png
-                          </div>
-                          <div
-                            aria-hidden="true"
-                            class="back"
-                          >
-                            <span>
-                               12.35 KB
-                            </span>
-                          </div>
-                          <div
-                            class="whole"
-                          >
-                            image/png 12.35 KB
+                            <div
+                              aria-hidden="true"
+                              class="front"
+                            >
+                              image/png
+                            </div>
+                            <div
+                              aria-hidden="true"
+                              class="back"
+                            >
+                              <span>
+                                 12.35 KB
+                              </span>
+                            </div>
+                            <div
+                              class="whole"
+                            >
+                              image/png 12.35 KB
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                    <div>
-                      <button
-                        class="downloadButton"
-                      >
-                        <span
-                          aria-label="fa-cloud-download"
-                          class="fa fa-cloud-download"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    class="media"
-                  >
-                    <img
-                      alt="Title 1"
-                      src="http://lorempixel.com/240/100"
-                    />
-                    <div
-                      class="cover"
-                    >
-                      <span
-                        aria-label="su-pen"
-                        class="su-pen mediaIcon"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </li>
-              <li
-                style="margin-bottom:30px"
-              >
-                <div
-                  class="mediaCard"
-                >
-                  <div
-                    class="header"
-                  >
-                    <div
-                      class="description"
-                    >
-                      <div
-                        class="title"
-                      >
-                        <label
-                          class="label"
+                      <div>
+                        <button
+                          class="downloadButton"
                         >
                           <span
-                            class="switch checkbox dark checkbox"
+                            aria-label="fa-cloud-download"
+                            class="fa fa-cloud-download"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="media"
+                    >
+                      <img
+                        alt="Title 1"
+                        src="http://lorempixel.com/240/100"
+                      />
+                      <div
+                        class="cover"
+                      >
+                        <span
+                          aria-label="su-pen"
+                          class="su-pen mediaIcon"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  style="margin-bottom:30px"
+                >
+                  <div
+                    class="mediaCard"
+                  >
+                    <div
+                      class="header"
+                    >
+                      <div
+                        class="description"
+                      >
+                        <div
+                          class="title"
+                        >
+                          <label
+                            class="label"
                           >
-                            <input
-                              type="checkbox"
-                              value="2"
-                            />
-                            <span />
-                          </span>
-                          <div>
-                            <div
-                              class="titleText"
+                            <span
+                              class="switch checkbox dark checkbox"
                             >
+                              <input
+                                type="checkbox"
+                                value="2"
+                              />
+                              <span />
+                            </span>
+                            <div>
                               <div
-                                aria-label="Title 1"
-                                class="croppedText"
-                                title="Title 1"
+                                class="titleText"
                               >
                                 <div
-                                  aria-hidden="true"
-                                  class="front"
+                                  aria-label="Title 1"
+                                  class="croppedText"
+                                  title="Title 1"
                                 >
-                                  Titl
-                                </div>
-                                <div
-                                  aria-hidden="true"
-                                  class="back"
-                                >
-                                  <span>
-                                    e 1
-                                  </span>
-                                </div>
-                                <div
-                                  class="whole"
-                                >
-                                  Title 1
+                                  <div
+                                    aria-hidden="true"
+                                    class="front"
+                                  >
+                                    Titl
+                                  </div>
+                                  <div
+                                    aria-hidden="true"
+                                    class="back"
+                                  >
+                                    <span>
+                                      e 1
+                                    </span>
+                                  </div>
+                                  <div
+                                    class="whole"
+                                  >
+                                    Title 1
+                                  </div>
                                 </div>
                               </div>
                             </div>
-                          </div>
-                        </label>
-                      </div>
-                      <div
-                        class="meta"
-                      >
+                          </label>
+                        </div>
                         <div
-                          aria-label="image/jpeg 54.32 KB"
-                          class="croppedText"
-                          title="image/jpeg 54.32 KB"
+                          class="meta"
                         >
                           <div
-                            aria-hidden="true"
-                            class="front"
+                            aria-label="image/jpeg 54.32 KB"
+                            class="croppedText"
+                            title="image/jpeg 54.32 KB"
                           >
-                            image/jpeg
-                          </div>
-                          <div
-                            aria-hidden="true"
-                            class="back"
-                          >
-                            <span>
-                               54.32 KB
-                            </span>
-                          </div>
-                          <div
-                            class="whole"
-                          >
-                            image/jpeg 54.32 KB
+                            <div
+                              aria-hidden="true"
+                              class="front"
+                            >
+                              image/jpeg
+                            </div>
+                            <div
+                              aria-hidden="true"
+                              class="back"
+                            >
+                              <span>
+                                 54.32 KB
+                              </span>
+                            </div>
+                            <div
+                              class="whole"
+                            >
+                              image/jpeg 54.32 KB
+                            </div>
                           </div>
                         </div>
                       </div>
+                      <div>
+                        <button
+                          class="downloadButton"
+                        >
+                          <span
+                            aria-label="fa-cloud-download"
+                            class="fa fa-cloud-download"
+                          />
+                        </button>
+                      </div>
                     </div>
-                    <div>
-                      <button
-                        class="downloadButton"
+                    <div
+                      class="media"
+                    >
+                      <img
+                        alt="Title 1"
+                        src="http://lorempixel.com/240/100"
+                      />
+                      <div
+                        class="cover"
                       >
                         <span
-                          aria-label="fa-cloud-download"
-                          class="fa fa-cloud-download"
+                          aria-label="su-pen"
+                          class="su-pen mediaIcon"
                         />
-                      </button>
+                      </div>
                     </div>
                   </div>
-                  <div
-                    class="media"
-                  >
-                    <img
-                      alt="Title 1"
-                      src="http://lorempixel.com/240/100"
-                    />
-                    <div
-                      class="cover"
-                    >
-                      <span
-                        aria-label="su-pen"
-                        class="su-pen mediaIcon"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </li>
+                </li>
+              </div>
             </div>
-          </div>
-          <div
-            class="indicator"
-          />
-        </section>
+            <div
+              class="indicator"
+            />
+          </section>
+        </div>
       </div>
     </div>
     <input

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
@@ -27,6 +27,6 @@ export default class PageTabs extends React.Component<ViewProps> {
             ? this.webspace.allLocalizations.map((localization) => localization.name)
             : [];
 
-        return <ResourceTabs {...props} locales={locales} />;
+        return <ResourceTabs {...props} locales={locales} titleProperty="title" />;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/tests/PageTabs.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/tests/PageTabs.test.js
@@ -13,7 +13,7 @@ jest.mock('sulu-admin-bundle/views', () => ({
     ResourceTabs: jest.fn(() => null),
 }));
 
-test('Load webspace and pass locales to ResourceTabs component', () => {
+test('Pass locales from webspace and titleProperty to ResourceTabs component', () => {
     const webspace = {
         allLocalizations: [
             {name: 'en'},
@@ -43,5 +43,6 @@ test('Load webspace and pass locales to ResourceTabs component', () => {
     return webspacePromise.then(() => {
         pageTabs.update();
         expect(pageTabs.find(ResourceTabs).prop('locales')).toEqual(['en', 'de']);
+        expect(pageTabs.find(ResourceTabs).prop('titleProperty')).toEqual('title');
     });
 });

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceOverview/tests/__snapshots__/WebspaceOverview.test.js.snap
@@ -5,126 +5,130 @@ exports[`Render WebspaceOverview 1`] = `
   class="webspaceOverview"
 >
   <div
-    class="headerContainer"
+    class="datagridContainer"
   >
     <div
-      class="webspaceSelect"
-    >
-      <button
-        class="button"
-      >
-        <span
-          aria-label="su-webspace"
-          class="su-webspace buttonIcon"
-        />
-        <span
-          class="buttonValue"
-        />
-        <span
-          aria-label="su-angle-down"
-          class="su-angle-down buttonIcon"
-        />
-      </button>
-    </div>
-    <div
-      class="toolbar"
-    >
-      <div>
-        <button
-          class="button icon active button"
-          type="button"
-        >
-          <span
-            class="text"
-          >
-            <span
-              aria-label="su-columns"
-              class="su-columns"
-            />
-          </span>
-        </button>
-        <button
-          class="button icon button"
-          type="button"
-        >
-          <span
-            class="text"
-          >
-            <span
-              aria-label="su-columns"
-              class="su-columns"
-            />
-          </span>
-        </button>
-      </div>
-    </div>
-  </div>
-  <div
-    class="datagrid"
-  >
-    <div
-      class="columnListAdapter"
+      class="headerContainer"
     >
       <div
-        class="columnListToolbarContainer"
+        class="webspaceSelect"
+      >
+        <button
+          class="button"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace buttonIcon"
+          />
+          <span
+            class="buttonValue"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down buttonIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="toolbar"
+      >
+        <div>
+          <button
+            class="button icon active button"
+            type="button"
+          >
+            <span
+              class="text"
+            >
+              <span
+                aria-label="su-columns"
+                class="su-columns"
+              />
+            </span>
+          </button>
+          <button
+            class="button icon button"
+            type="button"
+          >
+            <span
+              class="text"
+            >
+              <span
+                aria-label="su-columns"
+                class="su-columns"
+              />
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="datagrid"
+    >
+      <div
+        class="columnListAdapter"
       >
         <div
-          class="toolbarContainer"
-          style="margin-left: 0px;"
+          class="columnListToolbarContainer"
         >
           <div
-            class="toolbar"
+            class="toolbarContainer"
+            style="margin-left: 0px;"
           >
             <div
-              class="item primary"
-            >
-              <span
-                aria-label="su-plus-circle"
-                class="su-plus-circle"
-              />
-            </div>
-            <div
-              class="item primary"
-            >
-              <span
-                aria-label="su-cog"
-                class="su-cog"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
-        >
-          <div
-            class="columnList"
-          >
-            <div
-              class="column"
+              class="toolbar"
             >
               <div
-                class="item"
-                role="button"
+                class="item primary"
               >
                 <span
-                  class="buttons"
+                  aria-label="su-plus-circle"
+                  class="su-plus-circle"
+                />
+              </div>
+              <div
+                class="item primary"
+              >
+                <span
+                  aria-label="su-cog"
+                  class="su-cog"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
+          >
+            <div
+              class="columnList"
+            >
+              <div
+                class="column"
+              >
+                <div
+                  class="item"
+                  role="button"
                 >
                   <span
-                    aria-label="su-pen"
-                    class="su-pen clickable button"
-                    role="button"
-                    tabindex="0"
+                    class="buttons"
+                  >
+                    <span
+                      aria-label="su-pen"
+                      class="su-pen clickable button"
+                      role="button"
+                      tabindex="0"
+                    />
+                  </span>
+                  <span
+                    class="text"
                   />
-                </span>
-                <span
-                  class="text"
-                />
-                <span
-                  class="indicator"
-                />
-                <span
-                  class="children"
-                />
+                  <span
+                    class="indicator"
+                  />
+                  <span
+                    class="children"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceOverview/webspaceOverview.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceOverview/webspaceOverview.scss
@@ -2,16 +2,4 @@
 
 .webspace-overview {
     height: 100%;
-    padding: $viewPadding;
-    display: flex;
-    flex-direction: column;
-
-    > :not(.webspace-select) {
-        flex-grow: 1;
-    }
-}
-
-.webspace-select {
-    flex-grow: unset;
-    margin-bottom: 30px;
 }

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -121,6 +121,7 @@ class SecurityAdmin extends Admin
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/roles/:id')
                 ->setResourceKey('roles')
                 ->setBackRoute(static::DATAGRID_ROUTE)
+                ->setTitleProperty('name')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_security.role_edit_form.details', '/details')
                 ->setResourceKey('roles')

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -141,6 +141,7 @@ class SnippetAdmin extends Admin
                 ->setResourceKey('snippets')
                 ->addLocales($snippetLocales)
                 ->setBackRoute(static::DATAGRID_ROUTE)
+                ->setTitleProperty('title')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_snippet.edit_form.details', '/details')
                 ->setResourceKey('snippets')

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -107,6 +107,7 @@ class SnippetAdminTest extends TestCase
             'resourceKey' => 'snippets',
             'backRoute' => 'sulu_snippet.datagrid',
             'locales' => array_keys($locales),
+            'titleProperty' => 'title',
         ], 'options', $editFormRoute);
         $this->assertAttributeEquals('sulu_snippet.edit_form.details', 'name', $editDetailRoute);
         $this->assertAttributeEquals('sulu_snippet.edit_form', 'parent', $editDetailRoute);

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -93,6 +93,7 @@ class TagAdmin extends Admin
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/tags/:id')
                 ->setResourceKey('tags')
                 ->setBackRoute(static::DATAGRID_ROUTE)
+                ->setTitleProperty('name')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_tag.edit_form.details', '/details')
                 ->setResourceKey('tags')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR shows a property as header in the ResourceTabs. It is possible to define which property from the associated `resourceStore` is taken.

#### Why?

Because it allows the content manager to easier locate where they are currently editing.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] ~~Make `titleProperty` mandatory?~~
- [x] Style the tab title
