### PR TITLE
Add autowiring for template attribute resolver service

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -165,6 +165,9 @@
             <argument>%kernel.environment%</argument>
         </service>
 
+        <service id="Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolverInterface"
+                 alias="sulu_website.resolver.template_attribute"/>
+
         <service id="sulu_website.resolver.parameter" class="%sulu_website.resolver.parameter.class%" public="true">
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add autowiring for template attribute resolver service.

#### Why?

That you can autowire the template attribute service.

#### Example Usage

~~~php
class TestController {
    public function __construct(
        EngineInterface $templating,
        TemplateAttributeResolverInterface $attributeResolver
    ) {
        $this->templating = $templating;
        $this->attributeResolver = $attributeResolver;
    }

    public function testAction()
    {
         return new Reponse(
             $this->templating->render('test.html.twig', $this->attributeResolver->resolve([]));
         );
    }
}
~~~
