### PR TITLE
Set position of content section of Dialog to relative to hide overflow

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
@@ -57,6 +57,7 @@ $transitionDuration: 300ms;
     border-radius: $borderRadius;
     background: $contentBackgroundColor;
     overflow: hidden;
+    position: relative;
 
     header {
         color: $titleColor;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR sets the CSS `position` property of the content section of our `Dialog` to `relative`. This is needed in order to actually hide overflow in the y direction.

#### Why?

Because we want to hide elements that are placed inside the `Dialog` content but would be positioned outside of the `Dialog`.