### PR TITLE
Add separate FieldType for route paths

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,48 @@
 
 ## dev-develop
 
+### RouteBundle API
+
+The API for routes under `/admin/api/routes` has changed a bit, in order to avoid having PHP class names in the
+frontent. Instead it uses the already known `resourceKey` now.
+
+Therefore the API has changed, instead of `entityClass` it now takes the `resourceKey`, and the `entityId` attribute has
+changed to just `id`.
+
+```
+# before
+/admin/api/routes?history=true&entityClass=Sulu\Bundle\ArticleBundle\Document\ArticleDocument&entityId=c88e4b89-7e2b-4161-b5d0-c33993535140&locale=en
+
+# after
+/admin/api/routes?history=true&resourceKey=articles&id=101b58ef-d422-4122-98f9-a4009bd74bd1&locale=en
+```
+
+This `resourceKey` now has to be configured in the `sulu_route` configuration as well:
+
+```yaml
+# before
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
+            generator: "schema"
+            options:
+                route_schema: "/articles/{object.getTitle()}"
+
+# after
+sulu_route:
+    mappings:
+        Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
+            resource_key: "articles"
+            generator: "schema"
+            options:
+                route_schema: "/articles/{object.getTitle()}"
+```
+
+### Page ResourceLocator API
+
+The API for the history of resource locators (`/admin/api/pages/<id>/resourcelocators`) for pages has changed in order
+to be more consistent with the API from the `RouteBundle`. The property `resourcelocator` has now be renamed to `path`.
+
 ### Display options in MediaSelection
 
 The `media_selection` content type showed all available display options(left top, top, right, ...) except for `middle`

--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -18,6 +18,7 @@ import 'sulu-custom-url-bundle';
 import 'sulu-media-bundle';
 import 'sulu-page-bundle';
 import 'sulu-preview-bundle';
+import 'sulu-route-bundle';
 import 'sulu-security-bundle';
 import 'sulu-snippet-bundle';
 import 'sulu-website-bundle';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "sulu-media-bundle": "file:src/Sulu/Bundle/MediaBundle/Resources/js",
         "sulu-page-bundle": "file:src/Sulu/Bundle/PageBundle/Resources/js",
         "sulu-preview-bundle": "file:src/Sulu/Bundle/PreviewBundle/Resources/js",
+        "sulu-route-bundle": "file:src/Sulu/Bundle/RouteBundle/Resources/js",
         "sulu-security-bundle": "file:src/Sulu/Bundle/SecurityBundle/Resources/js",
         "sulu-snippet-bundle": "file:src/Sulu/Bundle/SnippetBundle/Resources/js",
         "sulu-website-bundle": "file:src/Sulu/Bundle/WebsiteBundle/Resources/js"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkPlugin.js
@@ -10,8 +10,8 @@ import {render, unmountComponentAtNode} from 'react-dom';
 import {addLinkConversion, findModelItemInSelection, findViewLinkItemInSelection} from '../../utils';
 import LinkBalloonView from '../../LinkBalloonView';
 import LinkCommand from '../../LinkCommand';
-import ExternalLinkOverlay from './ExternalLinkOverlay';
 import UnlinkCommand from '../../UnlinkCommand';
+import ExternalLinkOverlay from './ExternalLinkOverlay';
 // $FlowFixMe
 import linkIcon from '!!raw-loader!./link.svg'; // eslint-disable-line import/no-webpack-loader-syntax
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
@@ -10,11 +10,11 @@ import ListItemView from '@ckeditor/ckeditor5-ui/src/list/listitemview';
 import {createDropdown} from '@ckeditor/ckeditor5-ui/src/dropdown/utils';
 import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextualballoon';
 import ClickObserver from '@ckeditor/ckeditor5-engine/src/view/observer/clickobserver';
-import internalLinkTypeRegistry from './registries/InternalLinkTypeRegistry';
 import LinkBalloonView from '../../LinkBalloonView';
 import LinkCommand from '../../LinkCommand';
 import {addLinkConversion, findModelItemInSelection, findViewLinkItemInSelection} from '../../utils';
 import UnlinkCommand from '../../UnlinkCommand';
