### PR TITLE
Fix usage of translator in SuluRouteBundle

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
+++ b/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\RouteBundle\DependencyInjection\RouteGeneratorCompilerPass;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -32,7 +33,7 @@ class SuluRouteBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new RouteGeneratorCompilerPass());
+        $container->addCompilerPass(new RouteGeneratorCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1024);
         $container->addCompilerPass(
             new TaggedServiceCollectorCompilerPass('sulu_route.routing.defaults_provider', 'sulu_route.defaults_provider')
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4583 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes a bug occuring in combination with the SuluArticleBundle and Symfony > 4.3.

#### Why?

Because we would still like to use the translator service in the router bundle.