### PR TITLE
List and assign contacts to accounts

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/NavigationRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/NavigationRegistry.php
@@ -95,7 +95,7 @@ class NavigationRegistry
         if ($navigationItem->getMainRoute()) {
             $mainPath = $this->routeRegistry->findRouteByName($navigationItem->getMainRoute())->getPath();
             foreach ($this->routeRegistry->getRoutes() as $route) {
-                if (false !== strpos($route->getPath(), $mainPath)) {
+                if (0 === strpos($route->getPath(), $mainPath)) {
                     $navigationItem->addChildRoute($route->getName());
                 }
             }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilder.php
@@ -58,6 +58,19 @@ class ResourceTabRouteBuilder implements ResourceTabRouteBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToBlacklist(
+        array $routerAttributesToBlacklist
+    ): ResourceTabRouteBuilderInterface {
+        $oldRouterAttributesToBlacklist = $this->route->getOption('routerAttributesToBlacklist');
+        $newRouterAttributesToBlacklist = $oldRouterAttributesToBlacklist
+            ? array_merge($oldRouterAttributesToBlacklist, $routerAttributesToBlacklist)
+            : $routerAttributesToBlacklist;
+
+        $this->route->setOption('routerAttributesToBlacklist', $newRouterAttributesToBlacklist);
+
+        return $this;
+    }
+
     public function setTitleProperty(string $titleProperty): ResourceTabRouteBuilderInterface
     {
         $this->route->setOption('titleProperty', $titleProperty);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ResourceTabRouteBuilderInterface.php
@@ -27,6 +27,11 @@ interface ResourceTabRouteBuilderInterface
      */
     public function addRouterAttributesToBackRoute(array $routerAttributesToBackRoute): self;
 
+    /**
+     * @param string[] $routerAttributesToBlacklist
+     */
+    public function addRouterAttributesToBlacklist(array $routerAttributesToBlacklist): self;
+
     public function setTitleProperty(string $titleProperty): self;
 
     public function getRoute(): Route;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -201,6 +201,12 @@ export default class SingleSelection extends React.Component<Props>
             disabled,
             dataPath,
             fieldTypeOptions,
+            formInspector,
+            schemaOptions: {
+                data_path_to_auto_complete: {
+                    value: dataPathToAutoComplete = [],
+                } = {},
+            },
             value,
         } = this.props;
 
@@ -227,12 +233,31 @@ export default class SingleSelection extends React.Component<Props>
             },
         } = fieldTypeOptions;
 
