### PR TITLE
Fix failing ColumnList after deleting the last selected page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -489,7 +489,13 @@ export default class ListStore {
                     });
                 this.initialSelectionIds = undefined;
             }
-        }));
+        })).catch((response) => {
+            if (this.active.get() && response.status === 404) {
+                // need to set the user setting to null manually, because the autorun runs too late
+                ListStore.setActiveSetting(this.listKey, this.userSettingsKey, undefined);
+                this.setActive(undefined);
+            }
+        });
     };
 
     @action setDataLoading(dataLoading: boolean) {

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -141,7 +141,7 @@ class PageSelectionContainer implements ArrayableInterface
 
             // map pages
             foreach ($pages as $page) {
-                $map[$page['uuid']] = $page;
+                $map[$page['id']] = $page;
             }
 
             foreach ($this->ids as $id) {

--- a/src/Sulu/Bundle/PageBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/NodeController.php
@@ -53,7 +53,7 @@ class NodeController extends RestController implements ClassResourceInterface, S
 
     const WEBSPACE_NODES_ALL = 'all';
 
-    protected static $relationName = 'nodes';
+    protected static $relationName = 'pages';
 
     public function __construct()
     {

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -24,8 +24,6 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class PageController extends NodeController
 {
-    protected static $relationName = 'pages';
-
     public function cgetAction(Request $request)
     {
         if ('true' === $request->query->get('flat')
@@ -39,7 +37,7 @@ class PageController extends NodeController
             $request->query->set('fields', 'title,published');
         }
 
-        return $this->transformResponse(parent::cgetAction($request));
+        return parent::cgetAction($request);
     }
 
     /**
@@ -66,29 +64,5 @@ class PageController extends NodeController
         }
 
         return parent::cgetContent($request);
-    }
-
-    private function transformResponse(Response $response)
-    {
-        $responseContent = json_decode($response->getContent(), true);
-
-        if (array_key_exists('nodes', $responseContent['_embedded'])) {
-            // sometime the NodeController does not listen the relation name set in this controller,
-            // so we replace it on our own.
-            $responseContent['_embedded']['pages'] = $responseContent['_embedded']['nodes'];
-            unset($responseContent['_embedded']['nodes']);
-        }
-
-        // sometimes the NodeController has an uuid field instead of id, so we replace it
-        array_walk($responseContent['_embedded']['pages'], function(&$node) {
-            if (array_key_exists('uuid', $node)) {
-                $node['id'] = $node['uuid'];
-                unset($node['uuid']);
-            }
-        });
-
-        $response->setContent(json_encode($responseContent));
-
-        return $response;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -153,7 +153,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         // add default embedded property with empty nodes array
         $result['_embedded'] = [];
-        $result['_embedded']['nodes'] = [];
+        $result['_embedded']['pages'] = [];
 
         // add api links
         $result['_links'] = [
@@ -270,7 +270,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         $parentNode = $this->getParentNode($parent, $webspaceKey, $languageCode);
         $result = $this->prepareNode($parentNode, $webspaceKey, $languageCode, 1, $complete, $excludeGhosts);
-        $result['_embedded']['nodes'] = $this->prepareNodesTree(
+        $result['_embedded']['pages'] = $this->prepareNodesTree(
             $nodes,
             $webspaceKey,
             $languageCode,
@@ -278,7 +278,7 @@ class NodeRepository implements NodeRepositoryInterface
             $excludeGhosts,
             $flat ? 1 : $depth
         );
-        $result['total'] = count($result['_embedded']['nodes']);
+        $result['total'] = count($result['_embedded']['pages']);
 
         return $result;
     }
@@ -311,7 +311,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         return [
             '_embedded' => [
-                'nodes' => $result,
+                'pages' => $result,
             ],
             'total' => count($result),
             '_links' => [
@@ -334,7 +334,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         // add default empty embedded property
         $data['_embedded'] = [
-            'nodes' => [$this->createWebspaceNode($webspaceKey, $languageCode, $depth, $excludeGhosts)],
+            'pages' => [$this->createWebspaceNode($webspaceKey, $languageCode, $depth, $excludeGhosts)],
         ];
         // add api links
         $data['_links'] = [
@@ -353,11 +353,11 @@ class NodeRepository implements NodeRepositoryInterface
     public function getWebspaceNodes($languageCode)
     {
         // init result
-        $data = ['_embedded' => ['nodes' => []]];
+        $data = ['_embedded' => ['pages' => []]];
 
         /** @var Webspace $webspace */
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            $data['_embedded']['nodes'][] = $this->createWebspaceNode($webspace->getKey(), $languageCode, 0);
+            $data['_embedded']['pages'][] = $this->createWebspaceNode($webspace->getKey(), $languageCode, 0);
         }
 
         // add api links
@@ -453,8 +453,8 @@ class NodeRepository implements NodeRepositoryInterface
             $parentNode = $this->getParentNode($node->getIdentifier(), $webspaceKey, $languageCode);
             $result = $this->prepareNode($parentNode, $webspaceKey, $languageCode, 1, false);
 
-            $result['_embedded']['nodes'] = $data;
-            $result['total'] = count($result['_embedded']['nodes']);
+            $result['_embedded']['pages'] = $data;
+            $result['total'] = count($result['_embedded']['pages']);
         } else {
             $result = $data;
         }
@@ -508,7 +508,7 @@ class NodeRepository implements NodeRepositoryInterface
                 $node->getHasChildren() &&
                 null != $node->getChildren()
             ) {
-                $result['_embedded']['nodes'] = $this->prepareNodesTree(
+                $result['_embedded']['pages'] = $this->prepareNodesTree(
                     $node->getChildren(),
                     $webspaceKey,
                     $languageCode,
@@ -538,7 +538,7 @@ class NodeRepository implements NodeRepositoryInterface
 
         $result = [
             '_embedded' => [
-                'nodes' => $nodes,
+                'pages' => $nodes,
             ],
         ];
 
@@ -634,7 +634,7 @@ class NodeRepository implements NodeRepositoryInterface
         if (is_array($result)) {
             foreach ($result as &$node) {
                 if ($node['id'] === $uuid) {
-                    $node['_embedded']['nodes'] = $tier;
+                    $node['_embedded']['pages'] = $tier;
                     $found = true;
                     break;
                 }
@@ -654,7 +654,7 @@ class NodeRepository implements NodeRepositoryInterface
             );
         }
 
-        $this->iterateTiers($tiers, $node['_embedded']['nodes']);
+        $this->iterateTiers($tiers, $node['_embedded']['pages']);
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
@@ -49,7 +49,7 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(3, $items);
 
@@ -73,7 +73,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(3, $items);
 
@@ -98,7 +98,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(2, $items);
 
@@ -118,7 +118,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(3, $items);
 
@@ -143,7 +143,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(2, $items);
 
@@ -163,7 +163,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(3, $items);
 
@@ -188,7 +188,7 @@ class NodeControllerFieldsTest extends SuluTestCase
 
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $items = $result['_embedded']['nodes'];
+        $items = $result['_embedded']['pages'];
 
         $this->assertCount(1, $items);
 
@@ -238,7 +238,7 @@ class NodeControllerFieldsTest extends SuluTestCase
         );
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $layer = $result['_embedded']['nodes'];
+        $layer = $result['_embedded']['pages'];
         $this->assertCount(2, $layer);
         $this->assertEquals($page1->getUuid(), $layer[0]['id']);
         $this->assertTrue($layer[0]['hasChildren']);
@@ -358,7 +358,7 @@ class NodeControllerFieldsTest extends SuluTestCase
         );
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $layer = $result['_embedded']['nodes'];
+        $layer = $result['_embedded']['pages'];
         $this->assertCount(1, $layer);
         $this->assertEquals($this->sessionManager->getContentNode('sulu_io')->getIdentifier(), $layer[0]['id']);
         $this->assertEquals('Sulu CMF', $layer[0]['title']);
@@ -392,7 +392,7 @@ class NodeControllerFieldsTest extends SuluTestCase
             ['webspace' => 'sulu_io', 'language' => 'de', 'webspace-nodes' => 'all', 'fields' => 'title']
         );
         $result = json_decode($client->getResponse()->getContent(), true);
-        $layer = $result['_embedded']['nodes'];
+        $layer = $result['_embedded']['pages'];
 
         usort($layer, function($layer1, $layer2) {
             return strcmp($layer1['title'], $layer2['title']);
@@ -443,7 +443,7 @@ class NodeControllerFieldsTest extends SuluTestCase
         );
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $layer = $result['_embedded']['nodes'];
+        $layer = $result['_embedded']['pages'];
         usort($layer, function($layer1, $layer2) {
             return strcmp($layer1['title'], $layer2['title']);
         });
@@ -495,7 +495,7 @@ class NodeControllerFieldsTest extends SuluTestCase
         );
         $result = json_decode($client->getResponse()->getContent(), true);
 
-        $layer = $result['_embedded']['nodes'];
+        $layer = $result['_embedded']['pages'];
         usort($layer, function($layer1, $layer2) {
             return strcmp($layer1['title'], $layer2['title']);
         });

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -949,7 +949,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(2, count($items));
         $this->assertEquals($data[0]['title'], $items[0]->title);
@@ -961,7 +961,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', str_replace('/admin', '', $items[1]->_links->children->href));
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(2, count($items));
         $this->assertEquals($data[2]['title'], $items[0]->title);
@@ -973,7 +973,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', str_replace('/admin', '', $items[1]->_links->children->href));
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(1, count($items));
         $this->assertEquals($data[4]['title'], $items[0]->title);
@@ -995,12 +995,12 @@ class NodeControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         // check if tree is correctly loaded till the given id
-        $node1 = $response->_embedded->nodes[0];
+        $node1 = $response->_embedded->pages[0];
         $this->assertEquals($data[0]['path'], $node1->path);
         $this->assertFalse($node1->hasChildren);
         $this->assertEmpty($node1->_embedded->pages);
 
-        $node2 = $response->_embedded->nodes[1];
+        $node2 = $response->_embedded->pages[1];
         $this->assertEquals($data[1]['path'], $node2->path);
         $this->assertTrue($node2->hasChildren);
         $this->assertCount(2, $node2->_embedded->pages);
@@ -1031,12 +1031,12 @@ class NodeControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         // check if tree is correctly loaded till the given id
-        $node1 = $response->_embedded->nodes[0];
+        $node1 = $response->_embedded->pages[0];
         $this->assertEquals($data[0]['path'], $node1->path);
         $this->assertFalse($node1->hasChildren);
         $this->assertEmpty($node1->_embedded->pages);
 
-        $node2 = $response->_embedded->nodes[1];
+        $node2 = $response->_embedded->pages[1];
         $this->assertEquals($data[1]['path'], $node2->path);
         $this->assertTrue($node2->hasChildren);
         $this->assertCount(2, $node2->_embedded->pages);
@@ -1061,7 +1061,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(2, count($items));
 
@@ -1075,7 +1075,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=2&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(4, count($items));
 
@@ -1095,7 +1095,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=3&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(5, count($items));
 
@@ -1118,7 +1118,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=3&webspace=sulu_io&language=en&parentId=' . $data[3]['id']);
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(1, count($items));
 
@@ -1135,87 +1135,87 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&flat=false&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(2, count($items));
 
         $this->assertEquals('test1', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
 
         $this->assertEquals('test2', $items[1]->title);
         $this->assertTrue($items[1]->hasSub);
-        $this->assertEquals(0, count($items[1]->_embedded->nodes));
+        $this->assertEquals(0, count($items[1]->_embedded->pages));
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=2&flat=false&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(2, count($items));
 
         $this->assertEquals('test1', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
 
         $this->assertEquals('test2', $items[1]->title);
         $this->assertTrue($items[1]->hasSub);
-        $this->assertEquals(2, count($items[1]->_embedded->nodes));
+        $this->assertEquals(2, count($items[1]->_embedded->pages));
 
-        $items = $items[1]->_embedded->nodes;
+        $items = $items[1]->_embedded->pages;
 
         $this->assertEquals('test3', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
 
         $this->assertEquals('test4', $items[1]->title);
         $this->assertTrue($items[1]->hasSub);
-        $this->assertEquals(0, count($items[1]->_embedded->nodes));
+        $this->assertEquals(0, count($items[1]->_embedded->pages));
 
         // get child nodes from root
         $client->request('GET', '/api/nodes?depth=3&flat=false&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(2, count($items));
 
         $this->assertEquals('test1', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
 
         $this->assertEquals('test2', $items[1]->title);
         $this->assertTrue($items[1]->hasSub);
-        $this->assertEquals(2, count($items[1]->_embedded->nodes));
+        $this->assertEquals(2, count($items[1]->_embedded->pages));
 
-        $items = $items[1]->_embedded->nodes;
+        $items = $items[1]->_embedded->pages;
 
         $this->assertEquals('test3', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
 
         $this->assertEquals('test4', $items[1]->title);
         $this->assertTrue($items[1]->hasSub);
-        $this->assertEquals(1, count($items[1]->_embedded->nodes));
+        $this->assertEquals(1, count($items[1]->_embedded->pages));
 
-        $items = $items[1]->_embedded->nodes;
+        $items = $items[1]->_embedded->pages;
 
         $this->assertEquals('test5', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
 
         // get child nodes from subNode
         $client->request('GET', '/api/nodes?depth=3&flat=false&webspace=sulu_io&language=en&parentId=' . $data[3]['id']);
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
-        $items = $response->_embedded->nodes;
+        $items = $response->_embedded->pages;
 
         $this->assertEquals(1, count($items));
 
         $this->assertEquals('test5', $items[0]->title);
         $this->assertFalse($items[0]->hasSub);
-        $this->assertEquals(0, count($items[0]->_embedded->nodes));
+        $this->assertEquals(0, count($items[0]->_embedded->pages));
     }
 
     public function testBreadcrumb()
@@ -1317,7 +1317,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $items = $response['_embedded']['nodes'];
+        $items = $response['_embedded']['pages'];
 
         $this->assertEquals(2, count($items));
 
@@ -1328,7 +1328,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertTrue($items[0]['publishedState']);
         $this->assertEmpty($items[0]['navContexts']);
         $this->assertFalse($items[0]['hasSub']);
-        $this->assertEquals(0, count($items[0]['_embedded']['nodes']));
+        $this->assertEquals(0, count($items[0]['_embedded']['pages']));
         $this->assertArrayHasKey('_links', $items[0]);
 
         $this->assertArrayHasKey('id', $items[1]);
@@ -1338,7 +1338,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertTrue($items[1]['publishedState']);
         $this->assertEmpty($items[1]['navContexts']);
         $this->assertTrue($items[1]['hasSub']);
-        $this->assertEquals(0, count($items[1]['_embedded']['nodes']));
+        $this->assertEquals(0, count($items[1]['_embedded']['pages']));
         $this->assertArrayHasKey('_links', $items[1]);
     }
 
@@ -1734,7 +1734,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $items = $response['_embedded']['nodes'];
+        $items = $response['_embedded']['pages'];
 
         $this->assertEquals(4, count($items));
         $this->assertEquals('test4', $items[0]['title']);
@@ -1786,7 +1786,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=de');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $items = $response['_embedded']['nodes'];
+        $items = $response['_embedded']['pages'];
 
         $this->assertEquals(4, count($items));
         $this->assertEquals('test4', $items[0]['title']);
@@ -1866,7 +1866,7 @@ class NodeControllerTest extends SuluTestCase
         $client->request('GET', '/api/nodes?depth=1&webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
-        $items = $response['_embedded']['nodes'];
+        $items = $response['_embedded']['pages'];
 
         $this->assertEquals(1, count($items));
 
@@ -1877,7 +1877,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertFalse($items[0]['publishedState']);
         $this->assertEquals(['main', 'footer'], $items[0]['navContexts']);
         $this->assertFalse($items[0]['hasSub']);
-        $this->assertEquals(0, count($items[0]['_embedded']['nodes']));
+        $this->assertEquals(0, count($items[0]['_embedded']['pages']));
         $this->assertArrayHasKey('_links', $items[0]);
     }
 
@@ -1972,7 +1972,7 @@ class NodeControllerTest extends SuluTestCase
 
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertArrayHasKey('_permissions', $response['_embedded']['nodes'][0]);
+        $this->assertArrayHasKey('_permissions', $response['_embedded']['pages'][0]);
 
         $client->request('GET', '/api/nodes/' . $securedPage->getUuid() . '?language=en&webspace=sulu_io');
 
@@ -1992,7 +1992,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $nodes = $response['_embedded']['nodes'];
+        $nodes = $response['_embedded']['pages'];
         $this->assertCount(3, $nodes);
 
         $titles = array_map(
@@ -2017,7 +2017,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $nodes = $response['_embedded']['nodes'];
+        $nodes = $response['_embedded']['pages'];
         $this->assertCount(1, $nodes);
 
         $titles = array_map(
@@ -2040,7 +2040,7 @@ class NodeControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $nodes = $response['_embedded']['nodes'];
+        $nodes = $response['_embedded']['pages'];
         $this->assertCount(1, $nodes);
 
         $titles = array_map(

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -115,16 +115,16 @@ class NodeRepositoryTest extends SuluTestCase
     {
         $result = $this->nodeRepository->getWebspaceNode('sulu_io', 'en');
 
-        $this->assertEquals('Sulu CMF', $result['_embedded']['nodes'][0]['title']);
+        $this->assertEquals('Sulu CMF', $result['_embedded']['pages'][0]['title']);
     }
 
     public function testGetWebspaceNodes()
     {
         $result = $this->nodeRepository->getWebspaceNodes('en');
 
-        $this->assertEquals('Destination CMF', $result['_embedded']['nodes'][0]['title']);
-        $this->assertEquals('Sulu CMF', $result['_embedded']['nodes'][1]['title']);
-        $this->assertEquals('Test CMF', $result['_embedded']['nodes'][2]['title']);
+        $this->assertEquals('Destination CMF', $result['_embedded']['pages'][0]['title']);
+        $this->assertEquals('Sulu CMF', $result['_embedded']['pages'][1]['title']);
+        $this->assertEquals('Test CMF', $result['_embedded']['pages'][2]['title']);
     }
 
     /**
@@ -137,7 +137,7 @@ class NodeRepositoryTest extends SuluTestCase
         $this->assertEquals('Child 1', $structure->getTitle());
 
         $result = $this->nodeRepository->getNodesTree($structure->getUuid(), 'sulu_io', 'en', false, false);
-        $this->assertEquals(2, count($result['_embedded']['nodes']));
+        $this->assertEquals(2, count($result['_embedded']['pages']));
     }
 
     /**
@@ -149,10 +149,10 @@ class NodeRepositoryTest extends SuluTestCase
         $structure = $structures[0];
 
         $result = $this->nodeRepository->getNodesTree($structure->getUuid(), 'sulu_io', 'en', false, false);
-        $this->assertEquals(2, count($result['_embedded']['nodes']));
-        $this->assertEquals('Testtitle', $result['_embedded']['nodes'][0]['title']);
-        $this->assertEquals('/testtitle', $result['_embedded']['nodes'][0]['path']);
-        $this->assertTrue($result['_embedded']['nodes'][0]['hasSub']);
+        $this->assertEquals(2, count($result['_embedded']['pages']));
+        $this->assertEquals('Testtitle', $result['_embedded']['pages'][0]['title']);
+        $this->assertEquals('/testtitle', $result['_embedded']['pages'][0]['path']);
+        $this->assertTrue($result['_embedded']['pages'][0]['hasSub']);
     }
 
     /**
@@ -164,12 +164,12 @@ class NodeRepositoryTest extends SuluTestCase
         $structure = $structures[0];
 
         $result = $this->nodeRepository->getNodesTree($structure->getUuid(), 'sulu_io', 'de', false, false);
-        $this->assertEquals(2, count($result['_embedded']['nodes']));
-        $this->assertEquals('Testtitle', $result['_embedded']['nodes'][0]['title']);
-        $this->assertEquals('/testtitle', $result['_embedded']['nodes'][0]['path']);
-        $this->assertEquals('ghost', $result['_embedded']['nodes'][0]['type']['name']);
-        $this->assertEquals('en', $result['_embedded']['nodes'][0]['type']['value']);
-        $this->assertTrue($result['_embedded']['nodes'][0]['hasSub']);
+        $this->assertEquals(2, count($result['_embedded']['pages']));
+        $this->assertEquals('Testtitle', $result['_embedded']['pages'][0]['title']);
+        $this->assertEquals('/testtitle', $result['_embedded']['pages'][0]['path']);
+        $this->assertEquals('ghost', $result['_embedded']['pages'][0]['type']['name']);
+        $this->assertEquals('en', $result['_embedded']['pages'][0]['type']['value']);
+        $this->assertTrue($result['_embedded']['pages'][0]['hasSub']);
     }
 
     private function prepareGetTreeTestData()
@@ -228,7 +228,7 @@ class NodeRepositoryTest extends SuluTestCase
         $data = $this->prepareGetTestData();
 
         $result = $this->nodeRepository->getNodesByIds([], 'sulu_io', 'en');
-        $this->assertEquals(0, count($result['_embedded']['nodes']));
+        $this->assertEquals(0, count($result['_embedded']['pages']));
         $this->assertEquals(0, $result['total']);
 
         $result = $this->nodeRepository->getNodesByIds(
@@ -238,10 +238,10 @@ class NodeRepositoryTest extends SuluTestCase
             'sulu_io',
             'en'
         );
-        $this->assertEquals(1, count($result['_embedded']['nodes']));
+        $this->assertEquals(1, count($result['_embedded']['pages']));
         $this->assertEquals(1, $result['total']);
-        $this->assertEquals('Testtitle', $result['_embedded']['nodes'][0]['title']);
-        $this->assertEquals('/testtitle', $result['_embedded']['nodes'][0]['path']);
+        $this->assertEquals('Testtitle', $result['_embedded']['pages'][0]['title']);
+        $this->assertEquals('/testtitle', $result['_embedded']['pages'][0]['path']);
     }
 
     public function testGetByIdsNotExisitingID()
@@ -249,7 +249,7 @@ class NodeRepositoryTest extends SuluTestCase
         $data = $this->prepareGetTestData();
 
         $result = $this->nodeRepository->getNodesByIds([], 'sulu_io', 'en');
-        $this->assertEquals(0, count($result['_embedded']['nodes']));
+        $this->assertEquals(0, count($result['_embedded']['pages']));
         $this->assertEquals(0, $result['total']);
 
         $result = $this->nodeRepository->getNodesByIds(
@@ -260,10 +260,10 @@ class NodeRepositoryTest extends SuluTestCase
             'sulu_io',
             'en'
         );
-        $this->assertEquals(1, count($result['_embedded']['nodes']));
+        $this->assertEquals(1, count($result['_embedded']['pages']));
         $this->assertEquals(1, $result['total']);
-        $this->assertEquals('Testtitle', $result['_embedded']['nodes'][0]['title']);
-        $this->assertEquals('/testtitle', $result['_embedded']['nodes'][0]['path']);
+        $this->assertEquals('Testtitle', $result['_embedded']['pages'][0]['title']);
+        $this->assertEquals('/testtitle', $result['_embedded']['pages'][0]['path']);
     }
 
     public function testGetFilteredNodesInOrder()
@@ -447,8 +447,8 @@ class NodeRepositoryTest extends SuluTestCase
         $this->assertEquals('/news/test1', $result['url']);
 
         $test = $this->nodeRepository->getNodes(null, 'sulu_io', 'en');
-        $this->assertEquals(4, count($test['_embedded']['nodes']));
-        $nodes = $test['_embedded']['nodes'];
+        $this->assertEquals(4, count($test['_embedded']['pages']));
+        $nodes = $test['_embedded']['pages'];
 
         $this->assertEquals('Test4', $nodes[0]['title']);
         $this->assertEquals('Test2', $nodes[1]['title']);

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
@@ -215,9 +215,9 @@ class SmartContentQueryBuilderTest extends SuluTestCase
 
         foreach ($result as $item) {
             /** @var PageDocument $expectedDocument */
-            $expectedDocument = $documents[$item['uuid']];
+            $expectedDocument = $documents[$item['id']];
 
-            $this->assertEquals($expectedDocument->getUuid(), $item['uuid']);
+            $this->assertEquals($expectedDocument->getUuid(), $item['id']);
             $this->assertEquals($expectedDocument->getRedirectType(), $item['nodeType']);
             $this->assertEquals($expectedDocument->getChanged(), $item['changed']);
             $this->assertEquals($expectedDocument->getChanger(), $item['changer']);
@@ -300,9 +300,9 @@ class SmartContentQueryBuilderTest extends SuluTestCase
         $this->assertEquals(count($nodes), count($result));
         foreach ($result as $item) {
             /** @var PageDocument $expectedDocument */
-            $expectedDocument = $nodes[$item['uuid']];
+            $expectedDocument = $nodes[$item['id']];
 
-            $this->assertEquals($expectedDocument->getUuid(), $item['uuid']);
+            $this->assertEquals($expectedDocument->getUuid(), $item['id']);
             $this->assertEquals($expectedDocument->getRedirectType(), $item['nodeType']);
             $this->assertEquals($expectedDocument->getPath(), '/cmf/sulu_io/contents' . $item['path']);
             $this->assertEquals($expectedDocument->getTitle(), $item['title']);
@@ -340,9 +340,9 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             $item = $result[$i];
 
             /** @var StructureInterface $expected */
-            $expected = $nodes[$item['uuid']];
+            $expected = $nodes[$item['id']];
 
-            $this->assertEquals($expected->getUuid(), $item['uuid']);
+            $this->assertEquals($expected->getUuid(), $item['id']);
             $this->assertEquals($expected->getRedirectType(), $item['nodeType']);
             $this->assertEquals($expected->getPath(), '/cmf/sulu_io/contents' . $item['path']);
             $this->assertEquals($expected->getTitle(), $item['title']);
@@ -1113,7 +1113,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
         $result = $this->contentQuery->execute('sulu_io', ['en'], $builder);
 
         foreach ($result as $item) {
-            $expectedDocument = $documents[$item['uuid']];
+            $expectedDocument = $documents[$item['id']];
 
             $this->assertEquals($expectedDocument->getTitle(), $item['my_title']);
             $this->assertEquals($expectedDocument->getExtensionsData()['excerpt']['title'], $item['ext_title']);
@@ -1138,8 +1138,8 @@ class SmartContentQueryBuilderTest extends SuluTestCase
         $tDiff = microtime(true) - $tStart;
 
         $this->assertEquals(2, count($result));
-        $this->assertArrayHasKey($result[0]['uuid'], $nodes);
-        $this->assertArrayHasKey($result[1]['uuid'], $nodes);
+        $this->assertArrayHasKey($result[0]['id'], $nodes);
+        $this->assertArrayHasKey($result[1]['id'], $nodes);
     }
 
     public function testExcluded()
@@ -1160,7 +1160,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
         $this->assertEquals(14, count($result));
         unset($uuids[0]);
         foreach ($result as $item) {
-            $this->assertContains($item['uuid'], $uuids);
+            $this->assertContains($item['id'], $uuids);
         }
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/PageSelectionContainerTest.php
@@ -53,7 +53,7 @@ class PageSelectionContainerTest extends TestCase
 
         $this->builder->init(['ids' => [2, 3, 1], 'properties' => [], 'published' => false])->shouldBeCalled();
         $this->executor->execute('default', ['en'], $this->builder)->willReturn(
-            [['uuid' => 1], ['uuid' => 2], ['uuid' => 3]]
+            [['id' => 1], ['id' => 2], ['id' => 3]]
         );
 
         $this->container->getData();
@@ -73,7 +73,7 @@ class PageSelectionContainerTest extends TestCase
 
         $this->builder->init(['ids' => [2, 3, 1], 'properties' => [], 'published' => true])->shouldBeCalled();
         $this->executor->execute('default', ['en'], $this->builder)->willReturn(
-            [['uuid' => 1], ['uuid' => 2], ['uuid' => 3]]
+            [['id' => 1], ['id' => 2], ['id' => 3]]
         );
 
         $this->container->getData();
@@ -82,7 +82,7 @@ class PageSelectionContainerTest extends TestCase
     public function testGetDataOrder()
     {
         $this->executor->execute('default', ['en'], $this->builder)->willReturn(
-            [['uuid' => 1], ['uuid' => 2], ['uuid' => 3]]
+            [['id' => 1], ['id' => 2], ['id' => 3]]
         );
 
         $this->container = new PageSelectionContainer(
@@ -96,6 +96,6 @@ class PageSelectionContainerTest extends TestCase
         );
 
         $result = $this->container->getData();
-        $this->assertEquals([['uuid' => 2], ['uuid' => 3], ['uuid' => 1]], $result);
+        $this->assertEquals([['id' => 2], ['id' => 3], ['id' => 1]], $result);
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetDataProvider.php
@@ -182,7 +182,7 @@ class SnippetDataProvider implements DataProviderInterface
     {
         return array_map(
             function($item) use ($locale) {
-                return new ContentDataItem($item, $this->getResource($item['uuid'], $locale));
+                return new ContentDataItem($item, $this->getResource($item['id'], $locale));
             },
             $data
         );
@@ -200,9 +200,9 @@ class SnippetDataProvider implements DataProviderInterface
     {
         return array_map(
             function($item) use ($locale) {
-                $this->referenceStore->add($item['uuid']);
+                $this->referenceStore->add($item['id']);
 
-                return new ArrayAccessItem($item['uuid'], $item, $this->getResource($item['uuid'], $locale));
+                return new ArrayAccessItem($item['id'], $item, $this->getResource($item['id'], $locale));
             },
             $data
         );

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
@@ -147,7 +147,7 @@ class SnippetDataProviderTest extends TestCase
                 null,
                 1,
                 null,
-                [['uuid' => 1], ['uuid' => 2]],
+                [['id' => 1], ['id' => 2]],
                 false,
             ],
             [
@@ -157,7 +157,7 @@ class SnippetDataProviderTest extends TestCase
                 1,
                 1,
                 null,
-                [['uuid' => 1]],
+                [['id' => 1]],
                 false,
             ],
             [
@@ -167,7 +167,7 @@ class SnippetDataProviderTest extends TestCase
                 null,
                 5,
                 2,
-                [['uuid' => 1], ['uuid' => 2]],
+                [['id' => 1], ['id' => 2]],
                 false,
             ],
             [
@@ -177,7 +177,7 @@ class SnippetDataProviderTest extends TestCase
                 null,
                 5,
                 2,
-                [['uuid' => 1], ['uuid' => 2]],
+                [['id' => 1], ['id' => 2]],
                 false,
             ],
         ];
@@ -197,7 +197,7 @@ class SnippetDataProviderTest extends TestCase
         $hasNextPage
     ) {
         foreach ($result as $item) {
-            $this->referenceStore->add($item['uuid'])->shouldBeCalled();
+            $this->referenceStore->add($item['id'])->shouldBeCalled();
         }
 
         $this->contentQueryExecutor->execute(
@@ -234,7 +234,7 @@ class SnippetDataProviderTest extends TestCase
 
         $result = [];
         foreach ($uuids as $uuid) {
-            $result[] = ['uuid' => $uuid];
+            $result[] = ['id' => $uuid];
             $this->referenceStore->add($uuid)->shouldBeCalled();
         }
 
@@ -295,7 +295,7 @@ class SnippetDataProviderTest extends TestCase
                 null,
                 1,
                 null,
-                [['uuid' => 1], ['uuid' => 2]],
+                [['id' => 1], ['id' => 2]],
                 false,
             ],
             [
@@ -305,7 +305,7 @@ class SnippetDataProviderTest extends TestCase
                 1,
                 1,
                 null,
-                [['uuid' => 1]],
+                [['id' => 1]],
                 false,
             ],
             [
@@ -315,7 +315,7 @@ class SnippetDataProviderTest extends TestCase
                 null,
                 5,
                 2,
-                [['uuid' => 1], ['uuid' => 2]],
+                [['id' => 1], ['id' => 2]],
                 false,
             ],
         ];

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Navigation/NavigationTest.php
@@ -212,11 +212,11 @@ class NavigationTest extends SuluTestCase
         $this->assertEquals(0, count($main[0]['children']));
         $this->assertEquals(0, count($main[1]['children']));
 
-        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[0]['uuid']);
+        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[0]['id']);
         $this->assertEquals('News-1', $main[0]['title']);
         $this->assertEquals('/news/news-1', $main[0]['url']);
 
-        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[1]['uuid']);
+        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[1]['id']);
         $this->assertEquals('News-2', $main[1]['title']);
         $this->assertEquals('/news/news-2', $main[1]['url']);
     }
@@ -464,11 +464,11 @@ class NavigationTest extends SuluTestCase
         $this->assertEquals(0, count($main[0]['children']));
         $this->assertEquals(0, count($main[1]['children']));
 
-        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[0]['uuid']);
+        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[0]['id']);
         $this->assertEquals('News-1', $main[0]['title']);
         $this->assertEquals('/news/news-1', $main[0]['url']);
 
-        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[1]['uuid']);
+        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[1]['id']);
         $this->assertEquals('News-2', $main[1]['title']);
         $this->assertEquals('/news/news-2', $main[1]['url']);
 
@@ -482,11 +482,11 @@ class NavigationTest extends SuluTestCase
         $this->assertEquals(0, count($main[0]['children']));
         $this->assertEquals(0, count($main[1]['children']));
 
-        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[0]['uuid']);
+        $this->assertEquals($this->data['news/news-2']->getUuid(), $main[0]['id']);
         $this->assertEquals('News-2', $main[0]['title']);
         $this->assertEquals('/news/news-2', $main[0]['url']);
 
