### PR TITLE
Fix FieldJoinDescriptor without a relation

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/config/list-builder/Contact.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/list-builder/Contact.xml
@@ -263,7 +263,7 @@
             </orm:joins>
         </group-concat-property>
 
-        <property name="user" visibility="no" searchability="yes" list:translation="sulu_security.user_name">
+        <property name="user" list:translation="sulu_security.user_name">
             <orm:field-name>username</orm:field-name>
             <orm:entity-name>%sulu.model.user.class%</orm:entity-name>
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -521,7 +521,7 @@ class DoctrineListBuilder extends AbstractListBuilder
             switch ($join->getJoinMethod()) {
                 case DoctrineJoinDescriptor::JOIN_METHOD_LEFT:
                     $queryBuilder->leftJoin(
-                        $join->getJoin() ?: $entity,
+                        $join->getJoin(),
                         $this->encodeAlias($entity),
                         $join->getJoinConditionMethod(),
                         $join->getJoinCondition()
@@ -529,7 +529,7 @@ class DoctrineListBuilder extends AbstractListBuilder
                     break;
                 case DoctrineJoinDescriptor::JOIN_METHOD_INNER:
                     $queryBuilder->innerJoin(
-                        $join->getJoin() ?: $entity,
+                        $join->getJoin(),
                         $this->encodeAlias($entity),
                         $join->getJoinConditionMethod(),
                         $join->getJoinCondition()

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineJoinDescriptor.php
@@ -64,11 +64,11 @@ class DoctrineJoinDescriptor
     private $joinMethod;
 
     public function __construct(
-        string $entityName,
-        string $join = null,
-        string $joinCondition = null,
-        string $joinMethod = self::JOIN_METHOD_LEFT,
-        string $joinConditionMethod = self::JOIN_CONDITION_METHOD_WITH
+        $entityName,
+        $join = null,
+        $joinCondition = null,
+        $joinMethod = self::JOIN_METHOD_LEFT,
+        $joinConditionMethod = self::JOIN_CONDITION_METHOD_WITH
     ) {
         $this->entityName = $entityName;
         $this->join = $join;
@@ -90,6 +90,11 @@ class DoctrineJoinDescriptor
      */
     public function getJoin()
     {
+        // When joining without a relation the join should not be encoded
+        if (null === $this->join || $this->entityName === $this->join) {
+            return $this->entityName;
+        }
+
         return $this->encodeAlias($this->join);
     }
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -728,6 +728,38 @@ class DoctrineListBuilderTest extends \PHPUnit_Framework_TestCase
         $this->doctrineListBuilder->execute();
     }
 
+    public function testJoinWithoutFieldNameByGivenEntity()
+    {
+        $fieldDescriptors = [
+            'name' => new DoctrineFieldDescriptor(
+                'name',
+                'name',
+                self::$entityName,
+                '',
+                [
+                    self::$translationEntityName => new DoctrineJoinDescriptor(
+                        self::$translationEntityName,
+                        self::$translationEntityName,
+                        'alias.id = translation.id'
+                    ),
+                ]
+            ),
+        ];
+
+        $this->doctrineListBuilder->setSelectFields($fieldDescriptors);
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name')->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(
+            self::$translationEntityName,
+            self::$translationEntityNameAlias,
+            'WITH',
+            'alias.id = translation.id'
+        )->shouldBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
     public function testJoinConditions()
     {
         $fieldDescriptors = [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add missing upgrade for field descriptors encode alias trait for 1.6.24

And fix DoctrineJoinFieldDescriptor without a relation by cherry picking: https://github.com/sulu/sulu/pull/4285 **So maybe not squash merge this PR**?

#### Why?

It is not documented that you need to use the EncodeAliasTrait now if you have custom field descriptors.

The FieldJoinDescriptor did not longer work without relation.

#### Example Usage

See Upgrade.md

#### To Do

- [x] Add breaking changes to UPGRADE.md
