### PR TITLE
Add setView for Admin Route object

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/Route.php
@@ -105,6 +105,13 @@ class Route
         return $this->view;
     }
 
+    public function setView(string $view): self
+    {
+        $this->view = $view;
+
+        return $this;
+    }
+
     public function setOption(string $key, $value): self
     {
         $this->options[$key] = $value;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add setView for Admin Route object.

#### Why?

In some cases you just want to extend an exist view and in this case you need to allow to overwrite the `view` attribute of the Route.

#### Example Usage

~~~php
$this->routeBuilderFactory->createFormOverlayListRouteBuilder('app.locations', '/locations')
    ....
    ->getRoute()
    ->setView('my_custom_view');
~~~

```js
// @flow
import React, {Fragment} from 'react';
import {observer} from 'mobx-react';
import FormOverlayList from 'sulu-admin-bundle/views/FormOverlayList';
import type {ViewProps} from 'sulu-admin-bundle/containers/ViewRenderer';
import type {ElementRef} from 'react';

@observer
export default class FormOverlayListFilter extends React.Component<ViewProps> {
 
    formOverlayListRef: ?ElementRef<typeof FormOverlayList>;

    setListRef = (formOverlayListRef: ?ElementRef<typeof FormOverlayList>) => {
        this.formOverlayListRef = formOverlayListRef;
    };

    render() {
        return (
            <Fragment>
                <div>Custom View</div>

                <FormOverlayList
                    {...this.props}
                    ref={this.setListRef}
                />
            </Fragment>
        );
    }
}
```
