### PR TITLE
Ask for confirmation when leaving an edited form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -163,7 +163,7 @@ result in the navigation not to happen. This way the application can e.g. stop t
 not saved yet (that's what it is used for in the [`Form`](#form) view).
 
 ```javascript static
-router.addUpdateRouteHook((route) => {
+router.addUpdateRouteHook((route, attributes, updateRouteMethod) => {
     if (route.name === 'test') {
         return false;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -156,3 +156,20 @@ router.addUpdateAttributesHooks((route) => ({
 // navigates to #/webspace/sulu_io/de?utf=true&test=true
 router.navigate('sulu_page.webspace_overview', {webspace: 'sulu_io', test: true})
 ```
+
+There are also the `updateRouteHooks`, which are called with the destination route, its attributes and a reference to
+the function that was called (`navigate`, `redirect` or `restore`). Each of these hooks can return `false`, which will
+result in the navigation not to happen. This way the application can e.g. stop the navigation process if some data is
+not saved yet (that's what it is used for in the [`Form`](#form) view).
+
+```javascript static
+router.addUpdateRouteHook((route) => {
+    if (route.name === 'test') {
+        return false;
+    }
+
+    return true;
+});
+
+router.navigate('test'); // This navigation will no happen because of the above hook
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -38,6 +38,13 @@ export default class Router {
                 this.redirectFlag = false;
             }
         });
+
+        window.addEventListener('beforeunload', (event) => {
+            if (this.updateRouteHooks.some((updateRouteHook) => updateRouteHook() === false)) {
+                event.preventDefault();
+                event.returnValue = true;
+            }
+        });
     }
 
     addUpdateRouteHook(hook: UpdateRouteHook) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -4,7 +4,7 @@ import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
 import equal from 'fast-deep-equal';
 import log from 'loglevel';
 import pathToRegexp, {compile} from 'path-to-regexp';
-import type {AttributeMap, Route, UpdateAttributesHook} from './types';
+import type {AttributeMap, Route, UpdateAttributesHook, UpdateRouteHook, UpdateRouteMethod} from './types';
 import routeRegistry from './registries/RouteRegistry';
 
 export default class Router {
@@ -14,6 +14,7 @@ export default class Router {
     @observable bindings: Map<string, IObservableValue<*>> = new Map();
     bindingDefaults: Map<string, ?string | number | boolean> = new Map();
     attributesHistory: {[string]: Array<AttributeMap>} = {};
+    updateRouteHooks: Array<UpdateRouteHook> = [];
     updateAttributesHooks: Array<UpdateAttributesHook> = [];
     redirectFlag: boolean = false;
 
@@ -37,6 +38,19 @@ export default class Router {
                 this.redirectFlag = false;
             }
         });
+    }
+
+    addUpdateRouteHook(hook: UpdateRouteHook) {
+        this.updateRouteHooks.push(hook);
+    }
+
+    removeUpdateRouteHook(hook: UpdateRouteHook) {
+        const hookIndex = this.updateRouteHooks.indexOf(hook);
+        if (hookIndex === -1) {
+            return;
+        }
+
+        this.updateRouteHooks.splice(hookIndex, 1);
     }
 
     addUpdateAttributesHook(hook: UpdateAttributesHook) {
@@ -88,34 +102,35 @@ export default class Router {
                 attributes[key] = Router.tryParse(value);
             });
 
-            this.handleNavigation(name, attributes);
+            this.handleNavigation(name, attributes, this.navigate);
 
             break;
         }
     }
 
-    handleNavigation(name: string, attributes: Object) {
+    handleNavigation(name: string, attributes: Object, updateRouteMethod: UpdateRouteMethod): void {
         if (!this.isRouteChanging(name, attributes)) {
             return;
         }
 
         this.createAttributesHistory();
-        this.update(name, attributes);
+        this.update(name, attributes, updateRouteMethod);
     }
 
-    @action navigate(name: string, attributes: Object = {}) {
+    @action navigate = (name: string, attributes: Object = {}): void => {
         this.clearBindings();
-        this.handleNavigation(name, attributes);
-    }
+        this.handleNavigation(name, attributes, this.navigate);
+    };
 
-    @action redirect(name: string, attributes: Object = {}) {
+    @action redirect = (name: string, attributes: Object = {}): void => {
         this.redirectFlag = true;
-        this.navigate(name, attributes);
-    }
+        this.clearBindings();
+        this.handleNavigation(name, attributes, this.redirect);
+    };
 
-    restore(name: string, attributes: Object = {}) {
+    restore = (name: string, attributes: Object = {}): void => {
         if (!this.attributesHistory[name] || this.attributesHistory[name].length === 0) {
-            this.update(name, attributes);
+            this.update(name, attributes, this.restore);
             return;
         }
 
@@ -125,10 +140,10 @@ export default class Router {
 
         const attributesHistory = this.attributesHistory[name].pop();
 
-        this.update(name, {...attributesHistory, ...attributes});
-    }
+        this.update(name, {...attributesHistory, ...attributes}, this.restore);
+    };
 
-    @action update(name: string, attributes: Object) {
+    @action update(name: string, attributes: Object, updateRouteMethod: UpdateRouteMethod): void {
         const route = routeRegistry.get(name);
 
         const updatedAttributes = {
@@ -139,9 +154,7 @@ export default class Router {
             ...attributes,
         };
 
-        this.route = route;
-
-        const attributeDefaults = this.route.attributeDefaults;
+        const attributeDefaults = route.attributeDefaults;
         Object.keys(attributeDefaults).forEach((key) => {
             // set default attributes if not passed, to automatically set important omitted attributes everywhere
             // e.g. allows to always pass the default locale if nothing is passed
@@ -151,6 +164,13 @@ export default class Router {
             updatedAttributes[key] = attributeDefaults[key];
         });
 
+        for (const updateRouteHook of this.updateRouteHooks) {
+            if (!updateRouteHook(route, updatedAttributes, updateRouteMethod)) {
+                return;
+            }
+        }
+
+        this.route = route;
         this.attributes = updatedAttributes;
 
         for (const [key, observableValue] of this.bindings.entries()) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -25,3 +25,7 @@ export type AttributeMap = {[string]: string};
 export type RouteMap = {[string]: Route};
 
 export type UpdateAttributesHook = (route: Route, attributes: AttributeMap) => AttributeMap;
+
+export type UpdateRouteHook = (route: Route, attributes: AttributeMap, updateRouteMethod: UpdateRouteMethod) => boolean;
+
+export type UpdateRouteMethod = (route: string, attributes: AttributeMap) => void;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/types.js
@@ -26,6 +26,10 @@ export type RouteMap = {[string]: Route};
 
 export type UpdateAttributesHook = (route: Route, attributes: AttributeMap) => AttributeMap;
 
-export type UpdateRouteHook = (route: Route, attributes: AttributeMap, updateRouteMethod: UpdateRouteMethod) => boolean;
+export type UpdateRouteHook = (
+    route: ?Route,
+    attributes: ?AttributeMap,
+    updateRouteMethod: ?UpdateRouteMethod
+) => boolean;
 
 export type UpdateRouteMethod = (route: string, attributes: AttributeMap) => void;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -86,6 +86,7 @@ export default class ResourceStore {
 
             this.initialized = true;
             this.setLoading(false);
+            this.dirty = false;
         }));
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -90,6 +90,10 @@ export default class ResourceStore {
         }));
     };
 
+    @action reload = () => {
+        this.load();
+    };
+
     @action setLoading(loading: boolean) {
         this.loading = loading;
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -115,6 +115,28 @@ test('Should not load the data with the ResourceRequester if locale should be pr
     expect(ResourceRequester.get).not.toBeCalled();
 });
 
+test('Should load the data with the ResourceRequester if a reload is requested', () => {
+    const promise1 = Promise.resolve({value: 'Value'});
+    ResourceRequester.get.mockReturnValue(promise1);
+    const resourceStore = new ResourceStore('snippets', '3', {locale: observable.box()}, {test: 10});
+    resourceStore.setLocale('en');
+    expect(ResourceRequester.get).toBeCalledWith('snippets', '3', {locale: 'en', test: 10});
+    return promise1.then(() => {
+        expect(resourceStore.data).toEqual({value: 'Value'});
+
+        const promise2 = Promise.resolve({value: 'new Value'});
+        ResourceRequester.get.mockReturnValue(promise2);
+        resourceStore.reload();
+
+        expect(ResourceRequester.get).toBeCalledWith('snippets', '3', {locale: 'en', test: 10});
+        expect(ResourceRequester.get).toHaveBeenCalledTimes(2);
+
+        return promise2.then(() => {
+            expect(resourceStore.data).toEqual({value: 'new Value'});
+        });
+    });
+});
+
 test('Loading flag should be set to true when loading', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve({}));
     const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -119,9 +119,9 @@ class Form extends React.Component<Props> {
     }
 
     @action checkFormStoreDirtyStateBeforeNavigation = (
-        route: Route,
-        attributes: AttributeMap,
-        updateRouteMethod: UpdateRouteMethod
+        route: ?Route,
+        attributes: ?AttributeMap,
+        updateRouteMethod: ?UpdateRouteMethod
     ) => {
         if (!this.resourceFormStore.dirty) {
             return true;
@@ -136,6 +136,11 @@ class Form extends React.Component<Props> {
             // If the warning has already been displayed for the exact same route and attributes we can assume that the
             // confirm button in the warning has been clicked, since it calls the same routing action again.
             return true;
+        }
+
+        if (!route && !attributes && !updateRouteMethod) {
+            // If none of these attributes are set the call comes because the user wants to close the window
+            return false;
         }
 
         this.showDirtyWarning = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -6,12 +6,15 @@ import {action, computed, toJS, isObservableArray, observable, when} from 'mobx'
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import jexl from 'jexl';
+import Dialog from '../../components/Dialog';
 import PublishIndicator from '../../components/PublishIndicator';
 import {default as FormContainer, ResourceFormStore} from '../../containers/Form';
 import {withToolbar} from '../../containers/Toolbar';
 import {withSidebar} from '../../containers/Sidebar';
 import type {ViewProps} from '../../containers/ViewRenderer';
+import type {AttributeMap, Route, UpdateRouteMethod} from '../../services/Router/types';
 import ResourceStore from '../../stores/ResourceStore';
+import {translate} from '../../utils/Translator';
 import toolbarActionRegistry from './registries/ToolbarActionRegistry';
 import formStyles from './form.scss';
 
@@ -29,6 +32,10 @@ class Form extends React.Component<Props> {
     showSuccess: IObservableValue<boolean> = observable.box(false);
     @observable toolbarActions = [];
     @observable hasPreview: boolean = false;
+    @observable showDirtyWarning = false;
+    postponedUpdateRouteMethod: ?UpdateRouteMethod;
+    postponedRoute: ?Route;
+    postponedRouteAttributes: ?AttributeMap;
 
     @computed get hasOwnResourceStore() {
         const {
@@ -107,7 +114,37 @@ class Form extends React.Component<Props> {
         if (this.resourceStore.locale) {
             router.bind('locale', this.resourceStore.locale);
         }
+
+        router.addUpdateRouteHook(this.checkFormStoreDirtyStateBeforeNavigation);
     }
+
+    @action checkFormStoreDirtyStateBeforeNavigation = (
+        route: Route,
+        attributes: AttributeMap,
+        updateRouteMethod: UpdateRouteMethod
+    ) => {
+        if (!this.resourceFormStore.dirty) {
+            return true;
+        }
+
+        if (
+            this.showDirtyWarning === true
+            && this.postponedRoute === route
+            && equals(this.postponedRouteAttributes, attributes)
+            && this.postponedUpdateRouteMethod === updateRouteMethod
+        ) {
+            // If the warning has already been displayed for the exact same route and attributes we can assume that the
+            // confirm button in the warning has been clicked, since it calls the same routing action again.
+            return true;
+        }
+
+        this.showDirtyWarning = true;
+        this.postponedUpdateRouteMethod = updateRouteMethod;
+        this.postponedRoute = route;
+        this.postponedRouteAttributes = attributes;
+
+        return false;
+    };
 
     buildFormStoreOptions(
         apiOptions: Object,
@@ -160,6 +197,9 @@ class Form extends React.Component<Props> {
     }
 
     componentWillUnmount() {
+        const {router} = this.props;
+        router.removeUpdateRouteHook(this.checkFormStoreDirtyStateBeforeNavigation);
+
         this.resourceFormStore.destroy();
 
         if (this.hasOwnResourceStore) {
@@ -260,6 +300,24 @@ class Form extends React.Component<Props> {
         this.errors.push('Errors occured when trying to save the data from the FormStore');
     };
 
+    @action handleDirtyWarningCancelClick = () => {
+        this.showDirtyWarning = false;
+        this.postponedUpdateRouteMethod = undefined;
+        this.postponedRoute = undefined;
+        this.postponedRouteAttributes = undefined;
+    };
+
+    @action handleDirtyWarningConfirmClick = () => {
+        if (!this.postponedUpdateRouteMethod || !this.postponedRoute || !this.postponedRouteAttributes) {
+            throw new Error('Some routing information is missing. This should not happen and is likely a bug.');
+        }
+
+        this.postponedUpdateRouteMethod(this.postponedRoute.name, this.postponedRouteAttributes);
+        this.postponedUpdateRouteMethod = undefined;
+        this.postponedRoute = undefined;
+        this.postponedRouteAttributes = undefined;
+    };
+
     setFormRef = (form: ?ElementRef<typeof FormContainer>) => {
         this.form = form;
     };
@@ -274,6 +332,16 @@ class Form extends React.Component<Props> {
                     store={this.resourceFormStore}
                 />
                 {this.toolbarActions.map((toolbarAction) => toolbarAction.getNode())}
+                <Dialog
+                    cancelText={translate('sulu_admin.cancel')}
+                    confirmText={translate('sulu_admin.confirm')}
+                    onCancel={this.handleDirtyWarningCancelClick}
+                    onConfirm={this.handleDirtyWarningConfirmClick}
+                    open={this.showDirtyWarning}
+                    title={translate('sulu_admin.dirty_warning_dialog_title')}
+                >
+                    {translate('sulu_admin.dirty_warning_dialog_text')}
+                </Dialog>
             </div>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -82,6 +82,7 @@ test('Should reuse the passed resourceStore if the passed resourceKey is the sam
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         route,
     };
@@ -103,6 +104,7 @@ test('Should create a new resourceStore if the passed resourceKey differs', () =
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         route,
     };
@@ -129,6 +131,7 @@ test('Should create a new resourceStore if the passed resourceKey differs with l
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         bind: jest.fn(),
         route,
@@ -156,6 +159,7 @@ test('Should create a new resourceStore if the passed resourceKey differs with o
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         bind: jest.fn(),
         route,
@@ -184,6 +188,7 @@ test('Should create a new resourceStore if the passed resourceKey differs with o
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         bind: jest.fn(),
         route,
@@ -211,6 +216,7 @@ test('Should instantiate the ResourceStore with the idQueryParameter if given', 
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         route,
     };
@@ -267,6 +273,7 @@ test('Should add items defined in ToolbarActions to Toolbar', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         route,
         attributes: {},
@@ -298,6 +305,7 @@ test('Should initialize preview sidebar', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         route,
         attributes: {},
@@ -332,6 +340,7 @@ test('Should not initialize preview sidebar when expression evaluates to false',
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         route,
         attributes: {},
@@ -362,6 +371,7 @@ test('Should not initialize preview sidebar when option is not set', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         route,
         attributes: {},
@@ -392,6 +402,7 @@ test('Should not add PublishIndicator if no publish status is available', () => 
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         restore: jest.fn(),
         bind: jest.fn(),
         route,
@@ -424,6 +435,7 @@ test('Should add PublishIndicator if publish status is available showing draft',
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         restore: jest.fn(),
         bind: jest.fn(),
         route,
@@ -462,6 +474,7 @@ test('Should add PublishIndicator if publish status is available showing publish
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         restore: jest.fn(),
         bind: jest.fn(),
         route,
@@ -500,6 +513,7 @@ test('Should add PublishIndicator if publish status is available showing publish
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         restore: jest.fn(),
         bind: jest.fn(),
         route,
@@ -548,6 +562,7 @@ test('Should set and update locales defined in ToolbarActions', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         route,
         attributes: {},
@@ -576,6 +591,7 @@ test('Should navigate to defined route on back button click', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         restore: jest.fn(),
         bind: jest.fn(),
         route,
@@ -604,6 +620,7 @@ test('Should navigate to defined route on back button click without locale', () 
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         restore: jest.fn(),
         bind: jest.fn(),
         route,
@@ -614,6 +631,98 @@ test('Should navigate to defined route on back button click without locale', () 
     const toolbarConfig = toolbarFunction.call(form.instance());
     toolbarConfig.backButton.onClick();
     expect(router.restore).toBeCalledWith('test_route', {});
+});
+
+test('Should navigate to defined route after dialog has been confirmed', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1);
+
+    const route = {
+        options: {
+            backRoute: 'test_route',
+            formKey: 'snippets',
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    form.instance().resourceFormStore.dirty = true;
+
+    const checkFormStoreDirtyStateBeforeNavigation = router.addUpdateRouteHook.mock.calls[0][0];
+
+    const backRoute = {
+        name: 'test_route',
+    };
+    const backRouteAttributes = {};
+
+    expect(form.find('Dialog').prop('open')).toEqual(false);
+    expect(checkFormStoreDirtyStateBeforeNavigation({}, backRouteAttributes, router.navigate)).toEqual(false);
+    form.update();
+    expect(form.find('Dialog').prop('open')).toEqual(true);
+
+    form.find('Dialog').prop('onCancel')();
+    form.update();
+    expect(form.find('Dialog').prop('open')).toEqual(false);
+    expect(router.navigate).not.toBeCalled();
+
+    expect(checkFormStoreDirtyStateBeforeNavigation(backRoute, backRouteAttributes, router.navigate)).toEqual(false);
+    form.find('Dialog').prop('onConfirm')();
+    form.update();
+    expect(router.navigate).toBeCalledWith('test_route', backRouteAttributes);
+});
+
+test('Should navigate to defined route after dialog has been confirmed using restore', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1);
+
+    const route = {
+        options: {
+            backRoute: 'test_route',
+            formKey: 'snippets',
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route,
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    form.instance().resourceFormStore.dirty = true;
+
+    const checkFormStoreDirtyStateBeforeNavigation = router.addUpdateRouteHook.mock.calls[0][0];
+
+    const backRoute = {
+        name: 'test_route',
+    };
+    const backRouteAttributes = {};
+
+    expect(form.find('Dialog').prop('open')).toEqual(false);
+    expect(checkFormStoreDirtyStateBeforeNavigation({}, backRouteAttributes, router.restore)).toEqual(false);
+    form.update();
+    expect(form.find('Dialog').prop('open')).toEqual(true);
+
+    form.find('Dialog').prop('onCancel')();
+    form.update();
+    expect(form.find('Dialog').prop('open')).toEqual(false);
+    expect(router.restore).not.toBeCalled();
+
+    expect(checkFormStoreDirtyStateBeforeNavigation(backRoute, backRouteAttributes, router.restore)).toEqual(false);
+    form.find('Dialog').prop('onConfirm')();
+    form.update();
+    expect(router.restore).toBeCalledWith('test_route', backRouteAttributes);
 });
 
 test('Should not render back button when no editLink is configured', () => {
@@ -630,6 +739,7 @@ test('Should not render back button when no editLink is configured', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         navigate: jest.fn(),
         bind: jest.fn(),
         route,
@@ -657,6 +767,7 @@ test('Should change locale in form store via locale chooser', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         navigate: jest.fn(),
         bind: jest.fn(),
         route,
@@ -685,6 +796,7 @@ test('Should show locales from router options in toolbar', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         navigate: jest.fn(),
         bind: jest.fn(),
         route,
@@ -713,6 +825,7 @@ test('Should show locales from props in toolbar if route has no locales', () => 
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         navigate: jest.fn(),
         bind: jest.fn(),
         route,
@@ -741,6 +854,7 @@ test('Should not show a locale chooser if no locales are passed in router option
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         navigate: jest.fn(),
         bind: jest.fn(),
         route,
@@ -766,6 +880,7 @@ test('Should initialize the ResourceStore with a schema', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         route,
         attributes: {
@@ -821,6 +936,7 @@ test('Should save form when submitted', (done) => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -881,6 +997,7 @@ test('Should save form when submitted with mapped router attributes', (done) => 
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -944,6 +1061,7 @@ test('Should save form when submitted with given apiOptions', (done) => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1001,6 +1119,7 @@ test('Should save form when submitted with mapped router attributes and given ap
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1065,6 +1184,7 @@ test('Should save form when submitted with mapped named router attributes and gi
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1118,6 +1238,7 @@ test('Should set showSuccess flag after form submission', (done) => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1167,6 +1288,7 @@ test('Should show error if form has been tried to save although it is not valid'
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1222,6 +1344,7 @@ test('Should keep errors after form submission has failed', (done) => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1274,6 +1397,7 @@ test('Should save form when submitted and redirect to editRoute', (done) => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {
             id: 8,
             webspace: 'sulu_io',
@@ -1316,6 +1440,7 @@ test('Should pass store and schema handler to FormContainer', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         bind: jest.fn(),
         navigate: jest.fn(),
         route,
@@ -1343,9 +1468,11 @@ test('Should destroy the store on unmount', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
         bind: jest.fn(),
         route,
-        attributes: {},
+        removeUpdateRouteHook: jest.fn(),
     };
 
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
@@ -1375,8 +1502,10 @@ test('Should destroy the own resourceStore if existing on unmount', () => {
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         route,
+        removeUpdateRouteHook: jest.fn(),
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
     const formResourceStore = form.instance().resourceStore;
@@ -1399,22 +1528,28 @@ test('Should not bind the locale if no locales have been passed via options', ()
         },
     };
     const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
         bind: jest.fn(),
         unbind: jest.fn(),
+        removeUpdateRouteHook: jest.fn(),
         route,
-        attributes: {},
     };
 
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
 
     expect(router.bind).not.toBeCalled();
 
+    const checkFormStoreDirtyStateBeforeNavigation = form.instance().checkFormStoreDirtyStateBeforeNavigation;
+
     form.unmount();
     expect(router.unbind).not.toBeCalled();
+    expect(router.removeUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation);
 });
 
 test('Should throw an error if the resourceStore is not passed', () => {
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         route: {
             options: {
@@ -1431,6 +1566,7 @@ test('Should throw an error if no formKey is passed', () => {
     const resourceStore = new ResourceStore('snippets', 12);
 
     const router = {
+        addUpdateRouteHook: jest.fn(),
         attributes: {},
         route: {
             options: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -725,6 +725,64 @@ test('Should navigate to defined route after dialog has been confirmed using res
     expect(router.restore).toBeCalledWith('test_route', backRouteAttributes);
 });
 
+test('Should not close the window if formStore is still dirty', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1);
+
+    const route = {
+        options: {
+            backRoute: 'test_route',
+            formKey: 'snippets',
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    form.instance().resourceFormStore.dirty = true;
+
+    const checkFormStoreDirtyStateBeforeNavigation = router.addUpdateRouteHook.mock.calls[0][0];
+
+    expect(form.find('Dialog').prop('open')).toEqual(false);
+    expect(checkFormStoreDirtyStateBeforeNavigation()).toEqual(false);
+});
+
+test('Should close the window if formStore is not dirty', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1);
+
+    const route = {
+        options: {
+            backRoute: 'test_route',
+            formKey: 'snippets',
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    form.instance().resourceFormStore.dirty = false;
+
+    const checkFormStoreDirtyStateBeforeNavigation = router.addUpdateRouteHook.mock.calls[0][0];
+
+    expect(form.find('Dialog').prop('open')).toEqual(false);
+    expect(checkFormStoreDirtyStateBeforeNavigation()).toEqual(true);
+});
+
 test('Should not render back button when no editLink is configured', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -53,7 +53,7 @@ export default class ResourceTabs extends React.Component<Props> {
     componentDidUpdate(prevProps: Props) {
         if (this.props.children !== prevProps.children) {
             // If the content for a new tab is loaded we reload the ResourceStore to make sure we have the right title
-            this.resourceStore.load();
+            this.resourceStore.reload();
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -50,6 +50,13 @@ export default class ResourceTabs extends React.Component<Props> {
         this.redirectToRouteWithHighestPriorityDisposer = autorun(this.redirectToRouteWithHighestPriority);
     }
 
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.children !== prevProps.children) {
+            // If the content for a new tab is loaded we reload the ResourceStore to make sure we have the right title
+            this.resourceStore.load();
+        }
+    }
+
     componentWillUnmount() {
         this.redirectToRouteWithHighestPriorityDisposer();
         this.resourceStore.destroy();
@@ -159,9 +166,6 @@ export default class ResourceTabs extends React.Component<Props> {
     handleSelect = (index: number) => {
         const {router} = this.props;
         router.navigate(this.visibleTabRoutes[index].name, router.attributes);
-
-        // TODO replace by asking for confirmation when changing tabs and reload only if dirty data should be deleted
-        this.resourceStore.load();
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -912,6 +912,7 @@ test('Should reload ResourceStore if children are updated', () => {
     ResourceStore.mockImplementation(function() {
         this.initialized = true;
         this.load = jest.fn();
+        this.reload = jest.fn();
         extendObservable(this, {data: {}});
     });
 
@@ -947,7 +948,7 @@ test('Should reload ResourceStore if children are updated', () => {
     const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => (<Child />)}</ResourceTabs>);
 
     resourceTabs.setProps({children: () => null});
-    expect(resourceTabs.instance().resourceStore.load).toBeCalledWith();
+    expect(resourceTabs.instance().resourceStore.reload).toBeCalledWith();
 });
 
 test('Should navigate to child route if tab is clicked', (done) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -908,7 +908,49 @@ test('Should not redirect if a tab is already active', () => {
     expect(router.redirect).not.toBeCalled();
 });
 
-test('Should navigate and reload ResourceStore to child route if tab is clicked', (done) => {
+test('Should reload ResourceStore if children are updated', () => {
+    ResourceStore.mockImplementation(function() {
+        this.initialized = true;
+        this.load = jest.fn();
+        extendObservable(this, {data: {}});
+    });
+
+    const childRoute1 = {
+        name: 'route1',
+        options: {},
+    };
+    const childRoute2 = {
+        name: 'route2',
+        options: {},
+    };
+    const route = {
+        options: {
+            resourceKey: 'test',
+        },
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+    };
+
+    const attributes = {
+        attribute: 'value',
+    };
+
+    const router = {
+        attributes,
+        navigate: jest.fn(),
+        route: childRoute1,
+    };
+
+    const Child = () => (<h1>Child</h1>);
+    const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => (<Child />)}</ResourceTabs>);
+
+    resourceTabs.setProps({children: () => null});
+    expect(resourceTabs.instance().resourceStore.load).toBeCalledWith();
+});
+
+test('Should navigate to child route if tab is clicked', (done) => {
     ResourceStore.mockImplementation(function() {
         this.initialized = true;
         this.load = jest.fn();
@@ -950,7 +992,6 @@ test('Should navigate and reload ResourceStore to child route if tab is clicked'
         resourceTabs.update();
         resourceTabs.find('Tab button').at(1).simulate('click');
         expect(router.navigate).toBeCalledWith('route2', attributes);
-        expect(resourceTabs.instance().resourceStore.load).toBeCalledWith();
         done();
     });
 });
@@ -1006,7 +1047,6 @@ test('Should navigate to child route if tab is clicked with hidden tabs', (done)
         resourceTabs.update();
         resourceTabs.find('Tab button').at(0).simulate('click');
         expect(router.navigate).toBeCalledWith('route2', attributes);
-        expect(resourceTabs.instance().resourceStore.load).toBeCalledWith();
         done();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -103,5 +103,7 @@
     "sulu_admin.heading3": "Überschrift 3",
     "sulu_admin.heading4": "Überschrift 4",
     "sulu_admin.heading5": "Überschrift 5",
-    "sulu_admin.heading6": "Überschrift 6"
+    "sulu_admin.heading6": "Überschrift 6",
+    "sulu_admin.dirty_warning_dialog_title": "Achtung!",
+    "sulu_admin.dirty_warning_dialog_text": "Es liegen nicht gespeicherte Daten vor, die beim Verlassen verloren gehen."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -104,6 +104,6 @@
     "sulu_admin.heading4": "Überschrift 4",
     "sulu_admin.heading5": "Überschrift 5",
     "sulu_admin.heading6": "Überschrift 6",
-    "sulu_admin.dirty_warning_dialog_title": "Achtung!",
-    "sulu_admin.dirty_warning_dialog_text": "Es liegen nicht gespeicherte Daten vor, die beim Verlassen verloren gehen."
+    "sulu_admin.dirty_warning_dialog_title": "Formular verlassen?",
+    "sulu_admin.dirty_warning_dialog_text": "Ihre Änderungen werden nicht gespeichert."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -103,5 +103,7 @@
     "sulu_admin.heading3": "Heading 3",
     "sulu_admin.heading4": "Heading 4",
     "sulu_admin.heading5": "Heading 5",
-    "sulu_admin.heading6": "Heading 6"
+    "sulu_admin.heading6": "Heading 6",
+    "sulu_admin.dirty_warning_dialog_title": "Attention!",
+    "sulu_admin.dirty_warning_dialog_text": "There is unsaved data being lost when leaving."
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -104,6 +104,6 @@
     "sulu_admin.heading4": "Heading 4",
     "sulu_admin.heading5": "Heading 5",
     "sulu_admin.heading6": "Heading 6",
-    "sulu_admin.dirty_warning_dialog_title": "Attention!",
-    "sulu_admin.dirty_warning_dialog_text": "There is unsaved data being lost when leaving."
+    "sulu_admin.dirty_warning_dialog_title": "Leave form?",
+    "sulu_admin.dirty_warning_dialog_text": "Changes you made will not be saved."
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -134,7 +134,7 @@ export default class CollectionSection extends React.Component<Props> {
     handleMoveCollectionConfirm = (collection: Object) => {
         const {resourceStore} = this.props;
         resourceStore.move(collection.id).then(() => {
-            resourceStore.load();
+            resourceStore.reload();
             this.closeCollectionOperationOverlay();
         });
     };

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -154,6 +154,7 @@ jest.mock('sulu-admin-bundle/stores', () => {
         this.setMultiple = jest.fn();
         this.changeSchema = jest.fn();
         this.load = jest.fn();
+        this.reload = jest.fn();
         this.loading = false;
         this.id = 1;
         this.data = {
@@ -654,6 +655,6 @@ test('Confirming the move dialog should move the item', () => {
         mediaCollection.update();
         expect(mediaCollection.find(SingleDatagridOverlay).prop('open')).toEqual(false);
         expect(mediaCollection.find(SingleDatagridOverlay).prop('confirmLoading')).toEqual(false);
-        expect(collectionStore.resourceStore.load).toBeCalledWith();
+        expect(collectionStore.resourceStore.reload).toBeCalledWith();
     });
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds some hooks to interfere the routing process, in order to enable the form to avoid routing if it has been edited.

#### Why?

Because doing this leads to data loss, so the user should be asked for confirmation.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
