### PR TITLE
Add excludedIds prop to DatagridOverlay containers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@
 ## dev-develop
 
 ### excluded query parameter of Media API
+
 The `excluded` query parameter which can be used to exclude specific ids from the media list returned by the Media API
 was renamed to `excludedIds` to increase the consistency within our APIs. 
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## dev-develop
 
+### excluded query parameter of Media API
+The `excluded` query parameter which can be used to exclude specific ids from the media list returned by the Media API
+was renamed to `excludedIds` to increase the consistency within our APIs. 
+
 ### Endpoint configuration
 
 **This change only affects you if you have used a 2.0.0 alpha release before**

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -414,7 +414,7 @@ test('Search using store when new search value is retrieved from MultiAutoComple
     expect(multiAutoComplete.instance().searchStore.search).toBeCalledWith('James', []);
 });
 
-test('Search using store with excluded ids when new search value is retrieved from MultiAutoComplete component', () => {
+test('Search using store with excluded-ids when new search value is retrieved from MultiAutoComplete component', () => {
     // $FlowFixMe
     SearchStore.mockImplementation(function() {
         this.searchResults = [];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -81,7 +81,7 @@ export default class MultiListOverlay extends React.Component<Props> {
         const newExcludedIds = excludedIds.length ? excludedIds : undefined;
 
         if (!equal(currentExcludedIds, newExcludedIds)) {
-            this.datagridStore.clear();
+            this.listStore.clear();
             this.excludedIds.set(newExcludedIds);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {observable, autorun, action, toJS} from 'mobx';
+import {action, autorun, observable, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import equal from 'fast-deep-equal';
 import {observer} from 'mobx-react';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -51,7 +51,7 @@ export default class MultiListOverlay extends React.Component<Props> {
         const {listKey, locale, options, preSelectedItems, resourceKey} = this.props;
         const observableOptions = {};
         observableOptions.page = this.page;
-        observableOptions.excluded = this.excludedIds;
+        observableOptions.excludedIds = this.excludedIds;
 
         if (locale) {
             observableOptions.locale = locale;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -34,8 +34,8 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     const multiListOverlay = shallow(
         <MultiListOverlay
             adapter="table"
-            listKey="snippets_list"
             excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
             locale={locale}
             onClose={jest.fn()}
             onConfirm={jest.fn()}
@@ -49,7 +49,7 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     expect(multiListOverlay.instance().listStore.listKey).toEqual('snippets_list');
     expect(multiListOverlay.instance().listStore.resourceKey).toEqual('snippets');
     expect(multiListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
-    expect(multiDatagridOverlay.instance().datagridStore.observableOptions.excluded.get()).toEqual(['id-1', 'id-2']);
+    expect(multiListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(['id-1', 'id-2']);
     expect(multiListOverlay.instance().listStore.options).toBe(options);
 });
 
@@ -67,7 +67,7 @@ test('Should instantiate the ListStore without locale, excluded-ids and options'
     );
 
     expect(multiListOverlay.instance().listStore.observableOptions.locale).toEqual(undefined);
-    expect(multiDatagridOverlay.instance().datagridStore.observableOptions.excluded.get()).toEqual(undefined);
+    expect(multiListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(undefined);
 });
 
 test('Should pass overlayType overlay by default', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -49,7 +49,7 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     expect(multiListOverlay.instance().listStore.listKey).toEqual('snippets_list');
     expect(multiListOverlay.instance().listStore.resourceKey).toEqual('snippets');
     expect(multiListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
-    expect(multiListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(['id-1', 'id-2']);
+    expect(multiListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(['id-1', 'id-2']);
     expect(multiListOverlay.instance().listStore.options).toBe(options);
 });
 
@@ -67,7 +67,7 @@ test('Should instantiate the ListStore without locale, excluded-ids and options'
     );
 
     expect(multiListOverlay.instance().listStore.observableOptions.locale).toEqual(undefined);
-    expect(multiListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(undefined);
+    expect(multiListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(undefined);
 });
 
 test('Should pass overlayType overlay by default', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js
@@ -22,11 +22,12 @@ jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
         this.options = options;
         this.observableOptions = observableOptions;
         this.select = jest.fn();
+        this.clear = jest.fn();
         this.selections = [];
     }
 ));
 
-test('Should instantiate the ListStore with locale and options', () => {
+test('Should instantiate the ListStore with locale, excluded-ids and options', () => {
     const locale = observable.box('en');
     const options = {};
 
@@ -34,6 +35,7 @@ test('Should instantiate the ListStore with locale and options', () => {
         <MultiListOverlay
             adapter="table"
             listKey="snippets_list"
+            excludedIds={['id-1', 'id-2']}
             locale={locale}
             onClose={jest.fn()}
             onConfirm={jest.fn()}
@@ -47,10 +49,11 @@ test('Should instantiate the ListStore with locale and options', () => {
     expect(multiListOverlay.instance().listStore.listKey).toEqual('snippets_list');
     expect(multiListOverlay.instance().listStore.resourceKey).toEqual('snippets');
     expect(multiListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
+    expect(multiDatagridOverlay.instance().datagridStore.observableOptions.excluded.get()).toEqual(['id-1', 'id-2']);
     expect(multiListOverlay.instance().listStore.options).toBe(options);
 });
 
-test('Should instantiate the ListStore without locale and options', () => {
+test('Should instantiate the ListStore without locale, excluded-ids and options', () => {
     const multiListOverlay = shallow(
         <MultiListOverlay
             adapter="table"
@@ -64,6 +67,7 @@ test('Should instantiate the ListStore without locale and options', () => {
     );
 
     expect(multiListOverlay.instance().listStore.observableOptions.locale).toEqual(undefined);
+    expect(multiDatagridOverlay.instance().datagridStore.observableOptions.excluded.get()).toEqual(undefined);
 });
 
 test('Should pass overlayType overlay by default', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -89,7 +89,7 @@ export default class MultiSelection extends React.Component<Props> {
     };
 
     handleOverlayConfirm = (selectedItems: Array<Object>) => {
-        this.selectionStore.set([...this.selectionStore.items, ...selectedItems]);
+        this.selectionStore.set(selectedItems);
         this.closeOverlay();
     };
 
@@ -116,7 +116,6 @@ export default class MultiSelection extends React.Component<Props> {
         } = this.props;
 
         const {items, loading} = this.selectionStore;
-        const itemIds = items.map((item) => item.id);
         const columns = displayProperties.length;
 
         return (
@@ -150,14 +149,13 @@ export default class MultiSelection extends React.Component<Props> {
                 </MultiItemSelection>
                 <MultiListOverlay
                     adapter={adapter}
-                    clearSelectionOnClose={true}
                     disabledIds={disabledIds}
-                    excludedIds={itemIds}
                     listKey={listKey}
                     locale={locale}
                     onClose={this.handleOverlayClose}
                     onConfirm={this.handleOverlayConfirm}
                     open={this.overlayOpen}
+                    preSelectedItems={items}
                     resourceKey={resourceKey}
                     title={overlayTitle}
                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -89,7 +89,7 @@ export default class MultiSelection extends React.Component<Props> {
     };
 
     handleOverlayConfirm = (selectedItems: Array<Object>) => {
-        this.selectionStore.set(selectedItems);
+        this.selectionStore.set([...this.selectionStore.items, ...selectedItems]);
         this.closeOverlay();
     };
 
@@ -116,6 +116,7 @@ export default class MultiSelection extends React.Component<Props> {
         } = this.props;
 
         const {items, loading} = this.selectionStore;
+        const itemIds = items.map((item) => item.id);
         const columns = displayProperties.length;
 
         return (
@@ -149,13 +150,14 @@ export default class MultiSelection extends React.Component<Props> {
                 </MultiItemSelection>
                 <MultiListOverlay
                     adapter={adapter}
+                    clearSelectionOnClose={true}
                     disabledIds={disabledIds}
+                    excludedIds={itemIds}
                     listKey={listKey}
                     locale={locale}
                     onClose={this.handleOverlayClose}
                     onConfirm={this.handleOverlayConfirm}
                     open={this.overlayOpen}
-                    preSelectedItems={items}
                     resourceKey={resourceKey}
                     title={overlayTitle}
                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -320,7 +320,7 @@ test('Should instantiate the ListStore with the correct resourceKey and destroy 
     expect(listStore.destroy).toBeCalled();
 });
 
-test('Should instantiate the ListStore with excluded-ids', () => {
+test('Should instantiate the ListStore with the preselected ids', () => {
     // $FlowFixMe
     MultiSelectionStore.mockImplementationOnce(function() {
         this.items = [{id: 1}, {id: 5}, {id: 8}];
@@ -340,7 +340,9 @@ test('Should instantiate the ListStore with excluded-ids', () => {
     selection.find('Button[icon="su-plus"]').simulate('click');
 
     const listStore = selection.find('MultiListOverlay').instance().listStore;
-    expect(listStore.observableOptions.excludedIds.get()).toEqual([1, 5, 8]);
+    expect(listStore.select).toBeCalledWith({id: 1});
+    expect(listStore.select).toBeCalledWith({id: 5});
+    expect(listStore.select).toBeCalledWith({id: 8});
 });
 
 test('Should reinstantiate the ListStore with the preselected ids when new props are received', () => {
@@ -367,7 +369,9 @@ test('Should reinstantiate the ListStore with the preselected ids when new props
     selection.find('Button[icon="su-plus"]').simulate('click');
 
     const listStore = selection.find('MultiListOverlay').instance().listStore;
-    expect(listStore.observableOptions.excludedIds.get()).toEqual([1, 5, 8]);
+    expect(listStore.select).toBeCalledWith({id: 1});
+    expect(listStore.select).toBeCalledWith({id: 5});
+    expect(listStore.select).toBeCalledWith({id: 8});
 
     selection.setProps({value: [1, 3]});
     const loadItemsCall = selection.instance().selectionStore.loadItems.mock.calls[0];
@@ -398,7 +402,9 @@ test('Should not reload items if none of the items changed', () => {
     selection.find('Button[icon="su-plus"]').simulate('click');
 
     const listStore = selection.find('MultiListOverlay').instance().listStore;
-    expect(listStore.observableOptions.excludedIds.get()).toEqual([1, 5, 8]);
+    expect(listStore.select).toBeCalledWith({id: 1});
+    expect(listStore.select).toBeCalledWith({id: 5});
+    expect(listStore.select).toBeCalledWith({id: 8});
 
     selection.setProps({value: [1, 5, 8]});
     expect(selection.instance().selectionStore.loadItems).not.toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -24,6 +24,10 @@ jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
         this.select = jest.fn();
         this.setActive = jest.fn();
         this.clear = jest.fn();
+
+        mockExtendObservable(this, {
+            selections: [],
+        });
     }
 ));
 
@@ -223,7 +227,7 @@ test('Should close an overlay using the confirm button', () => {
 
     selection.find('Button[icon="su-plus"]').simulate('click');
     const listStore = selection.find('MultiListOverlay').instance().listStore;
-    listStore.selections = [];
+    listStore.selections = [1];
 
     const confirmButton = document.querySelector('button.primary');
     if (confirmButton) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -45,7 +45,7 @@ exports[`Should open an overlay 1`] = `
             </div>
           </div>
         </article>
-        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">sulu_admin.confirm</span></button></footer>
+        <footer><button class=\\"button primary\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">sulu_admin.confirm</span></button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -51,7 +51,7 @@ export default class SingleListOverlay extends React.Component<Props> {
         const {listKey, locale, options, preSelectedItem, resourceKey} = this.props;
         const observableOptions = {};
         observableOptions.page = this.page;
-        observableOptions.excluded = this.excludedIds;
+        observableOptions.excludedIds = this.excludedIds;
 
         if (locale) {
             observableOptions.locale = locale;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -102,7 +102,7 @@ export default class SingleListOverlay extends React.Component<Props> {
         const newExcludedIds = excludedIds.length ? excludedIds : undefined;
 
         if (!equal(currentExcludedIds, newExcludedIds)) {
-            this.datagridStore.clear();
+            this.listStore.clear();
             this.excludedIds.set(newExcludedIds);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -40,8 +40,8 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     const singleListOverlay = shallow(
         <SingleListOverlay
             adapter="table"
-            listKey="snippets_list"
             excludedIds={['id-1', 'id-2']}
+            listKey="snippets_list"
             locale={locale}
             onClose={jest.fn()}
             onConfirm={jest.fn()}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -27,12 +27,13 @@ jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
             selections: [],
         });
 
+        this.clear = jest.fn();
         this.clearSelection = jest.fn();
         this.destroy = jest.fn();
     }
 ));
 
-test('Should instantiate the ListStore with locale and options', () => {
+test('Should instantiate the ListStore with locale, excluded-ids and options', () => {
     const locale = observable.box('en');
     const options = {};
 
@@ -40,6 +41,7 @@ test('Should instantiate the ListStore with locale and options', () => {
         <SingleListOverlay
             adapter="table"
             listKey="snippets_list"
+            excludedIds={['id-1', 'id-2']}
             locale={locale}
             onClose={jest.fn()}
             onConfirm={jest.fn()}
@@ -53,10 +55,11 @@ test('Should instantiate the ListStore with locale and options', () => {
     expect(singleListOverlay.instance().listStore.listKey).toEqual('snippets_list');
     expect(singleListOverlay.instance().listStore.resourceKey).toEqual('snippets');
     expect(singleListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
+    expect(singleListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(['id-1', 'id-2']);
     expect(singleListOverlay.instance().listStore.options).toBe(options);
 });
 
-test('Should instantiate the ListStore without locale and options', () => {
+test('Should instantiate the ListStore without locale, excluded-ids and options', () => {
     const singleListOverlay = shallow(
         <SingleListOverlay
             adapter="table"
@@ -70,6 +73,7 @@ test('Should instantiate the ListStore without locale and options', () => {
     );
 
     expect(singleListOverlay.instance().listStore.observableOptions.locale).toEqual(undefined);
+    expect(singleListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(undefined);
 });
 
 test('Should pass overlayType overlay by default', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -55,7 +55,7 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     expect(singleListOverlay.instance().listStore.listKey).toEqual('snippets_list');
     expect(singleListOverlay.instance().listStore.resourceKey).toEqual('snippets');
     expect(singleListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
-    expect(singleListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(['id-1', 'id-2']);
+    expect(singleListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(['id-1', 'id-2']);
     expect(singleListOverlay.instance().listStore.options).toBe(options);
 });
 
@@ -73,7 +73,7 @@ test('Should instantiate the ListStore without locale, excluded-ids and options'
     );
 
     expect(singleListOverlay.instance().listStore.observableOptions.locale).toEqual(undefined);
-    expect(singleListOverlay.instance().listStore.observableOptions.excluded.get()).toEqual(undefined);
+    expect(singleListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(undefined);
 });
 
 test('Should pass overlayType overlay by default', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -4,7 +4,7 @@ import type {IObservableValue} from 'mobx';
 import {arrayMove} from '../../components';
 import {ResourceRequester} from '../../services';
 
-export default class SelectionStore {
+export default class MultiSelectionStore {
     @observable items: Array<Object> = [];
     @observable loading: boolean = false;
     resourceKey: string;

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -243,7 +243,7 @@ class ContactController extends RestController implements ClassResourceInterface
         $listBuilder = $factory->create($this->container->getParameter('sulu.model.contact.class'));
         $restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
 
-        $listResponse = $this->prepareListResponse($request, $listBuilder, $locale);
+        $listResponse = $this->prepareListResponse($listBuilder, $locale);
 
         return new ListRepresentation(
             $listResponse,
@@ -259,28 +259,18 @@ class ContactController extends RestController implements ClassResourceInterface
     /**
      * Prepare list response.
      *
-     * @param Request $request
      * @param DoctrineListBuilder $listBuilder
      * @param string $locale
      *
      * @return array
      */
-    private function prepareListResponse(Request $request, DoctrineListBuilder $listBuilder, $locale)
+    private function prepareListResponse(DoctrineListBuilder $listBuilder, $locale)
     {
-        $idsParameter = $request->get('ids');
-        $ids = array_filter(explode(',', $idsParameter));
-        if (null !== $idsParameter && 0 === count($ids)) {
-            return [];
-        }
-
-        if (null !== $idsParameter) {
-            $listBuilder->in($this->fieldDescriptors['id'], $ids);
-        }
-
         $listResponse = $listBuilder->execute();
         $listResponse = $this->addAvatars($listResponse, $locale);
 
-        if (null !== $idsParameter) {
+        $ids = $listBuilder->getIds();
+        if (null !== $ids) {
             $comparator = $this->getComparator();
             // the @ is necessary in case of a PHP bug https://bugs.php.net/bug.php?id=50688
             @usort(

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1999,7 +1999,7 @@ class AccountControllerTest extends SuluTestCase
             'GET',
             '/api/accounts?flat=true',
             [
-                'ids' => $ids,
+                'ids' => implode(',', $ids),
             ]
         );
 
@@ -2030,7 +2030,7 @@ class AccountControllerTest extends SuluTestCase
             'GET',
             '/api/accounts?flat=true',
             [
-                'ids' => $ids,
+                'ids' => implode(',', $ids),
                 'page' => 2,
                 'limit' => 10,
             ]

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -47,7 +47,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
 
     static createMediaListStore(
         collectionId: IObservableValue<?string | number>,
-        excludedIds: IObservableValue<Array<number>>,
+        excludedIds: IObservableValue<?Array<number>>,
         locale: IObservableValue<string>
     ) {
         const options = {};

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -71,7 +71,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
             {
                 page: observable.box(),
                 collection: collectionId,
-                excluded: excludedIds,
+                excludedIds: excludedIds,
                 locale: locale,
             },
             options

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -47,7 +47,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
 
     static createMediaListStore(
         collectionId: IObservableValue<?string | number>,
-        excludedIdString: IObservableValue<string>,
+        excludedIds: IObservableValue<Array<number>>,
         locale: IObservableValue<string>
     ) {
         const options = {};
@@ -62,7 +62,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
             'mimeType',
             'subVersion',
             'thumbnails',
-        ].join(',');
+        ];
 
         return new ListStore(
             MEDIA_RESOURCE_KEY,
@@ -71,7 +71,7 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
             {
                 page: observable.box(),
                 collection: collectionId,
-                excluded: excludedIdString,
+                excluded: excludedIds,
                 locale: locale,
             },
             options

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -21,7 +21,7 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
         excludedIds: [],
     };
 
-    excludedIds: IObservableValue<Array<number>> = observable.box([]);
+    excludedIds: IObservableValue<?Array<number>> = observable.box();
     collectionId: IObservableValue<?string | number> = observable.box();
     mediaListStore: ListStore;
     collectionListStore: ListStore;
@@ -59,8 +59,9 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
         }
     }
 
-    @action updateExcludedIds(newExcludedIds: Array<number>) {
+    @action updateExcludedIds(excludedIds: Array<number>) {
         const currentExcludedIds = toJS(this.excludedIds.get());
+        const newExcludedIds = excludedIds.length ? excludedIds : undefined;
 
         if (!equal(currentExcludedIds, newExcludedIds)) {
             this.mediaListStore.clear();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -46,17 +46,9 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
     }
 
     componentWillUnmount() {
-        if (this.mediaListStore) {
-            this.mediaListStore.destroy();
-        }
-
-        if (this.collectionListStore) {
-            this.collectionListStore.destroy();
-        }
-
-        if (this.excludedIdsDisposer) {
-            this.excludedIdsDisposer();
-        }
+        this.mediaListStore.destroy();
+        this.collectionListStore.destroy();
+        this.excludedIdsDisposer();
     }
 
     @action updateExcludedIds(excludedIds: Array<number>) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -1,10 +1,9 @@
 // @flow
 import React from 'react';
-import {action, autorun, observable, toJS} from 'mobx';
+import {computed, observable} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import {ListStore} from 'sulu-admin-bundle/containers';
-import equal from 'fast-deep-equal';
 import MediaSelectionOverlay from '../MediaSelectionOverlay';
 
 type Props = {|
@@ -21,7 +20,6 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
         excludedIds: [],
     };
 
-    excludedIds: IObservableValue<?Array<number>> = observable.box();
     collectionId: IObservableValue<?string | number> = observable.box();
     mediaListStore: ListStore;
     collectionListStore: ListStore;
@@ -30,35 +28,24 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
+        const excludedIds = computed(() => this.props.excludedIds.length ? this.props.excludedIds : undefined);
+        this.excludedIdsDisposer = excludedIds.observe(() => this.mediaListStore.clear());
+
         this.mediaListStore = MediaSelectionOverlay.createMediaListStore(
             this.collectionId,
-            this.excludedIds,
+            excludedIds,
             props.locale
         );
         this.collectionListStore = MediaSelectionOverlay.createCollectionListStore(
             this.collectionId,
             props.locale
         );
-
-        this.excludedIdsDisposer = autorun(() => {
-            this.updateExcludedIds(this.props.excludedIds);
-        });
     }
 
     componentWillUnmount() {
         this.mediaListStore.destroy();
         this.collectionListStore.destroy();
         this.excludedIdsDisposer();
-    }
-
-    @action updateExcludedIds(excludedIds: Array<number>) {
-        const currentExcludedIds = toJS(this.excludedIds.get());
-        const newExcludedIds = excludedIds.length ? excludedIds : undefined;
-
-        if (!equal(currentExcludedIds, newExcludedIds)) {
-            this.mediaListStore.clear();
-            this.excludedIds.set(newExcludedIds);
-        }
     }
 
     render() {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js
@@ -20,7 +20,7 @@ jest.mock('../../MediaSelectionOverlay', () => {
     return MediaSelectionOverlay;
 });
 
-test('Should create list-stores with correct locale', () => {
+test('Should create list-stores with correct locale and excluded-ids', () => {
     const locale = observable.box('en');
     shallow(
         <MultiMediaSelectionOverlay
@@ -38,6 +38,26 @@ test('Should create list-stores with correct locale', () => {
         locale
     );
     expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual([44, 22]);
+    expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
+});
+
+test('Should create list-stores without excluded-ids', () => {
+    const locale = observable.box('en');
+    shallow(
+        <MultiMediaSelectionOverlay
+            locale={locale}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    ).render();
+
+    expect(MediaSelectionOverlay.createMediaListStore).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        locale
+    );
+    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual(undefined);
     expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
 });
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js
@@ -14,6 +14,7 @@ jest.mock('../../MediaSelectionOverlay', () => {
     });
     MediaSelectionOverlay.createMediaListStore = jest.fn().mockReturnValue({
         destroy: jest.fn(),
+        clear: jest.fn(),
     });
 
     return MediaSelectionOverlay;
@@ -36,12 +37,12 @@ test('Should create list-stores with correct locale', () => {
         expect.anything(),
         locale
     );
-    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual('22,44');
+    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual([44, 22]);
     expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
 });
 
 test('Should pass correct props to media-selection-overlay', () => {
-    const mediaListStoreMock = jest.fn();
+    const mediaListStoreMock = {clear: jest.fn()};
     MediaSelectionOverlay.createMediaListStore.mockReturnValueOnce(mediaListStoreMock);
     const collectionListStoreMock = jest.fn();
     MediaSelectionOverlay.createCollectionListStore.mockReturnValueOnce(collectionListStoreMock);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -63,21 +63,10 @@ export default class SingleMediaSelectionOverlay extends React.Component<Props> 
     }
 
     componentWillUnmount() {
-        if (this.mediaListStore) {
-            this.mediaListStore.destroy();
-        }
-
-        if (this.collectionListStore) {
-            this.collectionListStore.destroy();
-        }
-
-        if (this.excludedIdsDisposer) {
-            this.excludedIdsDisposer();
-        }
-
-        if (this.mediaSelectionDisposer) {
-            this.mediaSelectionDisposer();
-        }
+        this.mediaListStore.destroy();
+        this.collectionListStore.destroy();
+        this.excludedIdsDisposer();
+        this.mediaSelectionDisposer();
     }
 
     @action updateExcludedIds(excludedIds: Array<number>) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -74,7 +74,7 @@ export default class SingleMediaSelectionOverlay extends React.Component<Props> 
         const newExcludedIds = excludedIds.length ? excludedIds : undefined;
 
         if (!equal(currentExcludedIds, newExcludedIds)) {
-            this.mediaDatagridStore.clear();
+            this.mediaListStore.clear();
             this.excludedIds.set(newExcludedIds);
         }
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -21,7 +21,7 @@ export default class SingleMediaSelectionOverlay extends React.Component<Props> 
         excludedIds: [],
     };
 
-    excludedIds: IObservableValue<Array<number>> = observable.box([]);
+    excludedIds: IObservableValue<?Array<number>> = observable.box();
     collectionId: IObservableValue<?string | number> = observable.box();
     mediaListStore: ListStore;
     collectionListStore: ListStore;
@@ -80,8 +80,9 @@ export default class SingleMediaSelectionOverlay extends React.Component<Props> 
         }
     }
 
-    @action updateExcludedIds(newExcludedIds: Array<number>) {
+    @action updateExcludedIds(excludedIds: Array<number>) {
         const currentExcludedIds = toJS(this.excludedIds.get());
+        const newExcludedIds = excludedIds.length ? excludedIds : undefined;
 
         if (!equal(currentExcludedIds, newExcludedIds)) {
             this.mediaDatagridStore.clear();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
@@ -44,6 +44,26 @@ test('Should create list-stores with correct locale and excluded-ids', () => {
     expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
 });
 
+test('Should create list-stores without excluded-ids', () => {
+    const locale = mockObservable.box('en');
+    shallow(
+        <SingleMediaSelectionOverlay
+            locale={locale}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    ).render();
+
+    expect(MediaSelectionOverlay.createMediaListStore).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        locale
+    );
+    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual(undefined);
+    expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
+});
+
 test('Should update selections of media-list-store to only contain a single item', () => {
     const singleMediaSelectionOverlay = shallow(
         <SingleMediaSelectionOverlay

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
@@ -17,12 +17,13 @@ jest.mock('../../MediaSelectionOverlay', () => {
         select: jest.fn(),
         clearSelection: jest.fn(),
         destroy: jest.fn(),
+        clear: jest.fn(),
     });
 
     return MediaSelectionOverlay;
 });
 
-test('Should create list-stores with correct locale and excluded-id-string', () => {
+test('Should create list-stores with correct locale and excluded-ids', () => {
     const locale = mockObservable.box('en');
     shallow(
         <SingleMediaSelectionOverlay
@@ -39,7 +40,7 @@ test('Should create list-stores with correct locale and excluded-id-string', () 
         expect.anything(),
         locale
     );
-    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual('55,66');
+    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual([66, 55]);
     expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
 });
 
@@ -63,7 +64,7 @@ test('Should update selections of media-list-store to only contain a single item
 });
 
 test('Should pass correct props to media-selection-overlay', () => {
-    const mediaListStoreMock = {selections: mockObservable([])};
+    const mediaListStoreMock = {selections: mockObservable([]), clear: jest.fn()};
     MediaSelectionOverlay.createMediaListStore.mockReturnValueOnce(mediaListStoreMock);
     const collectionListStoreMock = jest.fn();
     MediaSelectionOverlay.createCollectionListStore.mockReturnValueOnce(collectionListStoreMock);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -531,18 +531,18 @@ class MediaControllerTest extends SuluTestCase
     /**
      * Test GET all Media.
      */
-    public function testCgetExcluded()
+    public function testCgetExcludedIds()
     {
         $media = $this->createMedia('photo');
         $this->createMedia('photo1');
         $media2 = $this->createMedia('photo2');
         $this->createMedia('photo3');
         $client = $this->createAuthenticatedClient();
-        $excluded = implode(',', [$media->getId(), $media2->getId()]);
+        $excludedIds = implode(',', [$media->getId(), $media2->getId()]);
 
         $client->request(
             'GET',
-            '/api/media?locale=en-gb&excluded=' . $excluded
+            '/api/media?locale=en-gb&excludedIds=' . $excludedIds
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -97,16 +97,6 @@ class TagController extends RestController implements ClassResourceInterface, Se
                 ->getFieldDescriptors('tags');
             $listBuilder = $factory->create($tagEntityName);
 
-            $ids = array_filter(explode(',', $request->get('ids', '')));
-            if (count($ids) > 0) {
-                $listBuilder->in($fieldDescriptors['id'], $ids);
-            }
-
-            $excludedIds = array_filter(explode(',', $request->get('excludedIds', '')));
-            if (count($excludedIds) > 0) {
-                $listBuilder->notIn($fieldDescriptors['id'], $excludedIds);
-            }
-
             $names = array_filter(explode(',', $request->get('names', '')));
             if (count($names) > 0) {
                 $listBuilder->in($fieldDescriptors['name'], $names);

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -60,6 +60,21 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     protected $limit = null;
 
     /**
+     * Array of ids to which the result of the query is restricted.
+     * If null, the result is not restricted to specific ids.
+     *
+     * @var ?array
+     */
+    protected $ids = null;
+
+    /**
+     * Array of ids which are excluded from the result of the query.
+     *
+     * @var array
+     */
+    protected $excludedIds = [];
+
+    /**
      * group by fields.
      *
      * @var array
@@ -266,6 +281,42 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     public function getCurrentPage()
     {
         return $this->page;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setIds($ids)
+    {
+        $this->ids = $ids;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIds()
+    {
+        return $this->ids;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExcludedIds($excludedIds)
+    {
+        $this->excludedIds = $excludedIds;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExcludedIds()
+    {
+        return $this->excludedIds;
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -63,16 +63,17 @@ abstract class AbstractListBuilder implements ListBuilderInterface
      * Array of ids to which the result of the query is restricted.
      * If null, the result is not restricted to specific ids.
      *
-     * @var ?array
+     * @var array|null
      */
     protected $ids = null;
 
     /**
      * Array of ids which are excluded from the result of the query.
+     * If null, no ids will be excluded from the result.
      *
-     * @var array
+     * @var array|null
      */
-    protected $excludedIds = [];
+    protected $excludedIds = null;
 
     /**
      * group by fields.

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -530,7 +530,7 @@ class DoctrineListBuilder extends AbstractListBuilder
             $this->in($this->idField, !empty($this->ids) ? $this->ids : [null]);
         }
 
-        if (!empty($this->excludedIds)) {
+        if (null !== $this->excludedIds && !empty($this->excludedIds)) {
             $this->notIn($this->idField, $this->excludedIds);
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -526,9 +526,9 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         $this->assignJoins($this->queryBuilder, $joins);
 
-        if (null != $this->ids) {
-            $this->queryBuilder->andWhere($this->idField->getSelect() . ' in (:ids)');
-            $this->queryBuilder->setParameter('ids', $this->ids);
+        if (null !== $this->ids) {
+            $this->queryBuilder->andWhere($this->idField->getSelect() . ' in (:idsFilter)');
+            $this->queryBuilder->setParameter('idsFilter', $this->ids);
         }
 
         if (!empty($this->excludedIds)) {

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -527,13 +527,11 @@ class DoctrineListBuilder extends AbstractListBuilder
         $this->assignJoins($this->queryBuilder, $joins);
 
         if (null !== $this->ids) {
-            $this->queryBuilder->andWhere($this->idField->getSelect() . ' in (:idsFilter)');
-            $this->queryBuilder->setParameter('idsFilter', $this->ids);
+            $this->in($this->idField, !empty($this->ids) ? $this->ids : [null]);
         }
 
         if (!empty($this->excludedIds)) {
-            $this->queryBuilder->andWhere($this->idField->getSelect() . ' not in (:excludedIs)');
-            $this->queryBuilder->setParameter('excludedIs', $this->excludedIds);
+            $this->notIn($this->idField, $this->excludedIds);
         }
 
         // set expressions

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -526,6 +526,16 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         $this->assignJoins($this->queryBuilder, $joins);
 
+        if (null != $this->ids) {
+            $this->queryBuilder->andWhere($this->idField->getSelect() . ' in (:ids)');
+            $this->queryBuilder->setParameter('ids', $this->ids);
+        }
+
+        if (!empty($this->excludedIds)) {
+            $this->queryBuilder->andWhere($this->idField->getSelect() . ' not in (:excludedIs)');
+            $this->queryBuilder->setParameter('excludedIs', $this->excludedIds);
+        }
+
         // set expressions
         if (!empty($this->expressions)) {
             foreach ($this->expressions as $expression) {

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineInExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineInExpression.php
@@ -59,10 +59,10 @@ class DoctrineInExpression extends AbstractDoctrineExpression implements InExpre
             $queryBuilder->setParameter($paramName, $values);
             $statement = $this->field->getSelect() . ' IN (:' . $paramName . ')';
 
-            if (array_search(null, $this->getValues())) {
+            if (false !== array_search(null, $this->getValues())) {
                 $statement .= ' OR ' . $this->field->getSelect() . ' IS NULL';
             }
-        } elseif (array_search(null, $this->getValues())) { // only null in values array
+        } elseif (false !== array_search(null, $this->getValues())) { // only null in values array
             $statement .= $paramName . ' IS NULL';
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineInExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineInExpression.php
@@ -63,7 +63,7 @@ class DoctrineInExpression extends AbstractDoctrineExpression implements InExpre
                 $statement .= ' OR ' . $this->field->getSelect() . ' IS NULL';
             }
         } elseif (false !== array_search(null, $this->getValues())) { // only null in values array
-            $statement .= $paramName . ' IS NULL';
+            $statement .= $this->field->getSelect() . ' IS NULL';
         }
 
         return $statement;

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -156,6 +156,38 @@ interface ListBuilderInterface
     public function getCurrentPage();
 
     /**
+     * Restricts the rows to return to have one of the given ids.
+     *
+     * @param ?array $ids
+     *
+     * @return ListBuilderInterface
+     */
+    public function setIds($ids);
+
+    /**
+     * Returns an array of ids to which the rows to return are restricted.
+     *
+     * @return ?array
+     */
+    public function getIds();
+
+    /**
+     * Excludes the given ids from the rows to return.
+     *
+     * @param array $excludedIds
+     *
+     * @return ListBuilderInterface
+     */
+    public function setExcludedIds($excludedIds);
+
+    /**
+     * Returns an array of ids which are excluded from the rows to return.
+     *
+     * @return array
+     */
+    public function getExcludedIds();
+
+    /**
      * Sets the permission check for the ListBuilder.
      *
      * @param UserInterface $user The user for which the permission must be granted

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -157,8 +157,9 @@ interface ListBuilderInterface
 
     /**
      * Restricts the rows to return to have one of the given ids.
+     * If null, the rows to return are not restricted to specific ids.
      *
-     * @param ?array $ids
+     * @param array|null $ids
      *
      * @return ListBuilderInterface
      */
@@ -166,15 +167,17 @@ interface ListBuilderInterface
 
     /**
      * Returns an array of ids to which the rows to return are restricted.
+     * If null, the rows to return are not restricted to specific ids.
      *
-     * @return ?array
+     * @return array|null
      */
     public function getIds();
 
     /**
      * Excludes the given ids from the rows to return.
+     * If null, no ids will be excluded from the rows to return.
      *
-     * @param array $excludedIds
+     * @param array|null $excludedIds
      *
      * @return ListBuilderInterface
      */
@@ -182,8 +185,9 @@ interface ListBuilderInterface
 
     /**
      * Returns an array of ids which are excluded from the rows to return.
+     * If null, no ids will be excluded from the rows to return.
      *
-     * @return array
+     * @return array|null
      */
     public function getExcludedIds();
 

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -51,8 +51,8 @@ class ListRestHelper implements ListRestHelperInterface
     }
 
     /**
-     * Returns an array of ids that specifies which entities should be included in the response.
-     * If null is returned, entities in the response should not be filtered by their id.
+     * Returns an array of ids to which the response should be restricted.
+     * If null is returned, entities in the response should not be restricted by their id.
      *
      * @return array
      */
@@ -64,7 +64,7 @@ class ListRestHelper implements ListRestHelperInterface
     }
 
     /**
-     * Returns an array of ids which should be excluded in the response.
+     * Returns an array of ids which should be excluded from the response.
      *
      * @return array
      */
@@ -105,6 +105,12 @@ class ListRestHelper implements ListRestHelperInterface
         $default = 10;
         if ('csv' === $this->getRequest()->getRequestFormat()) {
             $default = null;
+        }
+
+        // set default limit to count of ids if result is restricted to specific ids
+        $ids = $this->getIds();
+        if (null != $ids) {
+            $default = count($ids);
         }
 
         return $this->getRequest()->get('limit', $default);

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -60,7 +60,7 @@ class ListRestHelper implements ListRestHelperInterface
     {
         $idsString = $this->getRequest()->get('ids');
 
-        return (null !== $idsString) ? explode(',', $idsString) : null;
+        return (null !== $idsString) ? array_filter(explode(',', $idsString)) : null;
     }
 
     /**
@@ -72,7 +72,7 @@ class ListRestHelper implements ListRestHelperInterface
     {
         $excludedIdsString = $this->getRequest()->get('excludedIds');
 
-        return (null !== $excludedIdsString) ? explode(',', $excludedIdsString) : [];
+        return (null !== $excludedIdsString) ? array_filter(explode(',', $excludedIdsString)) : [];
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -63,7 +63,6 @@ class ListRestHelper implements ListRestHelperInterface
         return (null !== $idsString) ? explode(',', $idsString) : [];
     }
 
-
     /**
      * Returns an array of ids which should be excluded in the response.
      *

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -51,6 +51,32 @@ class ListRestHelper implements ListRestHelperInterface
     }
 
     /**
+     * Returns an array of ids that specifies which entities should be included in the response.
+     * If null is returned, entities in the response should not be filtered by their id.
+     *
+     * @return array
+     */
+    public function getIds()
+    {
+        $idsString = $this->getRequest()->get('ids');
+
+        return (null !== $idsString) ? explode(',', $idsString) : [];
+    }
+
+
+    /**
+     * Returns an array of ids which should be excluded in the response.
+     *
+     * @return array
+     */
+    public function getExcludedIds()
+    {
+        $excludedIdsString = $this->getRequest()->get('excludedIds');
+
+        return (null !== $excludedIdsString) ? explode(',', $excludedIdsString) : [];
+    }
+
+    /**
      * Returns the desired sort column.
      *
      * @return string

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -60,7 +60,7 @@ class ListRestHelper implements ListRestHelperInterface
     {
         $idsString = $this->getRequest()->get('ids');
 
-        return (null !== $idsString) ? explode(',', $idsString) : [];
+        return (null !== $idsString) ? explode(',', $idsString) : null;
     }
 
     /**

--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -39,8 +39,18 @@ class RestHelper implements RestHelperInterface
      */
     public function initializeListBuilder(ListBuilderInterface $listBuilder, array $fieldDescriptors)
     {
-        $listBuilder->limit($this->listRestHelper->getLimit())->setCurrentPage($this->listRestHelper->getPage());
+        $listBuilder->limit($this->listRestHelper->getLimit());
+        $listBuilder->setCurrentPage($this->listRestHelper->getPage());
         $listBuilder->setFieldDescriptors($fieldDescriptors);
+
+        if (array_key_exists('id', $fieldDescriptors)) {
+            $listBuilder->notIn($fieldDescriptors['id'], $this->listRestHelper->getExcludedIds());
+
+            $ids = $this->listRestHelper->getIds();
+            if (null !== $ids) {
+                $listBuilder->in($fieldDescriptors['id'], $ids);
+            }
+        }
 
         $fields = $this->listRestHelper->getFields();
         if (null != $fields) {

--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -42,15 +42,8 @@ class RestHelper implements RestHelperInterface
         $listBuilder->limit($this->listRestHelper->getLimit());
         $listBuilder->setCurrentPage($this->listRestHelper->getPage());
         $listBuilder->setFieldDescriptors($fieldDescriptors);
-
-        if (array_key_exists('id', $fieldDescriptors)) {
-            $listBuilder->notIn($fieldDescriptors['id'], $this->listRestHelper->getExcludedIds());
-
-            $ids = $this->listRestHelper->getIds();
-            if (null !== $ids) {
-                $listBuilder->in($fieldDescriptors['id'], $ids);
-            }
-        }
+        $listBuilder->setIds($this->listRestHelper->getIds());
+        $listBuilder->setExcludedIds($this->listRestHelper->getExcludedIds());
 
         $fields = $this->listRestHelper->getFields();
         if (null != $fields) {

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -555,6 +555,69 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->execute();
     }
 
+    public function testSetIds()
+    {
+        $this->doctrineListBuilder->setIds([11, 22]);
+
+        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id in (:idsFilter)')
+            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->setParameter('idsFilter', [11, 22])
+            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSetIdsEmpty()
+    {
+        $this->doctrineListBuilder->setIds([]);
+
+        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id in (:idsFilter)')
+            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->setParameter('idsFilter', [])
+            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSetIdsNull()
+    {
+        $this->doctrineListBuilder->setIds(null);
+
+        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id in (:idsFilter)')->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSetExcludedIds()
+    {
+        $this->doctrineListBuilder->setExcludedIds([55, 99]);
+
+        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id not in (:excludedIs)')
+            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->setParameter('excludedIs', [55, 99])
+            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSetExcludedIdsEmpty()
+    {
+        $this->doctrineListBuilder->setExcludedIds([]);
+
+        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id not in (:excludedIs)')->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testSetExcludedIdsNull()
+    {
+        $this->doctrineListBuilder->setExcludedIds(null);
+
+        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id not in (:excludedIs)')->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
     public function testCount()
     {
         $this->doctrineListBuilder->setSelectFields(

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -559,7 +559,6 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds([11, 22]);
 
-
         $this->queryBuilder->setParameter(Argument::containingString('id'), [11, 22])->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('SuluCoreBundle_Example.id IN (:id')

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -559,10 +559,11 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds([11, 22]);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id in (:idsFilter)')
-            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->setParameter('idsFilter', [11, 22])
-            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+
+        $this->queryBuilder->setParameter(Argument::containingString('id'), [11, 22])->shouldBeCalled();
+        $this->queryBuilder->andWhere(
+            Argument::containingString('SuluCoreBundle_Example.id IN (:id')
+        )->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -571,10 +572,9 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds([]);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id in (:idsFilter)')
-            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->setParameter('idsFilter', [])
-            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->andWhere(
+            Argument::containingString(' IS NULL')
+        )->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -583,7 +583,9 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds(null);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id in (:idsFilter)')->shouldNotBeCalled();
+        $this->queryBuilder->andWhere(
+            Argument::containingString('SuluCoreBundle_Example.id IN (:id')
+        )->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -592,10 +594,10 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setExcludedIds([55, 99]);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id not in (:excludedIs)')
-            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->setParameter('excludedIs', [55, 99])
-            ->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->setParameter(Argument::containingString('id'), [55, 99])->shouldBeCalled();
+        $this->queryBuilder->andWhere(
+            Argument::containingString('NOT(SuluCoreBundle_Example.id IN (:id')
+        )->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -604,7 +606,9 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setExcludedIds([]);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id not in (:excludedIs)')->shouldNotBeCalled();
+        $this->queryBuilder->andWhere(
+            Argument::containingString('NOT(SuluCoreBundle_Example.id IN (:id')
+        )->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -613,7 +617,9 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setExcludedIds(null);
 
-        $this->queryBuilder->andWhere('SuluCoreBundle_Example.id not in (:excludedIs)')->shouldNotBeCalled();
+        $this->queryBuilder->andWhere(
+            Argument::containingString('NOT(SuluCoreBundle_Example.id IN (:id')
+        )->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
@@ -60,4 +60,19 @@ class DoctrineInExpressionTest extends TestCase
 
         $this->assertEquals(1, $result);
     }
+
+    public function testGetStatementSingleNullValue()
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $values = [null];
+        $whereExpression = new DoctrineInExpression($fieldDescriptor, $values);
+
+        $statement = $whereExpression->getStatement($this->queryBuilder);
+        $result = preg_match(
+            sprintf('/^name\S{%s} IS NULL/', $this->uniqueIdLength),
+            $statement
+        );
+
+        $this->assertEquals(1, $result);
+    }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineInExpressionTest.php
@@ -69,7 +69,7 @@ class DoctrineInExpressionTest extends TestCase
 
         $statement = $whereExpression->getStatement($this->queryBuilder);
         $result = preg_match(
-            sprintf('/^name\S{%s} IS NULL/', $this->uniqueIdLength),
+            '/^SuluCoreBundle_Example\.name IS NULL/',
             $statement
         );
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
@@ -45,6 +45,17 @@ class ListRestHelperTest extends TestCase
                         '_format' => 'csv',
                     ]
                 ),
+                [
+                    'fields' => ['one', 'two', 'three'],
+                    'searchPattern' => 'now',
+                    'sortColumn' => null,
+                    'sortOrder' => 'asc',
+                    'searchFields' => ['title'],
+                    'limit' => 20,
+                    'offset' => 0,
+                    'ids' => null,
+                    'excludedIds' => [],
+                ],
             ],
             [
                 new Request(
@@ -59,6 +70,66 @@ class ListRestHelperTest extends TestCase
                         '_format' => 'csv',
                     ]
                 ),
+                [
+                    'fields' => ['one', 'two', 'three'],
+                    'searchPattern' => 'now',
+                    'sortColumn' => null,
+                    'sortOrder' => 'asc',
+                    'searchFields' => ['title'],
+                    'limit' => null,
+                    'offset' => 0,
+                    'ids' => null,
+                    'excludedIds' => [],
+                ],
+            ],
+            [
+                new Request(
+                    [
+                        'fields' => 'one,two,three',
+                        'search' => 'now',
+                        'page' => 1,
+                        'ids' => 'id1,id2',
+                        'excludedIds' => 'id3,id4',
+                    ],
+                    [],
+                    []
+                ),
+                [
+                    'fields' => ['one', 'two', 'three'],
+                    'searchPattern' => 'now',
+                    'sortColumn' => null,
+                    'sortOrder' => 'asc',
+                    'searchFields' => [],
+                    'limit' => 2,
+                    'offset' => 0,
+                    'ids' => ['id1', 'id2'],
+                    'excludedIds' => ['id3', 'id4'],
+                ],
+            ],
+            [
+                new Request(
+                    [
+                        'fields' => 'one,two,three',
+                        'search' => 'now',
+                        'page' => 1,
+                        'limit' => 1,
+                        'ids' => 'id1,id2',
+                        'excludedIds' => 'id3,id4',
+                    ],
+                    [],
+                    []
+                ),
+                [
+                    'fields' => ['one', 'two', 'three'],
+                    'searchPattern' => 'now',
+                    'sortColumn' => null,
+                    'sortOrder' => 'asc',
+                    'searchFields' => [],
+                    'limit' => 1,
+                    'offset' => 0,
+                    'ids' => ['id1', 'id2'],
+                    'excludedIds' => ['id3', 'id4'],
+                ],
             ],
         ];
     }
@@ -66,17 +137,19 @@ class ListRestHelperTest extends TestCase
     /**
      * @dataProvider dataFieldsProvider
      */
-    public function testGetFields($request)
+    public function testGetFields($request, $expected)
     {
         $this->requestStack->getCurrentRequest()->willReturn($request);
         $helper = new ListRestHelper($this->requestStack->reveal());
 
-        $this->assertEquals(explode(',', $request->get('fields')), $helper->getFields());
-        $this->assertEquals($request->get('sortBy'), $helper->getSortColumn());
-        $this->assertEquals($request->get('sortOrder', 'asc'), $helper->getSortOrder());
-        $this->assertEquals($request->get('search'), $helper->getSearchPattern());
-        $this->assertEquals(explode(',', $request->get('searchFields')), $helper->getSearchFields());
-        $this->assertEquals($request->get('limit'), $helper->getLimit());
-        $this->assertEquals($request->get('limit') * ($request->get('page') - 1), $helper->getOffset());
+        $this->assertEquals($expected['fields'], $helper->getFields());
+        $this->assertEquals($expected['sortColumn'], $helper->getSortColumn());
+        $this->assertEquals($expected['sortOrder'], $helper->getSortOrder());
+        $this->assertEquals($expected['searchPattern'], $helper->getSearchPattern());
+        $this->assertEquals($expected['searchFields'], $helper->getSearchFields());
+        $this->assertEquals($expected['limit'], $helper->getLimit());
+        $this->assertEquals($expected['offset'], $helper->getOffset());
+        $this->assertEquals($expected['ids'], $helper->getIds());
+        $this->assertEquals($expected['excludedIds'], $helper->getExcludedIds());
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
@@ -64,6 +64,8 @@ class ListRestHelperTest extends TestCase
                         'search' => 'now',
                         'searchFields' => 'title',
                         'page' => 1,
+                        'ids' => '',
+                        'excludedIds' => '',
                     ],
                     [],
                     [
@@ -78,7 +80,7 @@ class ListRestHelperTest extends TestCase
                     'searchFields' => ['title'],
                     'limit' => null,
                     'offset' => 0,
-                    'ids' => null,
+                    'ids' => [],
                     'excludedIds' => [],
                 ],
             ],

--- a/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
@@ -60,6 +60,28 @@ class RestHelperTest extends TestCase
         $this->restHelper->initializeListBuilder($listBuilder, []);
     }
 
+    public function testInitializeListBuilderIds()
+    {
+        $listBuilder = $this->getMockBuilder('Sulu\Component\Rest\ListBuilder\AbstractListBuilder')
+            ->getMock();
+
+        $this->listRestHelper->expects($this->any())->method('getIds')->willReturn([2, 4, 6]);
+        $listBuilder->expects($this->once())->method('setIds')->with([2, 4, 6])->willReturnSelf();
+
+        $this->restHelper->initializeListBuilder($listBuilder, []);
+    }
+
+    public function testInitializeListBuilderExcludedIds()
+    {
+        $listBuilder = $this->getMockBuilder('Sulu\Component\Rest\ListBuilder\AbstractListBuilder')
+            ->getMock();
+
+        $this->listRestHelper->expects($this->any())->method('getExcludedIds')->willReturn([11, 22]);
+        $listBuilder->expects($this->once())->method('setExcludedIds')->with([11, 22])->willReturnSelf();
+
+        $this->restHelper->initializeListBuilder($listBuilder, []);
+    }
+
     public function testInitializeListBuilderAddFields()
     {
         $listBuilder = $this->getMockBuilder('Sulu\Component\Rest\ListBuilder\AbstractListBuilder')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR add a `excludedIds` prop to the `SingleDatagridOverlay` and the `MultiDatagridOverlay`that allow to set an array of ids that are sent to the server as `excluded` query-parameter.

#### Why?

Because excluding specific ids from a `DatagridOverlay` might be handy in various situations. A simple example would be a `DatagridOverlay` that is used to add items to some list and should exclude items which are already added to that list.