### PR TITLE
Add loadExcerpt to snippet twig extension  and fix loadExcerpt for pages

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
@@ -185,4 +185,22 @@ class SnippetTwigExtensionTest extends SuluTestCase
         $this->assertEquals([], $snippet['view']['title']);
         $this->assertEquals([], $snippet['view']['description']);
     }
+
+    public function testLoadSnippetExcerpt()
+    {
+        /** @var SnippetDocument $snippet */
+        $snippet = $this->documentManager->create('snippet');
+        $snippet->setStructureType('car');
+        $snippet->setExtension('excerpt', ['tags' => ['Tag1', 'Tag2'], 'categories' => []]);
+        $snippet->setTitle('test-title');
+        $snippet->getStructure()->bind(['description' => 'test-description']);
+        $snippet->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $this->documentManager->persist($snippet, 'en');
+        $this->documentManager->flush();
+
+        $snippet = $this->extension->loadSnippet($snippet->getUuid(), null, true);
+
+        $this->assertEquals(['Tag1', 'Tag2'], $snippet['extension']['excerpt']['tags']);
+        $this->assertEquals([], $snippet['extension']['excerpt']['categories']);
+    }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
@@ -62,7 +62,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
     /**
      * {@inheritdoc}
      */
-    public function loadSnippet($uuid, $locale = null)
+    public function loadSnippet($uuid, $locale = null, $loadExcerpt = false)
     {
         if (null === $locale) {
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -71,7 +71,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
         try {
             $snippet = $this->contentMapper->load($uuid, $this->requestAnalyzer->getWebspace()->getKey(), $locale);
 
-            return $this->structureResolver->resolve($snippet);
+            return $this->structureResolver->resolve($snippet, $loadExcerpt);
         } catch (DocumentNotFoundException $ex) {
             return;
         }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtensionInterface.php
@@ -20,9 +20,10 @@ interface SnippetTwigExtensionInterface extends \Twig_ExtensionInterface
      * Returns snippet.
      *
      * @param string $uuid
-     * @param string $locale
+     * @param string|null $locale
+     * @param bool $loadExcerpt
      *
      * @return array
      */
-    public function loadSnippet($uuid, $locale = null);
+    public function loadSnippet($uuid, $locale = null, $loadExcerpt = false);
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolver.php
@@ -54,7 +54,7 @@ class ParameterResolver implements ParameterResolverInterface
         $preview = false
     ) {
         if (null !== $structure) {
-            $structureData = $this->structureResolver->resolve($structure);
+            $structureData = $this->structureResolver->resolve($structure, true);
         } else {
             $structureData = [];
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -49,7 +49,7 @@ class StructureResolver implements StructureResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(StructureInterface $structure, bool $loadExcerpt = false)
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true)
     {
         $data = [
             'view' => [],

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverInterface.php
@@ -22,8 +22,9 @@ interface StructureResolverInterface
      * This method receives a structure, and should return an array for the template.
      *
      * @param StructureInterface $structure The structure to resolve
+     * @param bool $loadExcerpt Resolves also the extension data of the structure
      *
      * @return array
      */
-    public function resolve(StructureInterface $structure, bool $loadExcerpt = false);
+    public function resolve(StructureInterface $structure, bool $loadExcerpt = true);
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/ParameterResolverTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Portal;
+
+class ParameterResolverTest extends TestCase
+{
+    /**
+     * @var StructureResolverInterface
+     */
+    private $structureResolver;
+
+    /**
+     * @var RequestAnalyzerResolverInterface
+     */
+    private $requestAnalyzerResolver;
+
+    /**
+     * @var RequestAnalyzerInterface
+     */
+    private $requestAnalyzer;
+
+    /**
+     * @var PageBridge
+     */
+    private $structure;
+
+    /**
+     * @var ParameterResolver
+     */
+    private $parameterResolver;
+
+    /**
+     * @var Portal
+     */
+    private $portal;
+
+    /**
+     * @var Localization
+     */
+    private $localization;
+
+    public function setUp()
+    {
+        $this->structureResolver = $this->prophesize(StructureResolverInterface::class);
+        $this->requestAnalyzerResolver = $this->prophesize(RequestAnalyzerResolver::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->structure = $this->prophesize(PageBridge::class);
+        $this->portal = $this->prophesize(Portal::class);
+        $this->localization = $this->prophesize(Localization::class);
+
+        $this->parameterResolver = new ParameterResolver(
+            $this->structureResolver->reveal(),
+            $this->requestAnalyzerResolver->reveal()
+        );
+    }
+
+    public function testResolve()
+    {
+        $this->structureResolver->resolve($this->structure->reveal(), true)
+            ->shouldBeCalledTimes(1)
+            ->willReturn([
+                'content' => [],
+                'view' => [],
+                'urls' => ['en' => '/test'],
+                'extension' => [
+                    'seo' => [],
+                    'excerpt' => [],
+                ],
+            ]);
+        $this->requestAnalyzerResolver->resolve($this->requestAnalyzer)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(['webspaceKey' => 'sulu']);
+        $this->requestAnalyzer->getPortal()->willReturn($this->portal->reveal())->shouldBeCalledTimes(1);
+        $this->portal->getLocalizations()->willReturn([$this->localization->reveal()])->shouldBeCalledTimes(1);
+        $this->localization->getLocale()->willReturn('en')->shouldBeCalledTimes(1);
+
+        $resolvedData = $this->parameterResolver->resolve(
+            [
+                'testKey' => 'testValue',
+            ],
+            $this->requestAnalyzer->reveal(),
+            $this->structure->reveal()
+        );
+
+        $this->assertSame([
+            'testKey' => 'testValue',
+            'content' => [],
+            'view' => [],
+            'urls' => ['en' => '/test'],
+            'extension' => [
+                'seo' => [],
+                'excerpt' => [],
+            ],
+            'webspaceKey' => 'sulu',
+        ], $resolvedData);
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
@@ -119,7 +119,7 @@ class StructureResolverTest extends TestCase
             'webspaceKey' => 'test',
         ];
 
-        $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal(), true));
+        $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal()));
     }
 
     public function testResolveWithoutExtensions()
@@ -182,6 +182,6 @@ class StructureResolverTest extends TestCase
             'webspaceKey' => 'test',
         ];
 
-        $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal()));
+        $this->assertEquals($expected, $this->structureResolver->resolve($structure->reveal(), false));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #4573
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix loading of extension data in parameter resolver for pages.

#### Why?

The parameter resolver did return excerpt in the past.

#### BC Breaks/Deprecations

Not sure was there a bc break implemented in #4573 with the structureResolver?