+import internalLinkTypeRegistry from './registries/InternalLinkTypeRegistry';
 // $FlowFixMe
 import linkIcon from '!!raw-loader!./link.svg'; // eslint-disable-line import/no-webpack-loader-syntax
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -15,6 +15,11 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
         const {dataPath, onChange, fieldTypeOptions, formInspector, value} = this.props;
 
         const {generationUrl} = fieldTypeOptions;
+
+        if (!generationUrl) {
+            return;
+        }
+
         if (typeof generationUrl !== 'string') {
             throw new Error('The "generationUrl" fieldTypeOption must be a string!');
         }
@@ -60,6 +65,22 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
 
     render() {
         const {
+            fieldTypeOptions: {
+                defaultMode = 'leaf',
+                historyResourceKey,
+                options = {},
+            },
+        } = this.props;
+
+        if (!historyResourceKey || typeof historyResourceKey !== 'string') {
+            throw new Error('The "historyResourceKey" field type option must be set to a string!');
+        }
+
+        if (typeof options !== 'object') {
+            throw new Error('The "options" field type must be an object if given!');
+        }
+
+        const {
             dataPath,
             disabled,
             formInspector,
@@ -67,7 +88,7 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
             schemaOptions: {
                 mode: {
                     value: mode,
-                } = {value: 'leaf'},
+                } = {value: defaultMode},
             } = {},
             value,
         } = this.props;
@@ -92,8 +113,13 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
                     <div className={resourceLocatorStyles.resourceLocatorHistory}>
                         <ResourceLocatorHistory
                             id={formInspector.id}
-                            options={{language: formInspector.locale, webspace: formInspector.options.webspace}}
-                            resourceKey="page_resourcelocators"
+                            options={{
+                                locale: formInspector.locale,
+                                resourceKey: formInspector.resourceKey,
+                                webspace: formInspector.options.webspace,
+                                ...options,
+                            }}
+                            resourceKey={historyResourceKey}
                         />
                     </div>
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -126,7 +126,7 @@ test('Throw an exception if a non-valid mode is passed', () => {
     ).toThrow(/"leaf" or "full"/);
 });
 