+        if (!Array.isArray(dataPathToAutoComplete)) {
+            throw new Error('The "data_path_to_auto_complete" schemaOption must be an array!');
+        }
+
+        const options = dataPathToAutoComplete.reduce((options, schemaEntry) => {
+            const {name, value} = schemaEntry;
+            if (typeof name !== 'string' || typeof value !== 'string') {
+                throw new Error(
+                    'An entry of the "data_path_to_auto_complete" schemaOption must provide strings for their name and '
+                    + 'value'
+                );
+            }
+
+            options[value] = formInspector.getValueByPath('/' + name);
+
+            return options;
+        }, {});
+
         return (
             <SingleAutoComplete
                 disabled={!!disabled}
                 displayProperty={displayProperty}
                 id={dataPath}
                 onChange={this.handleChange}
+                options={options}
                 resourceKey={resourceKey}
                 searchProperties={searchProperties}
                 value={value}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -30,6 +30,7 @@ jest.mock('../../FormInspector', () => jest.fn(function(formStore) {
     this.id = formStore.id;
     this.locale = formStore.locale;
     this.options = formStore.options;
+    this.getValueByPath = jest.fn();
 }));
 
 jest.mock('../../../../utils/Translator', () => ({
@@ -66,9 +67,57 @@ test('Pass correct props to SingleAutoComplete', () => {
     expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
         disabled: true,
         displayProperty: 'name',
+        options: {},
         resourceKey: 'accounts',
         searchProperties: ['name', 'number'],
         value,
+    }));
+});
+
+test('Pass correct options to SingleAutoComplete based on data_path_to_auto_complete schema option', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const value = {
+        test: 'value',
+    };
+
+    const fieldTypeOptions = {
+        default_type: 'auto_complete',
+        resource_key: 'accounts',
+        types: {
+            auto_complete: {
+                display_property: 'name',
+                search_properties: ['name', 'number'],
+            },
+        },
+    };
+
+    const schemaOptions = {
+        data_path_to_auto_complete: {
+            name: 'data_path_to_auto_complete',
+            value: [
+                {name: 'id', value: 'accountId'},
+            ],
+        },
+    };
+
+    formInspector.getValueByPath.mockReturnValue(5);
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+            value={value}
+        />
+    );
+
+    expect(formInspector.getValueByPath).toBeCalledWith('/id');
+    expect(singleSelection.find('SingleAutoComplete').props()).toEqual(expect.objectContaining({
+        options: {
+            accountId: 5,
+        },
     }));
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/Tabs.js
@@ -95,8 +95,24 @@ class Tabs extends React.Component<Props> {
     };
 
     handleSelect = (index: number) => {
-        const {router} = this.props;
-        router.navigate(this.sortedTabRoutes[index].name, router.attributes);
+        const {route, router} = this.props;
+
+        const {
+            options: {
+                routerAttributesToBlacklist,
+            },
+        } = route;
+
+        const filteredAttributes = routerAttributesToBlacklist
+            ? Object.keys(router.attributes)
+                .filter((key) => !routerAttributesToBlacklist.includes(key))
+                .reduce((attributes, key) => {
+                    attributes[key] = router.attributes[key];
+                    return attributes;
+                }, {})
+            : router.attributes;
+
+        router.navigate(this.sortedTabRoutes[index].name, filteredAttributes);
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/Tabs.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/Tabs.test.js
@@ -574,3 +574,69 @@ test('Navigate to tab if it was clicked', () => {
     tabs.find('Tab button').at(1).simulate('click');
     expect(router.navigate).toBeCalledWith('route2', attributes);
 });
+
+test('Navigate to tab if it was clicked', () => {
+    const childRoute1 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {
+            tabTitle: 'tabTitle1',
+        },
+        parent: null,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+    const childRoute2 = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route2',
+        options: {
+            tabTitle: 'tabTitle2',
+        },
+        parent: null,
+        path: '/route2',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const route = {
+        attributeDefaults: {},
+        children: [
+            childRoute1,
+            childRoute2,
+        ],
+        name: 'parent',
+        options: {
+            resourceKey: 'test',
+            routerAttributesToBlacklist: ['sortColumn', 'sortOrder'],
+        },
+        parent: null,
+        path: '/parent',
+        rerenderAttributes: [],
+        view: 'route1',
+    };
+
+    const attributes = {
+        id: 1,
+        sortColumn: 'size',
+        sortOrder: 'asc',
+    };
+
+    // $FlowFixMe
+    Router.mockImplementation(function() {
+        this.attributes = attributes;
+        this.navigate = jest.fn();
+        this.redirect = jest.fn();
+        this.route = route;
+    });
+
+    const router = new Router({});
+
+    const Child = () => (<h1>Child</h1>);
+    const tabs = mount(<Tabs route={route} router={router}>{() => (<Child />)}</Tabs>);
+
+    tabs.find('Tab button').at(1).simulate('click');
+    expect(router.navigate).toBeCalledWith('route2', {id: 1});
+});

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/NavigationRegistryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/NavigationRegistryTest.php
@@ -181,4 +181,35 @@ class NavigationRegistryTest extends TestCase
 
         $this->navigationRegistry->getNavigation();
     }
+
+    public function testGetNavigationWithChildren()
+    {
+        $rootItem = new NavigationItem('Root');
+        $this->admin1->getNavigation()->willReturn(new Navigation($rootItem));
+        $this->admin2->getNavigation()->willReturn(new Navigation());
+
+        $navigationItem1 = new NavigationItem('navigation_1');
+        $navigationItem1->setMainRoute('route1');
+
+        $rootItem->addChild($navigationItem1);
+
+        $route1 = $this->prophesize(Route::class);
+        $route1->getPath()->willReturn('/route1');
+        $route1->getName()->willReturn('route1');
+
+        $route11 = $this->prophesize(Route::class);
+        $route11->getPath()->willReturn('/route1/child1');
+        $route11->getName()->willReturn('route11');
+
+        $route21 = $this->prophesize(Route::class);
+        $route21->getPath()->willReturn('/route2/route1');
+        $route21->getName()->willReturn('route2_1');
+
+        $this->routeRegistry->getRoutes()->willReturn([$route1, $route11, $route21]);
+        $this->routeRegistry->findRouteByName('route1')->willReturn($route1);
+
+        $navigation = $this->navigationRegistry->getNavigation();
+
+        $this->assertEquals(['route1', 'route11'], $navigation->getRoot()->getChildren()[0]->getChildRoutes());
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ResourceTabRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ResourceTabRouteBuilderTest.php
@@ -42,6 +42,7 @@ class ResourceTabRouteBuilderTest extends TestCase
                 'categories',
                 'sulu_category.list',
                 null,
+                ['webspace'],
                 'title',
             ],
             [
@@ -50,6 +51,7 @@ class ResourceTabRouteBuilderTest extends TestCase
                 'tags',
                 null,
                 null,
+                ['sortColumn', 'sortOrder'],
                 null,
             ],
             [
@@ -58,6 +60,7 @@ class ResourceTabRouteBuilderTest extends TestCase
                 'categories',
                 'sulu_category.list',
                 ['webspace'],
+                null,
                 'title',
             ],
             [
@@ -66,6 +69,7 @@ class ResourceTabRouteBuilderTest extends TestCase
                 'categories',
                 'sulu_category.list',
                 ['webspace', 'active' => 'id'],
+                ['sortColumn', 'sortOrder'],
                 'title',
             ],
         ];
