### PR TITLE
Allow to create contacts and accounts without categories

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/field.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/field.scss
@@ -25,6 +25,7 @@ $errorLabelHeight: 20px;
     line-height: 19px;
     margin-bottom: 10px;
     text-align: left;
+    white-space: nowrap;
 
     &::after {
         content: '\200B';

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -835,6 +835,10 @@ abstract class AbstractContactManager implements ContactManagerInterface
     {
         $contact->getCategories()->clear();
 
+        if (!$categoryIds) {
+            return true;
+        }
+
         foreach ($categoryIds as $categoryId) {
             $category = $this->em->getRepository(self::$categoryEntityName)->find($categoryId);
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -298,6 +298,29 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals('Sehr geehrte Frau Dr Mustermann', $response->salutation);
     }
 
+    public function testPostCategoryNull()
+    {
+        $client = $this->createTestClient();
+
+        $client->request(
+            'POST',
+            '/api/contacts',
+            [
+                'firstName' => 'Erika',
+                'lastName' => 'Mustermann',
+                'formOfAddress' => 0,
+                'categories' => null,
+            ]
+        );
+
+        $response = json_decode($client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertEquals('Erika', $response->firstName);
+        $this->assertEquals('Mustermann', $response->lastName);
+        $this->assertEmpty($response->categories);
+    }
+
     public function testPost()
     {
         $title = $this->createTitle('MSc');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to pass `null` as value for categories in the contacts and accounts API.

#### Why?

Because creating a new contact or account failed when no categories were selected.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
