### PR TITLE
Fix width of role select size and order it by name

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/BaseItem.js
@@ -5,10 +5,11 @@ import classNames from 'classnames';
 import type {BaseItemProps} from './types';
 import baseItemStyles from './baseItem.scss';
 
-type Props = BaseItemProps & {
+type Props = {|
+    ...BaseItemProps,
     children: ?Node,
     className: string,
-};
+|};
 
 export default class BaseItem extends React.PureComponent<Props> {
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Item.js
@@ -6,10 +6,11 @@ import type {BaseItemProps} from './types';
 import BaseItem from './BaseItem';
 import itemStyles from './item.scss';
 
-type Props = BaseItemProps & {
+type Props = {|
+    ...BaseItemProps,
     children?: Node,
     className?: string,
-};
+|};
 
 export default class Item extends React.PureComponent<Props> {
     static defaultProps = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/Section.js
@@ -7,10 +7,11 @@ import BaseItem from './BaseItem';
 import Item from './Item';
 import sectionStyles from './section.scss';
 
-type Props = BaseItemProps & {
+type Props = {|
+    ...BaseItemProps,
     children: Element<typeof Item | typeof Section>,
     className?: string,
-};
+|};
 
 export default class Section extends React.PureComponent<Props> {
     static defaultProps = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Grid/types.js
@@ -1,8 +1,8 @@
 // @flow
 export type ColSpan = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-export type BaseItemProps = {
+export type BaseItemProps = {|
     colSpan: ColSpan,
     spaceAfter: ColSpan,
     spaceBefore: ColSpan,
-};
+|};

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
@@ -89,8 +89,9 @@ class RoleAssignments extends React.Component<Props> {
 
         return (
             <Grid>
-                <Grid.Item size={6}>
+                <Grid.Item colSpan={6}>
                     <ResourceMultiSelect
+                        apiOptions={{sortBy: 'name'}}
                         disabled={disabled}
                         displayProperty="name"
                         onChange={this.handleRoleChange}
@@ -99,7 +100,7 @@ class RoleAssignments extends React.Component<Props> {
                     />
                 </Grid.Item>
                 {this.selectedRoles.length > 0 &&
-                    <Grid.Item size={12}>
+                    <Grid.Item colSpan={12}>
                         <div className={roleAssignmentsStyle.roleAssignmentsContainer}>
                             {value.map((userRole, key) => {
                                 return (

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
@@ -5,7 +5,7 @@ exports[`Render component 1`] = `
   class="grid"
 >
   <div
-    class="item colSpan colSpan-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <div
       class="select"
@@ -162,7 +162,7 @@ exports[`Render component in disabled state 1`] = `
   class="grid"
 >
   <div
-    class="item colSpan colSpan-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <div
       class="select"
@@ -322,7 +322,7 @@ exports[`Render component without data 1`] = `
   class="grid"
 >
   <div
-    class="item colSpan colSpan-12 space-before-0 space-after-0"
+    class="item colSpan colSpan-6 space-before-0 space-after-0"
   >
     <div
       class="select"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the width of the `ResourceMultiSelect` in the `RoleAssignment` and also fixes the corresponding flow types, which allowed the wrong configuration. It also sorts the roles from the `ResourceMultiSelect` by name.

#### Why?

Because it does not look good if the select takes the whole width, and it is hard to find a role if the roles are "randomly" sorted.