### PR TITLE
Add missing translation for reset-password mail message

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
@@ -7,6 +7,7 @@
     "sulu_security.system": "System",
     "sulu_security.system_language": "Systemsprache",
     "sulu_security.reset_mail_subject": "Sulu Password zurücksetzen",
+    "sulu_security.reset.mail_message": "Klicken Sie auf den folgenden Link oder kopieren Sie ihn in Ihren Browser um Ihr Sulu Passwort zurückzusetzen:",
     "sulu_security.view": "Ansehen",
     "sulu_security.add": "Hinzufügen",
     "sulu_security.edit": "Bearbeiten",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
@@ -7,7 +7,7 @@
     "sulu_security.system": "System",
     "sulu_security.system_language": "Systemsprache",
     "sulu_security.reset_mail_subject": "Sulu Password zurücksetzen",
-    "sulu_security.reset.mail_message": "Klicken Sie auf den folgenden Link oder kopieren Sie ihn in Ihren Browser um Ihr Sulu Passwort zurückzusetzen:",
+    "sulu_security.reset_mail_message": "Klicken Sie auf den folgenden Link oder kopieren Sie ihn in Ihren Browser um Ihr Sulu Passwort zurückzusetzen:",
     "sulu_security.view": "Ansehen",
     "sulu_security.add": "Hinzufügen",
     "sulu_security.edit": "Bearbeiten",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
@@ -7,7 +7,7 @@
     "sulu_security.system": "System",
     "sulu_security.system_language": "System language",
     "sulu_security.reset_mail_subject": "Reset your Sulu password",
-    "sulu_security.reset.mail_message": "To reset your Sulu password please click on the following link or copy/paste it to your browser:",
+    "sulu_security.reset_mail_message": "To reset your Sulu password please click on the following link or copy/paste it to your browser:",
     "sulu_security.view": "View",
     "sulu_security.add": "Add",
     "sulu_security.edit": "Edit",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
@@ -7,6 +7,7 @@
     "sulu_security.system": "System",
     "sulu_security.system_language": "System language",
     "sulu_security.reset_mail_subject": "Reset your Sulu password",
+    "sulu_security.reset.mail_message": "To reset your Sulu password please click on the following link or copy/paste it to your browser:",
     "sulu_security.view": "View",
     "sulu_security.add": "Add",
     "sulu_security.edit": "Edit",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
@@ -1,2 +1,2 @@
-{{ 'sulu_security.reset.mail_message'|trans({}, translation_domain) }}
+{{ 'sulu_security.reset_mail_message'|trans({}, translation_domain) }}
 {{ reset_url }}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/views/mail_templates/reset_password.html.twig
@@ -1,2 +1,2 @@
-{{ 'security.reset.mail-message'|trans({}, translation_domain) }}
+{{ 'sulu_security.reset.mail_message'|trans({}, translation_domain) }}
 {{ reset_url }}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds missing translation for reset-password mail and changes translation key to new standard.

Also: changed line endings of mail template from CRLF to LF.

#### Why?

The mail message was not translated yet. The plain translation key `security.reset.mail-message` was shown in the mail
