### PR TITLE
Resolve taxonomies in snippet_selection ContentType

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
+++ b/src/Sulu/Bundle/SnippetBundle/Content/SnippetContent.php
@@ -191,7 +191,10 @@ class SnippetContent extends ComplexContentType implements ContentTypeExportInte
             $ids = $this->loadSnippetAreaIds($webspaceKey, $snippetArea, $locale);
         }
 
-        return $this->snippetResolver->resolve($ids, $webspaceKey, $locale, $shadowLocale);
+        $params = $property->getParams();
+        $loadExcerpt = isset($params['loadExcerpt']) ? $params['loadExcerpt']->getValue() : false;
+
+        return $this->snippetResolver->resolve($ids, $webspaceKey, $locale, $shadowLocale, $loadExcerpt);
     }
 
     private function loadSnippetAreaIds($webspaceKey, $snippetArea, $locale)

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -45,7 +45,7 @@ class SnippetResolver implements SnippetResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve($uuids, $webspaceKey, $locale, $shadowLocale = null)
+    public function resolve($uuids, $webspaceKey, $locale, $shadowLocale = null, $loadExcerpt = false)
     {
         $snippets = [];
         foreach ($uuids as $uuid) {
@@ -59,7 +59,13 @@ class SnippetResolver implements SnippetResolverInterface
                 $snippet->setIsShadow(null !== $shadowLocale);
                 $snippet->setShadowBaseLanguage($shadowLocale);
 
-                $resolved = $this->structureResolver->resolve($snippet);
+                $resolved = $this->structureResolver->resolve($snippet, $loadExcerpt);
+                if ($loadExcerpt) {
+                    $resolved['content']['taxonomies'] = [
+                        'categories' => $resolved['extension']['excerpt']['categories'],
+                        'tags' => $resolved['extension']['excerpt']['tags'],
+                    ];
+                }
                 $resolved['view']['template'] = $snippet->getKey();
                 $resolved['view']['uuid'] = $snippet->getUuid();
 

--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolverInterface.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolverInterface.php
@@ -23,8 +23,9 @@ interface SnippetResolverInterface
      * @param string $webspaceKey
      * @param string $locale
      * @param string $shadowLocale
+     * @param bool $loadExcerpt
      *
      * @return array
      */
-    public function resolve($uuids, $webspaceKey, $locale, $shadowLocale = null);
+    public function resolve($uuids, $webspaceKey, $locale, $shadowLocale = null, $loadExcerpt = false);
 }

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetContentTest.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
 
 class SnippetContentTest extends TestCase
@@ -68,7 +69,7 @@ class SnippetContentTest extends TestCase
         $property->getValue()->willReturn(['123-123-123']);
         $property->getParams()->willReturn([]);
 
-        $this->snippetResolver->resolve(['123-123-123'], 'sulu_io', 'de', 'en')
+        $this->snippetResolver->resolve(['123-123-123'], 'sulu_io', 'de', 'en', false)
             ->willReturn(
                 [['content' => ['title' => 'test-1'], 'view' => ['title' => 'test-2', 'template' => 'default']]]
             );
@@ -76,6 +77,33 @@ class SnippetContentTest extends TestCase
         $result = $this->contentType->getContentData($property->reveal());
 
         $this->assertEquals([['title' => 'test-1']], $result);
+    }
+
+    public function testGetContentDataWithExtensions()
+    {
+        $property = $this->prophesize(PropertyInterface::class);
+        $structure = $this->prophesize(StructureBridge::class);
+        $structure->getWebspaceKey()->willReturn('sulu_io');
+        $structure->getLanguageCode()->willReturn('de');
+        $structure->getIsShadow()->wilLReturn(true);
+        $structure->getShadowBaseLanguage()->wilLReturn('en');
+        $property->getStructure()->willReturn($structure->reveal());
+        $property->getValue()->willReturn(['123-123-123']);
+        $property->getParams()->willReturn(['loadExcerpt' => new PropertyParameter('loadExcerpt', true)]);
+
+        $this->snippetResolver->resolve(['123-123-123'], 'sulu_io', 'de', 'en', true)
+            ->willReturn(
+                [
+                    [
+                        'content' => ['title' => 'test-1', 'taxonomies' => ['categories' => [], 'tags' => []]],
+                        'view' => ['title' => 'test-2', 'template' => 'default'],
+                    ],
+                ]
+            );
+
+        $result = $this->contentType->getContentData($property->reveal());
+
+        $this->assertEquals([['title' => 'test-1', 'taxonomies' => ['categories' => [], 'tags' => []]]], $result);
     }
 
     public function testGetViewData()
@@ -90,7 +118,7 @@ class SnippetContentTest extends TestCase
         $property->getValue()->willReturn(['123-123-123']);
         $property->getParams()->willReturn([]);
 
