### PR TITLE
Add reload button for preview

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -163,6 +163,15 @@ export default class Preview extends React.Component<Props> {
         this.selectedDeviceOption = value;
     };
 
+    @action handleRefreshClick = () => {
+        const document = this.getPreviewDocument();
+        if (!document) {
+            return;
+        }
+
+        document.location.reload();
+    };
+
     handleStartClick = () => {
         this.startPreview();
     };
@@ -218,6 +227,12 @@ export default class Preview extends React.Component<Props> {
                             options={this.availableDeviceOptions}
                             value={this.selectedDeviceOption}
                         />
+                        <Toolbar.Button
+                            icon="su-sync"
+                            onClick={this.handleRefreshClick}
+                        >
+                            {translate('sulu_preview.reload')}
+                        </Toolbar.Button>
                         <Toolbar.Button
                             icon="su-link"
                             onClick={this.handlePreviewWindowClick}

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
@@ -174,6 +174,17 @@ exports[`Render correct preview 1`] = `
         active={false}
         disabled={false}
         hasOptions={false}
+        icon="su-sync"
+        onClick={[Function]}
+        primary={false}
+        showText={true}
+      >
+        sulu_preview.reload
+      </Button>
+      <Button
+        active={false}
+        disabled={false}
+        hasOptions={false}
         icon="su-link"
         onClick={[Function]}
         primary={false}
@@ -248,6 +259,17 @@ exports[`Render nothing if separate window is opened and rerender if it is close
         active={false}
         disabled={false}
         hasOptions={false}
+        icon="su-sync"
+        onClick={[Function]}
+        primary={false}
+        showText={true}
+      >
+        sulu_preview.reload
+      </Button>
+      <Button
+        active={false}
+        disabled={false}
+        hasOptions={false}
         icon="su-link"
         onClick={[Function]}
         primary={false}
@@ -318,6 +340,17 @@ exports[`Render nothing if separate window is opened and rerender if it is close
         showText={true}
         value="auto"
       />
+      <Button
+        active={false}
+        disabled={false}
+        hasOptions={false}
+        icon="su-sync"
+        onClick={[Function]}
+        primary={false}
+        showText={true}
+      >
+        sulu_preview.reload
+      </Button>
       <Button
         active={false}
         disabled={false}

--- a/src/Sulu/Bundle/PreviewBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/translations/admin.de.json
@@ -3,5 +3,6 @@
     "sulu_preview.desktop": "Desktop",
     "sulu_preview.tablet": "Tablet",
     "sulu_preview.smartphone": "Smartphone",
+    "sulu_preview.reload": "Neu laden",
     "sulu_preview.open_in_window": "In Fenster öffnen"
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/translations/admin.en.json
@@ -3,5 +3,6 @@
     "sulu_preview.desktop": "Desktop",
     "sulu_preview.tablet": "Tablet",
     "sulu_preview.smartphone": "Smartphone",
+    "sulu_preview.reload": "Reload",
     "sulu_preview.open_in_window": "Open in window"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a reload button to reload the preview.

#### Why?

Although the situation has improved, the refresh button is still needed, e.g. because some JS which is loaded in the preview might not support changing the content while it is running.