### PR TITLE
Return undefined in TextArea and CKEditor5 field types when empty

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/TextArea.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/TextArea.js
@@ -9,7 +9,7 @@ type Props = {|
     maxCharacters?: number,
     name?: string,
     onBlur?: () => void,
-    onChange: (string) => void,
+    onChange: (?string) => void,
     placeholder?: string,
     valid: boolean,
     disabled: boolean,
@@ -23,7 +23,7 @@ export default class TextArea extends React.PureComponent<Props> {
     };
 
     handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
-        this.props.onChange(event.currentTarget.value);
+        this.props.onChange(event.currentTarget.value || undefined);
     };
 
     handleBlur = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/TextArea/tests/TextArea.test.js
@@ -45,9 +45,16 @@ test('TextArea should call onBlur when it loses focus', () => {
     expect(blurSpy).toBeCalledWith();
 });
 
-test('TextArea should call the callback when the TextArea changes', () => {
+test('TextArea should call onChange when the TextArea changes', () => {
     const changeSpy = jest.fn();
     const textArea = shallow(<TextArea onChange={changeSpy} value="My value" />);
     textArea.find('textarea').simulate('change', {currentTarget: {value: 'my-value'}});
     expect(changeSpy).toHaveBeenCalledWith('my-value');
+});
+
+test('TextArea should call onChange with undefined when the TextArea changes to empty', () => {
+    const changeSpy = jest.fn();
+    const textArea = shallow(<TextArea onChange={changeSpy} value="My value" />);
+    textArea.find('textarea').simulate('change', {currentTarget: {value: ''}});
+    expect(changeSpy).toHaveBeenCalledWith(undefined);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -214,7 +214,7 @@ export default class CKEditor5 extends React.Component<Props> {
 
     getEditorData() {
         const editorData = this.editorInstance.getData();
-        return editorData === '<p>&nbsp;</p>' ? undefined : editorData;
+        return editorData === '' ? undefined : editorData;
     }
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/CKEditor5.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/CKEditor5.test.js
@@ -321,7 +321,7 @@ test('Call onChange prop when something changed', () => {
     });
 });
 
-test('Call onChange prop with undefined if editor only contains an empty paragraph', () => {
+test('Call onChange prop with undefined if editor is empty', () => {
     const changeSpy = jest.fn();
     const editor = {
         editing: {
@@ -331,7 +331,7 @@ test('Call onChange prop with undefined if editor only contains an empty paragra
                 },
             },
         },
-        getData: jest.fn().mockReturnValue('<p>&nbsp;</p>'),
+        getData: jest.fn().mockReturnValue(''),
         model: {
             document: {
                 on: jest.fn(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the `TextArea` and `TextEditor` field type return undefined if they are an empty string.

#### Why?

Because this fixes some issue with the validation.
