### PR TITLE
Fix generation of inset thumbnails

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\FormatLoader;
 
+use Imagine\Image\ImageInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\InvalidMediaFormatException;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Util\XmlUtils;
@@ -26,7 +27,7 @@ abstract class BaseXmlFormatLoader extends FileLoader
 
     const SCHEME_PATH = '';
 
-    const SCALE_MODE_DEFAULT = 'outbound';
+    const SCALE_MODE_DEFAULT = ImageInterface::THUMBNAIL_OUTBOUND;
 
     const SCALE_RETINA_DEFAULT = false;
 
@@ -171,6 +172,28 @@ abstract class BaseXmlFormatLoader extends FileLoader
                 $e
             );
         }
+    }
+
+    /**
+     * @internal
+     */
+    protected function getMode($modeNode)
+    {
+        if (!$modeNode) {
+            return static::SCALE_MODE_DEFAULT;
+        }
+
+        $mode = $modeNode->nodeValue;
+
+        if ('outbound' === $mode) {
+            $mode = ImageInterface::THUMBNAIL_OUTBOUND;
+        } elseif ('inset' === $mode) {
+            $mode = ImageInterface::THUMBNAIL_INSET;
+        } else {
+            throw new InvalidMediaFormatException(sprintf('The scale mode "%s" is not supported', $mode));
+        }
+
+        return $mode;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -104,7 +104,7 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
                 return [
                     'x' => $xValue,
                     'y' => $yValue,
-                    'mode' => (null !== $modeNode) ? $modeNode->nodeValue : static::SCALE_MODE_DEFAULT,
+                    'mode' => $this->getMode($modeNode),
                     'retina' => $retina,
                     'forceRatio' => $forceRatio,
                 ];

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
@@ -91,7 +91,7 @@ class XmlFormatLoader11 extends BaseXmlFormatLoader
             $scale = [
                 'x' => (null !== $xNode) ? intval($xNode->nodeValue) : null,
                 'y' => (null !== $yNode) ? intval($yNode->nodeValue) : null,
-                'mode' => (null !== $modeNode) ? $modeNode->nodeValue : static::SCALE_MODE_DEFAULT,
+                'mode' => $this->getMode($modeNode),
                 'retina' => $retina,
                 'forceRatio' => $forceRatio,
             ];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/image-formats/version11.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Fixtures/image-formats/version11.xml
@@ -25,14 +25,14 @@
             <title lang="en">My 400 Format</title>
             <title lang="de">Mein 400 Format</title>
         </meta>
-        <scale x="400"/>
+        <scale x="400" mode="inset"/>
         <options>
             <option name="jpeg_quality">70</option>
         </options>
     </format>
 
     <format key="200x180-inset">
-        <scale x="200" y="180"/>
+        <scale x="200" y="180" mode="inset" />
     </format>
 
     <format key="3840x2160-retina">

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
+use Imagine\Image\ImageInterface;
 use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
@@ -40,7 +41,7 @@ class FormatControllerTest extends SuluTestCase
             [
                 'x' => 400,
                 'y' => 400,
-                'mode' => 'outbound',
+                'mode' => ImageInterface::THUMBNAIL_OUTBOUND,
                 'retina' => false,
                 'forceRatio' => true,
             ],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader10Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader10Test.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\FormatLoader;
 
+use Imagine\Image\ImageInterface;
 use Prophecy\Argument;
 use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionException;
 use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
@@ -66,7 +67,7 @@ class XmlFormatLoader10Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '640',
                     'y' => '480',
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_OUTBOUND,
                     'forceRatio' => false,
                     'retina' => false,
                 ],
@@ -99,7 +100,7 @@ class XmlFormatLoader10Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '300',
                     'y' => null,
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_OUTBOUND,
                     'forceRatio' => true,
                     'retina' => false,
                 ],
@@ -121,7 +122,7 @@ class XmlFormatLoader10Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '3840',
                     'y' => '2160',
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_OUTBOUND,
                     'forceRatio' => true,
                     'retina' => true,
                 ],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader11Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader11Test.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\FormatLoader;
 
+use Imagine\Image\ImageInterface;
 use Prophecy\Argument;
 use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionException;
 use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
@@ -66,7 +67,7 @@ class XmlFormatLoader11Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '400',
                     'y' => '400',
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_OUTBOUND,
                     'forceRatio' => false,
                     'retina' => false,
                 ],
@@ -102,7 +103,7 @@ class XmlFormatLoader11Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '400',
                     'y' => null,
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_INSET,
                     'forceRatio' => true,
                     'retina' => false,
                 ],
@@ -126,7 +127,7 @@ class XmlFormatLoader11Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '200',
                     'y' => '180',
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_INSET,
                     'forceRatio' => true,
                     'retina' => false,
                 ],
@@ -148,7 +149,7 @@ class XmlFormatLoader11Test extends WebspaceTestCase
                 'scale' => [
                     'x' => '3840',
                     'y' => '2160',
-                    'mode' => 'outbound',
+                    'mode' => ImageInterface::THUMBNAIL_OUTBOUND,
                     'forceRatio' => true,
                     'retina' => true,
                 ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4449
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Fix generation of inset thumbnails.

#### Why?

Some constants in the imagine library where changed from strings (inset, outbound)  to integer values so we need to change our xml loader to match inset / outbound to the new values.

#### Example Usage

```xml
<format key="small">
    <meta>
        <title lang="en">Small</title>
    </meta>
    <scale x="343" y="343" mode="inset"/>
</format>
```
