### PR TITLE
JMS Serializer: Handle DateTimeImmutable correctly

### DIFF
--- a/src/Sulu/Component/Rest/Handler/DateHandler.php
+++ b/src/Sulu/Component/Rest/Handler/DateHandler.php
@@ -34,7 +34,19 @@ class DateHandler implements SubscribingHandlerInterface
                 'method' => 'deserialize',
             ],
             [
+                'type' => 'DateTimeImmutable',
+                'direction' => GraphNavigator::DIRECTION_DESERIALIZATION,
+                'format' => 'array',
+                'method' => 'deserialize',
+            ],
+            [
                 'type' => 'DateTime',
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'format' => 'array',
+                'method' => 'serialize',
+            ],
+            [
+                'type' => 'DateTimeImmutable',
                 'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
                 'format' => 'array',
                 'method' => 'serialize',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Handle DateTimeImmutable in array serialization correctly.

#### Why?

DateTimeImmutable is lost.
