### PR TITLE
Add options constructor-parameter to SearchStore

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -17,6 +17,7 @@ type Props = {|
     idProperty: string,
     locale?: ?IObservableValue<string>,
     onChange: (value: Array<string | number>) => void,
+    options: Object,
     resourceKey: string,
     searchProperties: Array<string>,
     value: ?Array<string | number>,
@@ -29,6 +30,7 @@ export default class MultiAutoComplete extends React.Component<Props> {
         disabled: false,
         filterParameter: 'ids',
         idProperty: 'id',
+        options: {},
     };
 
     searchStore: SearchStore;
@@ -42,12 +44,13 @@ export default class MultiAutoComplete extends React.Component<Props> {
             filterParameter,
             idProperty,
             locale,
+            options,
             resourceKey,
             searchProperties,
             value,
         } = this.props;
 
-        this.searchStore = new SearchStore(resourceKey, searchProperties);
+        this.searchStore = new SearchStore(resourceKey, searchProperties, options);
         this.selectionStore = new MultiSelectionStore(resourceKey, value || [], locale, filterParameter);
         this.changeDisposer = reaction(
             () => (this.selectionStore.items.map((item) => item[idProperty])),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js
@@ -635,3 +635,30 @@ test('Should call disposer when component unmounts', () => {
 
     expect(changeDisposerSpy).toBeCalledWith();
 });
+
+test('Construct SearchStore with correct parameters on mount', () => {
+    // $FlowFixMe
+    SearchStore.mockImplementation(function() {});
+
+    // $FlowFixMe
+    MultiSelectionStore.mockImplementation(function() {
+        mockExtendObservable(this, {
+            items: [],
+        });
+    });
+
+    shallow(
+        <MultiAutoComplete
+            allowAdd={true}
+            displayProperty="name"
+            idProperty="name"
+            onChange={jest.fn()}
+            options={{country: 'US'}}
+            resourceKey="contact"
+            searchProperties={['firstName', 'lastName']}
+            value={undefined}
+        />
+    );
+
+    expect(SearchStore).toBeCalledWith('contact', ['firstName', 'lastName'], {country: 'US'});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
@@ -10,6 +10,7 @@ type Props = {|
     id?: string,
     searchProperties: Array<string>,
     onChange: (value: ?Object) => void,
+    options: Object,
     resourceKey: string,
     value: ?Object,
 |};
@@ -18,6 +19,7 @@ type Props = {|
 export default class SingleAutoComplete extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
+        options: {},
     };
 
     searchStore: SearchStore;
@@ -25,9 +27,9 @@ export default class SingleAutoComplete extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
 
-        const {resourceKey, searchProperties} = this.props;
+        const {options, resourceKey, searchProperties} = this.props;
 
-        this.searchStore = new SearchStore(resourceKey, searchProperties);
+        this.searchStore = new SearchStore(resourceKey, searchProperties, options);
     }
 
     handleChange = (value: ?Object) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js
@@ -147,3 +147,25 @@ test('Call onChange and clear search result when chosen option has changed', () 
     expect(changeSpy).toBeCalledWith(data);
     expect(singleAutoComplete.instance().searchStore.clearSearchResults).toBeCalledWith();
 });
+
+test('Construct SearchStore with correct parameters on mount', () => {
+    // $FlowFixMe
+    SearchStore.mockImplementation(function() {
+        this.searchResults = [];
+        this.loading = false;
+        this.search = jest.fn();
+    });
+
+    shallow(
+        <SingleAutoComplete
+            displayProperty="name"
+            onChange={jest.fn()}
+            options={{country: 'US'}}
+            resourceKey="contact"
+            searchProperties={['firstName', 'lastName']}
+            value={undefined}
+        />
+    );
+
+    expect(SearchStore).toBeCalledWith('contact', ['firstName', 'lastName'], {country: 'US'});
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/SearchStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/SearchStore.js
@@ -6,12 +6,14 @@ import ResourceRequester from '../../services/ResourceRequester';
 export default class SearchStore {
     resourceKey: string;
     searchProperties: Array<string>;
+    options: Object;
     @observable searchResults: Array<Object> = [];
     @observable loading: boolean = false;
 
-    constructor(resourceKey: string, searchProperties: Array<string>) {
+    constructor(resourceKey: string, searchProperties: Array<string>, options: Object = {}) {
         this.resourceKey = resourceKey;
         this.searchProperties = searchProperties;
+        this.options = options;
     }
 
     @action clearSearchResults = () => {
@@ -29,6 +31,7 @@ export default class SearchStore {
         this.loading = true;
 
         return ResourceRequester.getList(resourceKey, {
+            ...this.options,
             excludedIds,
             limit: 10,
             page: 1,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/tests/SearchStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SearchStore/tests/SearchStore.test.js
@@ -41,6 +41,33 @@ test('Send a request using the ResourceRequester when something is being searche
     });
 });
 
+test('Send a request using the ResourceRequester with given options when something is being searched', () => {
+    const searchStore = new SearchStore('accounts', ['name', 'number'], {country: 'US'});
+    const searchResults = [{id: 1, name: 'Sulu'}];
+    const searchPromise = Promise.resolve({
+        _embedded: {
+            accounts: searchResults,
+        },
+    });
+
+    ResourceRequester.getList.mockReturnValue(searchPromise);
+
+    const autoCompletePromise = searchStore.search('Sulu');
+    expect(searchStore.loading).toEqual(true);
+
+    return autoCompletePromise.then(() => {
+        expect(ResourceRequester.getList).toBeCalledWith('accounts', {
+            country: 'US',
+            limit: 10,
+            page: 1,
+            search: 'Sulu',
+            searchFields: ['name', 'number'],
+        });
+        expect(searchStore.searchResults).toEqual(searchResults);
+        expect(searchStore.loading).toEqual(false);
+    });
+});
+
 test('Send a request using the ResourceRequester with excludedIds when something is being searched', () => {
     const searchStore = new SearchStore('accounts', ['name', 'number']);
     const searchResults = [{id: 1, name: 'Sulu'}];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

This PR adds a `options` parameter to the constructor of the `SearchStore` class. The properties of the given `options` object are included as query parameters in the requests sent by the `SearchStore`. This behaviour is analogous to the `options` parameter of the `ListStore` class and the `ResourceFormStore` class.

Furthermore, this PR add a `options` prop to the `SingleAutoComplete` container that allows to specify options that are passed to the `SearchStore` that is constructed by the `SingleAutoComplete` container. This behaviour is analogous to the `options` prop of the `SingleListOverlay` and the `MultiListOverlay`.

#### Why?

Because it might be useful to set some options that will be sent to the server. A simple usecase would be limiting the results of the `SearchStore` to media with a specific type by setting the following hypothetical `options` object `{type: 'image'}`.
