### PR TITLE
Use reaction instead of autorun to observe changes in stores of selection containers

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -1,6 +1,6 @@
 // @flow
 import React, {Fragment} from 'react';
-import {action, autorun, toJS, observable, untracked} from 'mobx';
+import {action, toJS, observable, reaction} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import {MultiItemSelection} from 'sulu-admin-bundle/components';
@@ -29,8 +29,7 @@ export default class MultiMediaSelection extends React.Component<Props> {
     };
 
     mediaSelectionStore: MultiMediaSelectionStore;
-    changeDisposer: () => void;
-    changeAutorunInitialized: boolean = false;
+    changeDisposer: () => *;
 
     @observable overlayOpen: boolean = false;
 
@@ -40,21 +39,16 @@ export default class MultiMediaSelection extends React.Component<Props> {
         const {locale, value} = this.props;
 
         this.mediaSelectionStore = new MultiMediaSelectionStore(value.ids, locale);
-        this.changeDisposer = autorun(() => {
-            const {onChange, value} = untracked(() => this.props);
-            const loadedMediaIds = this.mediaSelectionStore.selectedMediaIds;
+        this.changeDisposer = reaction(
+            () => (this.mediaSelectionStore.selectedMediaIds),
+            (loadedMediaIds: Array<number>) => {
+                const {onChange, value} = this.props;
 
-            if (!this.changeAutorunInitialized) {
-                this.changeAutorunInitialized = true;
-                return;
+                if (!equals(toJS(value.ids), toJS(loadedMediaIds))) {
+                    onChange({ids: loadedMediaIds});
+                }
             }
-
-            if (equals(toJS(value.ids), toJS(loadedMediaIds))) {
-                return;
-            }
-
-            onChange({ids: loadedMediaIds});
-        });
+        );
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR changes our selection containers to use a `reaction` instead of a `autorun` to observe changes in the store of the container.

#### Why?

Because the listener that calls the `onChange` callback of the container should only be executed if the value of the store of the container changes. In contrast to `autorun`, `reaction` allows us to specify precisely which data should be observed.

Right now, when using `autorun`, our `onChange` handler is unnecessarily called multiple times in various places. For example, this can be observed when changing the value of a `SingleSelection` inside a `Form` (ie. the author selection on the page-settings tag).

Furthermore, the unnecessary calls to our `onChange` handler lead to a strange bug that discards the ordering of the medias in our `MultiMediaSelection` container.