### PR TITLE
Added errors array to list view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -29,7 +29,9 @@ class List extends React.Component<Props> {
     locale: IObservableValue<string>;
     listStore: ListStore;
     list: ?ElementRef<typeof ListContainer>;
+
     @observable toolbarActions = [];
+    @observable errors = [];
 
     static getDerivedRouteAttributes(route: Route) {
         const {
@@ -282,6 +284,7 @@ class List extends React.Component<Props> {
 }
 
 export default withToolbar(List, function() {
+    const {errors} = this;
     const {router} = this.props;
 
     const {
@@ -323,6 +326,7 @@ export default withToolbar(List, function() {
 
     return {
         backButton,
+        errors,
         locale,
         items,
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -444,6 +444,33 @@ test('Should navigate to defined route on back button click', () => {
     expect(router.restore).toBeCalledWith('backRoute', {locale: 'de'});
 });
 
+test('Should propagate errors to toolbar', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const List = require('../List').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, List);
+    const router = {
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                backRoute: 'backRoute',
+                addRoute: 'addRoute',
+                listKey: 'test',
+                resourceKey: 'test',
+            },
+        },
+    };
+
+    const list = mount(<List router={router} />);
+    const error = 'This is an error';
+    list.instance().errors.push(error);
+
+    const toolbarConfig = toolbarFunction.call(list.instance());
+    expect(toolbarConfig.errors.length).toBe(1);
+    expect(toolbarConfig.errors[0]).toBe(error);
+});
+
 test('Should navigate to defined route on back button click without locale', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const List = require('../List').default;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the errors array to the list view.

#### Why?

Can be used in ToolbarAction to propagate errors.

#### Example Usage

```
    getToolbarItemConfig() {
        return {
            icon: 'su-upload',
            label: translate('app.import_ticket_passes'),
            onClick: () => this.list.errors.push('This is an error'),
            type: 'button',
        };
    }

```