### PR TITLE
Fix missing webspace and active item on back navigation when page form was directly loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 
 cache:
   directories:
@@ -26,6 +27,8 @@ matrix:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
         - SYMFONY_DEPRECATIONS_HELPER="weak"
         - PHPSTAN=true
+      services:
+        - mysql
 
     - language: php
       php: 7.1
@@ -35,7 +38,9 @@ matrix:
         - PHPCR_TRANSPORT=jackrabbit
         - DATABASE_CHARSET=UTF8
         - DATABASE_COLLATE=
-        - SYMFONY_DEPRECATIONS_HELPER="weak"
+        - SYMFONY_DEPRECATIONS_HELPER="disabled"
+      services:
+        - postgresql
 
 before_script:
   - if [ ! -d downloads ]; then mkdir downloads; fi

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilder.php
@@ -112,6 +112,14 @@ class FormRouteBuilder implements FormRouteBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToBackRoute(
+        array $routerAttributesToBackRoute
+    ): FormRouteBuilderInterface {
+        $this->addRouterAttributesToBackRouteToRoute($this->route, $routerAttributesToBackRoute);
+
+        return $this;
+    }
+
     public function setIdQueryParameter(string $idQueryParameter): FormRouteBuilderInterface
     {
         $this->setIdQueryParameterToRoute($this->route, $idQueryParameter);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilderTrait.php
@@ -71,4 +71,14 @@ trait FormRouteBuilderTrait
 
         $route->setOption('routerAttributesToEditRoute', $newRouterAttributesToEditRoute);
     }
