### PR TITLE
Avoid remains of link set without selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/LinkCommand.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/LinkCommand.js
@@ -20,7 +20,13 @@ export default class LinkCommand extends Command {
     execute(eventInfo: Object) {
         this.editor.model.change((writer) => {
             const linkAttributes = Object.keys(this.attributeMap).reduce((attributes, key) => {
-                attributes[key] = eventInfo[this.attributeMap[key]];
+                const eventInfoValue = eventInfo[this.attributeMap[key]];
+
+                if (!eventInfoValue) {
+                    return attributes;
+                }
+
+                attributes[key] = eventInfoValue;
                 return attributes;
             }, {});
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4305 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR sets the title only if an actual title not being `undefined` has been added.

#### Why?

Because otherwise parts of the link remain, when it is added without selecting a text and it is removed afterwards.