### PR TITLE
Add resource store properties to list store options

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,44 @@
 The `excluded` query parameter which can be used to exclude specific ids from the media list returned by the Media API
 was renamed to `excludedIds` to increase the consistency within our APIs. 
 
+### Router Attributes to to List or Form Store switched
+
+**This change only affects you if you have used a 2.0.0 alpha release before**
+
+If you have use the `routerPropertiesToListStore` or `routerPropertiesToFormStore` the properties where switched:
+
+**Before**
+
+```php
+    ->addRouterAttributesToListStore([
+        'listStoreProperty' => 'routeAttribute',
+    ]);
+```
+
+or
+
+```php
+    ->addRouterAttributesToFormStore([
+        'formStoreProperty' => 'routeAttribute',
+    ]);
+```
+
+**After**
+
+```php
+    ->addRouterAttributesToListStore([
+        'routeAttribute' => 'listStoreProperty',
+    ]);
+```
+
+or
+
+```php
+    ->addRouterAttributesToFormStore([
+        'routeProperty' => 'formStoreProperty',
+    ]);
+```
+
 ### Endpoint configuration
 
 **This change only affects you if you have used a 2.0.0 alpha release before**

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,11 +7,11 @@
 The `excluded` query parameter which can be used to exclude specific ids from the media list returned by the Media API
 was renamed to `excludedIds` to increase the consistency within our APIs. 
 
-### Router Attributes to to List or Form Store switched
+### Router Attributes to List or Form Store switched
 
 **This change only affects you if you have used a 2.0.0 alpha release before**
 
-If you have use the `routerPropertiesToListStore` or `routerPropertiesToFormStore` the properties where switched:
+If you have use the `routerPropertiesToListStore` or `routerPropertiesToFormStore` options the properties where switched:
 
 **Before**
 
@@ -41,7 +41,7 @@ or
 
 ```php
     ->addRouterAttributesToFormStore([
-        'routeProperty' => 'formStoreProperty',
+        'routeAttribute' => 'formStoreProperty',
     ]);
 ```
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilder.php
@@ -159,6 +159,15 @@ class ListRouteBuilder implements ListRouteBuilderInterface
         return $this;
     }
 
+    public function addResourceStorePropertiesToListStore(array $resourceStorePropertiesToListStore): ListRouteBuilderInterface
+    {
+        $oldResourceStorePropertiesToListStore = $this->route->getOption('resourceStorePropertiesToListStore');
+        $newResourceStorePropertiesToListStore = $oldResourceStorePropertiesToListStore ? array_merge($oldResourceStorePropertiesToListStore, $resourceStorePropertiesToListStore) : $resourceStorePropertiesToListStore;
+        $this->route->setOption('resourceStorePropertiesToListStore', $newResourceStorePropertiesToListStore);
+
+        return $this;
+    }
+
     public function setParent(string $parent): ListRouteBuilderInterface
     {
         $this->route->setParent($parent);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderInterface.php
@@ -57,6 +57,11 @@ interface ListRouteBuilderInterface
      */
     public function addRouterAttributesToListStore(array $routerAttributesToListStore): self;
 
+    /**
+     * @param string[] $resourceStorePropertiesToListStore
+     */
+    public function addResourceStorePropertiesToListStore(array $resourceStorePropertiesToListStore): self;
+
     public function setParent(string $parent): self;
 
     public function getRoute(): Route;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -160,8 +160,8 @@ class Form extends React.Component<Props> {
 
         routerAttributesToFormStore = toJS(routerAttributesToFormStore);
         Object.keys(routerAttributesToFormStore).forEach((key) => {
-            const attributeName = routerAttributesToFormStore[key];
-            const formOptionKey = isNaN(key) ? key : routerAttributesToFormStore[key];
+            const formOptionKey = routerAttributesToFormStore[key];
+            const attributeName = isNaN(key) ? key : routerAttributesToFormStore[key];
 
             formStoreOptions[formOptionKey] = attributes[attributeName];
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1170,7 +1170,7 @@ test('Should save form when submitted with mapped router attributes and given ap
             formKey: 'snippets',
             locales: [],
             apiOptions: {apiKey: 'api-option-value'},
-            routerAttributesToFormStore: {'id': 'parentId', '0': 'webspace', 1: 'title'},
+            routerAttributesToFormStore: {'parentId': 'id', '0': 'webspace', 1: 'title'},
             toolbarActions: [],
         },
     };
@@ -1234,7 +1234,7 @@ test('Should save form when submitted with mapped named router attributes and gi
             formKey: 'snippets',
             locales: [],
             apiOptions: {apiKey: 'api-option-value'},
-            routerAttributesToFormStore: {'parentId': 'id'},
+            routerAttributesToFormStore: {'id': 'parentId'},
             toolbarActions: [],
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -17,7 +17,7 @@ import listStyles from './list.scss';
 const USER_SETTINGS_KEY = 'list';
 
 type Props = ViewProps & {
-    resourceStore: ResourceStore,
+    resourceStore?: ResourceStore,
 };
 
 @observer

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -6,6 +6,7 @@ import TableAdapter from '../../../containers/List/adapters/TableAdapter';
 import listFieldTransformRegistry from '../../../containers/List/registries/ListFieldTransformerRegistry';
 import StringFieldTransformer from '../../../containers/List/fieldTransformers/StringFieldTransformer';
 import {findWithHighOrderFunction} from '../../../utils/TestHelper';
+import ResourceStore from '../../../stores/ResourceStore';
 
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
 
@@ -86,6 +87,19 @@ jest.mock(
             moving: false,
             movingSelection: false,
         });
+    })
+);
+
+jest.mock(
+    '../../../stores/ResourceStore/ResourceStore',
+    () => jest.fn(function(resourceKey, id) {
+        this.resourceKey = resourceKey;
+        this.id = id;
+        this.data = {
+            id: id,
+            title: 'Sulu rocks',
+            locale: 'de',
+        };
     })
 );
 
