### PR TITLE
Set correct mixed return type for content type interface

### DIFF
--- a/src/Sulu/Component/Content/ContentTypeInterface.php
+++ b/src/Sulu/Component/Content/ContentTypeInterface.php
@@ -116,7 +116,7 @@ interface ContentTypeInterface
      *
      * @param PropertyInterface $property
      *
-     * @return array
+     * @return mixed
      */
     public function getViewData(PropertyInterface $property);
 
@@ -125,7 +125,7 @@ interface ContentTypeInterface
      *
      * @param PropertyInterface $property
      *
-     * @return array
+     * @return mixed
      */
     public function getContentData(PropertyInterface $property);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Set correct mixed return type for content type interface.

#### Why?

Its also possible to return objects or null in getContentData and getViewData.
