### PR TITLE
Fix sorting in SmartContent for custom simple entities

### DIFF
--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -81,7 +81,11 @@ trait DataProviderRepositoryTrait
             $this->appendSortBy($sortBy, $sortMethod, $queryBuilder, 'c', $locale);
 
             foreach ($sortBy as $sortColumn) {
-                $queryBuilder->addSelect('c.'.$sortColumn);
+                if (strpos($sortColumn, '.') === false) {
+                    $queryBuilder->addSelect('c.'.$sortColumn);
+                } else {
+                    $queryBuilder->addSelect($sortColumn);
+                }
             }
         }
 
@@ -383,7 +387,11 @@ trait DataProviderRepositoryTrait
                 $this->appendSortByJoins($queryBuilder, $alias, $locale);
             }
 
-            $queryBuilder->orderBy($alias.'.'.$column, $sortMethod);
+            if (strpos($column, '.') === false) {
+                $queryBuilder->orderBy($alias.'.'.$column, $sortMethod);
+            } else {
+                $queryBuilder->orderBy($column, $sortMethod);
+            }
         }
     }
 

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -30,9 +30,14 @@ trait DataProviderRepositoryTrait
             ->orderBy($alias . '.id', 'ASC');
         $this->appendJoins($queryBuilder, $alias, $locale);
 
-        if (array_key_exists('sortBy', $filters) && is_array($filters['sortBy'])) {
+        if (array_key_exists('sortBy', $filters)) {
+            if (! is_array($filters['sortBy'])) {
+                $sortBy = [$filters['sortBy']];
+            } else {
+                $sortBy = $filters['sortBy'];
+            }
             $sortMethod = array_key_exists('sortMethod', $filters) ? $filters['sortMethod'] : 'asc';
-            $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, $alias, $locale);
+            $this->appendSortBy($sortBy, $sortMethod, $queryBuilder, $alias, $locale);
         }
 
         $query = $queryBuilder->getQuery();
@@ -66,12 +71,17 @@ trait DataProviderRepositoryTrait
         $tagRelation = $this->appendTagsRelation($queryBuilder, 'c');
         $categoryRelation = $this->appendCategoriesRelation($queryBuilder, 'c');
 
-        if (array_key_exists('sortBy', $filters) && is_array($filters['sortBy'])) {
+        if (array_key_exists('sortBy', $filters)) {
+            if (! is_array($filters['sortBy'])) {
+                $sortBy = [$filters['sortBy']];
+            } else {
+                $sortBy = $filters['sortBy'];
+            }
             $sortMethod = array_key_exists('sortMethod', $filters) ? $filters['sortMethod'] : 'asc';
-            $this->appendSortBy($filters['sortBy'], $sortMethod, $queryBuilder, 'c', $locale);
+            $this->appendSortBy($sortBy, $sortMethod, $queryBuilder, 'c', $locale);
 
-            foreach ($filters['sortBy'] as $sortColumn) {
-                $queryBuilder->addSelect($sortColumn);
+            foreach ($sortBy as $sortColumn) {
+                $queryBuilder->addSelect('c.'.$sortColumn);
             }
         }
 
@@ -373,7 +383,7 @@ trait DataProviderRepositoryTrait
                 $this->appendSortByJoins($queryBuilder, $alias, $locale);
             }
 
-            $queryBuilder->orderBy($column, $sortMethod);
+            $queryBuilder->orderBy($alias.'.'.$column, $sortMethod);
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add retype sortBy parameter to array, because from public part it came only as scalar value.
Add prefix for entity alias when adding sortBy columns to queryBuilder.

#### Why?

There was no way to sort custom simple entities.

#### ToDo

- [x] - Fix MediaBundle tests, which is broken by this.
