### PR TITLE
Fix false 406 status code for controller InvalidArgumentExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.5
+    * BUGFIX      #4572 [WebsiteBundle]         Fix false 406 status code for controller InvalidArgumentExceptions
     * BUGFIX      #4571 [WebsiteBundle]         Fix language switcher for static routes
     * BUGFIX      #4579 [ContentBundle]         Fix controller reference validation with FQCN
 
@@ -10,7 +11,7 @@ CHANGELOG for Sulu
     
 * 1.5.22 (2019-03-26)
     * HOTFIX      #4491 [ContentBundle]         Set ghost-locale to first available-locale if locale not exists in webspace
-    * BUGFIX      #4433 [SecurityBundle]       Fix fresh User object comparison to the deserialized User object
+    * BUGFIX      #4433 [SecurityBundle]        Fix fresh User object comparison to the deserialized User object
     
 * 1.5.21 (2019-02-28)
     * ENHANCEMENT #4367 [WebsiteBundle]         Remove false deprecation of WebsiteController::renderStructure

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
-use InvalidArgumentException;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,29 +48,31 @@ abstract class WebsiteController extends Controller
 
         $viewTemplate = $structure->getView() . '.' . $requestFormat . '.twig';
 
-        try {
-            // get attributes to render template
-            $data = $this->getAttributes($attributes, $structure, $preview);
-
-            // if partial render only content block else full page
-            if ($partial) {
-                $content = $this->renderBlock(
-                    $viewTemplate,
-                    'content',
-                    $data
-                );
-            } else {
-                $content = parent::renderView(
-                    $viewTemplate,
-                    $data
-                );
-            }
-
-            return new Response($content);
-        } catch (InvalidArgumentException $e) {
-            // template not found
-            throw new HttpException(406, 'Error encountered when rendering content', $e);
+        if (!$this->get('twig')->getLoader()->exists($viewTemplate)) {
+            throw new HttpException(
+                406,
+                sprintf('Page does not exist in "%s" format.', $requestFormat)
+            );
         }
+
+        // get attributes to render template
+        $data = $this->getAttributes($attributes, $structure, $preview);
+
+        // if partial render only content block else full page
+        if ($partial) {
+            $content = $this->renderBlock(
+                $viewTemplate,
+                'content',
+                $data
+            );
+        } else {
+            $content = parent::renderView(
+                $viewTemplate,
+                $data
+            );
+        }
+
+        return new Response($content);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/DefaultControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/DefaultControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Controller;
+
+use Prophecy\Argument;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class DefaultControllerTest extends \PHPUnit_Framework_TestCase
+{
+    private $defaultController;
+
+    private $container;
+
+    private $twig;
+
+    private $twigLoader;
+
+    private $request;
+
+    private $requestStack;
+
+    private $structure;
+
+    private $parameterResolver;
+
+    private $requestAnalyzer;
+
+    public function setUp()
+    {
+        $this->structure = $this->prophesize(PageBridge::class);
+        $this->structure->getView()->willReturn('pages/default');
+        $this->request = $this->prophesize(Request::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
+        $this->twig = $this->prophesize(\Twig_Environment::class);
+        $this->twigLoader = $this->prophesize(\Twig_Loader_Filesystem::class);
+        $this->twig->getLoader()->willReturn($this->twigLoader->reveal());
+        $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container->has('templating')->willReturn(false);
+        $this->container->has('twig')->willReturn(true);
+        $this->container->get('twig')->willReturn($this->twig->reveal());
+        $this->container->get('request_stack')->willReturn($this->requestStack->reveal());
+        $this->container->has('sulu_http_cache.cache_lifetime.enhancer')->willReturn(false);
+        $this->container->get('sulu_website.resolver.parameter')->willReturn($this->parameterResolver->reveal());
+        $this->container->get('sulu_core.webspace.request_analyzer')->willReturn($this->requestAnalyzer->reveal());
+        $this->defaultController = new DefaultController();
+        $this->defaultController->setContainer($this->container->reveal());
+    }
+
+    public function testInvalidTemplate()
+    {
+        $this->setExpectedException(HttpException::class, function(HttpException $exception) {
+            $this->assertSame(406, $exception->getStatusCode());
+        });
+
+        $this->request->getRequestFormat()->willReturn('html')->shouldBeCalled();
+        $this->twigLoader->exists('pages/default.html.twig')->willReturn(false)->shouldBeCalled();
+        $this->defaultController->indexAction($this->structure->reveal(), false, false);
+    }
+
+    public function testValidTemplate()
+    {
+        $this->request->getRequestFormat()->willReturn('html')->shouldBeCalled();
+        $this->twigLoader->exists('pages/default.html.twig')->willReturn(true)->shouldBeCalled();
+        $this->parameterResolver->resolve(Argument::any(), Argument::any(), Argument::any(), false)
+            ->willReturn(['argument' => 'value'])->shouldBeCalled();
+        $this->twig->render(
+            'pages/default.html.twig',
+            ['argument' => 'value']
+        )->willReturn('My Content')->shouldBeCalled();
+        $response = $this->defaultController->indexAction($this->structure->reveal(), false, false);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('My Content', $response->getContent());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4568
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Check for the existence of the requested template and only throw then a 406 error and not always when a InvalidArgumentException happens.

#### Why?

Currently this 406 catch hide other InvalidArgumentException which should not be converted to 406 status code.

#### Example Usage

E.g. use a not exist content type in your template.
