### PR TITLE
Fix single media selection content data for deleted media

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Content\Types;
 
 use Sulu\Bundle\MediaBundle\Api\Media;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
@@ -48,7 +49,13 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
             return null;
         }
 
-        return $this->mediaManager->getById($data['id'], $property->getStructure()->getLanguageCode());
+        try {
+            $entity = $this->mediaManager->getById($data['id'], $property->getStructure()->getLanguageCode());
+        } catch (MediaNotFoundException $e) {
+            return null;
+        }
+
+        return $entity;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/SingleMediaSelectionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/SingleMediaSelectionTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Content\Types\SingleMediaSelection;
+use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManager;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
@@ -206,6 +207,20 @@ class SingleMediaSelectionTest extends TestCase
         $this->mediaManager->getById(11, 'de')->willReturn($this->media->reveal());
 
         $this->assertEquals($this->media->reveal(), $this->singleMediaSelection->getContentData($property));
+    }
+
+    public function testContentDataDeleted()
+    {
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getLanguageCode()->willReturn('de');
+
+        $property = new Property('media', [], 'single_media_selection');
+        $property->setValue(['id' => 11]);
+        $property->setStructure($structure->reveal());
+
+        $this->mediaManager->getById(11, 'de')->willThrow(MediaNotFoundException::class);
+
+        $this->assertNull($this->singleMediaSelection->getContentData($property));
     }
 
     public function testPreResolveEmpty()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4463
| Related issues/PRs | -
| License | MIT
| Documentation PR | 

#### What's in this PR?

In SingleMediaSelection returned content data wraped in try-catch block.
