### PR TITLE
Add autowiring for tag manager

### DIFF
--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -9,11 +9,14 @@
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
         </service>
+
         <service id="sulu_tag.tag_manager" class="Sulu\Bundle\TagBundle\Tag\TagManager" public="true">
             <argument type="service" id="sulu.repository.tag"/>
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
+        <service id="Sulu\Bundle\TagBundle\Tag\TagManagerInterface" alias="sulu_tag.tag_manager"/>
+
         <service id="sulu_tag.content.type.tag_selection" class="Sulu\Bundle\TagBundle\Content\Types\TagSelection">
             <tag name="sulu.content.type" alias="tag_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add autowiring for tag manager.

#### Why?

To easily use the tag manager in your project.

#### Example Usage

~~~php
use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;

    /**
     * @var TagManagerInterface
     */
    private $tagManager;

    public function __construct(TagManagerInterface $tagManager)
    {
        $this->tagManager = $tagManager;
    }
~~~

