### PR TITLE
WIP: Fix usage of symfony cache with shared max age 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.5
+    * BUGFIX      #4385 [SuluHttpCacheBundle]   Fix usage of symfony cache with s-max-age 0
     * ENHANCEMENT #4367 [WebsiteBundle]         Remove false deprecation of WebsiteController::renderStructure
     * BUGFIX      #4376 [SecurityBundle]        Exclude role permissions in user API to improve performance
 

--- a/src/Sulu/Component/HttpCache/Handler/PublicHandler.php
+++ b/src/Sulu/Component/HttpCache/Handler/PublicHandler.php
@@ -85,9 +85,13 @@ class PublicHandler implements HandlerUpdateResponseInterface
         // mark the response as either public or private
         $response->setPublic();
 
-        // set the private and shared max age
+        // set the private max age
         $response->setMaxAge($this->maxAge);
-        $response->setSharedMaxAge($this->sharedMaxAge);
+
+        // set shared max age only when not 0 else symfony cache will not work
+        if ($this->sharedMaxAge) {
+            $response->setSharedMaxAge($this->sharedMaxAge);
+        }
 
         $proxyTtl = $this->usePageTtl ?
             $response->getAge() + $cacheLifetime :

--- a/src/Sulu/Component/HttpCache/Tests/Unit/Handler/PublicHandlerTest.php
+++ b/src/Sulu/Component/HttpCache/Tests/Unit/Handler/PublicHandlerTest.php
@@ -88,6 +88,30 @@ class PublicHandlerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSharedMaxAgeZeroResponse()
+    {
+        $this->response->setPublic()->shouldBeCalled();
+        $this->response->setMaxAge($this->maxAge)->shouldBeCalled();
+        // setSharedMaxAge should not be called else symfony cache will not work on s-max-age 0
+        $this->response->setSharedMaxAge(0)->shouldNotBeCalled();
+        $this->structure->getCacheLifeTime()
+            ->willReturn(['type' => CacheLifetimeResolverInterface::TYPE_SECONDS, 'value' => 10]);
+        $this->cacheLifetimeResolver->resolve(CacheLifetimeResolverInterface::TYPE_SECONDS, 10)->willReturn(10);
+        $this->response->getAge()->willReturn(50);
+
+        $handler = new PublicHandler(
+            $this->cacheLifetimeResolver->reveal(),
+            $this->maxAge,
+            0,
+            true
+        );
+
+        $handler->updateResponse(
+            $this->response->reveal(),
+            $this->structure->reveal()
+        );
+    }
+
     public function testDisableCache()
     {
         // disable cache


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Fix usage of symfony cache with shared max age 0.

#### Why?

Symfony will not cache if shared max age is set and 0 because of $response->getMaxAge() in $response->isCacheable() will return at first s-max-age.

#### Example Usage

~~~php
sulu_http_cache:
    handlers:
        public:
            max_age: 100 
            shared_max_age: 0
~~~
