### PR TITLE
Reset page of medias to one when returning from MediaDetails view

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/MediaDetails.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/MediaDetails.js
@@ -203,7 +203,7 @@ export default withToolbar(MediaDetails, function() {
         locale,
         backButton: {
             onClick: () => {
-                router.restore(COLLECTION_ROUTE, {locale: resourceStore.locale.get()});
+                router.restore(COLLECTION_ROUTE, {locale: resourceStore.locale.get(), mediaPage: 1});
             },
         },
         items: [

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/MediaDetails.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/MediaDetails.test.js
@@ -130,7 +130,7 @@ test('Should navigate to defined route on back button click', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaDetails);
     toolbarConfig.backButton.onClick();
-    expect(router.restore).toBeCalledWith('sulu_media.overview', {locale: 'de'});
+    expect(router.restore).toBeCalledWith('sulu_media.overview', {locale: 'de', mediaPage: 1});
 });
 
 test('Should show locales from router options in toolbar', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR resets the `mediaPage` route parameter to 1 each time the back button in a `MediaDetail` view is pressed.

#### Why?

Because previously the following scenario made problems:

1. Go to a collection
2. Change to the table view
3. Go to the second page in the table view
4. Click on the edit button on any media
5. Press the back button in the form
6. You land on the list again, but in the Masonry view and the mediaPage parameter, resulting in skipping the first few images.