### PR TITLE
Disallow interactions with static elements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
         "babel",
         "import",
         "react",
-        "flowtype"
+        "flowtype",
+        "jsx-a11y"
     ],
     "rules": {
         "indent": [
@@ -200,6 +201,7 @@
             "always-multiline"
         ],
         "flowtype/sort-keys": "error",
-        "babel/semi": "error"
+        "babel/semi": "error",
+        "jsx-a11y/no-static-element-interactions": "error"
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "eslint-plugin-babel": "^4.1.2",
         "eslint-plugin-flowtype": "^2.41.1",
         "eslint-plugin-import": "^2.7.0",
+        "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-react": "^7.6.1",
         "file-loader": "^3.0.1",
         "flow-bin": "^0.98.0",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/Backdrop.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/Backdrop.js
@@ -41,7 +41,7 @@ export default class Backdrop extends React.PureComponent<Props> {
                 [backdropStyles.fixed]: fixed,
             }
         );
-        const backdrop = <div className={backdropClass} onClick={this.handleClick} />;
+        const backdrop = <div className={backdropClass} onClick={this.handleClick} role="button" />;
 
         if (!open) {
             return null;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/__snapshots__/Backdrop.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Backdrop/tests/__snapshots__/Backdrop.test.js.snap
@@ -4,12 +4,13 @@ exports[`The component should not render local when closed 1`] = `null`;
 
 exports[`The component should render in body when open 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>"
 `;
 
 exports[`The component should render normally when local property is set 1`] = `
 <div
   class="backdrop visible fixed"
+  role="button"
 />
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/tests/__snapshots__/ColorPicker.test.js.snap
@@ -129,7 +129,7 @@ exports[`ColorPicker should render when disabled 1`] = `
 
 exports[`ColorPicker should render with open overlay 1`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Column.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Column.js
@@ -60,7 +60,7 @@ export default class Column extends React.Component<Props> {
         );
 
         return (
-            <div className={columnClass} onMouseEnter={this.handleMouseEnter}>
+            <div className={columnClass} onMouseEnter={this.handleMouseEnter} role="button">
                 {loading ?
                     <div className={columnStyles.loader}>
                         <Loader />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarButton.js
@@ -23,9 +23,9 @@ export default class ToolbarButton extends React.Component<ToolbarButtonProps> {
         );
 
         return (
-            <a className={className} onClick={this.handleClick}>
+            <button className={className} onClick={this.handleClick}>
                 <Icon name={icon} />
-            </a>
+            </button>
         );
     };
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
@@ -32,10 +32,10 @@ class ToolbarDropdown extends React.Component<ToolbarDropdownProps> {
             toolbarStyles[skin]
         );
         return (
-            <a className={className} onClick={this.handleClick}>
+            <button className={className} onClick={this.handleClick}>
                 <Icon name={icon} />
                 <Icon className={toolbarDropdownStyles.buttonArrowIcon} name="su-angle-down" />
-            </a>
+            </button>
         );
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdownList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdownList.js
@@ -45,11 +45,11 @@ export default class ToolbarDropdownList extends React.Component<Props> {
         );
 
         return (
-            <div className={toolbarDropdownStyles.listContainer} onClick={onClick}>
+            <button className={toolbarDropdownStyles.listContainer} onClick={onClick}>
                 <ul className={className}>
                     {this.renderOptions()}
                 </ul>
-            </div>
+            </button>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Toolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/Toolbar.test.js
@@ -44,7 +44,7 @@ test('Should render with active', () => {
 
     // check for opened dropdown in body
     expect(body.innerHTML).toBe('');
-    toolbar.find(ToolbarDropdown).find('a').simulate('click');
+    toolbar.find(ToolbarDropdown).find('button').simulate('click');
     expect(pretty(body.innerHTML)).toMatchSnapshot();
 });
 
@@ -69,7 +69,7 @@ test('Should close dropdown when item is clicked', () => {
     const toolbar = mount(<Toolbar toolbarItems={toolbarItems} />);
 
     expect(toolbar.find('ToolbarDropdown').find('Action')).toHaveLength(0);
-    toolbar.find(ToolbarDropdown).find('a').simulate('click');
+    toolbar.find(ToolbarDropdown).find('button').simulate('click');
     expect(toolbar.find('ToolbarDropdown').find('Action')).toHaveLength(2);
 
     toolbar.find('ToolbarDropdown Action[children="Option1"]').simulate('click');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Column.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Column.test.js.snap
@@ -3,5 +3,6 @@
 exports[`Should render column with toolbar 1`] = `
 <div
   class="column"
+  role="button"
 />
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
@@ -11,23 +11,23 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
     <div
       class="toolbar"
     >
-      <a
+      <button
         class="item primary"
       >
         <span
           aria-label="fa-plus"
           class="fa fa-plus"
         />
-      </a>
-      <a
+      </button>
+      <button
         class="item primary"
       >
         <span
           aria-label="fa-search"
           class="fa fa-search"
         />
-      </a>
-      <a
+      </button>
+      <button
         class="item primary"
       >
         <span
@@ -38,7 +38,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
           aria-label="su-angle-down"
           class="su-angle-down buttonArrowIcon"
         />
-      </a>
+      </button>
     </div>
   </div>
   <div
@@ -49,6 +49,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
     >
       <div
         class="column"
+        role="button"
       >
         <div
           class="item selected"
@@ -204,6 +205,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
       </div>
       <div
         class="column"
+        role="button"
       >
         <div
           class="item"
@@ -319,6 +321,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
       </div>
       <div
         class="column"
+        role="button"
       >
         <div
           class="item"
@@ -429,6 +432,7 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
       </div>
       <div
         class="column"
+        role="button"
       >
         <div
           class="loader"
@@ -462,14 +466,14 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
     <div
       class="toolbar"
     >
-      <a
+      <button
         class="item primary"
       >
         <span
           aria-label="fa-plus"
           class="fa fa-plus"
         />
-      </a>
+      </button>
     </div>
   </div>
   <div
@@ -480,6 +484,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
     >
       <div
         class="column scrolling"
+        role="button"
       >
         <div
           class="item selected"
@@ -609,6 +614,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
       </div>
       <div
         class="column scrolling"
+        role="button"
       >
         <div
           class="item"
@@ -698,6 +704,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
       </div>
       <div
         class="column scrolling"
+        role="button"
       >
         <div
           class="item"
@@ -782,6 +789,7 @@ exports[`The ColumnList component should render in a scrolling container 1`] = `
       </div>
       <div
         class="column scrolling"
+        role="button"
       >
         <div
           class="loader"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/Toolbar.test.js.snap
@@ -4,15 +4,15 @@ exports[`Should render with active 1`] = `
 <div
   class="toolbar"
 >
-  <a
+  <button
     class="item primary"
   >
     <span
       aria-label="fa-plus"
       class="fa fa-plus"
     />
-  </a>
-  <a
+  </button>
+  <button
     class="item primary"
   >
     <span
@@ -23,13 +23,13 @@ exports[`Should render with active 1`] = `
       aria-label="su-angle-down"
       class="su-angle-down buttonArrowIcon"
     />
-  </a>
+  </button>
 </div>
 `;
 
 exports[`Should render with active 2`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/toolbar.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/toolbar.scss
@@ -4,6 +4,9 @@
 $itemBackgroundColorPrimary: $silver;
 $itemBackgroundColorSecondary: $shakespeare;
 
+$itemPrimaryColor: $black;
+$itemSecondaryColor: $white;
+
 $borderRadius: 3px;
 $dropdownContainerBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
 
@@ -21,6 +24,7 @@ $dropdownContainerBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
     padding: 5px 0;
     cursor: pointer;
     margin-left: 1px;
+    border: 0;
 
     &:first-child {
         border-top-left-radius: $borderRadius;
@@ -33,10 +37,11 @@ $dropdownContainerBoxShadow: 2px 6px 12px 0 rgba($silver, .22);
 
     &.primary {
         background: $itemBackgroundColorPrimary;
+        color: $itemPrimaryColor;
     }
 
     &.secondary {
         background: $itemBackgroundColorSecondary;
-        color: $white;
+        color: $itemSecondaryColor;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -4,7 +4,7 @@ exports[`The component should not render in body when closed 1`] = `null`;
 
 exports[`The component should render in body when open 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"dialogContainer open\\">
@@ -23,7 +23,7 @@ exports[`The component should render in body when open 1`] = `
 
 exports[`The component should render in body with a large class 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"dialogContainer open\\">
@@ -42,7 +42,7 @@ exports[`The component should render in body with a large class 1`] = `
 
 exports[`The component should render in body with disabled confirm button 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"dialogContainer open\\">
@@ -61,7 +61,7 @@ exports[`The component should render in body with disabled confirm button 1`] = 
 
 exports[`The component should render in body with loader instead of confirm button 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"dialogContainer open\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/__snapshots__/ImageRectangleSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/__snapshots__/ImageRectangleSelection.test.js.snap
@@ -11,10 +11,12 @@ exports[`The component should calculate the selection with respect to the image 
   />
   <div
     class="rectangle"
+    role="button"
     style="left: 0px; top: 0px; width: 640px; height: 360px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"
@@ -35,10 +37,12 @@ exports[`The component should render with image source 1`] = `
   />
   <div
     class="rectangle"
+    role="button"
     style="left: 0px; top: 0px; width: 640px; height: 360px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"
@@ -59,10 +63,12 @@ exports[`The component should render with initial selection 1`] = `
   />
   <div
     class="rectangle"
+    role="button"
     style="left: 100px; top: 66.66666666666667px; width: 500px; height: 266.6666666666667px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/tests/__snapshots__/MultiAutoComplete.test.js.snap
@@ -81,7 +81,7 @@ exports[`MultiAutoComplete should render in disabled state 1`] = `
 
 exports[`Render the MultiAutoComplete with open suggestions list 1`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -91,9 +91,9 @@ class Navigation extends React.Component<Props> {
         }
 
         return (
-            <div className={navigationStyles.noUserImage} onClick={onProfileClick}>
+            <button className={navigationStyles.noUserImage} onClick={onProfileClick}>
                 <Icon name="fa-user" />
-            </div>
+            </button>
         );
     }
 
@@ -147,8 +147,14 @@ class Navigation extends React.Component<Props> {
                     <div className={navigationStyles.userContent}>
                         {this.renderUserImage()}
                         <div className={navigationStyles.userProfile}>
-                            <span onClick={onProfileClick}>{username}</span>
-                            <button onClick={onLogoutClick}><Icon name="su-exit" />Log out</button>
+                            <button className={navigationStyles.username} onClick={onProfileClick}>{username}</button>
+                            <button
+                                className={navigationStyles.logout}
+                                onClick={onLogoutClick}
+                            >
+                                <Icon name="su-exit" />
+                                Log out
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/navigation.scss
@@ -71,6 +71,8 @@ $pinBorderColor: $shakespeare;
 
     .no-user-image {
         background-color: $silver;
+        color: $color;
+        border: 0;
 
         span {
             font-size: 30px;
@@ -85,16 +87,24 @@ $pinBorderColor: $shakespeare;
 
 .user-profile {
     margin-left: 20px;
-    font-weight: 600;
-    cursor: pointer;
+
+    .username {
+        color: $color;
+        font-size: 14px;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .logout {
+        font-size: 12px;
+        color: $buttonColor;
+        line-height: 16px;
+        margin-top: 10px;
+    }
 
     button {
         background: none;
-        font-size: 12px;
-        line-height: 16px;
-        color: $buttonColor;
         border: none;
-        margin-top: 10px;
         padding: 0;
         cursor: pointer;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
@@ -23,11 +23,11 @@ test('The component should render and handle clicks correctly', () => {
     );
     expect(navigation.render()).toMatchSnapshot();
 
-    navigation.find('.userProfile button').simulate('click');
+    navigation.find('.userProfile button').at(1).simulate('click');
     expect(handleLogoutClick).toBeCalled();
 
     navigation.find('.noUserImage').simulate('click');
-    navigation.find('.userProfile span').at(0).simulate('click');
+    navigation.find('.userProfile button').at(0).simulate('click');
     expect(handleProfileClick).toHaveBeenCalledTimes(2);
 });
 
@@ -75,14 +75,14 @@ test('The component should render with all available props and handle clicks cor
     );
     expect(navigation.render()).toMatchSnapshot();
 
-    navigation.find('.userProfile button').simulate('click');
+    navigation.find('.userProfile button').at(1).simulate('click');
     expect(handleLogoutClick).toBeCalled();
 
     navigation.find('button.pin').simulate('click');
     expect(handlePinClick).toBeCalled();
 
     navigation.find('.userContent img').simulate('click');
-    navigation.find('.userProfile span').at(0).simulate('click');
+    navigation.find('.userProfile button').at(0).simulate('click');
     expect(handleProfileClick).toHaveBeenCalledTimes(2);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -27,21 +27,25 @@ exports[`The component should render and handle clicks correctly 1`] = `
     <div
       class="userContent"
     >
-      <div
+      <button
         class="noUserImage"
       >
         <span
           aria-label="fa-user"
           class="fa fa-user"
         />
-      </div>
+      </button>
       <div
         class="userProfile"
       >
-        <span>
+        <button
+          class="username"
+        >
           John Terence Maximilian Travolta
-        </span>
-        <button>
+        </button>
+        <button
+          class="logout"
+        >
           <span
             aria-label="su-exit"
             class="su-exit"
@@ -139,10 +143,14 @@ exports[`The component should render with all available props and handle clicks 
       <div
         class="userProfile"
       >
-        <span>
+        <button
+          class="username"
+        >
           John Travolta
-        </span>
-        <button>
+        </button>
+        <button
+          class="logout"
+        >
           <span
             aria-label="su-exit"
             class="su-exit"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -4,7 +4,7 @@ exports[`The component should not render in body when closed 1`] = `null`;
 
 exports[`The component should render in body when open 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container isDown\\">
@@ -25,7 +25,7 @@ exports[`The component should render in body when open 1`] = `
 
 exports[`The component should render in body with actions when open 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container isDown\\">
@@ -48,7 +48,7 @@ exports[`The component should render in body with actions when open 1`] = `
 
 exports[`The component should render in body with loader instead of confirm button 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container isDown\\">
@@ -75,7 +75,7 @@ exports[`The component should render in body with loader instead of confirm butt
 
 exports[`The component should render with a disabled confirm button 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container isDown\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -4,7 +4,7 @@ exports[`The popover should not render in body when not open 1`] = `""`;
 
 exports[`The popover should render in body when open 1`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">
@@ -19,7 +19,7 @@ exports[`The popover should render in body when open 1`] = `
 
 exports[`The popover should take its dimensions from the positioner 1`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
@@ -107,11 +107,13 @@ class ModifiableRectangle extends React.Component<Props> {
                     className={modifiableRectangleStyles.rectangle}
                     onDoubleClick={this.handleDoubleClick}
                     onMouseDown={this.handleMoveMouseDown}
+                    role="button"
                     style={{left: left + 'px', top: top + 'px', width: width + 'px', height: height + 'px'}}
                 >
                     <div
                         className={modifiableRectangleStyles.resizeHandle}
                         onMouseDown={this.handleResizeMouseDown}
+                        role="slider"
                     />
                     <div
                         className={modifiableRectangleStyles.backdrop}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/__snapshots__/ModifiableRectangle.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/__snapshots__/ModifiableRectangle.test.js.snap
@@ -3,10 +3,12 @@
 exports[`The component should render 1`] = `
 <div
   class="rectangle"
+  role="button"
   style="left:0px;top:0px;width:200px;height:100px"
 >
   <div
     class="resizeHandle"
+    role="slider"
   />
   <div
     class="backdrop"
@@ -18,10 +20,12 @@ exports[`The component should render 1`] = `
 exports[`The component should render with correct positions 1`] = `
 <div
   class="rectangle"
+  role="button"
   style="left:10px;top:20px;width:200px;height:100px"
 >
   <div
     class="resizeHandle"
+    role="slider"
   />
   <div
     class="backdrop"
@@ -40,10 +44,12 @@ Array [
   </div>,
   <div
     class="rectangle"
+    role="button"
     style="left:0px;top:0px;width:200px;height:100px"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/__snapshots__/RectangleSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/tests/__snapshots__/RectangleSelection.test.js.snap
@@ -9,10 +9,12 @@ exports[`The component should center and maximize the selection when a minHeight
   </p>
   <div
     class="rectangle"
+    role="button"
     style="left: 0px; top: 250px; width: 2000px; height: 500px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"
@@ -31,10 +33,12 @@ exports[`The component should render with children 1`] = `
   </p>
   <div
     class="rectangle"
+    role="button"
     style="left:0px;top:0px;width:2000px;height:1000px"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"
@@ -59,10 +63,12 @@ exports[`The component should render with minimum size notification 1`] = `
   </div>
   <div
     class="rectangle"
+    role="button"
     style="left: 40px; top: 30px; width: 100px; height: 200px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"
@@ -81,10 +87,12 @@ exports[`The component should render with value as selection 1`] = `
   </p>
   <div
     class="rectangle"
+    role="button"
     style="left: 4px; top: 3px; width: 1px; height: 2px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"
@@ -103,10 +111,12 @@ exports[`The component should render without minimum size notification 1`] = `
   </p>
   <div
     class="rectangle"
+    role="button"
     style="left: 40px; top: 30px; width: 100px; height: 200px;"
   >
     <div
       class="resizeHandle"
+      role="slider"
     />
     <div
       class="backdrop"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -87,7 +87,7 @@ exports[`The component should open the popover when the display value is clicked
 
 exports[`The component should open the popover when the display value is clicked 2`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -27,7 +27,7 @@ exports[`Render the SingleAutoComplete with open suggestions list 1`] = `
 
 exports[`Render the SingleAutoComplete with open suggestions list 2`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/Snackbar.js
@@ -35,7 +35,7 @@ export default class Snackbar extends React.Component<Props> {
         );
 
         return (
-            <div className={snackbarClass} onClick={onClick}>
+            <div className={snackbarClass} onClick={onClick} role="button">
                 <Icon className={snackbarStyles.icon} name={ICONS[type]} />
                 {type !== 'success' &&
                     <div className={snackbarStyles.text}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Render a clickable success snackbar 1`] = `
 <div
   class="snackbar success clickable visible"
+  role="button"
 >
   <span
     aria-label="su-check"
@@ -14,6 +15,7 @@ exports[`Render a clickable success snackbar 1`] = `
 exports[`Render a success snackbar 1`] = `
 <div
   class="snackbar success visible"
+  role="button"
 >
   <span
     aria-label="su-check"
@@ -25,6 +27,7 @@ exports[`Render a success snackbar 1`] = `
 exports[`Render an error snackbar 1`] = `
 <div
   class="snackbar error visible"
+  role="button"
 >
   <span
     aria-label="su-exclamation-triangle"
@@ -52,6 +55,7 @@ exports[`Render an error snackbar 1`] = `
 exports[`Render an error snackbar without close button 1`] = `
 <div
   class="snackbar error visible"
+  role="button"
 >
   <span
     aria-label="su-exclamation-triangle"
@@ -70,6 +74,7 @@ exports[`Render an error snackbar without close button 1`] = `
 exports[`Render an invisible success snackbar 1`] = `
 <div
   class="snackbar success"
+  role="button"
 >
   <span
     aria-label="su-check"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -72,6 +72,7 @@ exports[`Render with Snackbar 1`] = `
 >
   <div
     class="snackbar error visible"
+    role="button"
   >
     <span
       aria-label="su-exclamation-triangle"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/__snapshots__/Application.test.js.snap
@@ -33,21 +33,25 @@ exports[`Render based on current route 1`] = `
         <div
           class="userContent"
         >
-          <div
+          <button
             class="noUserImage"
           >
             <span
               aria-label="fa-user"
               class="fa fa-user"
             />
-          </div>
+          </button>
           <div
             class="userProfile"
           >
-            <span>
+            <button
+              class="username"
+            >
               Hikaru Sulu
-            </span>
-            <button>
+            </button>
+            <button
+              class="logout"
+            >
               <span
                 aria-label="su-exit"
                 class="su-exit"
@@ -104,6 +108,7 @@ exports[`Render based on current route 1`] = `
         >
           <div
             class="snackbar error"
+            role="button"
           >
             <span
               aria-label="su-exclamation-triangle"
@@ -128,6 +133,7 @@ exports[`Render based on current route 1`] = `
           </div>
           <div
             class="snackbar success clickable"
+            role="button"
           >
             <span
               aria-label="su-check"
@@ -201,21 +207,25 @@ exports[`Render based on current route with app version 1`] = `
         <div
           class="userContent"
         >
-          <div
+          <button
             class="noUserImage"
           >
             <span
               aria-label="fa-user"
               class="fa fa-user"
             />
-          </div>
+          </button>
           <div
             class="userProfile"
           >
-            <span>
+            <button
+              class="username"
+            >
               Hikaru Sulu
-            </span>
-            <button>
+            </button>
+            <button
+              class="logout"
+            >
               <span
                 aria-label="su-exit"
                 class="su-exit"
@@ -275,6 +285,7 @@ exports[`Render based on current route with app version 1`] = `
         >
           <div
             class="snackbar error"
+            role="button"
           >
             <span
               aria-label="su-exclamation-triangle"
@@ -299,6 +310,7 @@ exports[`Render based on current route with app version 1`] = `
           </div>
           <div
             class="snackbar success clickable"
+            role="button"
           >
             <span
               aria-label="su-check"
@@ -592,7 +604,7 @@ exports[`Render opened navigation 1`] = `
               <div
                 className="userContent"
               >
-                <div
+                <button
                   className="noUserImage"
                   onClick={[Function]}
                 >
@@ -604,16 +616,18 @@ exports[`Render opened navigation 1`] = `
                       className="fa fa-user"
                     />
                   </Icon>
-                </div>
+                </button>
                 <div
                   className="userProfile"
                 >
-                  <span
+                  <button
+                    className="username"
                     onClick={[Function]}
                   >
                     Hikaru Sulu
-                  </span>
+                  </button>
                   <button
+                    className="logout"
                     onClick={[Function]}
                   >
                     <Icon
@@ -699,6 +713,7 @@ exports[`Render opened navigation 1`] = `
         <div
           className="backdrop"
           onClick={[Function]}
+          role="button"
         />
       </Backdrop>
       <main
@@ -726,6 +741,7 @@ exports[`Render opened navigation 1`] = `
                 >
                   <div
                     className="snackbar error"
+                    role="button"
                   >
                     <Icon
                       className="icon"
@@ -770,6 +786,7 @@ exports[`Render opened navigation 1`] = `
                   <div
                     className="snackbar success clickable"
                     onClick={[Function]}
+                    role="button"
                   >
                     <Icon
                       className="icon"
@@ -903,21 +920,25 @@ exports[`Should not fail if current route does not exist 1`] = `
         <div
           class="userContent"
         >
-          <div
+          <button
             class="noUserImage"
           >
             <span
               aria-label="fa-user"
               class="fa fa-user"
             />
-          </div>
+          </button>
           <div
             class="userProfile"
           >
-            <span>
+            <button
+              class="username"
+            >
               Hikaru Sulu
-            </span>
-            <button>
+            </button>
+            <button
+              class="logout"
+            >
               <span
                 aria-label="su-exit"
                 class="su-exit"
@@ -974,6 +995,7 @@ exports[`Should not fail if current route does not exist 1`] = `
         >
           <div
             class="snackbar error"
+            role="button"
           >
             <span
               aria-label="su-exclamation-triangle"
@@ -998,6 +1020,7 @@ exports[`Should not fail if current route does not exist 1`] = `
           </div>
           <div
             class="snackbar success clickable"
+            role="button"
           >
             <span
               aria-label="su-check"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Should render a Dialog 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"dialogContainer open\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -362,7 +362,7 @@ test('Call onRequestItemOrder callback when an item ordering has been changed', 
         />
     );
 
-    columnListAdapter.find('Toolbar ToolbarDropdown a').simulate('click');
+    columnListAdapter.find('Toolbar ToolbarDropdown button').simulate('click');
     columnListAdapter.find('ToolbarDropdown').find('ArrowMenu Action[children="sulu_admin.order"]').prop('onClick')(0);
 
     columnListAdapter.update();
@@ -408,7 +408,7 @@ test('Do not execute onItemActivate callback when a column is ordering', () => {
         />
     );
 
-    columnListAdapter.find('Toolbar ToolbarDropdown a').simulate('click');
+    columnListAdapter.find('Toolbar ToolbarDropdown button').simulate('click');
     columnListAdapter.find('ToolbarDropdown').find('ArrowMenu Action[children="sulu_admin.order"]').prop('onClick')(0);
 
     columnListAdapter.find('Item').at(0).simulate('click');
@@ -485,7 +485,7 @@ test('Execute onRequestItemCopy callback when an item is copied with the correct
         />
     );
 
-    columnListAdapter.find('ToolbarDropdown a').simulate('click');
+    columnListAdapter.find('ToolbarDropdown button').simulate('click');
     columnListAdapter.find('ToolbarDropdown').find('ArrowMenu Action[children="sulu_admin.copy"]').simulate('click');
 
     expect(copyClickSpy).toBeCalledWith(3);
@@ -525,7 +525,7 @@ test('Execute onRequestItemMove callback when an item is moved with the correct 
         />
     );
 
-    columnListAdapter.find('ToolbarDropdown a').simulate('click');
+    columnListAdapter.find('ToolbarDropdown button').simulate('click');
     columnListAdapter.find('ToolbarDropdown').find('ArrowMenu Action[children="sulu_admin.move"]').simulate('click');
 
     expect(moveClickSpy).toBeCalledWith(3);
@@ -565,7 +565,7 @@ test('Execute onRequestItemDelete callback when an item is deleted with the corr
         />
     );
 
-    columnListAdapter.find('ToolbarDropdown a').simulate('click');
+    columnListAdapter.find('ToolbarDropdown button').simulate('click');
     columnListAdapter.find('ToolbarDropdown').find('ArrowMenu Action[children="sulu_admin.delete"]').simulate('click');
 
     expect(deleteClickSpy).toBeCalledWith(3);
@@ -605,9 +605,9 @@ test('Enable delete and move button if an item in this column has been activated
         />
     );
 
-    columnListAdapter.find('Toolbar ToolbarDropdown a').simulate('click');
-    expect(columnListAdapter.find('Toolbar ToolbarDropdown button').at(0).prop('disabled')).toEqual(false);
-    expect(columnListAdapter.find('Toolbar ToolbarDropdown button').at(1).prop('disabled')).toEqual(false);
+    columnListAdapter.find('Toolbar ToolbarDropdown button').simulate('click');
+    expect(columnListAdapter.find('Toolbar ToolbarDropdown Popover button').at(0).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar ToolbarDropdown Popover button').at(1).prop('disabled')).toEqual(false);
 });
 
 test('Disable delete and move button if no item in this column has been activated', () => {
@@ -644,9 +644,9 @@ test('Disable delete and move button if no item in this column has been activate
         />
     );
 
-    columnListAdapter.find('Toolbar ToolbarDropdown a').simulate('click');
-    expect(columnListAdapter.find('Toolbar ToolbarDropdown button').at(0).prop('disabled')).toEqual(true);
-    expect(columnListAdapter.find('Toolbar ToolbarDropdown button').at(1).prop('disabled')).toEqual(true);
+    columnListAdapter.find('Toolbar ToolbarDropdown button').simulate('click');
+    expect(columnListAdapter.find('Toolbar ToolbarDropdown Popover button').at(0).prop('disabled')).toEqual(true);
+    expect(columnListAdapter.find('Toolbar ToolbarDropdown Popover button').at(1).prop('disabled')).toEqual(true);
 });
 
 test('Do not show settings if no options are available', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -14,7 +14,7 @@ exports[`Render data with disabled items 1`] = `
       <div
         class="toolbar"
       >
-        <a
+        <button
           class="item primary"
         >
           <span
@@ -25,7 +25,7 @@ exports[`Render data with disabled items 1`] = `
             aria-label="su-angle-down"
             class="su-angle-down buttonArrowIcon"
           />
-        </a>
+        </button>
       </div>
     </div>
     <div
@@ -36,6 +36,7 @@ exports[`Render data with disabled items 1`] = `
       >
         <div
           class="column"
+          role="button"
         >
           <div
             class="item active selected"
@@ -95,6 +96,7 @@ exports[`Render data with disabled items 1`] = `
         </div>
         <div
           class="column"
+          role="button"
         >
           <div
             class="item active disabled"
@@ -149,6 +151,7 @@ exports[`Render data with disabled items 1`] = `
         </div>
         <div
           class="column"
+          role="button"
         />
       </div>
     </div>
@@ -170,7 +173,7 @@ exports[`Render data with loading column 1`] = `
       <div
         class="toolbar"
       >
-        <a
+        <button
           class="item primary"
         >
           <span
@@ -181,7 +184,7 @@ exports[`Render data with loading column 1`] = `
             aria-label="su-angle-down"
             class="su-angle-down buttonArrowIcon"
           />
-        </a>
+        </button>
       </div>
     </div>
     <div
@@ -192,6 +195,7 @@ exports[`Render data with loading column 1`] = `
       >
         <div
           class="column"
+          role="button"
         >
           <div
             class="item active"
@@ -287,6 +291,7 @@ exports[`Render data with loading column 1`] = `
         </div>
         <div
           class="column"
+          role="button"
         >
           <div
             class="loader"
@@ -325,6 +330,7 @@ exports[`Render data with name as fallback for title 1`] = `
       >
         <div
           class="column"
+          role="button"
         >
           <div
             class="item"
@@ -390,7 +396,7 @@ exports[`Render data with selection 1`] = `
       <div
         class="toolbar"
       >
-        <a
+        <button
           class="item primary"
         >
           <span
@@ -401,7 +407,7 @@ exports[`Render data with selection 1`] = `
             aria-label="su-angle-down"
             class="su-angle-down buttonArrowIcon"
           />
-        </a>
+        </button>
       </div>
     </div>
     <div
@@ -412,6 +418,7 @@ exports[`Render data with selection 1`] = `
       >
         <div
           class="column"
+          role="button"
         >
           <div
             class="item selected"
@@ -489,7 +496,7 @@ exports[`Render data without edit button 1`] = `
       <div
         class="toolbar"
       >
-        <a
+        <button
           class="item primary"
         >
           <span
@@ -500,7 +507,7 @@ exports[`Render data without edit button 1`] = `
             aria-label="su-angle-down"
             class="su-angle-down buttonArrowIcon"
           />
-        </a>
+        </button>
       </div>
     </div>
     <div
@@ -511,6 +518,7 @@ exports[`Render data without edit button 1`] = `
       >
         <div
           class="column"
+          role="button"
         >
           <div
             class="item"
@@ -581,15 +589,15 @@ exports[`Render different kind of data with edit button 1`] = `
       <div
         class="toolbar"
       >
-        <a
+        <button
           class="item primary"
         >
           <span
             aria-label="su-plus-circle"
             class="su-plus-circle"
           />
-        </a>
-        <a
+        </button>
+        <button
           class="item primary"
         >
           <span
@@ -600,7 +608,7 @@ exports[`Render different kind of data with edit button 1`] = `
             aria-label="su-angle-down"
             class="su-angle-down buttonArrowIcon"
           />
-        </a>
+        </button>
       </div>
     </div>
     <div
@@ -611,6 +619,7 @@ exports[`Render different kind of data with edit button 1`] = `
       >
         <div
           class="column"
+          role="button"
         >
           <div
             class="item"
@@ -851,6 +860,7 @@ exports[`Render different kind of data with edit button 1`] = `
         </div>
         <div
           class="column"
+          role="button"
         >
           <div
             class="item active"
@@ -1097,6 +1107,7 @@ exports[`Render different kind of data with edit button 1`] = `
         </div>
         <div
           class="column"
+          role="button"
         >
           <div
             class="item"
@@ -1218,6 +1229,7 @@ exports[`Render different kind of data with edit button 1`] = `
         </div>
         <div
           class="column"
+          role="button"
         />
       </div>
     </div>
@@ -1239,15 +1251,15 @@ exports[`Render with add button in toolbar when onItemAdd callback is given 1`] 
       <div
         class="toolbar"
       >
-        <a
+        <button
           class="item primary"
         >
           <span
             aria-label="su-plus-circle"
             class="su-plus-circle"
           />
-        </a>
-        <a
+        </button>
+        <button
           class="item primary"
         >
           <span
@@ -1258,7 +1270,7 @@ exports[`Render with add button in toolbar when onItemAdd callback is given 1`] 
             aria-label="su-angle-down"
             class="su-angle-down buttonArrowIcon"
           />
-        </a>
+        </button>
       </div>
     </div>
     <div
@@ -1269,6 +1281,7 @@ exports[`Render with add button in toolbar when onItemAdd callback is given 1`] 
       >
         <div
           class="column"
+          role="button"
         />
       </div>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -29,7 +29,7 @@ exports[`Render in disabled state 1`] = `
 
 exports[`Should open an overlay 1`] = `
 "<div>
-  <div class=\\"backdrop visible fixed\\"></div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -27,19 +27,23 @@ exports[`Should render navigation 1`] = `
     <div
       class="userContent"
     >
-      <div
+      <button
         class="noUserImage"
       >
         <span
           aria-label="fa-user"
           class="fa fa-user"
         />
-      </div>
+      </button>
       <div
         class="userProfile"
       >
-        <span />
-        <button>
+        <button
+          class="username"
+        />
+        <button
+          class="logout"
+        >
           <span
             aria-label="su-exit"
             class="su-exit"
@@ -177,19 +181,23 @@ exports[`Should render navigation without appVersion 1`] = `
     <div
       class="userContent"
     >
-      <div
+      <button
         class="noUserImage"
       >
         <span
           aria-label="fa-user"
           class="fa fa-user"
         />
-      </div>
+      </button>
       <div
         class="userProfile"
       >
-        <span />
-        <button>
+        <button
+          class="username"
+        />
+        <button
+          class="logout"
+        >
           <span
             aria-label="su-exit"
             class="su-exit"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
@@ -4,6 +4,7 @@ exports[`Show history routes in overlay 1`] = `
 Array [
   <div
     class="backdrop visible fixed"
+    role="button"
   />,
   <div
     class="container"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/__snapshots__/Toolbar.test.js.snap
@@ -6,6 +6,7 @@ exports[`Render the items and icons from the ToolbarStore 1`] = `
 >
   <div
     class="snackbar error"
+    role="button"
   >
     <span
       aria-label="su-exclamation-triangle"
@@ -30,6 +31,7 @@ exports[`Render the items and icons from the ToolbarStore 1`] = `
   </div>
   <div
     class="snackbar success"
+    role="button"
   >
     <span
       aria-label="su-check"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -13,6 +13,7 @@ Array [
   </div>,
   <div
     class="backdrop visible fixed"
+    role="button"
   />,
 ]
 `;
@@ -21,6 +22,7 @@ exports[`View should render with opened overlay 2`] = `
 Array [
   <div
     class="backdrop visible fixed"
+    role="button"
   />,
   <div
     class="container isDown"
@@ -48,6 +50,7 @@ Array [
           >
             <div
               class="snackbar error"
+              role="button"
             >
               <span
                 aria-label="su-exclamation-triangle"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -4,6 +4,7 @@ exports[`Render export dialog 1`] = `
 Array [
   <div
     class="backdrop visible fixed"
+    role="button"
   />,
   <div
     class="container"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -138,6 +138,7 @@ class MediaCard extends React.Component<Props> {
                     <div
                         className={mediaCardStyles.description}
                         onClick={this.handleHeaderClick}
+                        role="button"
                     >
                         <div className={mediaCardStyles.title}>
                             {onSelectionChange
@@ -182,6 +183,7 @@ class MediaCard extends React.Component<Props> {
                 <div
                     className={mediaCardStyles.media}
                     onClick={this.handleClick}
+                    role="button"
                 >
                     {image
                         ? <img alt={title} src={image} />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -9,6 +9,7 @@ exports[`Render a MediaCard component 1`] = `
   >
     <div
       class="description"
+      role="button"
     >
       <div
         class="title"
@@ -76,6 +77,7 @@ exports[`Render a MediaCard component 1`] = `
   </div>
   <div
     class="media"
+    role="button"
   >
     <img
       alt="Test"
@@ -97,6 +99,7 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
   >
     <div
       class="description"
+      role="button"
     >
       <div
         class="title"
@@ -178,6 +181,7 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
   </div>
   <div
     class="media"
+    role="button"
   >
     <img
       alt="Test"
@@ -192,7 +196,7 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
 
 exports[`Render a MediaCard with download list 1`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
@@ -17,6 +17,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           >
             <div
               class="description"
+              role="button"
             >
               <div
                 class="title"
@@ -109,6 +110,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           </div>
           <div
             class="media"
+            role="button"
           >
             <img
               alt="Title 1"
@@ -136,6 +138,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           >
             <div
               class="description"
+              role="button"
             >
               <div
                 class="title"
@@ -228,6 +231,7 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
           </div>
           <div
             class="media"
+            role="button"
           >
             <img
               alt="Title 1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
@@ -17,6 +17,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           >
             <div
               class="description"
+              role="button"
             >
               <div
                 class="title"
@@ -109,6 +110,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           </div>
           <div
             class="media"
+            role="button"
           >
             <img
               alt="Title 1"
@@ -136,6 +138,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           >
             <div
               class="description"
+              role="button"
             >
               <div
                 class="title"
@@ -228,6 +231,7 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
           </div>
           <div
             class="media"
+            role="button"
           >
             <img
               alt="Title 1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -284,6 +284,7 @@ exports[`Render the MediaCollection 1`] = `
                   >
                     <div
                       class="description"
+                      role="button"
                     >
                       <div
                         class="title"
@@ -376,6 +377,7 @@ exports[`Render the MediaCollection 1`] = `
                   </div>
                   <div
                     class="media"
+                    role="button"
                   >
                     <img
                       alt="Title 1"
@@ -403,6 +405,7 @@ exports[`Render the MediaCollection 1`] = `
                   >
                     <div
                       class="description"
+                      role="button"
                     >
                       <div
                         class="title"
@@ -495,6 +498,7 @@ exports[`Render the MediaCollection 1`] = `
                   </div>
                   <div
                     class="media"
+                    role="button"
                   >
                     <img
                       alt="Title 1"
@@ -791,6 +795,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   >
                     <div
                       class="description"
+                      role="button"
                     >
                       <div
                         class="title"
@@ -883,6 +888,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   </div>
                   <div
                     class="media"
+                    role="button"
                   >
                     <img
                       alt="Title 1"
@@ -910,6 +916,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   >
                     <div
                       class="description"
+                      role="button"
                     >
                       <div
                         class="title"
@@ -1002,6 +1009,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   </div>
                   <div
                     class="media"
+                    role="button"
                   >
                     <img
                       alt="Title 1"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Render an open MediaSelectionOverlay 1`] = `
 <div
   class="backdrop visible fixed"
+  role="button"
 />
 `;
 
@@ -316,6 +317,7 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
                             >
                               <div
                                 class="description"
+                                role="button"
                               >
                                 <div
                                   class="title"
@@ -408,6 +410,7 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
                             </div>
                             <div
                               class="media"
+                              role="button"
                             >
                               <img
                                 alt="Title 1"
@@ -435,6 +438,7 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
                             >
                               <div
                                 class="description"
+                                role="button"
                               >
                                 <div
                                   class="title"
@@ -527,6 +531,7 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
                             </div>
                             <div
                               class="media"
+                              role="button"
                             >
                               <img
                                 alt="Title 2"
@@ -596,6 +601,7 @@ exports[`Render an open MediaSelectionOverlay 2`] = `
 exports[`Render an open MediaSelectionOverlay with selected items 1`] = `
 <div
   class="backdrop visible fixed"
+  role="button"
 />
 `;
 
@@ -909,6 +915,7 @@ exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
                             >
                               <div
                                 class="description"
+                                role="button"
                               >
                                 <div
                                   class="title"
@@ -1001,6 +1008,7 @@ exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
                             </div>
                             <div
                               class="media"
+                              role="button"
                             >
                               <img
                                 alt="Title 1"
@@ -1028,6 +1036,7 @@ exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
                             >
                               <div
                                 class="description"
+                                role="button"
                               >
                                 <div
                                   class="title"
@@ -1120,6 +1129,7 @@ exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
                             </div>
                             <div
                               class="media"
+                              role="button"
                             >
                               <img
                                 alt="Title 2"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -71,7 +71,7 @@ class DropzoneOverlay extends React.Component<Props> {
         }
 
         return (
-            <div className={dropzoneOverlayStyles.dropzoneOverlay} onClick={this.handleClose}>
+            <div className={dropzoneOverlayStyles.dropzoneOverlay} onClick={this.handleClose} role="button">
                 <div className={dropzoneOverlayStyles.dropArea}>
                     <div className={dropzoneOverlayStyles.uploadInfoContainer}>
                         {children &&

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/__snapshots__/MultiMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/__snapshots__/MultiMediaDropzone.test.js.snap
@@ -24,6 +24,7 @@ exports[`Render a MultiMediaDropzone while media is uploaded 1`] = `
 >
   <div
     class="dropzoneOverlay"
+    role="button"
   >
     <div
       class="dropArea"
@@ -90,6 +91,7 @@ exports[`Render a MultiMediaDropzone while the overlay is visible 1`] = `
 >
   <div
     class="dropzoneOverlay"
+    role="button"
   >
     <div
       class="dropArea"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -325,6 +325,7 @@ exports[`Render a simple MediaOverview 1`] = `
                     >
                       <div
                         class="description"
+                        role="button"
                       >
                         <div
                           class="title"
@@ -417,6 +418,7 @@ exports[`Render a simple MediaOverview 1`] = `
                     </div>
                     <div
                       class="media"
+                      role="button"
                     >
                       <img
                         alt="Title 1"
@@ -444,6 +446,7 @@ exports[`Render a simple MediaOverview 1`] = `
                     >
                       <div
                         class="description"
+                        role="button"
                       >
                         <div
                           class="title"
@@ -536,6 +539,7 @@ exports[`Render a simple MediaOverview 1`] = `
                     </div>
                     <div
                       class="media"
+                      role="button"
                     >
                       <img
                         alt="Title 1"

--- a/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/tests/__snapshots__/WebspaceSelect.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/tests/__snapshots__/WebspaceSelect.test.js.snap
@@ -52,7 +52,7 @@ exports[`Render WebspaceSelect opened 1`] = `
 
 exports[`Render WebspaceSelect opened 2`] = `
 "<div>
-  <div class=\\"backdrop fixed\\"></div>
+  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
 </div>
 <div>
   <div class=\\"container\\">

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
@@ -59,15 +59,15 @@ exports[`Render PageList 1`] = `
             <div
               class="toolbar"
             >
-              <a
+              <button
                 class="item primary"
               >
                 <span
                   aria-label="su-plus-circle"
                   class="su-plus-circle"
                 />
-              </a>
-              <a
+              </button>
+              <button
                 class="item primary"
               >
                 <span
@@ -78,7 +78,7 @@ exports[`Render PageList 1`] = `
                   aria-label="su-angle-down"
                   class="su-angle-down buttonArrowIcon"
                 />
-              </a>
+              </button>
             </div>
           </div>
           <div


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds an eslint rule which disallows interactions with static elements like `div`s. See https://github.com/evcohen/eslint-plugin-jsx-a11y for more details.

#### Why?

Because this is better for accessibility, and avoid "errors" like this in the future.