### PR TITLE
Use router navigate to change locale in order to avoid ignoring dirty check

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js
@@ -30,7 +30,7 @@ jest.mock('../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
     this.id = resourceStore.id;
     this.resourceKey = resourceStore.resourceKey;
     this.data = resourceStore.data;
-    this.locale = resourceStore.locale;
+    this.locale = resourceStore.observableOptions.locale;
     this.loading = resourceStore.loading;
     this.validate = jest.fn().mockReturnValue(true);
     this.schema = {};
@@ -47,8 +47,7 @@ jest.mock('../../../stores/ResourceStore', () => jest.fn(function(resourceKey, i
     this.resourceKey = resourceKey;
     this.id = id;
     this.data = {};
-    this.locale = observableOptions.locale;
-    this.setLocale = jest.fn((locale) => this.locale.set(locale));
+    this.observableOptions = observableOptions;
     this.loading = false;
 }));
 
@@ -368,7 +367,11 @@ test('Should show a GhostDialog after the locale has been switched to a non-tran
 
     expect(form.find('GhostDialog').prop('open')).toEqual(false);
 
-    resourceStore.setLocale('de');
+    const {locale} = resourceStore.observableOptions;
+    if (!locale) {
+        throw new Error('The "locale" must be set!');
+    }
+    locale.set('de');
 
     form.update();
     expect(form.find('GhostDialog').prop('open')).toEqual(true);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -98,17 +98,6 @@ export default class ResourceStore {
         this.loading = loading;
     }
 
-    @action setLocale(locale: string) {
-        const {locale: observableLocale} = this.observableOptions;
-        if (!observableLocale) {
-            throw new Error(
-                '"setLocale" should not be called on a ResourceStore which got no locale passed in the constructor'
-            );
-        }
-
-        observableLocale.set(locale);
-    }
-
     @action save(options: Object = {}): Promise<*> {
         const {locale} = this.observableOptions;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -75,8 +75,7 @@ test('Should set nested values', () => {
 test('Should load the data with the ResourceRequester', () => {
     const promise = Promise.resolve({value: 'Value'});
     ResourceRequester.get.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', '3', {locale: observable.box()}, {test: 10});
-    resourceStore.setLocale('en');
+    const resourceStore = new ResourceStore('snippets', '3', {locale: observable.box('en')}, {test: 10});
     expect(ResourceRequester.get).toBeCalledWith('snippets', {id: '3', locale: 'en', test: 10});
     return promise.then(() => {
         expect(resourceStore.data).toEqual({value: 'Value'});
@@ -128,8 +127,7 @@ test('Should not load the data with the ResourceRequester if locale should be pr
 test('Should load the data with the ResourceRequester if a reload is requested', () => {
     const promise1 = Promise.resolve({value: 'Value'});
     ResourceRequester.get.mockReturnValue(promise1);
-    const resourceStore = new ResourceStore('snippets', '3', {locale: observable.box()}, {test: 10});
-    resourceStore.setLocale('en');
+    const resourceStore = new ResourceStore('snippets', '3', {locale: observable.box('en')}, {test: 10});
     expect(ResourceRequester.get).toBeCalledWith('snippets', {id: '3', locale: 'en', test: 10});
     return promise1.then(() => {
         expect(resourceStore.data).toEqual({value: 'Value'});
@@ -149,9 +147,8 @@ test('Should load the data with the ResourceRequester if a reload is requested',
 
 test('Loading flag should be set to true when loading', () => {
     ResourceRequester.get.mockReturnValue(Promise.resolve({}));
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.loading = false;
-    resourceStore.setLocale('en');
 
     resourceStore.load();
     expect(resourceStore.loading).toBe(true);
@@ -160,9 +157,8 @@ test('Loading flag should be set to true when loading', () => {
 test('Loading flag should be set to false when loading has finished', () => {
     const promise = Promise.resolve({});
     ResourceRequester.get.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     const oldData = resourceStore.data;
-    resourceStore.setLocale('en');
     resourceStore.loading = true;
 
     resourceStore.load();
@@ -174,9 +170,8 @@ test('Loading flag should be set to false when loading has finished', () => {
 
 test('Saving flag should be set to true when saving', () => {
     ResourceRequester.put.mockReturnValue(Promise.resolve({}));
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.saving = false;
-    resourceStore.setLocale('en');
 
     resourceStore.save();
     expect(resourceStore.saving).toBe(true);
@@ -185,8 +180,7 @@ test('Saving flag should be set to true when saving', () => {
 test('Saving flag should be set to false when saving has finished', () => {
     const promise = Promise.resolve({});
     ResourceRequester.put.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
-    resourceStore.setLocale('en');
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.saving = true;
 
     resourceStore.save();
@@ -285,10 +279,9 @@ test('Saving and dirty flag should be set to false when creating has failed', (d
 
 test('Deleting flag should be set to true when deleting', () => {
     ResourceRequester.delete.mockReturnValue(Promise.resolve({}));
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.data = {id: 1};
     resourceStore.deleting = false;
-    resourceStore.setLocale('en');
 
     resourceStore.delete();
     expect(resourceStore.saving).toBe(false);
@@ -298,10 +291,9 @@ test('Deleting flag should be set to true when deleting', () => {
 test('Deleting flag and id should be reset to false when deleting has finished', () => {
     const promise = Promise.resolve({});
     ResourceRequester.delete.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.data = {id: 1};
     const oldData = resourceStore.data;
-    resourceStore.setLocale('en');
     resourceStore.deleting = false;
 
     resourceStore.delete();
@@ -336,10 +328,9 @@ test('Calling the delete method with options should send a DELETE request', () =
 
 test('Moving flag should be set to true when moving', () => {
     ResourceRequester.post.mockReturnValue(Promise.resolve({}));
-    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', '1', {locale: observable.box('en')});
     resourceStore.data = {id: 1};
     resourceStore.moving = false;
-    resourceStore.setLocale('en');
 
     resourceStore.move(1);
     expect(resourceStore.saving).toBe(false);
@@ -349,10 +340,9 @@ test('Moving flag should be set to true when moving', () => {
 test('Moving flag and id should be reset to false when moving has finished', () => {
     const promise = Promise.resolve({});
     ResourceRequester.post.mockReturnValue(promise);
-    const resourceStore = new ResourceStore('snippets', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippets', 1, {locale: observable.box('en')});
     resourceStore.data = {id: 1};
     const oldData = resourceStore.data;
-    resourceStore.setLocale('en');
     resourceStore.moving = false;
 
     resourceStore.move(5);
@@ -380,8 +370,7 @@ test('Calling the move method should send a POST request', () => {
 
 test('Calling the move method should send a POST request with locale', () => {
     ResourceRequester.post.mockReturnValue(Promise.resolve({}));
-    const resourceStore = new ResourceStore('snippets', 3, {locale: observable.box()});
-    resourceStore.setLocale('de');
+    const resourceStore = new ResourceStore('snippets', 3, {locale: observable.box('de')});
     resourceStore.data = {id: 3, title: 'Title'};
 
     resourceStore.move(9);
@@ -530,11 +519,6 @@ test('Copying the content from different locale should fail if no id is given', 
 test('Copying the content from different locale should fail if no locale is given', () => {
     const resourceStore = new ResourceStore('pages', 4);
     expect(() => resourceStore.copyFromLocale('de')).toThrow(/with locales/);
-});
-
-test('Calling setLocale on a non-localizable ResourceStore should throw an exception', () => {
-    const resourceStore = new ResourceStore('snippets', '1', {});
-    expect(() => resourceStore.setLocale('de')).toThrow();
 });
 
 test('Cloning should return a new instance of the ResourceStore with same data', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -310,6 +310,7 @@ class Form extends React.Component<Props> {
         this.postponedUpdateRouteMethod = undefined;
         this.postponedRoute = undefined;
         this.postponedRouteAttributes = undefined;
+        this.showDirtyWarning = false;
     };
 
     @action handleHasChangedWarningCancelClick = () => {
@@ -413,7 +414,7 @@ export default withToolbar(Form, function() {
         ? {
             value: resourceStore.locale.get(),
             onChange: (locale) => {
-                resourceStore.setLocale(locale);
+                router.navigate(router.route.name, {...router.attributes, locale});
             },
             options: this.locales.map((locale) => ({
                 value: locale,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -314,7 +314,7 @@ test('Should not add PublishIndicator if no publish status is available', () => 
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
 
     const route = {
         options: {
@@ -331,7 +331,6 @@ test('Should not add PublishIndicator if no publish status is available', () => 
         attributes: {},
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
 
@@ -343,7 +342,7 @@ test('Should add PublishIndicator if publish status is available showing draft',
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
     resourceStore.data = {
         publishedState: false,
         published: false,
@@ -364,7 +363,6 @@ test('Should add PublishIndicator if publish status is available showing draft',
         attributes: {},
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
 
@@ -382,7 +380,7 @@ test('Should add PublishIndicator if publish status is available showing publish
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
     resourceStore.data = {
         publishedState: true,
         published: '2018-07-05',
@@ -403,7 +401,6 @@ test('Should add PublishIndicator if publish status is available showing publish
         attributes: {},
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
 
@@ -421,7 +418,7 @@ test('Should add PublishIndicator if publish status is available showing publish
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
     resourceStore.data = {
         publishedState: false,
         published: '2018-07-05',
@@ -442,7 +439,6 @@ test('Should add PublishIndicator if publish status is available showing publish
         attributes: {},
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
 
@@ -502,7 +498,7 @@ test('Should navigate to defined route on back button click', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
 
     const route = {
         options: {
@@ -520,7 +516,6 @@ test('Should navigate to defined route on back button click', () => {
         attributes: {},
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
     toolbarConfig.backButton.onClick();
@@ -532,7 +527,7 @@ test('Should navigate to defined route on back button click with routerAttribues
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
 
     const route = {
         options: {
@@ -553,7 +548,6 @@ test('Should navigate to defined route on back button click with routerAttribues
         route,
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
     toolbarConfig.backButton.onClick();
@@ -565,7 +559,7 @@ test('Should navigate to defined route on back button click with mixed routerAtt
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, Form);
-    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
 
     const route = {
         options: {
@@ -587,7 +581,6 @@ test('Should navigate to defined route on back button click with mixed routerAtt
         route,
     };
     const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(form.instance());
     toolbarConfig.backButton.onClick();
@@ -798,7 +791,7 @@ test('Should not render back button when no editLink is configured', () => {
     expect(toolbarConfig.backButton).toBe(undefined);
 });
 
-test('Should change locale in form store via locale chooser', () => {
+test('Should change locale by route navigation via locale chooser', () => {
     const withToolbar = require('../../../containers/Toolbar/withToolbar');
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;
@@ -806,6 +799,7 @@ test('Should change locale in form store via locale chooser', () => {
     const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box()});
 
     const route = {
+        name: 'sulu_admin.form',
         options: {
             backRoute: 'test_route',
             formKey: 'snippets',
@@ -825,7 +819,7 @@ test('Should change locale in form store via locale chooser', () => {
 
     const toolbarConfig = toolbarFunction.call(form.instance());
     toolbarConfig.locale.onChange('en');
-    expect(resourceStore.locale.get()).toBe('en');
+    expect(router.navigate).toBeCalledWith('sulu_admin.form', {locale: 'en'});
 });
 
 test('Should show locales from router options in toolbar', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -1,5 +1,6 @@
 // @flow
 import {shallow} from 'enzyme';
+import {observable} from 'mobx';
 import DeleteToolbarAction from '../../toolbarActions/DeleteToolbarAction';
 import {ResourceFormStore} from '../../../../containers/Form';
 import ResourceStore from '../../../../stores/ResourceStore';
@@ -10,15 +11,9 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id) {
+jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, observableOptions) {
     this.id = id;
-    this.locale = {
-        get: jest.fn(),
-    };
-
-    this.setLocale = jest.fn((locale) => {
-        this.locale.get.mockReturnValue(locale);
-    });
+    this.observableOptions = observableOptions;
 }));
 
 jest.mock('../../../../containers/Form', () => ({
@@ -33,7 +28,7 @@ jest.mock('../../../../containers/Form', () => ({
         }
 
         get locale() {
-            return this.resourceStore.locale;
+            return this.resourceStore.observableOptions.locale;
         }
 
         delete = jest.fn();
@@ -52,7 +47,7 @@ jest.mock('../../../../views/Form', () => jest.fn(function() {
 }));
 
 function createDeleteToolbarAction() {
-    const resourceStore = new ResourceStore('test');
+    const resourceStore = new ResourceStore('test', undefined, {locale: observable.box('en')});
     const resourceFormStore = new ResourceFormStore(resourceStore, 'test');
     const router = new Router({});
     const form = new Form({
@@ -129,7 +124,6 @@ test('Close dialog on cancel click', () => {
 test('Call delete when dialog is confirmed', () => {
     const deleteToolbarAction = createDeleteToolbarAction();
     deleteToolbarAction.resourceFormStore.resourceStore.id = 3;
-    deleteToolbarAction.resourceFormStore.resourceStore.setLocale('en');
     deleteToolbarAction.router.route.options.backRoute = 'sulu_test.list';
 
     const deletePromise = Promise.resolve();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/MediaDetails.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/MediaDetails.js
@@ -190,7 +190,7 @@ export default withToolbar(MediaDetails, function() {
         ? {
             value: resourceStore.locale.get(),
             onChange: (locale) => {
-                resourceStore.setLocale(locale);
+                router.navigate(router.route.name, {...router.attributes, locale});
             },
             options: locales.map((locale) => ({
                 value: locale,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/MediaDetails.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaDetails/tests/MediaDetails.test.js
@@ -83,17 +83,18 @@ test('Render a loading MediaDetails view', () => {
     )).toMatchSnapshot();
 });
 
-test('Should change locale via locale chooser', () => {
+test('Should change locale by navigating to different route via locale chooser', () => {
     const MediaDetails = require('../MediaDetails').default;
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaDetails);
-    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box('de')});
 
     const router = {
         navigate: jest.fn(),
         bind: jest.fn(),
         route: {
+            name: 'sulu_media.details',
             options: {
                 backRoute: 'test_route',
                 locales: [],
@@ -101,11 +102,10 @@ test('Should change locale via locale chooser', () => {
         },
     };
     const mediaDetails = mount(<MediaDetails resourceStore={resourceStore} router={router} />).get(0);
-    resourceStore.locale.set('de');
 
     const toolbarConfig = toolbarFunction.call(mediaDetails);
     toolbarConfig.locale.onChange('en');
-    expect(resourceStore.locale.get()).toBe('en');
+    expect(router.navigate).toBeCalledWith('sulu_media.details', {locale: 'en'});
 });
 
 test('Should navigate to defined route on back button click', () => {
@@ -113,7 +113,7 @@ test('Should navigate to defined route on back button click', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const ResourceStore = require('sulu-admin-bundle/stores').ResourceStore;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaDetails);
-    const resourceStore = new ResourceStore('media', '1', {locale: observable.box()});
+    const resourceStore = new ResourceStore('media', '1', {locale: observable.box('de')});
 
     const router = {
         restore: jest.fn(),
@@ -126,7 +126,6 @@ test('Should navigate to defined route on back button click', () => {
         attributes: {},
     };
     const mediaDetails = mount(<MediaDetails resourceStore={resourceStore} router={router} />).get(0);
-    resourceStore.setLocale('de');
 
     const toolbarConfig = toolbarFunction.call(mediaDetails);
     toolbarConfig.backButton.onClick();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/MediaFormats.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/MediaFormats.js
@@ -118,7 +118,7 @@ export default withToolbar(MediaFormats, function() {
         ? {
             value: resourceStore.locale.get(),
             onChange: (locale) => {
-                resourceStore.setLocale(locale);
+                router.navigate(router.route.name, {...router.attributes, locale});
             },
             options: locales.map((locale) => ({
                 value: locale,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js
@@ -18,7 +18,6 @@ jest.mock('sulu-admin-bundle/stores', () => ({
         this.data = {
             thumbnails: {},
         };
-        this.setLocale = jest.fn();
     }),
 }));
 
@@ -215,7 +214,9 @@ test('Should change locale via locale chooser', () => {
 
     const router = {
         bind: jest.fn(),
+        navigate: jest.fn(),
         route: {
+            name: 'sulu_media.media_formats',
             options: {
                 locales: [],
             },
@@ -226,7 +227,7 @@ test('Should change locale via locale chooser', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaFormats);
     toolbarConfig.locale.onChange('en');
-    expect(resourceStore.setLocale).toBeCalledWith('en');
+    expect(router.navigate).toBeCalledWith('sulu_media.media_formats', {locale: 'en'});
 });
 
 test('Should show locales from router options in toolbar', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/MediaHistory.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/MediaHistory.js
@@ -91,7 +91,7 @@ export default withToolbar(MediaHistory, function() {
         ? {
             value: resourceStore.locale.get(),
             onChange: (locale) => {
-                resourceStore.setLocale(locale);
+                router.navigate(router.route.name, {...router.attributes, locale});
             },
             options: locales.map((locale) => ({
                 value: locale,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js
@@ -14,7 +14,6 @@ jest.mock('sulu-admin-bundle/stores', () => ({
         this.data = {
             versions: {},
         };
-        this.setLocale = jest.fn();
     }),
 }));
 
@@ -122,6 +121,7 @@ test('Should change locale via locale chooser', () => {
         navigate: jest.fn(),
         bind: jest.fn(),
         route: {
+            name: 'sulu_media.media_history',
             options: {
                 locales: [],
             },
@@ -132,7 +132,7 @@ test('Should change locale via locale chooser', () => {
 
     const toolbarConfig = toolbarFunction.call(mediaHistory);
     toolbarConfig.locale.onChange('en');
-    expect(resourceStore.setLocale).toBeCalledWith('en');
+    expect(router.navigate).toBeCalledWith('sulu_media.media_history', {locale: 'en'});
 });
 
 test('Should show locales from router options in toolbar', () => {

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -41,7 +41,6 @@ class AdminControllerTest extends SuluTestCase
 
         $this->assertObjectHasAttribute('id', $response);
         $this->assertObjectHasAttribute('title', $response);
-        $this->assertObjectHasAttribute('order', $response);
         $this->assertObjectHasAttribute('published', $response);
 
         $this->assertEquals('ID', $response->id->label);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses `router.navigate` instead of `resourceStore.setLocale`.

#### Why?

Because this way the dirty check is working correctly. Previously the dirty check was triggered but still the locale change was immediately done. That meant that the navigation could not be canceled.

#### BC Breaks/Deprecations

Removed the `setLocale` resource store method, since this was the only use case for it.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [ ] Also remove `MediaDetails` in order to make it working in media as well? (And make it easier to add the delete button) (Would also to extract left column in own field type and require an `onSuccess` callback on `FieldTypeProps` in order to allow to set the success icon after changing the crop)