@@ -80,6 +84,7 @@ class ResourceTabRouteBuilderTest extends TestCase
         string $resourceKey,
         ?string $backRoute,
         ?array $routerAttributesToBackRoute,
+        ?array $routerAttributesToBlacklist,
         ?string $titleProperty
     ) {
         $routeBuilder = (new ResourceTabRouteBuilder($name, $path))

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -174,6 +174,7 @@ class ContactAdmin extends Admin
                 ->setResourceKey('accounts')
                 ->setBackRoute(static::ACCOUNT_LIST_ROUTE)
                 ->setTitleProperty('name')
+                ->addRouterAttributesToBlacklist(['sortColumn', 'sortOrder'])
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_contact.account_edit_form.details', '/details')
                 ->setResourceKey('accounts')

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -174,7 +174,7 @@ class ContactAdmin extends Admin
                 ->setResourceKey('accounts')
                 ->setBackRoute(static::ACCOUNT_LIST_ROUTE)
                 ->setTitleProperty('name')
-                ->addRouterAttributesToBlacklist(['sortColumn', 'sortOrder'])
+                ->addRouterAttributesToBlacklist(['active', 'limit', 'page', 'search', 'sortColumn', 'sortOrder'])
                 ->getRoute(),
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_contact.account_edit_form.details', '/details')
                 ->setResourceKey('accounts')

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -192,6 +192,15 @@ class ContactAdmin extends Admin
                 ->addToolbarActions($documentsToolbarAction)
                 ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
                 ->getRoute(),
+            $this->routeBuilderFactory->createListRouteBuilder('sulu_contact.account_contacts_list', '/contacts')
+                ->setResourceKey('account_contacts')
+                ->setListKey('account_contacts')
+                ->setTabTitle('sulu_contact.people')
+                ->addListAdapters(['table'])
+                ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
+                ->addRouterAttributesToListStore(['id'])
+                ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
+                ->getRoute(),
         ];
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -199,6 +199,8 @@ class ContactAdmin extends Admin
                 ->addListAdapters(['table'])
                 ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
                 ->addRouterAttributesToListStore(['id'])
+                ->addToolbarActions(['sulu_admin.delete'])
+                ->addRouterAttributesToListStore(['id' => 'accountId'])
                 ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
                 ->getRoute(),
         ];

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -137,6 +137,7 @@ class ContactAdmin extends Admin
                 ->setFormKey('contact_details')
                 ->setTabTitle('sulu_admin.details')
                 ->addToolbarActions($formToolbarActions)
