### PR TITLE
Fix empty table look in firefox

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/table.scss
@@ -26,7 +26,6 @@ $borderRadius: 3px;
     margin: -5px 0;
     overflow: hidden;
     min-width: 100%;
-    height: 100%;
 }
 
 .header {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | 

#### What's in this PR?

Fix empty table look in firefox by set the table height to auto when empty.

#### Why?

The **empty** table currently looks really strange on current Firefox (65):

![bildschirmfoto 2019-02-15 um 08 13 51](https://user-images.githubusercontent.com/1698337/52841588-f6adfc00-30fc-11e9-8f2d-20c143612d5b.png)

This happens because of the table height 100% (introduced in https://github.com/sulu/sulu/pull/3893) ~~as I'm not sure why this height 100% there I introduced a new class table-empty to fix this problem.~~ **EDIT:** As discussed with @danrot we remove the height 100% as we could not find a need for it. 

Firefox behaviour happens because of the placeholder as the placeholder is on the same level as the table and the table height is 100% firefox add the height of the placeholder as this is at rendering time the height of the parent. 