### PR TITLE
Fix symfony 4.3 compatibility by change priority of SnippetAreaCompilerPass

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Symfony\Bundle\FrameworkBundle\Client;
 
 class ResettingControllerTest extends SuluTestCase
 {
@@ -410,7 +409,7 @@ class ResettingControllerTest extends SuluTestCase
         $this->assertEquals(1009, $response['code']);
     }
 
-    protected function getExpectedEmailData(Client $client, User $user)
+    protected function getExpectedEmailData($client, User $user)
     {
         $sender = $this->getContainer()->getParameter('sulu_security.reset_password.mail.sender');
         $template = $this->getContainer()->getParameter('sulu_security.reset_password.mail.template');

--- a/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
+++ b/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\SnippetBundle;
 
 use Sulu\Bundle\SnippetBundle\DependencyInjection\Compiler\SnippetAreaCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,7 +23,7 @@ class SuluSnippetBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new SnippetAreaCompilerPass());
+        $container->addCompilerPass(new SnippetAreaCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1024);
 
         parent::build($container);
     }

--- a/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
+++ b/src/Sulu/Component/DocumentManager/EventDispatcher/DebugEventDispatcher.php
@@ -40,6 +40,7 @@ class DebugEventDispatcher extends EventDispatcher
         Stopwatch $stopwatch,
         LoggerInterface $logger = null
     ) {
+        parent::__construct();
         $this->stopwatch = $stopwatch;
         $this->logger = $logger ?: new NullLogger();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Change the priority of the SnippetAreaCompilerPass to have access to the translator service.

#### Why?

The priority of the translator servcie has change in https://github.com/symfony/symfony/commit/31d7a09bf5c423ad2003d6863d7372e49a195af1#diff-687bdbb38a4dc672ca2a79f23e764892R110

#### Example Usage

~~~php
bin/console cache:clear
~~~
