### PR TITLE
add basic linking plugin to ckeditor class

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,9 @@
         "transformIgnorePatterns": [
             "node_modules/(?!(sulu-(.*)-bundle|@ckeditor|lodash-es)/)"
         ],
-        "testPathIgnorePatterns": ["vendor/friendsofsymfony"],
+        "testPathIgnorePatterns": [
+            "vendor/friendsofsymfony"
+        ],
         "testURL": "http://localhost"
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CKEditor5/CKEditor5.js
@@ -8,6 +8,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor'
 import EssentialsPlugin from '@ckeditor/ckeditor5-essentials/src/essentials';
 import HeadingPlugin from '@ckeditor/ckeditor5-heading/src/heading';
 import ItalicPlugin from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import LinkPlugin from '@ckeditor/ckeditor5-link/src/link';
 import ListPlugin from '@ckeditor/ckeditor5-list/src/list';
 import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import StrikethroughPlugin from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
@@ -80,6 +81,7 @@ export default class CKEditor5 extends React.Component<Props> {
                     EssentialsPlugin,
                     HeadingPlugin,
                     ItalicPlugin,
+                    LinkPlugin,
                     ListPlugin,
                     ParagraphPlugin,
                     StrikethroughPlugin,
@@ -104,6 +106,7 @@ export default class CKEditor5 extends React.Component<Props> {
                     'numberedlist',
                     '|',
                     'insertTable',
+                    'link',
                 ],
                 heading: {
                     options: [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/package.json
@@ -11,6 +11,7 @@
         "@ckeditor/ckeditor5-essentials": "^10.1.0",
         "@ckeditor/ckeditor5-heading": "^10.1.0",
         "@ckeditor/ckeditor5-list": "^11.0.0",
+        "@ckeditor/ckeditor5-link": "^10.1.0",
         "@ckeditor/ckeditor5-table": "^11.0.0",
         "@ckeditor/ckeditor5-theme-lark": "^11.1.0",
         "@ckeditor/ckeditor5-paragraph": "^10.0.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | no
| Related issues/PRs | #4305
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add simple 'Link' Plugin and Toolbar Icon for CKEditor to enable Links in HTML Editor

#### Why?

Because Links are important. Should be temporary until #4305 has been merged.

#### Example Usage

-

#### BC Breaks/Deprecations

-

#### To Do
