### PR TITLE
Allow to unpublish a page

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/EditToolbarAction.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/EditToolbarAction.js
@@ -11,6 +11,8 @@ export default class EditToolbarAction extends AbstractFormToolbarAction {
     @observable showCopyLocaleDialog = false;
     @observable showDeleteDraftDialog = false;
     @observable deletingDraft = false;
+    @observable showUnpublishDialog = false;
+    @observable unpublishing = false;
 
     getNode() {
         const {
@@ -61,6 +63,17 @@ export default class EditToolbarAction extends AbstractFormToolbarAction {
                 >
                     {translate('sulu_page.delete_draft_warning_text')}
                 </Dialog>
+                <Dialog
+                    cancelText={translate('sulu_admin.cancel')}
+                    confirmLoading={this.unpublishing}
+                    confirmText={translate('sulu_admin.ok')}
+                    onCancel={this.handleUnpublishDialogClose}
+                    onConfirm={this.handleUnpublishDialogConfirm}
+                    open={this.showUnpublishDialog}
+                    title={translate('sulu_page.unpublish_warning_title')}
+                >
+                    {translate('sulu_page.unpublish_warning_text')}
+                </Dialog>
             </Fragment>
         );
     }
@@ -86,6 +99,13 @@ export default class EditToolbarAction extends AbstractFormToolbarAction {
                     label: translate('sulu_page.delete_draft'),
                     onClick: action(() => {
                         this.showDeleteDraftDialog = true;
+                    }),
+                },
+                {
+                    disabled: !id || !published,
+                    label: translate('sulu_page.unpublish'),
+                    onClick: action(() => {
+                        this.showUnpublishDialog = true;
                     }),
                 },
             ],
@@ -136,5 +156,43 @@ export default class EditToolbarAction extends AbstractFormToolbarAction {
 
     @action handleDeleteDraftDialogClose = () => {
         this.showDeleteDraftDialog = false;
+    };
+
+    @action handleUnpublishDialogConfirm = () => {
+        const {
+            id,
+            locale,
+            options: {
+                webspace,
+            },
+        } = this.resourceFormStore;
+
+        if (!id) {
+            throw new Error(
+                'The page can only be unpublished if an ID is given! This should not happen and is likely a bug.'
+            );
+        }
+
+        this.unpublishing = true;
+
+        ResourceRequester.post(
+            'pages',
+            undefined,
+            {
+                action: 'unpublish',
+                locale,
+                id,
+                webspace,
+            }
+        ).then(action((response) => {
+            this.unpublishing = false;
+            this.showUnpublishDialog = false;
+            this.resourceFormStore.setMultiple(response);
+            this.resourceFormStore.dirty = false;
+        }));
+    };
+
+    @action handleUnpublishDialogClose = () => {
+        this.showUnpublishDialog = false;
     };
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -44,5 +44,8 @@
     "sulu_page.hide_in_sitemap": "In Sitemap ausblenden",
     "sulu_page.delete_draft": "Entwurf löschen",
     "sulu_page.delete_draft_warning_title": "Entwurf löschen?",
-    "sulu_page.delete_draft_warning_text": "Soll der Entwurf wirklich gelöscht werden? Alle Daten gehen dadurch verloren. Die veröffentlichte Seite bleibt unverändert bestehen."
+    "sulu_page.delete_draft_warning_text": "Soll der Entwurf wirklich gelöscht werden? Alle Daten gehen dadurch verloren. Die veröffentlichte Seite bleibt unverändert bestehen.",
+    "sulu_page.unpublish_warning_title": "Nicht mehr veröffentlichen?",
+    "sulu_page.unpublish_warning_text": "Soll die Seite wirklich nicht mehr veröffentlicht werden? Dadurch gehen sämtliche Verknüpfungen auf der Website verloren. Dieser Status kann jederzeit ohne Datenverlust geändert werden.",
+    "sulu_page.unpublish": "Nicht mehr veröffentlichen"
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -44,5 +44,8 @@
     "sulu_page.hide_in_sitemap": "Hide in sitemap",
     "sulu_page.delete_draft": "Delete draft",
     "sulu_page.delete_draft_warning_title": "Delete Draft?",
-    "sulu_page.delete_draft_warning_text": "Do you really want to delete the draft? All data will be lost. The published page will not be changed."
+    "sulu_page.delete_draft_warning_text": "Do you really want to delete the draft? All data will be lost. The published page will not be changed.",
+    "sulu_page.unpublish_warning_title": "Set to unpublished?",
+    "sulu_page.unpublish_warning_text": "Do you really want to unpublish the page? All website links will be lost. This setting can be changed at any time without data loss.",
+    "sulu_page.unpublish": "Set to unpublished"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to unpublish a page, in the same way as a draft can be deleted.

#### Why?

Because it was already possible in Sulu 1.x.