+                ->setTabOrder(1024)
                 ->setParent(static::CONTACT_EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createListRouteBuilder('sulu_contact.contact_documents_list', '/documents')
@@ -147,6 +148,7 @@ class ContactAdmin extends Admin
                 ->addListAdapters(['table'])
                 ->addToolbarActions($documentsToolbarAction)
                 ->addRouterAttributesToListStore(['id' => 'contactId'])
+                ->setTabOrder(2048)
                 ->setParent(static::CONTACT_EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createListRouteBuilder(static::ACCOUNT_LIST_ROUTE, '/accounts')
@@ -182,16 +184,7 @@ class ContactAdmin extends Admin
                 ->setTabTitle('sulu_admin.details')
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
-                ->getRoute(),
-            $this->routeBuilderFactory->createListRouteBuilder('sulu_contact.account_documents_list', '/documents')
-                ->setResourceKey('account_media')
-                ->setListKey('media')
-                ->setUserSettingsKey('contact_media')
-                ->setTabTitle('sulu_contact.documents')
-                ->addListAdapters(['table'])
-                ->addRouterAttributesToListStore(['id' => 'contactId'])
-                ->addToolbarActions($documentsToolbarAction)
-                ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
+                ->setTabOrder(1024)
                 ->getRoute(),
             $this->routeBuilderFactory->createListRouteBuilder('sulu_contact.account_contacts_list', '/contacts')
                 ->setResourceKey('account_contacts')
@@ -202,6 +195,18 @@ class ContactAdmin extends Admin
                 ->addRouterAttributesToListStore(['id'])
                 ->addToolbarActions(['sulu_admin.delete'])
                 ->addRouterAttributesToListStore(['id' => 'accountId'])
+                ->setTabOrder(2048)
+                ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
+                ->getRoute(),
+            $this->routeBuilderFactory->createListRouteBuilder('sulu_contact.account_documents_list', '/documents')
+                ->setResourceKey('account_media')
+                ->setListKey('media')
+                ->setUserSettingsKey('contact_media')
+                ->setTabTitle('sulu_contact.documents')
+                ->addListAdapters(['table'])
+                ->addRouterAttributesToListStore(['id' => 'contactId'])
+                ->addToolbarActions($documentsToolbarAction)
+                ->setTabOrder(3072)
                 ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)
                 ->getRoute(),
         ];

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -288,24 +288,24 @@ class AccountController extends RestController implements ClassResourceInterface
      *
      * @return Response
      */