-        $this->snippetResolver->resolve(['123-123-123'], 'sulu_io', 'de', 'en')
+        $this->snippetResolver->resolve(['123-123-123'], 'sulu_io', 'de', 'en', false)
             ->willReturn(
                 [['content' => ['title' => 'test-1'], 'view' => ['title' => 'test-2', 'template' => 'default']]]
             );

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
@@ -25,5 +25,5 @@ interface StructureResolverInterface
      *
      * @return array
      */
-    public function resolve(StructureInterface $structure);
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = false);
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\Content\ContentTypeInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\LocalizedAuthorBehavior;
 use Sulu\Component\Content\Document\Extension\ExtensionContainer;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
@@ -88,6 +89,7 @@ class StructureResolverTest extends TestCase
         $authored = new \DateTime();
 
         $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
+        $document->willImplement(ExtensionBehavior::class);
         $structure->getDocument()->willReturn($document->reveal());
         $document->getAuthored()->willReturn($authored);
         $document->getAuthor()->willReturn(1);
@@ -96,6 +98,69 @@ class StructureResolverTest extends TestCase
             'extension' => [
                 'excerpt' => ['test1' => 'test1'],
             ],
+            'uuid' => 'some-uuid',
+            'view' => [
+                'property' => 'view',
+            ],
+            'content' => [
+                'property' => 'content',
+            ],
+            'creator' => 1,
+            'changer' => 1,
+            'created' => 'date',
+            'changed' => 'date',
+            'published' => 'date',
+            'template' => 'test',
+            'urls' => ['en' => '/description', 'de' => '/beschreibung', 'es' => null],
+            'path' => 'test-path',
+            'shadowBaseLocale' => 'en',
+            'authored' => $authored,
+            'author' => 1,
+            'webspaceKey' => 'test',
+        ];
+
+        $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal(), true));
+    }
+
+    public function testResolveWithoutExtensions()
+    {
+        $this->contentTypeManager->get('content_type')->willReturn($this->contentType);
+
+        $this->contentType->getViewData(Argument::any())->willReturn('view');
+        $this->contentType->getContentData(Argument::any())->willReturn('content');
+
+        $excerptExtension = $this->prophesize('Sulu\Component\Content\Extension\ExtensionInterface');
+        $excerptExtension->getContentData(['test1' => 'test1'])->willReturn(['test1' => 'test1']);
+        $this->extensionManager->getExtension('test', 'excerpt')->willReturn($excerptExtension);
+
+        $property = $this->prophesize('Sulu\Component\Content\Compat\PropertyInterface');
+        $property->getName()->willReturn('property');
+        $property->getContentTypeName()->willReturn('content_type');
+
+        $structure = $this->prophesize('Sulu\Component\Content\Compat\Structure\PageBridge');
+        $structure->getKey()->willReturn('test');
+        $structure->getExt()->willReturn(new ExtensionContainer(['excerpt' => ['test1' => 'test1']]));
+        $structure->getUuid()->willReturn('some-uuid');
+        $structure->getProperties(true)->willReturn([$property->reveal()]);
+        $structure->getCreator()->willReturn(1);
+        $structure->getChanger()->willReturn(1);
+        $structure->getCreated()->willReturn('date');
+        $structure->getChanged()->willReturn('date');
+        $structure->getPublished()->willReturn('date');
+        $structure->getPath()->willReturn('test-path');
+        $structure->getUrls()->willReturn(['en' => '/description', 'de' => '/beschreibung', 'es' => null]);
+        $structure->getShadowBaseLanguage()->willReturn('en');
+        $structure->getWebspaceKey()->willReturn('test');
+
+        $authored = new \DateTime();
+
+        $document = $this->prophesize()->willImplement(LocalizedAuthorBehavior::class);
+        $document->willImplement(ExtensionBehavior::class);
+        $structure->getDocument()->willReturn($document->reveal());
+        $document->getAuthored()->willReturn($authored);
+        $document->getAuthor()->willReturn(1);
+
+        $expected = [
             'uuid' => 'some-uuid',
             'view' => [
                 'property' => 'view',

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/ContentTwigExtensionTest.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension;
 use Sulu\Component\Content\Compat\Property;
-use Sulu\Component\Content\Compat\Structure;
+use Sulu\Component\Content\Compat\Structure\StructureBridge;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
@@ -30,21 +30,6 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
-
-class TestStructure extends Structure
-{
-    public function __construct($uuid, $title, $userId)
-    {
-        parent::__construct('test', '', '');
-
-        $this->setUuid($uuid);
-        $this->setCreator($userId);
-        $this->setChanger($userId);
-
-        $this->addChild(new Property('title', [], 'text_line'));
-        $this->getProperty('title')->setValue($title);
-    }
-}
 
 class ContentTwigExtensionTest extends TestCase
 {
@@ -165,10 +150,24 @@ class ContentTwigExtensionTest extends TestCase
 
     public function testLoad()
     {
+        $testStructure = $this->prophesize(StructureBridge::class);
+        $testStructure->getKey()->willReturn('test');
+        $testStructure->getPath()->willReturn(null);
+        $testStructure->getUuid()->willReturn('123-123-123');
+        $testStructure->getCreator()->willReturn(1);
+        $testStructure->getChanger()->willReturn(1);
+        $testStructure->getCreated()->willReturn(null);
+        $testStructure->getChanged()->willReturn(null);
+        $testStructure->getDocument()->willReturn(null);
+
+        $titleProperty = new Property('title', [], 'text_line');
+        $titleProperty->setValue('test');
+        $testStructure->getProperties(true)->willReturn([$titleProperty]);
+
         $this
             ->contentMapper
             ->load('123-123-123', 'sulu_test', 'en_us')
-            ->willReturn(new TestStructure('123-123-123', 'test', 1));
+            ->willReturn($testStructure);
 
         $result = $this->extension->load('123-123-123');
 
@@ -209,10 +208,24 @@ class ContentTwigExtensionTest extends TestCase
 
     public function testLoadParent()
     {
+        $testStructure = $this->prophesize(StructureBridge::class);
+        $testStructure->getKey()->willReturn('test');
+        $testStructure->getPath()->willReturn(null);
+        $testStructure->getUuid()->willReturn('321-321-321');
+        $testStructure->getCreator()->willReturn(1);
+        $testStructure->getChanger()->willReturn(1);
+        $testStructure->getCreated()->willReturn(null);
+        $testStructure->getChanged()->willReturn(null);
+        $testStructure->getDocument()->willReturn(null);
+
+        $titleProperty = new Property('title', [], 'text_line');
+        $titleProperty->setValue('test');
+        $testStructure->getProperties(true)->willReturn([$titleProperty]);
+
         $this
             ->contentMapper
             ->load('321-321-321', 'sulu_test', 'en_us')
-            ->willReturn(new TestStructure('321-321-321', 'test', 1));
+            ->willReturn($testStructure);
 
         $result = $this->extension->loadParent('123-123-123');
 

--- a/src/Sulu/Component/Content/Compat/PageInterface.php
+++ b/src/Sulu/Component/Content/Compat/PageInterface.php
@@ -60,18 +60,6 @@ interface PageInterface extends StructureInterface
     public function setNavContexts($navContexts);
 
     /**
-     * @return array
-     */
-    public function getExt();
-
-    /**
-     * @param $data
-     *
-     * @return array
-     */
-    public function setExt($data);
-
-    /**
      * returns content node that holds the internal link.
      *
      * @return StructureInterface

--- a/src/Sulu/Component/Content/Compat/Structure/PageBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/PageBridge.php
@@ -93,22 +93,6 @@ class PageBridge extends StructureBridge implements PageInterface
     /**
      * {@inheritdoc}
      */
-    public function getExt()
-    {
-        return $this->document->getExtensionsData();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setExt($data)
-    {
-        $this->readOnlyException(__METHOD__);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getInternalLinkContent()
     {
         $target = $this->getDocument()->getRedirectTarget();

--- a/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
+++ b/src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
@@ -270,6 +270,22 @@ class StructureBridge implements StructureInterface
     /**
      * {@inheritdoc}
      */
+    public function getExt()
+    {
+        return $this->document->getExtensionsData();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExt($data)
+    {
+        $this->readOnlyException(__METHOD__);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setHasChildren($hasChildren)
     {
         $this->readOnlyException(__METHOD__);

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -887,7 +887,6 @@ class ContentMapper implements ContentMapperInterface
         // get extension data from cache
         $data = $this->extensionDataCache->fetch($extension->getName());
 
-        // if property exists set it to target (with default value '')
         return isset($data[$propertyName]) ? $data[$propertyName] : null;
     }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/StructureBridgeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Compat/Structure/StructureBridgeTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\Structure\LegacyPropertyFactory;
 use Sulu\Component\Content\Compat\Structure\StructureBridge;
+use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
@@ -166,6 +167,31 @@ class StructureBridgeTest extends TestCase
 
         $this->assertFalse($structure->getIsShadow());
         $this->assertNull($structure->getShadowBaseLanguage());
+    }
+
+    public function testGetExt()
+    {
+        $ext = [
+            'seo' => [],
+            'excerpt' => [],
+        ];
+
+        $metadata = $this->prophesize(StructureMetadata::class);
+        $inspector = $this->prophesize(DocumentInspector::class);
+        $propertyFactory = $this->prophesize(LegacyPropertyFactory::class);
+
+        $document = $this->prophesize(\stdClass::class);
+        $document->willImplement(ExtensionBehavior::class);
+        $document->getExtensionsData()->willReturn($ext);
+
+        $structure = new StructureBridge(
+            $metadata->reveal(),
+            $inspector->reveal(),
+            $propertyFactory->reveal(),
+            $document->reveal()
+        );
+
+        $this->assertSame($ext, $structure->getExt());
     }
 
     public function testWithoutDocument()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | enhances #4564 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | sulu/sulu-docs#440

#### What's in this PR?

This PR adds the possibility to load the extension data from snippets in the `snippet_selection` content type.

#### Why?

Because this information might be useful.