### PR TITLE
Update jexl to avoid having callbacks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {toJS} from 'mobx';
 import SingleSelectComponent from '../../../components/SingleSelect';
 import type {FieldTypeProps} from '../../../types';
 
@@ -47,7 +48,7 @@ export default class SingleSelect extends React.Component<FieldTypeProps<string 
             throw new Error(MISSING_VALUES_OPTIONS);
         }
 
-        const {values} = schemaOptions;
+        const values = toJS(schemaOptions.values);
 
         if (!Array.isArray(values.value)) {
             throw new Error(MISSING_VALUES_OPTIONS);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/CardCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/CardCollection.test.js
@@ -12,6 +12,15 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
 }));
 
 jest.mock('../../../../stores/ResourceStore', () => jest.fn());
+jest.mock('../../stores/MemoryFormStore', () => jest.fn(function(data, schema) {
+    this.data = data;
+    this.schema = schema;
+    this.change = jest.fn().mockImplementation((name, value) => {
+        this.data[name] = value;
+    });
+    this.validate = jest.fn().mockReturnValue(true);
+    this.destroy = jest.fn();
+}));
 jest.mock('../../stores/ResourceFormStore', () => jest.fn());
 jest.mock('../../FormInspector', () => jest.fn(function() {
     this.isFieldModified = jest.fn();
@@ -159,7 +168,7 @@ test('Add a new card using the overlay', () => {
     expect(changeSpy).toBeCalledWith([...value, {firstName: 'John', lastName: 'Doe'}]);
 });
 
-test('Add a new card using the overlay', () => {
+test('Do not add a new card if validation fails', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
 
     const changeSpy = jest.fn();
@@ -196,6 +205,8 @@ test('Add a new card using the overlay', () => {
     expect(cardCollection.find('Overlay').prop('open')).toEqual(false);
     cardCollection.find('.addButtonContainer button').simulate('click');
     expect(cardCollection.find('Overlay').prop('open')).toEqual(true);
+
+    cardCollection.instance().formStore.validate.mockReturnValue(false);
 
     cardCollection.find('Input[dataPath="/firstName"]').prop('onChange')('John');
     cardCollection.find('Overlay').prop('onConfirm')();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {shallow} from 'enzyme';
+import {observable} from 'mobx';
 import fieldTypeDefaultProps from '../../../../utils/TestHelper/fieldTypeDefaultProps';
 import ResourceStore from '../../../../stores/ResourceStore';
 import FormInspector from '../../FormInspector';
@@ -13,7 +14,7 @@ jest.mock('../../FormInspector', () => jest.fn());
 
 test('Pass props correctly to SingleSelect', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
-    const schemaOptions = {
+    const schemaOptions = observable({
         values: {
             value: [
                 {
@@ -26,7 +27,7 @@ test('Pass props correctly to SingleSelect', () => {
                 },
             ],
         },
-    };
+    });
     const singleSelect = shallow(
         <SingleSelect
             {...fieldTypeDefaultProps}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -85,7 +85,7 @@ test('Create data object for schema with sections', () => {
     memoryFormStore.destroy();
 });
 
-test('Evaluate all disabledConditions and visibleConditions for schema', (done) => {
+test('Evaluate all disabledConditions and visibleConditions for schema', () => {
     const schema = {
         item1: {
             type: 'text_line',
@@ -133,113 +133,110 @@ test('Evaluate all disabledConditions and visibleConditions for schema', (done) 
     const memoryFormStore = new MemoryFormStore({}, schema);
 
     setTimeout(() => {
-        const sectionItems = memoryFormStore.schema.section.items;
-        if (!sectionItems) {
+        const sectionItems1 = memoryFormStore.schema.section.items;
+        if (!sectionItems1) {
             throw new Error('Section items should be defined!');
         }
-        const blockTypes = memoryFormStore.schema.block.types;
-        if (!blockTypes) {
+        const blockTypes1 = memoryFormStore.schema.block.types;
+        if (!blockTypes1) {
             throw new Error('Block types should be defined!');
         }
 
         expect(memoryFormStore.schema.item2.disabled).toEqual(true);
         expect(memoryFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems.item32.disabled).toEqual(true);
-        expect(sectionItems.item32.visible).toEqual(false);
+        expect(sectionItems1.item32.disabled).toEqual(true);
+        expect(sectionItems1.item32.visible).toEqual(false);
         expect(memoryFormStore.schema.section.disabled).toEqual(true);
         expect(memoryFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        expect(blockTypes1.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes1.text_line.form.item41.visible).toEqual(false);
 
         memoryFormStore.data = observable({item1: 'item2'});
         expect(memoryFormStore.schema.item2.disabled).toEqual(true);
         expect(memoryFormStore.schema.item2.visible).toEqual(false);
 
-        memoryFormStore.finishField('/item1').then(() => {
-            const sectionItems = memoryFormStore.schema.section.items;
-            if (!sectionItems) {
-                throw new Error('Section items should be defined!');
-            }
-            const blockTypes = memoryFormStore.schema.block.types;
-            if (!blockTypes) {
-                throw new Error('Block types should be defined!');
-            }
+        memoryFormStore.finishField('/item1');
+        const sectionItems2 = memoryFormStore.schema.section.items;
+        if (!sectionItems2) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes2 = memoryFormStore.schema.block.types;
+        if (!blockTypes2) {
+            throw new Error('Block types should be defined!');
+        }
 
-            expect(memoryFormStore.schema.item2.disabled).toEqual(false);
-            expect(memoryFormStore.schema.item2.visible).toEqual(true);
-            expect(sectionItems.item32.disabled).toEqual(true);
-            expect(sectionItems.item32.visible).toEqual(false);
-            expect(memoryFormStore.schema.section.disabled).toEqual(true);
-            expect(memoryFormStore.schema.section.visible).toEqual(false);
-            expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-            expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        expect(memoryFormStore.schema.item2.disabled).toEqual(false);
+        expect(memoryFormStore.schema.item2.visible).toEqual(true);
+        expect(sectionItems2.item32.disabled).toEqual(true);
+        expect(sectionItems2.item32.visible).toEqual(false);
+        expect(memoryFormStore.schema.section.disabled).toEqual(true);
+        expect(memoryFormStore.schema.section.visible).toEqual(false);
+        expect(blockTypes2.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes2.text_line.form.item41.visible).toEqual(false);
 
-            memoryFormStore.data = observable({item1: 'item32'});
-            memoryFormStore.finishField('/item1').then(() => {
-                const sectionItems = memoryFormStore.schema.section.items;
-                if (!sectionItems) {
-                    throw new Error('Section items should be defined!');
-                }
-                const blockTypes = memoryFormStore.schema.block.types;
-                if (!blockTypes) {
-                    throw new Error('Block types should be defined!');
-                }
+        memoryFormStore.data = observable({item1: 'item32'});
 
-                expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-                expect(memoryFormStore.schema.item2.visible).toEqual(false);
-                expect(sectionItems.item32.disabled).toEqual(false);
-                expect(sectionItems.item32.visible).toEqual(true);
-                expect(memoryFormStore.schema.section.disabled).toEqual(true);
-                expect(memoryFormStore.schema.section.visible).toEqual(false);
-                expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-                expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        memoryFormStore.finishField('/item1');
+        const sectionItems3 = memoryFormStore.schema.section.items;
+        if (!sectionItems3) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes3 = memoryFormStore.schema.block.types;
+        if (!blockTypes3) {
+            throw new Error('Block types should be defined!');
+        }
 
-                memoryFormStore.data = observable({item1: 'section'});
-                memoryFormStore.finishField('/item1').then(() => {
-                    const sectionItems = memoryFormStore.schema.section.items;
-                    if (!sectionItems) {
-                        throw new Error('Section items should be defined!');
-                    }
-                    const blockTypes = memoryFormStore.schema.block.types;
-                    if (!blockTypes) {
-                        throw new Error('Block types should be defined!');
-                    }
+        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
+        expect(memoryFormStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems3.item32.disabled).toEqual(false);
+        expect(sectionItems3.item32.visible).toEqual(true);
+        expect(memoryFormStore.schema.section.disabled).toEqual(true);
+        expect(memoryFormStore.schema.section.visible).toEqual(false);
+        expect(blockTypes3.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes3.text_line.form.item41.visible).toEqual(false);
 
-                    expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-                    expect(memoryFormStore.schema.item2.visible).toEqual(false);
-                    expect(sectionItems.item32.disabled).toEqual(true);
-                    expect(sectionItems.item32.visible).toEqual(false);
-                    expect(memoryFormStore.schema.section.disabled).toEqual(false);
-                    expect(memoryFormStore.schema.section.visible).toEqual(true);
-                    expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-                    expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        memoryFormStore.data = observable({item1: 'section'});
+        memoryFormStore.finishField('/item1');
 
-                    memoryFormStore.data = observable({item1: 'item41'});
-                    memoryFormStore.finishField('/item1').then(() => {
-                        const sectionItems = memoryFormStore.schema.section.items;
-                        if (!sectionItems) {
-                            throw new Error('Section items should be defined!');
-                        }
-                        const blockTypes = memoryFormStore.schema.block.types;
-                        if (!blockTypes) {
-                            throw new Error('Block types should be defined!');
-                        }
+        const sectionItems4 = memoryFormStore.schema.section.items;
+        if (!sectionItems4) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes4 = memoryFormStore.schema.block.types;
+        if (!blockTypes4) {
+            throw new Error('Block types should be defined!');
+        }
 
-                        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
-                        expect(memoryFormStore.schema.item2.visible).toEqual(false);
-                        expect(sectionItems.item32.disabled).toEqual(true);
-                        expect(sectionItems.item32.visible).toEqual(false);
-                        expect(memoryFormStore.schema.section.disabled).toEqual(true);
-                        expect(memoryFormStore.schema.section.visible).toEqual(false);
-                        expect(blockTypes.text_line.form.item41.disabled).toEqual(false);
-                        expect(blockTypes.text_line.form.item41.visible).toEqual(true);
+        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
+        expect(memoryFormStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems4.item32.disabled).toEqual(true);
+        expect(sectionItems4.item32.visible).toEqual(false);
+        expect(memoryFormStore.schema.section.disabled).toEqual(false);
+        expect(memoryFormStore.schema.section.visible).toEqual(true);
+        expect(blockTypes4.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes4.text_line.form.item41.visible).toEqual(false);
 
-                        memoryFormStore.destroy();
-                        done();
-                    });
-                });
-            });
-        });
+        memoryFormStore.data = observable({item1: 'item41'});
+        memoryFormStore.finishField('/item1');
+        const sectionItems5 = memoryFormStore.schema.section.items;
+        if (!sectionItems5) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes5 = memoryFormStore.schema.block.types;
+        if (!blockTypes5) {
+            throw new Error('Block types should be defined!');
+        }
+
+        expect(memoryFormStore.schema.item2.disabled).toEqual(true);
+        expect(memoryFormStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems5.item32.disabled).toEqual(true);
+        expect(sectionItems5.item32.visible).toEqual(false);
+        expect(memoryFormStore.schema.section.disabled).toEqual(true);
+        expect(memoryFormStore.schema.section.visible).toEqual(false);
+        expect(blockTypes5.text_line.form.item41.disabled).toEqual(false);
+        expect(blockTypes5.text_line.form.item41.visible).toEqual(true);
+
+        memoryFormStore.destroy();
     }, 0);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -32,7 +32,7 @@ beforeEach(() => {
     metadataStore.getSchemaTypes = jest.fn().mockReturnValue(Promise.resolve({}));
 });
 
-test('Create data object for schema', () => {
+test('Create data object for schema', (done) => {
     const metadata = {
         title: {
             label: 'Title',
@@ -63,10 +63,11 @@ test('Create data object for schema', () => {
             description: undefined,
         });
         resourceFormStore.destroy();
+        done();
     }, 0);
 });
 
-test('Evaluate all disabledConditions and visibleConditions for schema', (done) => {
+test('Evaluate all disabledConditions and visibleConditions for schema', () => {
     const metadata = {
         item1: {
             type: 'text_line',
@@ -119,113 +120,108 @@ test('Evaluate all disabledConditions and visibleConditions for schema', (done) 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
 
     setTimeout(() => {
-        const sectionItems = resourceFormStore.schema.section.items;
-        if (!sectionItems) {
+        const sectionItems1 = resourceFormStore.schema.section.items;
+        if (!sectionItems1) {
             throw new Error('Section items should be defined!');
         }
-        const blockTypes = resourceFormStore.schema.block.types;
-        if (!blockTypes) {
+        const blockTypes1 = resourceFormStore.schema.block.types;
+        if (!blockTypes1) {
             throw new Error('Block types should be defined!');
         }
 
         expect(resourceFormStore.schema.item2.disabled).toEqual(true);
         expect(resourceFormStore.schema.item2.visible).toEqual(false);
-        expect(sectionItems.item32.disabled).toEqual(true);
-        expect(sectionItems.item32.visible).toEqual(false);
+        expect(sectionItems1.item32.disabled).toEqual(true);
+        expect(sectionItems1.item32.visible).toEqual(false);
         expect(resourceFormStore.schema.section.disabled).toEqual(true);
         expect(resourceFormStore.schema.section.visible).toEqual(false);
-        expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-        expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        expect(blockTypes1.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes1.text_line.form.item41.visible).toEqual(false);
 
         resourceStore.data = observable({item1: 'item2'});
         expect(resourceFormStore.schema.item2.disabled).toEqual(true);
         expect(resourceFormStore.schema.item2.visible).toEqual(false);
 
-        resourceFormStore.finishField('/item1').then(() => {
-            const sectionItems = resourceFormStore.schema.section.items;
-            if (!sectionItems) {
-                throw new Error('Section items should be defined!');
-            }
-            const blockTypes = resourceFormStore.schema.block.types;
-            if (!blockTypes) {
-                throw new Error('Block types should be defined!');
-            }
+        resourceFormStore.finishField('/item1');
+        const sectionItems2 = resourceFormStore.schema.section.items;
+        if (!sectionItems2) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes2 = resourceFormStore.schema.block.types;
+        if (!blockTypes2) {
+            throw new Error('Block types should be defined!');
+        }
 
-            expect(resourceFormStore.schema.item2.disabled).toEqual(false);
-            expect(resourceFormStore.schema.item2.visible).toEqual(true);
-            expect(sectionItems.item32.disabled).toEqual(true);
-            expect(sectionItems.item32.visible).toEqual(false);
-            expect(resourceFormStore.schema.section.disabled).toEqual(true);
-            expect(resourceFormStore.schema.section.visible).toEqual(false);
-            expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-            expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        expect(resourceFormStore.schema.item2.disabled).toEqual(false);
+        expect(resourceFormStore.schema.item2.visible).toEqual(true);
+        expect(sectionItems2.item32.disabled).toEqual(true);
+        expect(sectionItems2.item32.visible).toEqual(false);
+        expect(resourceFormStore.schema.section.disabled).toEqual(true);
+        expect(resourceFormStore.schema.section.visible).toEqual(false);
+        expect(blockTypes2.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes2.text_line.form.item41.visible).toEqual(false);
 
-            resourceStore.data = observable({item1: 'item32'});
-            resourceFormStore.finishField('/item1').then(() => {
-                const sectionItems = resourceFormStore.schema.section.items;
-                if (!sectionItems) {
-                    throw new Error('Section items should be defined!');
-                }
-                const blockTypes = resourceFormStore.schema.block.types;
-                if (!blockTypes) {
-                    throw new Error('Block types should be defined!');
-                }
+        resourceStore.data = observable({item1: 'item32'});
+        resourceFormStore.finishField('/item1');
+        const sectionItems3 = resourceFormStore.schema.section.items;
+        if (!sectionItems3) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes3 = resourceFormStore.schema.block.types;
+        if (!blockTypes3) {
+            throw new Error('Block types should be defined!');
+        }
 
-                expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-                expect(resourceFormStore.schema.item2.visible).toEqual(false);
-                expect(sectionItems.item32.disabled).toEqual(false);
-                expect(sectionItems.item32.visible).toEqual(true);
-                expect(resourceFormStore.schema.section.disabled).toEqual(true);
-                expect(resourceFormStore.schema.section.visible).toEqual(false);
-                expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-                expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
+        expect(resourceFormStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems3.item32.disabled).toEqual(false);
+        expect(sectionItems3.item32.visible).toEqual(true);
+        expect(resourceFormStore.schema.section.disabled).toEqual(true);
+        expect(resourceFormStore.schema.section.visible).toEqual(false);
+        expect(blockTypes3.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes3.text_line.form.item41.visible).toEqual(false);
 
-                resourceStore.data = observable({item1: 'section'});
-                resourceFormStore.finishField('/item1').then(() => {
-                    const sectionItems = resourceFormStore.schema.section.items;
-                    if (!sectionItems) {
-                        throw new Error('Section items should be defined!');
-                    }
-                    const blockTypes = resourceFormStore.schema.block.types;
-                    if (!blockTypes) {
-                        throw new Error('Block types should be defined!');
-                    }
+        resourceStore.data = observable({item1: 'section'});
+        resourceFormStore.finishField('/item1');
+        const sectionItems4 = resourceFormStore.schema.section.items;
+        if (!sectionItems4) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes4 = resourceFormStore.schema.block.types;
+        if (!blockTypes4) {
+            throw new Error('Block types should be defined!');
+        }
 
-                    expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-                    expect(resourceFormStore.schema.item2.visible).toEqual(false);
-                    expect(sectionItems.item32.disabled).toEqual(true);
-                    expect(sectionItems.item32.visible).toEqual(false);
-                    expect(resourceFormStore.schema.section.disabled).toEqual(false);
-                    expect(resourceFormStore.schema.section.visible).toEqual(true);
-                    expect(blockTypes.text_line.form.item41.disabled).toEqual(true);
-                    expect(blockTypes.text_line.form.item41.visible).toEqual(false);
+        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
+        expect(resourceFormStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems4.item32.disabled).toEqual(true);
+        expect(sectionItems4.item32.visible).toEqual(false);
+        expect(resourceFormStore.schema.section.disabled).toEqual(false);
+        expect(resourceFormStore.schema.section.visible).toEqual(true);
+        expect(blockTypes4.text_line.form.item41.disabled).toEqual(true);
+        expect(blockTypes4.text_line.form.item41.visible).toEqual(false);
 
-                    resourceStore.data = observable({item1: 'item41'});
-                    resourceFormStore.finishField('/item1').then(() => {
-                        const sectionItems = resourceFormStore.schema.section.items;
-                        if (!sectionItems) {
-                            throw new Error('Section items should be defined!');
-                        }
-                        const blockTypes = resourceFormStore.schema.block.types;
-                        if (!blockTypes) {
-                            throw new Error('Block types should be defined!');
-                        }
+        resourceStore.data = observable({item1: 'item41'});
+        resourceFormStore.finishField('/item1');
+        const sectionItems5 = resourceFormStore.schema.section.items;
+        if (!sectionItems5) {
+            throw new Error('Section items should be defined!');
+        }
+        const blockTypes5 = resourceFormStore.schema.block.types;
+        if (!blockTypes5) {
+            throw new Error('Block types should be defined!');
+        }
 
-                        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
-                        expect(resourceFormStore.schema.item2.visible).toEqual(false);
-                        expect(sectionItems.item32.disabled).toEqual(true);
-                        expect(sectionItems.item32.visible).toEqual(false);
-                        expect(resourceFormStore.schema.section.disabled).toEqual(true);
-                        expect(resourceFormStore.schema.section.visible).toEqual(false);
-                        expect(blockTypes.text_line.form.item41.disabled).toEqual(false);
-                        expect(blockTypes.text_line.form.item41.visible).toEqual(true);
+        expect(resourceFormStore.schema.item2.disabled).toEqual(true);
+        expect(resourceFormStore.schema.item2.visible).toEqual(false);
+        expect(sectionItems5.item32.disabled).toEqual(true);
+        expect(sectionItems5.item32.visible).toEqual(false);
+        expect(resourceFormStore.schema.section.disabled).toEqual(true);
+        expect(resourceFormStore.schema.section.visible).toEqual(false);
+        expect(blockTypes5.text_line.form.item41.disabled).toEqual(false);
+        expect(blockTypes5.text_line.form.item41.visible).toEqual(true);
 
-                        resourceFormStore.destroy();
-                        done();
-                    });
-                });
-            });
-        });
+        resourceFormStore.destroy();
     }, 0);
 });
 
@@ -282,8 +278,8 @@ test('Evaluate disabledConditions and visibleConditions when changing locale', (
             expect(resourceFormStore.schema.item.disabled).toEqual(false);
             expect(resourceFormStore.schema.item.visible).toEqual(true);
             done();
-        }, 0);
-    }, 0);
+        });
+    });
 });
 
 test('Read resourceKey from ResourceStore', () => {
@@ -427,7 +423,7 @@ test('Create data object for schema with sections', () => {
     });
 });
 
-test('Change schema should keep data', () => {
+test('Change schema should keep data', (done) => {
     const metadata = {
         title: {
             label: 'Title',
@@ -461,6 +457,7 @@ test('Change schema should keep data', () => {
             slogan: 'Slogan',
         });
         resourceFormStore.destroy();
+        done();
     }, 0);
 });
 
@@ -492,7 +489,7 @@ test('Change type should update schema and data', (done) => {
     const cachedPathsByTag = resourceFormStore.pathsByTag;
 
     setTimeout(() => {
-        expect(resourceFormStore.rawSchema).toBe(sidebarMetadata);
+        expect(resourceFormStore.rawSchema).toEqual(sidebarMetadata);
         expect(resourceFormStore.pathsByTag).not.toBe(cachedPathsByTag);
         expect(resourceFormStore.data).toEqual({
             title: 'Title',
@@ -567,7 +564,7 @@ test('Type should not be set from response if types are not supported', () => {
     });
 });
 
-test('Changing type should set the appropriate property in the ResourceStore', () => {
+test('Changing type should set the appropriate property in the ResourceStore', (done) => {
     const resourceStore = new ResourceStore('snippets', '1');
     resourceStore.data = observable({
         template: 'sidebar',
@@ -588,7 +585,8 @@ test('Changing type should set the appropriate property in the ResourceStore', (
         resourceFormStore.changeType('footer');
         expect(resourceFormStore.type).toEqual('footer');
         setTimeout(() => { // The observe command is executed later
-            expect(resourceStore.set).toBeCalledWith('template', 'footer');
+            expect(resourceStore.change).toBeCalledWith('template', 'footer');
+            done();
         });
     });
 });
@@ -1102,44 +1100,55 @@ test('Return all the values for a given tag within blocks', () => {
     expect(resourceFormStore.getValuesByTag('sulu.resource_locator_part')).toEqual(['Value 1', 'Block 1', 'Block 2']);
 });
 
-test('Return SchemaEntry for given schemaPath', () => {
+test('Return SchemaEntry for given schemaPath', (done) => {
+    const schemaTypesPromise = Promise.resolve({});
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const metadataPromise = Promise.resolve(
+        {
+            title: {
+                tags: [
+                    {name: 'sulu.resource_locator_part'},
+                ],
+                type: 'text_line',
+            },
+            description: {
+                type: 'text_area',
+            },
+            block: {
+                type: 'block',
+                types: {
+                    default: {
+                        form: {
+                            text: {
+                                tags: [
+                                    {name: 'sulu.resource_locator_part'},
+                                ],
+                                type: 'text_line',
+                            },
+                            description: {
+                                type: 'text_line',
+                            },
+                        },
+                        title: 'Default',
+                    },
+                },
+            },
+        }
+    );
+    metadataStore.getSchema.mockReturnValue(metadataPromise);
+
     const resourceFormStore = new ResourceFormStore(new ResourceStore('test'), 'snippets');
-    resourceFormStore.rawSchema = {
-        title: {
+
+    setTimeout(() => {
+        expect(resourceFormStore.getSchemaEntryByPath('/block/types/default/form/text')).toEqual({
             tags: [
                 {name: 'sulu.resource_locator_part'},
             ],
             type: 'text_line',
-        },
-        description: {
-            type: 'text_area',
-        },
-        block: {
-            type: 'block',
-            types: {
-                default: {
-                    form: {
-                        text: {
-                            tags: [
-                                {name: 'sulu.resource_locator_part'},
-                            ],
-                            type: 'text_line',
-                        },
-                        description: {
-                            type: 'text_line',
-                        },
-                    },
-                    title: 'Default',
-                },
-            },
-        },
-    };
-
-    expect(resourceFormStore.getSchemaEntryByPath('/block/types/default/form/text')).toEqual({
-        tags: [
-            {name: 'sulu.resource_locator_part'},
-        ],
-        type: 'text_line',
+        });
+        resourceFormStore.destroy();
+        done();
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -98,7 +98,7 @@ export interface FormStoreInterface {
     // Only exists in one implementation, therefore optional. Maybe we can remove that definition one day...
     +copyFromLocale?: (string) => Promise<*>,
     isFieldModified(dataPath: string): boolean,
-    finishField(dataPath: string): Promise<*>, // TODO remove promise once jexl is synchronous
+    finishField(dataPath: string):void,
     change(name: string, value: mixed): void,
     validate(): boolean,
     getValueByPath(path: string): mixed,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -23,7 +23,7 @@
         "imagesloaded": "^4.1.3",
         "intl-messageformat": "^2.2.0",
         "isemail": "^3.1.2",
-        "jexl": "^1.1.4",
+        "jexl": "^2.1.0",
         "jsonpointer": "^4.0.1",
         "loglevel": "^1.4.1",
         "masonry-layout": "^4.2.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | --
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR contains an update to jexl 2.1, and use the new `evalSync` function.
#### Why?

Because this way we can avoid having unnecessary asynchronity and therefore easier to read code.