### PR TITLE
Allow to create a contact with an account but without a position

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/Input.js
@@ -56,6 +56,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
     render() {
         const {
             alignment,
+            autocomplete,
             headline,
             id,
             inputClass,
@@ -141,6 +142,7 @@ export default class Input<T: ?string | ?number> extends React.PureComponent<Inp
                     }
 
                     <input
+                        autoComplete={autocomplete}
                         className={inputClass}
                         disabled={disabled}
                         id={id}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/Input.test.js
@@ -12,6 +12,13 @@ test('Input should render', () => {
     expect(render(<Input onBlur={jest.fn()} onChange={onChange} value="My value" />)).toMatchSnapshot();
 });
 
+test('Input should render with autocomplete off', () => {
+    const onChange = jest.fn();
+    expect(
+        render(<Input autocomplete="off" disabled={true} onChange={onChange} value="My value" />)
+    ).toMatchSnapshot();
+});
+
 test('Input should render as headline', () => {
     expect(render(<Input headline={true} onChange={jest.fn()} value="My value" />)).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/tests/__snapshots__/Input.test.js.snap
@@ -150,6 +150,19 @@ Array [
 ]
 `;
 
+exports[`Input should render with autocomplete off 1`] = `
+<label
+  class="input default left disabled"
+>
+  <input
+    autocomplete="off"
+    disabled=""
+    type="text"
+    value="My value"
+  />
+</label>
+`;
+
 exports[`Input should render with dark skin 1`] = `
 <label
   class="input dark left hasAppendIcon"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/types.js
@@ -3,6 +3,7 @@ import type {ElementRef} from 'react';
 
 export type InputProps<T: ?string | ?number> = {|
     alignment: 'left' | 'center' | 'right',
+    autocomplete?: string,
     collapsed?: boolean,
     name?: string,
     headline?: boolean,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -102,6 +102,7 @@ export default class SingleAutoComplete extends React.Component<Props> {
         return (
             <div className={singleAutoCompleteStyles.singleAutoComplete}>
                 <Input
+                    autocomplete="off"
                     disabled={disabled}
                     icon={LENS_ICON}
                     id={id}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -16,6 +16,7 @@ exports[`Render the SingleAutoComplete with open suggestions list 1`] = `
       />
     </div>
     <input
+      autocomplete="off"
       class="mousetrap"
       type="text"
       value="Test"
@@ -55,6 +56,7 @@ exports[`SingleAutoComplete should render 1`] = `
       />
     </div>
     <input
+      autocomplete="off"
       class="mousetrap"
       type="text"
       value="Test"
@@ -79,6 +81,7 @@ exports[`SingleAutoComplete should render in disabled state 1`] = `
       />
     </div>
     <input
+      autocomplete="off"
       class="mousetrap"
       disabled=""
       type="text"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/__snapshots__/SingleAutoComplete.test.js.snap
@@ -23,6 +23,7 @@ exports[`Render in disabled state 1`] = `
       </div>
     </div>
     <input
+      autocomplete="off"
       class="mousetrap"
       disabled=""
       type="text"
@@ -55,6 +56,7 @@ exports[`Render in loading state 1`] = `
       </div>
     </div>
     <input
+      autocomplete="off"
       class="mousetrap"
       type="text"
       value=""
@@ -86,6 +88,7 @@ exports[`Render with given value 1`] = `
       </div>
     </div>
     <input
+      autocomplete="off"
       class="mousetrap"
       type="text"
       value="James Bond"

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -342,7 +342,11 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
                 }
 
                 // Set position on contact
-                $position = $this->getPosition($this->getProperty($data, 'position'));
+                $positionId = $this->getProperty($data, 'position');
+                $position = null;
+                if ($positionId) {
+                    $position = $this->getPosition($positionId);
+                }
 
                 // create new account-contact relation
                 $this->createMainAccountContact(

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -483,6 +483,37 @@ class ContactControllerTest extends SuluTestCase
         $this->assertEquals($category2->getId(), $response->categories[1]);
     }
 
+    public function testPostWithAccountWithoutPosition()
+    {
+        $collectionType = $this->createCollectionType('My collection type');
+        $account = $this->createAccount('Musterfirma');
+        $this->em->flush();
+
+        $client = $this->createTestClient();
+
+        $client->request(
+            'POST',
+            '/api/contacts',
+            [
+                'firstName' => 'Erika',
+                'lastName' => 'Mustermann',
+                'formOfAddress' => 1,
+                'account' => [
+                    'id' => $account->getId(),
+                ],
+            ]
+        );
+
+        $response = json_decode($client->getResponse()->getContent());
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $this->assertNotNull($response->id);
+        $this->assertEquals('Erika', $response->firstName);
+        $this->assertEquals('Mustermann', $response->lastName);
+        $this->assertEquals(1, $response->formOfAddress);
+        $this->assertEquals($account->getid(), $response->account->id);
+    }
+
     public function testPostEmptyAddress()
     {
         $addressType = $this->createAddressType('Private');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes a bug, which appears when a new contact is created. It is only possible to assign an organization to a contact, if also a position is chosen.

#### Why?

Because that should work.