@@ -702,7 +716,7 @@ test('Should pass router attributes from router to the ListStore', () => {
                 listKey: 'test',
                 locales: ['en', 'de'],
                 resourceKey: 'test',
-                routerAttributesToListStore: {'0': 'locale', 1: 'title', 'parentId': 'id'},
+                routerAttributesToListStore: {'0': 'locale', 1: 'title', 'id': 'parentId'},
             },
         },
     };
@@ -713,6 +727,31 @@ test('Should pass router attributes from router to the ListStore', () => {
     expect(listStore.options.locale).toEqual('en');
     expect(listStore.options.parentId).toEqual('123-123-123');
     expect(listStore.options.title).toEqual('Sulu is awesome');
+});
+
+test('Should pass resourceStore properties from router to the ListStore', () => {
+    const List = require('../List').default;
+    const resourceStore = new ResourceStore('tests', '123-456-789');
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                apiOptions: {},
+                listKey: 'test',
+                locales: ['en', 'de'],
+                resourceKey: 'test',
+                resourceStorePropertiesToListStore: {'0': 'locale', 1: 'title', 'id': 'parentId'},
+            },
+        },
+    };
+
+    const list = mount(<List resourceStore={resourceStore} router={router} />);
+    const listStore = list.instance().listStore;
+
+    expect(listStore.options.locale).toEqual('de');
+    expect(listStore.options.parentId).toEqual('123-456-789');
+    expect(listStore.options.title).toEqual('Sulu rocks');
 });
 
 test('Should pass router attributes array from router to the ListStore', () => {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ListRouteBuilderTest.php
@@ -196,7 +196,7 @@ class ListRouteBuilderTest extends TestCase
         $this->assertFalse($route->getOption('searchable'));
     }
 
-    public function testBuildListWithRouterAttributesToFormStore()
+    public function testBuildListWithRouterAttributesToListStore()
     {
         $route = (new ListRouteBuilder('sulu_role.list', '/roles'))
             ->setResourceKey('roles')
@@ -209,6 +209,22 @@ class ListRouteBuilderTest extends TestCase
         $this->assertEquals(
             ['webspace' => 'webspaceId', 'parent' => 'parentId', 'locale'],
             $route->getOption('routerAttributesToListStore')
+        );
+    }
+
+    public function testBuildListWithResourceStorePropertiesToListStore()
+    {
+        $route = (new ListRouteBuilder('sulu_role.datagrid', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->addListAdapters(['tree'])
+            ->addResourceStorePropertiesToListStore(['id' => 'dimensionId', 'parent' => 'parentId'])
+            ->addResourceStorePropertiesToListStore(['locale'])
+            ->getRoute();
+
+        $this->assertEquals(
+            ['id' => 'dimensionId', 'parent' => 'parentId', 'locale'],
+            $route->getOption('resourceStorePropertiesToListStore')
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add resource store properties to list store route options.

#### Why?

In some cases you want to use resourceStore properties as list store options to example filter by a specific value.

#### Example Usage

```php
$this->routeBuilderFactory->createListRouteBuilder(...)
    ->addResourceStorePropertiesToListStore([
        'resourceStoreProperty' => 'listStoreProperty',
    ]);
```

This pull request also change the `addRouterAttributesToListStore` from:

```php
    ->addRouterAttributesToListStore([
        'listStoreProperty' => 'routeAttribute',
    ]);
```

to

```php
    ->addRouterAttributesToListStore([
        'routeAttribute' => 'listStoreProperty',
    ]);
```
