### PR TITLE
Use default template from webspace when adding new pages

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -61,8 +61,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
                     () => !this.resourceStore.loading,
                     (): void => this.setType(this.resourceStore.data[TYPE])
                 );
-            } else if (this.defaultType) {
-                this.setType(this.defaultType);
             }
         }
 
@@ -93,14 +91,6 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
     @computed get hasTypes(): boolean {
         return Object.keys(this.types).length > 0;
-    }
-
-    @computed get defaultType(): ?string {
-        if (!this.hasTypes) {
-            return undefined;
-        }
-
-        return Object.keys(this.types)[0];
     }
 
     @computed get loading(): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -339,27 +339,6 @@ test('Set dirty flag from ResourceStore', () => {
     expect(resourceFormStore.dirty).toEqual(true);
 });
 
-test('Set template property of ResourceStore to first type be default', () => {
-    const metadata = {};
-
-    const schemaTypesPromise = Promise.resolve({
-        type1: {},
-        type2: {},
-    });
-    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
-
-    const metadataPromise = Promise.resolve(metadata);
-    metadataStore.getSchema.mockReturnValue(metadataPromise);
-
-    const resourceStore = new ResourceStore('snippets');
-    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
-
-    return Promise.all([schemaTypesPromise, metadataPromise]).then(() => {
-        expect(resourceStore.set).toBeCalledWith('template', 'type1');
-        resourceFormStore.destroy();
-    });
-});
-
 test('Set template property of ResourceStore from the loaded data', () => {
     const metadata = {};
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -1,6 +1,8 @@
 // @flow
 import type {FieldTypeProps} from './containers/Form/types';
+import type {ToolbarItemConfig} from './containers/Toolbar/types';
 
 export type {
     FieldTypeProps,
+    ToolbarItemConfig,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -22,6 +22,7 @@ jest.mock('../../../../containers/Form', () => ({
         }
 
         changeType = jest.fn();
+        setType = jest.fn();
     },
 }));
 
@@ -89,6 +90,31 @@ test('Return item config with loading select', () => {
         options: [],
         value: 'homepage',
     }));
