### PR TITLE
Add own parameter for the structure default type

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -336,6 +336,14 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             'sulu.content.structure.default_types',
             $contentConfig['structure']['default_type']
         );
+
+        foreach ($contentConfig['structure']['default_type'] as $type => $default) {
+            $container->setParameter(
+                'sulu.content.structure.default_type.' . $type,
+                $default
+            );
+        }
+
         $container->setParameter(
             'sulu.content.structure.required_properties',
             $contentConfig['structure']['required_properties']
@@ -343,10 +351,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter(
             'sulu.content.structure.required_tags',
             $contentConfig['structure']['required_tags']
-        );
-        $container->setParameter(
-            'sulu.content.structure.default_type.snippet',
-            $contentConfig['structure']['default_type']['snippet']
         );
         $container->setParameter(
             'sulu.content.internal_prefix',

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/SuluCoreExtensionTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/SuluCoreExtensionTest.php
@@ -40,6 +40,7 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
                 'structure' => [
                     'default_type' => [
                         'snippet' => 'default',
+                        'test' => 'default_test',
                     ],
                     'paths' => [],
                     'type_map' => [
@@ -60,6 +61,11 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
         $this->assertEquals(
             'default',
             $this->container->getParameter('sulu.content.structure.default_type.snippet')
+        );
+
+        $this->assertEquals(
+            'default_test',
+            $this->container->getParameter('sulu.content.structure.default_type.test')
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add own parameter for the structure default type.

#### Why?

Currently only the snippet default type is set to a parameter this should be done for all default types so they can be used.

#### Example Usage

~~~yaml
sulu_core:
    content:
        structure:
            default_type:
                test: default_test
~~~

```bash
bin/websiteconsole debug:container --parameter sulu.content.structure.default_type.test
```
