### PR TITLE
Use default type of blocks when adding a new block

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/Form/Field.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/Form/Field.php
@@ -24,6 +24,11 @@ class Field extends Item
     protected $types = [];
 
     /**
+     * @var string
+     */
+    protected $defaultType;
+
+    /**
      * @var bool
      */
     protected $required;
@@ -51,6 +56,16 @@ class Field extends Item
     public function addOption(Option $option): void
     {
         $this->options[$option->getName()] = $option;
+    }
+
+    public function getDefaultType(): string
+    {
+        return $this->defaultType;
+    }
+
+    public function setDefaultType(string $defaultType): void
+    {
+        $this->defaultType = $defaultType;
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Metadata/Form/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/Form/FormMetadataProvider.php
@@ -288,6 +288,7 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
     private function mapBlock(BlockMetadata $property, string $locale): Field
     {
         $field = $this->mapProperty($property, $locale);
+        $field->setDefaultType($property->getDefaultComponentName());
 
         foreach ($property->getComponents() as $component) {
             $blockType = new Form();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, computed, observable, toJS} from 'mobx';
+import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import {arrayMove} from 'react-sortable-hoc';
 import {translate} from '../../utils/Translator';
@@ -10,6 +10,7 @@ import blockCollectionStyles from './blockCollection.scss';
 import type {BlockEntry, RenderBlockContentCallback} from './types';
 
 type Props = {|
+    defaultType: string,
     disabled: boolean,
     maxOccurs?: ?number,
     minOccurs?: ?number,
@@ -31,16 +32,6 @@ export default class BlockCollection extends React.Component<Props> {
 
     @observable expandedBlocks: Array<boolean> = [];
 
-    @computed get defaultType(): ?string {
-        const {types} = this.props;
-
-        if (!types) {
-            return undefined;
-        }
-
-        return Object.keys(types)[0];
-    }
-
     constructor(props: Props) {
         super(props);
 
@@ -48,7 +39,7 @@ export default class BlockCollection extends React.Component<Props> {
     }
 
     fillArrays() {
-        const {onChange, minOccurs, value} = this.props;
+        const {defaultType, onChange, minOccurs, value} = this.props;
         const {expandedBlocks} = this;
 
         if (!value) {
@@ -62,14 +53,14 @@ export default class BlockCollection extends React.Component<Props> {
                 ...value,
                 ...Array.from(
                     {length: minOccurs - value.length},
-                    () => this.defaultType ? {type: this.defaultType} : {}
+                    () => ({type: defaultType})
                 ),
             ]);
         }
     }
 
     @action handleAddBlock = () => {
-        const {onChange, value} = this.props;
+        const {defaultType, onChange, value} = this.props;
 
         if (this.hasMaximumReached()) {
             throw new Error('The maximum amount of blocks has already been reached!');
@@ -78,8 +69,7 @@ export default class BlockCollection extends React.Component<Props> {
         if (value) {
             this.expandedBlocks.push(true);
 
-            const newBlock = this.defaultType ? {type: this.defaultType} : {};
-            onChange([...value, newBlock]);
+            onChange([...value, {type: defaultType}]);
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlock.js
@@ -7,7 +7,7 @@ import SortableHandle from './SortableHandle';
 import type {RenderBlockContentCallback} from './types';
 
 type Props = {
-    activeType?: string,
+    activeType: string,
     expanded: boolean,
     onCollapse: (index: number) => void,
     onExpand: (index: number) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -19,15 +19,18 @@ jest.mock('../../../utils/Translator', () => ({
 }));
 
 test('Should render an empty block list', () => {
-    expect(render(<BlockCollection onChange={jest.fn()} renderBlockContent={jest.fn()} />)).toMatchSnapshot();
+    expect(render(
+        <BlockCollection defaultType="editor" onChange={jest.fn()} renderBlockContent={jest.fn()} />
+    )).toMatchSnapshot();
 });
 
 test('Should render a block list', () => {
     expect(render(
         <BlockCollection
+            defaultType="editor"
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
-            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
         />
     )).toMatchSnapshot();
 });
@@ -35,10 +38,11 @@ test('Should render a block list', () => {
 test('Should render a disabled block list', () => {
     expect(render(
         <BlockCollection
+            defaultType="editor"
             disabled={true}
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
-            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
         />
     )).toMatchSnapshot();
 });
@@ -46,19 +50,28 @@ test('Should render a disabled block list', () => {
 test('Should render a fully filled block list without add button if maxOccurs is reached', () => {
     expect(render(
         <BlockCollection
+            defaultType="editor"
             maxOccurs={2}
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
-            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
         />
     )).toMatchSnapshot();
 });
 
 test('Should add at least the minOccurs amount of blocks', () => {
     const changeSpy = jest.fn();
-    const value = [{}];
+    const value = [{type: 'editor'}];
 
-    shallow(<BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />);
+    shallow(
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
 
     expect(changeSpy).toBeCalledWith([
         expect.objectContaining({}),
@@ -70,7 +83,15 @@ test('Should fill the array up to minOccurs with different objects', () => {
     const changeSpy = jest.fn();
     const value = [];
 
-    shallow(<BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />);
+    shallow(
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
 
     expect(changeSpy).toBeCalledWith([
         expect.objectContaining({}),
@@ -84,7 +105,15 @@ test('Should add at least the minOccurs amount of blocks with empty starting val
     const changeSpy = jest.fn();
     const value = [];
 
-    shallow(<BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />);
+    shallow(
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
 
     expect(changeSpy).toBeCalledWith([
         expect.objectContaining({}),
@@ -98,17 +127,18 @@ test('Should add at least the minOccurs amount of blocks with types', () => {
 
     shallow(
         <BlockCollection
+            defaultType="editor"
             minOccurs={2}
             onChange={changeSpy}
             renderBlockContent={jest.fn()}
-            types={{default: 'Default'}}
+            types={{default: 'Default', editor: 'Editor'}}
             value={value}
         />
     );
 
     expect(changeSpy).toBeCalledWith([
         expect.objectContaining({type: 'default'}),
-        expect.objectContaining({type: 'default'}),
+        expect.objectContaining({type: 'editor'}),
     ]);
 });
 
@@ -127,6 +157,7 @@ test('Choosing a different type should call the onChange callback', () => {
     ];
     const blockCollection = mount(
         <BlockCollection
+            defaultType="editor"
             onChange={changeSpy}
             renderBlockContent={renderBlockContent}
             types={{type1: 'Type 1', type2: 'Type2'}}
@@ -151,9 +182,10 @@ test('Choosing a different type should call the onChange callback', () => {
 test('Should allow to expand blocks', () => {
     const blockCollection = mount(
         <BlockCollection
+            defaultType="editor"
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
-            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
         />
     );
 
@@ -169,9 +201,10 @@ test('Should allow to expand blocks', () => {
 test('Should allow to collapse blocks', () => {
     const blockCollection = mount(
         <BlockCollection
+            defaultType="editor"
             onChange={jest.fn()}
             renderBlockContent={jest.fn()}
-            value={[{content: 'Test 1'}, {content: 'Test 2'}]}
+            value={[{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]}
         />
     );
 
@@ -190,9 +223,19 @@ test('Should allow to collapse blocks', () => {
 test('Should allow to reorder blocks by using drag and drop', () => {
     const changeSpy = jest.fn();
     const sortEndSpy = jest.fn();
-    const value = [{content: 'Test 1'}, {content: 'Test 2'}, {content: 'Test 3'}];
+    const value = [
+        {content: 'Test 1', type: 'editor'},
+        {content: 'Test 2', type: 'editor'},
+        {content: 'Test 3', type: 'editor'},
+    ];
     const blockCollection = mount(
-        <BlockCollection onChange={changeSpy} onSortEnd={sortEndSpy} renderBlockContent={jest.fn()} value={value} />
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            onSortEnd={sortEndSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
     );
 
     blockCollection.find('Block').at(0).simulate('click');
@@ -212,22 +255,33 @@ test('Should allow to reorder blocks by using drag and drop', () => {
 
 test('Should allow to add a new block', () => {
     const changeSpy = jest.fn();
-    const value = [{content: 'Test 1'}, {content: 'Test 2'}];
+    const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
     const blockCollection = shallow(
-        <BlockCollection onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
     );
 
     blockCollection.find('Button').simulate('click');
 
-    expect(changeSpy).toBeCalledWith([...value, {}]);
+    expect(changeSpy).toBeCalledWith([...value, {type: 'editor'}]);
 });
 
 test('Should throw an exception if a new block is added and the maximum has already been reached', () => {
     const changeSpy = jest.fn();
-    const value = [{content: 'Test 1'}, {content: 'Test 2'}];
+    const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
 
     const blockCollection = shallow(
-        <BlockCollection maxOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />
+        <BlockCollection
+            defaultType="editor"
+            maxOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
     );
 
     expect(() => blockCollection.instance().handleAddBlock()).toThrow(/maximum amount of blocks/);
@@ -236,13 +290,18 @@ test('Should throw an exception if a new block is added and the maximum has alre
 test('Should allow to remove an existing block', () => {
     // observable makes calling onChange with deleting an entry from expandedBlocks
     // otherwise the value and BlockCollection.expandedBlocks variable get out of sync and emit a warning
-    const value: any = observable([{content: 'Test 1'}, {content: 'Test 2'}]);
+    const value: any = observable([{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}]);
     const changeSpy = jest.fn().mockImplementation((newValue) => {
         value.splice(0, value.length);
         value.push(...newValue);
     });
     const blockCollection = mount(
-        <BlockCollection onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
     );
 
     blockCollection.find('Block').at(0).simulate('click');
@@ -252,10 +311,16 @@ test('Should allow to remove an existing block', () => {
 });
 
 test('Should not render the remove icon if less or the exact amount of items are passed', () => {
-    const value = [{content: 'Value 1'}, {content: 'Value 2'}];
+    const value = [{content: 'Value 1', type: 'editor'}, {content: 'Value 2', type: 'editor'}];
 
     const blockCollection = mount(
-        <BlockCollection minOccurs={2} onChange={jest.fn()} renderBlockContent={jest.fn()} value={value} />
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={2}
+            onChange={jest.fn()}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
     );
 
     blockCollection.find('Block').at(0).simulate('click');
@@ -265,10 +330,16 @@ test('Should not render the remove icon if less or the exact amount of items are
 
 test('Should throw an exception if a block is removed and the minimum has already been reached', () => {
     const changeSpy = jest.fn();
-    const value = [{content: 'Test 1'}, {content: 'Test 2'}];
+    const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
 
     const blockCollection = shallow(
-        <BlockCollection minOccurs={2} onChange={changeSpy} renderBlockContent={jest.fn()} value={value} />
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
     );
 
     expect(() => blockCollection.instance().handleRemoveBlock()).toThrow(/minimum amount of blocks/);
@@ -276,10 +347,11 @@ test('Should throw an exception if a block is removed and the minimum has alread
 
 test('Should apply renderBlockContent before rendering the block content', () => {
     const prefix = 'This is the test for ';
-    const value = [{content: 'Test 1'}, {content: 'Test 2'}];
+    const value = [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}];
     const renderBlockContent = jest.fn().mockImplementation((value) => prefix + value.content);
     const blockCollection = mount(
         <BlockCollection
+            defaultType="editor"
             onChange={jest.fn()}
             renderBlockContent={renderBlockContent}
             value={value}
@@ -316,6 +388,7 @@ test('Should apply renderBlockContent before rendering the block content includi
 
     const blockCollection = mount(
         <BlockCollection
+            defaultType="editor"
             onChange={jest.fn()}
             renderBlockContent={renderBlockContent}
             types={types}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/SortableBlock.test.js
@@ -15,6 +15,7 @@ jest.mock('../../../utils/Translator', () => ({
 test('Render collapsed sortable block', () => {
     expect(render(
         <SortableBlock
+            activeType="editor"
             expanded={false}
             onCollapse={jest.fn()}
             onExpand={jest.fn()}
@@ -31,6 +32,7 @@ test('Render expanded sortable block', () => {
 
     expect(render(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={jest.fn()}
             onExpand={jest.fn()}
@@ -47,6 +49,7 @@ test('Render expanded sortable block without remove icon', () => {
 
     expect(render(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={jest.fn()}
             onExpand={jest.fn()}
@@ -84,6 +87,7 @@ test('Should call onCollapse when the block is being collapsed', () => {
 
     const sortableBlock = shallow(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={collapseSpy}
             onExpand={expandSpy}
@@ -108,6 +112,7 @@ test('Should call onExpand when the block is being expanded', () => {
 
     const sortableBlock = shallow(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={collapseSpy}
             onExpand={expandSpy}
@@ -132,6 +137,7 @@ test('Should call onRemove when the block is being removed', () => {
 
     const sortableBlock = shallow(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={collapseSpy}
             onExpand={expandSpy}
@@ -154,6 +160,7 @@ test('Should call onTypeChange when the block has changed its type', () => {
 
     const sortableBlock = shallow(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={jest.fn()}
             onExpand={jest.fn()}
@@ -176,6 +183,7 @@ test('Should call renderBlockContent with the correct arguments', () => {
 
     shallow(
         <SortableBlock
+            activeType="editor"
             expanded={true}
             onCollapse={jest.fn()}
             onExpand={jest.fn()}
@@ -186,7 +194,7 @@ test('Should call renderBlockContent with the correct arguments', () => {
         />
     );
 
-    expect(renderBlockContentSpy).toBeCalledWith(value, undefined, 7);
+    expect(renderBlockContentSpy).toBeCalledWith(value, 'editor', 7);
 });
 
 test('Should call renderBlockContent with the correct arguments when types are involved', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/types.js
@@ -3,7 +3,7 @@ import type {Node} from 'react';
 
 export type BlockEntry = {
     __id?: number,
-    type?: string,
+    type: string,
 };
 
-export type RenderBlockContentCallback = (value: *, type: ?string, index: number) => Node;
+export type RenderBlockContentCallback = (value: *, type: string, index: number) => Node;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -27,7 +27,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
         onFinish();
     };
 
-    renderBlockContent = (value: Object, type: ?string, index: number) => {
+    renderBlockContent = (value: Object, type: string, index: number) => {
         const {dataPath, error, formInspector, onFinish, schemaPath, showAllErrors, types} = this.props;
 
         if (!formInspector) {
@@ -38,8 +38,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
             throw new Error(MISSING_BLOCK_ERROR_MESSAGE);
         }
 
-        const blockTypeKey = type || Object.keys(types)[0]; // TODO replace with a default type
-        const blockType = types[blockTypeKey];
+        const blockType = types[type];
 
         const errors = ((toJS(error): any): ?BlockError);
 
@@ -53,14 +52,18 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
                 onChange={this.handleBlockChange}
                 onFieldFinish={onFinish}
                 schema={blockType.form}
-                schemaPath={schemaPath + '/types/' + blockTypeKey + '/form'}
+                schemaPath={schemaPath + '/types/' + type + '/form'}
                 showAllErrors={showAllErrors}
             />
         );
     };
 
     render() {
-        const {disabled, maxOccurs, minOccurs, onChange, types, value} = this.props;
+        const {defaultType, disabled, maxOccurs, minOccurs, onChange, types, value} = this.props;
+
+        if (!defaultType) {
+            throw new Error('The "block" field type needs a defaultType!');
+        }
 
         if (!types) {
             throw new Error(MISSING_BLOCK_ERROR_MESSAGE);
@@ -73,6 +76,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
 
         return (
             <BlockCollection
+                defaultType={defaultType}
                 disabled={!!disabled}
                 maxOccurs={maxOccurs}
                 minOccurs={minOccurs}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -55,16 +55,19 @@ test('Render block with schema', () => {
         {
             text1: 'Test 1',
             text2: 'Test 2',
+            type: 'default',
         },
         {
             text1: 'Test 3',
             text2: 'Test 4',
+            type: 'default',
         },
     ];
 
     const fieldBlocks = mount(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="editor"
             formInspector={formInspector}
             types={types}
             value={value}
@@ -96,12 +99,15 @@ test('Render block with schema and error on fields already being modified', () =
     const value = [
         {
             text: 'Test1',
+            type: 'default',
         },
         {
             text: 'T2',
+            type: 'default',
         },
         {
             text: 'T3',
+            type: 'default',
         },
     ];
 
@@ -129,6 +135,7 @@ test('Render block with schema and error on fields already being modified', () =
         <FieldBlocks
             {...fieldTypeDefaultProps}
             dataPath="/block"
+            defaultType="editor"
             error={error}
             formInspector={formInspector}
             schemaPath="/block"
@@ -163,12 +170,15 @@ test('Render block with schema and error on fields already being modified', () =
     const value = [
         {
             text: 'Test1',
+            type: 'default',
         },
         {
             text: 'T2',
+            type: 'default',
         },
         {
             text: 'T3',
+            type: 'default',
         },
     ];
 
@@ -191,6 +201,7 @@ test('Render block with schema and error on fields already being modified', () =
     const fieldBlocks = mount(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="editor"
             error={error}
             formInspector={formInspector}
             showAllErrors={true}
@@ -229,6 +240,7 @@ test('Should correctly pass props to the BlockCollection', () => {
     const fieldBlocks = shallow(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="editor"
             disabled={true}
             formInspector={formInspector}
             label="Test"
@@ -271,10 +283,11 @@ test('Should pass correct schemaPath to FieldRender', () => {
         <FieldBlocks
             {...fieldTypeDefaultProps}
             dataPath=""
+            defaultType="editor"
             formInspector={formInspector}
             schemaPath=""
             types={types}
-            value={[{}, {}]}
+            value={[{type: 'default'}, {type: 'default'}]}
         />
     );
 
@@ -301,13 +314,14 @@ test('Should call onFinish when a field from the child renderer has finished edi
             },
         },
     };
-    const value = [{}];
+    const value = [{type: 'default'}];
 
     const finishSpy = jest.fn();
     const fieldBlocks = mount(
         <FieldBlocks
             {...fieldTypeDefaultProps}
             dataPath=""
+            defaultType="editor"
             fieldTypeOptions={{}}
             formInspector={formInspector}
             onFinish={finishSpy}
@@ -337,12 +351,13 @@ test('Should call onFinish when the order of the blocks has changed', () => {
             },
         },
     };
-    const value = [{}];
+    const value = [{type: 'default'}];
 
     const finishSpy = jest.fn();
     const fieldBlocks = mount(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="editor"
             formInspector={formInspector}
             onFinish={finishSpy}
             types={types}
@@ -355,11 +370,22 @@ test('Should call onFinish when the order of the blocks has changed', () => {
     expect(finishSpy).toBeCalledWith();
 });
 
+test('Throw error if no default type are passed', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    expect(() => shallow(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+        />
+    )).toThrow('The "block" field type needs a defaultType!');
+});
+
 test('Throw error if no types are passed', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     expect(() => shallow(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="editor"
             formInspector={formInspector}
         />
     )).toThrow('The "block" field type needs at least one type to be configured!');
@@ -370,6 +396,7 @@ test('Throw error if empty type array is passed', () => {
     expect(() => shallow(
         <FieldBlocks
             {...fieldTypeDefaultProps}
+            defaultType="editor"
             formInspector={formInspector}
             value={[]}
         />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -81,6 +81,7 @@ export default class Field extends React.Component<Props> {
     render() {
         const {dataPath, error, value, formInspector, schema, schemaPath, showAllErrors, name} = this.props;
         const {
+            defaultType,
             description,
             disabled,
             label,
@@ -135,6 +136,7 @@ export default class Field extends React.Component<Props> {
                     <div className={fieldStyles.field}>
                         <FieldType
                             dataPath={dataPath}
+                            defaultType={defaultType}
                             disabled={disabled}
                             error={error}
                             fieldTypeOptions={fieldTypeOptions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -193,6 +193,7 @@ test('Call finish handlers with dataPath and schemaPath when a block field has f
     // $FlowFixMe
     store.schema = {
         block: {
+            defaultType: 'default',
             type: 'block',
             types: {
                 default: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -52,6 +52,7 @@ export type SchemaOption = {
 export type SchemaOptions = {[key: string]: SchemaOption};
 
 type BaseSchemaEntry = {
+    defaultType?: string,
     description?: string,
     label?: string,
     maxOccurs?: number,
@@ -107,6 +108,7 @@ export interface FormStoreInterface {
 
 export type FieldTypeProps<T> = {|
     dataPath: string,
+    defaultType: ?string,
     disabled: ?boolean,
     error: ?Error | ErrorCollection,
     fieldTypeOptions: Object,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/fieldTypeDefaultProps.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/TestHelper/fieldTypeDefaultProps.js
@@ -2,6 +2,7 @@
 
 const fieldTypeDefaultProps = {
     dataPath: '/',
+    defaultType: undefined,
     disabled: undefined,
     error: undefined,
     fieldTypeOptions: {},

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/Form/FormMetadataProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Tests\Functional\Metadata\Form;
 
+use Sulu\Bundle\AdminBundle\Metadata\Form\Field;
 use Sulu\Bundle\AdminBundle\Metadata\Form\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\Form\Section;
 use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
@@ -109,5 +110,20 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertEquals('test11', $section1->getItems()['test11']->getName());
         $this->assertEquals('test21', $section2->getItems()['test21']->getName());
         $this->assertEquals('test221', $section22->getItems()['test221']->getName());
+    }
+
+    public function testGetMetadataWithBlocks()
+    {
+        $form = $this->formMetadataProvider->getMetadata('form_with_blocks', 'en');
+
+        $blocks = $form->getItems()['blocks'];
+
+        $this->assertInstanceOf(Field::class, $blocks);
+        $this->assertEquals('editor', $blocks->getDefaultType());
+
+        $types = $blocks->getTypes();
+        $this->assertCount(2, $types);
+        $this->assertEquals('editor', $types['editor']->getName());
+        $this->assertEquals('editor_image', $types['editor_image']->getName());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the default type configuration on the `types` node from our XML template to determine which type should be preselected when a new block is added.

#### Why?

Because otherwise it wouldn't make a lot of sense to have this configuration anyway.