+});
+
+test('Set the first value as default if nothing is given', () => {
+    const typeToolbarAction = createTypeToolbarAction();
+    typeToolbarAction.resourceFormStore.typesLoading = false;
+    typeToolbarAction.resourceFormStore.types = {
+        default: {
+            key: 'default',
+            title: 'Default',
+        },
+        homepage: {
+            key: 'homepage',
+            title: 'Homepage',
+        },
+    };
+
+    const toolbarItemConfig = typeToolbarAction.getToolbarItemConfig();
+
+    if (toolbarItemConfig.type !== 'select') {
+        throw new Error(
+            'The returned toolbar item must be of type "select", but "' + toolbarItemConfig.type + '" was given!'
+        );
+    }
+
+    expect(typeToolbarAction.resourceFormStore.setType).toBeCalledWith('default');
 });
 
 test('Change the type of the FormStore when another type is selcted', () => {

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -100,7 +100,7 @@ class PageAdmin extends Admin
 
         $formToolbarActionsWithType = [
             'sulu_admin.save_with_publishing',
-            'sulu_admin.type',
+            'sulu_page.templates',
             'sulu_admin.delete',
             'sulu_page.edit',
         ];

--- a/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Webspace.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Webspace.xml
@@ -7,5 +7,6 @@
         <property name="localizations" expose="true">
             <type><![CDATA[array<Sulu\Component\Localization\Localization>]]></type>
         </property>
+        <property name="defaultTemplates" expose="true"/>
     </class>
 </serializer>

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -6,6 +6,7 @@ import SearchResult from './containers/Form/fields/SearchResult';
 import PageSettingsNavigationSelect from './containers/Form/fields/PageSettingsNavigationSelect';
 import PageSettingsShadowLocaleSelect from './containers/Form/fields/PageSettingsShadowLocaleSelect';
 import EditToolbarAction from './views/Form/toolbarActions/EditToolbarAction';
+import TemplateToolbarAction from './views/Form/toolbarActions/TemplateToolbarAction';
 import PageTabs from './views/PageTabs';
 import WebspaceOverview from './views/WebspaceOverview';
 
@@ -21,5 +22,6 @@ fieldRegistry.add('page_settings_navigation_select', PageSettingsNavigationSelec
 fieldRegistry.add('page_settings_shadow_locale_select', PageSettingsShadowLocaleSelect);
 
 toolbarActionRegistry.add('sulu_page.edit', EditToolbarAction);
+toolbarActionRegistry.add('sulu_page.templates', TemplateToolbarAction);
 
 bundleReady();

--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/WebspaceStore/types.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/WebspaceStore/types.js
@@ -2,13 +2,14 @@
 import type {Localization} from 'sulu-admin-bundle/stores';
 
 export type Webspace = {
-    name: string,
+    allLocalizations: Array<LocalizationItem>,
+    defaultTemplates: {[type: string]: string},
     key: string,
     localizations: Array<Localization>,
-    urls: Array<Url>,
-    allLocalizations: Array<LocalizationItem>,
-    portalInformation: Array<PortalInformation>,
+    name: string,
     navigations: Array<Navigation>,
+    portalInformation: Array<PortalInformation>,
+    urls: Array<Url>,
 };
 
 export type Navigation = {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/TemplateToolbarAction.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/TemplateToolbarAction.test.js
@@ -1,0 +1,182 @@
+// @flow
+import {ResourceFormStore} from 'sulu-admin-bundle/containers';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {Router} from 'sulu-admin-bundle/services';
+import {Form} from 'sulu-admin-bundle/views';
+import webspaceStore from '../../../../stores/WebspaceStore';
+import TemplateToolbarAction from '../../toolbarActions/TemplateToolbarAction';
+
+jest.mock('sulu-admin-bundle/utils', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('sulu-admin-bundle/stores', () => ({
+    ResourceStore: jest.fn(),
+}));
+
+jest.mock('sulu-admin-bundle/containers', () => ({
+    ResourceFormStore: class {
+        resourceStore;
+        types = {};
+        typesLoading = true;
+
+        constructor(resourceStore) {
+            this.resourceStore = resourceStore;
+        }
+
+        changeType = jest.fn();
+        setType = jest.fn();
+    },
+}));
+
+jest.mock('sulu-admin-bundle/services', () => ({
+    Router: jest.fn(function() {}),
+}));
+
+jest.mock('sulu-admin-bundle/views', () => ({
+    // $FlowFixMe
+    AbstractToolbarAction: require.requireActual('sulu-admin-bundle/views').AbstractToolbarAction,
+    Form: jest.fn(function() {
+        this.submit = jest.fn();
+    }),
+}));
+
+jest.mock('../../../../stores/WebspaceStore', () => ({
+    loadWebspace: jest.fn(),
+}));
+
+function createTemplateToolbarAction() {
+    const resourceStore = new ResourceStore('test');
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'test');
+    const router = new Router({});
+    const form = new Form({
+        locales: [],
+        resourceStore,
+        route: router.route,
+        router,
+    });
+
+    return new TemplateToolbarAction(resourceFormStore, form, router);
+}
+
+test('Return item config with correct disabled, loading, options, icon, type and value ', () => {
+    const templateToolbarAction = createTemplateToolbarAction();
+    templateToolbarAction.resourceFormStore.typesLoading = false;
+    templateToolbarAction.resourceFormStore.type = 'default';
+    templateToolbarAction.resourceFormStore.types = {
+        default: {
+            key: 'default',
+            title: 'Default',
+        },
+        homepage: {
+            key: 'homepage',
+            title: 'Homepage',
+        },
+    };
+
+    expect(templateToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        icon: 'su-brush',
+        loading: false,
+        options: [
+            {
+                label: 'Default',
+                value: 'default',
+            },
+            {
+                label: 'Homepage',
+                value: 'homepage',
+            },
+        ],
+        type: 'select',
+        value: 'default',
+    }));
+});
+
+test('Return item config with loading select', () => {
+    const templateToolbarAction = createTemplateToolbarAction();
+    templateToolbarAction.resourceFormStore.typesLoading = true;
+    templateToolbarAction.resourceFormStore.type = 'homepage';
+    templateToolbarAction.resourceFormStore.types = {};
+
+    expect(templateToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        loading: true,
+        options: [],
+        value: 'homepage',
+    }));
+});
+
+test('Set the first value as default if nothing is given', () => {
+    const templateToolbarAction = createTemplateToolbarAction();
+
+    templateToolbarAction.router.attributes = {
+        webspace: 'sulu',
+    };
+
+    templateToolbarAction.resourceFormStore.typesLoading = false;
+    templateToolbarAction.resourceFormStore.types = {
+        default: {
+            key: 'default',
+            title: 'Default',
+        },
+        homepage: {
+            key: 'homepage',
+            title: 'Homepage',
+        },
+    };
+
+    const webspacePromise = Promise.resolve({
+        defaultTemplates: {
+            page: 'homepage',
+        },
+    });
+    webspaceStore.loadWebspace.mockReturnValue(webspacePromise);
+
+    const toolbarItemConfig = templateToolbarAction.getToolbarItemConfig();
+
+    if (toolbarItemConfig.type !== 'select') {
+        throw new Error(
+            'The returned toolbar item must be of type "select", but "' + toolbarItemConfig.type + '" was given!'
+        );
+    }
+
+    return webspacePromise.then(() => {
+        templateToolbarAction.getToolbarItemConfig();
+        expect(templateToolbarAction.resourceFormStore.setType).toBeCalledWith('homepage');
+    });
+});
+
+test('Change the type of the FormStore when another type is selected', () => {
+    const templateToolbarAction = createTemplateToolbarAction();
+    templateToolbarAction.resourceFormStore.typesLoading = false;
+    templateToolbarAction.resourceFormStore.type = 'default';
+    templateToolbarAction.resourceFormStore.types = {
+        default: {
+            key: 'default',
+            title: 'Default',
+        },
+        homepage: {
+            key: 'homepage',
+            title: 'Homepage',
+        },
+    };
+
+    const toolbarItemConfig = templateToolbarAction.getToolbarItemConfig();
+
+    if (toolbarItemConfig.type !== 'select') {
+        throw new Error(
+            'The returned toolbar item must be of type "select", but "' + toolbarItemConfig.type + '" was given!'
+        );
+    }
+
+    toolbarItemConfig.onChange('homepage');
+
+    expect(templateToolbarAction.resourceFormStore.changeType).toBeCalledWith('homepage');
+});
+
+test('Throw error if no types are available in FormStore', () => {
+    const templateToolbarAction = createTemplateToolbarAction();
+    templateToolbarAction.resourceFormStore.typesLoading = false;
+    templateToolbarAction.resourceFormStore.types = {};
+
+    expect(() => templateToolbarAction.getToolbarItemConfig()).toThrow(/actually supporting types/);
+});

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/TemplateToolbarAction.js
@@ -1,13 +1,29 @@
 // @flow
