### PR TITLE
Fix closing of confirmation overlay for clearing the website cache

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
@@ -34,7 +34,7 @@ class CacheController extends Controller
 
         $this->get('sulu_website.http_cache.clearer')->clear();
 
-        return new JsonResponse([], 200);
+        return new JsonResponse(null, 204);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the cache clear route return an empty response.

#### Why?

Because the loader in the confirmation overlay breaks otherwise.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
