### PR TITLE
Add support for newest imagine version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "goodby/csv": "^1.3",
         "guzzlehttp/guzzle": "^6.2",
         "guzzlehttp/psr7": "^1.5",
-        "imagine/imagine": "~0.6.1 || ~0.7.0",
+        "imagine/imagine": "~0.6.1 || ~0.7.0 || ^1.0",
         "jms/serializer": "^1.13",
         "jms/serializer-bundle": "^2.2",
         "layershifter/tld-extract": "^1.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Upgrade imagine library version to allow ^1.0.

#### Why?

To support webp in future release.

#### To Do

- [x] Test Animated gif 