-    public function deleteContactsAction($accountId, $contactId)
+    public function deleteContactsAction($accountId, $id)
     {
         try {
             // Check if relation exists.
             /** @var AccountContactEntity $accountContact */
             $accountContact = $this->getDoctrine()
                 ->getRepository(self::$accountContactEntityName)
-                ->findByForeignIds($accountId, $contactId);
+                ->findByForeignIds($accountId, $id);
 
             if (!$accountContact) {
-                throw new EntityNotFoundException('AccountContact', $accountId . $contactId);
+                throw new EntityNotFoundException('AccountContact', $accountId . $id);
             }
             $id = $accountContact->getId();
 
             $account = $accountContact->getAccount();
 
             // Remove main contact when relation with main was removed.
-            if ($account->getMainContact() && strval($account->getMainContact()->getId()) === $contactId) {
+            if ($account->getMainContact() && strval($account->getMainContact()->getId()) === $id) {
                 $account->setMainContact(null);
             }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -579,14 +579,14 @@ class AccountController extends RestController implements ClassResourceInterface
 
         $this->setParent($request->get('parent'), $account);
 
+        $mainContact = null;
         if (null !== ($mainContactRequest = $request->get('mainContact'))) {
             $mainContact = $entityManager->getRepository(
                 $this->container->getParameter('sulu.model.contact.class')
             )->find($mainContactRequest['id']);
-            if ($mainContact) {
-                $account->setMainContact($mainContact);
-            }
         }
+
+        $account->setMainContact($mainContact);
 
         $user = $this->getUser();
         $account->setChanger($user);
@@ -701,14 +701,14 @@ class AccountController extends RestController implements ClassResourceInterface
             $accountManager->setMedias($account, $request->get('medias'));
         }
 
+        $mainContact = null;
         if (null !== ($mainContactRequest = $request->get('mainContact'))) {
             $mainContact = $entityManager->getRepository(
                 $this->container->getParameter('sulu.model.contact.class')
             )->find($mainContactRequest['id']);
-            if ($mainContact) {
-                $account->setMainContact($mainContact);
-            }
         }
+
+        $account->setMainContact($mainContact);
 
         if (null !== $request->get('bankAccounts')) {
             $accountManager->processBankAccounts($account, $request->get('bankAccounts', []));

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -139,7 +139,7 @@ class AccountController extends RestController implements ClassResourceInterface
 
             $list = new ListRepresentation(
                 $values,
-                'contacts',
+                'account_contacts',
                 'get_account_contacts',
                 array_merge(['id' => $id], $request->query->all()),
                 $listBuilder->getCurrentPage(),

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -240,8 +240,14 @@ class ContactController extends RestController implements ClassResourceInterface
         /** @var DoctrineListBuilderFactory $factory */
         $factory = $this->get('sulu_core.doctrine_list_builder_factory');
 
+        $fieldDescriptors = $this->getFieldDescriptors();
         $listBuilder = $factory->create($this->container->getParameter('sulu.model.contact.class'));
-        $restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
+        $restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
+
+        $account = $request->get('accountId');
+        if ($account) {
+            $listBuilder->where($fieldDescriptors['accountId'], $account);
+        }
 
         $listResponse = $this->prepareListResponse($listBuilder, $locale);
 

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -120,6 +120,11 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                                 'detail' => 'delete_account_medias',
                             ],
                         ],
+                        'account_contacts' => [
+                            'routes' => [
+                                'list' => 'get_account_contacts',
+                            ],
+                        ],
                     ],
                     'field_type_options' => [
                         'single_selection' => [

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -123,6 +123,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                         'account_contacts' => [
                             'routes' => [
                                 'list' => 'get_account_contacts',
+                                'detail' => 'delete_account_contacts',
                             ],
                         ],
                     ],
@@ -195,6 +196,17 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                     'routes_to_expose' => [
                         'delete_contact_medias',
                         'delete_account_medias',
+                    ],
+                ]
+            );
+        }
+
+        if ($container->hasExtension('fos_js_routing')) {
+            $container->prependExtensionConfig(
+                'fos_js_routing',
+                [
+                    'routes_to_expose' => [
+                        'delete_account_contacts',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -151,6 +151,10 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                                 'default_type' => 'list_overlay',
                                 'resource_key' => 'contacts',
                                 'types' => [
+                                    'auto_complete' => [
+                                        'display_property' => 'fullName',
+                                        'search_properties' => ['fullName'],
+                                    ],
                                     'list_overlay' => [
                                         'adapter' => 'table',
                                         'list_key' => 'contacts',

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/forms/account_details.xml
@@ -37,7 +37,7 @@
                     </params>
                 </property>
 
-                <property name="corporation" type="text_line">
+                <property name="corporation" type="text_line" colspan="6">
                     <meta>
                         <title>sulu_contact.corporation</title>
                     </meta>
@@ -53,6 +53,19 @@
                     <meta>
                         <title>sulu_contact.uid</title>
                     </meta>
+                </property>
+
+                <property name="mainContact" type="single_contact_selection" colspan="6">
+                    <meta>
+                        <title>sulu_contact.main_contact</title>
+                    </meta>
+
+                    <params>
+                        <param name="type" value="auto_complete" />
+                        <param name="data_path_to_auto_complete" type="collection">
+                            <param name="id" value="accountId" />
+                        </param>
+                    </params>
                 </property>
 
                 <property name="note" type="text_area">

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/lists/account_contacts.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/lists/account_contacts.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<list xmlns="http://schemas.sulu.io/list-builder/list">
+    <key>account_contacts</key>
+
+    <properties>
+        <property
+            name="fullName"
+            searchability="yes"
+            sortable="true"
+            translation="sulu_contact.name"
+            visibility="always"
+        />
+
+        <property
+            name="position"
+            searchability="no"
+            sortable="true"
+            translation="sulu_contact.position"
+            visibility="yes"
+        />
+    </properties>
+</list>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -201,7 +201,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(0, $response->total);
-        $this->assertCount(0, $response->_embedded->contacts);
+        $this->assertCount(0, $response->_embedded->account_contacts);
     }
 
     public function testGetAccountContacts()
@@ -259,10 +259,10 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(2, $response['total']);
-        $this->assertCount(2, $response['_embedded']['contacts']);
+        $this->assertCount(2, $response['_embedded']['account_contacts']);
 
-        $this->assertEquals('Erika', $response['_embedded']['contacts'][0]['firstName']);
-        $this->assertEquals('Max', $response['_embedded']['contacts'][1]['firstName']);
+        $this->assertEquals('Erika', $response['_embedded']['account_contacts'][0]['firstName']);
+        $this->assertEquals('Max', $response['_embedded']['account_contacts'][1]['firstName']);
     }
 
     public function testGetAccountContactsSearch()
@@ -309,9 +309,9 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $this->assertEquals(1, $response['total']);
-        $this->assertCount(1, $response['_embedded']['contacts']);
+        $this->assertCount(1, $response['_embedded']['account_contacts']);
 
-        $this->assertEquals('Max Mustermann', $response['_embedded']['contacts'][0]['fullName']);
+        $this->assertEquals('Max Mustermann', $response['_embedded']['account_contacts'][0]['fullName']);
     }
 
     public function testPost()

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -850,6 +850,7 @@ class AccountControllerTest extends SuluTestCase
             ]
         );
         $logo = $this->createMedia('logo.jpeg', 'image/jpeg', $mediaType, $collection);
+        $contact = $this->createContact($account, 'Vorname', 'Nachname');
 
         $this->em->flush();
 
@@ -861,6 +862,7 @@ class AccountControllerTest extends SuluTestCase
                 'name' => 'ExampleCompany',
                 'note' => 'A small notice',
                 'logo' => ['id' => $logo->getId()],
+                'mainContact' => ['id' => $contact->getId()],
                 'contactDetails' => [
                     'websites' => [
                         [
@@ -949,6 +951,7 @@ class AccountControllerTest extends SuluTestCase
 
         $this->assertEquals('ExampleCompany', $response->name);
         $this->assertEquals('A small notice', $response->note);
+        $this->assertEquals($contact->getId(), $response->mainContact->id);
 
         $this->assertEquals(2, count($response->contactDetails->websites));
         $this->assertEquals('http://example.company.com', $response->contactDetails->websites[0]->website);

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\ContactBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\ContactBundle\Entity\Account;
+use Sulu\Bundle\ContactBundle\Entity\AccountContact;
 use Sulu\Bundle\ContactBundle\Entity\Address;
 use Sulu\Bundle\ContactBundle\Entity\AddressType;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
@@ -740,6 +741,40 @@ class ContactControllerTest extends SuluTestCase
 
         $client = $this->createTestClient();
         $client->request('GET', '/api/contacts?flat=true&search=Erika&searchFields=fullName&fields=fullName');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertEquals(1, $response->total);
+        $this->assertEquals(1, count($response->_embedded->contacts));
+        $this->assertEquals('Erika Mustermann', $response->_embedded->contacts[0]->fullName);
+    }
+
+    public function testGetListByAccountId()
+    {
+        $account = $this->createAccount('Musterfirma');
+        $this->em->persist($account);
+
+        $contact1 = new Contact();
+        $contact1->setFirstName('Erika');
+        $contact1->setLastName('Mustermann');
+        $accountContact1 = new AccountContact();
+        $accountContact1->setMain(false);
+        $accountContact1->setContact($contact1);
+        $accountContact1->setAccount($account);
+        $contact1->addAccountContact($accountContact1);
+        $this->em->persist($accountContact1);
+        $this->em->persist($contact1);
+
+        $contact2 = new Contact();
+        $contact2->setFirstName('Max');
+        $contact2->setLastName('Mustermann');
+        $this->em->persist($contact2);
+
+        $this->em->flush();
+
+        $client = $this->createTestClient();
+        $client->request('GET', '/api/contacts?flat=true&accountId=' . $account->getId());
 
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -154,6 +154,7 @@ class PageAdmin extends Admin
                 ->addToolbarActions($formToolbarActionsWithType)
                 ->addRouterAttributesToFormStore($routerAttributesToFormStore)
                 ->setPreviewCondition($previewCondition)
+                ->setTabOrder(1024)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.seo', '/seo')
@@ -165,6 +166,7 @@ class PageAdmin extends Admin
                 ->addRouterAttributesToFormStore($routerAttributesToFormStore)
                 ->setPreviewCondition($previewCondition)
                 ->setTitleVisible(true)
+                ->setTabOrder(2048)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.excerpt', '/excerpt')
@@ -176,6 +178,7 @@ class PageAdmin extends Admin
                 ->addRouterAttributesToFormStore($routerAttributesToFormStore)
                 ->setPreviewCondition($previewCondition)
                 ->setTitleVisible(true)
+                ->setTabOrder(3072)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
             $this->routeBuilderFactory->createPreviewFormRouteBuilder('sulu_page.page_edit_form.settings', '/settings')
@@ -187,6 +190,7 @@ class PageAdmin extends Admin
                 ->addRouterAttributesToFormStore($routerAttributesToFormStore)
                 ->setPreviewCondition($previewCondition)
                 ->setTitleVisible(true)
+                ->setTabOrder(4096)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
         ];

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -145,6 +145,7 @@ class SecurityAdmin extends Admin
                 ->addToolbarActions(['sulu_admin.save'])
                 ->setIdQueryParameter('contactId')
                 ->setTitleVisible(true)
+                ->setTabOrder(3072)
                 ->setParent(ContactAdmin::CONTACT_EDIT_FORM_ROUTE)
                 ->getRoute(),
         ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a list to show all the contacts assigned to an account and allow to assign a main contact to the account using an auto complete field.

#### Why?

Because it already was possible to do that in the old Admin.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] ~~What about the add options in the old UI?~~
- [x] Switcthing between people and documents list in tabs keeps wrong URL parameters