### PR TITLE
Show error message if media upload fails for SingleMediaDropzone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 CHANGELOG for Sulu
 ==================
+* 2.0.0-alpha4
+    * BUGFIX      #4297 [MediaBundle]           Fix unhandled server errors on media upload for SingleMediaDropzone
 
 * 1.6.24 (2019-01-09)
     * BUGFIX      #4349 [ContentBundle]         Fix compatibility to symfony 3.4.21, 4.1.10 and 4.2.2

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -9,6 +9,7 @@ import MimeTypeIndicator from '../MimeTypeIndicator';
 import singleMediaDropzoneStyles from './singleMediaDropzone.scss';
 
 const UPLOAD_ICON = 'fa-cloud-upload';
+const ERROR_ICON = 'su-exclamation-triangle';
 
 type Props = {|
     disabled: boolean,
@@ -20,6 +21,8 @@ type Props = {|
     onDrop: (data: File) => void,
     skin: 'default' | 'round',
     uploadText?: ?string,
+    hasError ?: ?boolean,
+    errorMessage?: ?string,    
 |};
 
 @observer
@@ -31,12 +34,19 @@ export default class SingleMediaDropzone extends React.Component<Props> {
         progress: 0,
         skin: 'default',
         uploading: false,
+        hasError: false,
+        errorMessage: '',    
     };
 
     @observable uploadIndicatorVisibility: boolean;
+    @observable errorMessageVisibility: boolean;
 
     @action setUploadIndicatorVisibility(visibility: boolean) {
         this.uploadIndicatorVisibility = visibility;
+    }
+
+    @action setErrorMessageVisibility(visibility: boolean) {
+        this.errorMessageVisibility = visibility;
     }
 
     handleDrop = (files: Array<File>) => {
@@ -44,14 +54,17 @@ export default class SingleMediaDropzone extends React.Component<Props> {
 
         this.props.onDrop(file);
         this.setUploadIndicatorVisibility(false);
+        this.setErrorMessageVisibility(false);
     };
 
     handleDragEnter = () => {
         this.setUploadIndicatorVisibility(true);
+        this.setErrorMessageVisibility(false);
     };
 
     handleDragLeave = () => {
         this.setUploadIndicatorVisibility(false);
+        this.setErrorMessageVisibility(false);
     };
 
     render() {
@@ -64,6 +77,8 @@ export default class SingleMediaDropzone extends React.Component<Props> {
             skin,
             uploading,
             uploadText,
+            hasError,
+            errorMessage,
         } = this.props;
 
         const mediaContainerClass = classNames(
@@ -71,6 +86,7 @@ export default class SingleMediaDropzone extends React.Component<Props> {
             singleMediaDropzoneStyles[skin],
             {
                 [singleMediaDropzoneStyles.showUploadIndicator]: this.uploadIndicatorVisibility,
+                [singleMediaDropzoneStyles.showErrorIndicator]: this.errorMessageVisibility,
                 [singleMediaDropzoneStyles.disabled]: disabled,
             }
         );
@@ -99,6 +115,19 @@ export default class SingleMediaDropzone extends React.Component<Props> {
                     </div>
                 }
 
+                {hasError && !uploading &&
+                    <div className={singleMediaDropzoneStyles.errorIndicatorContainer}>
+                        <div className={singleMediaDropzoneStyles.errorIndicator}>
+                            <div>
+                                <Icon className={singleMediaDropzoneStyles.errorIcon} name={ERROR_ICON} />
+                                {errorMessage &&
+                                    <div className={singleMediaDropzoneStyles.errorInfoText}>{errorMessage}</div>
+                                }
+                            </div>
+                        </div>                    
+                    </div>
+                }
+                
                 {!uploading
                     ? <div className={singleMediaDropzoneStyles.uploadIndicatorContainer}>
                         <div className={singleMediaDropzoneStyles.uploadIndicator}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -22,7 +22,7 @@ type Props = {|
     skin: 'default' | 'round',
     uploadText?: ?string,
     hasError ?: ?boolean,
-    errorMessage?: ?string,    
+    errorMessage?: ?string,
 |};
 
 @observer
@@ -30,12 +30,12 @@ export default class SingleMediaDropzone extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         emptyIcon: 'su-image',
+        errorMessage: '',
+        hasError: false,
         mimeType: '',
         progress: 0,
         skin: 'default',
         uploading: false,
-        hasError: false,
-        errorMessage: '',    
     };
 
     @observable uploadIndicatorVisibility: boolean;
@@ -124,10 +124,10 @@ export default class SingleMediaDropzone extends React.Component<Props> {
                                     <div className={singleMediaDropzoneStyles.errorInfoText}>{errorMessage}</div>
                                 }
                             </div>
-                        </div>                    
+                        </div>
                     </div>
                 }
-                
+
                 {!uploading
                     ? <div className={singleMediaDropzoneStyles.uploadIndicatorContainer}>
                         <div className={singleMediaDropzoneStyles.uploadIndicator}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -34,7 +34,6 @@ $errorIndicatorBackgroundColor: $persianRed;
             opacity: 0;
             transform: scale(1);
         }
-
     }
 
     &::after {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -29,10 +29,12 @@ $errorIndicatorBackgroundColor: $persianRed;
             opacity: 1;
             transform: scale(1);
         }
+
         .error-indicator {
             opacity: 0;
             transform: scale(1);
-        }          
+        }
+
     }
 
     &::after {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/singleMediaDropzone.scss
@@ -7,6 +7,8 @@ $mediaContainerBreakpoint: 520px; /* $dropzoneSize + 2 * $viewPadding because ca
 $imageBorderColor: $silver;
 $emptyBackgroundColor: $white;
 $emptyColor: $alto;
+$errorColor: $white;
+$errorIndicatorBackgroundColor: $persianRed;
 
 .media-container {
     position: relative;
@@ -27,6 +29,10 @@ $emptyColor: $alto;
             opacity: 1;
             transform: scale(1);
         }
+        .error-indicator {
+            opacity: 0;
+            transform: scale(1);
+        }          
     }
 
     &::after {
@@ -50,7 +56,8 @@ $emptyColor: $alto;
 }
 
 .progressbar,
-.upload-indicator-container {
+.upload-indicator-container,
+.error-indicator-container {
     position: absolute;
     top: 0;
     left: 0;
@@ -61,7 +68,8 @@ $emptyColor: $alto;
     align-items: center;
 }
 
-.upload-indicator {
+.upload-indicator,
+.error-indicator {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -73,6 +81,12 @@ $emptyColor: $alto;
     opacity: 0;
     transform: scale(.5);
     transition: all .25s cubic-bezier(.68, -.55, .265, 1.55);
+}
+
+.error-indicator {
+    opacity: 1;
+    transform: scale(1);
+    background-color: $errorIndicatorBackgroundColor;
 }
 
 .mime-type-indicator,
@@ -93,16 +107,31 @@ $emptyColor: $alto;
     font-size: 120px;
 }
 
+.error-indicator {
+    color: $errorColor;
+}
+
 .upload-icon {
     font-size: 45px;
     color: $uploadIconColor;
 }
 
-.upload-info-text {
+.error-icon {
+    font-size: 65px;
+    color: $errorColor;
+}
+
+.upload-info-text,
+.error-info-text {
     color: $uploadInfoTextColor;
     font-size: 14px;
     margin-top: 20px;
     padding: 0 20px;
+}
+
+.error-info-text {
+    color: $errorColor;
+    text-align: center;
 }
 
 .thumbnail {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -36,7 +36,6 @@ export default class SingleMediaUpload extends React.Component<Props> {
     @observable hasError: boolean = false;
     @observable errorMessage: string = '';
 
-
     constructor(props: Props) {
         super(props);
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -33,6 +33,8 @@ export default class SingleMediaUpload extends React.Component<Props> {
 
     @observable showDeleteDialog: boolean = false;
     @observable deleting: boolean = false;
+    @observable hasError: boolean = false;
+    @observable errorMessage: string = '';
 
     constructor(props: Props) {
         super(props);
@@ -55,10 +57,12 @@ export default class SingleMediaUpload extends React.Component<Props> {
 
         if (mediaUploadStore.id) {
             mediaUploadStore.update(file)
-                .then(this.callUploadComplete);
+                .then(this.callUploadComplete)
+                .catch(this.showErrorMessage);
         } else if (collectionId) {
             mediaUploadStore.create(collectionId, file)
-                .then(this.callUploadComplete);
+                .then(this.callUploadComplete)
+                .catch(this.showErrorMessage);
         }
     };
 
@@ -84,10 +88,22 @@ export default class SingleMediaUpload extends React.Component<Props> {
             }));
     };
 
-    callUploadComplete = (media: Object) => {
-        const {onUploadComplete} = this.props;
+    /**
+     * Set Dropzone to error-mode if upload fails
+     */
+    @action showErrorMessage = (error: any) => {
+        this.hasError = true;
+        this.errorMessage = error.toString();
+    }
 
+    @action callUploadComplete = (media: Object) => {
+        const { onUploadComplete } = this.props;
+        
         if (onUploadComplete) {
+            // reset error message if present
+            this.hasError = false;
+            this.errorMessage = '';
+          
             onUploadComplete(media);
         }
     };
@@ -122,6 +138,8 @@ export default class SingleMediaUpload extends React.Component<Props> {
                     skin={skin}
                     uploading={uploading}
                     uploadText={uploadText}
+                    hasError={this.hasError}
+                    errorMessage={this.errorMessage}
                 />
                 {mediaUploadStore.id && !disabled &&
                     <div className={singleMediaUploadStyles.buttons}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -36,6 +36,7 @@ export default class SingleMediaUpload extends React.Component<Props> {
     @observable hasError: boolean = false;
     @observable errorMessage: string = '';
 
+
     constructor(props: Props) {
         super(props);
 
@@ -94,16 +95,16 @@ export default class SingleMediaUpload extends React.Component<Props> {
     @action showErrorMessage = (error: any) => {
         this.hasError = true;
         this.errorMessage = error.toString();
-    }
+    };
 
     @action callUploadComplete = (media: Object) => {
-        const { onUploadComplete } = this.props;
-        
+        const {onUploadComplete} = this.props;
+
         if (onUploadComplete) {
             // reset error message if present
             this.hasError = false;
             this.errorMessage = '';
-          
+
             onUploadComplete(media);
         }
     };
@@ -131,6 +132,8 @@ export default class SingleMediaUpload extends React.Component<Props> {
                 <SingleMediaDropzone
                     disabled={disabled}
                     emptyIcon={emptyIcon}
+                    errorMessage={this.errorMessage}
+                    hasError={this.hasError}
                     image={mediaUploadStore.getThumbnail(imageSize)}
                     mimeType={mimeType}
                     onDrop={this.handleMediaDrop}
@@ -138,8 +141,6 @@ export default class SingleMediaUpload extends React.Component<Props> {
                     skin={skin}
                     uploading={uploading}
                     uploadText={uploadText}
-                    hasError={this.hasError}
-                    errorMessage={this.errorMessage}
                 />
                 {mediaUploadStore.id && !disabled &&
                     <div className={singleMediaUploadStyles.buttons}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -93,7 +93,7 @@ export default class SingleMediaUpload extends React.Component<Props> {
      */
     @action showErrorMessage = (error: any) => {
         this.hasError = true;
-        this.errorMessage = error.toString();
+        this.errorMessage = translate(error.message);
     };
 
     @action callUploadComplete = (media: Object) => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -3,9 +3,8 @@ import {action, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {ResourceMetadataStore} from 'sulu-admin-bundle/stores';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
-import {buildQueryString} from 'sulu-admin-bundle/utils';
+import {buildQueryString, translate} from 'sulu-admin-bundle/utils';
 import type {Media} from '../../types';
-import {translate} from 'sulu-admin-bundle/utils';
 
 const RESOURCE_KEY = 'media';
 
@@ -133,9 +132,9 @@ export default class MediaUploadStore {
 
     /**
      * Handle upload errors
-     * 
+     *
      * Trigger an error message and reset upload indicators
-     * 
+     *
      * @param  error Exception from XHR promise
      * @throws Error Including translated error message based on status code
      */
@@ -143,10 +142,10 @@ export default class MediaUploadStore {
         this.setUploading(false);
         this.setProgress(0);
 
-        let statusCode = error.status;
+        const statusCode = error.status;
         throw new Error(translate('sulu_media.error_' + statusCode));
     };
-  
+
     upload(file: File, url: string): Promise<*> {
         return new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
@@ -155,24 +154,24 @@ export default class MediaUploadStore {
             xhr.open('POST', url);
 
             xhr.onload = (event: any) => {
-                let uploadStatus = parseInt(event.target.status);
+                const uploadStatus = parseInt(event.target.status);
                 if (uploadStatus >= 200 && uploadStatus < 300) {
                     resolve(JSON.parse(event.target.response));
                 } else {
-                    // reject if HTTP status isn't 2xx  
+                    // reject if HTTP status isn't 2xx
                     reject({
                         status: uploadStatus,
-                        statusText: event.target.response
+                        statusText: event.target.response,
                     });
                 }
             };
-          
-            xhr.onerror = (event: any) => {
+
+            xhr.onerror = () => {
                 reject({
                     status: 'general',
-                    statusText: 'Unknown error'
+                    statusText: 'Unknown error',
                 });
-            }
+            };
 
             if (xhr.upload) {
                 xhr.upload.onprogress = (event) => this.setProgress(event.loaded / event.total * 100);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -5,6 +5,7 @@ import {ResourceMetadataStore} from 'sulu-admin-bundle/stores';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
 import {buildQueryString} from 'sulu-admin-bundle/utils';
 import type {Media} from '../../types';
+import {translate} from 'sulu-admin-bundle/utils';
 
 const RESOURCE_KEY = 'media';
 
@@ -103,7 +104,8 @@ export default class MediaUploadStore {
         this.setUploading(true);
 
         return this.upload(file, url)
-            .then(this.handleResponse);
+            .then(this.handleResponse)
+            .catch(this.handleErrorResponse);
     }
 
     create(collectionId: string | number, file: File): Promise<*> {
@@ -117,7 +119,8 @@ export default class MediaUploadStore {
         this.setUploading(true);
 
         return this.upload(file, url)
-            .then(this.handleResponse);
+            .then(this.handleResponse)
+            .catch(this.handleErrorResponse);
     }
 
     @action handleResponse = (media: Object) => {
@@ -128,6 +131,22 @@ export default class MediaUploadStore {
         return media;
     };
 
+    /**
+     * Handle upload errors
+     * 
+     * Trigger an error message and reset upload indicators
+     * 
+     * @param  error Exception from XHR promise
+     * @throws Error Including translated error message based on status code
+     */
+    @action handleErrorResponse = (error: any) => {
+        this.setUploading(false);
+        this.setProgress(0);
+
+        let statusCode = error.status;
+        throw new Error(translate('sulu_media.error_' + statusCode));
+    };
+  
     upload(file: File, url: string): Promise<*> {
         return new Promise((resolve, reject) => {
             const xhr = new XMLHttpRequest();
@@ -135,8 +154,25 @@ export default class MediaUploadStore {
 
             xhr.open('POST', url);
 
-            xhr.onload = (event: any) => resolve(JSON.parse(event.target.response));
-            xhr.onerror = (event: any) => reject(event.target.response);
+            xhr.onload = (event: any) => {
+                let uploadStatus = parseInt(event.target.status);
+                if (uploadStatus >= 200 && uploadStatus < 300) {
+                    resolve(JSON.parse(event.target.response));
+                } else {
+                    // reject if HTTP status isn't 2xx  
+                    reject({
+                        status: uploadStatus,
+                        statusText: event.target.response
+                    });
+                }
+            };
+          
+            xhr.onerror = (event: any) => {
+                reject({
+                    status: 'general',
+                    statusText: 'Unknown error'
+                });
+            }
 
             if (xhr.upload) {
                 xhr.upload.onprogress = (event) => this.setProgress(event.loaded / event.total * 100);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/MediaUploadStore.js
@@ -3,7 +3,7 @@ import {action, computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {ResourceMetadataStore} from 'sulu-admin-bundle/stores';
 import {ResourceRequester} from 'sulu-admin-bundle/services';
-import {buildQueryString, translate} from 'sulu-admin-bundle/utils';
+import {buildQueryString} from 'sulu-admin-bundle/utils';
 import type {Media} from '../../types';
 
 const RESOURCE_KEY = 'media';
@@ -133,17 +133,17 @@ export default class MediaUploadStore {
     /**
      * Handle upload errors
      *
-     * Trigger an error message and reset upload indicators
+     * Trigger an error and reset upload indicators
      *
      * @param  error Exception from XHR promise
-     * @throws Error Including translated error message based on status code
+     * @throws Error With error message key based on status code
      */
     @action handleErrorResponse = (error: any) => {
         this.setUploading(false);
         this.setProgress(0);
 
         const statusCode = error.status;
-        throw new Error(translate('sulu_media.error_' + statusCode));
+        throw new Error('sulu_media.error_' + statusCode);
     };
 
     upload(file: File, url: string): Promise<*> {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/MediaUploadStore/tests/MediaUploadStore.test.js
@@ -7,6 +7,7 @@ import MediaUploadStore from '../MediaUploadStore';
 
 jest.mock('sulu-admin-bundle/utils', () => ({
     buildQueryString: jest.fn(),
+    translate: jest.fn(),
 }));
 
 jest.mock('sulu-admin-bundle/services', () => ({

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -34,5 +34,7 @@
     "sulu_media.formats": "Formate",
     "sulu_media.all_collections": "Alle Kollektionen",
     "sulu_media.move_media": "Medien verschieben",
-    "sulu_media.set_focus_point": "Fokuspunkt setzen"
+    "sulu_media.set_focus_point": "Fokuspunkt setzen",
+    "sulu_media.error_413": "Medienelement zu groß für den Upload",
+    "sulu_media.error_general": "Fehler beim Upload" 
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -34,5 +34,7 @@
     "sulu_media.formats": "Formats",
     "sulu_media.all_collections": "All collections",
     "sulu_media.move_media": "Move media",
-    "sulu_media.set_focus_point": "Set focus point"
+    "sulu_media.set_focus_point": "Set focus point",
+    "sulu_media.error_413": "Uploaded media element too big",
+    "sulu_media.error_general": "Problem with upload"    
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4297 
| Related issues/PRs | -
| License | MIT
| Documentation PR | No

#### What's in this PR?

This PR contains React/SCSS code to check the server response for uploaded media elements. If an error occurs when using media upload in the SingleDropzone component, the Dropzone shows a translatable error message. A translation for HTTP status code 413 and a general error message for failing XHR requests is included for DE and EN.

#### To Do

- [ ] Refactor implementation so it can be used also for MultiMediaDropzone
- [x] Write e2e tests
- [ ] Currently, only HTTP status code 413 and general XHR errors are handled properly, because each status code needs a specific translation at the moment. I'll try to find a more generic way (In combination with translated error messages) soon.
