### PR TITLE
Add taxonomy fields to form for contacts and accounts

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,11 @@ $webspace->getTemplate('search');
 $webspace->getTemplate('search', $request->getRequestFormat());
 ```
 
+### Contact and Account API
+
+The APIs on `/admin/api/contacts` and `/admin/api/accounts` now use an array of IDS for their `categories` instead of
+returning resp. passing an entire object.
+
 ### SuluKernel::construct changed
 
 The `suluContext` is optional now to support extending from Symfony `KernelTestCase` of Symfony:

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -1,12 +1,14 @@
 // @flow
 import React from 'react';
 import {autorun, computed, observable, toJS} from 'mobx';
+import type {IObservableValue} from 'mobx';
 import equal from 'fast-deep-equal';
 import Datagrid from '../../../containers/Datagrid';
 import DatagridStore from '../../../containers/Datagrid/stores/DatagridStore';
 import MultiAutoComplete from '../../../containers/MultiAutoComplete';
 import {translate} from '../../../utils/Translator';
 import MultiSelectionComponent from '../../MultiSelection';
+import userStore from '../../../stores/UserStore';
 import type {FieldTypeProps} from '../../../types';
 import selectionStyles from './selection.scss';
 
@@ -47,7 +49,6 @@ export default class Selection extends React.Component<Props> {
                         },
                     },
                 },
-                formInspector,
                 value,
             } = this.props;
 
@@ -55,7 +56,7 @@ export default class Selection extends React.Component<Props> {
                 resourceKey,
                 datagridKey || resourceKey,
                 USER_SETTINGS_KEY,
-                {locale: formInspector.locale, page: observable.box()},
+                {locale: this.locale, page: observable.box()},
                 {},
                 value
             );
@@ -68,6 +69,12 @@ export default class Selection extends React.Component<Props> {
         if (this.changeDatagridDisposer) {
             this.changeDatagridDisposer();
         }
+    }
+
+    @computed get locale(): IObservableValue<string> {
+        const {formInspector} = this.props;
+
+        return formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
     }
 
     @computed get type() {
@@ -144,7 +151,7 @@ export default class Selection extends React.Component<Props> {
                 displayProperties={displayProperties}
                 icon={icon}
                 label={translate(label, {count: value ? value.length : 0})}
-                locale={formInspector.locale}
+                locale={this.locale}
                 onChange={this.handleSelectionChange}
                 overlayTitle={translate(overlayTitle)}
                 resourceKey={resourceKey}
@@ -176,7 +183,6 @@ export default class Selection extends React.Component<Props> {
                     },
                 },
             },
-            formInspector,
             value,
         } = this.props;
 
@@ -196,7 +202,7 @@ export default class Selection extends React.Component<Props> {
                 filterParameter={filterParameter}
                 id={dataPath}
                 idProperty={idProperty}
-                locale={formInspector.locale}
+                locale={this.locale}
                 onChange={this.handleAutoCompleteChange}
                 resourceKey={resourceKey}
                 searchProperties={searchProperties}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react';
-import {extendObservable as mockExtendObservable, observable} from 'mobx';
+import {extendObservable as mockExtendObservable, observable, toJS} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
 import {translate} from '../../../../utils/Translator';
 import ResourceStore from '../../../../stores/ResourceStore';
+import userStore from '../../../../stores/UserStore';
 import Datagrid from '../../../Datagrid';
 import Selection from '../../fields/Selection';
 import FormInspector from '../../FormInspector';
@@ -26,6 +27,8 @@ jest.mock('../../../Datagrid/stores/DatagridStore',
         });
     }
 );
+
+jest.mock('../../../../stores/UserStore', () => ({}));
 
 jest.mock('../../FormInspector', () => jest.fn(function(formStore) {
     this.id = formStore.id;
@@ -138,6 +141,48 @@ test('Should pass resourceKey as datagridKey to selection component if no datagr
     );
 
     expect(selection.find('MultiSelection').prop('datagridKey')).toEqual('snippets');
+});
+
+test('Should pass locale from userStore to selection component if form has no locale', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'datagrid_overlay',
+        resource_key: 'snippets',
+        types: {
+            datagrid_overlay: {
+                adapter: 'table',
+                display_properties: ['id', 'title'],
+                icon: '',
+                label: 'sulu_snippet.selection_label',
+                overlay_title: 'sulu_snippet.selection_overlay_title',
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1),
+            'pages'
+        )
+    );
+
+    userStore.contentLocale = 'de';
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            onFinish={jest.fn()}
+            value={value}
+        />
+    );
+
+    expect(translate).toBeCalledWith('sulu_snippet.selection_label', {count: 3});
+
+    expect(toJS(selection.find('MultiSelection').prop('locale'))).toEqual('de');
 });
 
 test('Should pass props with schema-options type correctly to selection component', () => {
@@ -429,6 +474,41 @@ test('Should pass resourceKey as datagridKey to datagrid component if no datagri
     expect(selection.instance().datagridStore.datagridKey).toEqual('snippets');
 });
 
+test('Should pass locale from userStore to datagridStore if form has no locale', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'datagrid',
+        resource_key: 'snippets',
+        types: {
+            datagrid: {
+                adapter: 'table',
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1),
+            'pages'
+        )
+    );
+
+    userStore.contentLocale = 'en';
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            value={value}
+        />
+    );
+
+    expect(toJS(selection.instance().datagridStore.locale)).toEqual('en');
+});
+
 test('Should call onChange and onFinish prop when datagrid selection changes', () => {
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
@@ -554,6 +634,44 @@ test('Should pass props correctly to MultiAutoComplete component', () => {
         searchProperties: ['name'],
         value,
     }));
+});
+
+test('Should pass locale from userStore to MultiAutoComplete component if form has no locale', () => {
+    const value = [1, 6, 8];
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'snippets',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                filter_parameter: 'names',
+                id_property: 'uuid',
+                search_properties: ['name'],
+            },
+        },
+    };
+
+    const formInspector = new FormInspector(
+        new FormStore(
+            new ResourceStore('pages', 1),
+            'pages'
+        )
+    );
+
+    userStore.contentLocale = 'de';
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            value={value}
+        />
+    );
+
+    expect(toJS(selection.find('MultiAutoComplete').prop('locale'))).toEqual('de');
 });
 
 test('Should pass props with schema-options type correctly to MultiAutoComplete component', () => {

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -1116,14 +1116,9 @@ class Account extends ApiWrapper
      */
     public function getCategories()
     {
-        $entities = [];
-        if ($this->entity->getCategories()) {
-            foreach ($this->entity->getCategories() as $category) {
-                $entities[] = new Category($category, $this->locale);
-            }
-        }
-
-        return $entities;
+        return array_map(function($category) {
+            return $category->getId();
+        }, $this->entity->getCategories()->toArray());
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -1117,14 +1117,9 @@ class Contact extends ApiWrapper
      */
     public function getCategories()
     {
-        $entities = [];
-        if ($this->entity->getCategories()) {
-            foreach ($this->entity->getCategories() as $category) {
-                $entities[] = new Category($category, $this->locale);
-            }
-        }
-
-        return $entities;
+        return array_map(function($category) {
+            return $category->getId();
+        }, $this->entity->getCategories()->toArray());
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -847,62 +847,21 @@ abstract class AbstractContactManager implements ContactManagerInterface
      *
      * @return bool True if the processing was successful, otherwise false
      */
-    public function processCategories($contact, $categories)
+    public function processCategories($contact, $categoryIds)
     {
-        $get = function ($category) {
-            return $category->getId();
-        };
+        $contact->getCategories()->clear();
 
-        $delete = function ($category) use ($contact) {
-            return $contact->removeCategory($category);
-        };
+        foreach ($categoryIds as $categoryId) {
+            $category = $this->em->getRepository(self::$categoryEntityName)->find($categoryId);
 
-        $add = function ($category) use ($contact) {
-            return $this->addCategories($contact, $category);
-        };
+            if (!$category) {
+                throw new EntityNotFoundException(self::$categoryEntityName, $categoryId);
+            }
 
-        $entities = $contact->getCategories();
-
-        $result = $this->processSubEntities(
-            $entities,
-            $categories,
-            $get,
-            $add,
-            null,
-            $delete
-        );
-
-        $this->resetIndexOfSubentites($entities);
-
-        return $result;
-    }
-
-    /**
-     * Adds a new category to the given contact.
-     *
-     * @param $contact
-     * @param $data
-     *
-     * @return bool
-     *
-     * @throws EntityNotFoundException
-     * @throws EntityIdAlreadySetException
-     */
-    protected function addCategories($contact, $data)
-    {
-        $success = true;
-
-        $category = $this->em->getRepository(
-            self::$categoryEntityName
-        )->find($data['id']);
-
-        if (!$category) {
-            throw new EntityNotFoundException(self::$categoryEntityName, $data['id']);
-        } else {
             $contact->addCategory($category);
         }
 
-        return $success;
+        return true;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -586,7 +586,8 @@ class AccountController extends RestController implements ClassResourceInterface
             $account->setNote($request->get('note'));
         }
 
-        if (array_key_exists('id', $request->get('logo', []))) {
+        $logo = $request->get('logo', []);
+        if ($logo && array_key_exists('id', $logo)) {
             $accountManager->setLogo($account, $request->get('logo')['id']);
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
@@ -60,6 +60,26 @@
                         <title>sulu_contact.note</title>
                     </meta>
                 </property>
+
+                <section name="taxonomies">
+                    <meta>
+                        <title>sulu_contact.taxonomies</title>
+                    </meta>
+
+                    <properties>
+                        <property name="tags" type="tag_selection">
+                            <meta>
+                                <title>sulu_tag.tags</title>
+                            </meta>
+                        </property>
+
+                        <property name="categories" type="category_selection">
+                            <meta>
+                                <title>sulu_category.categories</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </section>
             </properties>
         </section>
     </properties>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/contact_details.xml
@@ -90,6 +90,26 @@
                         <title>sulu_contact.note</title>
                     </meta>
                 </property>
+
+                <section name="taxonomies">
+                    <meta>
+                        <title>sulu_contact.taxonomies</title>
+                    </meta>
+
+                    <properties>
+                        <property name="tags" type="tag_selection">
+                            <meta>
+                                <title>sulu_tag.tags</title>
+                            </meta>
+                        </property>
+
+                        <property name="categories" type="category_selection">
+                            <meta>
+                                <title>sulu_category.categories</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </section>
             </properties>
         </section>
     </properties>

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -42,5 +42,6 @@
     "sulu_contact.no_contact_selected": "Kein Kontakt ausgewählt",
     "sulu_contact.single_contact_selection_overlay_title": "Kontakt auswählen",
     "sulu_contact.no_account_selected": "Keine Organisation ausgewählt",
-    "sulu_contact.single_account_selection_overlay_title": "Organisation auswählen"
+    "sulu_contact.single_account_selection_overlay_title": "Organisation auswählen",
+    "sulu_contact.taxonomies": "Taxonomien"
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
@@ -42,5 +42,6 @@
     "sulu_contact.no_contact_selected": "No contact selected",
     "sulu_contact.single_contact_selection_overlay_title": "Choose contact",
     "sulu_contact.no_account_selected": "No account selected",
-    "sulu_contact.single_account_selection_overlay_title": "Choose account"
+    "sulu_contact.single_account_selection_overlay_title": "Choose account",
+    "sulu_contact.taxonomies": "Taxonomies"
 }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1214,7 +1214,6 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals('ExampleCompany', $response->name);
     }
 
-
     public function testPutNotExisting()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1163,6 +1163,58 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals(0, count($response->addresses));
     }
 
+    public function testPutWithNullLogo()
+    {
+        $urlType = $this->createUrlType('Private');
+        $url = $this->createUrl('http://www.company.example', $urlType);
+        $emailType = $this->createEmailType('Private');
+        $email = $this->createEmail('info@muster.at', $emailType);
+        $phoneType = $this->createPhoneType('Private');
+        $phone = $this->createPhone('123456789', $phoneType);
+        $faxType = $this->createFaxType('Private');
+        $fax = $this->createFax('123456789', $faxType);
+        $country = $this->createCountry('Musterland', 'ML');
+        $addressType = $this->createAddressType('Private');
+        $address = $this->createAddress(
+            $addressType,
+            'Musterstraße',
+            '1',
+            '0000',
+            'Musterstadt',
+            'Musterland',
+            $country,
+            true,
+            true,
+            false,
+            'Dornbirn',
+            '6850',
+            '4711',
+            'note',
+            47.4048346,
+            9.7602198
+        );
+        $note = $this->createNote('Note');
+        $account = $this->createAccount('Company', null, $url, $address, $email, $phone, $fax, $note);
+
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'PUT',
+            '/api/accounts/' . $account->getId(),
+            [
+                'name' => 'ExampleCompany',
+                'logo' => null,
+            ]
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertEquals('ExampleCompany', $response->name);
+    }
+
+
     public function testPutNotExisting()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -322,7 +322,7 @@ class ContactControllerTest extends SuluTestCase
         $country = $this->createCountry('Musterland', 'ML');
         $addressType = $this->createAddressType('Private');
         $account = $this->createAccount('Musterfirma');
-        $category = $this->createCategory('first-category-key', 'en', 'First Category', 'Description of Category');
+        $category1 = $this->createCategory('first-category-key', 'en', 'First Category', 'Description of Category');
         $category2 = $this->createCategory('second-category-key', 'en', 'Second Category', 'Description of second Category');
         $this->em->flush();
 
@@ -431,7 +431,7 @@ class ContactControllerTest extends SuluTestCase
                 ],
                 'categories' => [
                     [
-                        'id' => $category->getId(),
+                        'id' => $category1->getId(),
                     ],
                     [
                         'id' => $category2->getId(),
@@ -480,6 +480,8 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('Sehr geehrte Frau Dr Mustermann', $response->salutation);
 
         $this->assertEquals(2, count($response->categories));
+        $this->assertEquals($category1->getId(), $response->categories[0]->id);
+        $this->assertEquals($category2->getId(), $response->categories[1]->id);
     }
 
     public function testPostEmptyLatitude()
@@ -759,6 +761,10 @@ class ContactControllerTest extends SuluTestCase
         $collection = $this->createCollection($collectionType);
         $mediaType = $this->createMediaType('image', 'This is an image');
         $media = $this->createMedia('media1.jpeg', 'image/jpeg', $mediaType, $collection);
+        $category1 = $this->createCategory('first-category-key', 'en', 'First Category', 'Description of Category');
+        $category2 = $this->createCategory('second-category-key', 'en', 'Second Category', 'Description of second Category');
+        $category3 = $this->createCategory('third-category-key', 'en', 'Third Category', 'Description of third Category');
+
         $contact = $this->createContact(
             'Max',
             'Mustermann',
@@ -772,11 +778,11 @@ class ContactControllerTest extends SuluTestCase
             $phone,
             $fax,
             $address,
-            $note
+            $note,
+            null,
+            [$category1, $category2]
         );
 
-        $category = $this->createCategory('first-category-key', 'en', 'First Category', 'Description of Category');
-        $category2 = $this->createCategory('second-category-key', 'en', 'Second Category', 'Description of second Category');
 
         $this->em->flush();
 
@@ -887,10 +893,7 @@ class ContactControllerTest extends SuluTestCase
                 ],
                 'categories' => [
                     [
-                        'id' => $category->getId(),
-                    ],
-                    [
-                        'id' => $category2->getId(),
+                        'id' => $category3->getId(),
                     ],
                 ],
             ]
@@ -932,7 +935,8 @@ class ContactControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('sulu-100x100', $response->avatar->thumbnails);
         $this->assertTrue(is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
-        $this->assertEquals(2, count($response->categories));
+        $this->assertEquals(1, count($response->categories));
+        $this->assertEquals($category3->getId(), $response->categories[0]->id);
 
         $client->request('GET', '/api/contacts/' . $response->id);
         $response = json_decode($client->getResponse()->getContent());
@@ -971,7 +975,8 @@ class ContactControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('sulu-100x100', $response->avatar->thumbnails);
         $this->assertTrue(is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
-        $this->assertEquals(2, count($response->categories));
+        $this->assertEquals(1, count($response->categories));
+        $this->assertEquals($category3->getId(), $response->categories[0]->id);
     }
 
     public function testPutDeleteAndAddWithoutId()
@@ -2294,7 +2299,8 @@ class ContactControllerTest extends SuluTestCase
         ?Fax $fax = null,
         ?Address $address = null,
         ?Note $note = null,
-        ?Media $media = null
+        ?Media $media = null,
+        ?array $categories = null
     ) {
         $contact = new Contact();
         $contact->setFirstName($firstName);
@@ -2332,6 +2338,12 @@ class ContactControllerTest extends SuluTestCase
 
         if ($media) {
             $contact->setAvatar($media);
+        }
+
+        if ($categories) {
+            foreach ($categories as $category) {
+                $contact->addCategory($category);
+            }
         }
 
         $this->em->persist($contact);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -779,7 +779,6 @@ class ContactControllerTest extends SuluTestCase
             [$category1, $category2]
         );
 
-
         $this->em->flush();
 
         $client = $this->createTestClient();

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -430,12 +430,8 @@ class ContactControllerTest extends SuluTestCase
                     'id' => 0,
                 ],
                 'categories' => [
-                    [
-                        'id' => $category1->getId(),
-                    ],
-                    [
-                        'id' => $category2->getId(),
-                    ],
+                    $category1->getId(),
+                    $category2->getId(),
                 ],
             ]
         );
@@ -480,8 +476,8 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('Sehr geehrte Frau Dr Mustermann', $response->salutation);
 
         $this->assertEquals(2, count($response->categories));
-        $this->assertEquals($category1->getId(), $response->categories[0]->id);
-        $this->assertEquals($category2->getId(), $response->categories[1]->id);
+        $this->assertEquals($category1->getId(), $response->categories[0]);
+        $this->assertEquals($category2->getId(), $response->categories[1]);
     }
 
     public function testPostEmptyLatitude()
@@ -892,9 +888,7 @@ class ContactControllerTest extends SuluTestCase
                     'id' => 0,
                 ],
                 'categories' => [
-                    [
-                        'id' => $category3->getId(),
-                    ],
+                    $category3->getId(),
                 ],
             ]
         );
@@ -936,7 +930,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertTrue(is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(1, count($response->categories));
-        $this->assertEquals($category3->getId(), $response->categories[0]->id);
+        $this->assertEquals($category3->getId(), $response->categories[0]);
 
         $client->request('GET', '/api/contacts/' . $response->id);
         $response = json_decode($client->getResponse()->getContent());
@@ -976,7 +970,7 @@ class ContactControllerTest extends SuluTestCase
         $this->assertTrue(is_string($response->avatar->thumbnails->{'sulu-100x100'}));
 
         $this->assertEquals(1, count($response->categories));
-        $this->assertEquals($category3->getId(), $response->categories[0]->id);
+        $this->assertEquals($category3->getId(), $response->categories[0]);
     }
 
     public function testPutDeleteAndAddWithoutId()

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {ElementRef} from 'react';
 import {action, autorun, observable} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {Datagrid, DatagridStore, SingleDatagridOverlay, withToolbar} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the fields for categories and tags to the forms for accounts and contacts.

#### Why?

Because our entities have these values, and the fields were also there in the old UI.

#### BC Breaks/Deprecations

The `categories` field in the contacts and accounts API constists of IDs instead of objects now.