### PR TITLE
Persist persistent user settings with a value of false

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -145,14 +145,15 @@ class UserStore {
 
     updatePersistentSettings = debounce(() => {
         const persistentSettings = this.dirtyPersistentSettings.reduce((persistentSettings, persistentSettingKey) => {
-            const persistentSetting = this.persistentSettings.get(persistentSettingKey);
-            if (persistentSetting) {
-                persistentSettings[persistentSettingKey] = persistentSetting;
+            if (this.persistentSettings.has(persistentSettingKey)) {
+                persistentSettings[persistentSettingKey] = this.persistentSettings.get(persistentSettingKey);
             }
             return persistentSettings;
         }, {});
 
         Requester.patch(Config.endpoints.profileSettings, persistentSettings);
+
+        this.dirtyPersistentSettings.splice(0, this.dirtyPersistentSettings.length);
     }, UPDATE_PERSISTENT_SETTINGS_DELAY);
 
     @action setPersistentSetting(key: string, value: *) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -132,8 +132,15 @@ test('Should set persistent setting', () => {
 
 test('Should update persistent settings of server with a debounce delay of 5 seconds', () => {
     userStore.setPersistentSetting('test1', 'value1');
-
     expect(Requester.patch).toBeCalledWith('profile_settings_url', {test1: 'value1'});
+
+    userStore.setPersistentSetting('test2', 'value2');
+    expect(Requester.patch).toBeCalledWith('profile_settings_url', {test2: 'value2'});
+});
+
+test('Should also update persistent setting with the value of false on the server', () => {
+    userStore.setPersistentSetting('test1', false);
+    expect(Requester.patch).toBeCalledWith('profile_settings_url', {test1: false});
 });
 
 test('Should login', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses `has` instead of `get` to check if a value is in the user settings map. In addition to that it clears the array for the dirty settings after the changes have been set.

#### Why?

This allows to also persist the unpinned state of the navigation. It also avoids sending settings to the server that have already been persisted.