### PR TITLE
Set ghost-locale to first available-locale if locale not exists in webspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.5
+    * HOTFIX      #4491 [ContentBundle]         Set ghost-locale to first available-locale if locale not exists in webspace
     * BUGFIX      #4433 [SecurityBundle]       Fix fresh User object comparison to the deserialized User object
     
 * 1.5.21 (2019-02-28)

--- a/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/PreviewBundle/phpunit.xml.dist
@@ -20,6 +20,7 @@
     <php>
         <server name="KERNEL_DIR" value="Tests/app"/>
         <var name="APP_DB" value="mysql"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
 </phpunit>

--- a/src/Sulu/Component/Content/Repository/ContentRepository.php
+++ b/src/Sulu/Component/Content/Repository/ContentRepository.php
@@ -591,11 +591,15 @@ class ContentRepository implements ContentRepositoryInterface
         $webspaceKey = $this->nodeHelper->extractWebspaceFromPath($row->getPath());
 
         $originalLocale = $locale;
+        $availableLocales = $this->resolveAvailableLocales($row);
         $ghostLocale = $this->localizationFinder->findAvailableLocale(
             $webspaceKey,
-            $this->resolveAvailableLocales($row),
+            $availableLocales,
             $locale
         );
+        if (null === $ghostLocale) {
+            $ghostLocale = reset($availableLocales);
+        }
 
         $type = null;
         if ($row->getValue('shadowOn')) {

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -370,8 +370,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->createPage('test-2', 'de');
         $this->createPage('test-3', 'de');
 
-        $result = $this->contentRepository->findByWebspaceRoot('de', 'sulu_io',
-            MappingBuilder::create()->getMapping());
+        $result = $this->contentRepository->findByWebspaceRoot('de', 'sulu_io', MappingBuilder::create()->getMapping());
 
         $this->assertCount(3, $result);
 
@@ -381,6 +380,21 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals('/test-2', $result[1]->getPath());
         $this->assertNotNull($result[2]->getId());
         $this->assertEquals('/test-3', $result[2]->getPath());
+    }
+
+    public function testFindByWebspaceRootNonExistingLocale()
+    {
+        $this->createPage('test-1', 'de');
+
+        $result = $this->contentRepository->findByWebspaceRoot('fr', 'sulu_io', MappingBuilder::create()->getMapping());
+
+        $this->assertCount(1, $result);
+
+        $this->assertNotNull($result[0]->getId());
+        $this->assertEquals('/test-1', $result[0]->getPath());
+        $this->assertEquals('ghost', $result[0]->getLocalizationType()->getName());
+        $this->assertEquals('de', $result[0]->getLocalizationType()->getValue());
+        $this->assertEquals('fr', $result[0]->getLocale());
     }
 
     public function testFindByWebspaceRootMapping()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the ghost locale handling when you query for pages in a non-existing locale for the given webspace.

#### Why?

When you have 2 webspace with different locales:

* test1: de
* test2: en

And create a new custom-url for `test1` the content tree don't show any titles (user locale is en).

This PR uses the first available locale to display the titles

#### To Do

- [x] Tests
