### PR TITLE
 Add overlaySize option to FormOverlayList and Builder 

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
@@ -167,6 +167,13 @@ class FormOverlayListRouteBuilder implements FormOverlayListRouteBuilderInterfac
         return $this;
     }
 
+    public function setOverlaySize(string $overlaySize): FormOverlayListRouteBuilderInterface
+    {
+        $this->route->setOption('overlaySize', $overlaySize);
+
+        return $this;
+    }
+
     public function setParent(string $parent): FormOverlayListRouteBuilderInterface
     {
         $this->route->setParent($parent);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilderInterface.php
@@ -71,5 +71,7 @@ interface FormOverlayListRouteBuilderInterface
 
     public function setParent(string $parent): self;
 
+    public function setOverlaySize(string $overlaySize): self;
+
     public function getRoute(): Route;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -142,6 +142,7 @@ export default class FormOverlayList extends React.Component<ViewProps> {
                         addOverlayTitle,
                         editOverlayTitle,
                         formKey,
+                        overlaySize,
                     },
                 },
             },
@@ -168,7 +169,7 @@ export default class FormOverlayList extends React.Component<ViewProps> {
                         onClose={this.handleFormOverlayClose}
                         onConfirm={this.handleFormOverlayConfirm}
                         open={!!this.formStore}
-                        size="small"
+                        size={overlaySize ? overlaySize : 'small'}
                         title={overlayTitle}
                     >
                         <div className={formOverlayListStyles.form}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -96,6 +96,7 @@ test('Should pass correct props to List view', () => {
                 formKey: 'test-form-key',
                 addOverlayTitle: 'app.add_overlay_title',
                 editOverlayTitle: 'app.edit_overlay_title',
+                overlaySize: 'large',
                 resourceKey: 'test-resource-key',
                 toolbarActions: ['sulu_admin.add'],
                 routerAttributesToListStore: {'0': 'category', 'id': 'parentId'},
@@ -182,6 +183,7 @@ test('Should open Overlay with correct props when List fires the item-add callba
             options: {
                 formKey: 'test-form-key',
                 addOverlayTitle: 'app.add_overlay_title',
+                overlaySize: 'large',
             },
         },
     }: any);
@@ -197,7 +199,7 @@ test('Should open Overlay with correct props when List fires the item-add callba
         confirmLoading: false,
         confirmText: 'sulu_admin.save',
         open: true,
-        size: 'small',
+        size: 'large',
         title: 'app.add_overlay_title',
     }));
 });

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
@@ -61,6 +61,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
                 ['table', 'column_list'],
                 'sulu_category.add_category',
                 'sulu_category.edit_category',
+                'small',
             ],
             [
                 'sulu_tag.list',
@@ -72,6 +73,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
                 ['table'],
                 'sulu_tag.add_tag',
                 'sulu_tag.edit_tag',
+                'large',
             ],
         ];
     }
@@ -88,7 +90,8 @@ class FormOverlayListRouteBuilderTest extends TestCase
         string $title,
         array $listAdapters,
         string $addOverlayTitle,
-        string $editOverlayTitle
+        string $editOverlayTitle,
+        string $overlaySize
     ) {
         $route = (new FormOverlayListRouteBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -98,6 +101,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
             ->addListAdapters($listAdapters)
             ->setAddOverlayTitle($addOverlayTitle)
             ->setEditOverlayTitle($editOverlayTitle)
+            ->setOverlaySize($overlaySize)
             ->getRoute();
 
         $this->assertEquals($name, $route->getName());
@@ -109,6 +113,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
         $this->assertEquals($listAdapters, $route->getOption('adapters'));
         $this->assertEquals($addOverlayTitle, $route->getOption('addOverlayTitle'));
         $this->assertEquals($editOverlayTitle, $route->getOption('editOverlayTitle'));
+        $this->assertEquals($overlaySize, $route->getOption('overlaySize'));
         $this->assertEquals('sulu_admin.form_overlay_list', $route->getView());
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | based on #4452
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add overlaySize option to FormOverlayList and Builder.

#### Why?

In some cases you want to have a bigger overlay for this edit form.

#### Example Usage

~~~php
        $route = (new FormOverlayListRouteBuilder($name, $path))
            ->setOverlaySize('large')
            ->getRoute();
~~~

#### To Do

- ~~[ ] Create a documentation PR~~
- ~~[ ] Add breaking changes to UPGRADE.md~~
