### PR TITLE
Allow to manage default snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "sulu-page-bundle": "file:src/Sulu/Bundle/PageBundle/Resources/js",
         "sulu-preview-bundle": "file:src/Sulu/Bundle/PreviewBundle/Resources/js",
         "sulu-security-bundle": "file:src/Sulu/Bundle/SecurityBundle/Resources/js",
+        "sulu-snippet-bundle": "file:src/Sulu/Bundle/SnippetBundle/Resources/js",
         "sulu-website-bundle": "file:src/Sulu/Bundle/WebsiteBundle/Resources/js"
     },
     "devDependencies": {

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -275,11 +275,6 @@ class AdminController
                     ),
                 ],
             ],
-            'sulu_page' => [
-                'endpoints' => [
-                    'clearCache' => $this->urlGenerator->generate('sulu_website.cache.remove'),
-                ],
-            ],
             'sulu_preview' => [
                 'endpoints' => [
                     'start' => $this->urlGenerator->generate('sulu_preview.start'),
@@ -294,6 +289,11 @@ class AdminController
             'sulu_security' => [
                 'endpoints' => [
                     'contexts' => $this->urlGenerator->generate('cget_contexts'),
+                ],
+            ],
+            'sulu_website' => [
+                'endpoints' => [
+                    'clearCache' => $this->urlGenerator->generate('sulu_website.cache.remove'),
                 ],
             ],
         ]);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -8,7 +8,7 @@ import buttonStyles from './button.scss';
 
 const LOADER_SIZE = 25;
 
-type Props = {|
+type Props<T> = {|
     active: boolean,
     activeClassName?: string,
     children?: Node,
@@ -17,15 +17,15 @@ type Props = {|
     icon?: string,
     iconClassName?: string,
     loading: boolean,
-    onClick?: (value: *) => void,
+    onClick?: (value: T) => void,
     showDropdownIcon: boolean,
     size: 'small' | 'large',
     skin: 'primary' | 'secondary' | 'link' | 'icon',
     type: 'button' | 'submit' | 'reset',
-    value?: *,
+    value: T,
 |};
 
-export default class Button extends React.PureComponent<Props> {
+export default class Button<T> extends React.PureComponent<Props<T>> {
     static defaultProps = {
         active: false,
         disabled: false,
@@ -34,6 +34,7 @@ export default class Button extends React.PureComponent<Props> {
         size: 'large',
         skin: 'secondary',
         type: 'button',
+        value: undefined,
     };
 
     handleClick = (event: SyntheticEvent<HTMLButtonElement>) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/README.md
@@ -72,6 +72,12 @@ The buttons can also be used in combination with an icon.
 </Button>
 ```
 
+The link button can also be used with only a icon:
+
+```javascript
+<Button skin="link" icon="su-trash-alt" />
+```
+
 The prop `showDropdownIcon` displays a drop down icon on the right side.
 
 ```javascript

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -83,7 +83,6 @@ $iconColorActive: $white;
 
 .link {
     padding: 0;
-    margin: 0 10px 0 0;
     border: 0;
     background: transparent;
     cursor: pointer;
@@ -94,8 +93,8 @@ $iconColorActive: $white;
         text-decoration: underline;
     }
 
-    .button-icon {
-        margin-right: 10px;
+    .button-icon + .text {
+        margin-left: 10px;
     }
 
     .dropdown-icon {

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -72,7 +72,7 @@ class CustomUrlAdmin extends Admin
                 ->setFormKey('custom_url_details')
                 ->setTabTitle('sulu_custom_url.custom_urls')
                 ->addToolbarActions($listToolbarActions)
-                ->setTabOrder(1536)
+                ->setTabOrder(1024)
                 ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
                 ->addRerenderAttribute('webspace')
                 ->getRoute(),

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -72,6 +72,7 @@ class CustomUrlAdmin extends Admin
                 ->setFormKey('custom_url_details')
                 ->setTabTitle('sulu_custom_url.custom_urls')
                 ->addToolbarActions($listToolbarActions)
+                ->setTabOrder(1536)
                 ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
                 ->addRerenderAttribute('webspace')
                 ->getRoute(),

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -119,6 +119,7 @@ class PageAdmin extends Admin
             (new Route(static::PAGES_ROUTE, '/pages/:locale', 'sulu_page.webspace_overview'))
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())
                 ->setOption('tabTitle', 'sulu_page.pages')
+                ->setOption('tabOrder', 0)
                 ->addRerenderAttribute('webspace')
                 ->setParent(static::WEBSPACE_TABS_ROUTE),
             (new Route(

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -1,5 +1,5 @@
 // @flow
-import {bundleReady, initializer} from 'sulu-admin-bundle/services';
+import {bundleReady} from 'sulu-admin-bundle/services';
 import {fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
 import {formToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import SearchResult from './containers/Form/fields/SearchResult';
@@ -10,10 +10,6 @@ import TemplateToolbarAction from './views/Form/toolbarActions/TemplateToolbarAc
 import PageTabs from './views/PageTabs';
 import PageList from './views/PageList';
 import WebspaceTabs from './views/WebspaceTabs';
-
-initializer.addUpdateConfigHook('sulu_page', (config: Object) => {
-    PageList.clearCacheEndpoint = config.endpoints.clearCache;
-});
 
 viewRegistry.add('sulu_page.page_tabs', PageTabs);
 viewRegistry.add('sulu_page.webspace_overview', PageList);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/package.json
@@ -11,12 +11,14 @@
     "devDependencies": {
         "enzyme": "^3.3.0",
         "pretty": "^2.0.0",
-        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js",
+        "sulu-website-bundle": "file:../../../WebsiteBundle/Resources/js"
     },
     "peerDependencies": {
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "react": "^16.2.0",
-        "sulu-admin-bundle": "*"
+        "sulu-admin-bundle": "*",
+        "sulu-website-bundle": "*"
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -42,9 +42,6 @@
     "sulu_page.no_index": "no-index (Seite wird nicht von Suchmaschinen indiziert)",
     "sulu_page.no_follow": "no-follow (Links auf der Seite wird von Suchmaschinen nicht gefolgt)",
     "sulu_page.hide_in_sitemap": "In Sitemap ausblenden",
-    "sulu_page.cache_clear": "Webseiten Cache löschen",
-    "sulu_page.cache_clear_warning_title": "Webseiten Cache löschen?",
-    "sulu_page.cache_clear_warning_text": "Diese Operation leert den gesamten Cache für jeden Webspace. Wollen Sie wirklich fortfahren?",
     "sulu_page.delete_draft": "Entwurf löschen",
     "sulu_page.delete_draft_warning_title": "Entwurf löschen?",
     "sulu_page.delete_draft_warning_text": "Soll der Entwurf wirklich gelöscht werden? Alle Daten gehen dadurch verloren. Die veröffentlichte Seite bleibt unverändert bestehen."

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -42,9 +42,6 @@
     "sulu_page.no_index": "no-index (page will not be indexed by search engines)",
     "sulu_page.no_follow": "no-follow (links on this page will not be followed by the search engine)",
     "sulu_page.hide_in_sitemap": "Hide in sitemap",
-    "sulu_page.cache_clear": "Clear website cache",
-    "sulu_page.cache_clear_warning_title": "Clear website cache?",
-    "sulu_page.cache_clear_warning_text": "This operation will clear the entire cache for all webspaces. Do you really wish to proceed?",
     "sulu_page.delete_draft": "Delete draft",
     "sulu_page.delete_draft_warning_title": "Delete Draft?",
     "sulu_page.delete_draft_warning_text": "Do you really want to delete the draft? All data will be lost. The published page will not be changed."

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle\Admin;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\Routing\Route;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 use Sulu\Bundle\AdminBundle\Navigation\NavigationItem;
@@ -158,6 +159,9 @@ class SnippetAdmin extends Admin
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
+            (new Route('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas'))
+                ->setOption('tabOrder', 1024)
+                ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE),
         ];
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -160,8 +160,10 @@ class SnippetAdmin extends Admin
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
             (new Route('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas'))
+                ->setOption('tabTitle', 'sulu_snippet.default_snippets')
                 ->setOption('tabOrder', 1024)
-                ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE),
+                ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
+                ->addRerenderAttribute('webspace'),
         ];
     }
 

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -161,7 +161,7 @@ class SnippetAdmin extends Admin
                 ->getRoute(),
             (new Route('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas'))
                 ->setOption('tabTitle', 'sulu_snippet.default_snippets')
-                ->setOption('tabOrder', 1024)
+                ->setOption('tabOrder', 3072)
                 ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
                 ->addRerenderAttribute('webspace'),
         ];

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetAreaController.php
@@ -106,7 +106,7 @@ class SnippetAreaController extends Controller implements ClassResourceInterface
             PermissionTypes::EDIT
         );
 
-        $default = $request->get('default');
+        $default = $request->get('defaultUuid');
 
         $areas = $this->getLocalizedAreas();
         $area = $areas[$key];

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -43,6 +43,12 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
                                 'detail' => 'get_snippet',
                             ],
                         ],
+                        'snippet_areas' => [
+                            'routes' => [
+                                'list' => 'get_snippet-areas',
+                                'detail' => 'put_snippet-area',
+                            ],
+                        ],
                     ],
                     'field_type_options' => [
                         'selection' => [
@@ -61,6 +67,17 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
                                 ],
                             ],
                         ],
