### PR TITLE
Generate URL for ghost locales

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: npm install
       - run: npm run lint:js
       - run: npm run lint:scss
-      - run: npm run flow
+      - run: npm run flow -- check
       - run: npm run styleguide:build
       - run: npm test -- --maxWorkers=4
       - run: rm composer.json && composer require friendsofsymfony/jsrouting-bundle:^2.3 --no-interaction

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "eslint-plugin-import": "^2.7.0",
         "eslint-plugin-react": "^7.6.1",
         "file-loader": "^3.0.1",
-        "flow-bin": "^0.97.0",
+        "flow-bin": "^0.98.0",
         "glob": "^7.1.2",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^23.0.0",

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
@@ -177,6 +177,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             /** @var PageDocument $document */
             $document = $this->documentManager->create('page');
             $document->setTitle($data['title']);
+            $document->setResourceSegment($data['url']);
             $document->getStructure()->bind($data);
             $document->setStructureType($template);
             $document->setWorkflowStage(WorkflowStage::PUBLISHED);

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -149,7 +149,7 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
                 $property->getName(),
                 $locale
             ),
-            ''
+            null
         );
 
         $document->setResourceSegment($segment);

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
@@ -141,7 +141,7 @@ class ResourceSegmentSubscriberTest extends TestCase
 
         $this->documentInspector->getOriginalLocale($this->document->reveal())->willReturn('de');
 
-        $node->getPropertyValueWithDefault('i18n:de-url', '')->willReturn($segment);
+        $node->getPropertyValueWithDefault('i18n:de-url', null)->willReturn($segment);
 
         // Asserts
         $this->document->setResourceSegment($segment)->shouldBeCalled();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | --
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will return null for the URL on a ghost locale, because this URL does not exist.

#### Why?

This way the JS code knows that it has to generate an URL for ghost locales as well.