### PR TITLE
Fix language switcher for static routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.5
+    * BUGFIX      #4571 [WebsiteBundle]         Fix language switcher for static routes
     * BUGFIX      #4579 [ContentBundle]         Fix controller reference validation with FQCN
 
 * 1.5.23 (2019-05-16)

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\Resolver;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -138,10 +139,14 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
                         $routeParams['prefix'] = $portalInformation->getPrefix();
                     }
 
+                    if (isset($routeParams['_locale'])) {
+                        $routeParams['_locale'] = $portalInformation->getLocale();
+                    }
+
                     $url = $this->router->generate(
                         $routeName,
                         $routeParams,
-                        true
+                        UrlGeneratorInterface::ABSOLUTE_URL
                     );
 
                     $urls[$portalInformation->getLocale()] = $url;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix language switcher for static routes.

#### Why?

The sulu_content_path does prefix 

#### Example Usage

Webspace Setting:

```xml
<urls>
    <url>{host}/{localization}</url>
</urls>
```

Example Route:

```yaml
test_route:
    path:         /{_locale}/test
    controller:   Symfony\Bundle\FrameworkBundle\Controller\TemplateController
    defaults:
        template: test.html.twig
    methods: GET
```

Twig:

```twig
{{- include 'SuluWebsiteBundle:Extension:seo.html.twig' with {
    seo: extension.seo|default([]),
    content: content|default([]),
    urls: urls|default([]),
    shadowBaseLocale: shadowBaseLocale|default(),
    defaultLocale: request.defaultLocale|default('en')
} -}}

{# or #}

{% for locale, url in urls %}
    {{ sulu_content_path(url, null, locale) }} <br>
{% endfor %}
```

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
