### PR TITLE
Sulu core configuration: Remove required attribute from paths

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -172,7 +172,6 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                         ->arrayNode('paths')
-                            ->isRequired()
                             ->prototype('array')
                                 ->children()
                                     ->scalarNode('path')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Remove `isRequired` from `sulu_core.content.structure.paths`.

#### Why?

Because it causes problems when trying to define for example only the `default_type`:

```
sulu_core:
    content:
        structure:
            default_type:
                article: "default"
```