### PR TITLE
Fix accidental reload when tab is changed from dirty form

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,5 @@ jobs:
       - run: npm run flow
       - run: npm run styleguide:build
       - run: npm test -- --maxWorkers=4
-      - run: composer install --no-dev -q
+      - run: rm composer.json && composer require friendsofsymfony/jsrouting-bundle:^2.3 --no-interaction
       - run: npm run build

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,13 @@
 **/flow-typed/
 styleguide/
 **/build/admin/
+
+.circleci/
+.git/
+.github/
+bin/
+config/
+public/
+templates/
+tests/
+var/

--- a/.flowconfig
+++ b/.flowconfig
@@ -11,3 +11,13 @@ module.name_mapper='fos-jsrouting/router' -> 'empty/object'
 .*/node_modules/npmconf/.*
 .*/node_modules/stylelint/.*
 .*/vendor/symfony/.*
+
+.circleci/
+.git/
+.github/
+bin/
+config/
+public/
+templates/
+tests/
+var/

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,25 @@
 
 ## dev-develop
 
+### Router removeUpdateRouteHook
+
+**This change only affects you if you have used a 2.0.0 alpha release before**
+
+The `removeUpdateRouteHook` function from the `Router` was removed. If you want to remove hooks again, you can now use
+the disposer being returned from the `addUpdateRouteHook` function.
+
+```javascript
+// Before
+const hook = () => {};
+router.addUpdateRouteHook(hook);
+router.removeUpdateRouteHook(hook);
+
+// After
+const hook = () => {};
+const disposer = router.addUpdateRouteHook(hook);
+disposer();
+```
+
 ### Custom URL services
 
 The `CustomUrlController` delivering the API for custom urls doesn't take a locale as query parameter anymore, because

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "eslint-plugin-import": "^2.7.0",
         "eslint-plugin-react": "^7.6.1",
         "file-loader": "^1.1.11",
-        "flow-bin": "^0.86.0",
+        "flow-bin": "^0.97.0",
         "glob": "^7.1.2",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^23.0.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -72,6 +72,10 @@ export default class Selection extends React.Component<Props> {
         if (this.changeListDisposer) {
             this.changeListDisposer();
         }
+
+        if (this.listStore) {
+            this.listStore.destroy();
+        }
     }
 
     @computed get locale(): IObservableValue<string> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed, observable, toJS, reaction} from 'mobx';
+import {computed, observable, intercept, toJS, reaction} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import equal from 'fast-deep-equal';
 import List from '../../../containers/List';
@@ -19,6 +19,7 @@ const USER_SETTINGS_KEY = 'selection';
 export default class Selection extends React.Component<Props> {
     listStore: ?ListStore;
     changeListDisposer: ?() => *;
+    changeLocaleDisposer: ?() => *;
 
     constructor(props: Props) {
         super(props);
@@ -65,12 +66,24 @@ export default class Selection extends React.Component<Props> {
                 () => (this.listStore ? this.listStore.selectionIds : []),
                 this.handleListSelectionChange
             );
+
+            this.changeLocaleDisposer = intercept(this.locale, '', (change) => {
+                if (this.listStore) {
+                    this.listStore.sendRequestDisposer();
+                }
+
+                return change;
+            });
         }
     }
 
     componentWillUnmount() {
         if (this.changeListDisposer) {
             this.changeListDisposer();
+        }
+
+        if (this.changeLocaleDisposer) {
+            this.changeLocaleDisposer();
         }
 
         if (this.listStore) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -22,6 +22,7 @@ jest.mock('../../../List/stores/ListStore',
         this.initialSelectionIds = initialSelectionIds;
         this.dataLoading = true;
         this.destroy = jest.fn();
+        this.sendRequestDisposer = jest.fn();
 
         mockExtendObservable(this, {
             selectionIds: [],
@@ -369,7 +370,7 @@ test('Should throw an error if no "adapter" option is passed for overlay type in
     )).toThrowError(/"adapter"/);
 });
 
-test('Should call the disposer for list selections and ListStore if unmounted', () => {
+test('Should call the disposers for list selections and locale and ListStore if unmounted', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
     const fieldTypeOptions = {
         default_type: 'list',
@@ -390,13 +391,54 @@ test('Should call the disposer for list selections and ListStore if unmounted', 
     );
 
     const changeListDisposerSpy = jest.fn();
+    const changeLocaleDisposerSpy = jest.fn();
     selection.instance().changeListDisposer = changeListDisposerSpy;
+    selection.instance().changeLocaleDisposer = changeLocaleDisposerSpy;
     const listStoreDestroy = selection.instance().listStore.destroy;
 
     selection.unmount();
 
     expect(changeListDisposerSpy).toBeCalledWith();
+    expect(changeLocaleDisposerSpy).toBeCalledWith();
     expect(listStoreDestroy).toBeCalledWith();
+});
+
+test('Should call sendRequestDisposer to avoid extra request when locale is changed', () => {
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const fieldTypeOptions = {
+        default_type: 'list',
+        resource_key: 'snippets',
+        types: {
+            list: {
+                adapter: 'table',
+            },
+        },
+    };
+
+    const locale = observable.box('en');
+
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('pages', 1, {locale}),
+            'pages'
+        )
+    );
+
+    const selection = shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+        />
+    );
+
+    locale.set('de');
+
+    expect(selection.instance().listStore.sendRequestDisposer).toBeCalledWith();
 });
 
 test('Should pass props correctly to list component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -21,6 +21,7 @@ jest.mock('../../../List/stores/ListStore',
         this.locale = observableOptions.locale;
         this.initialSelectionIds = initialSelectionIds;
         this.dataLoading = true;
+        this.destroy = jest.fn();
 
         mockExtendObservable(this, {
             selectionIds: [],
@@ -368,7 +369,7 @@ test('Should throw an error if no "adapter" option is passed for overlay type in
     )).toThrowError(/"adapter"/);
 });
 
