### PR TITLE
Render back-button in datagrid-view when back-route of route is set

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/Datagrid.js
@@ -212,6 +212,7 @@ export default withToolbar(Datagrid, function() {
     const {
         route: {
             options: {
+                backRoute,
                 addRoute,
                 locales,
                 movable,
@@ -219,6 +220,17 @@ export default withToolbar(Datagrid, function() {
         },
     } = router;
 
+    const backButton = backRoute
+        ? {
+            onClick: () => {
+                const options = {};
+                if (this.locale) {
+                    options.locale = this.locale.get();
+                }
+                router.restore(backRoute, options);
+            },
+        }
+        : undefined;
     const locale = locales
         ? {
             value: this.locale.get(),
@@ -265,6 +277,7 @@ export default withToolbar(Datagrid, function() {
     }
 
     return {
+        backButton,
         locale,
         items,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Datagrid/tests/Datagrid.test.js
@@ -340,6 +340,84 @@ test('Should destroy the store on unmount', () => {
     expect(datagridStore.destroy).toBeCalled();
 });
 
+test('Should navigate to defined route on back button click', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Datagrid = require('../Datagrid').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const router = {
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                backRoute: 'backRoute',
+                addRoute: 'addRoute',
+                datagridKey: 'test',
+                resourceKey: 'test',
+            },
+        },
+    };
+
+    const datagrid = mount(<Datagrid router={router} />);
+    datagrid.instance().locale = {
+        get: function() {
+            return 'de';
+        },
+    };
+
+    const toolbarConfig = toolbarFunction.call(datagrid.instance());
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('backRoute', {locale: 'de'});
+});
+
+test('Should navigate to defined route on back button click without locale', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Datagrid = require('../Datagrid').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const router = {
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                backRoute: 'backRoute',
+                addRoute: 'addRoute',
+                datagridKey: 'test',
+                resourceKey: 'test',
+            },
+        },
+    };
+
+    const datagrid = mount(<Datagrid router={router} />);
+
+    const toolbarConfig = toolbarFunction.call(datagrid.instance());
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('backRoute', {});
+});
+
+test('Should not render back button when no backRoute is configured', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Datagrid = require('../Datagrid').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, Datagrid);
+    const router = {
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                addRoute: 'addRoute',
+                datagridKey: 'test',
+                resourceKey: 'test',
+            },
+        },
+    };
+
+    const datagrid = mount(<Datagrid router={router} />);
+
+    const toolbarConfig = toolbarFunction.call(datagrid.instance());
+    expect(toolbarConfig.backButton).toBe(undefined);
+});
+
 test('Should render the add button in the toolbar only if an addRoute has been passed in options', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Datagrid = require('../Datagrid').default;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `DatagridView` to set a `backButton` in its `ToolbarConfig` if a `backRoute` is set in its route-options.

#### Why?

Because we want to display a button that makes use of the `backRoute`. Otherwise the `backRoute` option in the `DatagridRouteBuilder` is quite pointless 🙂 
