### PR TITLE
Add preview for collapsed form blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -266,6 +266,14 @@ class AdminController
                 'addressTypes' => $this->managerRegistry->getRepository('SuluContactBundle:AddressType')->findAll(),
                 'countries' => $this->managerRegistry->getRepository('SuluContactBundle:Country')->findAll(),
             ],
+            'sulu_media' => [
+                'endpoints' => [
+                    'image_format' => $this->urlGenerator->generate(
+                        'sulu_media.redirect',
+                        ['id' => ':id']
+                    ),
+                ],
+            ],
             'sulu_page' => [
                 'endpoints' => [
                     'clearCache' => $this->urlGenerator->generate('sulu_website.cache.remove'),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -1,18 +1,25 @@
 @import '../../containers/Application/colors.scss';
 
-$borderRadius: 3px;
+$blockBorderRadius: 3px;
 $blockBackgroundColor: $white;
 $blockBorderColor: $silver;
-$handleBackgroundColor: $silver;
+$blockHandleColor: $black;
+$blockHandleBackgroundColor: $silver;
+$blockCollapsedTextColor: $silver;
 
 .block {
     display: flex;
     background-color: $blockBackgroundColor;
-    border-radius: $borderRadius;
+    border-radius: $blockBorderRadius;
 
     &:not(.expanded) {
+        color: $blockCollapsedTextColor;
         cursor: pointer;
         border: 1px solid $blockBorderColor;
+
+        .content {
+            padding: 20px 40px;
+        }
     }
 }
 
@@ -21,8 +28,9 @@ $handleBackgroundColor: $silver;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;
-    background-color: $handleBackgroundColor;
-    border-radius: $borderRadius 0 0 $borderRadius;
+    color: $blockHandleColor;
+    background-color: $blockHandleBackgroundColor;
+    border-radius: $blockBorderRadius 0 0 $blockBorderRadius;
     width: 20px;
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -18,6 +18,7 @@ $handleBackgroundColor: $silver;
 
 .handle {
     display: flex;
+    flex-shrink: 0;
     align-items: center;
     justify-content: center;
     background-color: $handleBackgroundColor;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Block/block.scss
@@ -35,6 +35,8 @@ $blockCollapsedTextColor: $silver;
 }
 
 .content {
+    font-size: 12px;
+    line-height: 18px;
     flex-grow: 1;
     padding: 30px 60px 30px 40px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
@@ -62,7 +62,7 @@ class SortableBlock extends React.Component<Props> {
                 onTypeChange={this.handleTypeChange}
                 types={types}
             >
-                {expanded && renderBlockContent(value, activeType, sortIndex)}
+                {renderBlockContent(value, activeType, sortIndex, expanded)}
             </Block>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
@@ -194,7 +194,27 @@ test('Should call renderBlockContent with the correct arguments', () => {
         />
     );
 
-    expect(renderBlockContentSpy).toBeCalledWith(value, 'editor', 7);
+    expect(renderBlockContentSpy).toBeCalledWith(value, 'editor', 7, true);
+});
+
+test('Should call renderBlockContent with the correct arguments when block is collapsed', () => {
+    const renderBlockContentSpy = jest.fn();
+    const value = {content: 'Test 1'};
+
+    shallow(
+        <SortableBlock
+            activeType="editor"
+            expanded={false}
+            onCollapse={jest.fn()}
+            onExpand={jest.fn()}
+            onRemove={jest.fn()}
+            renderBlockContent={renderBlockContentSpy}
+            sortIndex={7}
+            value={value}
+        />
+    );
+
+    expect(renderBlockContentSpy).toBeCalledWith(value, 'editor', 7, false);
 });
 
 test('Should call renderBlockContent with the correct arguments when types are involved', () => {
@@ -214,5 +234,5 @@ test('Should call renderBlockContent with the correct arguments when types are i
         />
     );
 
-    expect(renderBlockContentSpy).toBeCalledWith(value, 'test', 7);
+    expect(renderBlockContentSpy).toBeCalledWith(value, 'test', 7, true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
@@ -6,4 +6,4 @@ export type BlockEntry = {
     type: string,
 };
 
-export type RenderBlockContentCallback = (value: *, type: string, index: number) => Node;
+export type RenderBlockContentCallback = (value: *, type: string, index: number, expanded: boolean) => Node;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/registries/DatagridFieldTransformerRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Datagrid/registries/DatagridFieldTransformerRegistry.js
@@ -1,7 +1,7 @@
 // @flow
 import type {FieldTransformer} from '../types';
 
-class FieldTransformerRegistry {
+class DatagridFieldTransformerRegistry {
     fieldTransformers: {[string]: FieldTransformer};
 
     constructor() {
@@ -36,4 +36,4 @@ class FieldTransformerRegistry {
     }
 }
 
-export default new FieldTransformerRegistry();
+export default new DatagridFieldTransformerRegistry();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -1,12 +1,15 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import {toJS} from 'mobx';
 import BlockCollection from '../../components/BlockCollection';
 import type {BlockEntry} from '../../components/BlockCollection/types';
 import type {BlockError, FieldTypeProps} from '../Form/types';
+import blockPreviewTransformerRegistry from './registries/BlockPreviewTransformerRegistry';
 import FieldRenderer from './FieldRenderer';
+import fieldBlocksStyles from './fieldBlocks.scss';
 
 const MISSING_BLOCK_ERROR_MESSAGE = 'The "block" field type needs at least one type to be configured!';
+const BLOCK_PREVIEW_TAG = 'sulu.block_preview';
 
 export default class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
     handleBlockChange = (index: number, name: string, value: Object) => {
@@ -28,10 +31,12 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
     };
 
     renderBlockContent = (value: Object, type: string, index: number, expanded: boolean) => {
-        if (!expanded) {
-            return null;
-        }
+        return expanded
+            ? this.renderExpandedBlockContent(value, type, index)
+            : this.renderCollapsedBlockContent(value, type, index);
+    };
 
+    renderExpandedBlockContent = (value: Object, type: string, index: number) => {
         const {dataPath, error, formInspector, onFinish, schemaPath, showAllErrors, types} = this.props;
 
         if (!formInspector) {
@@ -59,6 +64,53 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
                 schemaPath={schemaPath + '/types/' + type + '/form'}
                 showAllErrors={showAllErrors}
             />
+        );
+    };
+
+    // eslint-disable-next-line no-unused-vars
+    renderCollapsedBlockContent = (value: Object, type: string, index: number) => {
+        if (!type) {
+            throw new Error(
+                'It is impossible that a collapsed block has no type. This should not happen and is likely a bug.'
+            );
+        }
+
+        const {formInspector, schemaPath} = this.props;
+        const blockSchemaTypes = formInspector.getSchemaEntryByPath(schemaPath).types;
+
+        if (!blockSchemaTypes) {
+            throw new Error(
+                'It is impossible that the schema for blocks has no types. This should not happen and is likely a bug.'
+            );
+        }
+
+        const blockSchemaType = blockSchemaTypes[type];
+        const blockSchemaTypeForm = blockSchemaType.form;
+
+        const previewPropertyNames = Object.keys(blockSchemaTypeForm)
+            .filter((schemaKey) => {
+                const schemaEntryTags = blockSchemaTypeForm[schemaKey].tags;
+                return schemaEntryTags && schemaEntryTags.some((tag) => tag.name === BLOCK_PREVIEW_TAG);
+            });
+
+        return (
+            <Fragment>
+                <div className={fieldBlocksStyles.type}>
+                    {blockSchemaType.title}
+                </div>
+                {previewPropertyNames.map((previewPropertyName) =>
+                    blockPreviewTransformerRegistry.has(blockSchemaTypeForm[previewPropertyName].type)
+                    && value[previewPropertyName]
+                    && (
+                        <Fragment key={previewPropertyName}>
+                            {blockPreviewTransformerRegistry
+                                .get(blockSchemaTypeForm[previewPropertyName].type)
+                                .transform(value[previewPropertyName], blockSchemaTypeForm[previewPropertyName])
+                            }
+                        </Fragment>
+                    )
+                )}
+            </Fragment>
         );
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -91,6 +91,29 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
             .filter((schemaKey) => {
                 const schemaEntryTags = blockSchemaTypeForm[schemaKey].tags;
                 return schemaEntryTags && schemaEntryTags.some((tag) => tag.name === BLOCK_PREVIEW_TAG);
+            })
+            .sort((propertyName1, propertyName2) => {
+                const propertyTags1 = blockSchemaTypeForm[propertyName1].tags;
+                const propertyTags2 = blockSchemaTypeForm[propertyName2].tags;
+
+                if (!propertyTags1 || !propertyTags2) {
+                    throw new Error(
+                        'All properties without any tag should have been filtered before.'
+                        + ' This should not happen and is likely a bug.'
+                    );
+                }
+
+                const propertyTag1 = propertyTags1.find((tag) => tag.name === BLOCK_PREVIEW_TAG);
+                const propertyTag2 = propertyTags2.find((tag) => tag.name === BLOCK_PREVIEW_TAG);
+
+                if (!propertyTag1 || !propertyTag2) {
+                    throw new Error(
+                        'All properties not having the "sulu.block_preview" tag should have been filtered before.'
+                        + ' This should not happen and is likely a bug.'
+                    );
+                }
+
+                return (propertyTag2.priority || 0) - (propertyTag1.priority || 0);
             });
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -116,6 +116,21 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
                 return (propertyTag2.priority || 0) - (propertyTag1.priority || 0);
             });
 
+        if (previewPropertyNames.length === 0) {
+            for (const fieldTypeKey of blockPreviewTransformerRegistry.blockPreviewTransformerKeysByPriority) {
+                for (const propertyName of Object.keys(blockSchemaTypeForm)) {
+                    if (blockSchemaTypeForm[propertyName].type === fieldTypeKey) {
+                        previewPropertyNames.push(propertyName);
+                        break;
+                    }
+                }
+
+                if (previewPropertyNames.length >= 3) {
+                    break;
+                }
+            }
+        }
+
         return (
             <Fragment>
                 <div className={fieldBlocksStyles.type}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -27,7 +27,11 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
         onFinish();
     };
 
-    renderBlockContent = (value: Object, type: string, index: number) => {
+    renderBlockContent = (value: Object, type: string, index: number, expanded: boolean) => {
+        if (!expanded) {
+            return null;
+        }
+
         const {dataPath, error, formInspector, onFinish, schemaPath, showAllErrors, types} = this.props;
 
         if (!formInspector) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/DateTimeBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/DateTimeBlockPreviewTransformer.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import moment from 'moment';
+import log from 'loglevel';
+import type {BlockPreviewTransformer} from '../types';
+
+const format = 'YYYY-MM-DD';
+
+export default class DateTimeBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *): Node {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        const momentObject = moment(value, format);
+
+        if (!momentObject.isValid()) {
+            log.error('Invalid date given: "' + value + '". Format needs to be "' + format + '"');
+
+            return null;
+        }
+
+        return <p>{momentObject.format('L')}</p>;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
@@ -1,12 +1,13 @@
 // @flow
 import React from 'react';
 import type {Node} from 'react';
+import {isObservableArray} from 'mobx';
 import type {BlockPreviewTransformer} from '../types';
 import type {SchemaEntry} from '../../Form/types';
 
 export default class SelectBlockPreviewTransformer implements BlockPreviewTransformer {
     transform(value: *, schema: SchemaEntry): Node {
-        if (!Array.isArray(value)) {
+        if (!Array.isArray(value) && !isObservableArray(value)) {
             return null;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SelectBlockPreviewTransformer.js
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import type {BlockPreviewTransformer} from '../types';
+import type {SchemaEntry} from '../../Form/types';
+
+export default class SelectBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *, schema: SchemaEntry): Node {
+        if (!Array.isArray(value)) {
+            return null;
+        }
+
+        if (!schema.options || !schema.options.values) {
+            throw new Error('The "Select" field type must have a "values" schema option!');
+        }
+
+        const values = schema.options.values.value;
+        if (!Array.isArray(values)) {
+            throw new Error('The "SingleSelect" field type must have a "values" option defined being an array!');
+        }
+
+        const selectedValues = values.filter((option) => value.includes(option.name));
+
+        if (!selectedValues) {
+            return null;
+        }
+
+        return <p>{selectedValues.map((selectedValue) => selectedValue.title).join(', ')}</p>;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import type {BlockPreviewTransformer} from '../types';
+import type {SchemaEntry} from '../../Form/types';
+
+export default class SingleSelectBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *, schema: SchemaEntry): Node {
+        if (!schema.options || !schema.options.values) {
+            throw new Error('The "SingleSelect" field type must have a "values" schema option!');
+        }
+
+        const values = schema.options.values.value;
+        if (!Array.isArray(values)) {
+            throw new Error('The "SingleSelect" field type must have a "values" option defined being an array!');
+        }
+
+        const selectedValue = values.find((option) => option.name === value);
+
+        if (!selectedValue) {
+            return null;
+        }
+
+        return <p>{selectedValue.title}</p>;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SmartContentBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SmartContentBlockPreviewTransformer.js
@@ -1,0 +1,20 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import type {BlockPreviewTransformer} from '../types';
+import {translate} from '../../../utils/Translator';
+
+export default class SmartContentBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *): Node {
+        return (
+            <p>
+                <em>
+                    {translate(
+                        'sulu_admin.smart_content_block_preview',
+                        {limit: value.limitResult ? value.limitResult : 'undefined'}
+                    )}
+                </em>
+            </p>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StringBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StringBlockPreviewTransformer.js
@@ -1,0 +1,14 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import type {BlockPreviewTransformer} from '../types';
+
+export default class StringBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *): Node {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        return <p>{value}</p>;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.js
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import textVersion from 'textversionjs';
+import type {BlockPreviewTransformer} from '../types';
+
+export default class StripHtmlBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *): Node {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        return (
+            <p>
+                {textVersion(value, {headingStyle: 'linebreak', listStyle: 'linebreak'})}
+            </p>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.js
@@ -4,15 +4,19 @@ import type {Node} from 'react';
 import textVersion from 'textversionjs';
 import type {BlockPreviewTransformer} from '../types';
 
+const MAX_LENGTH = 500;
+
 export default class StripHtmlBlockPreviewTransformer implements BlockPreviewTransformer {
     transform(value: *): Node {
         if (typeof value !== 'string') {
             return null;
         }
 
+        const text = textVersion(value, {headingStyle: 'linebreak', listStyle: 'linebreak'});
+
         return (
             <p>
-                {textVersion(value, {headingStyle: 'linebreak', listStyle: 'linebreak'})}
+                {text.length > MAX_LENGTH ? text.substring(0, MAX_LENGTH) + '...' : text}
             </p>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/TimeBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/TimeBlockPreviewTransformer.js
@@ -1,0 +1,25 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import moment from 'moment';
+import log from 'loglevel';
+import type {BlockPreviewTransformer} from '../types';
+
+const format = 'HH:mm:ss';
+
+export default class TimeBlockPreviewTransformer implements BlockPreviewTransformer {
+    transform(value: *): Node {
+        if (typeof value !== 'string') {
+            return null;
+        }
+        const momentObject = moment(value, format);
+
+        if (!momentObject.isValid()) {
+            log.error('Invalid time given: "' + value + '". Format needs to be "' + format + '"');
+
+            return null;
+        }
+
+        return <p>{momentObject.format('LT')}</p>;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/fieldBlocks.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/fieldBlocks.scss
@@ -1,0 +1,5 @@
+.type {
+    margin-bottom: 10px;
+    text-align: right;
+    font-size: 10px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/index.js
@@ -1,4 +1,19 @@
 // @flow
+import blockPreviewTransformerRegistry from './registries/BlockPreviewTransformerRegistry';
 import FieldBlocks from './FieldBlocks';
+import SelectBlockPreviewTransformer from './blockPreviewTransformers/SelectBlockPreviewTransformer';
+import SingleSelectBlockPreviewTransformer from './blockPreviewTransformers/SingleSelectBlockPreviewTransformer';
+import SmartContentBlockPreviewTransformer from './blockPreviewTransformers/SmartContentBlockPreviewTransformer';
+import StringBlockPreviewTransformer from './blockPreviewTransformers/StringBlockPreviewTransformer';
+import StripHtmlBlockPreviewTransformer from './blockPreviewTransformers/StripHtmlBlockPreviewTransformer';
 
 export default FieldBlocks;
+
+export {
+    blockPreviewTransformerRegistry,
+    SelectBlockPreviewTransformer,
+    SingleSelectBlockPreviewTransformer,
+    SmartContentBlockPreviewTransformer,
+    StringBlockPreviewTransformer,
+    StripHtmlBlockPreviewTransformer,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/index.js
@@ -1,19 +1,23 @@
 // @flow
 import blockPreviewTransformerRegistry from './registries/BlockPreviewTransformerRegistry';
 import FieldBlocks from './FieldBlocks';
+import DateTimeBlockPreviewTransformer from './blockPreviewTransformers/DateTimeBlockPreviewTransformer';
 import SelectBlockPreviewTransformer from './blockPreviewTransformers/SelectBlockPreviewTransformer';
 import SingleSelectBlockPreviewTransformer from './blockPreviewTransformers/SingleSelectBlockPreviewTransformer';
 import SmartContentBlockPreviewTransformer from './blockPreviewTransformers/SmartContentBlockPreviewTransformer';
 import StringBlockPreviewTransformer from './blockPreviewTransformers/StringBlockPreviewTransformer';
 import StripHtmlBlockPreviewTransformer from './blockPreviewTransformers/StripHtmlBlockPreviewTransformer';
+import TimeBlockPreviewTransformer from './blockPreviewTransformers/TimeBlockPreviewTransformer';
 
 export default FieldBlocks;
 
 export {
     blockPreviewTransformerRegistry,
+    DateTimeBlockPreviewTransformer,
     SelectBlockPreviewTransformer,
     SingleSelectBlockPreviewTransformer,
     SmartContentBlockPreviewTransformer,
     StringBlockPreviewTransformer,
     StripHtmlBlockPreviewTransformer,
+    TimeBlockPreviewTransformer,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/registries/BlockPreviewTransformerRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/registries/BlockPreviewTransformerRegistry.js
@@ -1,0 +1,39 @@
+// @flow
+import type {BlockPreviewTransformer} from '../types';
+
+class BlockPreviewTransformerRegistry {
+    blockPreviewTransformers: {[string]: BlockPreviewTransformer};
+
+    constructor() {
+        this.clear();
+    }
+
+    clear() {
+        this.blockPreviewTransformers = {};
+    }
+
+    has(name: string) {
+        return !!this.blockPreviewTransformers[name];
+    }
+
+    add(name: string, blockPreviewTransformer: BlockPreviewTransformer) {
+        if (name in this.blockPreviewTransformers) {
+            throw new Error('The key "' + name + '" has already been used for another BlockPreviewTransformer');
+        }
+
+        this.blockPreviewTransformers[name] = blockPreviewTransformer;
+    }
+
+    get(name: string): BlockPreviewTransformer {
+        if (!(name in this.blockPreviewTransformers)) {
+            throw new Error(
+                'The BlockPreviewTransformer with the key "' + name + '" is not defined. ' +
+                'You probably forgot to add it to the registry using the "add" method.'
+            );
+        }
+
+        return this.blockPreviewTransformers[name];
+    }
+}
+
+export default new BlockPreviewTransformerRegistry();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/registries/BlockPreviewTransformerRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/registries/BlockPreviewTransformerRegistry.js
@@ -1,8 +1,10 @@
 // @flow
-import type {BlockPreviewTransformer} from '../types';
+import {computed, observable} from 'mobx';
+import type {BlockPreviewTransformer, BlockPreviewTransformerMap} from '../types';
 
 class BlockPreviewTransformerRegistry {
-    blockPreviewTransformers: {[string]: BlockPreviewTransformer};
+    @observable blockPreviewTransformers: BlockPreviewTransformerMap;
+    @observable priority: {[string]: number};
 
     constructor() {
         this.clear();
@@ -10,18 +12,20 @@ class BlockPreviewTransformerRegistry {
 
     clear() {
         this.blockPreviewTransformers = {};
+        this.priority = {};
     }
 
     has(name: string) {
         return !!this.blockPreviewTransformers[name];
     }
 
-    add(name: string, blockPreviewTransformer: BlockPreviewTransformer) {
+    add(name: string, blockPreviewTransformer: BlockPreviewTransformer, priority: number = 0) {
         if (name in this.blockPreviewTransformers) {
             throw new Error('The key "' + name + '" has already been used for another BlockPreviewTransformer');
         }
 
         this.blockPreviewTransformers[name] = blockPreviewTransformer;
+        this.priority[name] = priority;
     }
 
     get(name: string): BlockPreviewTransformer {
@@ -33,6 +37,13 @@ class BlockPreviewTransformerRegistry {
         }
 
         return this.blockPreviewTransformers[name];
+    }
+
+    @computed get blockPreviewTransformerKeysByPriority(): Array<string> {
+        return Object.keys(this.priority)
+            .sort((blockPreviewTransformerKey1, blockPreviewTransformerKey2) => {
+                return this.priority[blockPreviewTransformerKey2] - this.priority[blockPreviewTransformerKey1];
+            });
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -131,6 +131,90 @@ test('Render collapsed blocks with block previews', () => {
     expect(fieldBlocks.render()).toMatchSnapshot();
 });
 
+test('Render collapsed blocks with block previews', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text1: {
+                    label: 'Text 1',
+                    tags: [
+                        {name: 'sulu.block_preview', priority: -100},
+                    ],
+                    type: 'text_line',
+                    visible: true,
+                },
+                text2: {
+                    label: 'Text 2',
+                    tags: [
+                        {name: 'sulu.block_preview'},
+                    ],
+                    type: 'text_line',
+                    visible: true,
+                },
+                something: {
+                    label: 'Text 3',
+                    tags: [
+                        {name: 'sulu.block_preview', priority: 100},
+                    ],
+                    type: 'text_line',
+                    visible: true,
+                },
+            },
+        },
+    };
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const value = [
+        {
+            text1: 'Test 1',
+            text2: 'Test 2',
+            something: 'Test 3',
+            type: 'default',
+        },
+        {
+            text1: 'Test 4',
+            text2: 'Test 5',
+            something: 'Test 6',
+            type: 'default',
+        },
+    ];
+
+    blockPreviewTransformerRegistry.has.mockImplementation((key) => {
+        switch (key) {
+            case 'text_line':
+                return true;
+            default:
+                return false;
+        }
+    });
+
+    blockPreviewTransformerRegistry.get.mockImplementation((key) => {
+        switch (key) {
+            case 'text_line':
+                return {
+                    transform: function Transformer(value) {
+                        return <p>{value}</p>;
+                    },
+                };
+        }
+    });
+
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            types={types}
+            value={value}
+        />
+    );
+
+    expect(fieldBlocks.render()).toMatchSnapshot();
+});
+
 test('Render block with schema', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -34,11 +34,14 @@ jest.mock('../../../utils/Translator', () => ({
 jest.mock('../registries/BlockPreviewTransformerRegistry', () => ({
     has: jest.fn(),
     get: jest.fn(),
+    blockPreviewTransformerKeysByPriority: [],
 }));
 
 beforeEach(() => {
     blockPreviewTransformerRegistry.has.mockClear();
     blockPreviewTransformerRegistry.get.mockClear();
+    // $FlowFixMe
+    blockPreviewTransformerRegistry.blockPreviewTransformerKeysByPriority = [];
 });
 
 test('Render collapsed blocks with block previews', () => {
@@ -122,6 +125,116 @@ test('Render collapsed blocks with block previews', () => {
         <FieldBlocks
             {...fieldTypeDefaultProps}
             defaultType="editor"
+            formInspector={formInspector}
+            types={types}
+            value={value}
+        />
+    );
+
+    expect(fieldBlocks.render()).toMatchSnapshot();
+});
+
+test('Render collapsed blocks with block previews without tags', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                nothing: {
+                    label: 'Nothing',
+                    type: 'phone',
+                    visible: true,
+                },
+                text1: {
+                    label: 'Text 1',
+                    type: 'text_line',
+                    visible: true,
+                },
+                text2: {
+                    label: 'Text 2',
+                    type: 'media_selection',
+                    visible: true,
+                },
+                something: {
+                    label: 'Text 3',
+                    type: 'text_editor',
+                    visible: true,
+                },
+            },
+        },
+    };
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const value = [
+        {
+            nothing: 'phone',
+            text1: 'Test 1',
+            text2: 'Test 2',
+            something: 'Test 3',
+            type: 'default',
+        },
+        {
+            nothing: 'phone',
+            text1: 'Test 4',
+            text2: 'Test 5',
+            something: 'Test 6',
+            type: 'default',
+        },
+    ];
+
+    blockPreviewTransformerRegistry.has.mockImplementation((key) => {
+        switch (key) {
+            case 'media_selection':
+            case 'phone':
+            case 'text_line':
+            case 'text_editor':
+                return true;
+            default:
+                return false;
+        }
+    });
+
+    blockPreviewTransformerRegistry.get.mockImplementation((key) => {
+        switch (key) {
+            case 'phone':
+                return {
+                    transform: function Transformer() {
+                        return <p>phone</p>;
+                    },
+                };
+            case 'media_selection':
+                return {
+                    transform: function Transformer() {
+                        return <p>media_selection</p>;
+                    },
+                };
+            case 'text_line':
+                return {
+                    transform: function Transformer() {
+                        return <p>text_line</p>;
+                    },
+                };
+            case 'text_editor':
+                return {
+                    transform: function Transformer() {
+                        return <p>text_editor</p>;
+                    },
+                };
+        }
+    });
+
+    // $FlowFixMe
+    blockPreviewTransformerRegistry.blockPreviewTransformerKeysByPriority = [
+        'media_selection',
+        'text_line',
+        'text_editor',
+    ];
+
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
             formInspector={formInspector}
             types={types}
             value={value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -235,6 +235,7 @@ test('Render collapsed blocks with block previews without tags', () => {
     const fieldBlocks = mount(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="default"
             formInspector={formInspector}
             types={types}
             value={value}
@@ -319,6 +320,7 @@ test('Render collapsed blocks with block previews', () => {
     const fieldBlocks = mount(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="default"
             formInspector={formInspector}
             types={types}
             value={value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -786,3 +786,92 @@ exports[`Render collapsed blocks with block previews 1`] = `
   </button>
 </section>
 `;
+
+exports[`Render collapsed blocks with block previews 2`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article>
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <p>
+            Test 3
+          </p>
+          <p>
+            Test 2
+          </p>
+          <p>
+            Test 1
+          </p>
+        </article>
+      </div>
+    </section>
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article>
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <p>
+            Test 6
+          </p>
+          <p>
+            Test 5
+          </p>
+          <p>
+            Test 4
+          </p>
+        </article>
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -875,3 +875,92 @@ exports[`Render collapsed blocks with block previews 2`] = `
   </button>
 </section>
 `;
+
+exports[`Render collapsed blocks with block previews without tags 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article>
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <p>
+            media_selection
+          </p>
+          <p>
+            text_line
+          </p>
+          <p>
+            text_editor
+          </p>
+        </article>
+      </div>
+    </section>
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article>
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <p>
+            media_selection
+          </p>
+          <p>
+            text_line
+          </p>
+          <p>
+            text_editor
+          </p>
+        </article>
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -1,188 +1,788 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render block with schema 1`] = `
-"<section class=\\"blockCollection\\">
-  <div class=\\"sortableBlockList\\">
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"//0/text1\\">Text 1</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"Test 1\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="//0/text1"
+                >
+                  Text 1
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="Test 1"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"//0/text2\\">Text 2</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"Test 2\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="//0/text2"
+                >
+                  Text 2
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="Test 2"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"//1/text1\\">Text 1</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"Test 3\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="//1/text1"
+                >
+                  Text 1
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="Test 3"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"//1/text2\\">Text 2</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"Test 4\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="//1/text2"
+                >
+                  Text 2
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="Test 4"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-  </div><button class=\\"button secondary\\" type=\\"button\\"><span aria-label=\\"su-plus\\" class=\\"su-plus buttonIcon\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
-</section>"
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
 `;
 
 exports[`Render block with schema and error on fields already being modified 1`] = `
-"<section class=\\"blockCollection\\">
-  <div class=\\"sortableBlockList\\">
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"/block/0/text\\">Text</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"Test1\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="/block/0/text"
+                >
+                  Text
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="Test1"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field error\\"><label class=\\"label\\" for=\\"/block/1/text\\">Text</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input class=\\"minLength\\" type=\\"text\\" value=\\"T2\\"></div>
-                </div><label class=\\"errorLabel\\">sulu_admin.error_minlength</label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field error"
+              >
+                <label
+                  class="label"
+                  for="/block/1/text"
+                >
+                  Text
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      class="minLength"
+                      type="text"
+                      value="T2"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                >
+                  sulu_admin.error_minlength
+                </label>
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"/block/2/text\\">Text</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"T3\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="/block/2/text"
+                >
+                  Text
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="T3"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-  </div><button class=\\"button secondary\\" type=\\"button\\"><span aria-label=\\"su-plus\\" class=\\"su-plus buttonIcon\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
-</section>"
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
 `;
 
 exports[`Render block with schema and error on fields already being modified 2`] = `
-"<section class=\\"blockCollection\\">
-  <div class=\\"sortableBlockList\\">
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field\\"><label class=\\"label\\" for=\\"//0/text\\">Text</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input type=\\"text\\" value=\\"Test1\\"></div>
-                </div><label class=\\"errorLabel\\"></label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field"
+              >
+                <label
+                  class="label"
+                  for="//0/text"
+                >
+                  Text
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      type="text"
+                      value="Test1"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                />
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field error\\"><label class=\\"label\\" for=\\"//1/text\\">Text</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input class=\\"minLength\\" type=\\"text\\" value=\\"T2\\"></div>
-                </div><label class=\\"errorLabel\\">sulu_admin.error_minlength</label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field error"
+              >
+                <label
+                  class="label"
+                  for="//1/text"
+                >
+                  Text
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      class="minLength"
+                      type="text"
+                      value="T2"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                >
+                  sulu_admin.error_minlength
+                </label>
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-    <section class=\\"block expanded\\">
-      <div class=\\"handle\\"><span aria-label=\\"su-more\\" class=\\"su-more sortableHandle\\"></span></div>
-      <div class=\\"content\\">
-        <header class=\\"header\\">
-          <div class=\\"icons\\"><span aria-label=\\"su-trash-alt\\" class=\\"su-trash-alt clickable\\" role=\\"button\\" tabindex=\\"0\\"></span><span aria-label=\\"su-times\\" class=\\"su-times clickable\\" role=\\"button\\" tabindex=\\"0\\"></span></div>
+    <section
+      class="block expanded"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <header
+          class="header"
+        >
+          <div
+            class="icons"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt clickable"
+              role="button"
+              tabindex="0"
+            />
+            <span
+              aria-label="su-times"
+              class="su-times clickable"
+              role="button"
+              tabindex="0"
+            />
+          </div>
         </header>
         <article>
-          <div class=\\"grid grid\\">
-            <div class=\\"item gridItem size size-12 space-before-0 space-after-0\\">
-              <div class=\\"field error\\"><label class=\\"label\\" for=\\"//2/text\\">Text</label>
-                <div class=\\"fieldContainer\\">
-                  <div class=\\"field\\"><input class=\\"minLength\\" type=\\"text\\" value=\\"T3\\"></div>
-                </div><label class=\\"errorLabel\\">sulu_admin.error_minlength</label>
+          <div
+            class="grid grid"
+          >
+            <div
+              class="item gridItem size size-12 space-before-0 space-after-0"
+            >
+              <div
+                class="field error"
+              >
+                <label
+                  class="label"
+                  for="//2/text"
+                >
+                  Text
+                </label>
+                <div
+                  class="fieldContainer"
+                >
+                  <div
+                    class="field"
+                  >
+                    <input
+                      class="minLength"
+                      type="text"
+                      value="T3"
+                    />
+                  </div>
+                </div>
+                <label
+                  class="errorLabel"
+                >
+                  sulu_admin.error_minlength
+                </label>
               </div>
             </div>
           </div>
         </article>
       </div>
     </section>
-  </div><button class=\\"button secondary\\" type=\\"button\\"><span aria-label=\\"su-plus\\" class=\\"su-plus buttonIcon\\"></span><span class=\\"text\\">sulu_admin.add_block</span></button>
-</section>"
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
+`;
+
+exports[`Render collapsed blocks with block previews 1`] = `
+<section
+  class="blockCollection"
+>
+  <div
+    class="sortableBlockList"
+  >
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article>
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <p>
+            Test 1
+          </p>
+        </article>
+      </div>
+    </section>
+    <section
+      class="block"
+    >
+      <div
+        class="handle"
+      >
+        <span
+          aria-label="su-more"
+          class="su-more sortableHandle"
+        />
+      </div>
+      <div
+        class="content"
+      >
+        <article>
+          <div
+            class="type"
+          >
+            Default
+          </div>
+          <p>
+            Test 4
+          </p>
+        </article>
+      </div>
+    </section>
+  </div>
+  <button
+    class="button secondary"
+    type="button"
+  >
+    <span
+      aria-label="su-plus"
+      class="su-plus buttonIcon"
+    />
+    <span
+      class="text"
+    >
+      sulu_admin.add_block
+    </span>
+  </button>
+</section>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/DateTimeBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/DateTimeBlockPreviewTransformer.test.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react';
+import log from 'loglevel';
+import moment from 'moment-timezone';
+import DateTimeBlockPreviewTransformer from '../../blockPreviewTransformers/DateTimeBlockPreviewTransformer';
+
+beforeEach(() => {
+    moment.tz.setDefault('Europe/Vienna');
+});
+
+const dateTimeBlockPreviewTransformer = new DateTimeBlockPreviewTransformer();
+
+jest.mock('loglevel', () => ({
+    error: jest.fn(),
+}));
+
+test('Test undefined', () => {
+    expect(dateTimeBlockPreviewTransformer.transform(undefined)).toBe(null);
+});
+
+test('Test invalid format', () => {
+    expect(dateTimeBlockPreviewTransformer.transform('xxx')).toBe(null);
+    expect(log.error).toBeCalledWith('Invalid date given: "xxx". Format needs to be "YYYY-MM-DD"');
+});
+
+test('Test valid example', () => {
+    expect(dateTimeBlockPreviewTransformer.transform('2018-03-10T14:09:04+01:00')).toEqual(<p>03/10/2018</p>);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SelectBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SelectBlockPreviewTransformer.test.js
@@ -1,0 +1,84 @@
+// @flow
+import SelectBlockPreviewTransformer from '../../blockPreviewTransformers/SelectBlockPreviewTransformer';
+
+test('Return JSX for multiple selected items', () => {
+    const selectBlockPreviewTransformer = new SelectBlockPreviewTransformer();
+    expect(
+        selectBlockPreviewTransformer.transform(
+            ['value1', 'value3'],
+            {
+                options: {
+                    values: {
+                        value: [
+                            {
+                                name: 'value1',
+                                title: 'Value 1',
+                            },
+                            {
+                                name: 'value2',
+                                title: 'Value 2',
+                            },
+                            {
+                                name: 'value3',
+                                title: 'Value 3',
+                            },
+                        ],
+                    },
+                },
+                type: 'single_select',
+            }
+        )
+    ).toMatchSnapshot();
+});
+
+test('Return null if no array is passed', () => {
+    const selectBlockPreviewTransformer = new SelectBlockPreviewTransformer();
+    expect(
+        selectBlockPreviewTransformer.transform(
+            undefined,
+            {
+                options: {
+                    values: {
+                        value: [
+                            {
+                                name: 'value1',
+                                title: 'Value 1',
+                            },
+                            {
+                                name: 'value2',
+                                title: 'Value 2',
+                            },
+                            {
+                                name: 'value3',
+                                title: 'Value 3',
+                            },
+                        ],
+                    },
+                },
+                type: 'single_select',
+            }
+        )
+    ).toMatchSnapshot();
+});
+
+test('Throw an error if schema has no values schema option', () => {
+    const selectBlockPreviewTransformer = new SelectBlockPreviewTransformer();
+    expect(
+        () => selectBlockPreviewTransformer.transform(['value1', 'value3'], {type: 'single_select'})
+    ).toThrow(/"values" schema option/);
+});
+
+test('Throw an error if values schema option is not an array', () => {
+    const selectBlockPreviewTransformer = new SelectBlockPreviewTransformer();
+    expect(
+        () => selectBlockPreviewTransformer.transform(
+            ['value1', 'value3'],
+            {
+                options: {
+                    values: {},
+                },
+                type: 'single_select',
+            }
+        )
+    ).toThrow(/"values" option defined being an array/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SelectBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SelectBlockPreviewTransformer.test.js
@@ -1,11 +1,12 @@
 // @flow
+import {observable} from 'mobx';
 import SelectBlockPreviewTransformer from '../../blockPreviewTransformers/SelectBlockPreviewTransformer';
 
 test('Return JSX for multiple selected items', () => {
     const selectBlockPreviewTransformer = new SelectBlockPreviewTransformer();
     expect(
         selectBlockPreviewTransformer.transform(
-            ['value1', 'value3'],
+            observable(['value1', 'value3']),
             {
                 options: {
                     values: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleSelectBlockPreviewTransformer.test.js
@@ -1,0 +1,84 @@
+// @flow
+import SingleSelectBlockPreviewTransformer from '../../blockPreviewTransformers/SingleSelectBlockPreviewTransformer';
+
+test('Return JSX for selected item', () => {
+    const singleSelectBlockPreviewTransformer = new SingleSelectBlockPreviewTransformer();
+    expect(
+        singleSelectBlockPreviewTransformer.transform(
+            'value1',
+            {
+                options: {
+                    values: {
+                        value: [
+                            {
+                                name: 'value1',
+                                title: 'Value 1',
+                            },
+                            {
+                                name: 'value2',
+                                title: 'Value 2',
+                            },
+                            {
+                                name: 'value3',
+                                title: 'Value 3',
+                            },
+                        ],
+                    },
+                },
+                type: 'single_select',
+            }
+        )
+    ).toMatchSnapshot();
+});
+
+test('Return null if nothing is passed', () => {
+    const singleSelectBlockPreviewTransformer = new SingleSelectBlockPreviewTransformer();
+    expect(
+        singleSelectBlockPreviewTransformer.transform(
+            undefined,
+            {
+                options: {
+                    values: {
+                        value: [
+                            {
+                                name: 'value1',
+                                title: 'Value 1',
+                            },
+                            {
+                                name: 'value2',
+                                title: 'Value 2',
+                            },
+                            {
+                                name: 'value3',
+                                title: 'Value 3',
+                            },
+                        ],
+                    },
+                },
+                type: 'single_select',
+            }
+        )
+    ).toMatchSnapshot();
+});
+
+test('Throw an error if schema has no values schema option', () => {
+    const singleSelectBlockPreviewTransformer = new SingleSelectBlockPreviewTransformer();
+    expect(
+        () => singleSelectBlockPreviewTransformer.transform('value1', {type: 'single_select'})
+    ).toThrow(/"values" schema option/);
+});
+
+test('Throw an error if values schema option is not an array', () => {
+    const singleSelectBlockPreviewTransformer = new SingleSelectBlockPreviewTransformer();
+    expect(
+        () => singleSelectBlockPreviewTransformer.transform(
+            'value3',
+            {
+                options: {
+                    values: {},
+                },
+                type: 'single_select',
+            }
+        )
+    ).toThrow(/"values" option defined being an array/);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SmartContentBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SmartContentBlockPreviewTransformer.test.js
@@ -1,0 +1,19 @@
+// @flow
+import SmartContentBlockPreviewTransformer from '../../blockPreviewTransformers/SmartContentBlockPreviewTransformer';
+import {translate} from '../../../../utils/Translator';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Return JSX for configuration with a limit of 5', () => {
+    const smartContentBlockPreviewTransformer = new SmartContentBlockPreviewTransformer();
+    expect(smartContentBlockPreviewTransformer.transform({limitResult: 5})).toMatchSnapshot();
+    expect(translate).toBeCalledWith('sulu_admin.smart_content_block_preview', {limit: 5});
+});
+
+test('Return null for everything expect a string', () => {
+    const smartContentBlockPreviewTransformer = new SmartContentBlockPreviewTransformer();
+    expect(smartContentBlockPreviewTransformer.transform({})).toMatchSnapshot();
+    expect(translate).toBeCalledWith('sulu_admin.smart_content_block_preview', {limit: 'undefined'});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/StringBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/StringBlockPreviewTransformer.test.js
@@ -1,0 +1,12 @@
+// @flow
+import StringBlockPreviewTransformer from '../../blockPreviewTransformers/StringBlockPreviewTransformer';
+
+test('Return JSX for simple string', () => {
+    const stringBlockPreviewTransformer = new StringBlockPreviewTransformer();
+    expect(stringBlockPreviewTransformer.transform('Test')).toMatchSnapshot();
+});
+
+test('Return null for everything expect a string', () => {
+    const stringBlockPreviewTransformer = new StringBlockPreviewTransformer();
+    expect(stringBlockPreviewTransformer.transform({})).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.test.js
@@ -6,6 +6,11 @@ test('Return JSX for simple string', () => {
     expect(stripHtmlBlockPreviewTransformer.transform('<strong>Test</strong>')).toMatchSnapshot();
 });
 
+test('Return JSX for simple string', () => {
+    const stripHtmlBlockPreviewTransformer = new StripHtmlBlockPreviewTransformer();
+    expect(stripHtmlBlockPreviewTransformer.transform('<strong>' + 'c'.repeat(1000) + '</strong>')).toMatchSnapshot();
+});
+
 test('Return null for everything expect a string', () => {
     const stripHtmlBlockPreviewTransformer = new StripHtmlBlockPreviewTransformer();
     expect(stripHtmlBlockPreviewTransformer.transform({})).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/StripHtmlBlockPreviewTransformer.test.js
@@ -1,0 +1,12 @@
+// @flow
+import StripHtmlBlockPreviewTransformer from '../../blockPreviewTransformers/StripHtmlBlockPreviewTransformer';
+
+test('Return JSX for simple string', () => {
+    const stripHtmlBlockPreviewTransformer = new StripHtmlBlockPreviewTransformer();
+    expect(stripHtmlBlockPreviewTransformer.transform('<strong>Test</strong>')).toMatchSnapshot();
+});
+
+test('Return null for everything expect a string', () => {
+    const stripHtmlBlockPreviewTransformer = new StripHtmlBlockPreviewTransformer();
+    expect(stripHtmlBlockPreviewTransformer.transform({})).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/TimeBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/TimeBlockPreviewTransformer.test.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react';
+import log from 'loglevel';
+import moment from 'moment-timezone';
+import TimeBlockPreviewTransformer from '../../blockPreviewTransformers/TimeBlockPreviewTransformer';
+
+beforeEach(() => {
+    moment.tz.setDefault('Europe/Vienna');
+});
+
+const timeBlockPreviewTransformer = new TimeBlockPreviewTransformer();
+
+jest.mock('loglevel', () => ({
+    error: jest.fn(),
+}));
+
+test('Test undefined', () => {
+    expect(timeBlockPreviewTransformer.transform(undefined)).toBe(null);
+});
+
+test('Test invalid format', () => {
+    expect(timeBlockPreviewTransformer.transform('xxx')).toBe(null);
+    expect(log.error).toBeCalledWith('Invalid time given: "xxx". Format needs to be "HH:mm:ss"');
+});
+
+test('Test valid example', () => {
+    expect(timeBlockPreviewTransformer.transform('14:09:04')).toEqual(<p>2:09 PM</p>);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SelectBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SelectBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Return JSX for multiple selected items 1`] = `
+<p>
+  Value 1, Value 3
+</p>
+`;
+
+exports[`Return null if no array is passed 1`] = `null`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleSelectBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleSelectBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Return JSX for selected item 1`] = `
+<p>
+  Value 1
+</p>
+`;
+
+exports[`Return null if nothing is passed 1`] = `null`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SmartContentBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SmartContentBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Return JSX for configuration with a limit of 5 1`] = `
+<p>
+  <em>
+    sulu_admin.smart_content_block_preview
+  </em>
+</p>
+`;
+
+exports[`Return null for everything expect a string 1`] = `
+<p>
+  <em>
+    sulu_admin.smart_content_block_preview
+  </em>
+</p>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/StringBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/StringBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Return JSX for simple string 1`] = `
+<p>
+  Test
+</p>
+`;
+
+exports[`Return null for everything expect a string 1`] = `null`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/StripHtmlBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/StripHtmlBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Return JSX for simple string 1`] = `
+<p>
+  Test
+
+</p>
+`;
+
+exports[`Return null for everything expect a string 1`] = `null`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/StripHtmlBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/StripHtmlBlockPreviewTransformer.test.js.snap
@@ -7,4 +7,10 @@ exports[`Return JSX for simple string 1`] = `
 </p>
 `;
 
+exports[`Return JSX for simple string 2`] = `
+<p>
+  cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc...
+</p>
+`;
+
 exports[`Return null for everything expect a string 1`] = `null`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/registries/BlockPreviewTransformerRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/registries/BlockPreviewTransformerRegistry.test.js
@@ -1,0 +1,65 @@
+// @flow
+import blockPreviewTransformerRegistry from '../../registries/BlockPreviewTransformerRegistry';
+
+beforeEach(() => {
+    blockPreviewTransformerRegistry.clear();
+});
+
+test('Clear all transformers', () => {
+    const Test1 = class Test1 {
+        transform(value: *): * {
+            return value;
+        }
+    };
+    blockPreviewTransformerRegistry.add('test1', new Test1());
+    expect(Object.keys(blockPreviewTransformerRegistry.blockPreviewTransformers)).toHaveLength(1);
+
+    blockPreviewTransformerRegistry.clear();
+    expect(Object.keys(blockPreviewTransformerRegistry.blockPreviewTransformers)).toHaveLength(0);
+});
+
+test('Add transformer', () => {
+    const Test1 = class Test1 {
+        transform(value: *): * {
+            return value;
+        }
+    };
+    const Test2 = class Test1 {
+        transform(value: *): * {
+            return value;
+        }
+    };
+    blockPreviewTransformerRegistry.add('test1', new Test1());
+    blockPreviewTransformerRegistry.add('test2', new Test2());
+
+    expect(blockPreviewTransformerRegistry.get('test1')).toBeInstanceOf(Test1);
+    expect(blockPreviewTransformerRegistry.get('test2')).toBeInstanceOf(Test2);
+});
+
+test('Add transformer with existing key should throw', () => {
+    const Test1 = class Test1 {
+        transform(value: *): * {
+            return value;
+        }
+    };
+    blockPreviewTransformerRegistry.add('test1', new Test1());
+    expect(() => blockPreviewTransformerRegistry.add('test1', new Test1())).toThrow(/test1/);
+});
+
+test('Get transformer of not existing key', () => {
+    expect(() => blockPreviewTransformerRegistry.get('XXX')).toThrow();
+});
+
+test('Has a transformer with an existing key', () => {
+    const Test1 = class Test1 {
+        transform(value: *): * {
+            return value;
+        }
+    };
+    blockPreviewTransformerRegistry.add('test1', new Test1());
+    expect(blockPreviewTransformerRegistry.has('test1')).toEqual(true);
+});
+
+test('Has a transformer with not existing key', () => {
+    expect(blockPreviewTransformerRegistry.has('test')).toEqual(false);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/registries/BlockPreviewTransformerRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/registries/BlockPreviewTransformerRegistry.test.js
@@ -19,16 +19,16 @@ test('Clear all transformers', () => {
 });
 
 test('Add transformer', () => {
-    const Test1 = class Test1 {
+    class Test1 {
         transform(value: *): * {
             return value;
         }
-    };
-    const Test2 = class Test1 {
+    }
+    class Test2 {
         transform(value: *): * {
             return value;
         }
-    };
+    }
     blockPreviewTransformerRegistry.add('test1', new Test1());
     blockPreviewTransformerRegistry.add('test2', new Test2());
 
@@ -36,12 +36,28 @@ test('Add transformer', () => {
     expect(blockPreviewTransformerRegistry.get('test2')).toBeInstanceOf(Test2);
 });
 
-test('Add transformer with existing key should throw', () => {
-    const Test1 = class Test1 {
+test('Get transformer keys sorted by priority', () => {
+    class Test {
         transform(value: *): * {
             return value;
         }
-    };
+    }
+
+    blockPreviewTransformerRegistry.add('test1', new Test(), 10);
+    blockPreviewTransformerRegistry.add('test2', new Test(), 15);
+    blockPreviewTransformerRegistry.add('test3', new Test(), -10);
+    blockPreviewTransformerRegistry.add('test4', new Test());
+
+    expect(blockPreviewTransformerRegistry.blockPreviewTransformerKeysByPriority)
+        .toEqual(['test2', 'test1', 'test4', 'test3']);
+});
+
+test('Add transformer with existing key should throw', () => {
+    class Test1 {
+        transform(value: *): * {
+            return value;
+        }
+    }
     blockPreviewTransformerRegistry.add('test1', new Test1());
     expect(() => blockPreviewTransformerRegistry.add('test1', new Test1())).toThrow(/test1/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/types.js
@@ -1,0 +1,7 @@
+// @flow
+import type {Node} from 'react';
+import type {SchemaEntry} from '../Form/types';
+
+export interface BlockPreviewTransformer {
+    transform(value: *, schema: SchemaEntry): Node,
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/types.js
@@ -2,6 +2,8 @@
 import type {Node} from 'react';
 import type {SchemaEntry} from '../Form/types';
 
+export type BlockPreviewTransformerMap = {[string]: BlockPreviewTransformer};
+
 export interface BlockPreviewTransformer {
     transform(value: *, schema: SchemaEntry): Node,
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/registries/FieldRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/registries/FieldRegistry.js
@@ -1,6 +1,6 @@
 // @flow
 import type {ComponentType} from 'react';
-import type {FieldTypeProps} from '../../../types';
+import type {FieldTypeProps} from '../types';
 
 class FieldRegistry {
     fields: {[string]: ComponentType<FieldTypeProps<*>>};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -165,7 +165,7 @@ export default class AbstractFormStore
     pathsByTag: {[tagName: string]: Array<string>} = {};
 
     @computed.struct get schema(): Schema {
-        return this.evaluatedSchema;
+        return toJS(this.evaluatedSchema);
     }
 
     isFieldModified(dataPath: string): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -37,6 +37,7 @@ jest.mock('../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
     this.isFieldModified = jest.fn();
     this.copyFromLocale = jest.fn();
     this.getValueByPath = jest.fn();
+    this.getSchemaEntryByPath = jest.fn().mockReturnValue({types: {default: {form: {}}}});
 }));
 
 jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions = {}) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {observable, observable as mockObservable, toJS, when} from 'mobx';
+import {isObservable, observable, observable as mockObservable, toJS, when} from 'mobx';
 import ResourceFormStore from '../../stores/ResourceFormStore';
 import ResourceStore from '../../../../stores/ResourceStore';
 import metadataStore from '../../stores/MetadataStore';
@@ -120,6 +120,7 @@ test('Evaluate all disabledConditions and visibleConditions for schema', () => {
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
 
     setTimeout(() => {
+        expect(isObservable(resourceFormStore.schema)).toBe(false);
         const sectionItems1 = resourceFormStore.schema.section.items;
         if (!sectionItems1) {
             throw new Error('Section items should be defined!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
@@ -8,6 +8,7 @@ import Datagrid, {
     PaginatedLoadingStrategy,
 } from './Datagrid';
 import type {DatagridAdapterProps, LoadingStrategyInterface, StructureStrategyInterface} from './Datagrid';
+import {blockPreviewTransformerRegistry} from './FieldBlocks';
 import {textEditorRegistry} from './TextEditor';
 import {viewRegistry} from './ViewRenderer';
 import Sidebar, {sidebarStore, sidebarRegistry} from './Sidebar';
@@ -29,6 +30,7 @@ export type {
 
 export {
     AbstractAdapter,
+    blockPreviewTransformerRegistry,
     CardCollection,
     Datagrid,
     DatagridStore,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -35,11 +35,13 @@ import {
 } from './containers/Datagrid';
 import FieldBlocks, {
     blockPreviewTransformerRegistry,
+    DateTimeBlockPreviewTransformer,
     SelectBlockPreviewTransformer,
     SingleSelectBlockPreviewTransformer,
     SmartContentBlockPreviewTransformer,
     StringBlockPreviewTransformer,
     StripHtmlBlockPreviewTransformer,
+    TimeBlockPreviewTransformer,
 } from './containers/FieldBlocks';
 import {
     Checkbox,
@@ -87,16 +89,24 @@ Requester.handleResponseHooks.push(logoutOnUnauthorizedResponse);
 
 jexl.addTransform('values', (value: Array<*>) => Object.values(value));
 
+const FIELD_TYPE_BLOCK = 'block';
+const FIELD_TYPE_CHANGELOG_LINE = 'changelog_line';
+const FIELD_TYPE_CHECKBOX = 'checkbox';
 const FIELD_TYPE_COLOR = 'color';
+const FIELD_TYPE_DATE = 'date';
+const FIELD_TYPE_DATE_TIME = 'datetime';
 const FIELD_TYPE_EMAIL = 'email';
 const FIELD_TYPE_NUMBER = 'number';
+const FIELD_TYPE_PASSWORD_CONFIRMATION = 'password_confirmation';
 const FIELD_TYPE_PHONE = 'phone';
+const FIELD_TYPE_RESOURCE_LOCATOR = 'resource_locator';
 const FIELD_TYPE_SELECT = 'select';
 const FIELD_TYPE_SINGLE_SELECT = 'single_select';
 const FIELD_TYPE_SMART_CONTENT = 'smart_content';
 const FIELD_TYPE_TEXT_AREA = 'text_area';
 const FIELD_TYPE_TEXT_EDITOR = 'text_editor';
 const FIELD_TYPE_TEXT_LINE = 'text_line';
+const FIELD_TYPE_TIME = 'time';
 const FIELD_TYPE_URL = 'url';
 
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
@@ -146,24 +156,24 @@ function registerDatagridFieldTransformers() {
 }
 
 function registerFieldTypes(fieldTypeOptions) {
-    fieldRegistry.add('block', FieldBlocks);
-    fieldRegistry.add('changelog_line', ChangelogLine);
-    fieldRegistry.add('checkbox', Checkbox);
+    fieldRegistry.add(FIELD_TYPE_BLOCK, FieldBlocks);
+    fieldRegistry.add(FIELD_TYPE_CHANGELOG_LINE, ChangelogLine);
+    fieldRegistry.add(FIELD_TYPE_CHECKBOX, Checkbox);
     fieldRegistry.add(FIELD_TYPE_COLOR, ColorPicker);
-    fieldRegistry.add('date', DatePicker, {dateFormat: true, timeFormat: false});
-    fieldRegistry.add('datetime', DatePicker, {dateFormat: true, timeFormat: true});
+    fieldRegistry.add(FIELD_TYPE_DATE, DatePicker, {dateFormat: true, timeFormat: false});
+    fieldRegistry.add(FIELD_TYPE_DATE_TIME, DatePicker, {dateFormat: true, timeFormat: true});
     fieldRegistry.add(FIELD_TYPE_EMAIL, Email);
     fieldRegistry.add(FIELD_TYPE_SELECT, Select);
     fieldRegistry.add(FIELD_TYPE_NUMBER, Number);
-    fieldRegistry.add('password_confirmation', PasswordConfirmation);
+    fieldRegistry.add(FIELD_TYPE_PASSWORD_CONFIRMATION, PasswordConfirmation);
     fieldRegistry.add(FIELD_TYPE_PHONE, Phone);
-    fieldRegistry.add('resource_locator', ResourceLocator, {generationUrl: Config.endpoints.generateUrl});
+    fieldRegistry.add(FIELD_TYPE_RESOURCE_LOCATOR, ResourceLocator, {generationUrl: Config.endpoints.generateUrl});
     fieldRegistry.add(FIELD_TYPE_SMART_CONTENT, SmartContent);
     fieldRegistry.add(FIELD_TYPE_SINGLE_SELECT, SingleSelect);
     fieldRegistry.add(FIELD_TYPE_TEXT_AREA, TextArea);
     fieldRegistry.add(FIELD_TYPE_TEXT_EDITOR, TextEditor);
     fieldRegistry.add(FIELD_TYPE_TEXT_LINE, Input);
-    fieldRegistry.add('time', DatePicker, {dateFormat: false, timeFormat: true});
+    fieldRegistry.add(FIELD_TYPE_TIME, DatePicker, {dateFormat: false, timeFormat: true});
     fieldRegistry.add(FIELD_TYPE_URL, Url);
 
     registerFieldTypesWithOptions(fieldTypeOptions['selection'], Selection);
@@ -180,6 +190,8 @@ function registerFieldTypesWithOptions(fieldTypeOptions, Component) {
 
 function registerBlockPreviewTransformers() {
     blockPreviewTransformerRegistry.add(FIELD_TYPE_COLOR, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_DATE, new DateTimeBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_DATE_TIME, new DateTimeBlockPreviewTransformer());
     blockPreviewTransformerRegistry.add(FIELD_TYPE_EMAIL, new StringBlockPreviewTransformer());
     blockPreviewTransformerRegistry.add(FIELD_TYPE_NUMBER, new StringBlockPreviewTransformer());
     blockPreviewTransformerRegistry.add(FIELD_TYPE_PHONE, new StringBlockPreviewTransformer());
@@ -189,6 +201,7 @@ function registerBlockPreviewTransformers() {
     blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_AREA, new StringBlockPreviewTransformer(), 512);
     blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_EDITOR, new StripHtmlBlockPreviewTransformer(), 512);
     blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_LINE, new StringBlockPreviewTransformer(), 1024);
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TIME, new TimeBlockPreviewTransformer());
     blockPreviewTransformerRegistry.add(FIELD_TYPE_URL, new StringBlockPreviewTransformer());
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -87,6 +87,18 @@ Requester.handleResponseHooks.push(logoutOnUnauthorizedResponse);
 
 jexl.addTransform('values', (value: Array<*>) => Object.values(value));
 
+const FIELD_TYPE_COLOR = 'color';
+const FIELD_TYPE_EMAIL = 'email';
+const FIELD_TYPE_NUMBER = 'number';
+const FIELD_TYPE_PHONE = 'phone';
+const FIELD_TYPE_SELECT = 'select';
+const FIELD_TYPE_SINGLE_SELECT = 'single_select';
+const FIELD_TYPE_SMART_CONTENT = 'smart_content';
+const FIELD_TYPE_TEXT_AREA = 'text_area';
+const FIELD_TYPE_TEXT_EDITOR = 'text_editor';
+const FIELD_TYPE_TEXT_LINE = 'text_line';
+const FIELD_TYPE_URL = 'url';
+
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
     if (!initialized) {
         registerBlockPreviewTransformers();
@@ -137,22 +149,22 @@ function registerFieldTypes(fieldTypeOptions) {
     fieldRegistry.add('block', FieldBlocks);
     fieldRegistry.add('changelog_line', ChangelogLine);
     fieldRegistry.add('checkbox', Checkbox);
-    fieldRegistry.add('color', ColorPicker);
+    fieldRegistry.add(FIELD_TYPE_COLOR, ColorPicker);
     fieldRegistry.add('date', DatePicker, {dateFormat: true, timeFormat: false});
     fieldRegistry.add('datetime', DatePicker, {dateFormat: true, timeFormat: true});
-    fieldRegistry.add('email', Email);
-    fieldRegistry.add('select', Select);
-    fieldRegistry.add('number', Number);
+    fieldRegistry.add(FIELD_TYPE_EMAIL, Email);
+    fieldRegistry.add(FIELD_TYPE_SELECT, Select);
+    fieldRegistry.add(FIELD_TYPE_NUMBER, Number);
     fieldRegistry.add('password_confirmation', PasswordConfirmation);
-    fieldRegistry.add('phone', Phone);
+    fieldRegistry.add(FIELD_TYPE_PHONE, Phone);
     fieldRegistry.add('resource_locator', ResourceLocator, {generationUrl: Config.endpoints.generateUrl});
-    fieldRegistry.add('smart_content', SmartContent);
-    fieldRegistry.add('single_select', SingleSelect);
-    fieldRegistry.add('text_line', Input);
-    fieldRegistry.add('text_area', TextArea);
-    fieldRegistry.add('text_editor', TextEditor);
+    fieldRegistry.add(FIELD_TYPE_SMART_CONTENT, SmartContent);
+    fieldRegistry.add(FIELD_TYPE_SINGLE_SELECT, SingleSelect);
+    fieldRegistry.add(FIELD_TYPE_TEXT_AREA, TextArea);
+    fieldRegistry.add(FIELD_TYPE_TEXT_EDITOR, TextEditor);
+    fieldRegistry.add(FIELD_TYPE_TEXT_LINE, Input);
     fieldRegistry.add('time', DatePicker, {dateFormat: false, timeFormat: true});
-    fieldRegistry.add('url', Url);
+    fieldRegistry.add(FIELD_TYPE_URL, Url);
 
     registerFieldTypesWithOptions(fieldTypeOptions['selection'], Selection);
     registerFieldTypesWithOptions(fieldTypeOptions['single_selection'], SingleSelection);
@@ -167,16 +179,17 @@ function registerFieldTypesWithOptions(fieldTypeOptions, Component) {
 }
 
 function registerBlockPreviewTransformers() {
-    blockPreviewTransformerRegistry.add('color', new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('email', new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('number', new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('phone', new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('text_area', new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('text_editor', new StripHtmlBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('text_line', new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('select', new SelectBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('single_select', new SingleSelectBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add('smart_content', new SmartContentBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_COLOR, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_EMAIL, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_NUMBER, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_PHONE, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_SELECT, new SelectBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_SINGLE_SELECT, new SingleSelectBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_SMART_CONTENT, new SmartContentBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_AREA, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_EDITOR, new StripHtmlBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_LINE, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_URL, new StringBlockPreviewTransformer());
 }
 
 function registerTextEditors() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -33,7 +33,14 @@ import {
     TimeFieldTransformer,
     TreeTableAdapter,
 } from './containers/Datagrid';
-import FieldBlocks from './containers/FieldBlocks';
+import FieldBlocks, {
+    blockPreviewTransformerRegistry,
+    SelectBlockPreviewTransformer,
+    SingleSelectBlockPreviewTransformer,
+    SmartContentBlockPreviewTransformer,
+    StringBlockPreviewTransformer,
+    StripHtmlBlockPreviewTransformer,
+} from './containers/FieldBlocks';
 import {
     Checkbox,
     ColorPicker,
@@ -82,12 +89,13 @@ jexl.addTransform('values', (value: Array<*>) => Object.values(value));
 
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
     if (!initialized) {
-        registerViews();
+        registerBlockPreviewTransformers();
         registerDatagridAdapters();
         registerDatagridFieldTransformers();
         registerFieldTypes(config.fieldTypeOptions);
         registerTextEditors();
         registerToolbarActions();
+        registerViews();
     }
 
     processConfig(config);
@@ -156,6 +164,19 @@ function registerFieldTypesWithOptions(fieldTypeOptions, Component) {
             fieldRegistry.add(fieldTypeKey, Component, fieldTypeOptions[fieldTypeKey]);
         }
     }
+}
+
+function registerBlockPreviewTransformers() {
+    blockPreviewTransformerRegistry.add('color', new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('email', new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('number', new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('phone', new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('text_area', new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('text_editor', new StripHtmlBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('text_line', new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('select', new SelectBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('single_select', new SingleSelectBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add('smart_content', new SmartContentBlockPreviewTransformer());
 }
 
 function registerTextEditors() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -186,9 +186,9 @@ function registerBlockPreviewTransformers() {
     blockPreviewTransformerRegistry.add(FIELD_TYPE_SELECT, new SelectBlockPreviewTransformer());
     blockPreviewTransformerRegistry.add(FIELD_TYPE_SINGLE_SELECT, new SingleSelectBlockPreviewTransformer());
     blockPreviewTransformerRegistry.add(FIELD_TYPE_SMART_CONTENT, new SmartContentBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_AREA, new StringBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_EDITOR, new StripHtmlBlockPreviewTransformer());
-    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_LINE, new StringBlockPreviewTransformer());
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_AREA, new StringBlockPreviewTransformer(), 512);
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_EDITOR, new StripHtmlBlockPreviewTransformer(), 512);
+    blockPreviewTransformerRegistry.add(FIELD_TYPE_TEXT_LINE, new StringBlockPreviewTransformer(), 1024);
     blockPreviewTransformerRegistry.add(FIELD_TYPE_URL, new StringBlockPreviewTransformer());
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -37,6 +37,7 @@
         "react-portal": "^4.1.0",
         "react-sortable-hoc": "^0.6.7",
         "resize-observer-polyfill": "^1.5.0",
+        "textversionjs": "^1.1.3",
         "url-search-params-polyfill": "^2.0.0",
         "whatwg-fetch": "^2.0.3"
     },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -1,8 +1,10 @@
 // @flow
 import type {FieldTypeProps} from './containers/Form/types';
+import type {BlockPreviewTransformer} from './containers/FieldBlocks/types';
 import type {ToolbarItemConfig} from './containers/Toolbar/types';
 
 export type {
+    BlockPreviewTransformer,
     FieldTypeProps,
     ToolbarItemConfig,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -82,6 +82,7 @@
     "sulu_admin.present_as": "Darstellen als",
     "sulu_admin.limit_result_to": "Ergebnis limitieren auf",
     "sulu_admin.smart_content_label": "{count} {count, plural, =1 {Element} other {Elemente}} ausgewählt",
+    "sulu_admin.smart_content_block_preview": "Smart Content {limit, select, undefined{} other{mit bis zu {limit} Elementen}}",
     "sulu_admin.order_warning_title": "Elemente neu anordnen",
     "sulu_admin.order_warning_text": "Sie sind dabei ein Element neu anzuordnen.",
     "sulu_admin.activate_all": "Alle aktivieren",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -82,6 +82,7 @@
     "sulu_admin.present_as": "Present as",
     "sulu_admin.limit_result_to": "Limit result to",
     "sulu_admin.smart_content_label": "{count} {count, plural, =1 {element} other {elements}} selected",
+    "sulu_admin.smart_content_block_preview": "Smart Content {limit, select, undefined{} other{displaying up to {limit} elements}}",
     "sulu_admin.order_warning_title": "Rearrange items",
     "sulu_admin.order_warning_text": "The operation you are about to do will rearrange items.",
     "sulu_admin.activate_all": "Activate all",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -258,6 +258,7 @@ class AdminControllerTest extends TestCase
         $this->urlGenerator->generate('sulu_preview.stop')->willReturn('/preview/stop');
         $this->urlGenerator->generate('cget_contexts')->willReturn('/security/contexts');
         $this->urlGenerator->generate('sulu_website.cache.remove')->willReturn('/admin/website/cache');
+        $this->urlGenerator->generate('sulu_media.redirect', ['id' => ':id'])->willReturn('/media/redirect');
 
         $this->resourceMetadataPool->getAllResourceMetadata('en')->willReturn(
             [$resourceMetadata1->reveal(), $resourceMetadata2->reveal()]

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
@@ -9,6 +9,9 @@ sulu_contact_api:
 
 # The following route are necessary to get AdminController::configAction work.
 # Can be removed once its content is not hardcoded anymore.
+sulu_media:
+    resource: "@SuluMediaBundle/Resources/config/routing.yml"
+    prefix:
 
 sulu_snippet_api:
     resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
@@ -1,0 +1,29 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import {isObservableArray} from 'mobx';
+import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
+
+export default class MediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
+    imageFormatUrl: string;
+
+    constructor(imageFormatUrl: string) {
+        this.imageFormatUrl = imageFormatUrl;
+    }
+
+    transform(value: *): Node {
+        const {ids} = value;
+
+        if ((!Array.isArray(ids) && !isObservableArray(ids)) || ids.length === 0) {
+            return null;
+        }
+
+        return (
+            <div>
+                {ids.map((id) => (
+                    <img key={id} src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'} />
+                ))}
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
@@ -3,6 +3,9 @@ import React from 'react';
 import type {Node} from 'react';
 import {isObservableArray} from 'mobx';
 import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
+import mediaSelectionBlockPreviewTransformerStyles from './mediaSelectionBlockPreviewTransformer.scss';
+
+const MAX_LENGTH = 8;
 
 export default class MediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
     imageFormatUrl: string;
@@ -20,8 +23,12 @@ export default class MediaSelectionBlockPreviewTransformer implements BlockPrevi
 
         return (
             <div>
-                {ids.map((id) => (
-                    <img key={id} src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'} />
+                {ids.slice(0, MAX_LENGTH).map((id) => (
+                    <img
+                        className={mediaSelectionBlockPreviewTransformerStyles.image}
+                        key={id}
+                        src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'}
+                    />
                 ))}
             </div>
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
@@ -1,0 +1,29 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
+import singleMediaSelectionBlockPreviewTransformerStyles from './singleMediaSelectionBlockPreviewTransformer.scss';
+
+export default class SingleMediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
+    imageFormatUrl: string;
+
+    constructor(imageFormatUrl: string) {
+        this.imageFormatUrl = imageFormatUrl;
+    }
+
+    transform(value: *): Node {
+        const {id} = value;
+
+        if (!id) {
+            return null;
+        }
+
+        return (
+            <img
+                className={singleMediaSelectionBlockPreviewTransformerStyles.image}
+                key={id}
+                src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'}
+            />
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/mediaSelectionBlockPreviewTransformer.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/mediaSelectionBlockPreviewTransformer.scss
@@ -1,0 +1,3 @@
+.image {
+    margin-right: 10px;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/singleMediaSelectionBlockPreviewTransformer.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/singleMediaSelectionBlockPreviewTransformer.scss
@@ -1,0 +1,4 @@
+.image {
+    float: left;
+    margin-right: 10px;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/index.js
@@ -1,0 +1,9 @@
+// @flow
+import MediaSelectionBlockPreviewTransformer from './blockPreviewTransformers/MediaSelectionBlockPreviewTransformer';
+import SingleMediaSelectionBlockPreviewTransformer
+    from './blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer';
+
+export {
+    MediaSelectionBlockPreviewTransformer,
+    SingleMediaSelectionBlockPreviewTransformer,
+};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
@@ -9,6 +9,11 @@ test('Render a single image if an id is given', () => {
     expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7]})).toMatchSnapshot();
 });
 
+test('Render only eight images if more are given if an id is given', () => {
+    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7, 9, 11, 13, 2, 1, 4, 5]})).toMatchSnapshot();
+});
+
 test('Render nothing if no id is given', () => {
     const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
     expect(mediaSelectionBlockPreviewTransformer.transform({ids: []})).toMatchSnapshot();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
@@ -1,0 +1,20 @@
+// @flow
+import MediaSelectionBlockPreviewTransformer
+    from '../../blockPreviewTransformers/MediaSelectionBlockPreviewTransformer';
+
+const MEDIA_URL = '/admin/media/redirect/media/:id';
+
+test('Render a single image if an id is given', () => {
+    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7]})).toMatchSnapshot();
+});
+
+test('Render nothing if no id is given', () => {
+    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(mediaSelectionBlockPreviewTransformer.transform({ids: []})).toMatchSnapshot();
+});
+
+test('Render nothing if a wrong type of value is given', () => {
+    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(mediaSelectionBlockPreviewTransformer.transform('')).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.test.js
@@ -1,0 +1,20 @@
+// @flow
+import SingleMediaSelectionBlockPreviewTransformer
+    from '../../blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer';
+
+const MEDIA_URL = '/admin/media/redirect/media/:id';
+
+test('Render a single image if an id is given', () => {
+    const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(singleMediaSelectionBlockPreviewTransformer.transform({id: 5})).toMatchSnapshot();
+});
+
+test('Render nothing if no id is given', () => {
+    const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(singleMediaSelectionBlockPreviewTransformer.transform({})).toMatchSnapshot();
+});
+
+test('Render nothing if a wrong type of value is given', () => {
+    const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    expect(singleMediaSelectionBlockPreviewTransformer.transform('')).toMatchSnapshot();
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/MediaSelectionBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/MediaSelectionBlockPreviewTransformer.test.js.snap
@@ -3,9 +3,11 @@
 exports[`Render a single image if an id is given 1`] = `
 <div>
   <img
+    className="image"
     src="/admin/media/redirect/media/3?locale=en&format=sulu-50x50"
   />
   <img
+    className="image"
     src="/admin/media/redirect/media/7?locale=en&format=sulu-50x50"
   />
 </div>
@@ -14,3 +16,40 @@ exports[`Render a single image if an id is given 1`] = `
 exports[`Render nothing if a wrong type of value is given 1`] = `null`;
 
 exports[`Render nothing if no id is given 1`] = `null`;
+
+exports[`Render only eight images if more are given if an id is given 1`] = `
+<div>
+  <img
+    className="image"
+    src="/admin/media/redirect/media/3?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/7?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/9?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/11?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/13?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/2?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/1?locale=en&format=sulu-50x50"
+  />
+  <img
+    className="image"
+    src="/admin/media/redirect/media/4?locale=en&format=sulu-50x50"
+  />
+</div>
+`;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/MediaSelectionBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/MediaSelectionBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render a single image if an id is given 1`] = `
+<div>
+  <img
+    src="/admin/media/redirect/media/3?locale=en&format=sulu-50x50"
+  />
+  <img
+    src="/admin/media/redirect/media/7?locale=en&format=sulu-50x50"
+  />
+</div>
+`;
+
+exports[`Render nothing if a wrong type of value is given 1`] = `null`;
+
+exports[`Render nothing if no id is given 1`] = `null`;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleMediaSelectionBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleMediaSelectionBlockPreviewTransformer.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render a single image if an id is given 1`] = `
+<img
+  className="image"
+  src="/admin/media/redirect/media/5?locale=en&format=sulu-50x50"
+/>
+`;
+
+exports[`Render nothing if a wrong type of value is given 1`] = `null`;
+
+exports[`Render nothing if no id is given 1`] = `null`;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -1,23 +1,41 @@
 // @flow
-import {bundleReady} from 'sulu-admin-bundle/services';
-import {datagridAdapterRegistry, fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
+import {bundleReady, initializer} from 'sulu-admin-bundle/services';
+import {
+    blockPreviewTransformerRegistry,
+    datagridAdapterRegistry,
+    fieldRegistry,
+    viewRegistry,
+} from 'sulu-admin-bundle/containers';
 import {MediaCardOverviewAdapter, MediaCardSelectionAdapter} from './containers/Datagrid';
 import {MediaSelection, SingleMediaUpload, SingleMediaSelection} from './containers/Form';
+import {
+    MediaSelectionBlockPreviewTransformer,
+    SingleMediaSelectionBlockPreviewTransformer,
+} from './containers/FieldBlocks';
 import MediaOverview from './views/MediaOverview';
 import MediaDetails from './views/MediaDetails';
 import MediaHistory from './views/MediaHistory';
 import MediaFormats from './views/MediaFormats';
 
-viewRegistry.add('sulu_media.overview', MediaOverview);
-viewRegistry.add('sulu_media.details', MediaDetails);
-viewRegistry.add('sulu_media.formats', MediaFormats);
-viewRegistry.add('sulu_media.history', MediaHistory);
+initializer.addUpdateConfigHook('sulu_media', (config: Object) => {
+    viewRegistry.add('sulu_media.overview', MediaOverview);
+    viewRegistry.add('sulu_media.details', MediaDetails);
+    viewRegistry.add('sulu_media.formats', MediaFormats);
+    viewRegistry.add('sulu_media.history', MediaHistory);
 
-datagridAdapterRegistry.add('media_card_overview', MediaCardOverviewAdapter);
-datagridAdapterRegistry.add('media_card_selection', MediaCardSelectionAdapter);
+    datagridAdapterRegistry.add('media_card_overview', MediaCardOverviewAdapter);
+    datagridAdapterRegistry.add('media_card_selection', MediaCardSelectionAdapter);
 
-fieldRegistry.add('media_selection', MediaSelection);
-fieldRegistry.add('single_media_selection', SingleMediaSelection);
-fieldRegistry.add('single_media_upload', SingleMediaUpload);
+    fieldRegistry.add('media_selection', MediaSelection);
+    fieldRegistry.add('single_media_selection', SingleMediaSelection);
+    fieldRegistry.add('single_media_upload', SingleMediaUpload);
+
+    const imageFormatUrl = config.endpoints.image_format;
+    blockPreviewTransformerRegistry.add('media_selection', new MediaSelectionBlockPreviewTransformer(imageFormatUrl));
+    blockPreviewTransformerRegistry.add(
+        'single_media_selection',
+        new SingleMediaSelectionBlockPreviewTransformer(imageFormatUrl)
+    );
+});
 
 bundleReady();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -36,11 +36,13 @@ initializer.addUpdateConfigHook('sulu_media', (config: Object) => {
     const imageFormatUrl = config.endpoints.image_format;
     blockPreviewTransformerRegistry.add(
         FIELD_TYPE_MEDIA_SELECTION,
-        new MediaSelectionBlockPreviewTransformer(imageFormatUrl)
+        new MediaSelectionBlockPreviewTransformer(imageFormatUrl),
+        2048
     );
     blockPreviewTransformerRegistry.add(
         FIELD_TYPE_SINGLE_MEDIA_SELECTION,
-        new SingleMediaSelectionBlockPreviewTransformer(imageFormatUrl)
+        new SingleMediaSelectionBlockPreviewTransformer(imageFormatUrl),
+        2048
     );
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -17,6 +17,9 @@ import MediaDetails from './views/MediaDetails';
 import MediaHistory from './views/MediaHistory';
 import MediaFormats from './views/MediaFormats';
 
+const FIELD_TYPE_MEDIA_SELECTION = 'media_selection';
+const FIELD_TYPE_SINGLE_MEDIA_SELECTION = 'single_media_selection';
+
 initializer.addUpdateConfigHook('sulu_media', (config: Object) => {
     viewRegistry.add('sulu_media.overview', MediaOverview);
     viewRegistry.add('sulu_media.details', MediaDetails);
@@ -26,14 +29,17 @@ initializer.addUpdateConfigHook('sulu_media', (config: Object) => {
     datagridAdapterRegistry.add('media_card_overview', MediaCardOverviewAdapter);
     datagridAdapterRegistry.add('media_card_selection', MediaCardSelectionAdapter);
 
-    fieldRegistry.add('media_selection', MediaSelection);
-    fieldRegistry.add('single_media_selection', SingleMediaSelection);
+    fieldRegistry.add(FIELD_TYPE_MEDIA_SELECTION, MediaSelection);
+    fieldRegistry.add(FIELD_TYPE_SINGLE_MEDIA_SELECTION, SingleMediaSelection);
     fieldRegistry.add('single_media_upload', SingleMediaUpload);
 
     const imageFormatUrl = config.endpoints.image_format;
-    blockPreviewTransformerRegistry.add('media_selection', new MediaSelectionBlockPreviewTransformer(imageFormatUrl));
     blockPreviewTransformerRegistry.add(
-        'single_media_selection',
+        FIELD_TYPE_MEDIA_SELECTION,
+        new MediaSelectionBlockPreviewTransformer(imageFormatUrl)
+    );
+    blockPreviewTransformerRegistry.add(
+        FIELD_TYPE_SINGLE_MEDIA_SELECTION,
         new SingleMediaSelectionBlockPreviewTransformer(imageFormatUrl)
     );
 });

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing.yml
@@ -14,3 +14,53 @@ sulu_media:
 sulu_media_website:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
     prefix:
+
+# The following route are necessary to get AdminController::configAction work.
+# Can be removed once its content is not hardcoded anymore.
+
+sulu_contact_api:
+    type: rest
+    resource: "@SuluContactBundle/Resources/config/routing_api.yml"
+    prefix: /admin
+
+sulu_snippet_api:
+    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
+    prefix: /admin
+
+sulu_pages_api:
+    resource: "@SuluPageBundle/Resources/config/routing_api.yml"
+    prefix: /admin
+
+sulu_core_api:
+    type: rest
+    resource: "@SuluCoreBundle/Resources/config/routing_api.xml"
+    prefix: /admin
+
+sulu_categories_api:
+    type: rest
+    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
+    prefix: /admin
+
+sulu_tag_api:
+    resource: "@SuluTagBundle/Resources/config/routing_api.yml"
+    prefix: /admin
+
+sulu_security_api:
+    type: rest
+    resource: "@SuluSecurityBundle/Resources/config/routing_api.xml"
+    prefix: /admin
+
+sulu_security:
+    type: rest
+    resource: "@SuluSecurityBundle/Resources/config/routing.xml"
+    prefix: /admin
+
+sulu_website:
+    type: rest
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    prefix: /admin
+
+sulu_preview:
+    type: rest
+    resource: "@SuluPreviewBundle/Resources/config/routing.xml"
+    prefix: /admin

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -15,6 +15,19 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class AdminControllerTest extends SuluTestCase
 {
+    public function testContactsConfig()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/admin/config');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $mediaConfig = $response->sulu_media;
+
+        $this->assertEquals('/redirect/media/:id', $mediaConfig->endpoints->image_format);
+    }
+
     public function testCollectionMetadataAction()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a preview for blocks which are collapsed in the Form. This works by introducing another Registry (`BlockPreviewTransformerRegistry`), which maps the field type to a transformer, which is called with the current value of the property. All properties with the `sulu.block_preview` will be taken into account.

#### Why?

Because it makes it easier for the content manager to get an idea what is in the block without expanding it.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Add fallback mechanism for blocks without a single `sulu.block_preview`