### PR TITLE
Remove wrong call to translate for non-translatable social media services

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/index.js
@@ -34,7 +34,7 @@ initializer.addUpdateConfigHook('sulu_contact', (config: Object, initialized: bo
             Phone.types = config.phoneTypes
                 .map((phoneType) => ({label: translate(phoneType.name), value: phoneType.id}));
             SocialMedia.types = config.socialMediaTypes
-                .map((socialMediaType) => ({label: translate(socialMediaType.name), value: socialMediaType.id}));
+                .map((socialMediaType) => ({label: socialMediaType.name, value: socialMediaType.id}));
             Website.types = config.websiteTypes
                 .map((urlType) => ({label: translate(urlType.name), value: urlType.id}));
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the wrong `translate` calls for the social media names.

#### Why?

Because these values are taken directly from the database, and are no translation keys.