### PR TITLE
Fix smart-content to allow null data

### DIFF
--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -224,7 +224,7 @@ class BlockProperty extends Property implements BlockPropertyInterface
                 $subName = $subProperty->getName();
                 $subValue = $item[$subName];
 
-                if ($value instanceof PropertyValue) {
+                if ($subValue instanceof PropertyValue) {
                     $subValueProperty = new PropertyValue($subName, $subValue);
                     $subProperty->setPropertyValue($subValueProperty);
                     $item[$subName] = $subValueProperty;

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -248,7 +248,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         if (!array_key_exists('tags', $filters) || null === $filters['tags']) {
             $filters['tags'] = [];
         }
-        if (!array_key_exists('categories', $filters)|| null === $filters['categories']) {
+        if (!array_key_exists('categories', $filters) || null === $filters['categories']) {
             $filters['categories'] = [];
         }
 

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -245,10 +245,10 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
         $filters['excluded'] = [$property->getStructure()->getUuid()];
 
         // default value of tags/category is an empty array
-        if (!array_key_exists('tags', $filters)) {
+        if (!array_key_exists('tags', $filters) || null === $filters['tags']) {
             $filters['tags'] = [];
         }
-        if (!array_key_exists('categories', $filters)) {
+        if (!array_key_exists('categories', $filters)|| null === $filters['categories']) {
             $filters['categories'] = [];
         }
 

--- a/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/ContentTypeTest.php
@@ -427,6 +427,41 @@ class ContentTypeTest extends TestCase
         );
     }
 
+    public function testGetContentDataNullTagsCategories()
+    {
+        $smartContent = new SmartContent(
+            $this->dataProviderPool,
+            $this->tagManager,
+            $this->requestStack,
+            $this->tagRequestHandler->reveal(),
+            $this->categoryRequestHandler->reveal(),
+            $this->categoryReferenceStore->reveal(),
+            $this->tagReferenceStore->reveal()
+        );
+
+        $property = $this->getContentDataProperty(
+            [
+                'dataSource' => '123-123-123',
+                'categories' => null,
+                'tags' => null,
+            ]
+        );
+
+        $pageData = $smartContent->getContentData($property);
+
+        $this->assertEquals(
+            [
+                ['uuid' => 1],
+                ['uuid' => 2],
+                ['uuid' => 3],
+                ['uuid' => 4],
+                ['uuid' => 5],
+                ['uuid' => 6],
+            ],
+            $pageData
+        );
+    }
+
     public function testGetContentDataPaged()
     {
         $smartContent = new SmartContent(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fix the preview for null values of tags/categories.

#### Why?

When you selct no tag/category the value is now null.