### PR TITLE
Conflict symfony/framework-bundle 4.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,8 +125,9 @@
         "jackalope/jackalope": "1.2.8 || 1.3.0 || 1.3.1",
         "jackalope/jackalope-jackrabbit": "1.2.0 - 1.2.1",
         "phpcr/phpcr-utils": "1.2.0 - 1.2.10 || 1.3.0 - 1.3.2",
-        "symfony/symfony": "3.4.12 || 3.4.16 || 3.4.17",
-        "symfony/web-profiler-bundle": "3.4.7"
+        "symfony/symfony": "3.4.12 || 3.4.16 || 3.4.17 || 4.2.7",
+        "symfony/web-profiler-bundle": "3.4.7",
+        "symfony/framework-bundle": "4.2.7"
     },
     "replace": {
         "sulu/document-manager": "self.version",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/symfony/symfony/pull/31108, https://github.com/symfony/symfony/issues/31152, https://github.com/symfony/symfony/pull/31156
| License | MIT
| Documentation PR | -

#### What's in this PR?

Conflict symfony/framework-bundle 4.2.7

#### Why?

It will crash the current sulu state as the translation can not be set correctly.
