### PR TITLE
Upgrade to es7 compatible decorators

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
@@ -21,7 +21,7 @@ type Props = {
 const VERTICAL_OFFSET = 20;
 
 @observer
-export default class ArrowMenu extends React.Component<Props> {
+class ArrowMenu extends React.Component<Props> {
     static Section = Section;
     static SingleItemSection = SingleItemSection;
     static Item = Item;
@@ -140,3 +140,5 @@ export default class ArrowMenu extends React.Component<Props> {
         );
     }
 }
+
+export default ArrowMenu;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -22,7 +22,7 @@ type Props = {|
 |};
 
 @observer
-export default class BlockCollection extends React.Component<Props> {
+class BlockCollection extends React.Component<Props> {
     static idCounter = 0;
 
     static defaultProps = {
@@ -163,3 +163,5 @@ export default class BlockCollection extends React.Component<Props> {
         );
     }
 }
+
+export default BlockCollection;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/ColorPicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColorPicker/ColorPicker.js
@@ -21,7 +21,7 @@ type Props = {|
 |};
 
 @observer
-export default class ColorPicker extends React.Component<Props> {
+class ColorPicker extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         valid: true,
@@ -168,3 +168,5 @@ export default class ColorPicker extends React.Component<Props> {
         );
     }
 }
+
+export default ColorPicker;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
@@ -17,7 +17,7 @@ type Props = {|
 |};
 
 @observer
-export default class ColumnList extends React.Component<Props> {
+class ColumnList extends React.Component<Props> {
     static Column = Column;
 
     static Item = Item;
@@ -155,3 +155,5 @@ export default class ColumnList extends React.Component<Props> {
         );
     }
 }
+
+export default ColumnList;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -27,7 +27,7 @@ type Props = {|
 |};
 
 @observer
-export default class Item extends React.Component<Props> {
+class Item extends React.Component<Props> {
     static defaultProps = {
         active: false,
         disabled: false,
@@ -150,3 +150,5 @@ export default class Item extends React.Component<Props> {
         );
     }
 }
+
+export default Item;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Toolbar.js
@@ -14,7 +14,7 @@ type Props = {|
 |};
 
 @observer
-export default class Toolbar extends React.Component<Props> {
+class Toolbar extends React.Component<Props> {
     static defaultProps = {
         toolbarItems: [],
     };
@@ -55,3 +55,5 @@ export default class Toolbar extends React.Component<Props> {
         );
     }
 }
+
+export default Toolbar;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ToolbarDropdown.js
@@ -10,7 +10,7 @@ import toolbarStyles from './toolbar.scss';
 import toolbarDropdownStyles from './toolbarDropdown.scss';
 
 @observer
-export default class ToolbarDropdown extends React.Component<ToolbarDropdownProps> {
+class ToolbarDropdown extends React.Component<ToolbarDropdownProps> {
     static defaultProps = {
         skin: 'primary',
     };
@@ -57,3 +57,5 @@ export default class ToolbarDropdown extends React.Component<ToolbarDropdownProp
         );
     }
 }
+
+export default ToolbarDropdown;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -29,7 +29,7 @@ type Props = {|
 |};
 
 @observer
-export default class DatePicker extends React.Component<Props> {
+class DatePicker extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         options: {},
@@ -220,3 +220,5 @@ export default class DatePicker extends React.Component<Props> {
         );
     }
 }
+
+export default DatePicker;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -24,7 +24,7 @@ type Props = {|
 |};
 
 @observer
-export default class Dialog extends React.Component<Props> {
+class Dialog extends React.Component<Props> {
     static defaultProps = {
         confirmDisabled: false,
         confirmLoading: false,
@@ -137,3 +137,5 @@ export default class Dialog extends React.Component<Props> {
         );
     }
 }
+
+export default Dialog;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Email/Email.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Email/Email.js
@@ -17,7 +17,7 @@ type Props = {|
 |};
 
 @observer
-export default class Email extends React.Component<Props> {
+class Email extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         valid: true,
@@ -118,3 +118,5 @@ export default class Email extends React.Component<Props> {
         );
     }
 }
+
+export default Email;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -19,7 +19,7 @@ type Props = {|
 |};
 
 @observer
-export class ImageRectangleSelection extends React.Component<Props> {
+class ImageRectangleSelection extends React.Component<Props> {
     image: Image;
     rounding = new RoundingNormalizer();
     @observable imageLoaded = false;
@@ -109,5 +109,9 @@ export class ImageRectangleSelection extends React.Component<Props> {
         );
     }
 }
+
+export {
+    ImageRectangleSelection,
+};
 
 export default withContainerSize(ImageRectangleSelection, imageRectangleSelectionStyles.container);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
@@ -18,7 +18,7 @@ type Props = {|
 |};
 
 @observer
-export default class Row extends React.Component<Props> {
+class Row extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         values: {},
@@ -112,3 +112,5 @@ export default class Row extends React.Component<Props> {
         );
     }
 }
