### PR TITLE
Add loadExcerpt to snippet twig extension

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Twig/SnippetTwigExtensionTest.php
@@ -185,4 +185,22 @@ class SnippetTwigExtensionTest extends SuluTestCase
         $this->assertEquals([], $snippet['view']['title']);
         $this->assertEquals([], $snippet['view']['description']);
     }
+
+    public function testLoadSnippetExcerpt()
+    {
+        /** @var SnippetDocument $snippet */
+        $snippet = $this->documentManager->create('snippet');
+        $snippet->setStructureType('car');
+        $snippet->setExtension('excerpt', ['tags' => ['Tag1', 'Tag2'], 'categories' => []]);
+        $snippet->setTitle('test-title');
+        $snippet->getStructure()->bind(['description' => 'test-description']);
+        $snippet->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $this->documentManager->persist($snippet, 'en');
+        $this->documentManager->flush();
+
+        $snippet = $this->extension->loadSnippet($snippet->getUuid(), null, true);
+
+        $this->assertEquals(['Tag1', 'Tag2'], $snippet['extension']['excerpt']['tags']);
+        $this->assertEquals([], $snippet['extension']['excerpt']['categories']);
+    }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
@@ -62,7 +62,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
     /**
      * {@inheritdoc}
      */
-    public function loadSnippet($uuid, $locale = null)
+    public function loadSnippet($uuid, $locale = null, $loadExcerpt = false)
     {
         if (null === $locale) {
             $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -71,7 +71,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
         try {
             $snippet = $this->contentMapper->load($uuid, $this->requestAnalyzer->getWebspace()->getKey(), $locale);
 
-            return $this->structureResolver->resolve($snippet);
+            return $this->structureResolver->resolve($snippet, $loadExcerpt);
         } catch (DocumentNotFoundException $ex) {
             return;
         }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtensionInterface.php
@@ -20,9 +20,10 @@ interface SnippetTwigExtensionInterface extends \Twig_ExtensionInterface
      * Returns snippet.
      *
      * @param string $uuid
-     * @param string $locale
+     * @param string|null $locale
+     * @param bool $loadExcerpt
      *
      * @return array
      */
-    public function loadSnippet($uuid, $locale = null);
+    public function loadSnippet($uuid, $locale = null, $loadExcerpt = false);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes 
| Related issues/PRs | #4573
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add new parameter to load the excerpt over the snippet twig extension.

#### Why?

Should also be possible from twig not only from content type.

#### Example Usage

~~~php
{% set snippet = sulu_snippet_load(uuid, null, true) %}
~~~

