### PR TITLE
Rename snippet content type to snippet_selection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,20 @@
 
 When upgrading also have a look at the changes in the [sulu skeleton](https://github.com/sulu/sulu-minimal/compare/2.0.0-alpha5...2.0.0-alpha6).
 
+### Rename snippet content type to snippet_selection
+
+**Before**:
+
+```xml
+<property name="snippets" type="snippet" />
+```
+
+**After**:
+
+```xml
+<property name="snippets" type="snippet_selection" />
+```
+
 ### Router removeUpdateRouteHook
 
 **This change only affects you if you have used a 2.0.0 alpha release before**

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/test_page.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/test_page.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/with_snippet.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/with_snippet.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="internal_link" type="snippet"/>
+        <property name="internal_link" type="snippet_selection"/>
     </properties>
 </template>
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ContentTypesDumpCommandTest.php
@@ -69,7 +69,7 @@ class ContentTypesDumpCommandTest extends SuluTestCase
         $this->assertContains('location', $output);
         $this->assertContains('media_selection', $output);
         $this->assertContains('route', $output);
-        $this->assertContains('snippet', $output);
+        $this->assertContains('snippet_selection', $output);
         $this->assertContains('tag_selection', $output);
     }
 }

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/ResourceBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ResourceBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -57,7 +57,7 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
                     ],
                     'field_type_options' => [
                         'selection' => [
-                            'snippet' => [
+                            'snippet_selection' => [
                                 'default_type' => 'list_overlay',
                                 'resource_key' => 'snippets',
                                 'types' => [

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/content.xml
@@ -28,7 +28,7 @@
             <argument type="service" id="sulu_snippet.reference_store.snippet"/>
             <argument>%sulu_snippet.content-type.default_enabled%</argument>
 
-            <tag name="sulu.content.type" alias="snippet"/>
+            <tag name="sulu.content.type" alias="snippet_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
         <service id="sulu_snippet.smart_content.data_provider.query_builder"

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/hotel_page.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/templates/pages/hotel_page.xml
@@ -36,7 +36,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="hotels" type="snippet" mandatory="true">
+        <property name="hotels" type="snippet_selection" mandatory="true">
             <meta>
                 <title lang="de">Hotel</title>
                 <title lang="en">Hotel</title>

--- a/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
@@ -35,7 +35,7 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet">
+        <property name="animals" type="snippet_selection">
             <params>
                 <param name="snippetType" value="animal" />
             </params>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #3624 
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/438

#### What's in this PR?

Rename snippet content type.

#### Why?

Normalize content type names: #3624 

#### Example Usage

~~~php
<property name="snippets" type="snippet_selection" />
~~~

#### BC Breaks/Deprecations

See UPGRADE.md

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/438
- [x] Add breaking changes to UPGRADE.md
