### PR TITLE
Add set-back-route method to datagrid-route-builder

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilder.php
@@ -106,6 +106,13 @@ class DatagridRouteBuilder implements DatagridRouteBuilderInterface
         return $this;
     }
 
+    public function setBackRoute(string $backRoute): DatagridRouteBuilderInterface
+    {
+        $this->route->setOption('backRoute', $backRoute);
+
+        return $this;
+    }
+
     public function enableSearching(): DatagridRouteBuilderInterface
     {
         $this->route->setOption('searchable', true);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DatagridRouteBuilderInterface.php
@@ -41,6 +41,8 @@ interface DatagridRouteBuilderInterface
 
     public function setEditRoute(string $editRoute): self;
 
+    public function setBackRoute(string $editRoute): self;
+
     public function enableSearching(): self;
 
     public function disableSearching(): self;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/DatagridRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/DatagridRouteBuilderTest.php
@@ -285,4 +285,16 @@ class DatagridRouteBuilderTest extends TestCase
 
         $this->assertEquals('state == 1', $route->getOption('tabCondition'));
     }
+
+    public function testBuildDatagridSetBackRoute()
+    {
+        $route = (new DatagridRouteBuilder('sulu_role.datagrid', '/roles'))
+            ->setResourceKey('roles')
+            ->setDatagridKey('roles')
+            ->addDatagridAdapters(['tree'])
+            ->setBackRoute('sulu_category.edit_form')
+            ->getRoute();
+
+        $this->assertEquals('sulu_category.edit_form', $route->getOption('backRoute'));
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adds a `setBackRoute` method to the `DatagridRouteBuilder`.

#### Why?

Because we want to display a back-button when using a datagrid-view inside of a resource-tab. 