### PR TITLE
Remove deprecated highlight section and make default and homepage template differ

### DIFF
--- a/config/templates/pages/default.xml
+++ b/config/templates/pages/default.xml
@@ -15,30 +15,26 @@
     </meta>
 
     <properties>
-        <section name="highlight">
-            <properties>
-                <property name="title" type="text_line" mandatory="true">
-                    <meta>
-                        <title lang="en">Title</title>
-                        <title lang="de">Titel</title>
-                    </meta>
-                    <params>
-                        <param name="headline" value="true"/>
-                    </params>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
 
-                    <tag name="sulu.rlp.part"/>
-                </property>
+            <tag name="sulu.rlp.part"/>
+        </property>
 
-                <property name="url" type="resource_locator" mandatory="true">
-                    <meta>
-                        <title lang="en">Resourcelocator</title>
-                        <title lang="de">Adresse</title>
-                    </meta>
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
 
-                    <tag name="sulu.rlp"/>
-                </property>
-            </properties>
-        </section>
+            <tag name="sulu.rlp"/>
+        </property>
 
         <property name="article" type="text_editor">
             <meta>

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -15,35 +15,31 @@
     </meta>
 
     <properties>
-        <section name="highlight">
-            <properties>
-                <property name="title" type="text_line" mandatory="true">
-                    <meta>
-                        <title lang="en">Title</title>
-                        <title lang="de">Titel</title>
-                    </meta>
-                    <params>
-                        <param name="headline" value="true"/>
-                    </params>
-
-                    <tag name="sulu.rlp.part"/>
-                </property>
-
-                <property name="url" type="resource_locator" mandatory="true">
-                    <meta>
-                        <title lang="en">Resourcelocator</title>
-                        <title lang="de">Adresse</title>
-                    </meta>
-
-                    <tag name="sulu.rlp"/>
-                </property>
-            </properties>
-        </section>
-
-        <property name="article" type="text_editor">
+        <property name="title" type="text_line" mandatory="true">
             <meta>
-                <title lang="en">Article</title>
-                <title lang="de">Artikel</title>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="pages" type="smart_content">
+            <meta>
+                <title lang="en">Pages</title>
+                <title lang="de">Seiten</title>
             </meta>
         </property>
     </properties>

--- a/templates/templates/pages/default.html.twig
+++ b/templates/templates/pages/default.html.twig
@@ -1,9 +1,9 @@
 {% extends "base.html.twig" %}
 
 {% block content %}
-    <h1 property="title">{{ content.title }}</h1>
+    <h1>{{ content.title }}</h1>
 
-    <div property="article">
+    <div>
         {{ content.article|raw }}
     </div>
 {% endblock %}

--- a/templates/templates/pages/homepage.html.twig
+++ b/templates/templates/pages/homepage.html.twig
@@ -1,9 +1,13 @@
 {% extends "base.html.twig" %}
 
 {% block content %}
-    <h1 property="title">{{ content.title }}</h1>
+    <h1>{{ content.title }}</h1>
 
-    <div property="article">
-        {{ content.article|raw }}
-    </div>
+    <ul>
+        {% for page in content.pages  %}
+            <li>
+                <a href="{{sulu_content_path(page.url)}}">{{ page.title }}</a>
+            </li>
+        {% endfor %}
+    </ul>
 {% endblock %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the deprecated highlight section and makes the two templates provided in this repo differ a bit.

#### Why?

While trying to write some E2E tests I recognized that the highlight section is still in these template, and they break the design. Also, both template were exactly the same, which makes not a lot of sense, and doesn't allow to easily test if the correct template is shown.