+
+    private function addRouterAttributesToBackRouteToRoute(Route $route, array $routerAttributesToBackRoute): void
+    {
+        $oldRouterAttributesToBackRoute = $route->getOption('routerAttributesToBackRoute');
+        $newRouterAttributesToBackRoute = $oldRouterAttributesToBackRoute
+            ? array_merge($oldRouterAttributesToBackRoute, $routerAttributesToBackRoute)
+            : $routerAttributesToBackRoute;
+
+        $route->setOption('routerAttributesToBackRoute', $newRouterAttributesToBackRoute);
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilder.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\AdminBundle\Admin\Routing;
 
 class ResourceTabRouteBuilder implements ResourceTabRouteBuilderInterface
 {
+    use FormRouteBuilderTrait;
+
     const VIEW = 'sulu_admin.resource_tabs';
 
     /**
@@ -43,7 +45,15 @@ class ResourceTabRouteBuilder implements ResourceTabRouteBuilderInterface
 
     public function setBackRoute(string $backRoute): ResourceTabRouteBuilderInterface
     {
-        $this->route->setOption('backRoute', $backRoute);
+        $this->setBackRouteToRoute($this->route, $backRoute);
+
+        return $this;
+    }
+
+    public function addRouterAttributesToBackRoute(
+        array $routerAttributesToBackRoute
+    ): ResourceTabRouteBuilderInterface {
+        $this->addRouterAttributesToBackRouteToRoute($this->route, $routerAttributesToBackRoute);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilderInterface.php
@@ -22,6 +22,11 @@ interface ResourceTabRouteBuilderInterface
 
     public function setBackRoute(string $backRoute): self;
 
+    /**
+     * @param string[] $routerAttributesToBackRoute
+     */
+    public function addRouterAttributesToBackRoute(array $routerAttributesToBackRoute): self;
+
     public function setTitleProperty(string $titleProperty): self;
 
     public function getRoute(): Route;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -51,6 +51,10 @@ export default class ListStore {
     sortColumnDisposer: () => void;
     sortOrderDisposer: () => void;
     limitDisposer: () => void;
+    activeSettingDisposer: () => void;
+    limitSettingDisposer: () => void;
+    sortColumnSettingDisposer: () => void;
+    sortOrderSettingDisposer: () => void;
     sendRequestDisposer: () => void;
     initialSelectionIds: ?Array<string | number>;
 
@@ -153,6 +157,22 @@ export default class ListStore {
         this.sortColumnDisposer = intercept(this.sortColumn, '', callResetForChangedObservable);
         this.sortOrderDisposer = intercept(this.sortOrder, '', callResetForChangedObservable);
         this.limitDisposer = intercept(this.limit, '', callResetForChangedObservable);
+
+        this.activeSettingDisposer = autorun(
+            () => ListStore.setActiveSetting(this.listKey, this.userSettingsKey, this.active.get())
+        );
+
+        this.limitSettingDisposer = autorun(
+            () => ListStore.setLimitSetting(this.listKey, this.userSettingsKey, this.limit.get())
+        );
+
+        this.sortColumnSettingDisposer = autorun(
+            () => ListStore.setSortColumnSetting(this.listKey, this.userSettingsKey, this.sortColumn.get())
+        );
+
+        this.sortOrderSettingDisposer = autorun(
+            () => ListStore.setSortOrderSetting(this.listKey, this.userSettingsKey, this.sortOrder.get())
+        );
 
         metadataStore.getSchema(this.listKey)
             .then(action((schema) => {
@@ -490,8 +510,6 @@ export default class ListStore {
 
     @action setLimit(limit: number) {
         this.limit.set(limit);
-
-        ListStore.setLimitSetting(this.listKey, this.userSettingsKey, limit);
     }
 
     @action setActive(active: ?string | number) {
@@ -506,8 +524,6 @@ export default class ListStore {
         if (this.structureStrategy.activate) {
             this.structureStrategy.activate(id);
         }
-
-        ListStore.setActiveSetting(this.listKey, this.userSettingsKey, id);
     }
 
     @action deactivate(id: ?string | number) {
@@ -519,9 +535,6 @@ export default class ListStore {
     @action sort(column: string, order: SortOrder) {
         this.sortColumn.set(column);
         this.sortOrder.set(order);
-
-        ListStore.setSortColumnSetting(this.listKey, this.userSettingsKey, column);
-        ListStore.setSortOrderSetting(this.listKey, this.userSettingsKey, order);
     }
 
     @action order(id: string | number, order: number) {
@@ -596,6 +609,11 @@ export default class ListStore {
         this.sortColumnDisposer();
         this.sortOrderDisposer();
         this.limitDisposer();
+
+        this.activeSettingDisposer();
+        this.limitSettingDisposer();
+        this.sortColumnSettingDisposer();
+        this.sortOrderSettingDisposer();
 
         if (this.localeDisposer) {
             this.localeDisposer();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -49,6 +49,38 @@ class StructureStrategy {
     findById: (id: string | number) => ?Object = jest.fn();
 }
 
+test('The active item should be updated when set from the outside', () => {
+    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
+    expect(listStore.active.get()).toEqual();
+
+    listStore.active.set('123');
+    expect(userStore.setPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.active', '123');
+});
+
+test('The limit value should be updated when set from the outside', () => {
+    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
+    expect(listStore.limit.get()).toEqual(10);
+
+    listStore.limit.set(20);
+    expect(userStore.setPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.limit', 20);
+});
+
+test('The sort column value should be updated when set from the outside', () => {
+    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
+    expect(listStore.sortColumn.get()).toEqual();
+
+    listStore.sortColumn.set('title');
+    expect(userStore.setPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.sort_column', 'title');
+});
+
+test('The sort order value should be updated when set from the outside', () => {
+    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
+    expect(listStore.sortOrder.get()).toEqual();
+
+    listStore.sortOrder.set('asc');
+    expect(userStore.setPersistentSetting).toBeCalledWith('sulu_admin.list_store.tests.list_test.sort_order', 'asc');
+});
+
 test('The loading strategy should get passed the structure strategy', () => {
     const loadingStrategy = new LoadingStrategy();
     const structureStrategy = new StructureStrategy();
@@ -1771,6 +1803,10 @@ test('Should call all disposers if destroy is called', () => {
     listStore.sortColumnDisposer = jest.fn();
     listStore.sortOrderDisposer = jest.fn();
     listStore.limitDisposer = jest.fn();
+    listStore.activeSettingDisposer = jest.fn();
+    listStore.limitSettingDisposer = jest.fn();
+    listStore.sortColumnSettingDisposer = jest.fn();
+    listStore.sortOrderSettingDisposer = jest.fn();
 
     listStore.destroy();
 
@@ -1780,4 +1816,8 @@ test('Should call all disposers if destroy is called', () => {
     expect(listStore.sortColumnDisposer).toBeCalledWith();
     expect(listStore.sortOrderDisposer).toBeCalledWith();
     expect(listStore.limitDisposer).toBeCalledWith();
+    expect(listStore.activeSettingDisposer).toBeCalledWith();
+    expect(listStore.limitSettingDisposer).toBeCalledWith();
+    expect(listStore.sortColumnSettingDisposer).toBeCalledWith();
+    expect(listStore.sortOrderSettingDisposer).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -157,6 +157,10 @@ class UserStore {
     }, UPDATE_PERSISTENT_SETTINGS_DELAY);
 
     @action setPersistentSetting(key: string, value: *) {
+        if (this.persistentSettings.get(key) === value) {
+            return;
+        }
+
         this.persistentSettings.set(key, value);
         this.dirtyPersistentSettings.push(key);
         this.updatePersistentSettings();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -138,6 +138,15 @@ test('Should update persistent settings of server with a debounce delay of 5 sec
     expect(Requester.patch).toBeCalledWith('profile_settings_url', {test2: 'value2'});
 });
 
+test('Should not update persistent setting if the value did not change', () => {
+    userStore.setPersistentSetting('test1', 'test');
+    expect(Requester.patch).toBeCalledWith('profile_settings_url', {test1: 'test'});
+
+    Requester.patch.mockReset();
+    userStore.setPersistentSetting('test1', 'test');
+    expect(Requester.patch).not.toBeCalled();
+});
+
 test('Should also update persistent setting with the value of false on the server', () => {
     userStore.setPersistentSetting('test1', false);
     expect(Requester.patch).toBeCalledWith('profile_settings_url', {test1: false});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -247,7 +247,7 @@ class Form extends React.Component<Props> {
         const editRouteParameters = {};
 
         if (routerAttributesToEditRoute) {
-            Object.keys(routerAttributesToEditRoute).forEach((key) => {
+            Object.keys(toJS(routerAttributesToEditRoute)).forEach((key) => {
                 const formOptionKey = routerAttributesToEditRoute[key];
                 const attributeName = isNaN(key) ? key : routerAttributesToEditRoute[key];
 
@@ -347,7 +347,7 @@ export default withToolbar(Form, function() {
                 const backRouteParameters = {};
 
                 if (routerAttributesToBackRoute) {
-                    Object.keys(routerAttributesToBackRoute).forEach((key) => {
+                    Object.keys(toJS(routerAttributesToBackRoute)).forEach((key) => {
                         const formOptionKey = routerAttributesToBackRoute[key];
                         const attributeName = isNaN(key) ? key : routerAttributesToBackRoute[key];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -244,15 +244,16 @@ class Form extends React.Component<Props> {
             action: actionParameter,
         };
 
-        const editRouteParameters = routerAttributesToEditRoute
-            ? routerAttributesToEditRoute.reduce(
-                (parameters: Object, routerAttribute: string) => {
-                    parameters[routerAttribute] = attributes[routerAttribute];
-                    return parameters;
-                },
-                {}
-            )
-            : {};
+        const editRouteParameters = {};
+
+        if (routerAttributesToEditRoute) {
+            Object.keys(routerAttributesToEditRoute).forEach((key) => {
+                const formOptionKey = routerAttributesToEditRoute[key];
+                const attributeName = isNaN(key) ? key : routerAttributesToEditRoute[key];
+
+                editRouteParameters[formOptionKey] = attributes[attributeName];
+            });
+        }
 
         return this.resourceFormStore.save(saveOptions)
             .then((response) => {
@@ -343,15 +344,16 @@ export default withToolbar(Form, function() {
     const backButton = backRoute
         ? {
             onClick: () => {
-                const backRouteParameters = routerAttributesToBackRoute
-                    ? routerAttributesToBackRoute.reduce(
-                        (parameters: Object, routerAttribute: string) => {
-                            parameters[routerAttribute] = attributes[routerAttribute];
-                            return parameters;
-                        },
-                        {}
-                    )
-                    : {};
+                const backRouteParameters = {};
+
+                if (routerAttributesToBackRoute) {
+                    Object.keys(routerAttributesToBackRoute).forEach((key) => {
+                        const formOptionKey = routerAttributesToBackRoute[key];
+                        const attributeName = isNaN(key) ? key : routerAttributesToBackRoute[key];
+
+                        backRouteParameters[formOptionKey] = attributes[attributeName];
+                    });
+                }
 
                 if (resourceStore.locale) {
                     backRouteParameters.locale = resourceStore.locale.get();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -329,17 +329,35 @@ class Form extends React.Component<Props> {
 
 export default withToolbar(Form, function() {
     const {router} = this.props;
-    const {backRoute} = router.route.options;
+    const {
+        attributes,
+        route: {
+            options: {
+                backRoute,
+                routerAttributesToBackRoute,
+            },
+        },
+    } = router;
     const {errors, resourceStore, showSuccess} = this;
 
     const backButton = backRoute
         ? {
             onClick: () => {
-                const options = {};
+                const backRouteParameters = routerAttributesToBackRoute
+                    ? routerAttributesToBackRoute.reduce(
+                        (parameters: Object, routerAttribute: string) => {
+                            parameters[routerAttribute] = attributes[routerAttribute];
+                            return parameters;
+                        },
+                        {}
+                    )
+                    : {};
+
                 if (resourceStore.locale) {
-                    options.locale = resourceStore.locale.get();
+                    backRouteParameters.locale = resourceStore.locale.get();
                 }
-                router.restore(backRoute, options);
+
+                router.restore(backRoute, backRouteParameters);
             },
         }
         : undefined;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -496,6 +496,39 @@ test('Should navigate to defined route on back button click', () => {
     expect(router.restore).toBeCalledWith('test_route', {locale: 'de'});
 });
 
+test('Should navigate to defined route on back button click with routerAttribuesToBackRoute', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+
+    const route = {
+        options: {
+            backRoute: 'test_route',
+            formKey: 'snippets',
+            locales: [],
+            routerAttributesToBackRoute: ['webspace'],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {
+            webspace: 'sulu_io',
+        },
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route,
+    };
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+    resourceStore.setLocale('de');
+
+    const toolbarConfig = toolbarFunction.call(form.instance());
+    toolbarConfig.backButton.onClick();
+    expect(router.restore).toBeCalledWith('test_route', {locale: 'de', webspace: 'sulu_io'});
+});
+
 test('Should navigate to defined route on back button click without locale', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormRouteBuilderTest.php
@@ -61,6 +61,32 @@ class FormRouteBuilderTest extends TestCase
                 null,
                 null,
             ],
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+                'categories',
+                'categories',
+                'Details',
+                'name == "Test"',
+                100,
+                512,
+                'sulu_category.edit_form',
+                'sulu_category.list',
+                ['webspace'],
+            ],
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+                'categories',
+                'categories',
+                'Details',
+                'name == "Test"',
+                100,
+                512,
+                'sulu_category.edit_form',
+                'sulu_category.list',
+                ['webspace', 'id' => 'active'],
+            ],
         ];
     }
 
@@ -77,7 +103,8 @@ class FormRouteBuilderTest extends TestCase
         ?int $tabOrder,
         ?int $tabPriority,
         ?string $editRoute,
-        ?string $backRoute
+        ?string $backRoute,
+        ?array $routerAttributesToBackRoute = null
     ) {
         $routeBuilder = (new FormRouteBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -107,6 +134,10 @@ class FormRouteBuilderTest extends TestCase
             $routeBuilder->setBackRoute($backRoute);
         }
 
+        if ($routerAttributesToBackRoute) {
+            $routeBuilder->addRouterAttributesToBackRoute($routerAttributesToBackRoute);
+        }
+
         $route = $routeBuilder->getRoute();
 
         $this->assertSame($name, $route->getName());
@@ -119,6 +150,7 @@ class FormRouteBuilderTest extends TestCase
         $this->assertSame($tabPriority, $route->getOption('tabPriority'));
         $this->assertSame($editRoute, $route->getOption('editRoute'));
         $this->assertSame($backRoute, $route->getOption('backRoute'));
+        $this->assertSame($routerAttributesToBackRoute, $route->getOption('routerAttributesToBackRoute'));
         $this->assertNull($route->getParent());
         $this->assertSame('sulu_admin.form', $route->getView());
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ResourceTabRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ResourceTabRouteBuilderTest.php
@@ -41,6 +41,7 @@ class ResourceTabRouteBuilderTest extends TestCase
                 '/categories/add',
                 'categories',
                 'sulu_category.list',
+                null,
                 'title',
             ],
             [
@@ -49,6 +50,23 @@ class ResourceTabRouteBuilderTest extends TestCase
                 'tags',
                 null,
                 null,
+                null,
+            ],
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+                'categories',
+                'sulu_category.list',
+                ['webspace'],
+                'title',
+            ],
+            [
+                'sulu_category.add_form',
+                '/categories/add',
+                'categories',
+                'sulu_category.list',
+                ['webspace', 'active' => 'id'],
+                'title',
             ],
         ];
     }
@@ -61,6 +79,7 @@ class ResourceTabRouteBuilderTest extends TestCase
         string $path,
         string $resourceKey,
         ?string $backRoute,
+        ?array $routerAttributesToBackRoute,
         ?string $titleProperty
     ) {
         $routeBuilder = (new ResourceTabRouteBuilder($name, $path))
@@ -68,6 +87,10 @@ class ResourceTabRouteBuilderTest extends TestCase
 
         if ($backRoute) {
             $routeBuilder->setBackRoute($backRoute);
+        }
+
+        if ($routerAttributesToBackRoute) {
+            $routeBuilder->addRouterAttributesToBackRoute($routerAttributesToBackRoute);
         }
 
         if ($titleProperty) {
@@ -80,6 +103,7 @@ class ResourceTabRouteBuilderTest extends TestCase
         $this->assertSame($path, $route->getPath());
         $this->assertSame($resourceKey, $route->getOption('resourceKey'));
         $this->assertSame($backRoute, $route->getOption('backRoute'));
+        $this->assertSame($routerAttributesToBackRoute, $route->getOption('routerAttributesToBackRoute'));
         $this->assertSame($titleProperty, $route->getOption('titleProperty'));
         $this->assertSame('sulu_admin.resource_tabs', $route->getView());
     }

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -125,6 +125,7 @@ class CategoryAdmin extends Admin
                 ->setResourceKey('categories')
                 ->addLocales($locales)
                 ->setBackRoute(static::LIST_ROUTE)
+                ->addRouterAttributesToBackRoute(['id' => 'active'])
                 ->setTitleProperty('name')
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_category.edit_form.details', '/details')

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -112,7 +112,6 @@ class PageAdmin extends Admin
         ];
 
         $routerAttributesToFormStore = ['parentId', 'webspace'];
-        $routerAttributesToBackRoute = ['webspace'];
 
         $previewCondition = 'nodeType == 1';
 
@@ -130,7 +129,7 @@ class PageAdmin extends Admin
                 static::ADD_FORM_ROUTE, '/webspaces/:webspace/pages/:locale/add/:parentId', 'sulu_page.page_tabs'
             ))
                 ->setOption('backRoute', static::PAGES_ROUTE)
-                ->setOption('routerAttributesToBackRoute', $routerAttributesToBackRoute)
+                ->setOption('routerAttributesToBackRoute', ['webspace'])
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_add_form.details', '/details')
                 ->setResourceKey('pages')
@@ -144,7 +143,7 @@ class PageAdmin extends Admin
                 ->getRoute(),
             (new Route(static::EDIT_FORM_ROUTE, '/webspaces/:webspace/pages/:locale/:id', 'sulu_page.page_tabs'))
                 ->setOption('backRoute', static::PAGES_ROUTE)
-                ->setOption('routerAttributesToBackRoute', $routerAttributesToBackRoute)
+                ->setOption('routerAttributesToBackRoute', ['id' => 'active' , 'webspace'])
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.details', '/details')
                 ->setResourceKey('pages')

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -143,7 +143,7 @@ class PageAdmin extends Admin
                 ->getRoute(),
             (new Route(static::EDIT_FORM_ROUTE, '/webspaces/:webspace/pages/:locale/:id', 'sulu_page.page_tabs'))
                 ->setOption('backRoute', static::PAGES_ROUTE)
-                ->setOption('routerAttributesToBackRoute', ['id' => 'active' , 'webspace'])
+                ->setOption('routerAttributesToBackRoute', ['id' => 'active', 'webspace'])
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.details', '/details')
                 ->setResourceKey('pages')

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -112,6 +112,7 @@ class PageAdmin extends Admin
         ];
 
         $routerAttributesToFormStore = ['parentId', 'webspace'];
+        $routerAttributesToBackRoute = ['webspace'];
 
         $previewCondition = 'nodeType == 1';
 
@@ -129,6 +130,7 @@ class PageAdmin extends Admin
                 static::ADD_FORM_ROUTE, '/webspaces/:webspace/pages/:locale/add/:parentId', 'sulu_page.page_tabs'
             ))
                 ->setOption('backRoute', static::PAGES_ROUTE)
+                ->setOption('routerAttributesToBackRoute', $routerAttributesToBackRoute)
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_add_form.details', '/details')
                 ->setResourceKey('pages')
@@ -142,6 +144,7 @@ class PageAdmin extends Admin
                 ->getRoute(),
             (new Route(static::EDIT_FORM_ROUTE, '/webspaces/:webspace/pages/:locale/:id', 'sulu_page.page_tabs'))
                 ->setOption('backRoute', static::PAGES_ROUTE)
+                ->setOption('routerAttributesToBackRoute', $routerAttributesToBackRoute)
                 ->setOption('resourceKey', 'pages'),
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.details', '/details')
                 ->setResourceKey('pages')
@@ -167,7 +170,6 @@ class PageAdmin extends Admin
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.excerpt', '/excerpt')
                 ->setResourceKey('pages')
                 ->setFormKey('page_excerpt')
-                ->setBackRoute(static::PAGES_ROUTE)
                 ->setTabTitle('sulu_page.excerpt')
                 ->setTabCondition('(nodeType == 1 || nodeType == 4) && shadowOn == false')
                 ->addToolbarActions($formToolbarActionsWithoutType)
@@ -178,7 +180,6 @@ class PageAdmin extends Admin
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.settings', '/settings')
                 ->setResourceKey('pages')
                 ->setFormKey('page_settings')
-                ->setBackRoute(static::PAGES_ROUTE)
                 ->setTabTitle('sulu_page.settings')
                 ->setTabPriority(512)
                 ->addToolbarActions($formToolbarActionsWithoutType)

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -22,8 +22,8 @@ use Sulu\Component\Content\Metadata\Loader\StructureXmlLoader;
 use Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser;
 use Sulu\Component\Content\Metadata\Parser\SchemaXmlParser;
 use Sulu\Component\Content\Metadata\StructureMetadata;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class StructureMetadataFactoryTest extends TestCase
@@ -93,10 +93,10 @@ class StructureMetadataFactoryTest extends TestCase
         $this->overriddenDefaultMappingFile = implode(DIRECTORY_SEPARATOR, [__DIR__, 'data', 'page', 'default.xml']);
 
         $this->translator = $this->prophesize(TranslatorInterface::class);
-        $this->apostropheStructure = $this->prophesize('Sulu\Component\Content\Metadata\StructureMetadata');
-        $this->somethingStructure = $this->prophesize('Sulu\Component\Content\Metadata\StructureMetadata');
-        $this->defaultStructure = $this->prophesize('Sulu\Component\Content\Metadata\StructureMetadata');
-        $this->loader = $this->prophesize('Symfony\Component\Config\Loader\LoaderInterface');
+        $this->apostropheStructure = $this->prophesize(StructureMetadata::class);
+        $this->somethingStructure = $this->prophesize(StructureMetadata::class);
+        $this->defaultStructure = $this->prophesize(StructureMetadata::class);
+        $this->loader = $this->prophesize(LoaderInterface::class);
         $this->factory = new StructureMetadataFactory(
             $this->loader->reveal(),
             [
@@ -246,16 +246,18 @@ class StructureMetadataFactoryTest extends TestCase
      */
     public function testGetStructures()
     {
-        $this->loader->load($this->somethingMappingFile, 'page')->willReturn($this->somethingStructure->reveal());
-        $this->loader->load($this->defaultMappingFile, 'page')->willReturn($this->defaultStructure->reveal());
+        $revealedSomethingStructure = $this->somethingStructure->reveal();
+        $revealedDefaultStructure = $this->somethingStructure->reveal();
+        $this->loader->load($this->somethingMappingFile, 'page')->willReturn($revealedSomethingStructure);
+        $this->loader->load($this->defaultMappingFile, 'page')->willReturn($revealedDefaultStructure);
         $this->loader->load($this->somethingMappingFile, 'page')->shouldBeCalledTimes(1);
         $this->loader->load($this->defaultMappingFile, 'page')->shouldBeCalledTimes(1);
 
         $structures = $this->factory->getStructures('page');
         $this->assertCount(3, $structures);
-        $this->assertEquals($this->defaultStructure->reveal(), $structures[0]);
-        $this->assertEquals($this->somethingStructure->reveal(), $structures[1]);
-        $this->assertEquals($this->defaultStructure->reveal(), $structures[2]);
+        $this->assertEquals($revealedDefaultStructure, $structures[0]);
+        $this->assertEquals($revealedSomethingStructure, $structures[1]);
+        $this->assertEquals($revealedDefaultStructure, $structures[2]);
     }
 
     private function cleanUp()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a new route option on the form route called `routerAttributesToBackRoute`, which works exactly as the `routerAttributesToEditRoute` parameter, with the only exception that the passed router attribute are passed when the form navigates to the passed back route.

#### Why?

This allows to add the `webspace` in the page form whenever the back button is clicked. This is necessary, because in certain situations the webspace was missing when clicking the back button.

The following steps show a way to reproduce this problem:

1. Make a reload on a page form
2. Click on the back button
3. The webspace select now does not display any text, because the webspace is undefined

The webspace being undefined also causes some other problems, e.g. when opening a page again an error is thrown.

Additionally it is also used to set the correct active item when returning to the category or page list from one of its forms.