### PR TITLE
Add webspace and portal name to template attributes

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\WebsiteBundle\Resolver;
 
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Resolves the request_analyzer to an array.
@@ -30,18 +29,11 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
      */
     private $environment;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
-        RequestStack $requestStack,
         $environment
     ) {
         $this->webspaceManager = $webspaceManager;
-        $this->requestStack = $requestStack;
         $this->environment = $environment;
     }
 
@@ -64,7 +56,9 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
         return [
             'request' => [
                 'webspaceKey' => $requestAnalyzer->getWebspace()->getKey(),
+                'webspaceName' => $requestAnalyzer->getWebspace()->getName(),
                 'portalKey' => $requestAnalyzer->getPortal()->getKey(),
+                'portalName' => $requestAnalyzer->getPortal()->getName(),
                 'defaultLocale' => $defaultLocale,
                 'locale' => $currentLocale,
                 'portalUrl' => $requestAnalyzer->getPortalUrl(),

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -151,7 +151,6 @@
 
         <service id="sulu_website.resolver.request_analyzer" class="%sulu_website.resolver.request_analyzer.class%">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
-            <argument type="service" id="request_stack"/>
             <argument>%kernel.environment%</argument>
         </service>
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolverTest.php
@@ -88,9 +88,11 @@ class RequestAnalyzerResolverTest extends TestCase
     {
         $webspace = new Webspace();
         $webspace->setKey('sulu_io');
+        $webspace->setName('Sulu');
 
         $portal = new Portal();
         $portal->setKey('sulu_io_portal');
+        $portal->setName('Sulu Portal');
         $locale = new Localization();
         $locale->setLanguage('de');
         $locale->setDefault(true);
@@ -121,7 +123,9 @@ class RequestAnalyzerResolverTest extends TestCase
             [
                 'request' => [
                     'webspaceKey' => 'sulu_io',
+                    'webspaceName' => 'Sulu',
                     'portalKey' => 'sulu_io_portal',
+                    'portalName' => 'Sulu Portal',
                     'locale' => 'de_at',
                     'defaultLocale' => 'de',
                     'portalUrl' => 'sulu.io/de',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Related PRs | fixes https://github.com/sulu/sulu/pull/4492

#### What's in this PR?

Add webspace and portal name to template attributes.

#### Why?

Currently its not possible to access the portal and webspace name in twig.

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/430
