### PR TITLE
Fix bug in Requester for nested objects

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -76,7 +76,7 @@ function transformRequestObject(data: Object): Object {
     }, {});
 }
 
-function transformRequestArray(data: Array<Object>) {
+function transformRequestArray(data) {
     return data.map((value) => {
         if (Array.isArray(value) || isObservableArray(value)) {
             return transformRequestArray(value);
@@ -90,7 +90,7 @@ function transformRequestArray(data: Array<Object>) {
     });
 }
 
-function transformRequestData(data: Object | Array<Object>): Object | Array<Object> {
+function transformRequestData(data: Object | Array<Object>) {
     if (Array.isArray(data) || isObservableArray(data)) {
         return transformRequestArray(data);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -1,4 +1,5 @@
 // @flow
+import {isObservableArray} from 'mobx';
 import type {HandleResponseHook} from './types';
 
 const defaultOptions = {
@@ -12,25 +13,86 @@ const defaultOptions = {
 function transformResponseObject(data: Object) {
     return Object.keys(data).reduce((transformedData: Object, key) => {
         const value = data[key];
-        transformedData[key] = value === null ? undefined : data[key];
+
+        if (value === null) {
+            transformedData[key] = undefined;
+
+            return transformedData;
+        }
+
+        if (Array.isArray(value)) {
+            transformedData[key] = transformResponseArray(value);
+
+            return transformedData;
+        }
+
+        if (value instanceof Object) {
+            transformedData[key] = transformResponseObject(value);
+
+            return transformedData;
+        }
+
+        transformedData[key] = value;
+
         return transformedData;
     }, {});
 }
 
 function transformResponseArray(data: Array<Object>) {
-    return data.map(transformResponseObject);
+    return data.map((value) => {
+        if (value instanceof Object) {
+            return transformResponseObject(value);
+        }
+
+        return value;
+    });
 }
 
 function transformRequestObject(data: Object): Object {
     return Object.keys(data).reduce((transformedData: Object, key) => {
-        transformedData[key] = data[key] === undefined ? null : data[key];
+        const value = data[key];
+
+        if (value === undefined || value === null) {
+            transformedData[key] = null;
+
+            return transformedData;
+        }
+
+        if (Array.isArray(value) || isObservableArray(value)) {
+            transformedData[key] = transformRequestArray(value);
+
+            return transformedData;
+        }
+
+        if (value instanceof Object) {
+            transformedData[key] = transformRequestObject(value);
+
+            return transformedData;
+        }
+
+        transformedData[key] = value;
+
         return transformedData;
     }, {});
 }
 
+function transformRequestArray(data: Array<Object>) {
+    return data.map((value) => {
+        if (Array.isArray(value) || isObservableArray(value)) {
+            return transformRequestArray(value);
+        }
+
+        if (value instanceof Object) {
+            return transformRequestObject(value);
+        }
+
+        return value;
+    });
+}
+
 function transformRequestData(data: Object | Array<Object>): Object | Array<Object> {
-    if (Array.isArray(data)) {
-        return data.map(transformRequestObject);
+    if (Array.isArray(data) || isObservableArray(data)) {
+        return transformRequestArray(data);
     }
 
     return transformRequestObject(data);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -1,4 +1,5 @@
 // @flow
+import {observable} from 'mobx';
 import Requester from '../Requester';
 
 test('Should execute GET request and reject with response when the response contains error', () => {
@@ -51,6 +52,15 @@ test('Should execute GET request and replace null with undefined', () => {
         test2: null,
         test3: '',
         test4: 'something',
+        test5: {
+            test5_id: 5,
+            test5_test: null,
+        },
+        test6: [
+            {id: 1, test: 'abc', test2: null},
+            {id: 2, test: 'abc', test2: 'Test2'},
+        ],
+        test7: ['test1', 'test2'],
     }));
     const promise = new Promise((resolve) => resolve(response));
 
@@ -63,6 +73,15 @@ test('Should execute GET request and replace null with undefined', () => {
             test2: undefined,
             test3: '',
             test4: 'something',
+            test5: {
+                test5_id: 5,
+                test5_test: undefined,
+            },
+            test6: [
+                {id: 1, test: 'abc', test2: undefined},
+                {id: 2, test: 'abc', test2: 'Test2'},
+            ],
+            test7: ['test1', 'test2'],
         });
     });
 
@@ -89,6 +108,19 @@ test('Should execute POST request and return JSON', () => {
         title: 'Titel',
         description: 'Description',
         test: undefined,
+        contacts: [
+            {id: 1, test: 'Titel', other: undefined},
+            {id: 2, test: 'Titel', other: 'Other'},
+        ],
+        address: {
+            id: 1,
+            title: 'Title',
+            other: 'Other',
+            other2: undefined,
+        },
+        types: ['type1', 'type2'],
+        observableTest: observable({property1: 'test', property2: 'test2'}),
+        observableArrayTest: observable(['oa1', 'oa2']),
     };
     const requestPromise = Requester.post('/some-url', data).then((response) => {
         expect(response).toEqual({test: '', value: 'test'});
@@ -100,6 +132,51 @@ test('Should execute POST request and return JSON', () => {
             title: 'Titel',
             description: 'Description',
             test: null,
+            contacts: [
+                {id: 1, test: 'Titel', other: null},
+                {id: 2, test: 'Titel', other: 'Other'},
+            ],
+            address: {
+                id: 1,
+                title: 'Title',
+                other: 'Other',
+                other2: null,
+            },
+            types: ['type1', 'type2'],
+            observableTest: {
+                property1: 'test',
+                property2: 'test2',
+            },
+            observableArrayTest: ['oa1', 'oa2'],
+        }),
+        credentials: 'same-origin',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+    });
+
+    return requestPromise;
+});
+
+test('Should execute POST request and return JSON when value is observable', () => {
+    const response = {
+        json: jest.fn(),
+        ok: true,
+    };
+    response.json.mockReturnValue(Promise.resolve({test: '', value: 'test'}));
+    const promise = new Promise((resolve) => resolve(response));
+
+    window.fetch = jest.fn();
+    window.fetch.mockReturnValue(promise);
+
+    const data = observable({id: 'test', name: 'Cool object'});
+    const requestPromise = Requester.post('/some-url', data).then((response) => {
+        expect(response).toEqual({test: '', value: 'test'});
+    });
+
+    expect(window.fetch).toBeCalledWith('/some-url', {
+        method: 'POST',
+        body: JSON.stringify({
+            id: 'test',
+            name: 'Cool object',
         }),
         credentials: 'same-origin',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Fix bug in Requester for nested objects.

#### Why?

Because `undefined` is not converted to `null` currently, therefore the property will not be included in the payload.