### PR TITLE
Set user permissions on new content page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.5
+    * BUGFIX      #4589 [ContentBundle]         Set user permissions on new content page
     * BUGFIX      #4572 [WebsiteBundle]         Fix false 406 status code for controller InvalidArgumentExceptions
     * BUGFIX      #4571 [WebsiteBundle]         Fix language switcher for static routes
     * BUGFIX      #4579 [ContentBundle]         Fix controller reference validation with FQCN

--- a/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
+++ b/src/Sulu/Bundle/ContentBundle/Resources/public/js/components/content/main.js
@@ -170,8 +170,20 @@ define([
                     }
                 );
             } else {
-                this.data = this.content.toJSON();
-                promise.resolve();
+                var baseContent = new Content();
+                baseContent.fullFetch(
+                  this.options.webspace,
+                  this.options.language,
+                  true,
+                  template,
+                  {
+                      success: function(content) {
+                          this.data = this.content.toJSON();
+                          this.data._permissions = content._permissions;
+                          promise.resolve();
+                      }.bind(this)
+                  }
+                );
             }
 
             return promise;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3705 
| Related issues/PRs | #1482
| License | MIT
| Documentation PR | -

#### What's in this PR?

The fix loads the webspace's default content when no content id is present, but makes sure to only take the permissions from that response so we don't end up with conflicting data.

#### Why?

This fixes missing user permissions when creating a new content page, which causes the Save menu to display incorrect options.
