### PR TITLE
Fix rerenderings of AutoComplete

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {autorun} from 'mobx';
+import {autorun, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
@@ -53,6 +53,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
         this.selectionStore = new MultiSelectionStore(resourceKey, value || [], locale, filterParameter);
 
         this.changeDisposer = autorun(() => {
+            const {value} = this.props;
             const itemIds = this.selectionStore.items.map((item) => item[idProperty]);
 
             if (this.selectionStore.loading) {
@@ -61,6 +62,10 @@ export default class MultiAutoComplete extends React.Component<Props> {
 
             if (!this.changeAutorunInitialized) {
                 this.changeAutorunInitialized = true;
+                return;
+            }
+
+            if (equals(itemIds, toJS(value))) {
                 return;
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| Documentation PR | ----

#### What's in this PR?

This PR adds a check, to not rerender the `AutoComplete` field in a form when a new tag is added.

#### Why?

Before the component has been rerendered in an infinite loop if some tag was added.