### PR TITLE
Add resourceStorePropertiesToFormStore option to FormOverlayList

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
@@ -167,11 +167,11 @@ class FormOverlayListRouteBuilder implements FormOverlayListRouteBuilderInterfac
         return $this;
     }
 
-    public function addListStorePropertiesToFormStore(array $listStorePropertiesToFormStore): FormOverlayListRouteBuilderInterface
+    public function addResourceStorePropertiesToFormStore(array $resourceStorePropertiesToFormStore): FormOverlayListRouteBuilderInterface
     {
-        $oldListStorePropertiesToFormStore = $this->route->getOption('listStorePropertiesToFormStore');
-        $newListStorePropertiesToFormStore = $oldListStorePropertiesToFormStore ? array_merge($oldListStorePropertiesToFormStore, $listStorePropertiesToFormStore) : $listStorePropertiesToFormStore;
-        $this->route->setOption('listStorePropertiesToFormStore', $newListStorePropertiesToFormStore);
+        $oldResourceStorePropertiesToFormStore = $this->route->getOption('resourceStorePropertiesToFormStore');
+        $newResourceStorePropertiesToFormStore = $oldResourceStorePropertiesToFormStore ? array_merge($oldResourceStorePropertiesToFormStore, $resourceStorePropertiesToFormStore) : $resourceStorePropertiesToFormStore;
+        $this->route->setOption('resourceStorePropertiesToFormStore', $newResourceStorePropertiesToFormStore);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
@@ -167,6 +167,15 @@ class FormOverlayListRouteBuilder implements FormOverlayListRouteBuilderInterfac
         return $this;
     }
 
