### PR TITLE
Use colspan instead of size in grid

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -264,7 +264,7 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
             $section->setLabel($title);
         }
 
-        $section->setColspan($property->getColspan());
+        $section->setColSpan($property->getColSpan());
         $section->setDisabledCondition($property->getDisabledCondition());
         $section->setVisibleCondition($property->getVisibleCondition());
 
@@ -323,7 +323,7 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
         $field->setVisibleCondition($property->getVisibleCondition());
         $field->setDescription($property->getDescription($locale));
         $field->setType($property->getType());
-        $field->setColspan($property->getColspan());
+        $field->setColSpan($property->getColSpan());
         $field->setRequired($property->isRequired());
         $field->setSpaceAfter($property->getSpaceAfter());
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -264,7 +264,7 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
             $section->setLabel($title);
         }
 
-        $section->setSize($property->getSize());
+        $section->setColspan($property->getColspan());
         $section->setDisabledCondition($property->getDisabledCondition());
         $section->setVisibleCondition($property->getVisibleCondition());
 
@@ -323,7 +323,7 @@ class FormMetadataProvider implements MetadataProviderInterface, CacheWarmerInte
         $field->setVisibleCondition($property->getVisibleCondition());
         $field->setDescription($property->getDescription($locale));
         $field->setType($property->getType());
-        $field->setSize($property->getSize());
+        $field->setColspan($property->getColspan());
         $field->setRequired($property->isRequired());
         $field->setSpaceAfter($property->getSpaceAfter());
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
@@ -48,9 +48,9 @@ abstract class ItemMetadata
     protected $type;
 
     /**
-     * @var null|int
+     * @var int
      */
-    protected $size;
+    protected $colspan;
 
     public function __construct(string $name)
     {
@@ -102,14 +102,14 @@ abstract class ItemMetadata
         $this->description = $description;
     }
 
-    public function getSize(): ?int
+    public function getColspan(): int
     {
-        return $this->size;
+        return $this->colspan;
     }
 
-    public function setSize(int $size = null): void
+    public function setColspan(int $colspan): void
     {
-        $this->size = $size;
+        $this->colspan = $colspan;
     }
 
     public function getType(): string

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
@@ -50,7 +50,7 @@ abstract class ItemMetadata
     /**
      * @var int
      */
-    protected $colspan;
+    protected $colSpan;
 
     public function __construct(string $name)
     {
@@ -102,14 +102,14 @@ abstract class ItemMetadata
         $this->description = $description;
     }
 
-    public function getColspan(): int
+    public function getColSpan(): int
     {
-        return $this->colspan;
+        return $this->colSpan;
     }
 
-    public function setColspan(int $colspan): void
+    public function setColSpan(int $colSpan): void
     {
-        $this->colspan = $colspan;
+        $this->colSpan = $colSpan;
     }
 
     public function getType(): string

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
@@ -3,30 +3,30 @@ import React from 'react';
 import classNames from 'classnames';
 import type {Node} from 'react';
 import Grid from '../Grid';
