### PR TITLE
Fix types for getDerivedRouteAttributes function

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,5 +11,4 @@ bin/
 config/
 public/
 templates/
-tests/
 var/

--- a/.flowconfig
+++ b/.flowconfig
@@ -19,5 +19,4 @@ bin/
 config/
 public/
 templates/
-tests/
 var/

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/updateRouterAttributesFromView.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/updateRouterAttributesFromView.test.js
@@ -122,24 +122,3 @@ test('Return the combined attributes from the current and parent getDerivedroute
             routeName3: 'test3',
         });
 });
-
-test('Throw an error if attributes returned from the getDerivedRouterAttributes function are not an object', () => {
-    viewRegistry.get.mockImplementation((key) => {
-        if (key === 'test') {
-            return {
-                getDerivedRouteAttributes: jest.fn().mockReturnValue('test'),
-            };
-        }
-    });
-
-    expect(() => updateRouterAttributesFromView({
-        attributeDefaults: {},
-        children: [],
-        name: 'test',
-        options: {},
-        path: '/test',
-        parent: undefined,
-        rerenderAttributes: [],
-        view: 'test',
-    }, {})).toThrow(/"getDerivedRouteAttributes".*"test" view/);
-});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/types.js
@@ -1,7 +1,7 @@
 // @flow
 import type {Component, Element} from 'react';
 import Router from '../../services/Router';
-import type {Route} from '../../services/Router';
+import type {AttributeMap, Route} from '../../services/Router';
 
 export type ViewProps = {
     router: Router,
@@ -9,4 +9,8 @@ export type ViewProps = {
     children?: (?Object) => Element<*> | null,
 };
 
-export type View = Class<Component<ViewProps & *>>;
+interface GetDerivedRouteAttributesInterface {
+    +getDerivedRouteAttributes?: (route: Route, attributes: AttributeMap) => Object,
+}
+
+export type View = Class<Component<ViewProps & *>> & GetDerivedRouteAttributesInterface;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/updateRouterAttributesFromView.js
@@ -7,15 +7,8 @@ const updateRouterAttributesFromView: UpdateAttributesHook = function(route, att
 
     const View = viewRegistry.get(route.view);
 
-    // $FlowFixMe
     if (typeof View.getDerivedRouteAttributes === 'function') {
         const newAttributes = View.getDerivedRouteAttributes(route, {...parentAttributes, ...attributes});
-
-        if (typeof newAttributes !== 'object') {
-            throw new Error(
-                'The "getDerivedRouteAttributes" function of the "' + route.view + '" view did not return an object.'
-            );
-        }
 
         return {...parentAttributes, ...newAttributes};
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/index.js
@@ -1,8 +1,8 @@
 // @flow
 import Router from './Router';
 import routeRegistry from './registries/RouteRegistry';
-import type {Route} from './types';
+import type {AttributeMap, Route} from './types';
 
 export default Router;
 export {routeRegistry};
-export type {Route};
+export type {AttributeMap, Route};


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | facebook/flow#6318
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the typing for the `getDerivedRouteAttributes` function of a `View`.

#### Why?

Because this allows to encounter errors in this function even earlier.