### PR TITLE
Add regenerator runtime to webpack config to fix ckeditor build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
     entries.unshift('core-js/fn/symbol');
     entries.unshift('whatwg-fetch');
     entries.unshift('url-search-params-polyfill');
+    entries.unshift('regenerator-runtime/runtime');
 
     return {
         entry: entries,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds `regenerator-runtime` to the entrypoints in put webpack config. This is needed because we want to produce an ES5 build that includes ckeditor.

See: 
* https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/advanced-setup.html#option-building-to-es5-target
* https://github.com/ckeditor/ckeditor5/issues/568