### PR TITLE
Add button to upload media

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -21,7 +21,10 @@ type Props = {|
     collectionStore: CollectionStore,
     onCollectionNavigate: (collectionId: ?string | number) => void,
     onMediaNavigate?: (mediaId: string | number) => void,
+    onUploadOverlayOpen: () => void,
+    onUploadOverlayClose: () => void,
     overlayType: OverlayType,
+    uploadOverlayOpen: boolean,
 |};
 
 @observer
@@ -63,13 +66,19 @@ export default class MediaCollection extends React.Component<Props> {
             mediaListAdapters,
             mediaListRef,
             mediaListStore,
+            onUploadOverlayClose,
+            onUploadOverlayOpen,
+            uploadOverlayOpen,
         } = this.props;
 
         return (
             <MultiMediaDropzone
                 collectionId={collectionStore.id}
                 locale={locale}
+                onClose={onUploadOverlayClose}
+                onOpen={onUploadOverlayOpen}
                 onUpload={this.handleUpload}
+                open={uploadOverlayOpen}
             >
                 <CollectionSection
                     listStore={collectionListStore}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -27,6 +27,7 @@ type Props = {|
 @observer
 export default class MediaSelectionOverlay extends React.Component<Props> {
     @observable collectionStore: CollectionStore;
+    @observable showMediaUploadOverlay: boolean = false;
     updateCollectionStoreDisposer: () => void;
 
     static createCollectionListStore(
@@ -120,6 +121,14 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
         this.props.mediaListStore.setPage(1);
     };
 
+    @action handleUploadOverlayOpen = () => {
+        this.showMediaUploadOverlay = true;
+    };
+
+    @action handleUploadOverlayClose = () => {
+        this.showMediaUploadOverlay = false;
+    };
+
     handleClose = () => {
         this.props.onClose();
     };
@@ -163,7 +172,10 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
                         mediaListAdapters={['media_card_selection']}
                         mediaListStore={mediaListStore}
                         onCollectionNavigate={this.handleCollectionNavigate}
+                        onUploadOverlayClose={this.handleUploadOverlayClose}
+                        onUploadOverlayOpen={this.handleUploadOverlayOpen}
                         overlayType="dialog"
+                        uploadOverlayOpen={this.showMediaUploadOverlay}
                     />
                 </div>
             </Overlay>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import type {ChildrenArray, Element} from 'react';
 import {observer} from 'mobx-react';
+import Mousetrap from 'mousetrap';
 import {translate} from 'sulu-admin-bundle/utils';
 import {Icon} from 'sulu-admin-bundle/components';
 import MediaItem from './MediaItem';
@@ -14,11 +15,41 @@ type Props = {
     onClick: () => void,
 };
 
+const CLOSE_OVERLAY_KEY = 'esc';
+
 @observer
 export default class DropzoneOverlay extends React.Component<Props> {
     static defaultProps = {
         open: false,
     };
+
+    constructor(props: Props) {
+        super(props);
+
+        const {onClose, open} = this.props;
+
+        if (open) {
+            Mousetrap.bind(CLOSE_OVERLAY_KEY, onClose);
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.props.open) {
+            Mousetrap.unbind(CLOSE_OVERLAY_KEY);
+        }
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        const {onClose, open} = this.props;
+
+        if (prevProps.open !== open) {
+            if (this.props.open) {
+                Mousetrap.bind(CLOSE_OVERLAY_KEY, onClose);
+            } else {
+                Mousetrap.unbind(CLOSE_OVERLAY_KEY);
+            }
+        }
+    }
 
     handleClose = () => {
         this.props.onClose();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -7,8 +7,6 @@ import {Icon} from 'sulu-admin-bundle/components';
 import MediaItem from './MediaItem';
 import dropzoneOverlayStyles from './dropzoneOverlay.scss';
 
-const UPLOAD_ICON = 'fa-cloud-upload';
-
 type Props = {
     children?: ChildrenArray<Element<typeof MediaItem>>,
     open: boolean,
@@ -52,10 +50,10 @@ export default class DropzoneOverlay extends React.Component<Props> {
                                 role="button"
                                 tabIndex="0"
                             >
-                                <Icon className={dropzoneOverlayStyles.uploadIcon} name={UPLOAD_ICON} />
-                                <h3 className={dropzoneOverlayStyles.uploadInfoHeadline}>
+                                <Icon className={dropzoneOverlayStyles.uploadIcon} name="su-upload" />
+                                <div className={dropzoneOverlayStyles.uploadInfoHeadline}>
                                     {translate('sulu_media.drop_files_to_upload')}
-                                </h3>
+                                </div>
                                 <div className={dropzoneOverlayStyles.uploadInfoSubline}>
                                     {translate('sulu_media.click_here_to_upload')}
                                 </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -14,28 +14,21 @@ type Props = {
     children: any,
     locale: IObservableValue<string>,
     collectionId: ?string | number,
+    onClose: () => void,
+    onOpen: () => void,
     onUpload: (media: Array<Object>) => void,
+    open: boolean,
 };
 
 @observer
 export default class MultiMediaDropzone extends React.Component<Props> {
     dropzoneRef: ElementRef<Dropzone>;
 
-    @observable overlayOpen: boolean = false;
-
     @observable mediaUploadStores: Array<MediaUploadStore> = [];
 
     setDropzoneRef = (ref: Dropzone) => {
         this.dropzoneRef = ref;
     };
-
-    @action openOverlay() {
-        this.overlayOpen = true;
-    }
-
-    @action closeOverlay() {
-        this.overlayOpen = false;
-    }
 
     @action addMediaUploadStore(mediaUploadStore: MediaUploadStore) {
         this.mediaUploadStores.push(mediaUploadStore);
@@ -52,19 +45,19 @@ export default class MultiMediaDropzone extends React.Component<Props> {
     }
 
     handleDragEnter = () => {
-        const {collectionId} = this.props;
+        const {collectionId, onOpen} = this.props;
 
         if (collectionId) {
-            this.openOverlay();
+            onOpen();
         }
     };
 
     handleDragLeave = () => {
-        this.closeOverlay();
+        this.props.onClose();
     };
 
     handleOverlayClose = () => {
-        this.closeOverlay();
+        this.props.onClose();
     };
 
     handleDrop = (files: Array<File>) => {
@@ -86,11 +79,11 @@ export default class MultiMediaDropzone extends React.Component<Props> {
             this.addMediaUploadStore(mediaUploadStore);
         });
 
-        Promise.all(uploadPromises).then((...media) => {
+        return Promise.all(uploadPromises).then((...media) => {
             this.props.onUpload(...media);
 
             setTimeout(() => {
-                this.closeOverlay();
+                this.props.onClose();
                 this.destroyMediaUploadStores();
             }, 1000);
         });
@@ -101,7 +94,7 @@ export default class MultiMediaDropzone extends React.Component<Props> {
     };
 
     render() {
-        const {children} = this.props;
+        const {children, open} = this.props;
 
         return (
             <Dropzone
@@ -116,7 +109,7 @@ export default class MultiMediaDropzone extends React.Component<Props> {
                 <DropzoneOverlay
                     onClick={this.handleOverlayClick}
                     onClose={this.handleOverlayClose}
-                    open={this.overlayOpen}
+                    open={open}
                 >
                     {this.createMediaItems()}
                 </DropzoneOverlay>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/dropzoneOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/dropzoneOverlay.scss
@@ -42,6 +42,7 @@ $dropAreaInfoColor: $white;
 .upload-info-headline {
     margin: 0 0 10px;
     font-size: 24px;
+    font-weight: bold;
 }
 
 .upload-info-subline {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
 import {observable} from 'mobx';
-import {render, shallow} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
+import Mousetrap from 'mousetrap';
 import MultiMediaDropzone from '../MultiMediaDropzone';
 import MediaUploadStore from '../../../stores/MediaUploadStore';
 
@@ -137,4 +138,26 @@ test('Should upload media when it is dropped on the dropzone', () => {
         expect(multiMediaDropzoneInstance.mediaUploadStores.length).toBe(0);
         expect(closeSpy).toBeCalledWith();
     });
+});
+
+test('Should close overlay when escape button is pressed', () => {
+    const locale = observable.box('en');
+    const closeSpy = jest.fn();
+
+    mount(
+        <MultiMediaDropzone
+            collectionId={3}
+            locale={locale}
+            onClose={closeSpy}
+            onOpen={jest.fn()}
+            onUpload={jest.fn()}
+            open={true}
+        >
+            <div />
+        </MultiMediaDropzone>
+    );
+
+    expect(closeSpy).not.toBeCalled();
+    Mousetrap.trigger('esc');
+    expect(closeSpy).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/__snapshots__/MultiMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/__snapshots__/MultiMediaDropzone.test.js.snap
@@ -37,14 +37,14 @@ exports[`Render a MultiMediaDropzone while media is uploaded 1`] = `
           tabindex="0"
         >
           <span
-            aria-label="fa-cloud-upload"
-            class="fa fa-cloud-upload uploadIcon"
+            aria-label="su-upload"
+            class="su-upload uploadIcon"
           />
-          <h3
+          <div
             class="uploadInfoHeadline"
           >
             Upload files by dropping them here
-          </h3>
+          </div>
           <div
             class="uploadInfoSubline"
           >
@@ -103,14 +103,14 @@ exports[`Render a MultiMediaDropzone while the overlay is visible 1`] = `
           tabindex="0"
         >
           <span
-            aria-label="fa-cloud-upload"
-            class="fa fa-cloud-upload uploadIcon"
+            aria-label="su-upload"
+            class="su-upload uploadIcon"
           />
-          <h3
+          <div
             class="uploadInfoHeadline"
           >
             Upload files by dropping them here
-          </h3>
+          </div>
           <div
             class="uploadInfoSubline"
           >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
@@ -7,6 +7,7 @@
         "classnames": "^2.2.5",
         "copy-to-clipboard": "^3.0.8",
         "fast-deep-equal": "^1.0.0",
+        "mousetrap": "^1.6.1",
         "react-clipboard.js": "^1.1.2",
         "react-dropzone": "^4.2.1",
         "url-search-params-polyfill": "^2.0.0"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -30,6 +30,7 @@ class MediaOverview extends React.Component<ViewProps> {
     @observable collectionStore: CollectionStore;
     mediaList: ?ElementRef<typeof List>;
     @observable showMediaMoveOverlay: boolean = false;
+    @observable showMediaUploadOverlay: boolean = false;
     @observable mediaMoving: boolean = false;
     disposer: () => void;
 
@@ -135,6 +136,14 @@ class MediaOverview extends React.Component<ViewProps> {
         this.collectionId.set(collectionId);
     };
 
+    @action handleUploadOverlayOpen = () => {
+        this.showMediaUploadOverlay = true;
+    };
+
+    @action handleUploadOverlayClose = () => {
+        this.showMediaUploadOverlay = false;
+    };
+
     handleMediaNavigate = (mediaId: string | number) => {
         const {router} = this.props;
         router.navigate(
@@ -176,6 +185,9 @@ class MediaOverview extends React.Component<ViewProps> {
                     mediaListStore={this.mediaListStore}
                     onCollectionNavigate={this.handleCollectionNavigate}
                     onMediaNavigate={this.handleMediaNavigate}
+                    onUploadOverlayClose={this.handleUploadOverlayClose}
+                    onUploadOverlayOpen={this.handleUploadOverlayOpen}
+                    uploadOverlayOpen={this.showMediaUploadOverlay}
                 />
                 <SingleListOverlay
                     adapter="column_list"
@@ -239,6 +251,15 @@ export default withToolbar(MediaOverview, function() {
             }
             : undefined,
         items: [
+            {
+                disabled: !this.collectionId.get(),
+                icon: 'su-upload',
+                label: translate('sulu_media.upload'),
+                onClick: action(() => {
+                    this.showMediaUploadOverlay = true;
+                }),
+                type: 'button',
+            },
             {
                 disabled: this.mediaListStore.selectionIds.length === 0,
                 icon: 'su-trash-alt',

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -315,6 +315,57 @@ test('Should delete selected items when delete button is clicked', () => {
     expect(mediaOverview.find('Dialog').at(4).prop('open')).toEqual(true);
 });
 
+test('Upload button should be disabled if nothing is selected', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+            },
+        },
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />).at(0).instance();
+    mediaOverview.locale.set('de');
+
+    expect(toolbarFunction.call(mediaOverview).items[0].label).toEqual('sulu_media.upload');
+    expect(toolbarFunction.call(mediaOverview).items[0].disabled).toEqual(true);
+
+    mediaOverview.collectionId.set(4);
+    expect(toolbarFunction.call(mediaOverview).items[0].disabled).toEqual(false);
+});
+
+test('Upload overlay should be opened and closed as it requests', () => {
+    const MediaOverview = require('../MediaOverview').default;
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+
+    const mediaOverview = mount(<MediaOverview router={router} />);
+
+    expect(mediaOverview.find('MediaCollection').prop('uploadOverlayOpen')).toEqual(false);
+    mediaOverview.find('MediaCollection').prop('onUploadOverlayOpen')();
+    mediaOverview.update();
+    expect(mediaOverview.find('MediaCollection').prop('uploadOverlayOpen')).toEqual(true);
+    mediaOverview.find('MediaCollection').prop('onUploadOverlayClose')();
+    mediaOverview.update();
+    expect(mediaOverview.find('MediaCollection').prop('uploadOverlayOpen')).toEqual(false);
+});
+
 test('Move overlay button should be disabled if nothing is selected', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const MediaOverview = require('../MediaOverview').default;
@@ -336,11 +387,11 @@ test('Move overlay button should be disabled if nothing is selected', () => {
     mediaOverview.collectionId.set(4);
     mediaOverview.locale.set('de');
 
-    expect(toolbarFunction.call(mediaOverview).items[1].disabled).toEqual(true);
-    expect(toolbarFunction.call(mediaOverview).items[1].label).toEqual('sulu_admin.move_selected');
+    expect(toolbarFunction.call(mediaOverview).items[2].disabled).toEqual(true);
+    expect(toolbarFunction.call(mediaOverview).items[2].label).toEqual('sulu_admin.move_selected');
 
     mediaOverview.mediaListStore.selectionIds.push(8);
-    expect(toolbarFunction.call(mediaOverview).items[1].disabled).toEqual(false);
+    expect(toolbarFunction.call(mediaOverview).items[2].disabled).toEqual(false);
 });
 
 test('Move overlay should disappear when overlay is closed', () => {
@@ -367,8 +418,8 @@ test('Move overlay should disappear when overlay is closed', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaOverview.instance());
 
-    expect(toolbarConfig.items[1].label).toEqual('sulu_admin.move_selected');
-    toolbarConfig.items[1].onClick();
+    expect(toolbarConfig.items[2].label).toEqual('sulu_admin.move_selected');
+    toolbarConfig.items[2].onClick();
     mediaOverview.update();
     expect(mediaOverview.find(SingleListOverlay).at(1).prop('listKey')).toEqual('collections');
     expect(mediaOverview.find(SingleListOverlay).at(1).prop('resourceKey')).toEqual('collections');
@@ -405,8 +456,8 @@ test('Media should be moved when overlay is confirmed', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaOverview.instance());
 
-    expect(toolbarConfig.items[1].label).toEqual('sulu_admin.move_selected');
-    toolbarConfig.items[1].onClick();
+    expect(toolbarConfig.items[2].label).toEqual('sulu_admin.move_selected');
+    toolbarConfig.items[2].onClick();
     mediaOverview.update();
     expect(mediaOverview.find(SingleListOverlay).at(1).prop('resourceKey')).toEqual('collections');
     expect(mediaOverview.find(SingleListOverlay).at(1).prop('confirmLoading')).toEqual(false);

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.de.json
@@ -8,6 +8,7 @@
     "sulu_media.reset_selection": "Auswahl zurücksetzen",
     "sulu_media.copy_masterfile_url": "Original URL kopieren",
     "sulu_media.information_taxonomy": "Informationen und Taxonomien",
+    "sulu_media.upload": "Upload",
     "sulu_media.upload_or_replace": "Bild hochladen / ersetzen",
     "sulu_media.media_selected_singular": "Medien Element ausgewählt",
     "sulu_media.media_selected_plural": "Medien Elemente ausgewählt",

--- a/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/translations/admin.en.json
@@ -8,6 +8,7 @@
     "sulu_media.reset_selection": "Reset selection",
     "sulu_media.copy_masterfile_url": "Copy master file URL",
     "sulu_media.information_taxonomy": "Information and Taxonomy",
+    "sulu_media.upload": "Upload",
     "sulu_media.upload_or_replace": "Upload / replace image",
     "sulu_media.media_selected_singular": "media element selected",
     "sulu_media.media_selected_plural": "media elements selected",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a button in the toolbar of the media overview, which allows to upload media files without drag and drop.

#### Why?

Because it improves UX.