### PR TITLE
Fix resource-locator generation when creating a new page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -42,7 +42,7 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
                 generationUrl,
                 {
                     parts,
-                    locale: formInspector.locale,
+                    locale: formInspector.locale ? formInspector.locale.get() : undefined,
                     ...formInspector.options,
                 }
             ).then((response) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -12,7 +12,7 @@ import ResourceLocatorComponent from '../../../../components/ResourceLocator';
 
 jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions = {}) {
     this.id = id;
-    this.locale = observableOptions.locale ? observableOptions.locale.get() : undefined;
+    this.locale = observableOptions.locale;
 }));
 
 jest.mock('../../stores/ResourceFormStore', () => jest.fn(function(resourceStore, formKey, options) {


### PR DESCRIPTION
 by unboxing locale before passing it to the the requester

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR fixes the generation of the resource-locator when a new page is created. 

Before this PR, the `ResourceLocator` field-type passed the locale as `boxed observable` to the `Requester`. 
After https://github.com/sulu/sulu/pull/4460 was merged, this boxed observable lead to an infinite loop in the `transformRequestData` method of the `Requester` because boxed observables` do contain circular references.

#### Why?

Because we want to be able to automatically generate resource-locators for new pages 🙂 
