### PR TITLE
Fix rendering of preview

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Document.BasePageDocument.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/serializer/Document.BasePageDocument.xml
@@ -42,7 +42,7 @@
         <property name="path" exclude="true"/>
         <property name="internal" type="boolean" groups="defaultPage"/>
         <property name="webspaceName" type="string"/>
-        <property name="extensions" type="Sulu\Component\Content\Document\Extension\ExtensionContainer" exclude="true" />
+        <property name="extensions" type="Sulu\Component\Content\Document\Extension\ExtensionContainer" groups="preview"/>
         <property name="structure" type="Sulu\Component\Content\Document\Structure\Structure" groups="preview"/>
         <property name="children" exclude="true" type="Sulu\Component\DocumentManager\Collection\ChildrenCollection"/>
         <property name="suluOrder" type="integer" serialized-name="order" groups="defaultPage,smallPage"/>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -371,8 +371,11 @@ class PreviewTest extends TestCase
         $this->provider->serialize($newObject->reveal())->willReturn($expectedData['object'])->shouldBeCalled();
 
         $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, false, null)->willReturn(
-            '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>'
+            '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
         );
+
+        $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, true, null)
+            ->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -472,8 +475,11 @@ class PreviewTest extends TestCase
         $this->provider->serialize($newObject->reveal())->willReturn($expectedData['object'])->shouldBeCalled();
 
         $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, false, 2)->willReturn(
-            '<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>'
+            '<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>'
         );
+
+        $this->renderer->render($newObject->reveal(), 1, $this->webspaceKey, $this->locale, true, 2)
+            ->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -528,7 +534,10 @@ class PreviewTest extends TestCase
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson)->shouldBeCalled();
 
         $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, false, null)
-            ->willReturn('<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>');
+            ->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
+
+        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, null)
+            ->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,
@@ -583,7 +592,10 @@ class PreviewTest extends TestCase
         $this->provider->serialize($this->object->reveal())->willReturn($dataJson)->shouldBeCalled();
 
         $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, false, 2)
-            ->willReturn('<html><body><div id="content"><h1 property="title">SULU</h1></div></body></html>');
+            ->willReturn('<html><body><div id="content"><!-- CONTENT-REPLACER --><h1 property="title">SULU</h1><!-- CONTENT-REPLACER --></div></body></html>');
+
+        $this->renderer->render($this->object->reveal(), 1, $this->webspaceKey, $this->locale, true, 2)
+            ->willReturn('<h1 property="title">SULU</h1>');
 
         $this->cache->save(
             $token,

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\WebsiteBundle\Controller;
 
 use InvalidArgumentException;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer;
+use Sulu\Bundle\PreviewBundle\Preview\Preview;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -61,8 +62,13 @@ abstract class WebsiteController extends Controller
                     'content',
                     $data
                 );
+            } elseif ($preview) {
+                $content = $this->renderPreview(
+                    $viewTemplate,
+                    $data
+                );
             } else {
-                $content = parent::renderView(
+                $content = $this->renderView(
                     $viewTemplate,
                     $data
                 );
@@ -120,6 +126,14 @@ abstract class WebsiteController extends Controller
 
             throw $e;
         }
+    }
+
+    protected function renderPreview(string $view, array $parameters = []): string
+    {
+        $parameters['previewParentTemplate'] = $view;
+        $parameters['previewContentReplacer'] = Preview::CONTENT_REPLACER;
+
+        return parent::renderView('SuluWebsiteBundle:Preview:preview.html.twig', $parameters);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Preview/preview.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Preview/preview.html.twig
@@ -1,0 +1,7 @@
+{% extends previewParentTemplate %}
+
+{% block content %}
+    {{ previewContentReplacer|raw }}
+    {{ parent() }}
+    {{ previewContentReplacer|raw }}
+{% endblock %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fix #4455 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the rendering process of the preview when invalid HTML is provided

#### BC Breaks/Deprecations

Its not really a BC-Break but the `#content` id isnt needed anymore.
