### PR TITLE
Fix compatibility to massive search with php7.2 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * BUGFIX      #4414  [SearchBundle]         Add massive search bundle 0.17 as allowed version
     * FEATURE     #4394  [WebsiteBundle]        Add exception handling for breadcrumb function
     * FEATURE     #4400  [All]                  Fix FieldJoinDescriptor without a relation
     * ENHANCEMENT #4370  [WebsiteBundle]        Add attributes to sitemap-url

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "friendsofsymfony/rest-bundle": "^1.6",
         "guzzlehttp/guzzle": "^6.2",
         "imagine/imagine": "~0.6.1 || ~0.7.0",
-        "massive/search-bundle": "0.16.*",
+        "massive/search-bundle": "0.16.* || 0.17.*",
         "sensio/framework-extra-bundle": "^3.0",
         "sulu/document-manager": "~0.10.1",
         "stof/doctrine-extensions-bundle": "^1.2.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/126
| License | MIT

#### What's in this PR?

Allow massive search 0.17 version in sulu 1.6.24

#### Why?

In some cases it runs into a problem with php 7.2 so this version is needed to be allowed.
