### PR TITLE
Rename contact content type to contact_account_selection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,28 @@
 
 When upgrading also have a look at the changes in the [sulu skeleton](https://github.com/sulu/sulu-minimal/compare/2.0.0-alpha5...2.0.0-alpha6).
 
+### Rename contact content type to contact_account_selection
+
+**Before**:
+
+```xml
+<property name="contacts" type="contact" />
+```
+
+**After**:
+
+```xml
+<property name="contacts" type="contact_account_selection" />
+```
+
+Following container parameters removed:
+
+ - `sulu_contact.content.contact.class`
+
+Following service renamed:
+
+ - `sulu_contact.content.contact` to `sulu_contact.content.contact_account_selection`
+
 ### Rename snippet content type to snippet_selection
 
 **Before**:

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/ContactAccountSelection.php
@@ -29,7 +29,7 @@ use Sulu\Component\Content\PreResolvableContentTypeInterface;
 /**
  * ContentType for Contact.
  */
-class ContactSelectionContentType extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface
+class ContactAccountSelection extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface
 {
     const PREFIX_CONTACT = 'c';
 

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/content.xml
@@ -2,13 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_contact.content.contact.class">Sulu\Bundle\ContactBundle\Content\Types\ContactSelectionContentType</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_contact.content.contact" class="%sulu_contact.content.contact.class%">
+        <service id="sulu_contact.content.contact_account_selection" class="Sulu\Bundle\ContactBundle\Content\Types\ContactAccountSelection">
             <argument type="service" id="sulu_contact.contact_manager" />
             <argument type="service" id="sulu_contact.account_manager" />
             <argument type="service" id="jms_serializer" />
@@ -17,7 +12,7 @@
             <argument type="service" id="sulu_contact.reference_store.account" />
             <argument type="service" id="sulu_contact.reference_store.contact" />
 
-            <tag name="sulu.content.type" alias="contact"/>
+            <tag name="sulu.content.type" alias="contact_account_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false"/>
         </service>
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactAccountSelectionTest.php
@@ -20,7 +20,7 @@ use Prophecy\Argument;
 use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\ContactBundle\Api\Contact;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
-use Sulu\Bundle\ContactBundle\Content\Types\ContactSelectionContentType;
+use Sulu\Bundle\ContactBundle\Content\Types\ContactAccountSelection;
 use Sulu\Bundle\ContactBundle\Util\CustomerIdConverter;
 use Sulu\Bundle\ContactBundle\Util\IndexComparator;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
@@ -28,7 +28,7 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\StructureInterface;
 
-class ContactSelectionContentTypeTest extends TestCase
+class ContactAccountSelectionTest extends TestCase
 {
     /**
      * @var string
@@ -112,7 +112,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testRead()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -138,7 +138,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testReadNull()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -164,7 +164,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testReadPropertyNotExists()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -190,7 +190,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testWrite()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -216,7 +216,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testWriteNull()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -243,7 +243,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testRemove()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -275,7 +275,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetViewData()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -292,7 +292,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetDefaultValue()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -309,7 +309,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetDefaultParams()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -332,7 +332,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testHasValue()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -358,7 +358,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetContentDataOnlyContact()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -400,7 +400,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetContentDataCombined()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -442,7 +442,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetContentDataOrderOnlyContact()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -485,7 +485,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetContentDataEmpty()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -506,7 +506,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetContentDataNull()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -527,7 +527,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testGetContentDataWrongType()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),
@@ -548,7 +548,7 @@ class ContactSelectionContentTypeTest extends TestCase
 
     public function testPreResolve()
     {
-        $type = new ContactSelectionContentType(
+        $type = new ContactAccountSelection(
             $this->contactManager->reveal(),
             $this->accountManager->reveal(),
             $this->serializer->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #3624 
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/439

#### What's in this PR?

Rename contact content type to contact_account_selection.

#### Why?

Normalize content type names: #3624 

#### Example Usage

~~~php
<property name="contacts" type="contact_account_selection" />
~~~

**UI Missing**

#### BC Breaks/Deprecations

See UPGRADE.md

#### To Do

- [x] Create a documentation PR https://github.com/sulu/sulu-docs/pull/439
- [x] Add breaking changes to UPGRADE.md
