### PR TITLE
Registered FOSJsRoutingBundle in bundles.php and added a route config

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -56,6 +56,7 @@ return [
     Sulu\Bundle\AdminBundle\SuluAdminBundle::class => ['all' => true, 'admin' => true],
     Sulu\Bundle\CollaborationBundle\SuluCollaborationBundle::class => ['all' => true, 'admin' => true],
     Sulu\Bundle\PreviewBundle\SuluPreviewBundle::class => ['all' => true, 'admin' => true],
+    FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true, 'admin' => true],
     // Website
     Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle::class => ['all' => true, 'website' => true],
 ];

--- a/config/routes/fos_js_routing_admin.yaml
+++ b/config/routes/fos_js_routing_admin.yaml
@@ -1,0 +1,3 @@
+fos_js_routing:
+    prefix: /admin
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?
Adds FOSJsRoutingBundle to the bundles registration and routes configuration

#### Why?
sulu/sulu was missing the registration of FosJsRoutingBundle which is a new dependency of the admin area in 2.x.
