### PR TITLE
Add simple tab view for Webspaces

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/RouteBuilderFactory.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/RouteBuilderFactory.php
@@ -18,13 +18,18 @@ class RouteBuilderFactory implements RouteBuilderFactoryInterface
         return new ListRouteBuilder($name, $path);
     }
 
+    public function createFormRouteBuilder(string $name, string $path): FormRouteBuilderInterface
+    {
+        return new FormRouteBuilder($name, $path);
+    }
+
     public function createResourceTabRouteBuilder(string $name, string $path): ResourceTabRouteBuilderInterface
     {
         return new ResourceTabRouteBuilder($name, $path);
     }
 
-    public function createFormRouteBuilder(string $name, string $path): FormRouteBuilderInterface
+    public function createTabRouteBuilder(string $name, string $path): TabRouteBuilderInterface
     {
-        return new FormRouteBuilder($name, $path);
+        return new TabRouteBuilder($name, $path);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/RouteBuilderFactoryInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/RouteBuilderFactoryInterface.php
@@ -15,7 +15,9 @@ interface RouteBuilderFactoryInterface
 {
     public function createListRouteBuilder(string $name, string $path): ListRouteBuilderInterface;
 
+    public function createFormRouteBuilder(string $name, string $path): FormRouteBuilderInterface;
+
     public function createResourceTabRouteBuilder(string $name, string $path): ResourceTabRouteBuilderInterface;
 
-    public function createFormRouteBuilder(string $name, string $path): FormRouteBuilderInterface;
+    public function createTabRouteBuilder(string $name, string $path): TabRouteBuilderInterface;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/TabRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/TabRouteBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Routing;
+
+class TabRouteBuilder implements TabRouteBuilderInterface
+{
+    const VIEW = 'sulu_admin.tabs';
+
+    /**
+     * @var Route
+     */
+    private $route;
+
+    public function __construct(string $name, string $path)
+    {
+        $this->route = new Route($name, $path, static::VIEW);
+    }
+
+    public function getRoute(): Route
+    {
+        return clone $this->route;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/TabRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/TabRouteBuilderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Routing;
+
+interface TabRouteBuilderInterface
+{
+    public function getRoute(): Route;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -6,7 +6,7 @@ import type {Route} from '../../services/Router';
 export type ViewProps = {
     router: Router,
     route: Route,
-    children?: (?Object) => Element<View> | null,
+    children?: (?Object) => Element<*> | null,
 };
 
 export type View = Class<Component<ViewProps & *>>;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -21,6 +21,7 @@ import List, {
     MoveToolbarAction as ListMoveToolbarAction,
     toolbarActionRegistry as listToolbarActionRegistry,
 } from './views/List';
+import Tabs from './views/Tabs';
 import CKEditor5 from './containers/TextEditor/adapters/CKEditor5';
 import {
     BoolFieldTransformer,
@@ -135,8 +136,9 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
 
 function registerViews() {
     viewRegistry.add('sulu_admin.form', Form);
-    viewRegistry.add('sulu_admin.resource_tabs', (ResourceTabs: any));
     viewRegistry.add('sulu_admin.list', List);
+    viewRegistry.add('sulu_admin.resource_tabs', ResourceTabs);
+    viewRegistry.add('sulu_admin.tabs', Tabs);
 }
 
 function registerListAdapters() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/README.md
@@ -2,7 +2,6 @@ The `ResourceTabs` view shows all the children of its defined route as a [`Tab`]
 option as the title for the tab. This is enabled by the [`Router`](#router) with handling children and parent routes
 and by the [`ViewRenderer`](#viewrenderer) with nesting these routes into different views.
 
-| Option        | Description                                                                                         |
-|---------------|-----------------------------------------------------------------------------------------------------|
-| resourceKey   | The resourceKey for the type of entity which will be managed by the given tabs.                     |
-| locales       | The locales in which the given type of entity is available in.
+It will use the `tabOrder` option of its child routes to determine how to order the tabs. The other important option is
+the `tabPriority` option, which allows to define which tab should be opened by default. It will open the tab with the
+highest priority.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/README.md
@@ -5,3 +5,9 @@ and by the [`ViewRenderer`](#viewrenderer) with nesting these routes into differ
 It will use the `tabOrder` option of its child routes to determine how to order the tabs. The other important option is
 the `tabPriority` option, which allows to define which tab should be opened by default. It will open the tab with the
 highest priority.
+
+| Option        | Description                                                                                         |
+|---------------|-----------------------------------------------------------------------------------------------------|
+| locales       | The locales in which the given type of entity is available in.
+| resourceKey   | The resourceKey for the type of entity which will be managed by the given tabs.                     |
+| titleProperty | The property of the object in the ResourceStore being used in the headline of the tab.              |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/resourceTabs.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/resourceTabs.scss
@@ -1,10 +1,5 @@
 @import '../../components/Tabs/variables.scss';
-@import '../../containers/Application/variables.scss';
 
 .loader {
     margin-top: $tabMenuHeight;
-}
-
-.tabs-container {
-    margin: -$viewPadding -$viewPadding $viewPadding;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -67,7 +67,7 @@ test('Should render the tab title from the ResourceStore as configured in the ro
     resourceTabs.instance().resourceStore.data = {test1: 'value1'};
     resourceTabs.update();
 
-    expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value1');
+    expect(resourceTabs.find('ResourceTabs > Tabs > h1').text()).toEqual('value1');
 });
 
 test('Should not render the tab title from the ResourceStore if no titleProperty is set', () => {
@@ -152,7 +152,7 @@ test('Should render the tab title from the resourceStore as configured in the pr
     resourceTabs.instance().resourceStore.data = {test1: 'value1', test2: 'value2'};
     resourceTabs.update();
 
-    expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value2');
+    expect(resourceTabs.find('ResourceTabs > Tabs > h1').text()).toEqual('value2');
 });
 
 test('Should not render the tab title on the first tab', () => {
@@ -296,7 +296,7 @@ test('Should render the tab title on the first visible tab if the first tab is n
     resourceTabs.instance().resourceStore.data = {test1: 'value1'};
     setTimeout(() => {
         resourceTabs.update();
-        expect(resourceTabs.find('ResourceTabs > h1').text()).toEqual('value1');
+        expect(resourceTabs.find('ResourceTabs > Tabs > h1').text()).toEqual('value1');
         done();
     });
 });
@@ -340,7 +340,7 @@ test('Should render the child components after the tabs', (done) => {
 
     setTimeout(() => {
         expect(resourceTabs.find('Loader')).toHaveLength(0);
-        expect(resourceTabs.find('ResourceTabs Tabs').render()).toMatchSnapshot();
+        expect(resourceTabs.find('ResourceTabs Tabs Tabs').render()).toMatchSnapshot();
         expect(resourceTabs.find('ResourceTabs Child').render()).toMatchSnapshot();
         done();
     });
@@ -431,7 +431,7 @@ test('Should mark the currently active child route as selected tab', (done) => {
     );
 
     setTimeout(() => {
-        expect(resourceTabs.find('ResourceTabs Tabs').render()).toMatchSnapshot();
+        expect(resourceTabs.find('ResourceTabs Tabs Tabs').render()).toMatchSnapshot();
         expect(resourceTabs.find('ResourceTabs Child').render()).toMatchSnapshot();
         done();
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/README.md
@@ -1,9 +1,3 @@
 The `Tabs` view shows all the children of its defined route as a [`Tab`](#tab), and uses their `tabTitle` option as the
 title for the tab. This is enabled by the [`Router`](#router) with handling children and parent routes and by the
 [`ViewRenderer`](#viewrenderer) with nesting these routes into different views.
-
-| Option        | Description                                                                                         |
-|---------------|-----------------------------------------------------------------------------------------------------|
-| locales       | The locales in which the given type of entity is available in.
-| resourceKey   | The resourceKey for the type of entity which will be managed by the given tabs.                     |
-| titleProperty | The property of the object in the ResourceStore being used in the headline of the tab.              |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/README.md
@@ -1,0 +1,9 @@
+The `Tabs` view shows all the children of its defined route as a [`Tab`](#tab), and uses their `tabTitle` option as the
+title for the tab. This is enabled by the [`Router`](#router) with handling children and parent routes and by the
+[`ViewRenderer`](#viewrenderer) with nesting these routes into different views.
+
+| Option        | Description                                                                                         |
+|---------------|-----------------------------------------------------------------------------------------------------|
+| locales       | The locales in which the given type of entity is available in.
+| resourceKey   | The resourceKey for the type of entity which will be managed by the given tabs.                     |
+| titleProperty | The property of the object in the ResourceStore being used in the headline of the tab.              |

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
@@ -1,0 +1,124 @@
+// @flow
+import React, {Fragment} from 'react';
+import {autorun, computed} from 'mobx';
+import {observer} from 'mobx-react';
+import TabsComponent from '../../components/Tabs';
+import type {ViewProps} from '../../containers/ViewRenderer';
+import type {Route} from '../../services/Router';
+import {translate} from '../../utils/Translator';
+import tabsStyles from './tabs.scss';
+
+type Props = ViewProps & {
+    routeChildren?: Array<Route>,
+    selectedIndex?: number,
+};
+
+@observer
+export default class Tabs extends React.Component<Props> {
+    redirectToRouteWithHighestPriorityDisposer: () => void;
+
+    constructor(props: Props) {
+        super(props);
+
+        this.redirectToRouteWithHighestPriorityDisposer = autorun(this.redirectToRouteWithHighestPriority);
+    }
+
+    componentWillUnmount() {
+        this.redirectToRouteWithHighestPriorityDisposer();
+    }
+
+    @computed get tabRouteWithHighestPriority(): Object {
+        return this.routeChildren.reduce((prioritizedRoute, route) => {
+            if (!prioritizedRoute) {
+                return route;
+            }
+
+            const {
+                options: {
+                    tabPriority: highestTabPriority = 0,
+                },
+            } = prioritizedRoute;
+
+            const {
+                options: {
+                    tabPriority = 0,
+                },
+            } = route;
+
+            if (highestTabPriority >= tabPriority) {
+                return prioritizedRoute;
+            }
+
+            return route;
+        }, undefined);
+    }
+
+    @computed get routeChildren() {
+        const {route, routeChildren} = this.props;
+
+        return routeChildren || route.children;
+    }
+
+    @computed get sortedTabRoutes(): Array<Route> {
+        return this.routeChildren.concat()
+            .sort((childRoute1, childRoute2) => {
+                const {tabOrder: tabOrder1 = 0} = childRoute1.options;
+                const {tabOrder: tabOrder2 = 0} = childRoute2.options;
+
+                return tabOrder1 - tabOrder2;
+            });
+    }
+
+    redirectToRouteWithHighestPriority = (): void => {
+        const {route, router} = this.props;
+
+        if (!route.children.includes(router.route) && router.route !== route) {
+            return;
+        }
+
+        if (this.sortedTabRoutes.includes(router.route)) {
+            return;
+        }
+
+        if (!this.tabRouteWithHighestPriority) {
+            return;
+        }
+
+        router.redirect(this.tabRouteWithHighestPriority.name, router.attributes);
+    };
+
+    handleSelect = (index: number) => {
+        const {router} = this.props;
+        router.navigate(this.sortedTabRoutes[index].name, router.attributes);
+    };
+
+    render() {
+        const {children, selectedIndex} = this.props;
+
+        const ChildComponent = children ? children() : null;
+
+        const selectedTabIndex = selectedIndex !== undefined
+            ? selectedIndex
+            : ChildComponent
+                ? this.sortedTabRoutes.findIndex((childRoute) => childRoute === ChildComponent.props.route)
+                : undefined;
+
+        return (
+            <Fragment>
+                <div className={tabsStyles.tabsContainer}>
+                    <TabsComponent onSelect={this.handleSelect} selectedIndex={selectedTabIndex}>
+                        {this.sortedTabRoutes.map((tabRoute) => {
+                            const tabTitle = tabRoute.options.tabTitle;
+                            return (
+                                <TabsComponent.Tab key={tabRoute.name}>
+                                    {tabTitle ? translate(tabTitle) : tabRoute.name}
+                                </TabsComponent.Tab>
+                            );
+                        })}
+                    </TabsComponent>
+                </div>
+                {ChildComponent}
+            </Fragment>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/index.js
@@ -1,0 +1,4 @@
+// @flow
+import Tabs from './Tabs';
+
+export default Tabs;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tabs.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tabs.scss
@@ -1,0 +1,5 @@
+@import '../../containers/Application/variables.scss';
+
+.tabs-container {
+    margin: -$viewPadding -$viewPadding $viewPadding;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/Tabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/Tabs.test.js
@@ -1,0 +1,481 @@
+// @flow
+import React from 'react';
+import {mount, render} from 'enzyme';
+import Router from '../../../services/Router';
+import Tabs from '../Tabs';
+
+jest.mock('../../../services/Router', () => jest.fn());
+
+jest.mock('../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Should render the children after the tabs', () => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.redirect = jest.fn();
+        this.route = route;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    expect(render(<Tabs route={route} router={router}>{() => (<Child />)}</Tabs>)).toMatchSnapshot();
+});
+
+test('Should consider the tabOrder when rendering the tabs', () => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabOrder: 40,
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabOrder: 30,
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route2',
+    };
+    const childRoute3 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route3',
+        options: {
+            tabOrder: 50,
+            tabTitle: 'tabTitle3',
+        },
+        parent: null,
+        path: '/route3',
+        rerenderAttributes: [],
+        view: 'route3',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+            childRoute3,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.redirect = jest.fn();
+        this.route = route;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    const tabs = mount(<Tabs route={route} router={router}>{() => (<Child />)}</Tabs>);
+
+    expect(tabs.find('Tab').at(0).text()).toEqual('tabTitle2');
+    expect(tabs.find('Tab').at(1).text()).toEqual('tabTitle1');
+    expect(tabs.find('Tab').at(2).text()).toEqual('tabTitle3');
+});
+
+test('Should mark currently active tab as selected according to prop', (done) => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    const activeRoute = route.children[1];
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.redirect = jest.fn();
+        this.route = activeRoute;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    const tabs = mount(
+        <Tabs route={route} router={router} selectedIndex={0}>{() => (<Child route={activeRoute} />)}</Tabs>
+    );
+
+    setTimeout(() => {
+        expect(router.redirect).not.toBeCalled();
+        expect(tabs.find('Tab').at(0).prop('selected')).toEqual(true);
+        expect(tabs.find('Tab').at(1).prop('selected')).toEqual(false);
+        done();
+    });
+});
+
+test('Should mark currently active tab as selected', (done) => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    const activeRoute = route.children[1];
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.redirect = jest.fn();
+        this.route = activeRoute;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    const tabs = mount(
+        <Tabs route={route} router={router}>{() => (<Child route={activeRoute} />)}</Tabs>
+    );
+
+    setTimeout(() => {
+        expect(router.redirect).not.toBeCalled();
+        expect(tabs.find('Tab').at(0).prop('selected')).toEqual(false);
+        expect(tabs.find('Tab').at(1).prop('selected')).toEqual(true);
+        done();
+    });
+});
+
+test('Should redirect to child route with highest priority if no tab is active by default', (done) => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabPriority: 100,
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.redirect = jest.fn();
+        this.route = route;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    mount(<Tabs route={route} router={router}>{() => (<Child />)}</Tabs>);
+
+    setTimeout(() => {
+        expect(router.redirect).toBeCalledWith('route2', attributes);
+        done();
+    });
+});
+
+test('Should redirect to child route from props with highest priority if no tab is active by default', (done) => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabPriority: 100,
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const childRoutes = [childRoute1, childRoute2];
+
+    const route = {
+        attributeDefaults: {},
+        children: [],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.redirect = jest.fn();
+        this.route = route;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    mount(<Tabs route={route} routeChildren={childRoutes} router={router}>{() => (<Child />)}</Tabs>);
+
+    setTimeout(() => {
+        expect(router.redirect).toBeCalledWith('route2', attributes);
+        done();
+    });
+});
+
+test('Navigate to tab if it was clicked', () => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+    };
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.navigate = jest.fn();
+        this.redirect = jest.fn();
+        this.route = route;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    const tabs = mount(<Tabs route={route} router={router}>{() => (<Child />)}</Tabs>);
+
+    tabs.find('Tab button').at(1).simulate('click');
+    expect(router.navigate).toBeCalledWith('route2', attributes);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/__snapshots__/Tabs.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/__snapshots__/Tabs.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should render the children after the tabs 1`] = `
+Array [
+  <div
+    class="tabsContainer"
+  >
+    <ul
+      class="tabs"
+    >
+      <li
+        class="tab"
+      >
+        <button
+          title="tabTitle1"
+        >
+          tabTitle1
+        </button>
+      </li>
+      <li
+        class="tab"
+      >
+        <button
+          title="tabTitle2"
+        >
+          tabTitle2
+        </button>
+      </li>
+    </ul>
+  </div>,
+  <h1>
+    Child
+  </h1>,
+]
+`;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/TabRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/TabRouteBuilderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Admin\Routing\TabRouteBuilder;
+
+class TabRouteBuilderTest extends TestCase
+{
+    public function testBuildTabRouteWithClone()
+    {
+        $routeBuilder = (new TabRouteBuilder('sulu_role.add_form', '/roles'));
+
+        $this->assertNotSame($routeBuilder->getRoute(), $routeBuilder->getRoute());
+    }
+
+    public function provideBuildTabRoute()
+    {
+        return [
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+            ],
+            [
+                'sulu_tag.edit_form',
+                '/tags/:id',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBuildTabRoute
+     */
+    public function testBuildTabRoute(
+        string $name,
+        string $path
+    ) {
+        $routeBuilder = (new TabRouteBuilder($name, $path));
+        $route = $routeBuilder->getRoute();
+
+        $this->assertEquals($name, $route->getName());
+        $this->assertEquals($path, $route->getPath());
+        $this->assertEquals('sulu_admin.tabs', $route->getView());
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -31,7 +31,9 @@ class PageAdmin extends Admin
      */
     const SECURITY_CONTEXT_PREFIX = 'sulu.webspaces.';
 
-    const PAGES_ROUTE = 'sulu_page.webspaces';
+    const WEBSPACE_TABS_ROUTE = 'sulu_page.webspaces';
+
+    const PAGES_ROUTE = 'sulu_page.pages_datagrid';
 
     const ADD_FORM_ROUTE = 'sulu_page.page_add_form';
 
@@ -114,10 +116,14 @@ class PageAdmin extends Admin
         $previewExpression = 'nodeType == 1';
 
         return [
+            // TODO create route builder for default tabs
+            (new Route(static::WEBSPACE_TABS_ROUTE, '/webspaces/:webspace', 'sulu_admin.tabs')),
             (new Route(static::PAGES_ROUTE, '/webspaces/:webspace/pages/:locale', 'sulu_page.webspace_overview'))
                 ->setAttributeDefault('webspace', $firstWebspace->getKey())
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())
-                ->addRerenderAttribute('webspace'),
+                ->setOption('tabTitle', 'sulu_page.content')
+                ->addRerenderAttribute('webspace')
+                ->setParent(static::WEBSPACE_TABS_ROUTE),
             (new Route(static::ADD_FORM_ROUTE, '/webspaces/:webspace/:locale/add/:parentId', 'sulu_page.page_tabs'))
                 ->setOption('backRoute', static::PAGES_ROUTE)
                 ->setOption('resourceKey', 'pages'),

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -121,7 +121,7 @@ class PageAdmin extends Admin
                 ->setAttributeDefault('webspace', $firstWebspace->getKey()),
             (new Route(static::PAGES_ROUTE, '/pages/:locale', 'sulu_page.webspace_overview'))
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())
-                ->setOption('tabTitle', 'sulu_page.content')
+                ->setOption('tabTitle', 'sulu_page.pages')
                 ->addRerenderAttribute('webspace')
                 ->setParent(static::WEBSPACE_TABS_ROUTE),
             (new Route(static::ADD_FORM_ROUTE, '/webspaces/:webspace/:locale/add/:parentId', 'sulu_page.page_tabs'))

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -31,7 +31,7 @@ class PageAdmin extends Admin
      */
     const SECURITY_CONTEXT_PREFIX = 'sulu.webspaces.';
 
-    const WEBSPACES_ROUTE = 'sulu_page.webspaces';
+    const PAGES_ROUTE = 'sulu_page.webspaces';
 
     const ADD_FORM_ROUTE = 'sulu_page.page_add_form';
 
@@ -79,7 +79,7 @@ class PageAdmin extends Admin
                 $webspaceItem = new NavigationItem('sulu_page.webspaces');
                 $webspaceItem->setPosition(10);
                 $webspaceItem->setIcon('su-webspace');
-                $webspaceItem->setMainRoute(static::WEBSPACES_ROUTE);
+                $webspaceItem->setMainRoute(static::PAGES_ROUTE);
 
                 $rootNavigationItem->addChild($webspaceItem);
 
@@ -114,12 +114,12 @@ class PageAdmin extends Admin
         $previewExpression = 'nodeType == 1';
 
         return [
-            (new Route(static::WEBSPACES_ROUTE, '/webspaces/:webspace/:locale', 'sulu_page.webspace_overview'))
+            (new Route(static::PAGES_ROUTE, '/webspaces/:webspace/pages/:locale', 'sulu_page.webspace_overview'))
                 ->setAttributeDefault('webspace', $firstWebspace->getKey())
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())
                 ->addRerenderAttribute('webspace'),
             (new Route(static::ADD_FORM_ROUTE, '/webspaces/:webspace/:locale/add/:parentId', 'sulu_page.page_tabs'))
-                ->setOption('backRoute', static::WEBSPACES_ROUTE)
+                ->setOption('backRoute', static::PAGES_ROUTE)
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_add_form.details', '/details')
                 ->setResourceKey('pages')
@@ -132,7 +132,7 @@ class PageAdmin extends Admin
                 ->setParent(static::ADD_FORM_ROUTE)
                 ->getRoute(),
             (new Route(static::EDIT_FORM_ROUTE, '/webspaces/:webspace/:locale/:id', 'sulu_page.page_tabs'))
-                ->setOption('backRoute', static::WEBSPACES_ROUTE)
+                ->setOption('backRoute', static::PAGES_ROUTE)
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_edit_form.details', '/details')
                 ->setResourceKey('pages')
@@ -157,7 +157,7 @@ class PageAdmin extends Admin
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_edit_form.excerpt', '/excerpt')
                 ->setResourceKey('pages_excerpt')
                 ->setFormKey('page_excerpt')
-                ->setBackRoute(static::WEBSPACES_ROUTE)
+                ->setBackRoute(static::PAGES_ROUTE)
                 ->setTabTitle('sulu_page.excerpt')
                 ->setTabCondition('(nodeType == 1 || nodeType == 4) && shadowOn == false')
                 ->addToolbarActions($formToolbarActionsWithoutType)
@@ -167,7 +167,7 @@ class PageAdmin extends Admin
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_edit_form.settings', '/settings')
                 ->setResourceKey('pages')
                 ->setFormKey('page_settings')
-                ->setBackRoute(static::WEBSPACES_ROUTE)
+                ->setBackRoute(static::PAGES_ROUTE)
                 ->setTabTitle('sulu_page.settings')
                 ->setTabPriority(512)
                 ->addToolbarActions($formToolbarActionsWithoutType)

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -81,7 +81,7 @@ class PageAdmin extends Admin
                 $webspaceItem = new NavigationItem('sulu_page.webspaces');
                 $webspaceItem->setPosition(10);
                 $webspaceItem->setIcon('su-webspace');
-                $webspaceItem->setMainRoute(static::PAGES_ROUTE);
+                $webspaceItem->setMainRoute(static::WEBSPACE_TABS_ROUTE);
 
                 $rootNavigationItem->addChild($webspaceItem);
 
@@ -116,8 +116,8 @@ class PageAdmin extends Admin
         $previewExpression = 'nodeType == 1';
 
         return [
-            // TODO create route builder for default tabs
-            (new Route(static::WEBSPACE_TABS_ROUTE, '/webspaces/:webspace', 'sulu_admin.tabs')),
+            $this->routeBuilderFactory->createTabRouteBuilder(static::WEBSPACE_TABS_ROUTE, '/webspaces/:webspace')
+                ->getRoute(),
             (new Route(static::PAGES_ROUTE, '/webspaces/:webspace/pages/:locale', 'sulu_page.webspace_overview'))
                 ->setAttributeDefault('webspace', $firstWebspace->getKey())
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -117,9 +117,9 @@ class PageAdmin extends Admin
 
         return [
             $this->routeBuilderFactory->createTabRouteBuilder(static::WEBSPACE_TABS_ROUTE, '/webspaces/:webspace')
-                ->getRoute(),
-            (new Route(static::PAGES_ROUTE, '/webspaces/:webspace/pages/:locale', 'sulu_page.webspace_overview'))
-                ->setAttributeDefault('webspace', $firstWebspace->getKey())
+                ->getRoute()
+                ->setAttributeDefault('webspace', $firstWebspace->getKey()),
+            (new Route(static::PAGES_ROUTE, '/pages/:locale', 'sulu_page.webspace_overview'))
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())
                 ->setOption('tabTitle', 'sulu_page.content')
                 ->addRerenderAttribute('webspace')

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceOverview/webspaceOverview.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceOverview/webspaceOverview.scss
@@ -1,5 +1,5 @@
-@import 'sulu-admin-bundle/containers/Application/variables.scss';
+@import 'sulu-admin-bundle/components/Tabs/variables.scss';
 
 .webspace-overview {
-    height: 100%;
+    height: calc(100% - $tabMenuHeight);
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -14,6 +14,7 @@
     "sulu_page.all_navigations": "allen Navigationen",
     "sulu_page.page_type": "Seitentyp",
     "sulu_page.content": "Inhalt",
+    "sulu_page.pages": "Seiten",
     "sulu_page.internal_link": "Interner Link",
     "sulu_page.external_link": "Externer Link",
     "sulu_page.link_title": "Link Titel",

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -14,6 +14,7 @@
     "sulu_page.all_navigations": "all navigations",
     "sulu_page.page_type": "Page Type",
     "sulu_page.content": "Content",
+    "sulu_page.pages": "Pages",
     "sulu_page.internal_link": "Internal Link",
     "sulu_page.external_link": "External Link",
     "sulu_page.link_title": "Link Title",

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -81,6 +81,9 @@ class PageAdminTest extends TestCase
 
         $route = $admin->getRoutes()[0];
         $this->assertAttributeEquals('sulu_page.webspaces', 'name', $route);
+
+        $route = $admin->getRoutes()[1];
+        $this->assertAttributeEquals('sulu_page.pages_datagrid', 'name', $route);
         $this->assertAttributeEquals([
             'webspace' => 'test-1',
             'locale' => 'de',

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -81,11 +81,13 @@ class PageAdminTest extends TestCase
 
         $route = $admin->getRoutes()[0];
         $this->assertAttributeEquals('sulu_page.webspaces', 'name', $route);
+        $this->assertAttributeEquals([
+            'webspace' => 'test-1',
+        ], 'attributeDefaults', $route);
 
         $route = $admin->getRoutes()[1];
         $this->assertAttributeEquals('sulu_page.pages_datagrid', 'name', $route);
         $this->assertAttributeEquals([
-            'webspace' => 'test-1',
             'locale' => 'de',
         ], 'attributeDefaults', $route);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

A simple tab view that is used for the Webspace Overview.

#### Why?

It is necessary because there will appear more tabs later, which don't share a `ResourceStore`, and therefore it is not possible to use the `ResourceTabs`.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md