### PR TITLE
Add possibility to define a mailto link

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -7,7 +7,7 @@ exports[`The component should render in body when open 1`] = `
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"dialogContainer\\">
+  <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
         <header>My dialog title</header>
@@ -26,7 +26,7 @@ exports[`The component should render in body with a large class 1`] = `
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"dialogContainer\\">
+  <div class=\\"dialogContainer open\\">
     <div class=\\"dialog large\\">
       <section class=\\"content\\">
         <header>My dialog title</header>
@@ -45,7 +45,7 @@ exports[`The component should render in body with disabled confirm button 1`] = 
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"dialogContainer\\">
+  <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
         <header>My dialog title</header>
@@ -64,7 +64,7 @@ exports[`The component should render in body with loader instead of confirm butt
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"dialogContainer\\">
+  <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
         <header>My dialog title</header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/__snapshots__/Overlay.test.js.snap
@@ -7,7 +7,7 @@ exports[`The component should render in body when open 1`] = `
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"container\\">
+  <div class=\\"container isDown\\">
     <div class=\\"overlay small\\">
       <section class=\\"content\\">
         <header>
@@ -28,7 +28,7 @@ exports[`The component should render in body with actions when open 1`] = `
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"container\\">
+  <div class=\\"container isDown\\">
     <div class=\\"overlay\\">
       <section class=\\"content\\">
         <header>
@@ -51,7 +51,7 @@ exports[`The component should render in body with loader instead of confirm butt
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"container\\">
+  <div class=\\"container isDown\\">
     <div class=\\"overlay\\">
       <section class=\\"content\\">
         <header>
@@ -78,7 +78,7 @@ exports[`The component should render with a disabled confirm button 1`] = `
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"container\\">
+  <div class=\\"container isDown\\">
     <div class=\\"overlay\\">
       <section class=\\"content\\">
         <header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -4,6 +4,7 @@ import {observer} from 'mobx-react';
 import {action, computed, observable} from 'mobx';
 import classNames from 'classnames';
 import log from 'loglevel';
+import Isemail from 'isemail';
 import SingleSelect from '../SingleSelect';
 import urlStyles from './url.scss';
 
@@ -56,6 +57,10 @@ class Url extends React.Component<Props> {
     isValidUrl(url: ?string) {
         if (!url) {
             return true;
+        }
+
+        if (url.indexOf('mailto:') === 0) {
+            return Isemail.validate(url.substring(7));
         }
 
         return URL_REGEX.test(url);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -14,6 +14,7 @@ type Props = {|
     id?: string,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
+    onProtocolChange?: (protocol: ?string) => void,
     protocols: Array<string>,
     valid: boolean,
     value: ?string,
@@ -85,10 +86,16 @@ class Url extends React.Component<Props> {
             this.protocol = undefined;
             this.path = undefined;
 
+            const {defaultProtocol, onProtocolChange} = this.props;
+
+            if (onProtocolChange) {
+                onProtocolChange(defaultProtocol);
+            }
+
             return;
         }
 
-        const {protocols, value} = this.props;
+        const {onProtocolChange, protocols, value} = this.props;
 
         if (value === this.url) {
             return;
@@ -103,6 +110,10 @@ class Url extends React.Component<Props> {
         this.path = url.substring(protocol ? protocol.length : 0);
 
         this.validUrl = this.isValidUrl(this.url);
+
+        if (onProtocolChange) {
+            onProtocolChange(protocol);
+        }
     }
 
     @computed get url() {
@@ -115,8 +126,8 @@ class Url extends React.Component<Props> {
         return protocol + this.path;
     }
 
-    @action handleProtocolChange = (protocol: string | number) => {
-        const {onBlur, protocols} = this.props;
+    @action handleProtocolChange = (protocol: string) => {
+        const {onBlur, onProtocolChange, protocols} = this.props;
 
         if (typeof protocol !== 'string' || !protocols.includes(protocol)) {
             throw new Error(
@@ -128,6 +139,10 @@ class Url extends React.Component<Props> {
         this.protocol = protocol;
 
         this.callChangeCallback();
+
+        if (onProtocolChange) {
+            onProtocolChange(protocol);
+        }
 
         if (onBlur) {
             onBlur();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -168,6 +168,38 @@ test('Call onChange callback with undefined if URL is not valid but leave the cu
     expect(url.find('.error')).toHaveLength(1);
 });
 
+test('Call onChange callback with correct mail address', () => {
+    const changeSpy = jest.fn();
+    const url = shallow(<Url onChange={changeSpy} protocols={['mailto:']} value={undefined} />);
+    url.find('input').prop('onChange')({
+        currentTarget: {
+            value: 'test@example.com',
+        },
+    });
+    url.find('input').prop('onBlur')();
+
+    expect(changeSpy).toBeCalledWith('mailto:test@example.com');
+    expect(url.find('SingleSelect').prop('value')).toEqual('mailto:');
+    expect(url.find('input').prop('value')).toEqual('test@example.com');
+    expect(url.find('.error')).toHaveLength(0);
+});
+
+test('Call onChange callback with undefined if incorrect mail address is entered', () => {
+    const changeSpy = jest.fn();
+    const url = shallow(<Url onChange={changeSpy} protocols={['mailto:']} value={undefined} />);
+    url.find('input').prop('onChange')({
+        currentTarget: {
+            value: 'example.com',
+        },
+    });
+    url.find('input').prop('onBlur')();
+
+    expect(changeSpy).toBeCalledWith(undefined);
+    expect(url.find('SingleSelect').prop('value')).toEqual('mailto:');
+    expect(url.find('input').prop('value')).toEqual('example.com');
+    expect(url.find('.error')).toHaveLength(1);
+});
+
 test('Should remove the protocol from path and set it on the protocol select', () => {
     const changeSpy = jest.fn();
     const url = shallow(<Url onChange={changeSpy} value={undefined} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/tests/Url.test.js
@@ -228,13 +228,7 @@ test('Should remove the protocol from path and set it on the protocol select if 
 
 test('Call onBlur callback when protocol was changed', () => {
     const blurSpy = jest.fn();
-    const url = shallow(
-        <Url
-            onBlur={blurSpy}
-            onChange={jest.fn()}
-            value="https://www.sulu.io"
-        />
-    );
+    const url = shallow(<Url onBlur={blurSpy} onChange={jest.fn()} value="https://www.sulu.io" />);
     url.find('SingleSelect').prop('onChange')('http://');
 
     expect(blurSpy).toBeCalledWith();
@@ -242,14 +236,34 @@ test('Call onBlur callback when protocol was changed', () => {
 
 test('Call onBlur callback when path was changed', () => {
     const blurSpy = jest.fn();
-    const url = shallow(
-        <Url
-            onBlur={blurSpy}
-            onChange={jest.fn()}
-            value="https://www.sulu.io"
-        />
-    );
+    const url = shallow(<Url onBlur={blurSpy} onChange={jest.fn()} value="https://www.sulu.io" />);
     url.find('input').prop('onBlur')();
 
     expect(blurSpy).toBeCalledWith();
+});
+
+test('Should call onProtocolChange with default protocol', () => {
+    const protocolChangeSpy = jest.fn();
+    shallow(
+        <Url defaultProtocol="http://" onChange={jest.fn()} onProtocolChange={protocolChangeSpy} value={undefined} />
+    );
+
+    expect(protocolChangeSpy).toBeCalledWith('http://');
+});
+
+test('Should call onProtocolChange with initial value', () => {
+    const protocolChangeSpy = jest.fn();
+    shallow(<Url onChange={jest.fn()} onProtocolChange={protocolChangeSpy} value="http://www.google.at" />);
+
+    expect(protocolChangeSpy).toBeCalledWith('http://');
+});
+
+test('Should call onProtocolChange when protocol is changed', () => {
+    const changeSpy = jest.fn();
+    const protocolChangeSpy = jest.fn();
+    const url = shallow(<Url onChange={changeSpy} onProtocolChange={protocolChangeSpy} value={undefined} />);
+
+    url.find('SingleSelect').prop('onChange')('https://');
+
+    expect(protocolChangeSpy).toHaveBeenLastCalledWith('https://');
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -135,6 +135,9 @@ $textEditorUnpublishedLinkColor: $gold;
     .ck-preview-button {
         .ck-button__label {
             cursor: pointer !important;
+            max-width: 300px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -24,6 +24,7 @@ type Props = {|
 
 @observer
 class ExternalLinkOverlay extends React.Component<Props> {
+    @observable protocol: ?string = undefined;
     @observable url: ?string = undefined;
     @observable mailSubject: ?string = undefined;
     @observable mailBody: ?string = undefined;
@@ -93,6 +94,10 @@ class ExternalLinkOverlay extends React.Component<Props> {
 
     handleMailSubjectBlur = this.callUrlChange;
 
+    @action handleProtocolChange = (protocol: ?string) => {
+        this.protocol = protocol;
+    };
+
     @action handleMailSubjectChange = (mailSubject: ?string) => {
         this.mailSubject = mailSubject;
     };
@@ -131,13 +136,14 @@ class ExternalLinkOverlay extends React.Component<Props> {
                             defaultProtocol="https://"
                             onBlur={this.handleUrlBlur}
                             onChange={this.handleUrlChange}
+                            onProtocolChange={this.handleProtocolChange}
                             protocols={['http://', 'https://', 'ftp://', 'ftps://', 'mailto:']}
                             valid={true}
                             value={this.url}
                         />
                     </Form.Field>
 
-                    {url && !url.startsWith('mailto:') &&
+                    {this.protocol && this.protocol !== 'mailto:' &&
                         <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
                                 <SingleSelect.Option value="_blank">_blank</SingleSelect.Option>
@@ -148,7 +154,7 @@ class ExternalLinkOverlay extends React.Component<Props> {
                         </Form.Field>
                     }
 
-                    {url && url.startsWith('mailto:') &&
+                    {this.protocol && this.protocol === 'mailto:' &&
                         <Fragment>
                             <Form.Field label={translate('sulu_admin.mail_subject')}>
                                 <Input

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -56,8 +56,8 @@ class ExternalLinkOverlay extends React.Component<Props> {
         const mailSubject = urlParameters.get('subject');
         const mailBody = urlParameters.get('body');
 
-        this.mailSubject = mailSubject ? decodeURI(mailSubject) : undefined;
-        this.mailBody = mailBody ? decodeURI(mailBody) : undefined;
+        this.mailSubject = mailSubject ? mailSubject : undefined;
+        this.mailBody = mailBody ? mailBody : undefined;
     }
 
     callUrlChange = () => {
@@ -76,14 +76,21 @@ class ExternalLinkOverlay extends React.Component<Props> {
         const urlParameters = new URLSearchParams();
 
         if (mailSubject) {
-            urlParameters.set('subject', encodeURI(mailSubject));
+            urlParameters.set('subject', mailSubject);
         }
 
         if (mailBody) {
-            urlParameters.set('body', encodeURI(mailBody));
+            urlParameters.set('body', mailBody);
         }
 
-        onUrlChange(url + (Array.from(urlParameters).length > 0 ? '?' + urlParameters.toString() : ''));
+        onUrlChange(
+            url + (
+                Array.from(urlParameters).length > 0
+                    // Replacing value is required, because Apple Mail does not seem to understand it otherwise
+                    ? '?' + urlParameters.toString().replace(/\+/g, '%20')
+                    : ''
+            )
+        );
     };
 
     handleUrlBlur = this.callUrlChange;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -44,14 +44,16 @@ export default class ExternalLinkOverlay extends React.Component<Props> {
                         />
                     </Form.Field>
 
-                    <Form.Field label={translate('sulu_admin.link_target')} required={true}>
-                        <SingleSelect onChange={onTargetChange} value={target}>
-                            <SingleSelect.Option value="_blank">_blank</SingleSelect.Option>
-                            <SingleSelect.Option value="_self">_self</SingleSelect.Option>
-                            <SingleSelect.Option value="_parent">_parent</SingleSelect.Option>
-                            <SingleSelect.Option value="_top">_top</SingleSelect.Option>
-                        </SingleSelect>
-                    </Form.Field>
+                    {url && !url.startsWith('mailto:') &&
+                        <Form.Field label={translate('sulu_admin.link_target')} required={true}>
+                            <SingleSelect onChange={onTargetChange} value={target}>
+                                <SingleSelect.Option value="_blank">_blank</SingleSelect.Option>
+                                <SingleSelect.Option value="_self">_self</SingleSelect.Option>
+                                <SingleSelect.Option value="_parent">_parent</SingleSelect.Option>
+                                <SingleSelect.Option value="_top">_top</SingleSelect.Option>
+                            </SingleSelect>
+                        </Form.Field>
+                    }
 
                     <Form.Field label={translate('sulu_admin.link_title')}>
                         <Input onChange={onTitleChange} value={title} />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -20,8 +20,18 @@ type Props = {|
 |};
 
 export default class ExternalLinkOverlay extends React.Component<Props> {
+    handleUrlChange = (url: ?string) => {
+        const {onTargetChange, onUrlChange} = this.props;
+
+        if (url && url.startsWith('mailto:')) {
+            onTargetChange('_self');
+        }
+
+        onUrlChange(url);
+    };
+
     render() {
-        const {onCancel, onConfirm, onTargetChange, onTitleChange, onUrlChange, open, target, title, url} = this.props;
+        const {onCancel, onConfirm, onTargetChange, onTitleChange, open, target, title, url} = this.props;
 
         return (
             <Dialog
@@ -37,7 +47,7 @@ export default class ExternalLinkOverlay extends React.Component<Props> {
                     <Form.Field label={translate('sulu_admin.link_url')} required={true}>
                         <Url
                             defaultProtocol="https://"
-                            onChange={onUrlChange}
+                            onChange={this.handleUrlChange}
                             protocols={['http://', 'https://', 'ftp://', 'ftps://', 'mailto:']}
                             valid={true}
                             value={url}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -56,8 +56,8 @@ class ExternalLinkOverlay extends React.Component<Props> {
         const mailSubject = urlParameters.get('subject');
         const mailBody = urlParameters.get('body');
 
-        this.mailSubject = mailSubject ? mailSubject : undefined;
-        this.mailBody = mailBody ? mailBody : undefined;
+        this.mailSubject = mailSubject ? decodeURI(mailSubject) : undefined;
+        this.mailBody = mailBody ? decodeURI(mailBody) : undefined;
     }
 
     callUrlChange = () => {
@@ -76,11 +76,11 @@ class ExternalLinkOverlay extends React.Component<Props> {
         const urlParameters = new URLSearchParams();
 
         if (mailSubject) {
-            urlParameters.set('subject', mailSubject);
+            urlParameters.set('subject', encodeURI(mailSubject));
         }
 
         if (mailBody) {
-            urlParameters.set('body', mailBody);
+            urlParameters.set('body', encodeURI(mailBody));
         }
 
         onUrlChange(url + (Array.from(urlParameters).length > 0 ? '?' + urlParameters.toString() : ''));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkOverlay.js
@@ -35,7 +35,13 @@ export default class ExternalLinkOverlay extends React.Component<Props> {
             >
                 <Form>
                     <Form.Field label={translate('sulu_admin.link_url')} required={true}>
-                        <Url defaultProtocol="https://" onChange={onUrlChange} valid={true} value={url} />
+                        <Url
+                            defaultProtocol="https://"
+                            onChange={onUrlChange}
+                            protocols={['http://', 'https://', 'ftp://', 'ftps://', 'mailto:']}
+                            valid={true}
+                            value={url}
+                        />
                     </Form.Field>
 
                     <Form.Field label={translate('sulu_admin.link_target')} required={true}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
@@ -162,16 +162,16 @@ test('Call onUrlChange with all mail values', () => {
     expect(targetChangeSpy).toBeCalledWith('_self');
 
     externalLinkOverlay.update();
-    externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"] Input').prop('onChange')('Subject');
-    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org?subject=Subject');
+    externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"] Input').prop('onChange')('Subject Line');
+    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org?subject=Subject%20Line');
     externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"] Input').prop('onBlur')();
-    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org?subject=Subject');
+    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org?subject=Subject%20Line');
 
     externalLinkOverlay.update();
-    externalLinkOverlay.find('Field[label="sulu_admin.mail_body"] TextArea').prop('onChange')('Body');
-    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org?subject=Subject&body=Body');
+    externalLinkOverlay.find('Field[label="sulu_admin.mail_body"] TextArea').prop('onChange')('Body Text');
+    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org?subject=Subject%20Line&body=Body%20Text');
     externalLinkOverlay.find('Field[label="sulu_admin.mail_body"] TextArea').prop('onBlur')();
-    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org?subject=Subject&body=Body');
+    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org?subject=Subject%20Line&body=Body%20Text');
 });
 
 test('Reset target to self when a mailto link is entered', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
@@ -36,7 +36,7 @@ test('Render overlay with mailto URL', () => {
             open={true}
             target={undefined}
             title={undefined}
-            url="mailto:test@example.org"
+            url="mailto:test@example.org?subject=Subject&body=Body"
         />
     );
 
@@ -84,6 +84,65 @@ test('Pass correct props to Dialog', () => {
     expect(externalLinkOverlay.find('Dialog').prop('open')).toEqual(false);
 });
 
+test('Do not call onUrlChange handler if input did not loose focus', () => {
+    const targetChangeSpy = jest.fn();
+    const urlChangeSpy = jest.fn();
+
+    const externalLinkOverlay = shallow(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={targetChangeSpy}
+            onTitleChange={jest.fn()}
+            onUrlChange={urlChangeSpy}
+            open={true}
+            target="_blank"
+            title={undefined}
+            url={undefined}
+        />
+    );
+
+    externalLinkOverlay.find('Url').prop('onChange')('http://www.sulu.io');
+    expect(urlChangeSpy).not.toBeCalled();
+});
+
+test('Call onUrlChange with all mail values', () => {
+    const targetChangeSpy = jest.fn();
+    const urlChangeSpy = jest.fn();
+
+    const externalLinkOverlay = shallow(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={targetChangeSpy}
+            onTitleChange={jest.fn()}
+            onUrlChange={urlChangeSpy}
+            open={true}
+            target="_blank"
+            title={undefined}
+            url="mailto:bla@example.org"
+        />
+    );
+
+    externalLinkOverlay.find('Url').prop('onChange')('mailto:test@example.org');
+    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org');
+    externalLinkOverlay.find('Url').prop('onBlur')();
+    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org');
+    expect(targetChangeSpy).toBeCalledWith('_self');
+
+    externalLinkOverlay.update();
+    externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"] Input').prop('onChange')('Subject');
+    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org?subject=Subject');
+    externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"] Input').prop('onBlur')();
+    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org?subject=Subject');
+
+    externalLinkOverlay.update();
+    externalLinkOverlay.find('Field[label="sulu_admin.mail_body"] TextArea').prop('onChange')('Body');
+    expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org?subject=Subject&body=Body');
+    externalLinkOverlay.find('Field[label="sulu_admin.mail_body"] TextArea').prop('onBlur')();
+    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org?subject=Subject&body=Body');
+});
+
 test('Reset target to self when a mailto link is entered', () => {
     const targetChangeSpy = jest.fn();
     const urlChangeSpy = jest.fn();
@@ -103,6 +162,7 @@ test('Reset target to self when a mailto link is entered', () => {
     );
 
     externalLinkOverlay.find('Url').prop('onChange')('mailto:test@example.org');
+    externalLinkOverlay.find('Url').prop('onBlur')();
     expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org');
     expect(targetChangeSpy).toBeCalledWith('_self');
 });
@@ -126,6 +186,7 @@ test('Should not reset target to self when a non-mail URL is entered', () => {
     );
 
     externalLinkOverlay.find('Url').prop('onChange')('http://sulu.io');
+    externalLinkOverlay.find('Url').prop('onBlur')();
     expect(urlChangeSpy).toBeCalledWith('http://sulu.io');
     expect(targetChangeSpy).not.toBeCalled();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
@@ -83,3 +83,49 @@ test('Pass correct props to Dialog', () => {
     expect(externalLinkOverlay.find('Dialog').prop('onConfirm')).toEqual(confirmSpy);
     expect(externalLinkOverlay.find('Dialog').prop('open')).toEqual(false);
 });
+
+test('Reset target to self when a mailto link is entered', () => {
+    const targetChangeSpy = jest.fn();
+    const urlChangeSpy = jest.fn();
+
+    const externalLinkOverlay = shallow(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={targetChangeSpy}
+            onTitleChange={jest.fn()}
+            onUrlChange={urlChangeSpy}
+            open={true}
+            target="_blank"
+            title={undefined}
+            url="http://www.sulu.io"
+        />
+    );
+
+    externalLinkOverlay.find('Url').prop('onChange')('mailto:test@example.org');
+    expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org');
+    expect(targetChangeSpy).toBeCalledWith('_self');
+});
+
+test('Should not reset target to self when a non-mail URL is entered', () => {
+    const targetChangeSpy = jest.fn();
+    const urlChangeSpy = jest.fn();
+
+    const externalLinkOverlay = shallow(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={targetChangeSpy}
+            onTitleChange={jest.fn()}
+            onUrlChange={urlChangeSpy}
+            open={true}
+            target="_blank"
+            title={undefined}
+            url="http://www.sulu.io"
+        />
+    );
+
+    externalLinkOverlay.find('Url').prop('onChange')('http://sulu.io');
+    expect(urlChangeSpy).toBeCalledWith('http://sulu.io');
+    expect(targetChangeSpy).not.toBeCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
@@ -1,0 +1,85 @@
+// @flow
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+import ExternalLinkOverlay from '../../../plugins/ExternalLinkPlugin/ExternalLinkOverlay';
+
+jest.mock('../../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+test('Render overlay with an undefined URL', () => {
+    const externalLinkOverlay = mount(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={jest.fn()}
+            onTitleChange={jest.fn()}
+            onUrlChange={jest.fn()}
+            open={true}
+            target={undefined}
+            title={undefined}
+            url={undefined}
+        />
+    );
+
+    expect(externalLinkOverlay.find('Form').render()).toMatchSnapshot();
+});
+
+test('Render overlay with mailto URL', () => {
+    const externalLinkOverlay = mount(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={jest.fn()}
+            onTitleChange={jest.fn()}
+            onUrlChange={jest.fn()}
+            open={true}
+            target={undefined}
+            title={undefined}
+            url="mailto:test@example.org"
+        />
+    );
+
+    expect(externalLinkOverlay.find('Form').render()).toMatchSnapshot();
+});
+
+test('Render overlay with a URL', () => {
+    const externalLinkOverlay = mount(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={jest.fn()}
+            onTitleChange={jest.fn()}
+            onUrlChange={jest.fn()}
+            open={true}
+            target={undefined}
+            title={undefined}
+            url="http://www.sulu.io"
+        />
+    );
+
+    expect(externalLinkOverlay.find('Form').render()).toMatchSnapshot();
+});
+
+test('Pass correct props to Dialog', () => {
+    const cancelSpy = jest.fn();
+    const confirmSpy = jest.fn();
+
+    const externalLinkOverlay = shallow(
+        <ExternalLinkOverlay
+            onCancel={cancelSpy}
+            onConfirm={confirmSpy}
+            onTargetChange={jest.fn()}
+            onTitleChange={jest.fn()}
+            onUrlChange={jest.fn()}
+            open={false}
+            target={undefined}
+            title={undefined}
+            url={undefined}
+        />
+    );
+
+    expect(externalLinkOverlay.find('Dialog').prop('onCancel')).toEqual(cancelSpy);
+    expect(externalLinkOverlay.find('Dialog').prop('onConfirm')).toEqual(confirmSpy);
+    expect(externalLinkOverlay.find('Dialog').prop('open')).toEqual(false);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/ExternalLinkOverlay.test.js
@@ -106,6 +106,36 @@ test('Do not call onUrlChange handler if input did not loose focus', () => {
     expect(urlChangeSpy).not.toBeCalled();
 });
 
+test('Fields should change immediately after protocol was changed', () => {
+    const targetChangeSpy = jest.fn();
+    const urlChangeSpy = jest.fn();
+
+    const externalLinkOverlay = mount(
+        <ExternalLinkOverlay
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onTargetChange={targetChangeSpy}
+            onTitleChange={jest.fn()}
+            onUrlChange={urlChangeSpy}
+            open={true}
+            target="_blank"
+            title={undefined}
+            url={undefined}
+        />
+    );
+
+    expect(externalLinkOverlay.find('Field[label="sulu_admin.link_target"]')).toHaveLength(1);
+    expect(externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"]')).toHaveLength(0);
+    expect(externalLinkOverlay.find('Field[label="sulu_admin.mail_body"]')).toHaveLength(0);
+
+    externalLinkOverlay.find('Url').prop('onProtocolChange')('mailto:');
+
+    externalLinkOverlay.update();
+    expect(externalLinkOverlay.find('Field[label="sulu_admin.link_target"]')).toHaveLength(0);
+    expect(externalLinkOverlay.find('Field[label="sulu_admin.mail_subject"]')).toHaveLength(1);
+    expect(externalLinkOverlay.find('Field[label="sulu_admin.mail_body"]')).toHaveLength(1);
+});
+
 test('Call onUrlChange with all mail values', () => {
     const targetChangeSpy = jest.fn();
     const urlChangeSpy = jest.fn();
@@ -125,6 +155,7 @@ test('Call onUrlChange with all mail values', () => {
     );
 
     externalLinkOverlay.find('Url').prop('onChange')('mailto:test@example.org');
+    externalLinkOverlay.find('Url').prop('onProtocolChange')('mailto:');
     expect(urlChangeSpy).not.toBeCalledWith('mailto:test@example.org');
     externalLinkOverlay.find('Url').prop('onBlur')();
     expect(urlChangeSpy).toBeCalledWith('mailto:test@example.org');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/__snapshots__/ExternalLinkOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/__snapshots__/ExternalLinkOverlay.test.js.snap
@@ -1,0 +1,346 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render overlay with a URL 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_url *
+      </label>
+      <div
+        class="url"
+      >
+        <div
+          class="protocols"
+        >
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue flat"
+              type="button"
+            >
+              <div
+                aria-label="http://"
+                class="croppedText"
+                title="http://"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  http
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    ://
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  http://
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </div>
+        <input
+          type="text"
+          value="www.sulu.io"
+        />
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_target *
+      </label>
+      <div
+        class="select"
+      >
+        <button
+          class="displayValue default"
+          type="button"
+        >
+          <div
+            aria-label="sulu_admin.please_choose"
+            class="croppedText"
+            title="sulu_admin.please_choose"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              sulu_admin.p
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                lease_choose
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              sulu_admin.please_choose
+            </div>
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down toggle"
+          />
+        </button>
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_title
+      </label>
+      <label
+        class="input default left"
+      >
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render overlay with an undefined URL 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_url *
+      </label>
+      <div
+        class="url"
+      >
+        <div
+          class="protocols"
+        >
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue flat"
+              type="button"
+            >
+              <div
+                aria-label="https://"
+                class="croppedText"
+                title="https://"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  http
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    s://
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  https://
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </div>
+        <input
+          type="text"
+          value=""
+        />
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_title
+      </label>
+      <label
+        class="input default left"
+      >
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render overlay with mailto URL 1`] = `
+<div
+  class="grid grid"
+>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_url *
+      </label>
+      <div
+        class="url"
+      >
+        <div
+          class="protocols"
+        >
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue flat"
+              type="button"
+            >
+              <div
+                aria-label="mailto:"
+                class="croppedText"
+                title="mailto:"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  mail
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    to:
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  mailto:
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </div>
+        <input
+          type="text"
+          value="test@example.org"
+        />
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.link_title
+      </label>
+      <label
+        class="input default left"
+      >
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/__snapshots__/ExternalLinkOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/__snapshots__/ExternalLinkOverlay.test.js.snap
@@ -327,6 +327,51 @@ exports[`Render overlay with mailto URL 1`] = `
       <label
         class="label"
       >
