### PR TITLE
WIP: Add tags-header argument to TagsHandler

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\HttpCacheBundle\DependencyInjection;
 
+use Sulu\Component\HttpCache\Handler\TagsHandler;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -47,6 +48,10 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('tags')
                             ->canBeEnabled()
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('tags_header_name')->defaultValue(TagsHandler::TAGS_HEADER)->end()
+                            ->end()
                         ->end()
                         ->arrayNode('debug')
                             ->canBeDisabled()

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -140,6 +140,8 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
         $container->setParameter('sulu_http_cache.handler.public.shared_max_age', $config['public']['shared_max_age']);
         $container->setParameter('sulu_http_cache.handler.public.use_page_ttl', $config['public']['use_page_ttl']);
 
+        $container->setParameter('sulu_http_cache.handler.tags.tags_header_name', $config['tags']['tags_header_name']);
+
         $container->setParameter('sulu_http_cache.handler.aggregate.handlers', $enabledHandlers);
     }
 }

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/structure-cache-handlers.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/structure-cache-handlers.xml
@@ -13,6 +13,7 @@
         <service id="sulu_http_cache.handler.tags" class="Sulu\Component\HttpCache\Handler\TagsHandler" public="true">
             <argument type="service" id="sulu_http_cache.proxy_client"/>
             <argument type="service" id="sulu_website.reference_store_pool"/>
+            <argument>%sulu_http_cache.handler.tags.tags_header_name%</argument>
             <tag name="sulu_http_cache.handler" alias="tags" />
         </service>
 

--- a/src/Sulu/Component/HttpCache/Handler/TagsHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/TagsHandler.php
@@ -40,6 +40,11 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
     private $referenceStorePool;
 
     /**
+     * @var string
+     */
+    private $tagsHeader;
+
+    /**
      * @var array
      */
     private $referencesToInvalidate = [];
@@ -47,11 +52,16 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
     /**
      * @param ProxyClientInterface $proxyClient
      * @param ReferenceStorePoolInterface $referenceStorePool
+     * @param string $tagsHeader
      */
-    public function __construct(ProxyClientInterface $proxyClient, ReferenceStorePoolInterface $referenceStorePool)
-    {
+    public function __construct(
+        ProxyClientInterface $proxyClient,
+        ReferenceStorePoolInterface $referenceStorePool,
+        $tagsHeader
+    ) {
         $this->proxyClient = $proxyClient;
         $this->referenceStorePool = $referenceStorePool;
+        $this->tagsHeader = $tagsHeader;
     }
 
     /**
@@ -86,7 +96,7 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
     {
         $tags = array_merge([$structure->getUuid()], $this->getTags());
 
-        $response->headers->set(self::TAGS_HEADER, implode(',', $tags));
+        $response->headers->set($this->tagsHeader, implode(',', $tags));
     }
 
     /**
@@ -101,7 +111,7 @@ class TagsHandler implements HandlerInvalidateStructureInterface, HandlerInvalid
         foreach ($this->referencesToInvalidate as $reference) {
             $this->proxyClient->ban(
                 [
-                    self::TAGS_HEADER => sprintf('(%s)(,.+)?$', preg_quote($reference)),
+                    $this->tagsHeader => sprintf('(%s)(,.+)?$', preg_quote($reference)),
                 ]
             );
         }

--- a/src/Sulu/Component/HttpCache/Tests/Unit/Handler/TagsHandlerTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/Handler/TagsHandlerTest.php
@@ -63,7 +63,9 @@ class TagsHandlerTest extends \PHPUnit_Framework_TestCase
         $this->referenceStorePool = $this->prophesize(ReferenceStorePoolInterface::class);
 
         $this->handler = new TagsHandler(
-            $this->proxyCache->reveal(), $this->referenceStorePool->reveal()
+            $this->proxyCache->reveal(),
+            $this->referenceStorePool->reveal(),
+            TagsHandler::TAGS_HEADER
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR adds a attribute to `TagsHandler` to be able to configure the name of the cache tags-header.