### PR TITLE
Remove false deprecation of WebsiteController::renderStructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.5
+    * ENHANCEMENT #4367 [WebsiteBundle]         Remove false deprecation of WebsiteController::renderStructure
+
 * 1.5.20 (2019-01-09)
     * ENHANCEMENT #4319 [MediaBundle]           Added possibility to have a image format configuration file without formats
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -32,8 +32,6 @@ abstract class WebsiteController extends Controller
      * @param bool $partial Defines if only the content block of the template should be rendered
      *
      * @return Response
-     *
-     * @deprecated will be remove with 2.0
      */
     protected function renderStructure(
         StructureInterface $structure,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove false deprecation from website controller renderStructure.

#### Why?

There should be no deprecation without providing an alternative way to use. The renderStructure is still the correct way to render a structure element.

This deprecation mostly confuse people the first time creating a custom controller.