### PR TITLE
Add tab for snippet taxonomies

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -109,10 +109,14 @@ class SnippetAdmin extends Admin
             )
         );
 
-        $formToolbarActions = [
+        $formToolbarActionsWithType = [
             'sulu_admin.save',
             'sulu_admin.type',
             'sulu_admin.delete',
+        ];
+
+        $formToolbarActionsWithoutType = [
+            'sulu_admin.save',
         ];
 
         $listToolbarActions = [
@@ -143,7 +147,7 @@ class SnippetAdmin extends Admin
                 ->setFormKey('snippet')
                 ->setTabTitle('sulu_admin.details')
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
-                ->addToolbarActions($formToolbarActions)
+                ->addToolbarActions($formToolbarActionsWithType)
                 ->setParent(static::ADD_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/snippets/:locale/:id')
@@ -156,7 +160,14 @@ class SnippetAdmin extends Admin
                 ->setResourceKey('snippets')
                 ->setFormKey('snippet')
                 ->setTabTitle('sulu_admin.details')
-                ->addToolbarActions($formToolbarActions)
+                ->addToolbarActions($formToolbarActionsWithType)
+                ->setParent(static::EDIT_FORM_ROUTE)
+                ->getRoute(),
+            $this->routeBuilderFactory->createFormRouteBuilder('sulu_snippet.edit_form.taxonomies', '/taxonomies')
+                ->setResourceKey('snippets')
+                ->setFormKey('snippet_taxonomies')
+                ->setTabTitle('sulu_snippet.taxonomies')
+                ->addToolbarActions($formToolbarActionsWithoutType)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
             (new Route('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas'))

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -36,6 +36,11 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
                             __DIR__ . '/../Resources/config/lists',
                         ],
                     ],
+                    'forms' => [
+                        'directories' => [
+                            __DIR__ . '/../Resources/config/forms',
+                        ],
+                    ],
                     'resources' => [
                         'snippets' => [
                             'routes' => [

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/forms/snippet_taxonomies.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/forms/snippet_taxonomies.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>snippet_taxonomies</key>
+
+    <properties>
+        <property name="ext/excerpt/categories" type="category_selection">
+            <meta>
+                <title>sulu_category.categories</title>
+            </meta>
+        </property>
+        <property name="ext/excerpt/tags" type="tag_selection">
+            <meta>
+                <title>sulu_tag.tags</title>
+            </meta>
+        </property>
+    </properties>
+</form>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | depends on #4552
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the taxonomies tab to snippets.

#### Why?

Because this information should be edible.