-test('Should call the disposer for list selections if unmounted', () => {
+test('Should call the disposer for list selections and ListStore if unmounted', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
     const fieldTypeOptions = {
         default_type: 'list',
@@ -390,10 +391,12 @@ test('Should call the disposer for list selections if unmounted', () => {
 
     const changeListDisposerSpy = jest.fn();
     selection.instance().changeListDisposer = changeListDisposerSpy;
+    const listStoreDestroy = selection.instance().listStore.destroy;
 
     selection.unmount();
 
     expect(changeListDisposerSpy).toBeCalledWith();
+    expect(listStoreDestroy).toBeCalledWith();
 });
 
 test('Should pass props correctly to list component', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -162,14 +162,46 @@ the function that was called (`navigate`, `redirect` or `restore`). Each of thes
 result in the navigation not to happen. This way the application can e.g. stop the navigation process if some data is
 not saved yet (that's what it is used for in the [`Form`](#form) view).
 
+Note that the hooks have also to be removed with a reference to the function using the `removeUpdateRouteHook` function,
+if it is not needed anymore. Otherwise memory leaks and unexpected behavior can occur.
+
 ```javascript static
-router.addUpdateRouteHook((route, attributes, updateRouteMethod) => {
+function hook(route, attributes, updateRouteMethod) {
     if (route.name === 'test') {
         return false;
     }
 
     return true;
-});
+}
+
+router.addUpdateRouteHook(hook);
 
 router.navigate('test'); // This navigation will no happen because of the above hook
+
+router.removeUpdateRouteHook(hook);
+```
+
+Both of these functions also accept a second parameter, which is a number describing the priority of the hook. Hooks
+with a higher priority are executed first, and once a hook has cancelled the navigation hooks with a lower priority will
+not be executed at all.
+
+Note that the same priority has to be passed to both functions. This is necessary because the same hook could be
+registered multiple times.
+
+```javascript static
+function hook(route, attributes, updateRouteMethod) {
+    if (route.name === 'test') {
+        return false;
+    }
+
+    return true;
+}
+
+router.addUpdateRouteHook(hook, 1024);
+router.addUpdateRouteHook(hook, 512); // The second hook will not be executed, because the first one cancels navigation
+
+router.navigate('test'); // This navigation will no happen because of the above hook
+
+router.removeUpdateRouteHook(hook, 1024);
+router.addUpdateRouteHook(hook, 512);
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/README.md
@@ -162,7 +162,7 @@ the function that was called (`navigate`, `redirect` or `restore`). Each of thes
 result in the navigation not to happen. This way the application can e.g. stop the navigation process if some data is
 not saved yet (that's what it is used for in the [`Form`](#form) view).
 
-Note that the hooks have also to be removed with a reference to the function using the `removeUpdateRouteHook` function,
+Note that the hooks have also to be removed by calling the disposer function being returned from `addUpdateRouteHook` ,
 if it is not needed anymore. Otherwise memory leaks and unexpected behavior can occur.
 
 ```javascript static
@@ -174,19 +174,16 @@ function hook(route, attributes, updateRouteMethod) {
     return true;
 }
 
-router.addUpdateRouteHook(hook);
+const disposer = router.addUpdateRouteHook(hook);
 
 router.navigate('test'); // This navigation will no happen because of the above hook
 
-router.removeUpdateRouteHook(hook);
+disposer();
 ```
 
-Both of these functions also accept a second parameter, which is a number describing the priority of the hook. Hooks
-with a higher priority are executed first, and once a hook has cancelled the navigation hooks with a lower priority will
-not be executed at all.
-
-Note that the same priority has to be passed to both functions. This is necessary because the same hook could be
-registered multiple times.
+The `addUpdateRouteHook` functions also accept a second parameter, which is a number describing the priority of the
+hook. Hooks with a higher priority are executed first, and once a hook has cancelled the navigation hooks with a lower
+priority will not be executed at all.
 
 ```javascript static
 function hook(route, attributes, updateRouteMethod) {
@@ -201,7 +198,4 @@ router.addUpdateRouteHook(hook, 1024);
 router.addUpdateRouteHook(hook, 512); // The second hook will not be executed, because the first one cancels navigation
 
 router.navigate('test'); // This navigation will no happen because of the above hook
-
-router.removeUpdateRouteHook(hook, 1024);
-router.addUpdateRouteHook(hook, 512);
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -48,8 +48,6 @@ export default class Router {
     }
 
     @computed get sortedUpdateRouteHooks() {
-        // TODO Remove type casts with any when flow bug is fixed
-        // https://github.com/facebook/flow/issues/7652
         return Object.keys(this.updateRouteHooks)
             .sort((a, b) => ((b: any): number) - ((a: any): number))
             .reduce((sortedUpdateRouteHooks, priority) => {
@@ -67,17 +65,17 @@ export default class Router {
         }
 
         this.updateRouteHooks[priority].push(hook);
-    }
 
-    removeUpdateRouteHook(hook: UpdateRouteHook, priority: number = 0) {
-        const updateRouteHooksForPriority = this.updateRouteHooks[priority];
+        return () => {
+            const updateRouteHooksForPriority = this.updateRouteHooks[priority];
 
-        const hookIndex = updateRouteHooksForPriority.indexOf(hook);
-        if (hookIndex === -1) {
-            return;
-        }
+            const hookIndex = updateRouteHooksForPriority.indexOf(hook);
+            if (hookIndex === -1) {
+                return;
+            }
 
-        updateRouteHooksForPriority.splice(hookIndex, 1);
+            updateRouteHooksForPriority.splice(hookIndex, 1);
+        };
     }
 
     addUpdateAttributesHook(hook: UpdateAttributesHook) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -55,7 +55,7 @@ export default class Router {
             .reduce((sortedUpdateRouteHooks, priority) => {
                 sortedUpdateRouteHooks = [
                     ...sortedUpdateRouteHooks,
-                    ...this.updateRouteHooks[((priority: any): number)]
+                    ...this.updateRouteHooks[((priority: any): number)],
                 ];
                 return sortedUpdateRouteHooks;
             }, []);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -48,10 +48,15 @@ export default class Router {
     }
 
     @computed get sortedUpdateRouteHooks() {
+        // TODO Remove type casts with any when flow bug is fixed
+        // https://github.com/facebook/flow/issues/7652
         return Object.keys(this.updateRouteHooks)
-            .sort((a: number, b: number) => b - a)
+            .sort((a, b) => ((b: any): number) - ((a: any): number))
             .reduce((sortedUpdateRouteHooks, priority) => {
-                sortedUpdateRouteHooks = [...sortedUpdateRouteHooks, ...this.updateRouteHooks[priority]];
+                sortedUpdateRouteHooks = [
+                    ...sortedUpdateRouteHooks,
+                    ...this.updateRouteHooks[((priority: any): number)]
+                ];
                 return sortedUpdateRouteHooks;
             }, []);
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -14,7 +14,7 @@ export default class Router {
     @observable bindings: Map<string, IObservableValue<*>> = new Map();
     bindingDefaults: Map<string, ?string | number | boolean> = new Map();
     attributesHistory: {[string]: Array<AttributeMap>} = {};
-    updateRouteHooks: Array<UpdateRouteHook> = [];
+    updateRouteHooks: {[priority: number]: Array<UpdateRouteHook>} = {};
     updateAttributesHooks: Array<UpdateAttributesHook> = [];
     redirectFlag: boolean = false;
 
@@ -40,24 +40,39 @@ export default class Router {
         });
 
         window.addEventListener('beforeunload', (event) => {
-            if (this.updateRouteHooks.some((updateRouteHook) => updateRouteHook() === false)) {
+            if (this.sortedUpdateRouteHooks.some((updateRouteHook) => updateRouteHook() === false)) {
                 event.preventDefault();
                 event.returnValue = true;
             }
         });
     }
 
-    addUpdateRouteHook(hook: UpdateRouteHook) {
-        this.updateRouteHooks.push(hook);
+    @computed get sortedUpdateRouteHooks() {
+        return Object.keys(this.updateRouteHooks)
+            .sort((a: number, b: number) => b - a)
+            .reduce((sortedUpdateRouteHooks, priority) => {
+                sortedUpdateRouteHooks = [...sortedUpdateRouteHooks, ...this.updateRouteHooks[priority]];
+                return sortedUpdateRouteHooks;
+            }, []);
     }
 
-    removeUpdateRouteHook(hook: UpdateRouteHook) {
-        const hookIndex = this.updateRouteHooks.indexOf(hook);
+    addUpdateRouteHook(hook: UpdateRouteHook, priority: number = 0) {
+        if (!this.updateRouteHooks[priority]) {
+            this.updateRouteHooks[priority] = [];
+        }
+
+        this.updateRouteHooks[priority].push(hook);
+    }
+
+    removeUpdateRouteHook(hook: UpdateRouteHook, priority: number = 0) {
+        const updateRouteHooksForPriority = this.updateRouteHooks[priority];
+
+        const hookIndex = updateRouteHooksForPriority.indexOf(hook);
         if (hookIndex === -1) {
             return;
         }
 
-        this.updateRouteHooks.splice(hookIndex, 1);
+        updateRouteHooksForPriority.splice(hookIndex, 1);
     }
 
     addUpdateAttributesHook(hook: UpdateAttributesHook) {
@@ -171,7 +186,7 @@ export default class Router {
             updatedAttributes[key] = attributeDefaults[key];
         });
 
-        for (const updateRouteHook of this.updateRouteHooks) {
+        for (const updateRouteHook of this.sortedUpdateRouteHooks) {
             if (!updateRouteHook(route, updatedAttributes, updateRouteMethod)) {
                 return;
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/Router.test.js
@@ -1165,14 +1165,14 @@ test('Add and remove updateRouteHooks', () => {
     const updateRouteHook1 = jest.fn();
     const updateRouteHook2 = jest.fn();
 
-    router.addUpdateRouteHook(updateRouteHook1);
+    const updateRouteHookDisposer1 = router.addUpdateRouteHook(updateRouteHook1);
     router.addUpdateRouteHook(updateRouteHook2);
 
     expect(router.updateRouteHooks[0]).toHaveLength(2);
     expect(router.updateRouteHooks[0][0]).toBe(updateRouteHook1);
     expect(router.updateRouteHooks[0][1]).toBe(updateRouteHook2);
 
-    router.removeUpdateRouteHook(updateRouteHook1);
+    updateRouteHookDisposer1();
     expect(router.updateRouteHooks[0]).toHaveLength(1);
     expect(router.updateRouteHooks[0][0]).toBe(updateRouteHook2);
 });
@@ -1184,7 +1184,7 @@ test('Add and remove updateRouteHooks with different priorities', () => {
     const updateRouteHook1 = jest.fn();
     const updateRouteHook2 = jest.fn();
 
-    router.addUpdateRouteHook(updateRouteHook1, 1024);
+    const updateRouteHookDisposer1 = router.addUpdateRouteHook(updateRouteHook1, 1024);
     router.addUpdateRouteHook(updateRouteHook2, 512);
 
     expect(router.updateRouteHooks[1024]).toHaveLength(1);
@@ -1192,7 +1192,7 @@ test('Add and remove updateRouteHooks with different priorities', () => {
     expect(router.updateRouteHooks[512]).toHaveLength(1);
     expect(router.updateRouteHooks[512][0]).toBe(updateRouteHook2);
 
-    router.removeUpdateRouteHook(updateRouteHook1, 1024);
+    updateRouteHookDisposer1();
     expect(router.updateRouteHooks[1024]).toHaveLength(0);
     expect(router.updateRouteHooks[512]).toHaveLength(1);
     expect(router.updateRouteHooks[512][0]).toBe(updateRouteHook2);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -21,6 +21,8 @@ type Props = ViewProps & {
     resourceStore: ResourceStore,
 };
 
+const FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY = 1024;
+
 @observer
 class Form extends React.Component<Props> {
     resourceStore: ResourceStore;
@@ -112,7 +114,10 @@ class Form extends React.Component<Props> {
             router.bind('locale', this.resourceStore.locale);
         }
 
-        router.addUpdateRouteHook(this.checkFormStoreDirtyStateBeforeNavigation);
+        router.addUpdateRouteHook(
+            this.checkFormStoreDirtyStateBeforeNavigation,
+            FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY
+        );
     }
 
     @action checkFormStoreDirtyStateBeforeNavigation = (
@@ -198,7 +203,10 @@ class Form extends React.Component<Props> {
 
     componentWillUnmount() {
         const {router} = this.props;
-        router.removeUpdateRouteHook(this.checkFormStoreDirtyStateBeforeNavigation);
+        router.removeUpdateRouteHook(
+            this.checkFormStoreDirtyStateBeforeNavigation,
+            FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY
+        );
 
         this.resourceFormStore.destroy();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -35,6 +35,7 @@ class Form extends React.Component<Props> {
     postponedUpdateRouteMethod: ?UpdateRouteMethod;
     postponedRoute: ?Route;
     postponedRouteAttributes: ?AttributeMap;
+    checkFormStoreDirtyStateBeforeNavigationDisposer: () => void;
 
     @computed get hasOwnResourceStore() {
         const {
@@ -114,7 +115,7 @@ class Form extends React.Component<Props> {
             router.bind('locale', this.resourceStore.locale);
         }
 
-        router.addUpdateRouteHook(
+        this.checkFormStoreDirtyStateBeforeNavigationDisposer = router.addUpdateRouteHook(
             this.checkFormStoreDirtyStateBeforeNavigation,
             FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY
         );
@@ -202,11 +203,7 @@ class Form extends React.Component<Props> {
     }
 
     componentWillUnmount() {
-        const {router} = this.props;
-        router.removeUpdateRouteHook(
-            this.checkFormStoreDirtyStateBeforeNavigation,
-            FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY
-        );
+        this.checkFormStoreDirtyStateBeforeNavigationDisposer();
 
         this.resourceFormStore.destroy();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1477,20 +1477,44 @@ test('Should not bind the locale if no locales have been passed via options', ()
         addUpdateRouteHook: jest.fn(),
         attributes: {},
         bind: jest.fn(),
-        unbind: jest.fn(),
+        removeUpdateRouteHook: jest.fn(),
+        route,
+    };
+
+    mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    expect(router.bind).not.toBeCalled();
+});
+
+test('Should add and remove the UpdateRouteHook on mounting and unmounting', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
+
+    const route = {
+        options: {
+            formKey: 'snippets',
+            resourceKey: 'snippets',
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {},
+        bind: jest.fn(),
         removeUpdateRouteHook: jest.fn(),
         route,
     };
 
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
 
-    expect(router.bind).not.toBeCalled();
-
     const checkFormStoreDirtyStateBeforeNavigation = form.instance().checkFormStoreDirtyStateBeforeNavigation;
 
+    expect(router.addUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation, 1024);
+    expect(router.removeUpdateRouteHook).not.toBeCalled();
+
     form.unmount();
-    expect(router.unbind).not.toBeCalled();
-    expect(router.removeUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation);
+    expect(router.removeUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation, 1024);
 });
 
 test('Should throw an error if the resourceStore is not passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1418,9 +1418,9 @@ test('Should destroy the store on unmount', () => {
         attributes: {},
         bind: jest.fn(),
         route,
-        removeUpdateRouteHook: jest.fn(),
     };
 
+    router.addUpdateRouteHook.mockImplementationOnce(() => jest.fn());
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
     const locale = form.find('Form').at(1).prop('store').locale;
 
@@ -1451,8 +1451,9 @@ test('Should destroy the own resourceStore if existing on unmount', () => {
         addUpdateRouteHook: jest.fn(),
         attributes: {},
         route,
-        removeUpdateRouteHook: jest.fn(),
     };
+
+    router.addUpdateRouteHook.mockImplementationOnce(() => jest.fn());
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
     const formResourceStore = form.instance().resourceStore;
     formResourceStore.destroy = jest.fn();
@@ -1477,7 +1478,6 @@ test('Should not bind the locale if no locales have been passed via options', ()
         addUpdateRouteHook: jest.fn(),
         attributes: {},
         bind: jest.fn(),
-        removeUpdateRouteHook: jest.fn(),
         route,
     };
 
@@ -1502,19 +1502,20 @@ test('Should add and remove the UpdateRouteHook on mounting and unmounting', () 
         addUpdateRouteHook: jest.fn(),
         attributes: {},
         bind: jest.fn(),
-        removeUpdateRouteHook: jest.fn(),
         route,
     };
 
+    const checkFormStoreDirtyStateBeforeNavigationDisposerSpy = jest.fn();
+    router.addUpdateRouteHook.mockImplementationOnce(() => checkFormStoreDirtyStateBeforeNavigationDisposerSpy);
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
 
     const checkFormStoreDirtyStateBeforeNavigation = form.instance().checkFormStoreDirtyStateBeforeNavigation;
 
     expect(router.addUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation, 1024);
-    expect(router.removeUpdateRouteHook).not.toBeCalled();
+    expect(checkFormStoreDirtyStateBeforeNavigationDisposerSpy).not.toBeCalledWith();
 
     form.unmount();
-    expect(router.removeUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation, 1024);
+    expect(checkFormStoreDirtyStateBeforeNavigationDisposerSpy).toBeCalledWith();
 });
 
 test('Should throw an error if the resourceStore is not passed', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -52,7 +52,7 @@ export default class ResourceTabs extends React.Component<Props> {
     reloadResourceStoreOnRouteChange = (route: ?Route) => {
         const {router, route: viewRoute} = this.props;
 
-        if (router.route === viewRoute) {
+        if (router.route === viewRoute || router.route === route) {
             return true;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -18,6 +18,7 @@ type Props = ViewProps & {
 @observer
 export default class ResourceTabs extends React.Component<Props> {
     resourceStore: ResourceStore;
+    reloadResourceStoreOnRouteChangeDisposer: () => void;
 
     constructor(props: Props) {
         super(props);
@@ -46,7 +47,9 @@ export default class ResourceTabs extends React.Component<Props> {
 
         this.resourceStore = new ResourceStore(resourceKey, id, options);
 
-        router.addUpdateRouteHook(this.reloadResourceStoreOnRouteChange);
+        this.reloadResourceStoreOnRouteChangeDisposer = router.addUpdateRouteHook(
+            this.reloadResourceStoreOnRouteChange
+        );
     }
 
     reloadResourceStoreOnRouteChange = (route: ?Route) => {
@@ -64,10 +67,8 @@ export default class ResourceTabs extends React.Component<Props> {
     };
 
     componentWillUnmount() {
-        const {router} = this.props;
-
         this.resourceStore.destroy();
-        router.removeUpdateRouteHook(this.reloadResourceStoreOnRouteChange);
+        this.reloadResourceStoreOnRouteChangeDisposer();
     }
 
     @computed get locales() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -1213,9 +1213,9 @@ test('Should create a ResourceStore on mount and destroy it on unmount', () => {
         attributes: {
             id: 5,
         },
-        removeUpdateRouteHook: jest.fn(),
     };
 
+    router.addUpdateRouteHook.mockImplementationOnce(() => jest.fn());
     const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => null}</ResourceTabs>);
     const resourceStoreConstructorCall = ResourceStore.mock.calls;
     expect(resourceStoreConstructorCall[0][0]).toEqual('snippets');
@@ -1246,9 +1246,9 @@ test('Should create a ResourceStore with locale on mount if locales have been pa
         },
         bind: jest.fn(),
         route,
-        removeUpdateRouteHook: jest.fn(),
     };
 
+    router.addUpdateRouteHook.mockImplementationOnce(() => jest.fn());
     const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => null}</ResourceTabs>);
     const resourceStoreConstructorCall = ResourceStore.mock.calls;
     expect(resourceStoreConstructorCall[0][0]).toEqual('snippets');
@@ -1278,10 +1278,10 @@ test('Should create a ResourceStore with locale on mount if locales have been pa
             id: 5,
         },
         bind: jest.fn(),
-        removeUpdateRouteHook: jest.fn(),
         route,
     };
 
+    router.addUpdateRouteHook.mockImplementationOnce(() => jest.fn());
     const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => null}</ResourceTabs>);
     const resourceStoreConstructorCall = ResourceStore.mock.calls;
     expect(router.bind).toBeCalled();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js
@@ -938,6 +938,51 @@ test('Should reload ResourceStore if route is about to change to another child r
         name: 'route1',
         options: {},
     };
+    const childRoute2 = {
+        name: 'route2',
+        options: {},
+    };
+    const route = {
+        options: {
+            resourceKey: 'test',
+        },
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+    };
+
+    const attributes = {
+        attribute: 'value',
+    };
+
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes,
+        navigate: jest.fn(),
+        route: childRoute2,
+    };
+
+    const Child = () => (<h1>Child</h1>);
+    const resourceTabs = mount(<ResourceTabs route={route} router={router}>{() => (<Child />)}</ResourceTabs>);
+
+    router.addUpdateRouteHook.mock.calls[0][0](childRoute1);
+
+    expect(resourceTabs.instance().resourceStore.reload).toBeCalledWith();
+});
+
+test('Should not reload ResourceStore if route is about to change to same route', () => {
+    ResourceStore.mockImplementation(function() {
+        this.initialized = true;
+        this.load = jest.fn();
+        this.reload = jest.fn();
+        extendObservable(this, {data: {}});
+    });
+
+    const childRoute1 = {
+        name: 'route1',
+        options: {},
+    };
     const route = {
         options: {
             resourceKey: 'test',
@@ -963,10 +1008,10 @@ test('Should reload ResourceStore if route is about to change to another child r
 
     router.addUpdateRouteHook.mock.calls[0][0](childRoute1);
 
-    expect(resourceTabs.instance().resourceStore.reload).toBeCalledWith();
+    expect(resourceTabs.instance().resourceStore.reload).not.toBeCalledWith();
 });
 
-test('Should not reload ResourceStore if route is about to change to same route', () => {
+test('Should not reload ResourceStore if route is about to change to parent route', () => {
     ResourceStore.mockImplementation(function() {
         this.initialized = true;
         this.load = jest.fn();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/FocusPointOverlay.test.js
@@ -54,7 +54,7 @@ test('Should select the middle by default', () => {
         />
     );
 
-    focusPointOverlay.setProps({open: true})
+    focusPointOverlay.setProps({open: true});
 
     expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 1, y: 1});
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/FocusPointOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/FocusPointOverlay.test.js
@@ -17,6 +17,26 @@ jest.mock('sulu-admin-bundle/utils', () => ({
     translate: jest.fn((key) => key),
 }));
 
+test('Should not create a ResourceStore before overlay was opened', () => {
+    const resourceStore = new ResourceStore('media');
+    resourceStore.data = {
+        url: '/image.jpeg',
+        focusPointX: undefined,
+        focusPointY: undefined,
+    };
+
+    shallow(
+        <FocusPointOverlay
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={false}
+            resourceStore={resourceStore}
+        />
+    );
+
+    expect(resourceStore.clone).not.toBeCalled();
+});
+
 test('Should select the middle by default', () => {
     const resourceStore = new ResourceStore('media');
     resourceStore.data = {
@@ -33,6 +53,8 @@ test('Should select the middle by default', () => {
             resourceStore={resourceStore}
         />
     );
+
+    focusPointOverlay.setProps({open: true})
 
     expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 1, y: 1});
 });
@@ -54,14 +76,8 @@ test('Initialize with data from resourceStore when overlay opens', () => {
         />
     );
 
-    expect(focusPointOverlay.find('ImageFocusPoint').prop('image')).toEqual('/image.jpeg');
-    expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 2, y: 1});
-
     focusPointOverlay.instance().focusPointX = 0;
     focusPointOverlay.instance().focusPointY = 0;
-
-    focusPointOverlay.update();
-    expect(focusPointOverlay.find('ImageFocusPoint').prop('value')).toEqual({x: 0, y: 0});
 
     focusPointOverlay.setProps({open: true});
     focusPointOverlay.update();
@@ -81,7 +97,7 @@ test('Closing the overlay should call the onClose callback', () => {
         <FocusPointOverlay
             onClose={closeSpy}
             onConfirm={jest.fn()}
-            open={true}
+            open={false}
             resourceStore={resourceStore}
         />
     );
@@ -108,10 +124,12 @@ test('Should save the focus point when confirm button is clicked', () => {
         <FocusPointOverlay
             onClose={jest.fn()}
             onConfirm={confirmSpy}
-            open={true}
+            open={false}
             resourceStore={resourceStore}
         />
     );
+
+    focusPointOverlay.setProps({open: true});
 
     expect(focusPointOverlay.find('Overlay').prop('confirmDisabled')).toEqual(true);
     focusPointOverlay.find('ImageFocusPoint').prop('onChange')({x: 0, y: 2});

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/WebspaceTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/WebspaceTabs.js
@@ -21,6 +21,7 @@ export default class WebspaceTabs extends React.Component<ViewProps> {
     @observable webspaces: ?Array<Webspace>;
     webspaceKey: IObservableValue<string> = observable.box();
     webspaceDisposer: () => void;
+    bindWebspaceToRouterDisposer: () => void;
 
     static getDerivedRouteAttributes(route: Route, attributes: AttributeMap) {
         const webspace = attributes.webspace
@@ -57,13 +58,11 @@ export default class WebspaceTabs extends React.Component<ViewProps> {
             return change;
         });
 
-        router.addUpdateRouteHook(this.bindWebspaceToRouter);
+        this.bindWebspaceToRouterDisposer = router.addUpdateRouteHook(this.bindWebspaceToRouter);
     }
 
     componentWillUnmount() {
-        const {router} = this.props;
-        router.removeUpdateRouteHook(this.bindWebspaceToRouter);
-
+        this.bindWebspaceToRouterDisposer();
         this.webspaceDisposer();
     }
 

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/tests/WebspaceTabs.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/tests/WebspaceTabs.test.js
@@ -9,7 +9,6 @@ import webspaceStore from '../../../stores/WebspaceStore';
 jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function() {
     this.addUpdateRouteHook = jest.fn();
     this.bind = jest.fn();
-    this.removeUpdateRouteHook = jest.fn();
 }));
 
 jest.mock('../../../stores/WebspaceStore', () => ({
@@ -99,18 +98,19 @@ test('Should bind and unbind router attributes and updateRouteHook', () => {
         view: 'webspace_tabs',
     };
 
+    const bindWebspaceToRouterDisposerSpy = jest.fn();
+    router.addUpdateRouteHook.mockImplementationOnce(() => bindWebspaceToRouterDisposerSpy);
     const webspaceTabs = mount(<WebspaceTabs route={route} router={router}>{() => null}</WebspaceTabs>);
 
     expect(router.bind).toBeCalledWith('webspace', webspaceTabs.instance().webspaceKey);
     expect(router.addUpdateRouteHook).toBeCalledWith(webspaceTabs.instance().bindWebspaceToRouter);
 
-    const bindWebspaceToRouter = webspaceTabs.instance().bindWebspaceToRouter;
     const webspaceDisposer = jest.fn();
 
     webspaceTabs.instance().webspaceDisposer = webspaceDisposer;
 
     webspaceTabs.unmount();
-    expect(router.removeUpdateRouteHook).toBeCalledWith(bindWebspaceToRouter);
+    expect(bindWebspaceToRouterDisposerSpy).toBeCalledWith();
     expect(webspaceDisposer).toBeCalledWith();
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a priority on the `UpdateRouteHook`s.

#### Why?

Because this gives us more control on when to cancel the navigation, and let other hooks not be executed at all. This is required, because the `ResourceStore` was reloaded before the confirmation dialog was confirmed when the tab is changed in a dirty form. This already resulted in data loss, and a second change of the tab is not caught anymore.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [x] Check flow errors
