### PR TITLE
Respect tab order when deciding if title of resource-tabse should be displayed

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -81,11 +81,22 @@ export default class ResourceTabs extends React.Component<Props> {
         return this.resourceStore.data[titleProperty || routeTitleProperty];
     }
 
-    @computed get visibleTabRoutes(): Array<Object> {
+    @computed get sortedTabRoutes(): Array<Object> {
         const {route} = this.props;
+
+        return route.children.concat()
+            .sort((childRoute1, childRoute2) => {
+                const {tabOrder: tabOrder1 = 0} = childRoute1.options;
+                const {tabOrder: tabOrder2 = 0} = childRoute2.options;
+
+                return tabOrder1 - tabOrder2;
+            });
+    }
+
+    @computed get visibleTabRoutes(): Array<Object> {
         const data = toJS(this.resourceStore.data);
 
-        return route.children
+        return this.sortedTabRoutes
             .filter((childRoute) => {
                 const {
                     options: {
@@ -94,12 +105,6 @@ export default class ResourceTabs extends React.Component<Props> {
                 } = childRoute;
 
                 return !tabCondition || jexl.evalSync(tabCondition, data);
-            })
-            .sort((childRoute1, childRoute2) => {
-                const {tabOrder: tabOrder1 = 0} = childRoute1.options;
-                const {tabOrder: tabOrder2 = 0} = childRoute2.options;
-
-                return tabOrder1 - tabOrder2;
             });
     }
 
@@ -160,7 +165,7 @@ export default class ResourceTabs extends React.Component<Props> {
     };
 
     render() {
-        const {children, route} = this.props;
+        const {children} = this.props;
 
         const ChildComponent = children ? children({locales: this.locales, resourceStore: this.resourceStore}) : null;
 
@@ -185,7 +190,7 @@ export default class ResourceTabs extends React.Component<Props> {
                             })}
                         </Tabs>
                     </div>
-                    {route.children[0] !== selectedRoute && this.title &&
+                    {this.sortedTabRoutes[0] !== selectedRoute && this.title &&
                         <h1>{this.title}</h1>
                     }
                     {ChildComponent}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -198,6 +198,58 @@ test('Should not render the tab title on the first tab', () => {
     });
 });
 
+test('Should not render the tab title on the first tab when tabOrder is defined', (done) => {
+    ResourceStore.mockImplementation(function() {
+        this.initialized = true;
+        this.load = jest.fn();
+        extendObservable(this, {data: {}});
+    });
+
+    const route = {
+        options: {
+            resourceKey: 'test',
+            titleProperty: 'test1',
+        },
+        children: [
+            {
+                name: 'Tab 2',
+                options: {
+                    tabOrder: 2,
+                    tabTitle: 'tabTitle2',
+                },
+            },
+            {
+                name: 'Tab 1',
+                options: {
+                    tabOrder: 1,
+                    tabTitle: 'tabTitle1',
+                },
+            },
+        ],
+    };
+    const router = {
+        attributes: {
+            id: 1,
+        },
+        route: route.children[1],
+    };
+
+    const Child = () => (<h1>Child</h1>);
+
+    const resourceTabs = mount(
+        <ResourceTabs route={route} router={router}>
+            {() => (<Child route={route.children[1]} />)}
+        </ResourceTabs>
+    );
+
+    resourceTabs.instance().resourceStore.data = {test1: 'value1'};
+    setTimeout(() => {
+        resourceTabs.update();
+        expect(resourceTabs.find('ResourceTabs > h1')).toHaveLength(0);
+        done();
+    });
+});
+
 test('Should render the tab title on the first visible tab if the first tab is not visible', (done) => {
     ResourceStore.mockImplementation(function() {
         this.initialized = true;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

We want to hide the title inside the first tab of a ResourceTabs view. This PR adjusts the logic that decides if the title should be displayed to respect the tabOrder of the tabs.