+        sulu_admin.mail_subject
+      </label>
+      <label
+        class="input default left"
+      >
+        <input
+          type="text"
+          value="Subject"
+        />
+      </label>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
+        sulu_admin.mail_body
+      </label>
+      <textarea
+        class="textArea"
+      >
+        Body
+      </textarea>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
         sulu_admin.link_title
       </label>
       <label

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/__snapshots__/ExternalLinkOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/plugins/ExternalLinkPlugin/__snapshots__/ExternalLinkOverlay.test.js.snap
@@ -230,6 +230,60 @@ exports[`Render overlay with an undefined URL 1`] = `
       <label
         class="label"
       >
+        sulu_admin.link_target *
+      </label>
+      <div
+        class="select"
+      >
+        <button
+          class="displayValue default"
+          type="button"
+        >
+          <div
+            aria-label="sulu_admin.please_choose"
+            class="croppedText"
+            title="sulu_admin.please_choose"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              sulu_admin.p
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                lease_choose
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              sulu_admin.please_choose
+            </div>
+          </div>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down toggle"
+          />
+        </button>
+      </div>
+      <label
+        class="errorLabel"
+      />
+    </div>
+  </div>
+  <div
+    class="item gridItem colSpan colSpan-12 space-before-0 space-after-0"
+  >
+    <div
+      class="field"
+    >
+      <label
+        class="label"
+      >
         sulu_admin.link_title
       </label>
       <label

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -5,7 +5,7 @@ exports[`Should render a Dialog 1`] = `
   <div class=\\"backdrop visible fixed\\"></div>
 </div>
 <div>