-import type {Colspan} from '../Grid';
+import type {ColSpan} from '../Grid';
 import fieldStyles from './field.scss';
 import gridStyles from './grid.scss';
 
 type Props = {|
     children: Node,
+    colSpan: ColSpan,
     description?: string,
     error?: string,
     id?: string,
     label?: string,
     required: boolean,
-    colspan: Colspan,
-    spaceAfter: Colspan,
+    spaceAfter: ColSpan,
 |};
 
 export default class Field extends React.Component<Props> {
     static defaultProps = {
+        colSpan: 12,
         required: false,
-        colspan: 12,
         spaceAfter: 0,
     };
 
     render() {
-        const {children, id, description, error, label, required, colspan, spaceAfter} = this.props;
+        const {children, id, description, error, label, required, colSpan, spaceAfter} = this.props;
 
         const fieldClass = classNames(
             fieldStyles.field,
@@ -38,7 +38,7 @@ export default class Field extends React.Component<Props> {
         return (
             <Grid.Item
                 className={gridStyles.gridItem}
-                colspan={colspan}
+                colSpan={colSpan}
                 spaceAfter={spaceAfter}
             >
                 <div className={fieldClass}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import type {Node} from 'react';
 import Grid from '../Grid';
-import type {Size} from '../Grid';
+import type {Colspan} from '../Grid';
 import fieldStyles from './field.scss';
 import gridStyles from './grid.scss';
 
@@ -14,19 +14,19 @@ type Props = {|
     id?: string,
     label?: string,
     required: boolean,
-    size: Size,
-    spaceAfter: Size,
+    colspan: Colspan,
+    spaceAfter: Colspan,
 |};
 
 export default class Field extends React.Component<Props> {
     static defaultProps = {
         required: false,
-        size: 12,
+        colspan: 12,
         spaceAfter: 0,
     };
 
     render() {
-        const {children, id, description, error, label, required, size, spaceAfter} = this.props;
+        const {children, id, description, error, label, required, colspan, spaceAfter} = this.props;
 
         const fieldClass = classNames(
             fieldStyles.field,
@@ -38,7 +38,7 @@ export default class Field extends React.Component<Props> {
         return (
             <Grid.Item
                 className={gridStyles.gridItem}
-                size={size}
+                colspan={colspan}
                 spaceAfter={spaceAfter}
             >
                 <div className={fieldClass}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Section.js
@@ -3,27 +3,27 @@ import React from 'react';
 import type {Node} from 'react';
 import Divider from '../Divider';
 import Grid from '../Grid';
-import type {Colspan} from '../Grid';
+import type {ColSpan} from '../Grid';
 import gridStyles from './grid.scss';
 
 type Props = {|
     children: Node,
     label?: string,
-    colspan: Colspan,
+    colSpan: ColSpan,
 |};
 
 export default class Section extends React.Component<Props> {
     static defaultProps = {
-        colspan: 12,
+        colSpan: 12,
     };
 
     render() {
-        const {children, label, colspan} = this.props;
+        const {children, label, colSpan} = this.props;
 
         return (
-            <Grid.Section className={gridStyles.gridSection} colspan={colspan}>
-                {(label || colspan === 12) &&
-                    <Grid.Item colspan={12}>
+            <Grid.Section className={gridStyles.gridSection} colSpan={colSpan}>
+                {(label || colSpan === 12) &&
+                    <Grid.Item colSpan={12}>
                         <Divider>
                             {label}
                         </Divider>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Section.js
@@ -3,27 +3,27 @@ import React from 'react';
 import type {Node} from 'react';
 import Divider from '../Divider';
 import Grid from '../Grid';
-import type {Size} from '../Grid';
+import type {Colspan} from '../Grid';
 import gridStyles from './grid.scss';
 
 type Props = {|
     children: Node,
     label?: string,
-    size: Size,
+    colspan: Colspan,
 |};
 
 export default class Section extends React.Component<Props> {
     static defaultProps = {
-        size: 12,
+        colspan: 12,
     };
 
     render() {
-        const {children, label, size} = this.props;
+        const {children, label, colspan} = this.props;
 
         return (
-            <Grid.Section className={gridStyles.gridSection} size={size}>
-                {(label || size === 12) &&
-                    <Grid.Item size={12}>
+            <Grid.Section className={gridStyles.gridSection} colspan={colspan}>
+                {(label || colspan === 12) &&
+                    <Grid.Item colspan={12}>
                         <Divider>
                             {label}
                         </Divider>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Field.test.js
@@ -19,9 +19,9 @@ test('Display a field without label', () => {
     )).toMatchSnapshot();
 });
 
-test('Display a field with colspan and after space', () => {
+test('Display a field with colSpan and after space', () => {
     expect(render(
-        <Field colspan={7} spaceAfter={5}>
+        <Field colSpan={7} spaceAfter={5}>
             <div>Test</div>
         </Field>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Field.test.js
@@ -19,9 +19,9 @@ test('Display a field without label', () => {
     )).toMatchSnapshot();
 });
 
-test('Display a field with size and after space', () => {
+test('Display a field with colspan and after space', () => {
     expect(render(
-        <Field size={7} spaceAfter={5}>
+        <Field colspan={7} spaceAfter={5}>
             <div>Test</div>
         </Field>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Section.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Section.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {render} from 'enzyme';
 import Section from '../Section';
 
-test('Render section with given colspan', () => {
+test('Render section with given colSpan', () => {
     expect(render(
         <Section label="Test">
             <p>Test</p>
@@ -13,7 +13,7 @@ test('Render section with given colspan', () => {
 
 test('Render section without label', () => {
     expect(render(
-        <Section colspan={8}>
+        <Section colSpan={8}>
             <div>Test</div>
         </Section>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Section.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/Section.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {render} from 'enzyme';
 import Section from '../Section';
 
-test('Render section with given size', () => {
+test('Render section with given colspan', () => {
     expect(render(
         <Section label="Test">
             <p>Test</p>
@@ -13,7 +13,7 @@ test('Render section with given size', () => {
 
 test('Render section without label', () => {
     expect(render(
-        <Section size={8}>
+        <Section colspan={8}>
             <div>Test</div>
         </Section>
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Field.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Field.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Display a field with a required label 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -24,7 +24,7 @@ exports[`Display a field with a required label 1`] = `
 
 exports[`Display a field with an error 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field error"
@@ -46,9 +46,26 @@ exports[`Display a field with an error 1`] = `
 </div>
 `;
 
+exports[`Display a field with colSpan and after space 1`] = `
+<div
+  class="item gridItem colSpan colSpan-7 space-before-0 space-after-5"
+>
+  <div
+    class="field"
+  >
+    <div>
+      Test
+    </div>
+    <label
+      class="errorLabel"
+    />
+  </div>
+</div>
+`;
+
 exports[`Display a field with description 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -70,7 +87,7 @@ exports[`Display a field with description 1`] = `
 
 exports[`Display a field with label 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -90,26 +107,9 @@ exports[`Display a field with label 1`] = `
 </div>
 `;
 
-exports[`Display a field with size and after space 1`] = `
-<div
-  class="item gridItem size size-7 space-before-0 space-after-5"
->
-  <div
-    class="field"
-  >
-    <div>
-      Test
-    </div>
-    <label
-      class="errorLabel"
-    />
-  </div>
-</div>
-`;
-
 exports[`Display a field without label 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Section.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Section.test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render section with given size 1`] = `
+exports[`Render section with given colSpan 1`] = `
 <div
-  class="section gridSection size size-12 space-before-0 space-after-0"
+  class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
-    class="item size size-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="divider"
@@ -21,7 +21,7 @@ exports[`Render section with given size 1`] = `
 
 exports[`Render section without label 1`] = `
 <div
-  class="section gridSection size size-8 space-before-0 space-after-0"
+  class="section gridSection colSpan colSpan-8 space-before-0 space-after-0"
 >
   <div>
     Test
@@ -31,10 +31,10 @@ exports[`Render section without label 1`] = `
 
 exports[`Render section without label but with divider 1`] = `
 <div
-  class="section gridSection size size-12 space-before-0 space-after-0"
+  class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
-    class="item size size-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="divider"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
@@ -13,7 +13,7 @@ type Props = BaseItemProps & {
 export default class BaseItem extends React.PureComponent<Props> {
     render() {
         const {
-            colspan,
+            colSpan,
             children,
             className,
             spaceAfter,
@@ -22,8 +22,8 @@ export default class BaseItem extends React.PureComponent<Props> {
 
         const baseItemClass = classNames(
             className,
-            baseItemStyles.colspan,
-            baseItemStyles['colspan-' + colspan],
+            baseItemStyles.colSpan,
+            baseItemStyles['colSpan-' + colSpan],
             baseItemStyles['space-before-' + spaceBefore],
             baseItemStyles['space-after-' + spaceAfter]
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
@@ -13,7 +13,7 @@ type Props = BaseItemProps & {
 export default class BaseItem extends React.PureComponent<Props> {
     render() {
         const {
-            size,
+            colspan,
             children,
             className,
             spaceAfter,
@@ -22,8 +22,8 @@ export default class BaseItem extends React.PureComponent<Props> {
 
         const baseItemClass = classNames(
             className,
-            baseItemStyles.size,
-            baseItemStyles['size-' + size],
+            baseItemStyles.colspan,
+            baseItemStyles['colspan-' + colspan],
             baseItemStyles['space-before-' + spaceBefore],
             baseItemStyles['space-after-' + spaceAfter]
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
@@ -13,7 +13,7 @@ type Props = BaseItemProps & {
 
 export default class Item extends React.PureComponent<Props> {
     static defaultProps = {
-        size: 12,
+        colspan: 12,
         spaceAfter: 0,
         spaceBefore: 0,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
@@ -13,7 +13,7 @@ type Props = BaseItemProps & {
 
 export default class Item extends React.PureComponent<Props> {
     static defaultProps = {
-        colspan: 12,
+        colSpan: 12,
         spaceAfter: 0,
         spaceBefore: 0,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
@@ -14,7 +14,7 @@ type Props = BaseItemProps & {
 
 export default class Section extends React.PureComponent<Props> {
     static defaultProps = {
-        colspan: 12,
+        colSpan: 12,
         spaceAfter: 0,
         spaceBefore: 0,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
@@ -14,7 +14,7 @@ type Props = BaseItemProps & {
 
 export default class Section extends React.PureComponent<Props> {
     static defaultProps = {
-        size: 12,
+        colspan: 12,
         spaceAfter: 0,
         spaceBefore: 0,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/baseItem.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/baseItem.scss
@@ -1,55 +1,55 @@
 @import './variables.scss';
 
-.colspan {
+.colSpan {
     width: 100%;
 }
 
 @media (min-width: $gridMinWidth) {
-    .colspan-1 {
+    .colSpan-1 {
         width: calc(1 * 100% / 12);
     }
 
-    .colspan-2 {
+    .colSpan-2 {
         width: calc(2 * 100% / 12);
     }
 
-    .colspan-3 {
+    .colSpan-3 {
         width: calc(3 * 100% / 12);
     }
 
-    .colspan-4 {
+    .colSpan-4 {
         width: calc(4 * 100% / 12);
     }
 
-    .colspan-5 {
+    .colSpan-5 {
         width: calc(5 * 100% / 12);
     }
 
-    .colspan-6 {
+    .colSpan-6 {
         width: calc(6 * 100% / 12);
     }
 
-    .colspan-7 {
+    .colSpan-7 {
         width: calc(7 * 100% / 12);
     }
 
-    .colspan-8 {
+    .colSpan-8 {
         width: calc(8 * 100% / 12);
     }
 
-    .colspan-9 {
+    .colSpan-9 {
         width: calc(9 * 100% / 12);
     }
 
-    .colspan-10 {
+    .colSpan-10 {
         width: calc(10 * 100% / 12);
     }
 
-    .colspan-11 {
+    .colSpan-11 {
         width: calc(11 * 100% / 12);
     }
 
-    .colspan-12 {
+    .colSpan-12 {
         width: calc(12 * 100% / 12);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/baseItem.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/baseItem.scss
@@ -1,55 +1,55 @@
 @import './variables.scss';
 
-.size {
+.colspan {
     width: 100%;
 }
 
 @media (min-width: $gridMinWidth) {
-    .size-1 {
+    .colspan-1 {
         width: calc(1 * 100% / 12);
     }
 
-    .size-2 {
+    .colspan-2 {
         width: calc(2 * 100% / 12);
     }
 
-    .size-3 {
+    .colspan-3 {
         width: calc(3 * 100% / 12);
     }
 
-    .size-4 {
+    .colspan-4 {
         width: calc(4 * 100% / 12);
     }
 
-    .size-5 {
+    .colspan-5 {
         width: calc(5 * 100% / 12);
     }
 
-    .size-6 {
+    .colspan-6 {
         width: calc(6 * 100% / 12);
     }
 
-    .size-7 {
+    .colspan-7 {
         width: calc(7 * 100% / 12);
     }
 
-    .size-8 {
+    .colspan-8 {
         width: calc(8 * 100% / 12);
     }
 
-    .size-9 {
+    .colspan-9 {
         width: calc(9 * 100% / 12);
     }
 
-    .size-10 {
+    .colspan-10 {
         width: calc(10 * 100% / 12);
     }
 
-    .size-11 {
+    .colspan-11 {
         width: calc(11 * 100% / 12);
     }
 
-    .size-12 {
+    .colspan-12 {
         width: calc(12 * 100% / 12);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/index.js
@@ -1,6 +1,6 @@
 // @flow
 import Grid from './Grid';
-import type {Size} from './types';
+import type {Colspan} from './types';
 
 export default Grid;
-export type {Size};
+export type {Colspan};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/index.js
@@ -1,6 +1,6 @@
 // @flow
 import Grid from './Grid';
-import type {Colspan} from './types';
+import type {ColSpan} from './types';
 
 export default Grid;
-export type {Colspan};
+export type {ColSpan};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/tests/Grid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/tests/Grid.test.js
@@ -6,18 +6,18 @@ import Grid from '../Grid';
 test('Render a Grid with Items in all sizes', () => {
     expect(render(
         <Grid>
-            <Grid.Item size={1} />
-            <Grid.Item size={2} />
-            <Grid.Item size={3} />
-            <Grid.Item size={4} />
-            <Grid.Item size={5} />
-            <Grid.Item size={6} />
-            <Grid.Item size={7} />
-            <Grid.Item size={8} />
-            <Grid.Item size={9} />
-            <Grid.Item size={10} />
-            <Grid.Item size={11} />
-            <Grid.Item size={12} />
+            <Grid.Item colspan={1} />
+            <Grid.Item colspan={2} />
+            <Grid.Item colspan={3} />
+            <Grid.Item colspan={4} />
+            <Grid.Item colspan={5} />
+            <Grid.Item colspan={6} />
+            <Grid.Item colspan={7} />
+            <Grid.Item colspan={8} />
+            <Grid.Item colspan={9} />
+            <Grid.Item colspan={10} />
+            <Grid.Item colspan={11} />
+            <Grid.Item colspan={12} />
         </Grid>
     )).toMatchSnapshot();
 });
@@ -25,21 +25,21 @@ test('Render a Grid with Items in all sizes', () => {
 test('Render a Grid with Sections', () => {
     expect(render(
         <Grid>
-            <Grid.Section size={4}>
-                <Grid.Item size={1} />
-                <Grid.Item size={2} />
-                <Grid.Item size={3} />
-                <Grid.Item size={4} />
-                <Grid.Item size={5} />
-                <Grid.Item size={6} />
+            <Grid.Section colspan={4}>
+                <Grid.Item colspan={1} />
+                <Grid.Item colspan={2} />
+                <Grid.Item colspan={3} />
+                <Grid.Item colspan={4} />
+                <Grid.Item colspan={5} />
+                <Grid.Item colspan={6} />
             </Grid.Section>
-            <Grid.Section size={8}>
-                <Grid.Item size={7} />
-                <Grid.Item size={8} />
-                <Grid.Item size={9} />
-                <Grid.Item size={10} />
-                <Grid.Item size={11} />
-                <Grid.Item size={12} />
+            <Grid.Section colspan={8}>
+                <Grid.Item colspan={7} />
+                <Grid.Item colspan={8} />
+                <Grid.Item colspan={9} />
+                <Grid.Item colspan={10} />
+                <Grid.Item colspan={11} />
+                <Grid.Item colspan={12} />
             </Grid.Section>
         </Grid>
     )).toMatchSnapshot();
@@ -48,8 +48,8 @@ test('Render a Grid with Sections', () => {
 test('Render a Grid with Items having spaces between them', () => {
     expect(render(
         <Grid>
-            <Grid.Item size={4} spaceAfter={8} />
-            <Grid.Item size={2} spaceBefore={10} />
+            <Grid.Item colspan={4} spaceAfter={8} />
+            <Grid.Item colspan={2} spaceBefore={10} />
         </Grid>
     )).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/tests/Grid.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/tests/Grid.test.js
@@ -6,18 +6,18 @@ import Grid from '../Grid';
 test('Render a Grid with Items in all sizes', () => {
     expect(render(
         <Grid>
-            <Grid.Item colspan={1} />
-            <Grid.Item colspan={2} />
-            <Grid.Item colspan={3} />
-            <Grid.Item colspan={4} />
-            <Grid.Item colspan={5} />
-            <Grid.Item colspan={6} />
-            <Grid.Item colspan={7} />
-            <Grid.Item colspan={8} />
-            <Grid.Item colspan={9} />
-            <Grid.Item colspan={10} />
-            <Grid.Item colspan={11} />
-            <Grid.Item colspan={12} />
+            <Grid.Item colSpan={1} />
+            <Grid.Item colSpan={2} />
+            <Grid.Item colSpan={3} />
+            <Grid.Item colSpan={4} />
+            <Grid.Item colSpan={5} />
+            <Grid.Item colSpan={6} />
+            <Grid.Item colSpan={7} />
+            <Grid.Item colSpan={8} />
+            <Grid.Item colSpan={9} />
+            <Grid.Item colSpan={10} />
+            <Grid.Item colSpan={11} />
+            <Grid.Item colSpan={12} />
         </Grid>
     )).toMatchSnapshot();
 });
@@ -25,21 +25,21 @@ test('Render a Grid with Items in all sizes', () => {
 test('Render a Grid with Sections', () => {
     expect(render(
         <Grid>
-            <Grid.Section colspan={4}>
-                <Grid.Item colspan={1} />
-                <Grid.Item colspan={2} />
-                <Grid.Item colspan={3} />
-                <Grid.Item colspan={4} />
-                <Grid.Item colspan={5} />
-                <Grid.Item colspan={6} />
+            <Grid.Section colSpan={4}>
+                <Grid.Item colSpan={1} />
+                <Grid.Item colSpan={2} />
+                <Grid.Item colSpan={3} />
+                <Grid.Item colSpan={4} />
+                <Grid.Item colSpan={5} />
+                <Grid.Item colSpan={6} />
             </Grid.Section>
-            <Grid.Section colspan={8}>
-                <Grid.Item colspan={7} />
-                <Grid.Item colspan={8} />
-                <Grid.Item colspan={9} />
-                <Grid.Item colspan={10} />
-                <Grid.Item colspan={11} />
-                <Grid.Item colspan={12} />
+            <Grid.Section colSpan={8}>
+                <Grid.Item colSpan={7} />
+                <Grid.Item colSpan={8} />
+                <Grid.Item colSpan={9} />
+                <Grid.Item colSpan={10} />
+                <Grid.Item colSpan={11} />
+                <Grid.Item colSpan={12} />
             </Grid.Section>
         </Grid>
     )).toMatchSnapshot();
@@ -48,8 +48,8 @@ test('Render a Grid with Sections', () => {
 test('Render a Grid with Items having spaces between them', () => {
     expect(render(
         <Grid>
-            <Grid.Item colspan={4} spaceAfter={8} />
-            <Grid.Item colspan={2} spaceBefore={10} />
+            <Grid.Item colSpan={4} spaceAfter={8} />
+            <Grid.Item colSpan={2} spaceBefore={10} />
         </Grid>
     )).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/tests/__snapshots__/Grid.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/tests/__snapshots__/Grid.test.js.snap
@@ -5,10 +5,10 @@ exports[`Render a Grid with Items having spaces between them 1`] = `
   class="grid"
 >
   <div
-    class="item size size-4 space-before-0 space-after-8"
+    class="item colSpan colSpan-4 space-before-0 space-after-8"
   />
   <div
-    class="item size size-2 space-before-10 space-after-0"
+    class="item colSpan colSpan-2 space-before-10 space-after-0"
   />
 </div>
 `;
@@ -18,40 +18,40 @@ exports[`Render a Grid with Items in all sizes 1`] = `
   class="grid"
 >
   <div
-    class="item size size-1 space-before-0 space-after-0"
+    class="item colSpan colSpan-1 space-before-0 space-after-0"
   />
   <div
-    class="item size size-2 space-before-0 space-after-0"
+    class="item colSpan colSpan-2 space-before-0 space-after-0"
   />
   <div
-    class="item size size-3 space-before-0 space-after-0"
+    class="item colSpan colSpan-3 space-before-0 space-after-0"
   />
   <div
-    class="item size size-4 space-before-0 space-after-0"
+    class="item colSpan colSpan-4 space-before-0 space-after-0"
   />
   <div
-    class="item size size-5 space-before-0 space-after-0"
+    class="item colSpan colSpan-5 space-before-0 space-after-0"
   />
   <div
-    class="item size size-6 space-before-0 space-after-0"
+    class="item colSpan colSpan-6 space-before-0 space-after-0"
   />
   <div
-    class="item size size-7 space-before-0 space-after-0"
+    class="item colSpan colSpan-7 space-before-0 space-after-0"
   />
   <div
-    class="item size size-8 space-before-0 space-after-0"
+    class="item colSpan colSpan-8 space-before-0 space-after-0"
   />
   <div
-    class="item size size-9 space-before-0 space-after-0"
+    class="item colSpan colSpan-9 space-before-0 space-after-0"
   />
   <div
-    class="item size size-10 space-before-0 space-after-0"
+    class="item colSpan colSpan-10 space-before-0 space-after-0"
   />
   <div
-    class="item size size-11 space-before-0 space-after-0"
+    class="item colSpan colSpan-11 space-before-0 space-after-0"
   />
   <div
-    class="item size size-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   />
 </div>
 `;
@@ -61,47 +61,47 @@ exports[`Render a Grid with Sections 1`] = `
   class="grid"
 >
   <div
-    class="section size size-4 space-before-0 space-after-0"
+    class="section colSpan colSpan-4 space-before-0 space-after-0"
   >
     <div
-      class="item size size-1 space-before-0 space-after-0"
+      class="item colSpan colSpan-1 space-before-0 space-after-0"
     />
     <div
-      class="item size size-2 space-before-0 space-after-0"
+      class="item colSpan colSpan-2 space-before-0 space-after-0"
     />
     <div
-      class="item size size-3 space-before-0 space-after-0"
+      class="item colSpan colSpan-3 space-before-0 space-after-0"
     />
     <div
-      class="item size size-4 space-before-0 space-after-0"
+      class="item colSpan colSpan-4 space-before-0 space-after-0"
     />
     <div
-      class="item size size-5 space-before-0 space-after-0"
+      class="item colSpan colSpan-5 space-before-0 space-after-0"
     />
     <div
-      class="item size size-6 space-before-0 space-after-0"
+      class="item colSpan colSpan-6 space-before-0 space-after-0"
     />
   </div>
   <div
-    class="section size size-8 space-before-0 space-after-0"
+    class="section colSpan colSpan-8 space-before-0 space-after-0"
   >
     <div
-      class="item size size-7 space-before-0 space-after-0"
+      class="item colSpan colSpan-7 space-before-0 space-after-0"
     />
     <div
-      class="item size size-8 space-before-0 space-after-0"
+      class="item colSpan colSpan-8 space-before-0 space-after-0"
     />
     <div
-      class="item size size-9 space-before-0 space-after-0"
+      class="item colSpan colSpan-9 space-before-0 space-after-0"
     />
     <div
-      class="item size size-10 space-before-0 space-after-0"
+      class="item colSpan colSpan-10 space-before-0 space-after-0"
     />
     <div
-      class="item size size-11 space-before-0 space-after-0"
+      class="item colSpan colSpan-11 space-before-0 space-after-0"
     />
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     />
   </div>
 </div>
@@ -112,10 +112,10 @@ exports[`Render a Grid with class names attached 1`] = `
   class="grid test-grid"
 >
   <div
-    class="section test-section size size-12 space-before-0 space-after-0"
+    class="section test-section colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
-      class="item test-item size size-12 space-before-0 space-after-0"
+      class="item test-item colSpan colSpan-12 space-before-0 space-after-0"
     />
   </div>
 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/types.js
@@ -1,8 +1,8 @@
 // @flow
-export type Colspan = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type ColSpan = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type BaseItemProps = {
-    colspan: Colspan,
-    spaceBefore: Colspan,
-    spaceAfter: Colspan,
+    colSpan: ColSpan,
+    spaceBefore: ColSpan,
+    spaceAfter: ColSpan,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/types.js
@@ -1,8 +1,8 @@
 // @flow
-export type Size = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type Colspan = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type BaseItemProps = {
-    size: Size,
-    spaceBefore: Size,
-    spaceAfter: Size,
+    colspan: Colspan,
+    spaceBefore: Colspan,
+    spaceAfter: Colspan,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
@@ -78,7 +78,7 @@ export default class PasswordConfirmation extends React.Component<Props> {
 
         return (
             <Grid className={passwordConfirmationStyles.grid}>
-                <Grid.Item size={6}>
+                <Grid.Item colspan={6}>
                     <Input
                         disabled={disabled}
                         icon={LOCK_ICON}
@@ -88,7 +88,7 @@ export default class PasswordConfirmation extends React.Component<Props> {
                         value={this.firstValue}
                     />
                 </Grid.Item>
-                <Grid.Item className={passwordConfirmationStyles.item} size={6}>
+                <Grid.Item className={passwordConfirmationStyles.item} colspan={6}>
                     <Input
                         disabled={disabled}
                         icon={LOCK_ICON}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
@@ -78,7 +78,7 @@ export default class PasswordConfirmation extends React.Component<Props> {
 
         return (
             <Grid className={passwordConfirmationStyles.grid}>
-                <Grid.Item colspan={6}>
+                <Grid.Item colSpan={6}>
                     <Input
                         disabled={disabled}
                         icon={LOCK_ICON}
@@ -88,7 +88,7 @@ export default class PasswordConfirmation extends React.Component<Props> {
                         value={this.firstValue}
                     />
                 </Grid.Item>
-                <Grid.Item className={passwordConfirmationStyles.item} colspan={6}>
+                <Grid.Item className={passwordConfirmationStyles.item} colSpan={6}>
                     <Input
                         disabled={disabled}
                         icon={LOCK_ICON}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/__snapshots__/PasswordConfirmation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/tests/__snapshots__/PasswordConfirmation.test.js.snap
@@ -5,7 +5,7 @@ exports[`Should render disabled input-components when disabled 1`] = `
   class="grid grid"
 >
   <div
-    class="item size size-6 space-before-0 space-after-0"
+    class="item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <label
       class="input default left"
@@ -25,7 +25,7 @@ exports[`Should render disabled input-components when disabled 1`] = `
     </label>
   </div>
   <div
-    class="item item size size-6 space-before-0 space-after-0"
+    class="item item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <label
       class="input default left"
@@ -52,7 +52,7 @@ exports[`Should render two password fields and add a debounced function 1`] = `
   class="grid grid"
 >
   <div
-    class="item size size-6 space-before-0 space-after-0"
+    class="item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <label
       class="input default left disabled"
@@ -73,7 +73,7 @@ exports[`Should render two password fields and add a debounced function 1`] = `
     </label>
   </div>
   <div
-    class="item item size size-6 space-before-0 space-after-0"
+    class="item item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <label
       class="input default left disabled"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Cell.js
@@ -9,7 +9,7 @@ type Props = {
     className?: string,
     /** If set to true, the cell will not stretch and stay at minimal width */
     small: boolean,
-    colspan?: number,
+    colSpan?: number,
     depth?: number,
 };
 
@@ -22,7 +22,7 @@ export default class Cell extends React.PureComponent<Props> {
 
     render() {
         const {
-            colspan,
+            colSpan,
             children,
             className,
             depth,
@@ -44,7 +44,7 @@ export default class Cell extends React.PureComponent<Props> {
         return (
             <td
                 className={cellClass}
-                colSpan={colspan}
+                colSpan={colSpan}
             >
                 <div className={tableStyles.cellContent} style={style}>
                     {children}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -46,7 +46,7 @@ exports[`Render block with schema 1`] = `
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -75,7 +75,7 @@ exports[`Render block with schema 1`] = `
               </div>
             </div>
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -146,7 +146,7 @@ exports[`Render block with schema 1`] = `
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -175,7 +175,7 @@ exports[`Render block with schema 1`] = `
               </div>
             </div>
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -271,7 +271,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -342,7 +342,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field error"
@@ -416,7 +416,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -512,7 +512,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field"
@@ -583,7 +583,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field error"
@@ -657,7 +657,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
             class="grid grid"
           >
             <div
-              class="item gridItem size size-12 space-before-0 space-after-0"
+              class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
             >
               <div
                 class="field error"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -101,7 +101,7 @@ export default class Field extends React.Component<Props> {
 
             return (
                 <FieldComponent
-                    size={schema.size}
+                    colspan={schema.colspan}
                     spaceAfter={schema.spaceAfter}
                 >
                     <div className={fieldStyles.fieldContainer}>
@@ -129,7 +129,7 @@ export default class Field extends React.Component<Props> {
                 id={dataPath}
                 label={label}
                 required={required}
-                size={schema.size}
+                colspan={schema.colspan}
                 spaceAfter={schema.spaceAfter}
             >
                 <div className={fieldStyles.fieldContainer}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -101,7 +101,7 @@ export default class Field extends React.Component<Props> {
 
             return (
                 <FieldComponent
-                    colspan={schema.colspan}
+                    colSpan={schema.colSpan}
                     spaceAfter={schema.spaceAfter}
                 >
                     <div className={fieldStyles.fieldContainer}>
@@ -124,12 +124,12 @@ export default class Field extends React.Component<Props> {
 
         return (
             <FieldComponent
+                colSpan={schema.colSpan}
                 description={description}
                 error={errorKeyword ? translate('sulu_admin.error_' + errorKeyword.toLowerCase()) : undefined}
                 id={dataPath}
                 label={label}
                 required={required}
-                colspan={schema.colspan}
                 spaceAfter={schema.spaceAfter}
             >
                 <div className={fieldStyles.fieldContainer}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -34,9 +34,9 @@ export default class Renderer extends React.Component<Props> {
     };
 
     renderSection(schemaField: SchemaEntry, schemaKey: string, schemaPath: string) {
-        const {label, items, size} = schemaField;
+        const {label, items, colspan} = schemaField;
         return (
-            <Form.Section key={schemaKey} label={label} size={size}>
+            <Form.Section key={schemaKey} label={label} colspan={colspan}>
                 {!!items &&
                     Object.keys(items).map((key) => this.renderItem(items[key], key, schemaPath + '/items/' + key))
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -34,9 +34,9 @@ export default class Renderer extends React.Component<Props> {
     };
 
     renderSection(schemaField: SchemaEntry, schemaKey: string, schemaPath: string) {
-        const {label, items, colspan} = schemaField;
+        const {colSpan, label, items} = schemaField;
         return (
-            <Form.Section key={schemaKey} label={label} colspan={colspan}>
+            <Form.Section colSpan={colSpan} key={schemaKey} label={label}>
                 {!!items &&
                     Object.keys(items).map((key) => this.renderItem(items[key], key, schemaPath + '/items/' + key))
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -67,7 +67,7 @@ test('Render field with correct values for grid', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{label: 'label1', type: 'text', size: 8, spaceAfter: 3, visible: true}}
+            schema={{label: 'label1', type: 'text', colspan: 8, spaceAfter: 3, visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js
@@ -67,7 +67,7 @@ test('Render field with correct values for grid', () => {
             name="test"
             onChange={jest.fn()}
             onFinish={jest.fn()}
-            schema={{label: 'label1', type: 'text', colspan: 8, spaceAfter: 3, visible: true}}
+            schema={{label: 'label1', type: 'text', colSpan: 8, spaceAfter: 3, visible: true}}
             schemaPath=""
         />
     )).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -398,14 +398,14 @@ test('Should render nested sections', () => {
     )).toMatchSnapshot();
 });
 
-test('Should render sections with colspan', () => {
+test('Should render sections with colSpan', () => {
     const changeSpy = jest.fn();
 
     const schema = {
         section1: {
             label: 'Section 1',
             type: 'section',
-            colspan: 8,
+            colSpan: 8,
             items: {
                 item11: {
                     label: 'Item 1.1',
@@ -418,7 +418,7 @@ test('Should render sections with colspan', () => {
         section2: {
             label: 'Section 2',
             type: 'section',
-            colspan: 4,
+            colSpan: 4,
             items: {
                 item21: {
                     label: 'Item 2.1',
@@ -451,7 +451,7 @@ test('Should render sections without label', () => {
     const schema = {
         section1: {
             type: 'section',
-            colspan: 8,
+            colSpan: 8,
             items: {
                 item11: {
                     label: 'Item 1.1',
@@ -464,7 +464,7 @@ test('Should render sections without label', () => {
         section2: {
             label: 'Section 2',
             type: 'section',
-            colspan: 4,
+            colSpan: 4,
             items: {
                 item21: {
                     label: 'Item 2.1',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -398,14 +398,14 @@ test('Should render nested sections', () => {
     )).toMatchSnapshot();
 });
 
-test('Should render sections with size', () => {
+test('Should render sections with colspan', () => {
     const changeSpy = jest.fn();
 
     const schema = {
         section1: {
             label: 'Section 1',
             type: 'section',
-            size: 8,
+            colspan: 8,
             items: {
                 item11: {
                     label: 'Item 1.1',
@@ -418,7 +418,7 @@ test('Should render sections with size', () => {
         section2: {
             label: 'Section 2',
             type: 'section',
-            size: 4,
+            colspan: 4,
             items: {
                 item21: {
                     label: 'Item 2.1',
@@ -451,7 +451,7 @@ test('Should render sections without label', () => {
     const schema = {
         section1: {
             type: 'section',
-            size: 8,
+            colspan: 8,
             items: {
                 item11: {
                     label: 'Item 1.1',
@@ -464,7 +464,7 @@ test('Should render sections without label', () => {
         section2: {
             label: 'Section 2',
             type: 'section',
-            size: 4,
+            colspan: 4,
             items: {
                 item21: {
                     label: 'Item 2.1',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Field.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Field.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render a field with a description 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -38,7 +38,7 @@ exports[`Render a field with a description 1`] = `
 
 exports[`Render a field with a error collection 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field error"
@@ -71,7 +71,7 @@ exports[`Render a field with a error collection 1`] = `
 
 exports[`Render a field with an error 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field error"
@@ -104,7 +104,7 @@ exports[`Render a field with an error 1`] = `
 
 exports[`Render a field without a const error 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -135,7 +135,7 @@ exports[`Render a field without a const error 1`] = `
 
 exports[`Render a field without a label 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -160,7 +160,7 @@ exports[`Render a field without a label 1`] = `
 
 exports[`Render a required field with correct field type 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -191,7 +191,7 @@ exports[`Render a required field with correct field type 1`] = `
 
 exports[`Render correct label with correct field type 1`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -222,7 +222,7 @@ exports[`Render correct label with correct field type 1`] = `
 
 exports[`Render correct label with correct field type 2`] = `
 <div
-  class="item gridItem size size-12 space-before-0 space-after-0"
+  class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
 >
   <div
     class="field"
@@ -253,7 +253,7 @@ exports[`Render correct label with correct field type 2`] = `
 
 exports[`Render field with correct values for grid 1`] = `
 <div
-  class="item gridItem size size-8 space-before-0 space-after-3"
+  class="item gridItem colSpan colSpan-8 space-before-0 space-after-3"
 >
   <div
     class="field"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -5,17 +5,17 @@ exports[`Should not render fields when the schema contains a visible flag of fal
   class="grid grid"
 >
   <div
-    class="section gridSection size size-12 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="divider"
       />
     </div>
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"
@@ -38,7 +38,7 @@ exports[`Should not render fields when the schema contains a visible flag of fal
     </div>
   </div>
   <div
-    class="item gridItem size size-12 space-before-0 space-after-0"
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="field"
@@ -73,7 +73,7 @@ exports[`Should render field types based on schema 1`] = `
   class="grid grid"
 >
   <div
-    class="item gridItem size size-12 space-before-0 space-after-0"
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="field"
@@ -101,7 +101,7 @@ exports[`Should render field types based on schema 1`] = `
     </div>
   </div>
   <div
-    class="item gridItem size size-12 space-before-0 space-after-0"
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="field"
@@ -136,10 +136,10 @@ exports[`Should render nested sections 1`] = `
   class="grid grid"
 >
   <div
-    class="section gridSection size size-12 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="divider"
@@ -148,7 +148,7 @@ exports[`Should render nested sections 1`] = `
       </div>
     </div>
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"
@@ -176,10 +176,10 @@ exports[`Should render nested sections 1`] = `
       </div>
     </div>
     <div
-      class="section gridSection size size-12 space-before-0 space-after-0"
+      class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
-        class="item size size-12 space-before-0 space-after-0"
+        class="item colSpan colSpan-12 space-before-0 space-after-0"
       >
         <div
           class="divider"
@@ -190,10 +190,10 @@ exports[`Should render nested sections 1`] = `
     </div>
   </div>
   <div
-    class="section gridSection size size-12 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="divider"
@@ -202,7 +202,7 @@ exports[`Should render nested sections 1`] = `
       </div>
     </div>
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"
@@ -233,15 +233,15 @@ exports[`Should render nested sections 1`] = `
 </div>
 `;
 
-exports[`Should render sections with size 1`] = `
+exports[`Should render sections with colSpan 1`] = `
 <div
   class="grid grid"
 >
   <div
-    class="section gridSection size size-8 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-8 space-before-0 space-after-0"
   >
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="divider"
@@ -250,7 +250,7 @@ exports[`Should render sections with size 1`] = `
       </div>
     </div>
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"
@@ -279,10 +279,10 @@ exports[`Should render sections with size 1`] = `
     </div>
   </div>
   <div
-    class="section gridSection size size-4 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-4 space-before-0 space-after-0"
   >
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="divider"
@@ -291,7 +291,7 @@ exports[`Should render sections with size 1`] = `
       </div>
     </div>
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"
@@ -327,10 +327,10 @@ exports[`Should render sections without label 1`] = `
   class="grid grid"
 >
   <div
-    class="section gridSection size size-8 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-8 space-before-0 space-after-0"
   >
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"
@@ -359,10 +359,10 @@ exports[`Should render sections without label 1`] = `
     </div>
   </div>
   <div
-    class="section gridSection size size-4 space-before-0 space-after-0"
+    class="section gridSection colSpan colSpan-4 space-before-0 space-after-0"
   >
     <div
-      class="item size size-12 space-before-0 space-after-0"
+      class="item colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="divider"
@@ -371,7 +371,7 @@ exports[`Should render sections without label 1`] = `
       </div>
     </div>
     <div
-      class="item gridItem size size-12 space-before-0 space-after-0"
+      class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
     >
       <div
         class="field"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -1,6 +1,6 @@
 // @flow
 import type {IObservableValue} from 'mobx';
-import type {Size} from '../../components/Grid';
+import type {Colspan} from '../../components/Grid';
 import FormInspector from './FormInspector';
 
 export type SchemaType = {
@@ -59,8 +59,8 @@ type BaseSchemaEntry = {
     minOccurs?: number,
     options?: SchemaOptions,
     required?: boolean,
-    size?: Size,
-    spaceAfter?: Size,
+    colspan?: Colspan,
+    spaceAfter?: Colspan,
     tags?: Array<Tag>,
     type: string,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -1,6 +1,6 @@
 // @flow
 import type {IObservableValue} from 'mobx';
-import type {Colspan} from '../../components/Grid';
+import type {ColSpan} from '../../components/Grid';
 import FormInspector from './FormInspector';
 
 export type SchemaType = {
@@ -59,8 +59,8 @@ type BaseSchemaEntry = {
     minOccurs?: number,
     options?: SchemaOptions,
     required?: boolean,
-    colspan?: Colspan,
-    spaceAfter?: Colspan,
+    colSpan?: ColSpan,
+    spaceAfter?: ColSpan,
     tags?: Array<Tag>,
     type: string,
 };

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -288,10 +288,10 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertCount(2, $formMetadata->getChildren());
         $this->assertEquals('logo', $formMetadata->getChildren()['logo']->getName());
-        $this->assertEquals(4, $formMetadata->getChildren()['logo']->getColspan());
+        $this->assertEquals(4, $formMetadata->getChildren()['logo']->getColSpan());
         $this->assertCount(1, $formMetadata->getChildren()['logo']->getChildren());
         $this->assertEquals('name', $formMetadata->getChildren()['name']->getName());
-        $this->assertEquals(8, $formMetadata->getChildren()['name']->getColspan());
+        $this->assertEquals(8, $formMetadata->getChildren()['name']->getColSpan());
         $this->assertCount(1, $formMetadata->getChildren()['name']->getChildren());
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -288,10 +288,10 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertCount(2, $formMetadata->getChildren());
         $this->assertEquals('logo', $formMetadata->getChildren()['logo']->getName());
-        $this->assertEquals(4, $formMetadata->getChildren()['logo']->getSize());
+        $this->assertEquals(4, $formMetadata->getChildren()['logo']->getColspan());
         $this->assertCount(1, $formMetadata->getChildren()['logo']->getChildren());
         $this->assertEquals('name', $formMetadata->getChildren()['name']->getName());
-        $this->assertEquals(8, $formMetadata->getChildren()['name']->getSize());
+        $this->assertEquals(8, $formMetadata->getChildren()['name']->getColspan());
         $this->assertCount(1, $formMetadata->getChildren()['name']->getChildren());
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -295,7 +295,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn($fileName);
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getSize()->willReturn('123');
+        $uploadedFile->getColspan()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('img');
 
         $user = $this->prophesize(User::class)->willImplement(UserInterface::class);
@@ -326,7 +326,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn('test.pdf');
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getSize()->willReturn('123');
+        $uploadedFile->getColspan()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('img');
 
         $media = $this->prophesize(Media::class);
@@ -429,7 +429,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn('test.ogg');
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getSize()->willReturn('123');
+        $uploadedFile->getColspan()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('video/ogg');
         $this->ffprobe->format(Argument::any())->willThrow(ExecutableNotFoundException::class)->shouldBeCalled();
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -295,7 +295,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn($fileName);
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getColspan()->willReturn('123');
+        $uploadedFile->getColSpan()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('img');
 
         $user = $this->prophesize(User::class)->willImplement(UserInterface::class);
@@ -326,7 +326,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn('test.pdf');
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getColspan()->willReturn('123');
+        $uploadedFile->getColSpan()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('img');
 
         $media = $this->prophesize(Media::class);
@@ -429,7 +429,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn('test.ogg');
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getColspan()->willReturn('123');
+        $uploadedFile->getColSpan()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('video/ogg');
         $this->ffprobe->format(Argument::any())->willThrow(ExecutableNotFoundException::class)->shouldBeCalled();
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -295,7 +295,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn($fileName);
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getColSpan()->willReturn('123');
+        $uploadedFile->getSize()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('img');
 
         $user = $this->prophesize(User::class)->willImplement(UserInterface::class);
@@ -326,7 +326,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn('test.pdf');
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getColSpan()->willReturn('123');
+        $uploadedFile->getSize()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('img');
 
         $media = $this->prophesize(Media::class);
@@ -429,7 +429,7 @@ class MediaManagerTest extends TestCase
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith(['', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn('test.ogg');
         $uploadedFile->getPathname()->willReturn('');
-        $uploadedFile->getColSpan()->willReturn('123');
+        $uploadedFile->getSize()->willReturn('123');
         $uploadedFile->getMimeType()->willReturn('video/ogg');
         $this->ffprobe->format(Argument::any())->willThrow(ExecutableNotFoundException::class)->shouldBeCalled();
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
@@ -5,7 +5,7 @@ exports[`Render component 1`] = `
   class="grid"
 >
   <div
-    class="item size size-6 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="select"
@@ -47,7 +47,7 @@ exports[`Render component 1`] = `
     </div>
   </div>
   <div
-    class="item size size-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="roleAssignmentsContainer"
@@ -162,7 +162,7 @@ exports[`Render component in disabled state 1`] = `
   class="grid"
 >
   <div
-    class="item size size-6 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="select"
@@ -205,7 +205,7 @@ exports[`Render component in disabled state 1`] = `
     </div>
   </div>
   <div
-    class="item size size-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="roleAssignmentsContainer"
@@ -322,7 +322,7 @@ exports[`Render component without data 1`] = `
   class="grid"
 >
   <div
-    class="item size size-6 space-before-0 space-after-0"
+    class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
     <div
       class="select"

--- a/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
@@ -234,9 +234,9 @@ class BlockPropertyWrapper implements PropertyInterface
      *
      * @return string
      */
-    public function getColspan()
+    public function getColSpan()
     {
-        return $this->property->getColspan();
+        return $this->property->getColSpan();
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/Property.php
+++ b/src/Sulu/Component/Content/Compat/Property.php
@@ -86,7 +86,7 @@ class Property implements PropertyInterface, \JsonSerializable
      *
      * @var string
      */
-    private $col;
+    private $colSpan;
 
     /**
      * value of property.
@@ -117,7 +117,7 @@ class Property implements PropertyInterface, \JsonSerializable
         $minOccurs = 1,
         $params = [],
         $tags = [],
-        $col = null
+        $colSpan = null
     ) {
         $this->contentTypeName = $contentTypeName;
         $this->mandatory = $mandatory;
@@ -128,7 +128,7 @@ class Property implements PropertyInterface, \JsonSerializable
         $this->metadata = new Metadata($metaData);
         $this->params = $params;
         $this->tags = $tags;
-        $this->col = $col;
+        $this->colSpan = $colSpan;
     }
 
     public function setPropertyValue(PropertyValue $propertyValue)
@@ -255,9 +255,9 @@ class Property implements PropertyInterface, \JsonSerializable
      *
      * @return string
      */
-    public function getColspan()
+    public function getColSpan()
     {
-        return $this->col;
+        return $this->colSpan;
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/PropertyInterface.php
+++ b/src/Sulu/Component/Content/Compat/PropertyInterface.php
@@ -130,7 +130,7 @@ interface PropertyInterface extends ArrayableInterface
      *
      * @return string
      */
-    public function getColspan();
+    public function getColSpan();
 
     /**
      * returns title of property.

--- a/src/Sulu/Component/Content/Compat/Structure/LegacyPropertyFactory.php
+++ b/src/Sulu/Component/Content/Compat/Structure/LegacyPropertyFactory.php
@@ -104,7 +104,7 @@ class LegacyPropertyFactory
             $property->getMinOccurs(),
             $parameters,
             [],
-            $property->getColspan()
+            $property->getColSpan()
         );
 
         foreach ($property->getTags() as $tag) {
@@ -140,7 +140,7 @@ class LegacyPropertyFactory
                 'title' => $property->getTitles(),
                 'info_text' => $property->getDescriptions(),
             ],
-            $property->getColspan()
+            $property->getColSpan()
         );
 
         foreach ($property->getChildren() as $child) {
@@ -165,7 +165,7 @@ class LegacyPropertyFactory
             $property->getMinOccurs(),
             $property->getParameters(),
             [],
-            $property->getColspan()
+            $property->getColSpan()
         );
         $blockProperty->setStructure($structure);
 

--- a/src/Sulu/Component/Content/Mapper/Translation/TranslatedProperty.php
+++ b/src/Sulu/Component/Content/Mapper/Translation/TranslatedProperty.php
@@ -246,9 +246,9 @@ class TranslatedProperty implements PropertyInterface
      *
      * @return string
      */
-    public function getColspan()
+    public function getColSpan()
     {
-        return $this->property->getColspan();
+        return $this->property->getColSpan();
     }
 
     /**

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -72,7 +72,7 @@
 
         <xs:attribute type="xs:string" name="name" use="required"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
-        <xs:attribute type="xs:integer" name="colspan" use="optional"/>
+        <xs:attribute type="xs:integer" name="colspan" use="optional" default="12"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
@@ -100,8 +100,7 @@
         <xs:attribute type="xs:nonNegativeInteger" name="minOccurs" use="optional"/>
         <xs:attribute type="xs:positiveInteger" name="maxOccurs" use="optional"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
-        <xs:attribute type="xs:integer" name="colspan" use="optional"/>
-        <xs:attribute type="xs:integer" name="size" use="optional"/>
+        <xs:attribute type="xs:integer" name="colspan" use="optional" default="12"/>
         <xs:attribute type="xs:integer" name="spaceAfter" use="optional"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
@@ -122,7 +121,7 @@
         <xs:attribute type="xs:nonNegativeInteger" name="minOccurs" use="optional"/>
         <xs:attribute type="xs:positiveInteger" name="maxOccurs" use="optional"/>
         <xs:attribute type="xs:string" name="cssClass" use="optional"/>
-        <xs:attribute type="xs:integer" name="colspan" use="optional"/>
+        <xs:attribute type="xs:integer" name="colspan" use="optional" default="12"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -153,7 +153,7 @@ class PropertiesXmlParser
                 'default-type',
                 'minOccurs',
                 'maxOccurs',
-                'colSpan',
+                'colspan',
                 'cssClass',
                 'disabledCondition',
                 'visibleCondition',

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -90,7 +90,6 @@ class PropertiesXmlParser
                 'maxOccurs',
                 'colspan',
                 'cssClass',
-                'colspan',
                 'spaceAfter',
                 'disabledCondition',
                 'visibleCondition',
@@ -154,7 +153,7 @@ class PropertiesXmlParser
                 'default-type',
                 'minOccurs',
                 'maxOccurs',
-                'colspan',
+                'colSpan',
                 'cssClass',
                 'disabledCondition',
                 'visibleCondition',
@@ -379,7 +378,7 @@ class PropertiesXmlParser
         $section = new SectionMetadata();
         $section->setName($propertyName);
         if (isset($data['colspan'])) {
-            $section->setColspan($data['colspan']);
+            $section->setColSpan($data['colspan']);
         }
 
         if (isset($data['meta']['title'])) {
@@ -459,7 +458,7 @@ class PropertiesXmlParser
         $property->setLocalized($data['multilingual']);
         $property->setRequired($data['mandatory']);
         if (isset($data['colspan'])) {
-            $property->setColspan($data['colspan']);
+            $property->setColSpan($data['colspan']);
         }
         $property->setSpaceAfter($data['spaceAfter']);
         $property->setCssClass($data['cssClass']);
@@ -484,7 +483,7 @@ class PropertiesXmlParser
                 'type' => null,
                 'multilingual' => true,
                 'mandatory' => true,
-                'colSpan' => null,
+                'colspan' => null,
                 'cssClass' => null,
                 'minOccurs' => null,
                 'maxOccurs' => null,

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -487,7 +487,6 @@ class PropertiesXmlParser
                 'cssClass' => null,
                 'minOccurs' => null,
                 'maxOccurs' => null,
-                'colspan' => null,
                 'spaceAfter' => null,
             ],
             $this->normalizeItem($data)

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -90,7 +90,7 @@ class PropertiesXmlParser
                 'maxOccurs',
                 'colspan',
                 'cssClass',
-                'size',
+                'colspan',
                 'spaceAfter',
                 'disabledCondition',
                 'visibleCondition',
@@ -378,7 +378,9 @@ class PropertiesXmlParser
     {
         $section = new SectionMetadata();
         $section->setName($propertyName);
-        $section->setSize($data['colspan']);
+        if (isset($data['colspan'])) {
+            $section->setColspan($data['colspan']);
+        }
 
         if (isset($data['meta']['title'])) {
             $section->setTitles($data['meta']['title']);
@@ -456,8 +458,9 @@ class PropertiesXmlParser
         $property->setType($data['type']);
         $property->setLocalized($data['multilingual']);
         $property->setRequired($data['mandatory']);
-        $property->setColSpan($data['colspan']);
-        $property->setSize($data['size']);
+        if (isset($data['colspan'])) {
+            $property->setColspan($data['colspan']);
+        }
         $property->setSpaceAfter($data['spaceAfter']);
         $property->setCssClass($data['cssClass']);
         $property->setTags($data['tags']);
@@ -485,7 +488,7 @@ class PropertiesXmlParser
                 'cssClass' => null,
                 'minOccurs' => null,
                 'maxOccurs' => null,
-                'size' => null,
+                'colspan' => null,
                 'spaceAfter' => null,
             ],
             $this->normalizeItem($data)

--- a/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
@@ -49,7 +49,7 @@ class PropertyMetadata extends ItemMetadata
      *
      * @var int
      */
-    protected $colspan = 12;
+    protected $colSpan = 12;
 
     /**
      * The number of grid columns the property should have space after.
@@ -153,14 +153,14 @@ class PropertyMetadata extends ItemMetadata
         return false;
     }
 
-    public function getColspan(): int
+    public function getColSpan(): int
     {
-        return $this->colspan;
+        return $this->colSpan;
     }
 
-    public function setColspan(int $colspan): self
+    public function setColSpan(int $colSpan): self
     {
-        $this->colspan = $colspan;
+        $this->colSpan = $colSpan;
 
         return $this;
     }

--- a/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/PropertyMetadata.php
@@ -49,14 +49,7 @@ class PropertyMetadata extends ItemMetadata
      *
      * @var int
      */
-    protected $colSpan = null;
-
-    /**
-     * The number of grid columns the property should use in the admin interface.
-     *
-     * @var int
-     */
-    protected $size = null;
+    protected $colspan = 12;
 
     /**
      * The number of grid columns the property should have space after.
@@ -160,44 +153,14 @@ class PropertyMetadata extends ItemMetadata
         return false;
     }
 
-    public function getColSpan(): ?int
+    public function getColspan(): int
     {
-        @trigger_error(
-            sprintf('Do not use getter "%s" from "%s"', 'getColSpan', __CLASS__),
-            E_USER_DEPRECATED
-        );
-
-        return $this->colSpan;
+        return $this->colspan;
     }
 
-    public function setColSpan(int $colSpan = null): self
+    public function setColspan(int $colspan): self
     {
-        @trigger_error(
-            sprintf('Do not use setter "%s" from "%s"', 'setColSpan', __CLASS__),
-            E_USER_DEPRECATED
-        );
-
-        $this->colSpan = $colSpan;
-
-        return $this;
-    }
-
-    public function getSize(): ?int
-    {
-        if ($this->size) {
-            return $this->size;
-        }
-
-        if ($this->colSpan) {
-            return $this->getColSpan();
-        }
-
-        return null;
-    }
-
-    public function setSize(int $size = null): self
-    {
-        $this->size = $size;
+        $this->colspan = $colspan;
 
         return $this;
     }

--- a/src/Sulu/Component/Content/Metadata/SectionMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/SectionMetadata.php
@@ -22,14 +22,7 @@ class SectionMetadata extends ItemMetadata
      *
      * @var int
      */
-    public $colSpan = null;
-
-    /**
-     * The number of grid columns the property should use in the admin interface.
-     *
-     * @var int
-     */
-    protected $size = null;
+    protected $colspan = 12;
 
     public function getTitle($locale)
     {
@@ -40,32 +33,14 @@ class SectionMetadata extends ItemMetadata
         return $this->titles[$locale];
     }
 
-    public function getColSpan()
+    public function getColspan(): int
     {
-        @trigger_error(
-            sprintf('Do not use getter "%s" from "%s"', 'getColSpan', __CLASS__),
-            E_USER_DEPRECATED
-        );
-
-        return $this->colSpan;
+        return $this->colspan;
     }
 
-    public function getSize(): ?int
+    public function setColspan(int $colspan): self
     {
-        if ($this->size) {
-            return $this->size;
-        }
-
-        if ($this->colSpan) {
-            return $this->getColSpan();
-        }
-
-        return null;
-    }
-
-    public function setSize(int $size = null): self
-    {
-        $this->size = $size;
+        $this->colspan = $colspan;
 
         return $this;
     }

--- a/src/Sulu/Component/Content/Metadata/SectionMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/SectionMetadata.php
@@ -22,7 +22,7 @@ class SectionMetadata extends ItemMetadata
      *
      * @var int
      */
-    protected $colspan = 12;
+    protected $colSpan = 12;
 
     public function getTitle($locale)
     {
@@ -33,14 +33,14 @@ class SectionMetadata extends ItemMetadata
         return $this->titles[$locale];
     }
 
-    public function getColspan(): int
+    public function getColSpan(): int
     {
-        return $this->colspan;
+        return $this->colSpan;
     }
 
-    public function setColspan(int $colspan): self
+    public function setColSpan(int $colSpan): self
     {
-        $this->colspan = $colspan;
+        $this->colSpan = $colSpan;
 
         return $this;
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/LegacyPropertyFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/LegacyPropertyFactoryTest.php
@@ -130,7 +130,7 @@ class LegacyPropertyFactoryTest extends TestCase
         $this->assertEquals($legacyProperty->getMultilingual(), $localized);
         $this->assertEquals($legacyProperty->getMaxOccurs(), $maxOccurs);
         $this->assertEquals($legacyProperty->getMinOccurs(), $minOccurs);
-        $this->assertEquals($legacyProperty->getColspan(), $colSpan);
+        $this->assertEquals($legacyProperty->getColSpan(), $colSpan);
         $this->assertContainsOnlyInstancesOf(PropertyParameter::class, $legacyProperty->getParams());
         $this->assertArrayHasKey('prop', $legacyProperty->getParams());
         $this->assertArrayHasKey('propfoo', $legacyProperty->getParams());
@@ -181,7 +181,7 @@ class LegacyPropertyFactoryTest extends TestCase
 
         $this->assertInstanceOf(SectionPropertyInterface::class, $legacyProperty);
         $this->assertEquals($name, $legacyProperty->getName());
-        $this->assertEquals($colSpan, $legacyProperty->getColspan());
+        $this->assertEquals($colSpan, $legacyProperty->getColSpan());
         $this->assertEquals($title['de'], $legacyProperty->getTitle('de'));
         $this->assertEquals($description['de'], $legacyProperty->getInfoText('de'));
         $this->assertCount(1, $legacyProperty->getChildProperties());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Use `colspan` instead of `size` in grid in the frontend part.

#### Why?

No bc break.
