### PR TITLE
CustomUrl with redirect behavior redirects to HTTP schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu
 ==================
 
+* dev-release/1.5
+    * BUGFIX      #4538 [Component]             Fixed Redirect- and SeoEnhancer to respect current request schema.
+    
 * 1.5.22 (2019-03-26)
     * HOTFIX      #4491 [ContentBundle]         Set ghost-locale to first available-locale if locale not exists in webspace
     * BUGFIX      #4433 [SecurityBundle]       Fix fresh User object comparison to the deserialized User object

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/RedirectEnhancer.php
@@ -49,7 +49,9 @@ class RedirectEnhancer extends AbstractEnhancer
             $resourceSegment,
             $defaults['_environment'],
             $customUrl->getTargetLocale(),
-            $defaults['_webspace']->getKey()
+            $defaults['_webspace']->getKey(),
+            $request->getHost(),
+            $request->getScheme()
         );
 
         return [

--- a/src/Sulu/Component/CustomUrl/Routing/Enhancers/SeoEnhancer.php
+++ b/src/Sulu/Component/CustomUrl/Routing/Enhancers/SeoEnhancer.php
@@ -51,7 +51,9 @@ class SeoEnhancer extends AbstractEnhancer
                 $resourceSegment,
                 $defaults['_environment'],
                 $customUrl->getTargetLocale(),
-                $webspace->getKey()
+                $webspace->getKey(),
+                $request->getHost(),
+                $request->getScheme()
             );
         }
 

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
@@ -25,7 +25,7 @@ class RedirectEnhancerTest extends \PHPUnit_Framework_TestCase
         $request = $this->prophesize(Request::class);
         $request->getHost()->willReturn('sulu.io');
         $request->getScheme()->willReturn('http');
-        
+
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn('sulu_io');
 

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/RedirectEnhancerTest.php
@@ -23,6 +23,9 @@ class RedirectEnhancerTest extends \PHPUnit_Framework_TestCase
     public function testEnhance()
     {
         $request = $this->prophesize(Request::class);
+        $request->getHost()->willReturn('sulu.io');
+        $request->getScheme()->willReturn('http');
+        
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn('sulu_io');
 
@@ -39,7 +42,9 @@ class RedirectEnhancerTest extends \PHPUnit_Framework_TestCase
             '/test',
             'prod',
             'de',
-            'sulu_io'
+            'sulu_io',
+            'sulu.io',
+            'http'
         )->willReturn('sulu.io/test');
 
         $enhancer = new RedirectEnhancer($webspaceManager->reveal());

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/SeoEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/SeoEnhancerTest.php
@@ -63,15 +63,17 @@ class SeoEnhancerTest extends \PHPUnit_Framework_TestCase
     public function testEnhanceWithCanonical()
     {
         $request = $this->prophesize(Request::class);
+        $request->getHost()->willReturn('sulu.io');
+        $request->getScheme()->willReturn('http');
+
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn('sulu_io');
 
         $customUrl = $this->prophesize(CustomUrlDocument::class);
-        $customUrl->isRedirect()->willReturn(true);
         $customUrl->getTargetLocale()->willReturn('de');
-        $customUrl->isNoFollow()->willReturn(true);
+        $customUrl->isNoFollow()->willReturn(false);
         $customUrl->isNoIndex()->willReturn(true);
-        $customUrl->isCanonical()->willReturn(false);
+        $customUrl->isCanonical()->willReturn(true);
 
         $target = $this->prophesize(PageDocument::class);
         $target->getResourceSegment()->willReturn('/test');
@@ -82,7 +84,9 @@ class SeoEnhancerTest extends \PHPUnit_Framework_TestCase
             '/test',
             'prod',
             'de',
-            'sulu_io'
+            'sulu_io',
+            'sulu.io',
+            'http'
         )->willReturn('sulu.io/test');
 
         $enhancer = new SeoEnhancer($webspaceManager->reveal());
@@ -98,8 +102,9 @@ class SeoEnhancerTest extends \PHPUnit_Framework_TestCase
                 '_webspace' => $webspace->reveal(),
                 '_environment' => 'prod',
                 '_seo' => [
-                    'noFollow' => true,
+                    'noFollow' => false,
                     'noIndex' => true,
+                    'canonicalUrl' => 'sulu.io/test'
                 ],
             ],
             $defaults

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/SeoEnhancerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Routing/Enhancers/SeoEnhancerTest.php
@@ -104,7 +104,7 @@ class SeoEnhancerTest extends \PHPUnit_Framework_TestCase
                 '_seo' => [
                     'noFollow' => false,
                     'noIndex' => true,
-                    'canonicalUrl' => 'sulu.io/test'
+                    'canonicalUrl' => 'sulu.io/test',
                 ],
             ],
             $defaults


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4537 
| License | MIT

#### What's in this PR?

Url generation in the redirect behavior now respects the current request schema.