### PR TITLE
Fix webspace validate command

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -192,7 +192,7 @@ class ValidateWebspacesCommand extends Command
         $this->output->writeln('Templates:');
 
         foreach ($webspace->getTemplates() as $type => $template) {
-            $this->validateTemplate($type, $template);
+            $this->validateTemplate($type, $template . '.html.twig');
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix webspace validate command by validate the correct template.

#### Why?

As in 2.0 the webspace templates are configured without `.html.twig` the validate command need to add this itself like it does for the page templates.

#### Example Usage

~~~bash
bin/adminconsole sulu:content:validate:webspaces
~~~

