### PR TITLE
Remove required userId parameter from TagManagerInterface methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,11 @@ Following Function removed:
 
 The `TagManager` doesn't longer depend on FieldDescriptorFactory, TagEntityName and UserRepository so its constructor changed.
 
+Following Functions changed as the `$userId` is not longer needed:
+
+ - `TagManagerInterface::findOrCreateByName($name, $userId);` -> `TagManagerInterface::findOrCreateByName($name);`
+ - `TagManagerInterface::save($name, $userId, $id);` -> `TagManagerInterface::save($name, $id);`
+
 ### Change tag_list to tag_selection
 
 The tag_list content and field type was changed to `tag_selection`

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -157,7 +157,7 @@ class TagController extends RestController implements ClassResourceInterface, Se
                 throw new MissingArgumentException(self::$entityName, 'name');
             }
 
-            $tag = $this->getManager()->save($this->getData($request), $this->getUser()->getId());
+            $tag = $this->getManager()->save($this->getData($request));
 
             $context = new Context();
             $context->setGroups(['partialTag']);
@@ -196,7 +196,7 @@ class TagController extends RestController implements ClassResourceInterface, Se
                 throw new MissingArgumentException(self::$entityName, 'name');
             }
 
-            $tag = $this->getManager()->save($this->getData($request), $this->getUser()->getId(), $id);
+            $tag = $this->getManager()->save($this->getData($request), $id);
 
             $context = new Context();
             $context->setGroups(['partialTag']);
@@ -273,17 +273,11 @@ class TagController extends RestController implements ClassResourceInterface, Se
     }
 
     /**
-     * TODO: find out why pluralization does not work for this patch action
-     * ISSUE: https://github.com/sulu-cmf/SuluTagBundle/issues/6.
-     *
-     * @Route("/tags", name="tags")
-     * updates an array of tags
-     *
      * @param Request $request
      *
      * @return Response
      */
-    public function patchAction(Request $request)
+    public function cpatchAction(Request $request)
     {
         try {
             $tags = [];
@@ -293,7 +287,7 @@ class TagController extends RestController implements ClassResourceInterface, Se
                 if (isset($item['id'])) {
                     $tags[] = $this->getManager()->save($item, $item['id']);
                 } else {
-                    $tags[] = $this->getManager()->save($item, null);
+                    $tags[] = $this->getManager()->save($item);
                 }
                 ++$i;
             }

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -9,11 +9,14 @@
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
         </service>
+
         <service id="sulu_tag.tag_manager" class="Sulu\Bundle\TagBundle\Tag\TagManager" public="true">
             <argument type="service" id="sulu.repository.tag"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
+        <service id="Sulu\Bundle\TagBundle\Tag\TagManagerInterface" alias="sulu_tag.tag_manager"/>
+
         <service id="sulu_tag.content.type.tag_selection" class="Sulu\Bundle\TagBundle\Content\Types\TagSelection">
             <tag name="sulu.content.type" alias="tag_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
@@ -90,12 +90,12 @@ class TagManager implements TagManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function findOrCreateByName($name, $userId)
+    public function findOrCreateByName($name)
     {
         $tag = $this->findByName($name);
 
         if (!$tag) {
-            $tag = $this->save(['name' => $name], $userId);
+            $tag = $this->save(['name' => $name]);
         }
 
         return $tag;
@@ -104,7 +104,7 @@ class TagManager implements TagManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function save($data, $userId, $id = null)
+    public function save($data, $id = null)
     {
         $name = $data['name'];
 

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
@@ -46,22 +46,20 @@ interface TagManagerInterface
      * Loads the tag with the given name, or creates it, if it does not exist.
      *
      * @param string $name The name to find or create
-     * @param int $userId The id of the user who tries to find a tag
      *
      * @return TagInterface
      */
-    public function findOrCreateByName($name, $userId);
+    public function findOrCreateByName($name);
 
     /**
      * Saves the given Tag.
      *
      * @param array       $data   The data of the tag to save
-     * @param int         $userId The id of the user, who is doing this change
      * @param number|null $id     The id for saving the tag (optional)
      *
      * @return
      */
-    public function save($data, $userId, $id = null);
+    public function save($data, $id = null);
 
     /**
      * Deletes the given Tag.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Related PRs | #4336
| License | MIT

#### What's in this PR?

Remove required userId parameter from TagManagerInterface methods

#### Why?

The userId is not longer used and the changer is set over the AuditableInterface.

#### Example Usage

~~~php
$tagManager->findOrCreateByName($name);
$tagManager->save($data);
~~~

#### To Do

- [x] Add breaking changes to UPGRADE.md
