### PR TITLE
Add search field in ListOverlay

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -419,7 +419,6 @@ class List extends React.Component<Props> {
             onItemClick,
             onItemAdd,
             orderable,
-            searchable,
             selectable,
             store,
         } = this.props;
@@ -431,6 +430,8 @@ class List extends React.Component<Props> {
                 [listStyles.disabled]: disabled,
             }
         );
+
+        const searchable = this.props.searchable && Adapter.searchable;
 
         return (
             <div className={listStyles.listContainer}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/AbstractAdapter.js
@@ -10,4 +10,6 @@ export default class AbstractAdapter extends React.Component<ListAdapterProps> {
     static icon: string;
 
     static hasColumnOptions: boolean = false;
+
+    static searchable: boolean = true;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -20,6 +20,8 @@ class ColumnListAdapter extends AbstractAdapter {
 
     static icon = 'su-columns';
 
+    static searchable = false;
+
     static defaultProps = {
         data: [],
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -246,6 +246,28 @@ test('Render the adapter in non-searchable mode', () => {
     ).toMatchSnapshot();
 });
 
+test('Render the adapter in non-searchable mode if searchable is set to true but adapter does not support it', () => {
+    class TestAdapter extends AbstractAdapter {
+        static LoadingStrategy = LoadingStrategy;
+        static StructureStrategy = StructureStrategy;
+        static icon = 'su-th-large';
+        static searchable = false;
+
+        render() {
+            return (
+                <div>Test Adapter</div>
+            );
+        }
+    }
+
+    listAdapterRegistry.get.mockReturnValue(TestAdapter);
+
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    expect(
+        render(<List adapters={['test']} header={<h1>Title</h1>} searchable={true} store={listStore} />)
+    ).toMatchSnapshot();
+});
+
 test('Render the adapter in disabled state', () => {
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
     expect(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
@@ -154,3 +154,27 @@ exports[`Render the adapter in non-searchable mode 1`] = `
   </div>
 </div>
 `;
+
+exports[`Render the adapter in non-searchable mode if searchable is set to true but adapter does not support it 1`] = `
+<div
+  class="listContainer"
+>
+  <div
+    class="headerContainer"
+  >
+    <h1>
+      Title
+    </h1>
+    <div
+      class="toolbar"
+    />
+  </div>
+  <div
+    class="list"
+  >
+    <div>
+      Test Adapter
+    </div>
+  </div>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/ListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/ListOverlay.js
@@ -119,7 +119,7 @@ class ListOverlay extends React.Component<Props> {
                         disabledIds={disabledIds}
                         movable={false}
                         orderable={false}
-                        searchable={false}
+                        searchable={true}
                         store={this.listStore}
                     />
                 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js
@@ -132,6 +132,7 @@ test('Should pass correct flags to the List', () => {
     expect(listOverlay.find(List).prop('deletable')).toEqual(false);
     expect(listOverlay.find(List).prop('movable')).toEqual(false);
     expect(listOverlay.find(List).prop('orderable')).toEqual(false);
+    expect(listOverlay.find(List).prop('searchable')).toEqual(true);
 });
 
 test('Should pass confirmLoading and confirmDisabled flag to the Overlay', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The `ListOverlay` which is used e.g. in the `Selection` fields will show a search field now.

#### Why?

This overlay is also used for entity type with loads of instances, so a search is very convenient.