+                    ],
+                ]
+            );
+        }
+
+        if ($container->hasExtension('fos_js_routing')) {
+            $container->prependExtensionConfig(
+                'fos_js_routing',
+                [
+                    'routes_to_expose' => [
+                        'put_snippet-area',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/index.js
@@ -1,0 +1,8 @@
+// @flow
+import {viewRegistry} from 'sulu-admin-bundle/containers';
+import {bundleReady} from 'sulu-admin-bundle/services';
+import SnippetAreas from './views/SnippetAreas';
+
+viewRegistry.add('sulu_snippet.snippet_areas', SnippetAreas);
+
+bundleReady();

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/package.json
@@ -5,12 +5,14 @@
     "repository": "https://github.com/sulu/sulu.git",
     "devDependencies": {
         "enzyme": "^3.3.0",
-        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js",
+        "sulu-website-bundle": "file:../../../WebsiteBundle/Resources/js"
     },
     "peerDependencies": {
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "react": "^16.2.0",
-        "sulu-admin-bundle": "*"
+        "sulu-admin-bundle": "*",
+        "sulu-website-bundle": "*"
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "sulu-snippet-bundle",
+    "description": "Adds support for snippets to Sulu",
+    "license": "MIT",
+    "repository": "https://github.com/sulu/sulu.git",
+    "devDependencies": {
+        "enzyme": "^3.3.0",
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
+    },
+    "peerDependencies": {
+        "mobx": "^4.0.0",
+        "mobx-react": "^5.0.0",
+        "react": "^16.2.0",
+        "sulu-admin-bundle": "*"
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/README.md
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/README.md
@@ -1,0 +1,2 @@
+This view allows to assign snippets to snippet areas. It is registered in the `ViewRegistry` with the key
+`sulu_snippet.snippet_areas`.

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -6,6 +6,7 @@ import {Button, Dialog, Loader, Table} from 'sulu-admin-bundle/components';
 import {SingleListOverlay, withToolbar} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
+import {CacheClearToolbarAction} from 'sulu-website-bundle/containers';
 import SnippetAreaStore from './stores/SnippetAreaStore';
 import snippetAreasStyles from './snippetAreas.scss';
 
@@ -14,6 +15,7 @@ class SnippetAreas extends React.Component<ViewProps> {
     @observable openedAreaKey: ?string = undefined;
     snippetAreaStore: SnippetAreaStore;
     @observable deleteAreaKey: ?string = undefined;
+    cacheClearToolbarAction: CacheClearToolbarAction;
 
     constructor(props: ViewProps) {
         super(props);
@@ -26,6 +28,7 @@ class SnippetAreas extends React.Component<ViewProps> {
         } = router;
 
         this.snippetAreaStore = new SnippetAreaStore(webspace);
+        this.cacheClearToolbarAction = new CacheClearToolbarAction();
     }
 
     @action handleAddClick = (areaKey: string) => {
@@ -138,11 +141,16 @@ class SnippetAreas extends React.Component<ViewProps> {
                 >
                     {translate('sulu_admin.delete_warning_text')}
                 </Dialog>
+                {this.cacheClearToolbarAction.getNode()}
             </Fragment>
         );
     }
 }
 
 export default withToolbar(SnippetAreas, function() {
-    return {};
+    return {
+        items: [
+            this.cacheClearToolbarAction.getToolbarItemConfig(),
+        ],
+    };
 });

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -3,14 +3,14 @@ import React, {Fragment} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Button, Dialog, Loader, Table} from 'sulu-admin-bundle/components';
-import {SingleListOverlay} from 'sulu-admin-bundle/containers';
+import {SingleListOverlay, withToolbar} from 'sulu-admin-bundle/containers';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import SnippetAreaStore from './stores/SnippetAreaStore';
 import snippetAreasStyles from './snippetAreas.scss';
 
 @observer
-export default class SnippetAreas extends React.Component<ViewProps> {
+class SnippetAreas extends React.Component<ViewProps> {
     @observable openedAreaKey: ?string = undefined;
     snippetAreaStore: SnippetAreaStore;
     @observable deleteAreaKey: ?string = undefined;
@@ -142,3 +142,7 @@ export default class SnippetAreas extends React.Component<ViewProps> {
         );
     }
 }
+
+export default withToolbar(SnippetAreas, function() {
+    return {};
+});

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -1,0 +1,144 @@
+// @flow
+import React, {Fragment} from 'react';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import {Button, Dialog, Loader, Table} from 'sulu-admin-bundle/components';
+import {SingleListOverlay} from 'sulu-admin-bundle/containers';
+import type {ViewProps} from 'sulu-admin-bundle/containers';
+import {translate} from 'sulu-admin-bundle/utils';
+import SnippetAreaStore from './stores/SnippetAreaStore';
+import snippetAreasStyles from './snippetAreas.scss';
+
+@observer
+export default class SnippetAreas extends React.Component<ViewProps> {
+    @observable openedAreaKey: ?string = undefined;
+    snippetAreaStore: SnippetAreaStore;
+    @observable deleteAreaKey: ?string = undefined;
+
+    constructor(props: ViewProps) {
+        super(props);
+
+        const {router} = this.props;
+        const {
+            attributes: {
+                webspace,
+            },
+        } = router;
+
+        this.snippetAreaStore = new SnippetAreaStore(webspace);
+    }
+
+    @action handleAddClick = (areaKey: string) => {
+        this.openedAreaKey = areaKey;
+    };
+
+    @action handleListOverlayClose = () => {
+        this.openedAreaKey = undefined;
+    };
+
+    @action handleListOverlayConfirm = (snippet: Object) => {
+        if (!this.openedAreaKey) {
+            throw new Error(
+                'The snippet area for saving has not been defined! This should not happen and is likely a bug.'
+            );
+        }
+
+        this.snippetAreaStore.save(this.openedAreaKey, snippet.id).then(action(() => {
+            this.openedAreaKey = undefined;
+        }));
+    };
+
+    @action handleDeleteClick = (areaKey: string) => {
+        this.deleteAreaKey = areaKey;
+    };
+
+    handleDeleteDialogConfirm = () => {
+        if (!this.deleteAreaKey) {
+            throw new Error('The area to delete has not been set! This should not happen and is likely a bug.');
+        }
+
+        this.snippetAreaStore.delete(this.deleteAreaKey).then(action(() => {
+            this.deleteAreaKey = undefined;
+        }));
+    };
+
+    @action handleDeleteDialogCancel = () => {
+        this.deleteAreaKey = undefined;
+    };
+
+    render() {
+        if (this.snippetAreaStore.loading) {
+            return <Loader />;
+        }
+
+        return (
+            <Fragment>
+                <Table skin="light">
+                    <Table.Header>
+                        <Table.HeaderCell>{translate('sulu_snippet.snippet_area')}</Table.HeaderCell>
+                        <Table.HeaderCell>{translate('sulu_snippet.snippet')}</Table.HeaderCell>
+                    </Table.Header>
+                    <Table.Body>
+                        {Object.keys(this.snippetAreaStore.snippetAreas).map((areaKey) => {
+                            const {defaultTitle, defaultUuid, key, title} = this.snippetAreaStore.snippetAreas[areaKey];
+
+                            return (
+                                <Table.Row key={key}>
+                                    <Table.Cell>
+                                        {title}
+                                    </Table.Cell>
+                                    <Table.Cell>
+                                        {defaultUuid
+                                            ? <Fragment>
+                                                <div className={snippetAreasStyles.title}>
+                                                    {defaultTitle}
+                                                </div>
+                                                <Button
+                                                    className={snippetAreasStyles.deleteButton}
+                                                    icon="su-trash-alt"
+                                                    onClick={this.handleDeleteClick}
+                                                    skin="link"
+                                                    value={key}
+                                                />
+                                            </Fragment>
+                                            : <Button
+                                                className={snippetAreasStyles.addButton}
+                                                icon="su-plus-circle"
+                                                onClick={this.handleAddClick}
+                                                skin="link"
+                                                value={key}
+                                            />
+                                        }
+                                    </Table.Cell>
+                                </Table.Row>
+                            );
+                        })}
+                    </Table.Body>
+                </Table>
+                <SingleListOverlay
+                    adapter="table"
+                    confirmLoading={this.snippetAreaStore.saving}
+                    key={this.openedAreaKey}
+                    listKey="snippets"
+                    onClose={this.handleListOverlayClose}
+                    onConfirm={this.handleListOverlayConfirm}
+                    open={!!this.openedAreaKey}
+                    options={{type: this.openedAreaKey}}
+                    resourceKey="snippets"
+                    title={translate('sulu_snippet.selection_overlay_title')}
+                />
+                <Dialog
+                    cancelText={translate('sulu_admin.cancel')}
+                    confirmLoading={this.snippetAreaStore.deleting}
+                    confirmText={translate('sulu_admin.ok')}
+                    onCancel={this.handleDeleteDialogCancel}
+                    onConfirm={this.handleDeleteDialogConfirm}
+                    open={!!this.deleteAreaKey}
+                    title={translate('sulu_admin.delete_warning_title')}
+                >
+                    {translate('sulu_admin.delete_warning_text')}
+                </Dialog>
+            </Fragment>
+        );
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/index.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/index.js
@@ -1,0 +1,4 @@
+// @flow
+import SnippetAreas from './SnippetAreas';
+
+export default SnippetAreas;

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/snippetAreas.scss
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/snippetAreas.scss
@@ -1,0 +1,8 @@
+.add-button,
+.delete-button {
+    font-size: 18px;
+}
+
+.title {
+    flex-grow: 1;
+}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/stores/SnippetAreaStore.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/stores/SnippetAreaStore.js
@@ -1,0 +1,45 @@
+// @flow
+import {action, observable} from 'mobx';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import type {SnippetArea} from '../types';
+
+export default class SnippetAreaStore {
+    @observable snippetAreas: {[key: string]: SnippetArea} = {};
+    @observable loading: boolean = true;
+    @observable saving: boolean = false;
+    @observable deleting: boolean = false;
+    webspaceKey: string;
+
+    constructor(webspaceKey: string) {
+        this.webspaceKey = webspaceKey;
+
+        ResourceRequester.getList('snippet_areas', {webspace: webspaceKey}).then(action((response) => {
+            this.snippetAreas = response._embedded.areas.reduce((snippetAreas, snippetArea) => {
+                snippetAreas[snippetArea.key] = snippetArea;
+
+                return snippetAreas;
+            }, {});
+            this.loading = false;
+        }));
+    }
+
+    @action save(areaKey: string, defaultUuid: string) {
+        this.saving = true;
+
+        return ResourceRequester.put('snippet_areas', {defaultUuid}, {key: areaKey, webspace: this.webspaceKey})
+            .then(action((response) => {
+                this.snippetAreas[areaKey] = response;
+                this.saving = false;
+            }));
+    }
+
+    @action delete(areaKey: string) {
+        this.deleting = true;
+
+        return ResourceRequester.delete('snippet_areas', {key: areaKey, webspace: this.webspaceKey})
+            .then(action((response) => {
+                this.snippetAreas[areaKey] = response;
+                this.deleting = false;
+            }));
+    }
+}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -1,0 +1,225 @@
+// @flow
+import React from 'react';
+import {mount, render} from 'enzyme';
+import {SingleListOverlay} from 'sulu-admin-bundle/containers';
+import {Router} from 'sulu-admin-bundle/services';
+import SnippetAreaStore from '../stores/SnippetAreaStore';
+import SnippetAreas from '../SnippetAreas';
+
+jest.mock('sulu-admin-bundle/containers/SingleListOverlay', () => jest.fn(() => null));
+jest.mock('sulu-admin-bundle/services/Router', () => jest.fn());
+jest.mock('sulu-admin-bundle/utils', () => ({
+    translate: jest.fn((key) =>key),
+}));
+jest.mock('../stores/SnippetAreaStore', () => jest.fn());
+
+test('Render snippet areas with loading icon', () => {
+    const router = new Router({});
+    router.attributes = {
+        webspace: 'sulu',
+    };
+
+    // $FlowFixMe
+    const route = {};
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.loading = true;
+    });
+
+    expect(render(<SnippetAreas route={route} router={router} />)).toMatchSnapshot();
+    expect(SnippetAreaStore).toBeCalledWith('sulu');
+});
+
+test('Render snippet areas with data as table', () => {
+    const router = new Router({});
+    router.attributes = {
+        webspace: 'sulu',
+    };
+
+    // $FlowFixMe
+    const route = {};
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            default: {
+                defaultTitle: null,
+                defaultUuid: null,
+                key: 'default',
+                title: 'Default',
+            },
+            footer: {
+                defaultTitle: 'Footer Snippet',
+                defaultUuid: 'some-other-uuid',
+                key: 'footer',
+                title: 'Footer',
+            },
+        };
+    });
+
+    expect(render(<SnippetAreas route={route} router={router} />)).toMatchSnapshot();
+    expect(SnippetAreaStore).toBeCalledWith('sulu');
+});
+
+test('Close after clicking add without choosing a snippet', () => {
+    const router = new Router({});
+    router.attributes = {
+        webspace: 'sulu',
+    };
+
+    // $FlowFixMe
+    const route = {};
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            default: {
+                defaultTitle: null,
+                defaultUuid: null,
+                key: 'default',
+                title: 'Default',
+            },
+        };
+
+        this.save = jest.fn();
+    });
+
+    const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
+    // $FlowFixMe
+    const snippetAreaStore = SnippetAreaStore.mock.instances[0];
+
+    expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(false);
+    snippetAreas.find('Button[className="addButton"] button').simulate('click');
+    expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(true);
+
+    snippetAreas.find(SingleListOverlay).prop('onClose')();
+    snippetAreas.update();
+    expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(false);
+
+    expect(snippetAreaStore.save).not.toBeCalled();
+});
+
+test('Save after adding a new snippet area', () => {
+    const router = new Router({});
+    router.attributes = {
+        webspace: 'sulu',
+    };
+
+    // $FlowFixMe
+    const route = {};
+
+    const savePromise = Promise.resolve();
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            default: {
+                defaultTitle: null,
+                defaultUuid: null,
+                key: 'default',
+                title: 'Default',
+            },
+        };
+
+        this.save = jest.fn().mockReturnValue(savePromise);
+    });
+
+    const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
+    // $FlowFixMe
+    const snippetAreaStore = SnippetAreaStore.mock.instances[0];
+
+    expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(false);
+    snippetAreas.find('Button[className="addButton"] button').simulate('click');
+    expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(true);
+    snippetAreas.find(SingleListOverlay).prop('onConfirm')({id: 'some-uuid'});
+    expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(true);
+
+    expect(snippetAreaStore.save).toBeCalledWith('default', 'some-uuid');
+
+    return savePromise.then(() => {
+        snippetAreas.update();
+        expect(snippetAreas.find(SingleListOverlay).prop('open')).toEqual(false);
+    });
+});
+
+test('Close after clicking delete and cancel dialog', () => {
+    const router = new Router({});
+    router.attributes = {
+        webspace: 'sulu',
+    };
+
+    // $FlowFixMe
+    const route = {};
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            default: {
+                defaultTitle: 'Default Snippet',
+                defaultUuid: 'some-uuid',
+                key: 1,
+                title: 'Default',
+            },
+        };
+
+        this.save = jest.fn();
+    });
+
+    const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
+    // $FlowFixMe
+    const snippetAreaStore = SnippetAreaStore.mock.instances[0];
+
+    expect(snippetAreas.find('Dialog').prop('open')).toEqual(false);
+    snippetAreas.find('Button[className="deleteButton"] button').simulate('click');
+    expect(snippetAreas.find('Dialog').prop('open')).toEqual(true);
+
+    snippetAreas.find('Dialog').prop('onCancel')();
+    snippetAreas.update();
+    expect(snippetAreas.find('Dialog').prop('open')).toEqual(false);
+
+    expect(snippetAreaStore.save).not.toBeCalled();
+});
+
+test('Delete after confirming the confirmation dialog', () => {
+    const router = new Router({});
+    router.attributes = {
+        webspace: 'sulu',
+    };
+
+    // $FlowFixMe
+    const route = {};
+
+    const deletePromise = Promise.resolve();
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            default: {
+                defaultTitle: 'Default Snippet',
+                defaultUuid: 'some-uuid',
+                key: 'default',
+                title: 'Default',
+            },
+        };
+
+        this.delete = jest.fn().mockReturnValue(deletePromise);
+    });
+
+    const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
+    // $FlowFixMe
+    const snippetAreaStore = SnippetAreaStore.mock.instances[0];
+
+    expect(snippetAreas.find('Dialog').prop('open')).toEqual(false);
+    snippetAreas.find('Button[className="deleteButton"] button').simulate('click');
+    expect(snippetAreas.find('Dialog').prop('open')).toEqual(true);
+    snippetAreas.find('Dialog').prop('onConfirm')();
+    expect(snippetAreas.find('Dialog').prop('open')).toEqual(true);
+
+    expect(snippetAreaStore.delete).toBeCalledWith('default');
+
+    return deletePromise.then(() => {
+        snippetAreas.update();
+        expect(snippetAreas.find('Dialog').prop('open')).toEqual(false);
+    });
+});

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -6,7 +6,10 @@ import {Router} from 'sulu-admin-bundle/services';
 import SnippetAreaStore from '../stores/SnippetAreaStore';
 import SnippetAreas from '../SnippetAreas';
 
