### PR TITLE
Fix fresh User object comparison to the deserialized User object

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
@@ -43,7 +43,6 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
 
     /**
      * @var string
-     * @Expose
      */
     protected $password;
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
@@ -19,6 +19,7 @@ use JMS\Serializer\Annotation\VirtualProperty;
 use Serializable;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 /**
@@ -26,7 +27,7 @@ use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
  *
  * @ExclusionPolicy("all")
  */
-abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
+abstract class BaseUser extends ApiEntity implements UserInterface, Serializable, EquatableInterface
 {
     /**
      * @var string
@@ -523,5 +524,19 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
     public function getPasswordResetTokenEmailsSent()
     {
         return $this->passwordResetTokenEmailsSent;
+    }
+
+    public function isEqualTo(SymfonyUserInterface $user)
+    {
+        if (!$user instanceof self) {
+            return false;
+        }
+
+        return $this->id === $user->getId()
+            && $this->password === $user->getPassword()
+            && $this->salt === $user->getSalt()
+            && $this->username === $user->getUsername()
+            && $this->locked === $user->getLocked()
+            && $this->enabled === $user->getEnabled();
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
@@ -296,7 +296,7 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
                 $this->salt,
                 $this->username,
                 $this->locked,
-                $this->enabled
+                $this->enabled,
             ]
         );
     }

--- a/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/BaseUser.php
@@ -19,6 +19,7 @@ use JMS\Serializer\Annotation\VirtualProperty;
 use Serializable;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 /**
  * User.
@@ -289,6 +290,11 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
         return serialize(
             [
                 $this->id,
+                $this->password,
+                $this->salt,
+                $this->username,
+                $this->locked,
+                $this->enabled
             ]
         );
     }
@@ -302,7 +308,9 @@ abstract class BaseUser extends ApiEntity implements UserInterface, Serializable
      */
     public function unserialize($serialized)
     {
-        list($this->id) = unserialize($serialized);
+        list(
+            $this->id, $this->password, $this->salt, $this->username, $this->locked, $this->enabled
+        ) = unserialize($serialized);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

It fixes the fresh User object comparison to the deserialized User object to make sure that they represent the same user.

#### Why?

Once the user is logged in, the entire User object is serialized into the session. On the next request, the User object is deserialized. Then, the value of the id property is used to re-query for a fresh User object from the database. Finally, the fresh User object is compared to the deserialized User object to make sure that they represent the same user. This is not working now because the username, password and salt are not serialized.

[Understanding serialize and how a user is saved in the session](https://symfony.com/doc/2.8/security/entity_provider.html#understanding-serialize-and-how-a-user-is-saved-in-the-session)





