### PR TITLE
Add a default context to sulu kernel

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,22 @@
 
 ## dev-develop
 
+### SuluKernel::construct changed
+
+The `suluContext` is optional now to support extending from Symfony `KernelTestCase` of Symfony:
+
+**Before**:
+
+```php
+public function __construct($environment, $debug, $suluContext) {}
+```
+
+**After**:
+
+```php
+public function __construct($environment, $debug, $suluContext = self::CONTEXT_ADMIN) {}
+```
+
 ### Renamed ContentBundle to PageBundle
 
 Following things have changed:

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -49,7 +49,7 @@ abstract class SuluKernel extends Kernel
      * @param bool   $debug
      * @param string $suluContext The Sulu context (self::CONTEXT_ADMIN, self::CONTEXT_WEBSITE)
      */
-    public function __construct($environment, $debug, $suluContext)
+    public function __construct($environment, $debug, $suluContext = self::CONTEXT_ADMIN)
     {
         $this->name = $suluContext;
         $this->context = $suluContext;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set default sulu context of the SuluKernel to Admin.

#### Why?

It allow in not ContextBased tests extend from the `Symfony\Bundle\FrameworkBundle\Test\KernelTestCase`.

#### Example Usage

~~~php
namespace App\Tests\Functional\Migration;

use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

class MigrationTest extends KernelTestCase
{
}
~~~

#### To Do

- [x] Add breaking changes to UPGRADE.md