-import AbstractToolbarAction from '../toolbarActions/AbstractToolbarAction';
-import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import {action, computed, observable} from 'mobx';
+import {AbstractToolbarAction} from 'sulu-admin-bundle/views';
+import type {ToolbarItemConfig} from 'sulu-admin-bundle/types';
+import webspaceStore from '../../../stores/WebspaceStore';
+import type {Webspace} from '../../../stores/WebspaceStore/types';
 
-export default class TypeToolbarAction extends AbstractToolbarAction {
+export default class TemplateToolbarAction extends AbstractToolbarAction {
+    @observable webspace: ?Webspace = undefined;
+
+    @computed get defaultTemplate(): ?string {
+        if (!this.webspace) {
+            webspaceStore.loadWebspace(this.router.attributes.webspace).then(action((webspace) => {
+                this.webspace = webspace;
+            }));
+            return undefined;
+        }
+
+        return this.webspace.defaultTemplates.page;
+    }
+
     getToolbarItemConfig(): ToolbarItemConfig {
         const formTypes = this.resourceFormStore.types;
         const formKeys = Object.keys(formTypes);
-        if (formKeys.length > 0 && !this.resourceFormStore.type) {
-            this.resourceFormStore.setType(formKeys[0]);
+        if (formKeys.length > 0 && !this.resourceFormStore.type && this.defaultTemplate) {
+            this.resourceFormStore.setType(this.defaultTemplate);
         }
 
         if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the default template configured in the webspace XML to set the default template when a page is added.

#### Why?

Because it would be nice to be able to select the default template.