### PR TITLE
Fix extending forms without any schema information

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/Schema/Schema.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/Schema/Schema.php
@@ -44,7 +44,7 @@ class Schema
     {
         $jsonSchema = [];
 
-        $required = array_values(
+        $jsonSchema['required'] = array_values(
             array_filter(
                 array_map(function(Property $property) {
                     if ($property->isMandatory()) {
@@ -53,10 +53,6 @@ class Schema
                 }, $this->properties)
             )
         );
-
-        if (count($required) > 0) {
-            $jsonSchema['required'] = $required;
-        }
 
         $properties = [];
 

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Handler/SchemaHandler.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Handler/SchemaHandler.php
@@ -37,8 +37,6 @@ class SchemaHandler implements SubscribingHandlerInterface
         array $type,
         Context $context
     ) {
-        $jsonSchema = $schema->toJsonSchema();
-
-        return $context->accept(count($jsonSchema) > 0 ? $jsonSchema : null);
+        return $context->accept($schema->toJsonSchema());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
@@ -31,7 +31,8 @@ class FormMetadataProviderTest extends KernelTestCase
     {
         $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'en');
         $schema = $form->getSchema()->toJsonSchema();
-        $this->assertCount(1, array_keys($schema));
+        $this->assertCount(2, array_keys($schema));
+        $this->assertCount(0, $schema['required']);
         $this->assertCount(2, $schema['allOf']);
         $this->assertEquals(['first', 'third'], $schema['allOf'][0]['required']);
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -216,8 +216,10 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertEquals(
             [
+                'required' => [],
                 'anyOf' => [
                     [
+                        'required' => [],
                         'properties' => [
                             'first' => [
                                 'name' => 'first',
@@ -226,6 +228,7 @@ class FormXmlLoaderTest extends TestCase
                         ],
                     ],
                     [
+                        'required' => [],
                         'properties' => [
                             'second' => [
                                 'name' => 'second',
@@ -236,6 +239,7 @@ class FormXmlLoaderTest extends TestCase
                 ],
                 'allOf' => [
                     [
+                        'required' => [],
                         'properties' => [
                             'first' => [
                                 'name' => 'first',

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/Schema/SchemaTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/Schema/SchemaTest.php
@@ -17,11 +17,15 @@ use Sulu\Bundle\AdminBundle\Metadata\Schema\Schema;
 
 class SchemaTest extends TestCase
 {
-    public function testEmptyJsonSchema()
+    /**
+     * It is absolutely necessary that no empty array is returned, because an empty array would be serialized as array
+     * instead of an object in JSON, which would cause the JsonSchema library in the frontend to crash.
+     */
+    public function testEmptyJsonSchemaReturningNonEmptyArray()
     {
         $schema = new Schema();
 
-        $this->assertEquals([], $schema->toJsonSchema());
+        $this->assertEquals(['required' => []], $schema->toJsonSchema());
     }
 
     public function testNestedJsonSchema()
@@ -60,8 +64,10 @@ class SchemaTest extends TestCase
                 'required' => ['title'],
                 'allOf' => [
                     [
+                        'required' => [],
                         'anyOf' => [
                             [
+                                'required' => [],
                                 'properties' => [
                                     'nodeType' => [
                                         'name' => 'nodeType',
@@ -70,6 +76,7 @@ class SchemaTest extends TestCase
                                 ],
                             ],
                             [
+                                'required' => [],
                                 'properties' => [
                                     'nodeType' => [
                                         'name' => 'nodeType',

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -73,7 +73,8 @@ class AdminControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('url', $overviewType->form);
         $this->assertObjectHasAttribute('article', $overviewType->form);
         $this->assertObjectHasAttribute('schema', $overviewType);
-        $this->assertNull($overviewType->schema);
+
+        $this->assertEquals(['required' => []], (array) $overviewType->schema);
     }
 
     public function testPageSeoFormMetadataAction()
@@ -93,7 +94,7 @@ class AdminControllerTest extends SuluTestCase
 
         $schema = $response->schema;
 
-        $this->assertNull($schema);
+        $this->assertEquals(['required' => []], (array) $schema);
     }
 
     public function testPageExcerptFormMetadataAction()
@@ -113,7 +114,7 @@ class AdminControllerTest extends SuluTestCase
 
         $schema = $response->schema;
 
-        $this->assertNull($schema);
+        $this->assertEquals(['required' => []], (array) $schema);
     }
 
     public function testPageSettingFormMetadataAction()

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -94,6 +94,7 @@ class StructureXmlLoaderTest extends TestCase
 
         $this->assertEquals(
             [
+                'required' => [],
                 'anyOf' => [
                     [
                         'required' => [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the JSON schema objects (also the ones in `anyOf` and `allOf` properties) always return at least the property `required`, even if it is empty.

I've also tried to completely use JMS serializer, which would have allowed to fix that specific problem without the `required` property to be always returned. However, therefore all `properties` would have been returned, which would cause even more unnecessary data.

#### Why?

Because this allows to extend forms without any additional schema information. Before this would have returned an empty array in an `allOf` array, which is invalid JSON.

So before it was possible that something like this was returned when being serialized to JSON:

```json
{
    "allOf": [
        {
            "required": [
                "name"
            ]
        },
        []
    ]
}
```

Which would now be fixed to something like this:

```json
{
    "required": [],
    "allOf": [
        {
            "required": [
                "name"
            ]
        },
        {
            "required": []
        }
    ]
}
```