### PR TITLE
Add command to media cache files which not longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * FEATURE     #4532  [MediaBundle]          Add command to remove format cache files which not longer exists
     * HOTFIX      #4512  [Components]           Fix pathcleanup whitespace character problems
 
 * 1.6.26 (2019-03-26)

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Command;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NoResultException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class FormatCacheCleanupCommand extends Command
+{
+    /**
+     * @var EntityRepository
+     */
+    private $mediaRepository;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $localFormatCachePath;
+
+    public function __construct(
+        EntityRepository $mediaRepository,
+        Filesystem $filesystem,
+        $localFormatCachePath
+    ) {
+        parent::__construct('sulu:media:format:cache:cleanup');
+        $this->mediaRepository = $mediaRepository;
+        $this->filesystem = $filesystem;
+        $this->localFormatCachePath = $localFormatCachePath;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Remove media formats which medias not longer exist in the database')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do nothing')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $ui = new SymfonyStyle($input, $output);
+
+        $finder = new Finder();
+        $finder->in(realpath($this->localFormatCachePath));
+        $files = $finder->files();
+
+        $progressBar = $ui->createProgressBar(count($files));
+        $removedIds = [];
+        $removedCount = 0;
+        $existsIds = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($files as $file) {
+            $progressBar->setMessage($file->getPathname());
+            $mediaId = explode('-', $file->getBasename())[0];
+
+            if (!is_numeric($mediaId)) {
+                $progressBar->advance();
+                continue;
+            }
+
+            if (isset($removedIds[$mediaId]) || (!isset($existsIds[$mediaId]) && !$this->mediaExists($mediaId))) {
+                $removedIds[$mediaId] = $mediaId;
+                ++$removedCount;
+
+                if ($ui->isVerbose()) {
+                    $output->writeln('');
+                    $output->writeln($file->getPathname());
+                }
+
+                if (!$input->getOption('dry-run')) {
+                    $this->filesystem->remove($file->getPathname());
+                }
+            } else {
+                $existsIds[$mediaId] = $mediaId;
+            }
+
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+
+        $ui->writeln('');
+        $ui->writeln('');
+
+        $message = 'Removed Media: ' . count($removedIds) . ' Removed Files: ' . $removedCount;
+
+        if ($input->getOption('dry-run')) {
+            $ui->note('Dry Run: ' . $message);
+        } else {
+            $ui->success($message);
+        }
+    }
+
+    private function mediaExists($mediaId)
+    {
+        try {
+            $mediaId = $this->mediaRepository->createQueryBuilder('media')
+                ->select('media.id')
+                ->where('media.id = :id')
+                ->setParameter('id', $mediaId)
+                ->getQuery()->getSingleScalarResult();
+
+            return (bool) $mediaId;
+        } catch (NoResultException $e) {
+            return false;
+        }
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -304,5 +304,14 @@
             <tag name="doctrine.event_listener" event="postUpdate"/>
             <tag name="doctrine.event_listener" event="preRemove"/>
         </service>
+
+        <service id="sulu_media.command.format_cache.cleanup"
+                 class="Sulu\Bundle\MediaBundle\Command\FormatCacheCleanupCommand">
+            <argument type="service" id="sulu.repository.media"/>
+            <argument type="service" id="filesystem"/>
+            <argument>%sulu_media.format_cache.path%</argument>
+
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/437

#### What's in this PR?

Add command to media cache files which not longer exists.

#### Why?

In a multi server setup it can happen that not all images where deleted so we need a command to remove image formats which media does not longer exist in the database.

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/437
