### PR TITLE
Make click area of search button in List bigger

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Input/input.scss
@@ -128,10 +128,20 @@ $darkIconColor: $doveGray;
         flex: 0 0 $inputPrependWidth;
         height: calc($inputHeight - 2 * $iconBorderPadding);
         width: $inputPrependWidth;
+
+        &.collapsed {
+            height: 100%;
+        }
     }
 
     .icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        width: 100%;
         font-size: 14px;
+        text-align: center;
     }
 
     &.headline {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR allows to click the entire search button in the list.

#### Why?

Because previously it was necessary to click exactly the icon, which is not good for usability.
