### PR TITLE
Fix BinaryFileResponse of html files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * dev-master
+    * BUGFIX      #4562 [WebsiteBundle]         Fix BinaryFileResponse of html files.
     * FEATURE     #4532  [MediaBundle]          Add command to remove format cache files which not longer exists
     * HOTFIX      #4512  [Components]           Fix pathcleanup whitespace character problems
     * FEATURE     #4504  [WebsiteBundle]        Dispatch an event after cache clear. 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -94,8 +94,14 @@ class AppendAnalyticsListener
      */
     public function onResponse(FilterResponseEvent $event)
     {
-        if ($this->preview
-            || 0 !== strpos($event->getResponse()->headers->get('Content-Type'), 'text/html')
+        if ($this->preview) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        if (0 !== strpos($response->headers->get('Content-Type'), 'text/html')
+            || !$response->getContent()
             || null === $this->requestAnalyzer->getPortalInformation()
         ) {
             return;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsRepository;
 use Sulu\Bundle\WebsiteBundle\EventListener\AppendAnalyticsListener;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,6 +54,36 @@ class AppendAnalyticsListenerTest extends \PHPUnit_Framework_TestCase
         $request->getRequestFormat()->willReturn($format);
         $response = $this->prophesize(Response::class);
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/plain']);
+        $response->getContent()->shouldNotBeCalled();
+        $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
+        $event->getResponse()->willReturn($response->reveal());
+
+        $listener->onResponse($event->reveal());
+
+        $engine->render(Argument::any(), Argument::any())->shouldNotBeCalled();
+        $response->setContent(Argument::any())->shouldNotBeCalled();
+    }
+
+    public function testBinaryFileResponse()
+    {
+        $engine = $this->prophesize(EngineInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
+        $listener = new AppendAnalyticsListener(
+            $engine->reveal(),
+            $requestAnalyzer->reveal(),
+            $analyticsRepository->reveal(),
+            'prod'
+        );
+
+        $event = $this->prophesize(FilterResponseEvent::class);
+        $request = $this->prophesize(Request::class);
+        $event->getRequest()->willReturn($request->reveal());
+        $request->getRequestFormat()->willReturn('html');
+        $response = $this->prophesize(BinaryFileResponse::class);
+        $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
+        $response->getContent()->willReturn(false)->shouldBeCalled();
+        $requestAnalyzer->getPortalInformation()->shouldNotBeCalled();
         $event->getResponse()->willReturn($response->reveal());
 
         $listener->onResponse($event->reveal());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3745
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix binary file response of html files.

#### Why?

A binary file response set the file in the x-sendfile header and so the content is [not editable](https://github.com/symfony/symfony/blob/v3.4.27/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php#L315-L335) and should not be edited by the appendanalytics listener.

#### Example Usage

~~~php
$response = new BinaryFileResponse(__DIR__ . '/test.html');

return $response;
~~~
