### PR TITLE
Fix pathcleanup whitespace character problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-master
+    * HOTFIX      #4512  [Components]           Fix pathcleanup whitespace character problems
+
 * 1.6.26 (2019-03-26)
     * BUGFIX      #4343  [MediaBundle]          Fixed format manager types configuration cannot be changed
     * BUGFIX      #4471  [AdminBundle]          Fix CKEditor preview for content that is not wrapped in an HTML tag
@@ -18,6 +21,7 @@ CHANGELOG for Sulu
 * 1.6.24 (2019-01-09)
     * BUGFIX      #4349 [ContentBundle]         Fix compatibility to symfony 3.4.21, 4.1.10 and 4.2.2
     * ENHANCEMENT #4319 [MediaBundle]           Added possibility to have a image format configuration file without formats
+    * BUGFIX      #4313 [All]                   Fix php 7.3 compatibility
 
 * 1.6.23 (2018-12-03)
     * FEATURE     #4236 [MediaBundle]           Added autorotation based on exif

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -74,10 +74,13 @@ class PathCleanup implements PathCleanupInterface
 
         // Inspired by ZOOLU
         // delete problematic characters
-        $clean = str_replace('%2F', '/', urlencode(preg_replace('/([^A-za-z0-9 -_\/])/', '', $clean)));
+        $clean = str_replace('%2F', '/', urlencode(preg_replace('/([^A-za-z0-9\s\-_\/])/', '', $clean)));
 
         // replace multiple dash with one
         $clean = preg_replace('/([-]+)/', '-', $clean);
+
+        // remove dash before slash
+        $clean = preg_replace('/[-]+\//', '/', $clean);
 
         // remove dash after slash
         $clean = preg_replace('/\/[-]+/', '/', $clean);

--- a/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
+++ b/src/Sulu/Component/PHPCR/Tests/Unit/PathCleanupTest.php
@@ -49,9 +49,9 @@ class PathCleanupTest extends \PHPUnit_Framework_TestCase
 
     public function testCleanup()
     {
-        $clean = $this->cleaner->cleanup('-/aSDf     asdf/äöü-', 'de');
+        $clean = $this->cleaner->cleanup('-/aSDf     asdf/äöü-/hello: world\'s', 'de');
 
-        $this->assertEquals('/asdf-asdf/aeoeue', $clean);
+        $this->assertEquals('/asdf-asdf/aeoeue/hello-worlds', $clean);
     }
 
     public function testValidate()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4496
| Related issues/PRs | bug was introduced in #4313
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix pathcleanup whitespace character problems.

#### Why?

Not only spaces are whitespace characters also `'` and `:` should be replaced.

#### Example Usage

Add title with `'` or `:` should be replaced correctly.