+
+export default Row;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiAutoComplete/MultiAutoComplete.js
@@ -30,7 +30,7 @@ type Props = {|
 const DEBOUNCE_TIME = 300;
 
 @observer
-export default class MultiAutoComplete extends React.Component<Props> {
+class MultiAutoComplete extends React.Component<Props> {
     static defaultProps = {
         allowAdd: false,
         disabled: false,
@@ -217,3 +217,5 @@ export default class MultiAutoComplete extends React.Component<Props> {
         );
     }
 }
+
+export default MultiAutoComplete;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Navigation.js
@@ -24,7 +24,7 @@ type Props = {
 };
 
 @observer
-export default class Navigation extends React.Component<Props> {
+class Navigation extends React.Component<Props> {
     static defaultProps = {
         appVersion: undefined,
         pinned: false,
@@ -178,3 +178,5 @@ export default class Navigation extends React.Component<Props> {
         );
     }
 }
+
+export default Navigation;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -31,7 +31,7 @@ const CLOSE_ICON = 'su-times';
 const CLOSE_OVERLAY_KEY = 'esc';
 
 @observer
-export default class Overlay extends React.Component<Props> {
+class Overlay extends React.Component<Props> {
     static defaultProps = {
         actions: [],
         confirmDisabled: false,
@@ -169,3 +169,5 @@ export default class Overlay extends React.Component<Props> {
         );
     }
 }
+
+export default Overlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
@@ -22,7 +22,7 @@ type Props = {
 const AVAILABLE_LIMITS = [10, 20, 50, 100];
 
 @observer
-export default class Pagination extends React.Component<Props> {
+class Pagination extends React.Component<Props> {
     @observable currentInputValue = 1;
 
     static defaultProps = {
@@ -185,3 +185,5 @@ export default class Pagination extends React.Component<Props> {
         );
     }
 }
+
+export default Pagination;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/PasswordConfirmation/PasswordConfirmation.js
@@ -17,7 +17,7 @@ const LOCK_ICON = 'su-lock';
 const INPUT_TYPE = 'password';
 
 @observer
-export default class PasswordConfirmation extends React.Component<Props> {
+class PasswordConfirmation extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         valid: true,
@@ -102,3 +102,5 @@ export default class PasswordConfirmation extends React.Component<Props> {
         );
     }
 }
+
+export default PasswordConfirmation;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Popover/Popover.js
@@ -29,7 +29,7 @@ type Props = {
 };
 
 @observer
-export default class Popover extends React.Component<Props> {
+class Popover extends React.Component<Props> {
     static defaultProps = {
         backdrop: true,
         horizontalOffset: 0,
@@ -179,3 +179,5 @@ export default class Popover extends React.Component<Props> {
         );
     }
 }
+
+export default Popover;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/ModifiableRectangle.js
@@ -18,7 +18,7 @@ type Props = {
 };
 
 @observer
-export default class ModifiableRectangle extends React.Component<Props> {
+class ModifiableRectangle extends React.Component<Props> {
     static defaultProps = {
         backdropSize: 0,
         left: 0,
@@ -122,3 +122,5 @@ export default class ModifiableRectangle extends React.Component<Props> {
         );
     }
 }
+
+export default ModifiableRectangle;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -23,7 +23,7 @@ type Props = {
 };
 
 @observer
-export class RectangleSelection extends React.Component<Props> {
+class RectangleSelection extends React.Component<Props> {
     static defaultProps = {
         round: true,
     };
@@ -139,5 +139,9 @@ export class RectangleSelection extends React.Component<Props> {
         );
     }
 }
+
+export {
+    RectangleSelection,
+};
 
 export default withContainerSize(RectangleSelection, rectangleSelectionStyles.container);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Select/Select.js
@@ -24,7 +24,7 @@ type Props<T> = {|
 |};
 
 @observer
-export default class Select<T> extends React.Component<Props<T>> {
+class Select<T> extends React.Component<Props<T>> {
     static defaultProps = {
         closeOnSelect: true,
         disabled: false,
@@ -154,3 +154,5 @@ export default class Select<T> extends React.Component<Props<T>> {
         );
     }
 }
+
+export default Select;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/SingleAutoComplete/SingleAutoComplete.js
@@ -27,7 +27,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleAutoComplete extends React.Component<Props> {
+class SingleAutoComplete extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -127,3 +127,5 @@ export default class SingleAutoComplete extends React.Component<Props> {
         );
     }
 }
+
+export default SingleAutoComplete;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Table.js
@@ -28,7 +28,7 @@ type Props = {
 };
 
 @observer
-export default class Table extends React.Component<Props> {
+class Table extends React.Component<Props> {
     static defaultProps = {
         selectMode: 'none',
         skin: 'dark',
@@ -183,3 +183,5 @@ export default class Table extends React.Component<Props> {
         );
     }
 }
+
+export default Table;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Dropdown.js
@@ -11,7 +11,7 @@ import OptionList from './OptionList';
 import dropdownStyles from './dropdown.scss';
 
 @observer
-export default class Dropdown extends React.Component<DropdownProps> {
+class Dropdown extends React.Component<DropdownProps> {
     @observable open: boolean = false;
 
     static defaultProps = {
@@ -112,3 +112,5 @@ export default class Dropdown extends React.Component<DropdownProps> {
         );
     }
 }
+
+export default Dropdown;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Items.js
@@ -16,7 +16,7 @@ type Props = {
 const DEBOUNCE_TIME = 200;
 
 @observer
-export default class Items extends React.Component<Props> {
+class Items extends React.Component<Props> {
     @observable expandedWidth: number = 0;
     @observable parentWidth: number = 0;
 
@@ -104,3 +104,5 @@ export default class Items extends React.Component<Props> {
         );
     }
 }
+
+export default Items;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
@@ -11,7 +11,7 @@ import OptionList from './OptionList';
 import selectStyles from './select.scss';
 
 @observer
-export default class Select extends React.Component<SelectProps> {
+class Select extends React.Component<SelectProps> {
     @observable open: boolean = false;
 
     static defaultProps = {
@@ -122,3 +122,5 @@ export default class Select extends React.Component<SelectProps> {
         );
     }
 }
+
+export default Select;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Url/Url.js
@@ -30,7 +30,7 @@ const URL_REGEX = new RegExp(
 );
 
 @observer
-export default class Url extends React.Component<Props> {
+class Url extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         protocols: ['http://', 'https://', 'ftp://', 'ftps://'],
@@ -194,3 +194,5 @@ export default class Url extends React.Component<Props> {
         );
     }
 }
+
+export default Url;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/Application.js
@@ -27,7 +27,7 @@ type Props = {
 type NavigationState = 'pinned' | 'hidden' | 'visible';
 
 @observer
-export default class Application extends React.Component<Props> {
+class Application extends React.Component<Props> {
     @observable navigationState: NavigationState;
 
     @computed get navigationPinned() {
@@ -187,3 +187,5 @@ export default class Application extends React.Component<Props> {
         );
     }
 }
+
+export default Application;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Field.js
@@ -24,7 +24,7 @@ type Props = {|
 |};
 
 @observer
-export default class Field extends React.Component<Props> {
+class Field extends React.Component<Props> {
     static defaultProps = {
         showAllErrors: false,
     };
@@ -158,3 +158,5 @@ export default class Field extends React.Component<Props> {
         );
     }
 }
+
+export default Field;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Form.js
@@ -16,7 +16,7 @@ type Props = {
 };
 
 @observer
-export default class Form extends React.Component<Props> {
+class Form extends React.Component<Props> {
     @observable showAllErrors = false;
     @observable displayGhostDialog = false;
     displayGhostDialogDisposer: () => void;
@@ -141,3 +141,5 @@ export default class Form extends React.Component<Props> {
             );
     }
 }
+
+export default Form;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/GhostDialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/GhostDialog.js
@@ -15,7 +15,7 @@ type Props = {
 };
 
 @observer
-export default class GhostDialog extends React.Component<Props> {
+class GhostDialog extends React.Component<Props> {
     @observable selectedLocale: string;
 
     constructor(props: Props) {
@@ -72,3 +72,5 @@ export default class GhostDialog extends React.Component<Props> {
         );
     }
 }
+
+export default GhostDialog;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -21,7 +21,7 @@ type Props = {|
 |};
 
 @observer
-export default class Renderer extends React.Component<Props> {
+class Renderer extends React.Component<Props> {
     static defaultProps = {
         showAllErrors: false,
     };
@@ -100,3 +100,5 @@ export default class Renderer extends React.Component<Props> {
         );
     }
 }
+
+export default Renderer;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/CardCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/CardCollection.js
@@ -11,7 +11,7 @@ import type {FieldTypeProps} from '../../../types';
 import cardCollectionStyles from './cardCollection.scss';
 
 @observer
-export default class CardCollection extends React.Component<FieldTypeProps<Array<Object>>> {
+class CardCollection extends React.Component<FieldTypeProps<Array<Object>>> {
     @observable overlayIndex: number | typeof undefined = undefined;
     @observable formStore: ?MemoryFormStore = undefined;
     formRef: ?ElementRef<typeof Form>;
@@ -165,3 +165,5 @@ export default class CardCollection extends React.Component<FieldTypeProps<Array
         );
     }
 }
+
+export default CardCollection;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ChangelogLine.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ChangelogLine.js
@@ -8,7 +8,7 @@ import {translate} from '../../../utils/Translator';
 import type {FieldTypeProps} from '../../../types';
 
 @observer
-export default class ChangelogLine extends React.Component<FieldTypeProps<typeof undefined>> {
+class ChangelogLine extends React.Component<FieldTypeProps<typeof undefined>> {
     @observable changer: ?Object;
     @observable creator: ?Object;
     @observable changerLoaded: boolean = false;
@@ -119,3 +119,5 @@ export default class ChangelogLine extends React.Component<FieldTypeProps<typeof
         );
     }
 }
+
+export default ChangelogLine;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/DatePicker.js
@@ -29,7 +29,7 @@ function getValue(value: ?string, format: string): ?moment {
 }
 
 @observer
-export default class DatePicker extends React.Component<FieldTypeProps<?string>> {
+class DatePicker extends React.Component<FieldTypeProps<?string>> {
     @computed get format() {
         const {fieldTypeOptions} = this.props;
         const {dateFormat, timeFormat} = fieldTypeOptions;
@@ -83,3 +83,5 @@ export default class DatePicker extends React.Component<FieldTypeProps<?string>>
         );
     }
 }
+
+export default DatePicker;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Number.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Number.js
@@ -6,7 +6,7 @@ import NumberComponent from '../../../components/Number';
 import type {FieldTypeProps, SchemaOptions} from '../types';
 
 @observer
-export default class Number extends React.Component<FieldTypeProps<?number>> {
+class Number extends React.Component<FieldTypeProps<?number>> {
     @computed get schemaOptions(): SchemaOptions {
         const {schemaOptions} = this.props;
 
@@ -51,3 +51,5 @@ export default class Number extends React.Component<FieldTypeProps<?number>> {
         );
     }
 }
+
+export default Number;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/ColumnOptionsOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/ColumnOptionsOverlay.js
@@ -33,7 +33,7 @@ const SortableList = SortableContainer(({children, className}) => {
 });
 
 @observer
-export default class ColumnOptionsOverlay extends React.Component<Props> {
+class ColumnOptionsOverlay extends React.Component<Props> {
     @observable columnOptions: Array<ColumnOption> = [];
     @observable sorting: boolean = false;
 
@@ -144,3 +144,5 @@ export default class ColumnOptionsOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default ColumnOptionsOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -45,7 +45,7 @@ type Props = {|
 |};
 
 @observer
-export default class List extends React.Component<Props> {
+class List extends React.Component<Props> {
     static defaultProps = {
         allowActivateForDisabledItems: true,
         copyable: true,
@@ -558,3 +558,5 @@ export default class List extends React.Component<Props> {
         );
     }
 }
+
+export default List;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/Search.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/Search.js
@@ -11,7 +11,7 @@ type Props = {
 };
 
 @observer
-export default class Search extends React.Component<Props> {
+class Search extends React.Component<Props> {
     @observable collapsed: boolean = true;
     @observable value: ?string;
 
@@ -91,3 +91,5 @@ export default class Search extends React.Component<Props> {
         );
     }
 }
+
+export default Search;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -13,7 +13,7 @@ import AbstractAdapter from './AbstractAdapter';
 import columnListAdapterStyles from './columnListAdapter.scss';
 
 @observer
-export default class ColumnListAdapter extends AbstractAdapter {
+class ColumnListAdapter extends AbstractAdapter {
     static LoadingStrategy = FullLoadingStrategy;
 
     static StructureStrategy = ColumnStructureStrategy;
@@ -281,3 +281,5 @@ export default class ColumnListAdapter extends AbstractAdapter {
         );
     }
 }
+
+export default ColumnListAdapter;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/FolderAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/FolderAdapter.js
@@ -9,7 +9,7 @@ import FlatStructureStrategy from '../structureStrategies/FlatStructureStrategy'
 import AbstractAdapter from './AbstractAdapter';
 
 @observer
-export default class FolderAdapter extends AbstractAdapter {
+class FolderAdapter extends AbstractAdapter {
     static LoadingStrategy = PaginatedLoadingStrategy;
 
     static StructureStrategy = FlatStructureStrategy;
@@ -72,3 +72,5 @@ export default class FolderAdapter extends AbstractAdapter {
         );
     }
 }
+
+export default FolderAdapter;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TableAdapter.js
@@ -9,7 +9,7 @@ import FlatStructureStrategy from '../structureStrategies/FlatStructureStrategy'
 import AbstractTableAdapter from './AbstractTableAdapter';
 
 @observer
-export default class TableAdapter extends AbstractTableAdapter {
+class TableAdapter extends AbstractTableAdapter {
     static LoadingStrategy = PaginatedLoadingStrategy;
 
     static StructureStrategy = FlatStructureStrategy;
@@ -92,3 +92,5 @@ export default class TableAdapter extends AbstractTableAdapter {
         );
     }
 }
+
+export default TableAdapter;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/TreeTableAdapter.js
@@ -9,7 +9,7 @@ import FullLoadingStrategy from '../loadingStrategies/FullLoadingStrategy';
 import AbstractTableAdapter from './AbstractTableAdapter';
 
 @observer
-export default class TreeTableAdapter extends AbstractTableAdapter {
+class TreeTableAdapter extends AbstractTableAdapter {
     static LoadingStrategy = FullLoadingStrategy;
 
     static StructureStrategy = TreeStructureStrategy;
@@ -108,3 +108,5 @@ export default class TreeTableAdapter extends AbstractTableAdapter {
         );
     }
 }
+
+export default TreeTableAdapter;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/ListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/ListOverlay.js
@@ -29,7 +29,7 @@ type Props = {|
 |};
 
 @observer
-export default class ListOverlay extends React.Component<Props> {
+class ListOverlay extends React.Component<Props> {
     static defaultProps = {
         allowActivateForDisabledItems: true,
         clearSelectionOnClose: false,
@@ -164,3 +164,5 @@ export default class ListOverlay extends React.Component<Props> {
         throw new Error('The "' + overlayType + '" overlayType does not exist in the ListOverlay.');
     }
 }
+
+export default ListOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -19,7 +19,7 @@ type Props = {
 };
 
 @observer
-export default class Login extends React.Component<Props> {
+class Login extends React.Component<Props> {
     static defaultProps = {
         backLink: '/',
         initialized: false,
@@ -156,3 +156,5 @@ export default class Login extends React.Component<Props> {
         );
     }
 }
+
+export default Login;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/LoginForm.js
@@ -22,7 +22,7 @@ type Props = {
 };
 
 @observer
-export default class LoginForm extends React.Component<Props> {
+class LoginForm extends React.Component<Props> {
     static defaultProps = {
         error: false,
         loading: false,
@@ -116,3 +116,5 @@ export default class LoginForm extends React.Component<Props> {
         );
     }
 }
+
+export default LoginForm;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetForm.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/ResetForm.js
@@ -19,7 +19,7 @@ type Props = {
 };
 
 @observer
-export default class ResetForm extends React.Component<Props> {
+class ResetForm extends React.Component<Props> {
     static defaultProps = {
         loading: false,
         success: false,
@@ -95,3 +95,5 @@ export default class ResetForm extends React.Component<Props> {
         );
     }
 }
+
+export default ResetForm;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -24,7 +24,7 @@ type Props = {|
 |};
 
 @observer
-export default class MultiAutoComplete extends React.Component<Props> {
+class MultiAutoComplete extends React.Component<Props> {
     static defaultProps = {
         allowAdd: false,
         disabled: false,
@@ -114,3 +114,5 @@ export default class MultiAutoComplete extends React.Component<Props> {
         );
     }
 }
+
+export default MultiAutoComplete;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/MultiListOverlay.js
@@ -30,7 +30,7 @@ type Props = {|
 |};
 
 @observer
-export default class MultiListOverlay extends React.Component<Props> {
+class MultiListOverlay extends React.Component<Props> {
     static defaultProps = {
         clearSelectionOnClose: false,
         disabledIds: [],
@@ -111,3 +111,5 @@ export default class MultiListOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default MultiListOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -25,7 +25,7 @@ type Props = {|
 |};
 
 @observer
-export default class MultiSelection extends React.Component<Props> {
+class MultiSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         disabledIds: [],
@@ -163,3 +163,5 @@ export default class MultiSelection extends React.Component<Props> {
         );
     }
 }
+
+export default MultiSelection;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -21,7 +21,7 @@ type Props = {
 const SULU_CHANGELOG_URL = 'https://github.com/sulu/sulu/releases';
 
 @observer
-export default class Navigation extends React.Component<Props> {
+class Navigation extends React.Component<Props> {
     @computed get username(): string {
         if (!userStore.loggedIn || !userStore.contact) {
             return '';
@@ -108,3 +108,5 @@ export default class Navigation extends React.Component<Props> {
         );
     }
 }
+
+export default Navigation;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
@@ -18,7 +18,7 @@ type Props = {|
 |};
 
 @observer
-export default class ResourceLocatorHistory extends React.Component<Props> {
+class ResourceLocatorHistory extends React.Component<Props> {
     resourceListStore: ?ResourceListStore;
     @observable open = false;
     @observable showDeleteWarning = false;
@@ -120,3 +120,5 @@ export default class ResourceLocatorHistory extends React.Component<Props> {
         );
     }
 }
+
+export default ResourceLocatorHistory;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
@@ -19,7 +19,7 @@ type Props<T: string | number> = {|
 |};
 
 @observer
-export default class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> {
+class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> {
     static defaultProps = {
         apiOptions: {},
         disabled: false,
@@ -86,3 +86,5 @@ export default class ResourceMultiSelect<T: string | number> extends React.Compo
         );
     }
 }
+
+export default ResourceMultiSelect;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/EditOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/EditOverlay.js
@@ -20,7 +20,7 @@ type Props = {|
 |};
 
 @observer
-export default class EditOverlay extends React.Component<Props> {
+class EditOverlay extends React.Component<Props> {
     @observable data: Array<Object>;
     updateDataDisposer: () => void;
 
@@ -125,3 +125,5 @@ export default class EditOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default EditOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/ResourceSingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/ResourceSingleSelect.js
@@ -22,7 +22,7 @@ type Props<T> = {|
 |};
 
 @observer
-export default class ResourceSingleSelect<T: string | number> extends React.Component<Props<T>> {
+class ResourceSingleSelect<T: string | number> extends React.Component<Props<T>> {
     static defaultProps = {
         apiOptions: {},
         disabled: false,
@@ -103,3 +103,5 @@ export default class ResourceSingleSelect<T: string | number> extends React.Comp
         );
     }
 }
+
+export default ResourceSingleSelect;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/Sidebar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/Sidebar.js
@@ -11,7 +11,7 @@ type Props = {
 };
 
 @observer
-export default class Sidebar extends React.Component<Props> {
+class Sidebar extends React.Component<Props> {
     render() {
         if (!sidebarStore.view || sidebarRegistry.isDisabled(sidebarStore.view)) {
             return null;
@@ -34,3 +34,5 @@ export default class Sidebar extends React.Component<Props> {
         );
     }
 }
+
+export default Sidebar;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/SingleAutoComplete.js
@@ -16,7 +16,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleAutoComplete extends React.Component<Props> {
+class SingleAutoComplete extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         options: {},
@@ -66,3 +66,5 @@ export default class SingleAutoComplete extends React.Component<Props> {
         );
     }
 }
+
+export default SingleAutoComplete;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -30,7 +30,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleListOverlay extends React.Component<Props> {
+class SingleListOverlay extends React.Component<Props> {
     static defaultProps = {
         clearSelectionOnClose: false,
         disabledIds: [],
@@ -140,3 +140,5 @@ export default class SingleListOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default SingleListOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -26,7 +26,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleSelection extends React.Component<Props> {
+class SingleSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         disabledIds: [],
@@ -155,3 +155,5 @@ export default class SingleSelection extends React.Component<Props> {
         );
     }
 }
+
+export default SingleSelection;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
@@ -29,7 +29,7 @@ type Props = {
 };
 
 @observer
-export default class FilterOverlay extends React.Component<Props> {
+class FilterOverlay extends React.Component<Props> {
     @observable dataSource: ?Object;
     @observable includeSubElements: ?boolean;
     @observable categories: ?Array<Object>;
@@ -408,3 +408,5 @@ export default class FilterOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default FilterOverlay;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
@@ -18,7 +18,7 @@ type Props = {|
 |};
 
 @observer
-export default class SmartContent extends React.Component<Props> {
+class SmartContent extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         presentations: [],
@@ -145,3 +145,5 @@ export default class SmartContent extends React.Component<Props> {
         );
     }
 }
+
+export default SmartContent;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -36,7 +36,7 @@ function getItemComponentByType(itemConfig, key) {
 }
 
 @observer
-export default class Toolbar extends React.Component<*> {
+class Toolbar extends React.Component<*> {
     static defaultProps = {
         navigationOpen: false,
     };
@@ -177,3 +177,5 @@ export default class Toolbar extends React.Component<*> {
         );
     }
 }
+
+export default Toolbar;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -13,7 +13,7 @@ type Props = {
 };
 
 @observer
-export default class ViewRenderer extends React.Component<Props> {
+class ViewRenderer extends React.Component<Props> {
     componentDidUpdate() {
         this.clearSidebarConfig();
     }
@@ -98,3 +98,5 @@ export default class ViewRenderer extends React.Component<Props> {
         return this.renderView(this.props.router.route);
     }
 }
+
+export default ViewRenderer;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -19,7 +19,7 @@ type Props = ViewProps & {
 };
 
 @observer
-export default class FormOverlayList extends React.Component<Props> {
+class FormOverlayList extends React.Component<Props> {
     static getDerivedRouteAttributes = List.getDerivedRouteAttributes;
     locale: IObservableValue<string> = observable.box();
 
@@ -214,3 +214,5 @@ export default class FormOverlayList extends React.Component<Props> {
         );
     }
 }
+
+export default FormOverlayList;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/ResourceTabs.js
@@ -16,7 +16,7 @@ type Props = ViewProps & {
 };
 
 @observer
-export default class ResourceTabs extends React.Component<Props> {
+class ResourceTabs extends React.Component<Props> {
     resourceStore: ResourceStore;
     reloadResourceStoreOnRouteChangeDisposer: () => void;
 
@@ -157,3 +157,5 @@ export default class ResourceTabs extends React.Component<Props> {
             );
     }
 }
+
+export default ResourceTabs;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
@@ -17,7 +17,7 @@ type Props = ViewProps & {
 };
 
 @observer
-export default class Tabs extends React.Component<Props> {
+class Tabs extends React.Component<Props> {
     static defaultProps = {
         childrenProps: {},
     };
@@ -130,3 +130,5 @@ export default class Tabs extends React.Component<Props> {
         );
     }
 }
+
+export default Tabs;

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/Bic/Bic.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/Bic/Bic.js
@@ -17,7 +17,7 @@ type Props = {|
 |};
 
 @observer
-export default class Bic extends React.Component<Props> {
+class Bic extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         valid: true,
@@ -107,3 +107,5 @@ export default class Bic extends React.Component<Props> {
         );
     }
 }
+
+export default Bic;

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/Iban/Iban.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/Iban/Iban.js
@@ -17,7 +17,7 @@ type Props = {|
 |};
 
 @observer
-export default class Iban extends React.Component<Props> {
+class Iban extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         valid: true,
@@ -107,3 +107,5 @@ export default class Iban extends React.Component<Props> {
         );
     }
 }
+
+export default Iban;

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrl.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrl.js
@@ -7,7 +7,7 @@ import CustomUrlComponent from '../../../components/CustomUrl';
 import customUrlStyles from './customUrl.scss';
 
 @observer
-export default class CustomUrl extends React.Component<FieldTypeProps<Array<?string>>> {
+class CustomUrl extends React.Component<FieldTypeProps<Array<?string>>> {
     handleChange = (value: Array<?string>) => {
         const {onChange} = this.props;
 
@@ -52,3 +52,5 @@ export default class CustomUrl extends React.Component<FieldTypeProps<Array<?str
         );
     }
 }
+
+export default CustomUrl;

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsDomainSelect.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsDomainSelect.js
@@ -8,7 +8,7 @@ import {webspaceStore} from 'sulu-page-bundle/stores';
 import type {Webspace} from 'sulu-page-bundle/types';
 
 @observer
-export default class CustomUrlsDomainSelect extends React.Component<FieldTypeProps<string>> {
+class CustomUrlsDomainSelect extends React.Component<FieldTypeProps<string>> {
     @observable webspace: Webspace;
 
     componentDidMount() {
@@ -47,3 +47,5 @@ export default class CustomUrlsDomainSelect extends React.Component<FieldTypePro
         );
     }
 }
+
+export default CustomUrlsDomainSelect;

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsLocaleSelect.js
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/fields/CustomUrlsLocaleSelect.js
@@ -8,7 +8,7 @@ import {webspaceStore} from 'sulu-page-bundle/stores';
 import type {Webspace} from 'sulu-page-bundle/types';
 
 @observer
-export default class CustomUrlsLocaleSelect extends React.Component<FieldTypeProps<string>> {
+class CustomUrlsLocaleSelect extends React.Component<FieldTypeProps<string>> {
     @observable webspace: Webspace;
 
     componentDidMount() {
@@ -47,3 +47,5 @@ export default class CustomUrlsLocaleSelect extends React.Component<FieldTypePro
         );
     }
 }
+
+export default CustomUrlsLocaleSelect;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/ImageFocusPoint.js
@@ -16,7 +16,7 @@ type Props = {|
 |};
 
 @observer
-export default class ImageFocusPoint extends React.Component<Props> {
+class ImageFocusPoint extends React.Component<Props> {
     @observable imageDimension: ClientRect;
 
     createFocusPoints(selectedPoint: Point) {
@@ -140,3 +140,5 @@ export default class ImageFocusPoint extends React.Component<Props> {
         );
     }
 }
+
+export default ImageFocusPoint;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadListItem.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/DownloadListItem.js
@@ -15,7 +15,7 @@ type Props = {
 };
 
 @observer
-export default class DownloadListItem extends React.Component<Props> {
+class DownloadListItem extends React.Component<Props> {
     static defaultProps = {
         copyUrlOnClick: false,
     };
@@ -83,3 +83,5 @@ export default class DownloadListItem extends React.Component<Props> {
         );
     }
 }
+
+export default DownloadListItem;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -45,7 +45,7 @@ type Props = {
 };
 
 @observer
-export default class MediaCard extends React.Component<Props> {
+class MediaCard extends React.Component<Props> {
     static defaultProps = {
         downloadCopyText: '',
         imageSizes: [],
@@ -212,3 +212,5 @@ export default class MediaCard extends React.Component<Props> {
         );
     }
 }
+
+export default MediaCard;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -23,7 +23,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleMediaDropzone extends React.Component<Props> {
+class SingleMediaDropzone extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         emptyIcon: 'su-image',
@@ -121,3 +121,5 @@ export default class SingleMediaDropzone extends React.Component<Props> {
         );
     }
 }
+
+export default SingleMediaDropzone;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -8,7 +8,7 @@ import MultiMediaSelection from '../../MultiMediaSelection';
 import type {Value} from '../../MultiMediaSelection';
 
 @observer
-export default class MediaSelection extends React.Component<FieldTypeProps<Value>> {
+class MediaSelection extends React.Component<FieldTypeProps<Value>> {
     handleChange = (value: Value) => {
         const {onChange, onFinish} = this.props;
 
@@ -30,3 +30,5 @@ export default class MediaSelection extends React.Component<FieldTypeProps<Value
         );
     }
 }
+
+export default MediaSelection;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -8,7 +8,7 @@ import SingleMediaSelectionComponent from '../../SingleMediaSelection';
 import type {Value} from '../../SingleMediaSelection';
 
 @observer
-export default class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
+class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
     handleChange = (value: Value) => {
         const {onChange, onFinish} = this.props;
 
@@ -31,3 +31,5 @@ export default class SingleMediaSelection extends React.Component<FieldTypeProps
         );
     }
 }
+
+export default SingleMediaSelection;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
@@ -14,7 +14,7 @@ type Props = ListAdapterProps & {
 };
 
 @observer
-export default class MediaCardAdapter extends React.Component<Props> {
+class MediaCardAdapter extends React.Component<Props> {
     static formatFileSize(size: number) {
         const megaByteThreshold = 1000000;
         const kiloByteThreshold = 1000;
@@ -109,3 +109,5 @@ export default class MediaCardAdapter extends React.Component<Props> {
         );
     }
 }
+
+export default MediaCardAdapter;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardOverviewAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardOverviewAdapter.js
@@ -7,7 +7,7 @@ import MediaCardAdapter from './MediaCardAdapter';
 const EDIT_ICON = 'su-pen';
 
 @observer
-export default class MediaCardOverviewAdapter extends AbstractAdapter {
+class MediaCardOverviewAdapter extends AbstractAdapter {
     static LoadingStrategy = InfiniteLoadingStrategy;
 
     static StructureStrategy = FlatStructureStrategy;
@@ -23,3 +23,5 @@ export default class MediaCardOverviewAdapter extends AbstractAdapter {
         );
     }
 }
+
+export default MediaCardOverviewAdapter;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardSelectionAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardSelectionAdapter.js
@@ -7,7 +7,7 @@ import MediaCardAdapter from './MediaCardAdapter';
 const SELECT_ICON = 'su-check';
 
 @observer
-export default class MediaCardSelectionAdapter extends AbstractAdapter {
+class MediaCardSelectionAdapter extends AbstractAdapter {
     static LoadingStrategy = InfiniteLoadingStrategy;
 
     static StructureStrategy = FlatStructureStrategy;
@@ -35,3 +35,5 @@ export default class MediaCardSelectionAdapter extends AbstractAdapter {
         );
     }
 }
+
+export default MediaCardSelectionAdapter;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionBreadcrumb.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionBreadcrumb.js
@@ -13,7 +13,7 @@ type Props = {
 };
 
 @observer
-export default class CollectionBreadcrumb extends React.Component<Props> {
+class CollectionBreadcrumb extends React.Component<Props> {
     static getCurrentCollectionItem(data: Object): BreadcrumbItem {
         return {
             id: data.id,
@@ -77,3 +77,5 @@ export default class CollectionBreadcrumb extends React.Component<Props> {
         );
     }
 }
+
+export default CollectionBreadcrumb;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
@@ -20,7 +20,7 @@ type Props = {
 const FORM_KEY = 'collection_details';
 
 @observer
-export default class CollectionFormOverlay extends React.Component<Props> {
+class CollectionFormOverlay extends React.Component<Props> {
     formRef: ?Form;
     title: string;
     operationType: string;
@@ -115,3 +115,5 @@ export default class CollectionFormOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default CollectionFormOverlay;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -23,7 +23,7 @@ type Props = {
 };
 
 @observer
-export default class CollectionSection extends React.Component<Props> {
+class CollectionSection extends React.Component<Props> {
     @observable openedCollectionOperationOverlayType: OperationType;
 
     @action openCollectionOperationOverlay(operationType: OperationType) {
@@ -236,3 +236,5 @@ export default class CollectionSection extends React.Component<Props> {
         );
     }
 }
+
+export default CollectionSection;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -28,7 +28,7 @@ type Props = {|
 |};
 
 @observer
-export default class MediaCollection extends React.Component<Props> {
+class MediaCollection extends React.Component<Props> {
     static defaultProps = {
         overlayType: 'overlay',
     };
@@ -100,3 +100,5 @@ export default class MediaCollection extends React.Component<Props> {
         );
     }
 }
+
+export default MediaCollection;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/MediaSelectionOverlay.js
@@ -25,7 +25,7 @@ type Props = {|
 |};
 
 @observer
-export default class MediaSelectionOverlay extends React.Component<Props> {
+class MediaSelectionOverlay extends React.Component<Props> {
     @observable collectionStore: CollectionStore;
     @observable showMediaUploadOverlay: boolean = false;
     updateCollectionStoreDisposer: () => void;
@@ -182,3 +182,5 @@ export default class MediaSelectionOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default MediaSelectionOverlay;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/DropzoneOverlay.js
@@ -18,7 +18,7 @@ type Props = {
 const CLOSE_OVERLAY_KEY = 'esc';
 
 @observer
-export default class DropzoneOverlay extends React.Component<Props> {
+class DropzoneOverlay extends React.Component<Props> {
     static defaultProps = {
         open: false,
     };
@@ -101,3 +101,5 @@ export default class DropzoneOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default DropzoneOverlay;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MediaItem.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MediaItem.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 @observer
-export default class MediaItem extends React.Component<Props> {
+class MediaItem extends React.Component<Props> {
     render() {
         const {store} = this.props;
 
@@ -32,3 +32,5 @@ export default class MediaItem extends React.Component<Props> {
         );
     }
 }
+
+export default MediaItem;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/MultiMediaDropzone.js
@@ -21,7 +21,7 @@ type Props = {
 };
 
 @observer
-export default class MultiMediaDropzone extends React.Component<Props> {
+class MultiMediaDropzone extends React.Component<Props> {
     dropzoneRef: ElementRef<Dropzone>;
 
     @observable mediaUploadStores: Array<MediaUploadStore> = [];
@@ -118,3 +118,5 @@ export default class MultiMediaDropzone extends React.Component<Props> {
         );
     }
 }
+
+export default MultiMediaDropzone;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -24,7 +24,7 @@ const MEDIA_RESOURCE_KEY = 'media';
 const THUMBNAIL_SIZE = 'sulu-25x25';
 
 @observer
-export default class MultiMediaSelection extends React.Component<Props> {
+class MultiMediaSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         value: {ids: []},
@@ -164,3 +164,5 @@ export default class MultiMediaSelection extends React.Component<Props> {
         );
     }
 }
+
+export default MultiMediaSelection;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/MultiMediaSelectionOverlay.js
@@ -15,7 +15,7 @@ type Props = {|
 |};
 
 @observer
-export default class MultiMediaSelectionOverlay extends React.Component<Props> {
+class MultiMediaSelectionOverlay extends React.Component<Props> {
     static defaultProps = {
         excludedIds: [],
     };
@@ -69,3 +69,5 @@ export default class MultiMediaSelectionOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default MultiMediaSelectionOverlay;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -24,7 +24,7 @@ const MEDIA_RESOURCE_KEY = 'media';
 const THUMBNAIL_SIZE = 'sulu-25x25';
 
 @observer
-export default class SingleMediaSelection extends React.Component<Props> {
+class SingleMediaSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         valid: true,
@@ -146,3 +146,5 @@ export default class SingleMediaSelection extends React.Component<Props> {
         );
     }
 }
+
+export default SingleMediaSelection;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -15,7 +15,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleMediaSelectionOverlay extends React.Component<Props> {
+class SingleMediaSelectionOverlay extends React.Component<Props> {
     static defaultProps = {
         excludedIds: [],
     };
@@ -98,3 +98,5 @@ export default class SingleMediaSelectionOverlay extends React.Component<Props> 
         );
     }
 }
+
+export default SingleMediaSelectionOverlay;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/SingleMediaUpload.js
@@ -22,7 +22,7 @@ type Props = {|
 |};
 
 @observer
-export default class SingleMediaUpload extends React.Component<Props> {
+class SingleMediaUpload extends React.Component<Props> {
     static defaultProps = {
         deletable: true,
         disabled: false,
@@ -160,3 +160,5 @@ export default class SingleMediaUpload extends React.Component<Props> {
         );
     }
 }
+
+export default SingleMediaUpload;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/CropOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/CropOverlay.js
@@ -20,7 +20,7 @@ type Props = {|
 |};
 
 @observer
-export default class CropOverlay extends React.Component<Props> {
+class CropOverlay extends React.Component<Props> {
     @observable rawFormats: ?Array<Object>;
     @observable formatKey: ?string;
     @observable changedFormatCroppings: Map<string, Object> = new Map();
@@ -192,3 +192,5 @@ export default class CropOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default CropOverlay;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/FocusPointOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/FocusPointOverlay.js
@@ -17,7 +17,7 @@ type Props = {|
 |};
 
 @observer
-export default class FocusPointOverlay extends React.Component<Props> {
+class FocusPointOverlay extends React.Component<Props> {
     @observable focusPointX: number;
     @observable focusPointY: number;
     @observable resourceStore: ?ResourceStore;
@@ -114,3 +114,5 @@ export default class FocusPointOverlay extends React.Component<Props> {
         );
     }
 }
+
+export default FocusPointOverlay;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/WebspaceSelect.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/components/WebspaceSelect/WebspaceSelect.js
@@ -13,7 +13,7 @@ type Props = {
 };
 
 @observer
-export default class WebspaceSelect extends React.Component<Props> {
+class WebspaceSelect extends React.Component<Props> {
     static Item = ArrowMenu.Item;
 
     @observable open: boolean = false;
@@ -83,3 +83,5 @@ export default class WebspaceSelect extends React.Component<Props> {
         );
     }
 }
+
+export default WebspaceSelect;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsNavigationSelect.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/fields/PageSettingsNavigationSelect.js
@@ -9,7 +9,7 @@ import webspaceStore from '../../../stores/WebspaceStore';
 import type {Webspace} from '../../../stores/WebspaceStore/types';
 
 @observer
-export default class PageSettingsNavigationSelect extends React.Component<FieldTypeProps<Array<string | number>>> {
+class PageSettingsNavigationSelect extends React.Component<FieldTypeProps<Array<string | number>>> {
     @observable webspace: Webspace;
 
     componentDidMount() {
@@ -50,3 +50,5 @@ export default class PageSettingsNavigationSelect extends React.Component<FieldT
         );
     }
 }
+
+export default PageSettingsNavigationSelect;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/CopyLocaleDialog.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/toolbarActions/CopyLocaleDialog.js
@@ -18,7 +18,7 @@ type Props = {
 };
 
 @observer
-export default class CopyLocaleDialog extends React.Component<Props> {
+class CopyLocaleDialog extends React.Component<Props> {
     @observable copying: boolean = false;
     @observable selectedLocales: Array<string> = [];
 
@@ -97,3 +97,5 @@ export default class CopyLocaleDialog extends React.Component<Props> {
         );
     }
 }
+
+export default CopyLocaleDialog;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/PageTabs.js
@@ -8,7 +8,7 @@ import webspaceStore from '../../stores/WebspaceStore';
 import type {Webspace} from '../../stores/WebspaceStore/types';
 
 @observer
-export default class PageTabs extends React.Component<ViewProps> {
+class PageTabs extends React.Component<ViewProps> {
     @observable webspace: Webspace;
 
     constructor(props: ViewProps) {
@@ -30,3 +30,5 @@ export default class PageTabs extends React.Component<ViewProps> {
         return <ResourceTabs {...props} locales={locales} titleProperty="title" />;
     }
 }
+
+export default PageTabs;

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/WebspaceTabs.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/WebspaceTabs.js
@@ -17,7 +17,7 @@ const USER_SETTING_PREFIX = 'sulu_page.webspace_tabs';
 const USER_SETTING_WEBSPACE = [USER_SETTING_PREFIX, 'webspace'].join('.');
 
 @observer
-export default class WebspaceTabs extends React.Component<ViewProps> {
+class WebspaceTabs extends React.Component<ViewProps> {
     @observable webspaces: ?Array<Webspace>;
     webspaceKey: IObservableValue<string> = observable.box();
     webspaceDisposer: () => void;
@@ -99,3 +99,5 @@ export default class WebspaceTabs extends React.Component<ViewProps> {
             : <Loader />;
     }
 }
+
+export default WebspaceTabs;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -19,7 +19,7 @@ type Props = {|
 |};
 
 @observer
-export default class Preview extends React.Component<Props> {
+class Preview extends React.Component<Props> {
     static debounceDelay: number = 250;
     static mode: PreviewMode = 'auto';
 
@@ -245,3 +245,5 @@ export default class Preview extends React.Component<Props> {
         );
     }
 }
+
+export default Preview;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/Permissions.js
@@ -9,7 +9,7 @@ import type {ContextPermission} from '../../Permissions';
 type Props = FieldTypeProps<?Array<ContextPermission>>;
 
 @observer
-export default class Permissions extends React.Component<Props> {
+class Permissions extends React.Component<Props> {
     @computed get system(): ?string {
         const {formInspector} = this.props;
         const system = formInspector.getValueByPath('/system');
@@ -44,3 +44,5 @@ export default class Permissions extends React.Component<Props> {
         );
     }
 }
+
+export default Permissions;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
@@ -19,7 +19,7 @@ type Props = {|
 |};
 
 @observer
-export default class PermissionMatrix extends React.Component<Props> {
+class PermissionMatrix extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -127,3 +127,5 @@ export default class PermissionMatrix extends React.Component<Props> {
         );
     }
 }
+
+export default PermissionMatrix;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
@@ -19,7 +19,7 @@ type Props = {|
 |};
 
 @observer
-export default class Permissions extends React.Component<Props> {
+class Permissions extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -235,3 +235,5 @@ export default class Permissions extends React.Component<Props> {
         );
     }
 }
+
+export default Permissions;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
@@ -14,7 +14,7 @@ type Props = {|
 |};
 
 @observer
-export default class RoleAssignment extends React.Component<Props> {
+class RoleAssignment extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -57,3 +57,5 @@ export default class RoleAssignment extends React.Component<Props> {
         );
     }
 }
+
+export default RoleAssignment;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
@@ -16,7 +16,7 @@ type Props = {|
 |};
 
 @observer
-export default class RoleAssignments extends React.Component<Props> {
+class RoleAssignments extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -119,3 +119,5 @@ export default class RoleAssignments extends React.Component<Props> {
         );
     }
 }
+
+export default RoleAssignments;

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/fields/AnalyticsDomainSelect.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/fields/AnalyticsDomainSelect.js
@@ -8,7 +8,7 @@ import {webspaceStore} from 'sulu-page-bundle/stores';
 import type {Webspace} from 'sulu-page-bundle/types';
 
 @observer
-export default class AnalyticsDomainSelect extends React.Component<FieldTypeProps<Array<string>>> {
+class AnalyticsDomainSelect extends React.Component<FieldTypeProps<Array<string>>> {
     @observable webspace: Webspace;
 
     componentDidMount() {
@@ -47,3 +47,5 @@ export default class AnalyticsDomainSelect extends React.Component<FieldTypeProp
         );
     }
 }
+
+export default AnalyticsDomainSelect;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes - 
| Related issues/PRs | https://github.com/sulu/sulu/pull/4536
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Explain the contents of the PR.

Upgrade the decorators to compatible es7 decorators:

| Search | Replace |
|--------|----------|
| `(@observer\n)(export default )(class )([a-zA-Z]+)([\s\S^?]+?)(\n})` | `$1$3$4$5$6\n\n$2$4;` |
| `(@observer\n)(export )(class )([a-zA-Z]+)([\s\S^?]+?)(\n})` | `$1$3$4$5$6\n\n$2\{\n    $4,\n\};` |

#### Why?

The ES7 decorators are not allowed to be before an export or export default so we did move the export after the class.

#### Example Usage

~~~php
npm install
npm run build
~~~