-test('Throw an exception if no hisotryResourceKey is given', () => {
+test('Throw an exception if no historyResourceKey is given', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     expect(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -48,7 +48,10 @@ test('Pass props correctly to ResourceLocator', () => {
         <ResourceLocator
             {...fieldTypeDefaultProps}
             disabled={true}
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             schemaOptions={schemaOptions}
             value="/"
@@ -58,6 +61,46 @@ test('Pass props correctly to ResourceLocator', () => {
     expect(resourceLocator.find(ResourceLocatorComponent).prop('value')).toBe('/');
     expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
     expect(resourceLocator.find(ResourceLocatorComponent).prop('disabled')).toBe(true);
+});
+
+test('Do not render history link if new entity is created', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+        />
+    );
+
+    expect(resourceLocator.find('ResourceLocatorHistory')).toHaveLength(0);
+});
+
+test('Render history link if entity already existed including passed options', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(new ResourceStore('test', 1), 'test', {webspace: 'sulu'})
+    );
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                options: {history: true},
+            }}
+            formInspector={formInspector}
+        />
+    );
+
+    expect(resourceLocator.find('ResourceLocatorHistory')).toHaveLength(1);
+    expect(resourceLocator.find('ResourceLocatorHistory').prop('options')).toEqual({history: true, webspace: 'sulu'});
+    expect(resourceLocator.find('ResourceLocatorHistory').prop('resourceKey')).toEqual('page_resourcelocators');
+    expect(resourceLocator.find('ResourceLocatorHistory').prop('id')).toEqual(1);
 });
 
 test('Throw an exception if a non-valid mode is passed', () => {
@@ -72,7 +115,10 @@ test('Throw an exception if a non-valid mode is passed', () => {
         () => shallow(
             <ResourceLocator
                 {...fieldTypeDefaultProps}
-                fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+                fieldTypeOptions={{
+                    generationUrl: '/admin/api/resourcelocators?action=generate',
+                    historyResourceKey: 'page_resourcelocators',
+                }}
                 formInspector={formInspector}
                 schemaOptions={schemaOptions}
             />
@@ -80,17 +126,113 @@ test('Throw an exception if a non-valid mode is passed', () => {
     ).toThrow(/"leaf" or "full"/);
 });
 
-test('Throw an exception if a no generationUrl is passed', () => {
+test('Throw an exception if no hisotryResourceKey is given', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     expect(
         () => shallow(
             <ResourceLocator
                 {...fieldTypeDefaultProps}
+                fieldTypeOptions={{
+                    generationUrl: '/admin/api/resourcelocators?action=generate',
+                }}
                 formInspector={formInspector}
             />
         )
-    ).toThrow(/"generationUrl"/);
+    ).toThrow(/"historyResourceKey"/);
+});
+
+test('Throw an exception if given options are not an object', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    expect(
+        () => shallow(
+            <ResourceLocator
+                {...fieldTypeDefaultProps}
+                fieldTypeOptions={{
+                    generationUrl: '/admin/api/resourcelocators?action=generate',
+                    historyResourceKey: 'page_resourcelocators',
+                    options: true,
+                }}
+                formInspector={formInspector}
+            />
+        )
+    ).toThrow(/"options"/);
+});
+
+test('Do not add an addFinishFieldHandler for URL generation if no generationUrl was passed', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+        />
+    );
+
+    expect(formInspector.addFinishFieldHandler).not.toBeCalled();
+});
+
+test('Set mode to leaf by default', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+            value="/test/xxx"
+        />
+    );
+
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('leaf');
+});
+
+test('Set mode to full if set as defaultMode', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                defaultMode: 'full',
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+            value="/test/xxx"
+        />
+    );
+
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
+});
+
+test('Ignore defaultMode when a concrete mode is passed', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const schemaOptions = {
+        mode: {
+            value: 'leaf',
+        },
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                defaultMode: 'full',
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('leaf');
 });
 
 test('Set default mode correctly', () => {
@@ -98,7 +240,10 @@ test('Set default mode correctly', () => {
     const resourceLocator = mount(
         <ResourceLocator
             {...fieldTypeDefaultProps}
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             value="/test/xxx"
         />
@@ -114,7 +259,10 @@ test('Should not pass any argument to onFinish callback', () => {
     const resourceLocator = mount(
         <ResourceLocator
             {...fieldTypeDefaultProps}
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             onFinish={finishSpy}
         />
@@ -136,7 +284,10 @@ test('Should not request a new URL if on an edit form', () =>{
     shallow(
         <ResourceLocator
             {...fieldTypeDefaultProps}
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             schemaPath="/url"
         />
@@ -161,7 +312,10 @@ test('Should request a new URL if no URL was defined', () => {
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             onChange={changeSpy}
             schemaPath="/url"
@@ -208,7 +362,10 @@ test('Should not request a new URL if URL was defined', () => {
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             onChange={changeSpy}
             schemaPath="/url"
@@ -246,7 +403,10 @@ test('Should request a new URL including the options from the ResourceFormStore 
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             onChange={changeSpy}
             schemaPath="/url"
@@ -287,7 +447,10 @@ test('Should not request a new URL if no parts are available', () => {
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             schemaPath="/url"
         />
@@ -314,7 +477,10 @@ test('Should not request a new URL if only empty parts are available', () => {
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             schemaPath="/url"
         />
@@ -341,7 +507,10 @@ test('Should not request a new URL if a field without the "sulu.rlp.part" tag ha
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             schemaPath="/url"
         />
@@ -368,7 +537,10 @@ test('Should not request a new URL if a field without any tags has finished edit
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             schemaPath="/url"
         />
@@ -398,7 +570,10 @@ test('Should not request a new URL if the resource locator field has already bee
         <ResourceLocator
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
-            fieldTypeOptions={{generationUrl: '/admin/api/resourcelocators?action=generate'}}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
             formInspector={formInspector}
             onChange={changeSpy}
             schemaPath="/url"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
@@ -96,7 +96,7 @@ class ResourceLocatorHistory extends React.Component<Props> {
                                 <Table.Body>
                                     {historyRoutes.map((historyRoute) => (
                                         <Table.Row id={historyRoute.id} key={historyRoute.id}>
-                                            <Table.Cell>{historyRoute.resourcelocator}</Table.Cell>
+                                            <Table.Cell>{historyRoute.path}</Table.Cell>
                                             <Table.Cell>{(new Date(historyRoute.created)).toLocaleString()}</Table.Cell>
                                         </Table.Row>
                                     ))}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
@@ -51,12 +51,12 @@ test('Show history routes in overlay', () => {
     resourceListStore.data = [
         {
             id: 3,
-            resourcelocator: 'sulu.io/test',
+            path: 'sulu.io/test',
             created: '2019-04-10T13:06:16',
         },
         {
             id: 6,
-            resourcelocator: 'sulu.io/testing',
+            path: 'sulu.io/testing',
             created: '2019-04-10T16:01:12',
         },
     ];
@@ -120,7 +120,7 @@ test('Do not delete if confirmation dialog is cancelled', () => {
     resourceListStore.data = [
         {
             id: 3,
-            resourcelocator: 'sulu.io/test',
+            path: 'sulu.io/test',
             created: '2019-04-10T13:06:16',
         },
     ];
@@ -155,7 +155,7 @@ test('Delete if confirmation dialog is confirmed', () => {
     resourceListStore.data = [
         {
             id: 3,
-            resourcelocator: 'sulu.io/test',
+            path: 'sulu.io/test',
             created: '2019-04-10T13:06:16',
         },
     ];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
@@ -14,7 +14,7 @@ import {viewRegistry} from './ViewRenderer';
 import Sidebar, {sidebarStore, sidebarRegistry} from './Sidebar';
 import type {ViewProps} from './ViewRenderer';
 import {withToolbar} from './Toolbar';
-import Form, {CardCollection, fieldRegistry, FormInspector, ResourceFormStore} from './Form';
+import Form, {CardCollection, fieldRegistry, FormInspector, ResourceFormStore, ResourceLocator} from './Form';
 import type {SchemaOption} from './Form/types';
 import ResourceLocatorHistory from './ResourceLocatorHistory';
 import ResourceMultiSelect from './ResourceMultiSelect';
@@ -51,6 +51,7 @@ export {
     InfiniteLoadingStrategy,
     PaginatedLoadingStrategy,
     ResourceFormStore,
+    ResourceLocator,
     ResourceLocatorHistory,
     ResourceMultiSelect,
     SingleAutoComplete,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -184,7 +184,11 @@ function registerFieldTypes(fieldTypeOptions) {
     fieldRegistry.add(FIELD_TYPE_NUMBER, Number);
     fieldRegistry.add(FIELD_TYPE_PASSWORD_CONFIRMATION, PasswordConfirmation);
     fieldRegistry.add(FIELD_TYPE_PHONE, Phone);
-    fieldRegistry.add(FIELD_TYPE_RESOURCE_LOCATOR, ResourceLocator, {generationUrl: Config.endpoints.generateUrl});
+    fieldRegistry.add(
+        FIELD_TYPE_RESOURCE_LOCATOR,
+        ResourceLocator,
+        {defaultMode: 'leaf', generationUrl: Config.endpoints.generateUrl, historyResourceKey: 'page_resourcelocators'}
+    );
     fieldRegistry.add(FIELD_TYPE_SMART_CONTENT, SmartContent);
     fieldRegistry.add(FIELD_TYPE_SINGLE_SELECT, SingleSelect);
     fieldRegistry.add(FIELD_TYPE_TEXT_AREA, TextArea);

--- a/src/Sulu/Bundle/PageBundle/Controller/PageResourcelocatorController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageResourcelocatorController.php
@@ -39,13 +39,13 @@ class PageResourcelocatorController extends RestController implements ClassResou
         $parts = $this->getRequestParameter($request, 'parts', true);
         $templateKey = $this->getRequestParameter($request, 'template', true);
         $webspaceKey = $this->getRequestParameter($request, 'webspace', true);
-        $languageCode = $this->getLocale($request);
+        $locale = $this->getLocale($request);
 
         $result = $this->getResourceLocatorRepository()->generate(
             $parts,
             $parentUuid,
             $webspaceKey,
-            $languageCode,
+            $locale,
             $templateKey
         );
 
@@ -62,8 +62,8 @@ class PageResourcelocatorController extends RestController implements ClassResou
      */
     public function cgetAction($id, Request $request)
     {
-        list($webspaceKey, $languageCode) = $this->getWebspaceAndLanguage($request);
-        $result = $this->getResourceLocatorRepository()->getHistory($id, $webspaceKey, $languageCode);
+        list($webspaceKey, $locale) = $this->getWebspaceAndLanguage($request);
+        $result = $this->getResourceLocatorRepository()->getHistory($id, $webspaceKey, $locale);
 
         return $this->handleView($this->view($result));
     }
@@ -78,10 +78,10 @@ class PageResourcelocatorController extends RestController implements ClassResou
      */
     public function cdeleteAction($id, Request $request)
     {
-        list($webspaceKey, $languageCode) = $this->getWebspaceAndLanguage($request);
+        list($webspaceKey, $locale) = $this->getWebspaceAndLanguage($request);
         $path = $this->getRequestParameter($request, 'ids', true); // TODO rename path to id in all function names
 
-        $this->getResourceLocatorRepository()->delete($path, $webspaceKey, $languageCode);
+        $this->getResourceLocatorRepository()->delete($path, $webspaceKey, $locale);
         $this->getDocumentManager()->flush();
 
         return $this->handleView($this->view());
@@ -92,14 +92,14 @@ class PageResourcelocatorController extends RestController implements ClassResou
      *
      * @param Request $request
      *
-     * @return array list($webspaceKey, $languageCode)
+     * @return array list($webspaceKey, $locale)
      */
     private function getWebspaceAndLanguage(Request $request)
     {
         $webspaceKey = $this->getRequestParameter($request, 'webspace', true);
-        $languageCode = $this->getRequestParameter($request, 'language', true);
+        $locale = $this->getRequestParameter($request, 'locale', true);
 
-        return [$webspaceKey, $languageCode];
+        return [$webspaceKey, $locale];
     }
 
     /**
@@ -123,6 +123,6 @@ class PageResourcelocatorController extends RestController implements ClassResou
      */
     public function getLocale(Request $request)
     {
-        return $this->getRequestParameter($request, 'language', true);
+        return $this->getRequestParameter($request, 'locale', true);
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
@@ -100,7 +100,7 @@ class ResourceLocatorRepository implements ResourceLocatorRepositoryInterface
 
             $result[] = [
                 'id' => $url->getId(),
-                'resourcelocator' => $url->getResourceLocator(),
+                'path' => $url->getResourceLocator(),
                 'created' => $url->getCreated(),
                 '_links' => [
                     'delete' => $this->getBasePath(null, 0) . $deleteParameter,

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -1386,12 +1386,12 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request(
             'GET',
-            '/api/pages/' . $uuid . '/resourcelocators?webspace=sulu_io&language=en'
+            '/api/pages/' . $uuid . '/resourcelocators?webspace=sulu_io&locale=en'
         );
         $response = json_decode($client->getResponse()->getContent(), true);
 
-        $this->assertEquals('/a2', $response['_embedded']['page_resourcelocators'][0]['resourcelocator']);
-        $this->assertEquals('/a1', $response['_embedded']['page_resourcelocators'][1]['resourcelocator']);
+        $this->assertEquals('/a2', $response['_embedded']['page_resourcelocators'][0]['path']);
+        $this->assertEquals('/a1', $response['_embedded']['page_resourcelocators'][1]['path']);
     }
 
     public function testMove()

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -112,15 +112,15 @@ class PageResourcelocatorControllerTest extends SuluTestCase
                 'PHP_AUTH_PW' => 'test',
             ]
         );
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data[0]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish', $data[0]);
         $data[0] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data[1]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish', $data[1]);
         $data[1] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish&parent=' . $data[1]['id'], $data[2]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parent=' . $data[1]['id'], $data[2]);
         $data[2] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish&parent=' . $data[1]['id'], $data[3]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parent=' . $data[1]['id'], $data[3]);
         $data[3] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish&parent=' . $data[3]['id'], $data[4]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parent=' . $data[3]['id'], $data[4]);
         $data[4] = (array) json_decode($client->getResponse()->getContent(), true);
 
         return $data;
@@ -130,7 +130,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
     {
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?webspace=sulu_io&language=en&template=default',
+            '/api/pages/resourcelocators/generates?webspace=sulu_io&locale=en&template=default',
             ['parts' => ['title' => 'test']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -139,7 +139,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?parent=' . $this->data[0]['id'] . '&webspace=sulu_io&language=en&template=default',
+            '/api/pages/resourcelocators/generates?parent=' . $this->data[0]['id'] . '&webspace=sulu_io&locale=en&template=default',
             ['parts' => ['title' => 'test']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -148,7 +148,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?parent=' . $this->data[1]['id'] . '&webspace=sulu_io&language=en&template=default',
+            '/api/pages/resourcelocators/generates?parent=' . $this->data[1]['id'] . '&webspace=sulu_io&locale=en&template=default',
             ['parts' => ['title' => 'test']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -157,7 +157,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?parent=' . $this->data[3]['id'] . '&webspace=sulu_io&language=en&template=default',
+            '/api/pages/resourcelocators/generates?parent=' . $this->data[3]['id'] . '&webspace=sulu_io&locale=en&template=default',
             ['parts' => ['title' => 'test']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -169,7 +169,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
     {
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?webspace=sulu_io&language=en&template=overview',
+            '/api/pages/resourcelocators/generates?webspace=sulu_io&locale=en&template=overview',
             ['parts' => ['title' => 'test1', 'subtitle' => 'test2']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -178,7 +178,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?webspace=sulu_io&language=en&template=overview',
+            '/api/pages/resourcelocators/generates?webspace=sulu_io&locale=en&template=overview',
             ['parts' => ['title' => 'test']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -187,7 +187,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/pages/resourcelocators/generates?webspace=sulu_io&language=en&template=overview',
+            '/api/pages/resourcelocators/generates?webspace=sulu_io&locale=en&template=overview',
             ['parts' => ['subtitle' => 'test']]
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -202,7 +202,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
         $newsData['url'] = '/test';
         $this->client->request(
             'PUT',
-            '/api/pages/' . $newsData['id'] . '?webspace=sulu_io&language=en&action=publish',
+            '/api/pages/' . $newsData['id'] . '?webspace=sulu_io&locale=en&action=publish',
             $newsData
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -210,14 +210,14 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'GET',
-            '/api/pages/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
+            '/api/pages/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&locale=en'
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $result = (array) json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertEquals(1, count($result['_embedded']['page_resourcelocators']));
         $this->assertEquals(1, $result['total']);
-        $this->assertEquals('/news', $result['_embedded']['page_resourcelocators'][0]['resourcelocator']);
+        $this->assertEquals('/news', $result['_embedded']['page_resourcelocators'][0]['path']);
     }
 
     public function testDelete()
@@ -227,7 +227,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
         $newsData['url'] = '/test';
         $this->client->request(
             'PUT',
-            '/api/nodes/' . $newsData['id'] . '?webspace=sulu_io&language=en&action=publish',
+            '/api/nodes/' . $newsData['id'] . '?webspace=sulu_io&locale=en&action=publish',
             $newsData
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -235,7 +235,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'GET',
-            '/api/pages/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
+            '/api/pages/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&locale=en'
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $history = (array) json_decode($this->client->getResponse()->getContent(), true);
@@ -243,7 +243,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
         $this->client->request(
             'DELETE',
             sprintf(
-                '/api/pages/%s/resourcelocators?ids=%s&webspace=sulu_io&language=en',
+                '/api/pages/%s/resourcelocators?ids=%s&webspace=sulu_io&locale=en',
                 $newsData['id'],
                 $history['_embedded']['page_resourcelocators'][0]['id']
             )
@@ -252,7 +252,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->client->request(
             'GET',
-            '/api/pages/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&language=en'
+            '/api/pages/' . $newsData['id'] . '/resourcelocators?webspace=sulu_io&locale=en'
         );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
         $result = (array) json_decode($this->client->getResponse()->getContent(), true);

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Repository/ResourceLocatorRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Repository/ResourceLocatorRepositoryTest.php
@@ -133,8 +133,8 @@ class ResourceLocatorRepositoryTest extends TestCase
         $result = $this->repository->getHistory($uuid, $webspace, $locale);
         $this->assertEquals(3, $result['total']);
         $this->assertEquals(3, count($result['_embedded']['page_resourcelocators']));
-        $this->assertEquals('/test1', $result['_embedded']['page_resourcelocators'][0]['resourcelocator']);
-        $this->assertEquals('/test3', $result['_embedded']['page_resourcelocators'][2]['resourcelocator']);
+        $this->assertEquals('/test1', $result['_embedded']['page_resourcelocators'][0]['path']);
+        $this->assertEquals('/test3', $result['_embedded']['page_resourcelocators'][2]['path']);
     }
 
     public function testDelete()

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
@@ -43,6 +43,7 @@ class Configuration implements ConfigurationInterface
                                 ->useAttributeAsKey('name')
                                 ->prototype('scalar')->end()
                             ->end()
+                            ->scalarNode('resource_key')->isRequired()->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
@@ -14,8 +14,8 @@ namespace Sulu\Bundle\RouteBundle\DependencyInjection;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
@@ -15,14 +15,33 @@ use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * Container extension for sulu-route-bundle.
  */
-class SuluRouteExtension extends Extension
+class SuluRouteExtension extends Extension implements PrependExtensionInterface
 {
     use PersistenceExtensionTrait;
+
+    public function prepend(ContainerBuilder $container)
+    {
+        if ($container->hasExtension('sulu_admin')) {
+            $container->prependExtensionConfig(
+                'sulu_admin',
+                [
+                    'resources' => [
+                        'routes' => [
+                            'routes' => [
+                                'list' => 'get_routes',
+                            ],
+                        ],
+                    ],
+                ]
+            );
+        }
+    }
 
     /**
      * {@inheritdoc}
@@ -32,6 +51,14 @@ class SuluRouteExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('sulu_route.mappings', $config['mappings']);
+        $container->setParameter(
+            'sulu_route.resource_key_mappings',
+            array_flip(
+                array_map(function($mapping) {
+                    return $mapping['resource_key'];
+                }, $config['mappings'])
+            )
+        );
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Sulu/Bundle/RouteBundle/Entity/BaseRoute.php
+++ b/src/Sulu/Bundle/RouteBundle/Entity/BaseRoute.php
@@ -27,8 +27,8 @@ use Sulu\Component\Persistence\Model\AuditableTrait;
  * @Relation(
  *     "delete",
  *     href = @HateoasRoute(
- *         "delete_route",
- *         parameters = { "id" = "expr(object.getId())" }
+ *         "delete_routes",
+ *         parameters = { "ids" = "expr(object.getId())" }
  *     )
  * )
  *

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -1,0 +1,12 @@
+// @flow
+import {fieldRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
+
+fieldRegistry.add(
+    'route',
+    ResourceLocator,
+    {
+        defaultMode: 'full',
+        historyResourceKey: 'routes',
+        options: {history: true},
+    }
+);

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "sulu-route-bundle",
+    "description": "Adds support for routes to Sulu",
+    "license": "MIT",
+    "repository": "https://github.com/sulu/sulu.git",
+    "devDependencies": {
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
+    },
+    "peerDependencies": {
+        "sulu-admin-bundle": "*"
+    }
+}

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/config.yml
@@ -23,3 +23,11 @@ security:
 twig:
     debug: "%kernel.debug%"
     strict_variables: "%kernel.debug%"
+
+sulu_route:
+    mappings:
+        AppBundle\Entity\Test:
+            resource_key: tests
+            generator: schema
+            options:
+                route_schema: "/{object.getTitle()}"

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/test_config.yml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/test_config.yml
@@ -1,6 +1,7 @@
 sulu_route:
     mappings:
         Sulu\Bundle\ArticleBundle\Document\ArticleDocument:
+            resource_key: articles
             generator: template
             options:
                 test: "/{object.getTitle()}"

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Controller/RouteControllerTest.php
@@ -18,6 +18,8 @@ class RouteControllerTest extends SuluTestCase
 {
     const TEST_ENTITY = 'AppBundle\\Entity\\Test';
 
+    const TEST_RESOURCE_KEY = 'tests';
+
     const TEST_ID = 1;
 
     const TEST_LOCALE = 'de';
@@ -38,8 +40,8 @@ class RouteControllerTest extends SuluTestCase
         $client->request(
             'GET',
             sprintf(
-                '/api/routes?entityClass=%s&entityId=%s&locale=%s',
-                self::TEST_ENTITY,
+                '/api/routes?resourceKey=%s&id=%s&locale=%s',
+                self::TEST_RESOURCE_KEY,
                 self::TEST_ID,
                 self::TEST_LOCALE
             )
@@ -53,6 +55,25 @@ class RouteControllerTest extends SuluTestCase
         $items = $result['_embedded']['routes'];
         $this->assertEquals($routes[0]->getId(), $items[0]['id']);
         $this->assertEquals($routes[0]->getPath(), $items[0]['path']);
+    }
+
+    public function testCGetActionNotExistingResourceKey()
+    {
+        $this->purgeDatabase();
+
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            sprintf(
+                '/api/routes?resourceKey=%s&id=%s&locale=%s',
+                'articles',
+                self::TEST_ID,
+                self::TEST_LOCALE
+            )
+        );
+
+        $result = json_decode($client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testCGetActionHistory()
@@ -70,8 +91,8 @@ class RouteControllerTest extends SuluTestCase
         $client->request(
             'GET',
             sprintf(
-                '/api/routes?history=true&entityClass=%s&entityId=%s&locale=%s',
-                self::TEST_ENTITY,
+                '/api/routes?history=true&resourceKey=%s&id=%s&locale=%s',
+                self::TEST_RESOURCE_KEY,
                 self::TEST_ID,
                 self::TEST_LOCALE
             )
@@ -109,14 +130,14 @@ class RouteControllerTest extends SuluTestCase
         ];
 
         $client = $this->createAuthenticatedClient();
-        $client->request('DELETE', '/api/routes/' . $targetRoute->getId());
+        $client->request('DELETE', '/api/routes?ids=' . $targetRoute->getId());
         $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client->request(
             'GET',
             sprintf(
-                '/api/routes?history=true&entityClass=%s&entityId=%s&locale=%s',
-                self::TEST_ENTITY,
+                '/api/routes?history=true&resourceKey=%s&id=%s&locale=%s',
+                self::TEST_RESOURCE_KEY,
                 self::TEST_ID,
                 self::TEST_LOCALE
             )
@@ -138,15 +159,15 @@ class RouteControllerTest extends SuluTestCase
         ];
 
         $client = $this->createAuthenticatedClient();
-        $client->request('DELETE', '/api/routes/' . $routes[0]->getId());
+        $client->request('DELETE', '/api/routes?ids=' . $routes[0]->getId());
         $this->assertHttpStatusCode(204, $client->getResponse());
 
         $client = $this->createAuthenticatedClient();
         $client->request(
             'GET',
             sprintf(
-                '/api/routes?history=true&entityClass=%s&entityId=%s&locale=%s',
-                self::TEST_ENTITY,
+                '/api/routes?history=true&resourceKey=%s&id=%s&locale=%s',
+                self::TEST_RESOURCE_KEY,
                 self::TEST_ID,
                 self::TEST_LOCALE
             )

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -37,6 +37,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             [
                 'mappings' => [
                     'Sulu\Bundle\ArticleBundle\Document\ArticleDocument' => [
+                        'resource_key' => 'articles',
                         'generator' => 'template',
                         'options' => [
                             'test' => '/{object.getTitle()}',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the `route` FieldType, which is very similar to the `resource_locator` field type. However, the `resource_locator` FieldType is only working for pages. Both make use of the abstract `ResourceLocator` FieldType, which had to be adapted in order to work for both cases.

#### Why?

Because the `route` FieldType is used in the SuluArticleBundle, which has been updated to Sulu 2.0 in sulu/SuluArticleBundle#377.