-        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[1]['uuid']);
+        $this->assertEquals($this->data['news/news-1']->getUuid(), $main[1]['id']);
         $this->assertEquals('News-1', $main[1]['title']);
         $this->assertEquals('/news/news-1', $main[1]['url']);
     }

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -748,7 +748,7 @@ class ContentMapper implements ContentMapperInterface
         $shortPath = $this->inspector->getContentPath($originalDocument);
 
         $documentData = [
-            'uuid' => $originalDocument->getUuid(),
+            'id' => $originalDocument->getUuid(),
             'nodeType' => $redirectType,
             'path' => $shortPath,
             'changed' => $document->getChanged(),

--- a/src/Sulu/Component/Content/SmartContent/ContentDataItem.php
+++ b/src/Sulu/Component/Content/SmartContent/ContentDataItem.php
@@ -30,7 +30,7 @@ class ContentDataItem extends ArrayAccessItem implements ItemInterface, PublishI
      */
     public function __construct(array $data, $resource)
     {
-        parent::__construct($data['uuid'], $data, $resource);
+        parent::__construct($data['id'], $data, $resource);
     }
 
     /**

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -173,7 +173,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             return;
         }
 
-        return new DatasourceItem($result[0]['uuid'], $result[0]['title'], '/' . ltrim($result[0]['path'], '/'));
+        return new DatasourceItem($result[0]['id'], $result[0]['title'], '/' . ltrim($result[0]['path'], '/'));
     }
 
     /**
@@ -348,7 +348,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
     {
         return array_map(
             function($item) use ($locale) {
-                return new ContentDataItem($item, $this->getResource($item['uuid'], $locale));
+                return new ContentDataItem($item, $this->getResource($item['id'], $locale));
             },
             $data
         );
@@ -366,9 +366,9 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
     {
         return array_map(
             function($item) use ($locale) {
-                $this->referenceStore->add($item['uuid']);
+                $this->referenceStore->add($item['id']);
 
-                return new ArrayAccessItem($item['uuid'], $item, $this->getResource($item['uuid'], $locale));
+                return new ArrayAccessItem($item['id'], $item, $this->getResource($item['id'], $locale));
             },
             $data
         );

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -223,9 +223,9 @@ class PageDataProviderTest extends TestCase
     public function testResolveDataItemsHasNextPage()
     {
         $data = [
-            ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
-            ['uuid' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
-            ['uuid' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
+            ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
+            ['id' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
+            ['id' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
         ];
 
         $provider = new PageDataProvider(
@@ -256,9 +256,9 @@ class PageDataProviderTest extends TestCase
 
         $this->assertInstanceOf(DataProviderResult::class, $result);
         $items = $result->getItems();
-        $this->assertEquals($data[0]['uuid'], $items[0]->getId());
+        $this->assertEquals($data[0]['id'], $items[0]->getId());
         $this->assertEquals($data[0], $items[0]->getResource()->getWrappedValueHolderValue());
-        $this->assertEquals($data[1]['uuid'], $items[1]->getId());
+        $this->assertEquals($data[1]['id'], $items[1]->getId());
         $this->assertEquals($data[1], $items[1]->getResource()->getWrappedValueHolderValue());
         $this->assertTrue($result->getHasNextPage());
     }
@@ -266,9 +266,9 @@ class PageDataProviderTest extends TestCase
     public function testResolveDataItemsOnlyPublished()
     {
         $data = [
-            ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
-            ['uuid' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
-            ['uuid' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
+            ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
+            ['id' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
+            ['id' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
         ];
 
         $provider = new PageDataProvider(
@@ -299,9 +299,9 @@ class PageDataProviderTest extends TestCase
 
         $this->assertInstanceOf(DataProviderResult::class, $result);
         $items = $result->getItems();
-        $this->assertEquals($data[0]['uuid'], $items[0]->getId());
+        $this->assertEquals($data[0]['id'], $items[0]->getId());
         $this->assertEquals($data[0], $items[0]->getResource()->getWrappedValueHolderValue());
-        $this->assertEquals($data[1]['uuid'], $items[1]->getId());
+        $this->assertEquals($data[1]['id'], $items[1]->getId());
         $this->assertEquals($data[1], $items[1]->getResource()->getWrappedValueHolderValue());
         $this->assertTrue($result->getHasNextPage());
     }
@@ -309,9 +309,9 @@ class PageDataProviderTest extends TestCase
     public function testResolveResourceItems()
     {
         $data = [
-            ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
-            ['uuid' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
-            ['uuid' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
+            ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
+            ['id' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
+            ['id' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
         ];
 
         $referenceStore = new ReferenceStore();
@@ -343,9 +343,9 @@ class PageDataProviderTest extends TestCase
 
         $this->assertInstanceOf(DataProviderResult::class, $result);
         $items = $result->getItems();
-        $this->assertEquals($data[0]['uuid'], $items[0]->getId());
+        $this->assertEquals($data[0]['id'], $items[0]->getId());
         $this->assertEquals($data[0], $items[0]->getResource()->getWrappedValueHolderValue());
-        $this->assertEquals($data[1]['uuid'], $items[1]->getId());
+        $this->assertEquals($data[1]['id'], $items[1]->getId());
         $this->assertEquals($data[1], $items[1]->getResource()->getWrappedValueHolderValue());
         $this->assertTrue($result->getHasNextPage());
         $this->assertEquals(['123-123-123', '123-123-456'], $referenceStore->getAll());
@@ -354,9 +354,9 @@ class PageDataProviderTest extends TestCase
     public function testResolveDataItemsNoPagination()
     {
         $data = [
-            ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
-            ['uuid' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
-            ['uuid' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
+            ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
+            ['id' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
+            ['id' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
         ];
 
         $provider = new PageDataProvider(
@@ -388,11 +388,11 @@ class PageDataProviderTest extends TestCase
 
         $items = $result->getItems();
 
-        $this->assertEquals($data[0]['uuid'], $items[0]->getId());
+        $this->assertEquals($data[0]['id'], $items[0]->getId());
         $this->assertEquals($data[0], $items[0]->getResource()->getWrappedValueHolderValue());
-        $this->assertEquals($data[1]['uuid'], $items[1]->getId());
+        $this->assertEquals($data[1]['id'], $items[1]->getId());
         $this->assertEquals($data[1], $items[1]->getResource()->getWrappedValueHolderValue());
-        $this->assertEquals($data[2]['uuid'], $items[2]->getId());
+        $this->assertEquals($data[2]['id'], $items[2]->getId());
         $this->assertEquals($data[2], $items[2]->getResource()->getWrappedValueHolderValue());
         $this->assertFalse($result->getHasNextPage());
     }
@@ -422,14 +422,14 @@ class PageDataProviderTest extends TestCase
 
     public function testResolveDatasource()
     {
-        $data = ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'];
+        $data = ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'];
 
         $provider = new PageDataProvider(
             $this->getContentQueryBuilder(
-                ['ids' => [$data['uuid']], 'properties' => ['my-properties' => true], 'published' => false]
+                ['ids' => [$data['id']], 'properties' => ['my-properties' => true], 'published' => false]
             ),
             $this->getContentQueryExecutor(0, 1, [$data]),
-            $this->getDocumentManager([$data['uuid'] => $data]),
+            $this->getDocumentManager([$data['id'] => $data]),
             $this->getProxyFactory(),
             $this->getSession(),
             new ReferenceStore(),
@@ -437,13 +437,13 @@ class PageDataProviderTest extends TestCase
         );
 
         $result = $provider->resolveDatasource(
-            $data['uuid'],
+            $data['id'],
             ['properties' => new PropertyParameter('properties', ['my-properties' => true], 'collection')],
             ['webspaceKey' => 'sulu_io', 'locale' => 'en']
         );
 
         $this->assertInstanceOf(DatasourceItem::class, $result);
-        $this->assertEquals($data['uuid'], $result->getId());
+        $this->assertEquals($data['id'], $result->getId());
         $this->assertEquals($data['title'], $result->getTitle());
         $this->assertEquals($data['path'], $result->getPath());
         $this->assertNull($result->getImage());
@@ -451,11 +451,11 @@ class PageDataProviderTest extends TestCase
 
     public function testContentDataItem()
     {
-        $data = ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'];
+        $data = ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'];
         $resource = new \stdClass();
         $item = new ContentDataItem($data, $resource);
 
-        $this->assertEquals($data['uuid'], $item->getId());
+        $this->assertEquals($data['id'], $item->getId());
         $this->assertEquals($data['title'], $item->getTitle());
         $this->assertEquals($resource, $item->getResource());
 
@@ -465,9 +465,9 @@ class PageDataProviderTest extends TestCase
     public function testResolveResourceItemsExcluded()
     {
         $data = [
-            ['uuid' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
-            ['uuid' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
-            ['uuid' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
+            ['id' => '123-123-123', 'title' => 'My-Page', 'path' => '/my-page'],
+            ['id' => '123-123-456', 'title' => 'My-Page-1', 'path' => '/my-page-1'],
+            ['id' => '123-123-789', 'title' => 'My-Page-2', 'path' => '/my-page-2'],
         ];
 
         $referenceStore = new ReferenceStore();
@@ -505,7 +505,7 @@ class PageDataProviderTest extends TestCase
 
         $items = $result->getItems();
         for ($i = 0, $length = count($items); $i < $length; ++$i) {
-            $this->assertEquals($data[$i]['uuid'], $items[$i]->getId());
+            $this->assertEquals($data[$i]['id'], $items[$i]->getId());
             $this->assertEquals($data[$i], $items[$i]->jsonSerialize());
 
             $this->assertEquals($data[$i], $items[$i]->getResource()->getWrappedValueHolderValue());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4212
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR lets the `ListStore` reload without the passed IDs, if the request with the IDs fails.

#### Why?

Because currently the user just sees a loader if the page which was last selected according to his user settings was deleted.

#### BC Breaks/Deprecations

The `NodeController` returns now the correct results instead of being modified in the `PageController`. We should merge these two to a single `PageController` at some point.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Test if everything is still working
- [x] Apply the fix