+    public function addListStorePropertiesToFormStore(array $listStorePropertiesToFormStore): FormOverlayListRouteBuilderInterface
+    {
+        $oldListStorePropertiesToFormStore = $this->route->getOption('listStorePropertiesToFormStore');
+        $newListStorePropertiesToFormStore = $oldListStorePropertiesToFormStore ? array_merge($oldListStorePropertiesToFormStore, $listStorePropertiesToFormStore) : $listStorePropertiesToFormStore;
+        $this->route->setOption('listStorePropertiesToFormStore', $newListStorePropertiesToFormStore);
+
+        return $this;
+    }
+
     public function setOverlaySize(string $overlaySize): FormOverlayListRouteBuilderInterface
     {
         $this->route->setOption('overlaySize', $overlaySize);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilderInterface.php
@@ -70,9 +70,9 @@ interface FormOverlayListRouteBuilderInterface
     public function addResourceStorePropertiesToListStore(array $resourceStorePropertiesToListStore): self;
 
     /**
-     * @param string[] $listStorePropertiesToFormStore
+     * @param string[] $resourceStorePropertiesToFormStore
      */
-    public function addListStorePropertiesToFormStore(array $listStorePropertiesToFormStore): self;
+    public function addResourceStorePropertiesToFormStore(array $resourceStorePropertiesToFormStore): self;
 
     public function setParent(string $parent): self;
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilderInterface.php
@@ -69,6 +69,11 @@ interface FormOverlayListRouteBuilderInterface
      */
     public function addResourceStorePropertiesToListStore(array $resourceStorePropertiesToListStore): self;
 
+    /**
+     * @param string[] $listStorePropertiesToFormStore
+     */
+    public function addListStorePropertiesToFormStore(array $listStorePropertiesToFormStore): self;
+
     public function setParent(string $parent): self;
 
     public function setOverlaySize(string $overlaySize): self;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
@@ -170,9 +170,9 @@ exports[`ColorPicker should render with open overlay 1`] = `
 
                     .hue-vertical {
                       background: linear-gradient(to top, #f00 0%, #ff0 17%, #0f0 33%,
-                        #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
+                          #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
                       background: -webkit-linear-gradient(to top, #f00 0%, #ff0 17%,
-                        #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
+                          #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
                     }
                   </style>
                   <div style=\\"position: absolute; left: 69.44444444444443%;\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -76,6 +76,7 @@ export default class FormOverlayList extends React.Component<ViewProps> {
                         formKey,
                         resourceKey,
                         routerAttributesToFormStore = {},
+                        listStorePropertiesToFormStore = {},
                     },
                 },
             },
@@ -90,7 +91,12 @@ export default class FormOverlayList extends React.Component<ViewProps> {
             observableOptions.locale = this.locale;
         }
 
-        const formStoreOptions = this.buildFormStoreOptions(apiOptions, attributes, routerAttributesToFormStore);
+        const formStoreOptions = this.buildFormStoreOptions(
+            apiOptions,
+            attributes,
+            routerAttributesToFormStore,
+            listStorePropertiesToFormStore
+        );
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
         this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions);
     };
@@ -107,7 +113,8 @@ export default class FormOverlayList extends React.Component<ViewProps> {
     buildFormStoreOptions(
         apiOptions: Object,
         attributes: Object,
-        routerAttributesToFormStore: {[string | number]: string}
+        routerAttributesToFormStore: {[string | number]: string},
+        listStorePropertiesToFormStore: {[string | number]: string}
     ) {
         const formStoreOptions = apiOptions ? apiOptions : {};
 
@@ -117,6 +124,19 @@ export default class FormOverlayList extends React.Component<ViewProps> {
             const attributeName = isNaN(key) ? key : routerAttributesToFormStore[key];
 
             formStoreOptions[formOptionKey] = attributes[attributeName];
+        });
+
+        listStorePropertiesToFormStore = toJS(listStorePropertiesToFormStore);
+
+        Object.keys(listStorePropertiesToFormStore).forEach((key) => {
+            const formOptionKey = listStorePropertiesToFormStore[key];
+            const attributeName = isNaN(key) ? key : listStorePropertiesToFormStore[key];
+
+            if (!this.listRef || !this.listRef.listStore || !this.listRef.listStore.options) {
+                return;
+            }
+
+            formStoreOptions[formOptionKey] = this.listRef.listStore.options[attributeName];
         });
 
         return formStoreOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -14,8 +14,12 @@ import ResourceFormStore from '../../containers/Form/stores/ResourceFormStore';
 import Snackbar from '../../components/Snackbar';
 import formOverlayListStyles from './formOverlayList.scss';
 
+type Props = ViewProps & {
+    resourceStore?: ResourceStore,
+};
+
 @observer
-export default class FormOverlayList extends React.Component<ViewProps> {
+export default class FormOverlayList extends React.Component<Props> {
     static getDerivedRouteAttributes = List.getDerivedRouteAttributes;
     locale: IObservableValue<string> = observable.box();
 
@@ -76,7 +80,7 @@ export default class FormOverlayList extends React.Component<ViewProps> {
                         formKey,
                         resourceKey,
                         routerAttributesToFormStore = {},
-                        listStorePropertiesToFormStore = {},
+                        resourceStorePropertiesToFormStore = {},
                     },
                 },
             },
@@ -95,7 +99,7 @@ export default class FormOverlayList extends React.Component<ViewProps> {
             apiOptions,
             attributes,
             routerAttributesToFormStore,
-            listStorePropertiesToFormStore
+            resourceStorePropertiesToFormStore
         );
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
         this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions);
@@ -114,7 +118,7 @@ export default class FormOverlayList extends React.Component<ViewProps> {
         apiOptions: Object,
         attributes: Object,
         routerAttributesToFormStore: {[string | number]: string},
-        listStorePropertiesToFormStore: {[string | number]: string}
+        resourceStorePropertiesToFormStore: {[string | number]: string}
     ) {
         const formStoreOptions = apiOptions ? apiOptions : {};
 
@@ -126,17 +130,17 @@ export default class FormOverlayList extends React.Component<ViewProps> {
             formStoreOptions[formOptionKey] = attributes[attributeName];
         });
 
-        listStorePropertiesToFormStore = toJS(listStorePropertiesToFormStore);
+        resourceStorePropertiesToFormStore = toJS(resourceStorePropertiesToFormStore);
 
-        Object.keys(listStorePropertiesToFormStore).forEach((key) => {
-            const formOptionKey = listStorePropertiesToFormStore[key];
-            const attributeName = isNaN(key) ? key : listStorePropertiesToFormStore[key];
+        Object.keys(resourceStorePropertiesToFormStore).forEach((key) => {
+            const formOptionKey = resourceStorePropertiesToFormStore[key];
+            const attributeName = isNaN(key) ? key : resourceStorePropertiesToFormStore[key];
 
-            if (!this.listRef || !this.listRef.listStore || !this.listRef.listStore.options) {
+            if (!this.props.resourceStore) {
                 return;
             }
 
-            formStoreOptions[formOptionKey] = this.listRef.listStore.options[attributeName];
+            formStoreOptions[formOptionKey] = this.props.resourceStore.data[attributeName];
         });
 
         return formStoreOptions;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -15,13 +15,6 @@ import Snackbar from '../../../components/Snackbar';
 const React = mockReact;
 
 jest.mock('../../List', () => class ListMock extends mockReact.Component<*> {
-    listStore = {
-        options: {
-            webspace: 'test-webspace',
-            dimension: 'test-dimension',
-        },
-    };
-
     render() {
         return <div>list view mock</div>;
     }
@@ -131,12 +124,18 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
                 routerAttributesToFormStore: {'0': 'category', 'id': 'parentId'},
-                listStorePropertiesToFormStore: {'0': 'webspace', 'dimension': 'dimensionId'},
+                resourceStorePropertiesToFormStore: {'0': 'webspace', 'dimension': 'dimensionId'},
             },
         },
     }: any);
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+    const testResourceStore = new ResourceStore('test');
+    testResourceStore.data = {
+        webspace: 'test-webspace',
+        dimension: 'test-dimension',
+    };
+
+    const formOverlayList = mount(<FormOverlayList resourceStore={testResourceStore} route={route} router={router} />);
     formOverlayList.find(List).props().onItemAdd();
 
     expect(ResourceStore).toBeCalledWith('test-resource-key', undefined, {}, {
@@ -165,12 +164,18 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
                 routerAttributesToFormStore: {'0': 'category', 'id': 'parentId'},
-                listStorePropertiesToFormStore: {'0': 'webspace', 'dimension': 'dimensionId'},
+                resourceStorePropertiesToFormStore: {'0': 'webspace', 'dimension': 'dimensionId'},
             },
         },
     }: any);
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+    const testResourceStore = new ResourceStore('test');
+    testResourceStore.data = {
+        webspace: 'test-webspace',
+        dimension: 'test-dimension',
+    };
+
+    const formOverlayList = mount(<FormOverlayList resourceStore={testResourceStore} route={route} router={router} />);
 
     const locale = observable.box('en');
     formOverlayList.instance().locale = locale;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -15,7 +15,12 @@ import Snackbar from '../../../components/Snackbar';
 const React = mockReact;
 
 jest.mock('../../List', () => class ListMock extends mockReact.Component<*> {
-    listStore = {};
+    listStore = {
+        options: {
+            webspace: 'test-webspace',
+            dimension: 'test-dimension',
+        },
+    };
 
     render() {
         return <div>list view mock</div>;
@@ -126,6 +131,7 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
                 routerAttributesToFormStore: {'0': 'category', 'id': 'parentId'},
+                listStorePropertiesToFormStore: {'0': 'webspace', 'dimension': 'dimensionId'},
             },
         },
     }: any);
@@ -136,10 +142,14 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
     expect(ResourceStore).toBeCalledWith('test-resource-key', undefined, {}, {
         category: 'category-id',
         parentId: 'test-id',
+        webspace: 'test-webspace',
+        dimensionId: 'test-dimension',
     });
     expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {
         category: 'category-id',
         parentId: 'test-id',
+        webspace: 'test-webspace',
+        dimensionId: 'test-dimension',
     });
 });
 
@@ -155,6 +165,7 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
                 routerAttributesToFormStore: {'0': 'category', 'id': 'parentId'},
+                listStorePropertiesToFormStore: {'0': 'webspace', 'dimension': 'dimensionId'},
             },
         },
     }: any);
@@ -169,10 +180,14 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
     expect(ResourceStore).toBeCalledWith('test-resource-key', 'item-id', {locale}, {
         category: 'category-id',
         parentId: 'test-id',
+        webspace: 'test-webspace',
+        dimensionId: 'test-dimension',
     });
     expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {
         category: 'category-id',
         parentId: 'test-id',
+        webspace: 'test-webspace',
+        dimensionId: 'test-dimension',
     });
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
@@ -277,20 +277,20 @@ class FormOverlayListRouteBuilderTest extends TestCase
         );
     }
 
-    public function testBuildWithListStorePropertiesToFormStore()
+    public function testBuildWithResourceStorePropertiesToFormStore()
     {
         $route = (new FormOverlayListRouteBuilder('sulu_role.list', '/roles'))
             ->setResourceKey('roles')
             ->setListKey('roles')
             ->setFormKey('role_details')
             ->addListAdapters(['tree'])
-            ->addListStorePropertiesToFormStore(['webspace' => 'webspaceId', 'parent' => 'parentId'])
-            ->addListStorePropertiesToFormStore(['locale'])
+            ->addResourceStorePropertiesToFormStore(['webspace' => 'webspaceId', 'parent' => 'parentId'])
+            ->addResourceStorePropertiesToFormStore(['locale'])
             ->getRoute();
 
         $this->assertEquals(
             ['webspace' => 'webspaceId', 'parent' => 'parentId', 'locale'],
-            $route->getOption('listStorePropertiesToFormStore')
+            $route->getOption('resourceStorePropertiesToFormStore')
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
@@ -277,6 +277,23 @@ class FormOverlayListRouteBuilderTest extends TestCase
         );
     }
 
+    public function testBuildWithListStorePropertiesToFormStore()
+    {
+        $route = (new FormOverlayListRouteBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->setFormKey('role_details')
+            ->addListAdapters(['tree'])
+            ->addListStorePropertiesToFormStore(['webspace' => 'webspaceId', 'parent' => 'parentId'])
+            ->addListStorePropertiesToFormStore(['locale'])
+            ->getRoute();
+
+        $this->assertEquals(
+            ['webspace' => 'webspaceId', 'parent' => 'parentId', 'locale'],
+            $route->getOption('listStorePropertiesToFormStore')
+        );
+    }
+
     public function testBuildListSetParent()
     {
         $route = (new FormOverlayListRouteBuilder('sulu_role.list', '/roles'))


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR is build on top of @nnatter #4452 and my #4477 overlaySize feature and extend the FormOverlayList to a option to provide resourceStoreProperties to the formStore which will be used to load the resource.

#### Why?

Sometimes you need to forward listStore properties also to the formStore. In my case the list is filtered by a specific dimensionId and only the dimension which is currently shown should be edit in the FormOverlayList so this property need to be forwared from the listStore to the formStore. 

EDIT: as mentioned by danrot we will forward the property directly from the resourceStore so you can have different values between listStore and formStore. 

#### Example Usage

~~~php
            ->resourceStorePropertiesToFormStore([
                'resourceStoreProperty' => 'formStoreProperty',
            ])
~~~


#### To Do

 - ~~[ ] Create a documentation PR~~
 - ~~[ ] Add breaking changes to UPGRADE.md~~
 - [x] Tests