-  <div class=\\"dialogContainer\\">
+  <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
         <header></header>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/FilterOverlay.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render with all fields 1`] = `
 <div
-  class="container"
+  class="container isDown"
 >
   <div
     class="overlay small"
@@ -412,7 +412,7 @@ exports[`Render with all fields 1`] = `
 
 exports[`Render with no fields 1`] = `
 <div
-  class="container"
+  class="container isDown"
 >
   <div
     class="overlay small"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -23,7 +23,7 @@ Array [
     class="backdrop visible fixed"
   />,
   <div
-    class="container"
+    class="container isDown"
   >
     <div
       class="overlay small"

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -126,6 +126,8 @@
     "sulu_admin.link_title": "Alternativer Titel",
     "sulu_admin.link_target": "Link Ziel",
     "sulu_admin.link_url": "Link URL",
+    "sulu_admin.mail_subject": "E-Mail Betreff",
+    "sulu_admin.mail_body": "E-Mail Text",
     "sulu_admin.show_history": "Verlauf anzeigen",
     "sulu_admin.history": "Verlauf",
     "sulu_admin.resource_locator_history_delete_warning": "Die URL wird für alle Entwurfs- und Live-Versionen gelöscht, und kann nicht wieder hergestellt werden. Wollen Sie wirklich fortfahren?"

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -126,6 +126,8 @@
     "sulu_admin.link_title": "Alternative title",
     "sulu_admin.link_target": "Link Target",
     "sulu_admin.link_url": "Link URL",
+    "sulu_admin.mail_subject": "E-Mail Subject",
+    "sulu_admin.mail_body": "E-Mail Text",
     "sulu_admin.show_history": "Show history",
     "sulu_admin.history": "History",
     "sulu_admin.resource_locator_history_delete_warning": "The URL will be deleted for all draft and live versions. This cannot be undone. Do you wish to proceed?"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -8,7 +8,7 @@ exports[`Render an open MediaSelectionOverlay 1`] = `
 
 exports[`Render an open MediaSelectionOverlay 2`] = `
 <div
-  class="container"
+  class="container isDown"
 >
   <div
     class="overlay"
@@ -601,7 +601,7 @@ exports[`Render an open MediaSelectionOverlay with selected items 1`] = `
 
 exports[`Render an open MediaSelectionOverlay with selected items 2`] = `
 <div
-  class="container"
+  class="container isDown"
 >
   <div
     class="overlay"

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/__snapshots__/CopyLocaleDialog.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/__snapshots__/CopyLocaleDialog.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Render the dialog with given props 1`] = `
 <div
-  class="dialogContainer"
+  class="dialogContainer open"
 >
   <div
     class="dialog"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to define a `mailto:` link in the `Url` component.

#### Why?

Because this functionality is needed in the text editor.

#### Todo

- [x] Remove deprecations from `Overlay` component the same way as the `Dialog` component