-jest.mock('sulu-admin-bundle/containers/SingleListOverlay', () => jest.fn(() => null));
+jest.mock('sulu-admin-bundle/containers', () => ({
+    SingleListOverlay: jest.fn(() => null),
+    withToolbar: jest.fn((Component) => Component),
+}));
 jest.mock('sulu-admin-bundle/services/Router', () => jest.fn());
 jest.mock('sulu-admin-bundle/utils', () => ({
     translate: jest.fn((key) =>key),

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/__snapshots__/SnippetAreas.test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render snippet areas with data as table 1`] = `
+<div
+  class="tableContainer light"
+>
+  <table
+    class="table"
+  >
+    <thead
+      class="header"
+    >
+      <tr>
+        <th
+          class="headerCell"
+        >
+          <span>
+            sulu_snippet.snippet_area
+          </span>
+        </th>
+        <th
+          class="headerCell"
+        >
+          <span>
+            sulu_snippet.snippet
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Default
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <button
+              class="button link addButton"
+              type="button"
+            >
+              <span
+                aria-label="su-plus-circle"
+                class="su-plus-circle buttonIcon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            Footer
+          </div>
+        </td>
+        <td
+          class="cell"
+        >
+          <div
+            class="cellContent"
+          >
+            <div
+              class="title"
+            >
+              Footer Snippet
+            </div>
+            <button
+              class="button link deleteButton"
+              type="button"
+            >
+              <span
+                aria-label="su-trash-alt"
+                class="su-trash-alt buttonIcon"
+              />
+            </button>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`Render snippet areas with loading icon 1`] = `
+<div
+  class="spinner"
+  style="width:40px;height:40px"
+>
+  <div
+    class="doubleBounce1"
+  />
+  <div
+    class="doubleBounce2"
+  />
+</div>
+`;

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/stores/SnippetAreaStore.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/stores/SnippetAreaStore.test.js
@@ -1,0 +1,184 @@
+// @flow
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import SnippetAreaStore from '../../stores/SnippetAreaStore';
+
+jest.mock('sulu-admin-bundle/services', () => ({
+    ResourceRequester: {
+        getList: jest.fn(),
+        put: jest.fn(),
+        delete: jest.fn(),
+    },
+}));
+
+test('Load snippet areas when constructing the store', () => {
+    const listPromise = Promise.resolve({
+        _embedded: {
+            areas: [
+                {
+                    defaultTitle: 'Default 1',
+                    defaultUuid: 'some-uuid-1',
+                    key: 'default',
+                    template: 'default',
+                    title: 'Default',
+                },
+                {
+                    defaultTitle: 'Footer 1',
+                    defaultUuid: 'some-uuid-2',
+                    key: 'footer',
+                    template: 'footer',
+                    title: 'Footer',
+                },
+            ],
+        },
+    });
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const snippetAreaStore = new SnippetAreaStore('sulu');
+
+    expect(ResourceRequester.getList).toBeCalledWith('snippet_areas', {webspace: 'sulu'});
+
+    expect(snippetAreaStore.loading).toEqual(true);
+    expect(snippetAreaStore.snippetAreas).toEqual({});
+
+    return listPromise.then(() => {
+        expect(snippetAreaStore.loading).toEqual(false);
+        expect(snippetAreaStore.snippetAreas).toEqual({
+            default: {
+                defaultTitle: 'Default 1',
+                defaultUuid: 'some-uuid-1',
+                key: 'default',
+                template: 'default',
+                title: 'Default',
+            },
+            footer: {
+                defaultTitle: 'Footer 1',
+                defaultUuid: 'some-uuid-2',
+                key: 'footer',
+                template: 'footer',
+                title: 'Footer',
+            },
+        });
+    });
+});
+
+test('Save snippet area when save is calld', () => {
+    const listPromise = Promise.resolve({
+        _embedded: {
+            areas: [
+                {
+                    defaultTitle: 'Default 1',
+                    defaultUuid: 'some-uuid-1',
+                    key: 'default',
+                    template: 'default',
+                    title: 'Default',
+                },
+                {
+                    defaultTitle: 'Footer 1',
+                    defaultUuid: 'some-uuid-2',
+                    key: 'footer',
+                    template: 'footer',
+                    title: 'Footer',
+                },
+            ],
+        },
+    });
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const putPromise = Promise.resolve({
+        defaultTitle: 'Footer 2',
+        defaultUuid: 'some-uuid-3',
+        key: 'footer',
+        template: 'footer',
+        title: 'Footer',
+    });
+    ResourceRequester.put.mockReturnValue(putPromise);
+
+    const snippetAreaStore = new SnippetAreaStore('sulu');
+    snippetAreaStore.save('footer', 'some-uuid-3');
+
+    expect(ResourceRequester.put)
+        .toBeCalledWith('snippet_areas', {defaultUuid: 'some-uuid-3'}, {key: 'footer', webspace: 'sulu'});
+
+    expect(snippetAreaStore.saving).toEqual(true);
+
+    return listPromise.then(() => {
+        expect(snippetAreaStore.saving).toEqual(false);
+        expect(snippetAreaStore.snippetAreas).toEqual({
+            default: {
+                defaultTitle: 'Default 1',
+                defaultUuid: 'some-uuid-1',
+                key: 'default',
+                template: 'default',
+                title: 'Default',
+            },
+            footer: {
+                defaultTitle: 'Footer 2',
+                defaultUuid: 'some-uuid-3',
+                key: 'footer',
+                template: 'footer',
+                title: 'Footer',
+            },
+        });
+    });
+});
+
+test('Delete snippet area when delete is calld', () => {
+    const listPromise = Promise.resolve({
+        _embedded: {
+            areas: [
+                {
+                    defaultTitle: 'Default 1',
+                    defaultUuid: 'some-uuid-1',
+                    key: 'default',
+                    template: 'default',
+                    title: 'Default',
+                },
+                {
+                    defaultTitle: 'Footer 1',
+                    defaultUuid: 'some-uuid-2',
+                    key: 'footer',
+                    template: 'footer',
+                    title: 'Footer',
+                },
+            ],
+        },
+    });
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const deletePromise = Promise.resolve({
+        defaultTitle: null,
+        defaultUuid: null,
+        key: 'footer',
+        template: 'footer',
+        title: 'Footer',
+    });
+    ResourceRequester.delete.mockReturnValue(deletePromise);
+
+    const snippetAreaStore = new SnippetAreaStore('sulu');
+    snippetAreaStore.delete('footer');
+
+    expect(ResourceRequester.delete)
+        .toBeCalledWith('snippet_areas', {key: 'footer', webspace: 'sulu'});
+
+    expect(snippetAreaStore.deleting).toEqual(true);
+
+    return listPromise.then(() => {
+        expect(snippetAreaStore.deleting).toEqual(false);
+        expect(snippetAreaStore.snippetAreas).toEqual({
+            default: {
+                defaultTitle: 'Default 1',
+                defaultUuid: 'some-uuid-1',
+                key: 'default',
+                template: 'default',
+                title: 'Default',
+            },
+            footer: {
+                defaultTitle: null,
+                defaultUuid: null,
+                key: 'footer',
+                template: 'footer',
+                title: 'Footer',
+            },
+        });
+    });
+});

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/types.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/types.js
@@ -1,0 +1,9 @@
+// @flow
+
+export type SnippetArea = {
+    defaultTitle: ?string,
+    defaultUuid: ?string,
+    key: string,
+    template: string,
+    title: string,
+};

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.de.json
@@ -2,5 +2,8 @@
     "sulu_snippet.selection_overlay_title": "Schnipsel auswählen",
     "sulu_snippet.selection_label": "{count} Schnipsel ausgewählt",
     "sulu_snippet.snippets": "Schnipsel",
+    "sulu_snippet.snippet": "Schnipsel",
+    "sulu_snippet.default_snippets": "Standard Schnipsel",
+    "sulu_snippet.snippet_area": "Typ oder Bereich",
     "sulu_snippet.taxonomies": "Taxonomien"
 }

--- a/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/translations/admin.en.json
@@ -2,5 +2,8 @@
     "sulu_snippet.selection_overlay_title": "Choose snippets",
     "sulu_snippet.selection_label": "{count} {count, plural, =1 {snippet} other {snippets}} selected",
     "sulu_snippet.snippets": "Snippets",
+    "sulu_snippet.snippet": "Snippet",
+    "sulu_snippet.default_snippets": "Default Snippets",
+    "sulu_snippet.snippet_area": "Type or area",
     "sulu_snippet.taxonomies": "Taxonomies"
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetAreaControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetAreaControllerTest.php
@@ -59,7 +59,7 @@ class SnippetAreaControllerTest extends BaseFunctionalTestCase
         $client->request(
             'PUT',
             '/api/snippet-areas/car',
-            ['webspace' => 'sulu_io', 'default' => $this->car1->getUuid()]
+            ['webspace' => 'sulu_io', 'defaultUuid' => $this->car1->getUuid()]
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());
@@ -97,7 +97,7 @@ class SnippetAreaControllerTest extends BaseFunctionalTestCase
         $client->request(
             'DELETE',
             '/api/snippet-areas/car',
-            ['webspace' => 'sulu_io', 'default' => $this->car1->getUuid()]
+            ['webspace' => 'sulu_io']
         );
 
         $this->assertHttpStatusCode(200, $client->getResponse());

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Sulu.
  *

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Sulu.
  *
@@ -76,6 +75,7 @@ class WebsiteAdmin extends Admin
                 ->disableSearching()
                 ->setFormKey('analytic_details')
                 ->setTabTitle('sulu_website.analytics')
+                ->setTabOrder(512)
                 ->addToolbarActions($listToolbarActions)
                 ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
                 ->addRerenderAttribute('webspace')

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -76,7 +76,7 @@ class WebsiteAdmin extends Admin
                 ->disableSearching()
                 ->setFormKey('analytic_details')
                 ->setTabTitle('sulu_website.analytics')
-                ->setTabOrder(512)
+                ->setTabOrder(2048)
                 ->addToolbarActions($listToolbarActions)
                 ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
                 ->addRerenderAttribute('webspace')

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/CacheClearToolbarAction.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/CacheClearToolbarAction.js
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react';
+import {action, observable} from 'mobx';
+import {Dialog} from 'sulu-admin-bundle/components';
+import {Requester} from 'sulu-admin-bundle/services';
+import {translate} from 'sulu-admin-bundle/utils';
+
+export default class CacheClearToolbarAction {
+    static clearCacheEndpoint: string;
+
+    @observable cacheClearing = false;
+    @observable showDialog = false;
+
+    getNode() {
+        return (
+            <Dialog
+                cancelText={translate('sulu_admin.cancel')}
+                confirmLoading={this.cacheClearing}
+                confirmText={translate('sulu_admin.ok')}
+                onCancel={this.handleCancel}
+                onConfirm={this.handleConfirm}
+                open={this.showDialog}
+                title={translate('sulu_website.cache_clear_warning_title')}
+            >
+                {translate('sulu_website.cache_clear_warning_text')}
+            </Dialog>
+        );
+    }
+
+    getToolbarItemConfig() {
+        return {
+            icon: 'su-paint',
+            label: translate('sulu_website.cache_clear'),
+            onClick: action(() => {
+                this.showDialog = true;
+            }),
+            type: 'button',
+        };
+    }
+
+    @action handleCancel = () => {
+        this.showDialog = false;
+    };
+
+    @action handleConfirm = () => {
+        this.cacheClearing = true;
+        Requester.delete(CacheClearToolbarAction.clearCacheEndpoint).then(action(() => {
+            this.showDialog = false;
+            this.cacheClearing = false;
+        }));
+    };
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/index.js
@@ -1,0 +1,4 @@
+// @flow
+import CacheClearToolbarAction from './CacheClearToolbarAction';
+
+export default CacheClearToolbarAction;

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js
@@ -1,0 +1,91 @@
+// @flow
+import {shallow} from 'enzyme';
+import {Requester} from 'sulu-admin-bundle/services';
+import CacheClearToolbarAction from '../CacheClearToolbarAction';
+
+jest.mock('sulu-admin-bundle/services/Requester', () => ({
+    delete: jest.fn(),
+}));
+
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Return item config with correct icon, type and label and return closed dialog', () => {
+    const cacheClearToolbarAction = new CacheClearToolbarAction();
+
+    expect(cacheClearToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        icon: 'su-paint',
+        label: 'sulu_website.cache_clear',
+        type: 'button',
+    }));
+
+    const element = shallow(cacheClearToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        cancelText: 'sulu_admin.cancel',
+        children: 'sulu_website.cache_clear_warning_text',
+        confirmText: 'sulu_admin.ok',
+        open: false,
+        title: 'sulu_website.cache_clear_warning_title',
+    }));
+});
+
+test('Open dialog on toolbar item click', () => {
+    const cacheClearToolbarAction = new CacheClearToolbarAction();
+
+    const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    toolbarItemConfig.onClick();
+
+    const element = shallow(cacheClearToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+});
+
+test('Close dialog on cancel click', () => {
+    const cacheClearToolbarAction = new CacheClearToolbarAction();
+
+    const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    toolbarItemConfig.onClick();
+
+    let element = shallow(cacheClearToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    element.find('Button[skin="secondary"]').simulate('click');
+    element = shallow(cacheClearToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: false,
+    }));
+});
+
+test('Call delete when dialog is confirmed', () => {
+    const cacheClearToolbarAction = new CacheClearToolbarAction();
+
+    const deletePromise = Promise.resolve();
+    Requester.delete.mockReturnValue(deletePromise);
+
+    const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    toolbarItemConfig.onClick();
+
+    let element = shallow(cacheClearToolbarAction.getNode());
+    expect(element.instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    expect(element.instance().props.confirmLoading).toEqual(false);
+    element.find('Button[skin="primary"]').simulate('click');
+    expect(Requester.delete).toBeCalledWith(undefined);
+
+    element = shallow(cacheClearToolbarAction.getNode());
+    expect(element.instance().props.confirmLoading).toEqual(true);
+
+    return deletePromise.then(() => {
+        element = shallow(cacheClearToolbarAction.getNode());
+        expect(element.instance().props.confirmLoading).toEqual(false);
+        expect(element.instance().props).toEqual(expect.objectContaining({
+            open: false,
+        }));
+    });
+});

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/index.js
@@ -1,0 +1,4 @@
+// @flow
+import CacheClearToolbarAction from './CacheClearToolbarAction';
+
+export {CacheClearToolbarAction};

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
@@ -1,7 +1,12 @@
 // @flow
-import {bundleReady} from 'sulu-admin-bundle/services';
+import {bundleReady, initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry} from 'sulu-admin-bundle/containers';
+import CacheClearToolbarAction from './containers/CacheClearToolbarAction';
 import AnalyticsDomainSelect from './containers/Form/fields/AnalyticsDomainSelect';
+
+initializer.addUpdateConfigHook('sulu_website', (config: Object) => {
+    CacheClearToolbarAction.clearCacheEndpoint = config.endpoints.clearCache;
+});
 
 fieldRegistry.add('analytics_domain_select', AnalyticsDomainSelect);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/translations/admin.de.json
@@ -14,5 +14,8 @@
     "sulu_website.head_open": "Head open",
     "sulu_website.head_close": "Head close",
     "sulu_website.body_open": "Body open",
-    "sulu_website.body_close": "Body close"
+    "sulu_website.body_close": "Body close",
+    "sulu_website.cache_clear": "Webseiten Cache löschen",
+    "sulu_website.cache_clear_warning_title": "Webseiten Cache löschen?",
+    "sulu_website.cache_clear_warning_text": "Diese Operation leert den gesamten Cache für jeden Webspace. Wollen Sie wirklich fortfahren?"
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/translations/admin.en.json
@@ -14,5 +14,8 @@
     "sulu_website.head_open": "Head open",
     "sulu_website.head_close": "Head close",
     "sulu_website.body_open": "Body open",
-    "sulu_website.body_close": "Body close"
+    "sulu_website.body_close": "Body close",
+    "sulu_website.cache_clear": "Clear website cache",
+    "sulu_website.cache_clear_warning_title": "Clear website cache?",
+    "sulu_website.cache_clear_warning_text": "This operation will clear the entire cache for all webspaces. Do you really wish to proceed?"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
     entries.unshift('sulu-page-bundle');
     entries.unshift('sulu-preview-bundle');
     entries.unshift('sulu-security-bundle');
+    entries.unshift('sulu-snippet-bundle');
     entries.unshift('sulu-website-bundle');
 
     const entriesCount = entries.length;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will allow to manage default snippets in the new Admin UI.

#### Why?

Because this was already possible in the old UI.