### PR TITLE
Fix translation for snippet taxonimies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * BUGFIX      #4434  [SnippetBundle]        Fix translation for snippet taxonomies
     * BUGFIX      #4414  [SearchBundle]         Add massive search bundle 0.17 as allowed version
     * FEATURE     #4394  [WebsiteBundle]        Add exception handling for breadcrumb function
     * FEATURE     #4400  [All]                  Fix FieldJoinDescriptor without a relation

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.de.xlf
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.de.xlf
@@ -114,8 +114,8 @@
                 <source>snippet.settings.copy-locale-overlay.info</source>
                 <target>Neues Schnipsel wird erstellt</target>
             </trans-unit>
-            <trans-unit id="27" resname="content-navigation.snippets.excerpt">
-                <source>content-navigation.snippets.excerpt</source>
+            <trans-unit id="27" resname="content-navigation.snippets.taxonomies">
+                <source>content-navigation.snippets.taxonomies</source>
                 <target>Taxonomien</target>
             </trans-unit>
         </body>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.en.xlf
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.en.xlf
@@ -115,7 +115,7 @@
                 <target>New snippet will be created</target>
             </trans-unit>
             <trans-unit id="27" resname="content-navigation.snippets.taxonomies">
-                <source>content-navigation.snippets.excerpt</source>
+                <source>content-navigation.snippets.taxonomies</source>
                 <target>Taxonomies</target>
             </trans-unit>
         </body>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.fr.xlf
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.fr.xlf
@@ -99,7 +99,7 @@
                 <target> Un fragment nouveau est établi </target>
             </trans-unit>
             <trans-unit id="27" resname="content-navigation.snippets.taxonomies">
-                <source>content-navigation.snippets.excerpt</source>
+                <source>content-navigation.snippets.taxonomies</source>
                 <target>Taxonomies</target>
             </trans-unit>
         </body>

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.nl.xlf
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/sulu/backend.nl.xlf
@@ -115,7 +115,7 @@
                 <target>Een nieuw fragment zal worden aangemaakt</target>
             </trans-unit>
             <trans-unit id="27" resname="content-navigation.snippets.taxonomies">
-                <source>content-navigation.snippets.excerpt</source>
+                <source>content-navigation.snippets.taxonomies</source>
                 <target>Taxonomieën</target>
             </trans-unit>
         </body>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR |-

#### What's in this PR?

Finally found the issue why the translation export count of messages where different between the languages and fixed by using the correct key for them.

#### Why?

False key was used and it did fallback in some languages.

#### Example Usage

~~~php
bin/console sulu:translate:export
~~~

