### PR TITLE
Replace divs with proper tables in Permission components

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Item.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
-import matrixStyles from './matrix.scss';
+import itemStyles from './item.scss';
 
 type Props = {|
     disabled: boolean,
@@ -42,10 +42,10 @@ export default class Item extends React.PureComponent<Props> {
             value,
         } = this.props;
         const itemClass = classNames(
-            matrixStyles.item,
+            itemStyles.item,
             {
-                [matrixStyles.selected]: value,
-                [matrixStyles.disabled]: disabled,
+                [itemStyles.selected]: value,
+                [itemStyles.disabled]: disabled,
             }
         );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
@@ -64,9 +64,11 @@ export default class Matrix extends React.PureComponent<Props> {
         );
 
         return (
-            <div className={matrixClass}>
-                {this.cloneRows(children)}
-            </div>
+            <table className={matrixClass}>
+                <tbody>
+                    {this.cloneRows(children)}
+                </tbody>
+            </table>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
@@ -5,7 +5,7 @@ import {computed} from 'mobx';
 import type {ChildrenArray, Element} from 'react';
 import {translate} from '../../utils/index';
 import Item from './Item';
-import matrixStyles from './matrix.scss';
+import rowStyles from './row.scss';
 import type {MatrixRowValue} from './types';
 
 type Props = {|
@@ -87,7 +87,7 @@ class Row extends React.Component<Props> {
 
     renderAllButton() {
         return (
-            <button className={matrixStyles.rowButton} onClick={this.handleAllButtonClick}>
+            <button className={rowStyles.rowButton} onClick={this.handleAllButtonClick}>
                 {translate(this.allItemsDeactivated ? 'sulu_admin.activate_all' : 'sulu_admin.deactivate_all')}
             </button>
         );
@@ -102,7 +102,7 @@ class Row extends React.Component<Props> {
         } = this.props;
 
         return (
-            <div className={matrixStyles.row}>
+            <div className={rowStyles.row}>
                 <div>{title ? title : name}</div>
                 <div>
                     {this.cloneItems(children)}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Row.js
@@ -102,13 +102,13 @@ class Row extends React.Component<Props> {
         } = this.props;
 
         return (
-            <div className={rowStyles.row}>
-                <div>{title ? title : name}</div>
-                <div>
+            <tr className={rowStyles.row}>
+                <td className={rowStyles.name}>{title ? title : name}</td>
+                <td className={rowStyles.items}>
                     {this.cloneItems(children)}
                     {!disabled && this.renderAllButton()}
-                </div>
-            </div>
+                </td>
+            </tr>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/item.scss
@@ -1,0 +1,43 @@
+@import '../../containers/Application/colors.scss';
+
+$itemColor: $shakespeare;
+$itemBorderColor: $shakespeare;
+
+$itemBackgroundColorSelected: $shakespeare;
+$itemColorSelected: $white;
+
+$itemColorDisabled: $silver;
+$itemBorderColorDisabled: $silver;
+$itemColorDisabledSelected: $white;
+$itemBackgroundColorDisabledSelected: $silver;
+
+.item {
+    align-items: center;
+    border-radius: 6px;
+    border: 1px solid $itemBorderColor;
+    color: $itemColor;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 16px;
+    justify-content: center;
+    margin-right: 5px;
+    text-align: center;
+    height: 26px;
+    width: 26px;
+
+    &.selected {
+        background-color: $itemBackgroundColorSelected;
+        color: $itemColorSelected;
+    }
+
+    &.disabled {
+        cursor: default;
+        color: $itemColorDisabled;
+        border-color: $itemBorderColorDisabled;
+    }
+
+    &.selected.disabled {
+        background-color: $itemBackgroundColorDisabledSelected;
+        color: $itemColorDisabledSelected;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
@@ -1,95 +1,13 @@
 @import '../../containers/Application/colors.scss';
 
-$fontColor: $blueZodiac;
-
-$itemColor: $shakespeare;
-$itemBorderColor: $shakespeare;
-
-$itemBackgroundColorSelected: $shakespeare;
-$itemColorSelected: $white;
-
-$itemColorDisabled: $silver;
-$itemBorderColorDisabled: $silver;
-$itemColorDisabledSelected: $white;
-$itemBackgroundColorDisabledSelected: $silver;
+$matrixBackgroundColor: $white;
 
 .matrix {
-    background: $white;
+    background-color: $matrixBackgroundColor;
     border-radius: 3px;
     margin-top: 10px;
 
     &.disabled {
         opacity: .5;
-    }
-}
-
-.row {
-    border-bottom: 1px solid $mercury;
-    color: $fontColor;
-    padding: 8px 20px;
-
-    > div:first-child {
-        font-size: 12px;
-        line-height: 22px;
-        display: inline-block;
-        width: 50%;
-    }
-
-    > div:last-child {
-        display: inline-block;
-        width: 50%;
-    }
-
-    &:last-child {
-        border-bottom: none;
-    }
-
-    &:hover {
-        .row-button {
-            display: inline-block;
-        }
-    }
-}
-
-.row-button {
-    background: none;
-    border: none;
-    color: inherit;
-    cursor: pointer;
-    font-family: inherit;
-    font-size: 12px;
-    line-height: 22px;
-    margin: 0 7px;
-    display: none;
-}
-
-.item {
-    align-items: center;
-    border-radius: 6px;
-    border: 1px solid $itemBorderColor;
-    color: $itemColor;
-    cursor: pointer;
-    display: inline-flex;
-    font-size: 16px;
-    justify-content: center;
-    margin-right: 5px;
-    text-align: center;
-    height: 26px;
-    width: 26px;
-
-    &.selected {
-        background-color: $itemBackgroundColorSelected;
-        color: $itemColorSelected;
-    }
-
-    &.disabled {
-        cursor: default;
-        color: $itemColorDisabled;
-        border-color: $itemBorderColorDisabled;
-    }
-
-    &.selected.disabled {
-        background-color: $itemBackgroundColorDisabledSelected;
-        color: $itemColorDisabledSelected;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/matrix.scss
@@ -5,7 +5,8 @@ $matrixBackgroundColor: $white;
 .matrix {
     background-color: $matrixBackgroundColor;
     border-radius: 3px;
-    margin-top: 10px;
+    border-spacing: 0;
+    width: 100%;
 
     &.disabled {
         opacity: .5;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/row.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/row.scss
@@ -4,24 +4,25 @@ $rowFontColor: $blueZodiac;
 $rowBorderColor: $mercury;
 
 .row {
-    border-bottom: 1px solid $rowBorderColor;
     color: $rowFontColor;
-    padding: 8px 20px;
 
-    > div:first-child {
-        font-size: 12px;
-        line-height: 22px;
-        display: inline-block;
+    .name,
+    .items {
+        border-bottom: 1px solid $rowBorderColor;
         width: 50%;
+        padding: 8px 20px;
     }
 
-    > div:last-child {
-        display: inline-block;
-        width: 50%;
+    .name {
+        font-size: 12px;
+        line-height: 22px;
     }
 
     &:last-child {
-        border-bottom: none;
+        .name,
+        .items {
+            border-bottom: none;
+        }
     }
 
     &:hover {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/row.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/row.scss
@@ -1,0 +1,44 @@
+@import '../../containers/Application/colors.scss';
+
+$rowFontColor: $blueZodiac;
+$rowBorderColor: $mercury;
+
+.row {
+    border-bottom: 1px solid $rowBorderColor;
+    color: $rowFontColor;
+    padding: 8px 20px;
+
+    > div:first-child {
+        font-size: 12px;
+        line-height: 22px;
+        display: inline-block;
+        width: 50%;
+    }
+
+    > div:last-child {
+        display: inline-block;
+        width: 50%;
+    }
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    &:hover {
+        .row-button {
+            display: inline-block;
+        }
+    }
+}
+
+.row-button {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 22px;
+    margin: 0 7px;
+    display: none;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/tests/__snapshots__/Matrix.test.js.snap
@@ -1,295 +1,337 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render the Matrix component 1`] = `
-<div
+<table
   class="matrix"
 >
-  <div
-    class="row"
-  >
-    <div>
-      articles
-    </div>
-    <div>
-      <div
-        class="item"
-        title="View"
+  <tbody>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <div
-        class="item"
-        title="Edit"
+        articles
+      </td>
+      <td
+        class="items"
       >
-        <span
-          aria-label="su-plus"
-          class="su-plus"
-        />
-      </div>
-      <div
-        class="item"
-        title="Delete"
+        <div
+          class="item"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item"
+          title="Edit"
+        >
+          <span
+            aria-label="su-plus"
+            class="su-plus"
+          />
+        </div>
+        <div
+          class="item"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          Activate all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-trash-alt"
-          class="su-trash-alt"
-        />
-      </div>
-      <button
-        class="rowButton"
+        redirects
+      </td>
+      <td
+        class="items"
       >
-        Activate all
-      </button>
-    </div>
-  </div>
-  <div
-    class="row"
-  >
-    <div>
-      redirects
-    </div>
-    <div>
-      <div
-        class="item"
-        title="View"
+        <div
+          class="item"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          Activate all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <button
-        class="rowButton"
+        settings
+      </td>
+      <td
+        class="items"
       >
-        Activate all
-      </button>
-    </div>
-  </div>
-  <div
-    class="row"
-  >
-    <div>
-      settings
-    </div>
-    <div>
-      <div
-        class="item"
-        title="View"
-      >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <div
-        class="item"
-        title="Edit"
-      >
-        <span
-          aria-label="su-plus"
-          class="su-plus"
-        />
-      </div>
-      <button
-        class="rowButton"
-      >
-        Activate all
-      </button>
-    </div>
-  </div>
-</div>
+        <div
+          class="item"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item"
+          title="Edit"
+        >
+          <span
+            aria-label="su-plus"
+            class="su-plus"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          Activate all
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`Render the Matrix component with values 1`] = `
-<div
+<table
   class="matrix"
 >
-  <div
-    class="row"
-  >
-    <div>
-      articles
-    </div>
-    <div>
-      <div
-        class="item selected"
-        title="View"
+  <tbody>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <div
-        class="item selected"
-        title="Edit"
+        articles
+      </td>
+      <td
+        class="items"
       >
-        <span
-          aria-label="su-plus"
-          class="su-plus"
-        />
-      </div>
-      <div
-        class="item"
-        title="Delete"
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Edit"
+        >
+          <span
+            aria-label="su-plus"
+            class="su-plus"
+          />
+        </div>
+        <div
+          class="item"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          Deactivate all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-trash-alt"
-          class="su-trash-alt"
-        />
-      </div>
-      <button
-        class="rowButton"
+        redirects
+      </td>
+      <td
+        class="items"
       >
-        Deactivate all
-      </button>
-    </div>
-  </div>
-  <div
-    class="row"
-  >
-    <div>
-      redirects
-    </div>
-    <div>
-      <div
-        class="item selected"
-        title="View"
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          Deactivate all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <button
-        class="rowButton"
+        settings
+      </td>
+      <td
+        class="items"
       >
-        Deactivate all
-      </button>
-    </div>
-  </div>
-  <div
-    class="row"
-  >
-    <div>
-      settings
-    </div>
-    <div>
-      <div
-        class="item selected"
-        title="View"
-      >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <div
-        class="item"
-        title="Edit"
-      >
-        <span
-          aria-label="su-plus"
-          class="su-plus"
-        />
-      </div>
-      <button
-        class="rowButton"
-      >
-        Deactivate all
-      </button>
-    </div>
-  </div>
-</div>
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item"
+          title="Edit"
+        >
+          <span
+            aria-label="su-plus"
+            class="su-plus"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          Deactivate all
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`Render the Matrix component with values in disabled state 1`] = `
-<div
+<table
   class="matrix disabled"
 >
-  <div
-    class="row"
-  >
-    <div>
-      articles
-    </div>
-    <div>
-      <div
-        class="item selected disabled"
-        title="View"
+  <tbody>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <div
-        class="item selected disabled"
-        title="Edit"
+        articles
+      </td>
+      <td
+        class="items"
       >
-        <span
-          aria-label="su-plus"
-          class="su-plus"
-        />
-      </div>
-      <div
-        class="item disabled"
-        title="Delete"
+        <div
+          class="item selected disabled"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected disabled"
+          title="Edit"
+        >
+          <span
+            aria-label="su-plus"
+            class="su-plus"
+          />
+        </div>
+        <div
+          class="item disabled"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-trash-alt"
-          class="su-trash-alt"
-        />
-      </div>
-    </div>
-  </div>
-  <div
-    class="row"
-  >
-    <div>
-      redirects
-    </div>
-    <div>
-      <div
-        class="item selected disabled"
-        title="View"
+        redirects
+      </td>
+      <td
+        class="items"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-    </div>
-  </div>
-  <div
-    class="row"
-  >
-    <div>
-      settings
-    </div>
-    <div>
-      <div
-        class="item selected disabled"
-        title="View"
+        <div
+          class="item selected disabled"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
       >
-        <span
-          aria-label="su-pen"
-          class="su-pen"
-        />
-      </div>
-      <div
-        class="item disabled"
-        title="Edit"
+        settings
+      </td>
+      <td
+        class="items"
       >
-        <span
-          aria-label="su-plus"
-          class="su-plus"
-        />
-      </div>
-    </div>
-  </div>
-</div>
+        <div
+          class="item selected disabled"
+          title="View"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item disabled"
+          title="Edit"
+        >
+          <span
+            aria-label="su-plus"
+            class="su-plus"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/PermissionMatrix.test.js.snap
@@ -4,100 +4,110 @@ exports[`Render in disabled state 1`] = `
 <div
   class="matrixContainer"
 >
-  <div
+  <table
     class="matrix disabled"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.edit"
+          <div
+            class="item selected disabled"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -105,110 +115,120 @@ exports[`Render with minimal 1`] = `
 <div
   class="matrixContainer"
 >
-  <div
+  <table
     class="matrix"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -219,110 +239,120 @@ exports[`Render with subTitle 1`] = `
   <h3>
     Contact
   </h3>
-  <div
+  <table
     class="matrix"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -333,109 +363,119 @@ exports[`Render with title 1`] = `
   <h2>
     Contact
   </h2>
-  <div
+  <table
     class="matrix"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/__snapshots__/Permissions.test.js.snap
@@ -7,100 +7,110 @@ exports[`Render in disabled state 1`] = `
   <h2>
     Contacts
   </h2>
-  <div
+  <table
     class="matrix disabled"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.edit"
+          <div
+            class="item selected disabled"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected disabled"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected disabled"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -168,110 +178,120 @@ exports[`Render with empty webspace section 4`] = `
   <h2>
     Contacts
   </h2>
-  <div
+  <table
     class="matrix"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -282,110 +302,120 @@ exports[`Render with minimal 1`] = `
   <h2>
     Contacts
   </h2>
-  <div
+  <table
     class="matrix"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -450,178 +480,192 @@ exports[`Render with webspace section 3`] = `
     <h3>
       example
     </h3>
-    <div
+    <table
       class="matrix"
     >
-      <div
-        class="row"
-      >
-        <div>
-          example
-        </div>
-        <div>
-          <div
-            class="item selected"
-            title="sulu_security.view"
+      <tbody>
+        <tr
+          class="row"
+        >
+          <td
+            class="name"
           >
-            <span
-              aria-label="su-eye"
-              class="su-eye"
-            />
-          </div>
-          <div
-            class="item selected"
-            title="sulu_security.add"
+            example
+          </td>
+          <td
+            class="items"
           >
-            <span
-              aria-label="su-plus-circle"
-              class="su-plus-circle"
-            />
-          </div>
-          <div
-            class="item selected"
-            title="sulu_security.edit"
+            <div
+              class="item selected"
+              title="sulu_security.view"
+            >
+              <span
+                aria-label="su-eye"
+                class="su-eye"
+              />
+            </div>
+            <div
+              class="item selected"
+              title="sulu_security.add"
+            >
+              <span
+                aria-label="su-plus-circle"
+                class="su-plus-circle"
+              />
+            </div>
+            <div
+              class="item selected"
+              title="sulu_security.edit"
+            >
+              <span
+                aria-label="su-pen"
+                class="su-pen"
+              />
+            </div>
+            <div
+              class="item selected"
+              title="sulu_security.delete"
+            >
+              <span
+                aria-label="su-trash-alt"
+                class="su-trash-alt"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.live"
+            >
+              <span
+                aria-label="fa-signal"
+                class="fa fa-signal"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.security"
+            >
+              <span
+                aria-label="su-lock"
+                class="su-lock"
+              />
+            </div>
+            <button
+              class="rowButton"
+            >
+              sulu_admin.deactivate_all
+            </button>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="name"
           >
-            <span
-              aria-label="su-pen"
-              class="su-pen"
-            />
-          </div>
-          <div
-            class="item selected"
-            title="sulu_security.delete"
+            example.analytics
+          </td>
+          <td
+            class="items"
           >
-            <span
-              aria-label="su-trash-alt"
-              class="su-trash-alt"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.live"
+            <div
+              class="item"
+              title="sulu_security.view"
+            >
+              <span
+                aria-label="su-eye"
+                class="su-eye"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.add"
+            >
+              <span
+                aria-label="su-plus-circle"
+                class="su-plus-circle"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.edit"
+            >
+              <span
+                aria-label="su-pen"
+                class="su-pen"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.delete"
+            >
+              <span
+                aria-label="su-trash-alt"
+                class="su-trash-alt"
+              />
+            </div>
+            <button
+              class="rowButton"
+            >
+              sulu_admin.activate_all
+            </button>
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="name"
           >
-            <span
-              aria-label="fa-signal"
-              class="fa fa-signal"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.security"
+            example.default-snippets
+          </td>
+          <td
+            class="items"
           >
-            <span
-              aria-label="su-lock"
-              class="su-lock"
-            />
-          </div>
-          <button
-            class="rowButton"
-          >
-            sulu_admin.deactivate_all
-          </button>
-        </div>
-      </div>
-      <div
-        class="row"
-      >
-        <div>
-          example.analytics
-        </div>
-        <div>
-          <div
-            class="item"
-            title="sulu_security.view"
-          >
-            <span
-              aria-label="su-eye"
-              class="su-eye"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.add"
-          >
-            <span
-              aria-label="su-plus-circle"
-              class="su-plus-circle"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.edit"
-          >
-            <span
-              aria-label="su-pen"
-              class="su-pen"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.delete"
-          >
-            <span
-              aria-label="su-trash-alt"
-              class="su-trash-alt"
-            />
-          </div>
-          <button
-            class="rowButton"
-          >
-            sulu_admin.activate_all
-          </button>
-        </div>
-      </div>
-      <div
-        class="row"
-      >
-        <div>
-          example.default-snippets
-        </div>
-        <div>
-          <div
-            class="item"
-            title="sulu_security.view"
-          >
-            <span
-              aria-label="su-eye"
-              class="su-eye"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.add"
-          >
-            <span
-              aria-label="su-plus-circle"
-              class="su-plus-circle"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.edit"
-          >
-            <span
-              aria-label="su-pen"
-              class="su-pen"
-            />
-          </div>
-          <div
-            class="item"
-            title="sulu_security.delete"
-          >
-            <span
-              aria-label="su-trash-alt"
-              class="su-trash-alt"
-            />
-          </div>
-          <button
-            class="rowButton"
-          >
-            sulu_admin.activate_all
-          </button>
-        </div>
-      </div>
-    </div>
+            <div
+              class="item"
+              title="sulu_security.view"
+            >
+              <span
+                aria-label="su-eye"
+                class="su-eye"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.add"
+            >
+              <span
+                aria-label="su-plus-circle"
+                class="su-plus-circle"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.edit"
+            >
+              <span
+                aria-label="su-pen"
+                class="su-pen"
+              />
+            </div>
+            <div
+              class="item"
+              title="sulu_security.delete"
+            >
+              <span
+                aria-label="su-trash-alt"
+                class="su-trash-alt"
+              />
+            </div>
+            <button
+              class="rowButton"
+            >
+              sulu_admin.activate_all
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -633,109 +677,119 @@ exports[`Render with webspace section 4`] = `
   <h2>
     Contacts
   </h2>
-  <div
+  <table
     class="matrix"
   >
-    <div
-      class="row"
-    >
-      <div>
-        people
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
+    <tbody>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
+          people
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+      <tr
+        class="row"
+      >
+        <td
+          class="name"
         >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
+          organizations
+        </td>
+        <td
+          class="items"
         >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-    <div
-      class="row"
-    >
-      <div>
-        organizations
-      </div>
-      <div>
-        <div
-          class="item selected"
-          title="sulu_security.view"
-        >
-          <span
-            aria-label="su-eye"
-            class="su-eye"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.add"
-        >
-          <span
-            aria-label="su-plus-circle"
-            class="su-plus-circle"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.edit"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen"
-          />
-        </div>
-        <div
-          class="item selected"
-          title="sulu_security.delete"
-        >
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt"
-          />
-        </div>
-        <button
-          class="rowButton"
-        >
-          sulu_admin.deactivate_all
-        </button>
-      </div>
-    </div>
-  </div>
+          <div
+            class="item selected"
+            title="sulu_security.view"
+          >
+            <span
+              aria-label="su-eye"
+              class="su-eye"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.add"
+          >
+            <span
+              aria-label="su-plus-circle"
+              class="su-plus-circle"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.edit"
+          >
+            <span
+              aria-label="su-pen"
+              class="su-pen"
+            />
+          </div>
+          <div
+            class="item selected"
+            title="sulu_security.delete"
+          >
+            <span
+              aria-label="su-trash-alt"
+              class="su-trash-alt"
+            />
+          </div>
+          <button
+            class="rowButton"
+          >
+            sulu_admin.deactivate_all
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
@@ -29,18 +29,18 @@ class RoleAssignment extends React.Component<Props> {
     render() {
         const {disabled, localizations, value} = this.props;
 
-        const roleAssignmentContainerClass = classNames(
-            roleAssignmentStyle.roleAssignmentContainer,
+        const roleAssignmentClass = classNames(
+            roleAssignmentStyle.roleAssignment,
             {
                 [roleAssignmentStyle.disabled]: disabled,
             }
         );
 
         return (
-            <div className={roleAssignmentContainerClass}>
-                <div>{value.role.name}</div>
-                <div>{value.role.system}</div>
-                <div>
+            <tr className={roleAssignmentClass}>
+                <td>{value.role.name}</td>
+                <td>{value.role.system}</td>
+                <td>
                     <MultiSelect
                         disabled={disabled}
                         onChange={this.handleChange}
@@ -52,8 +52,8 @@ class RoleAssignment extends React.Component<Props> {
                             </MultiSelect.Option>
                         ))}
                     </MultiSelect>
-                </div>
-            </div>
+                </td>
+            </tr>
         );
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignments.js
@@ -101,19 +101,21 @@ class RoleAssignments extends React.Component<Props> {
                 </Grid.Item>
                 {this.selectedRoles.length > 0 &&
                     <Grid.Item colSpan={12}>
-                        <div className={roleAssignmentsStyle.roleAssignmentsContainer}>
-                            {value.map((userRole, key) => {
-                                return (
-                                    <RoleAssignment
-                                        disabled={disabled}
-                                        key={key}
-                                        localizations={localizations}
-                                        onChange={this.handleRoleAssignmentChange}
-                                        value={userRole}
-                                    />
-                                );
-                            })}
-                        </div>
+                        <table className={roleAssignmentsStyle.roleAssignments}>
+                            <tbody>
+                                {value.map((userRole, key) => {
+                                    return (
+                                        <RoleAssignment
+                                            disabled={disabled}
+                                            key={key}
+                                            localizations={localizations}
+                                            onChange={this.handleRoleAssignmentChange}
+                                            value={userRole}
+                                        />
+                                    );
+                                })}
+                            </tbody>
+                        </table>
                     </Grid.Item>
                 }
             </Grid>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignment.scss
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignment.scss
@@ -1,22 +1,19 @@
 @import 'sulu-admin-bundle/containers/Application/colors.scss';
 
 $roleAssignmentBorderColor: $silver;
-$roleAssignmentBackgroundColor: $white;
 
-.role-assignment-container {
-    border-bottom: 1px solid $roleAssignmentBorderColor;
-    background: $roleAssignmentBackgroundColor;
+.role-assignment {
     font-size: 12px;
-    padding: 10px;
-    display: flex;
 
-    &:last-child {
-        border-bottom: none;
+    td {
+        border-bottom: 1px solid $roleAssignmentBorderColor;
+        padding: 10px;
     }
 
-    > div {
-        align-self: center;
-        width: 33.33%;
+    &:last-child {
+        td {
+            border-bottom: none;
+        }
     }
 
     &.disabled {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignments.scss
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignments.scss
@@ -1,5 +1,11 @@
-.role-assignments-container {
+@import 'sulu-admin-bundle/containers/Application/colors.scss';
+
+$roleAssignmentBackgroundColor: $white;
+
+.role-assignments {
+    width: 100%;
+    background: $roleAssignmentBackgroundColor;
     border-radius: 3px;
+    border-spacing: 0;
     margin-top: 20px;
-    overflow: hidden;
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {mount, render} from 'enzyme';
+import {render, shallow} from 'enzyme';
 import type {Localization} from 'sulu-admin-bundle/stores';
 import {MultiSelect} from 'sulu-admin-bundle/components';
 import RoleAssignment from '../RoleAssignment';
@@ -125,7 +125,7 @@ test('The component should trigger the change callback', () => {
     ];
 
     const onChangeSpy = jest.fn();
-    const roleAssignment = mount(
+    const roleAssignment = shallow(
         <RoleAssignment
             localizations={localizations}
             onChange={onChangeSpy}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render component 1`] = `
-<div
-  class="roleAssignmentContainer"
+<tr
+  class="roleAssignment"
 >
-  <div>
+  <td>
     Role Name 5
-  </div>
-  <div>
+  </td>
+  <td>
     Sulu
-  </div>
-  <div>
+  </td>
+  <td>
     <div
       class="select"
     >
@@ -49,21 +49,21 @@ exports[`Render component 1`] = `
         />
       </button>
     </div>
-  </div>
-</div>
+  </td>
+</tr>
 `;
 
 exports[`Render component in disabled state 1`] = `
-<div
-  class="roleAssignmentContainer disabled"
+<tr
+  class="roleAssignment disabled"
 >
-  <div>
+  <td>
     Role Name 5
-  </div>
-  <div>
+  </td>
+  <td>
     Sulu
-  </div>
-  <div>
+  </td>
+  <td>
     <div
       class="select"
     >
@@ -103,6 +103,6 @@ exports[`Render component in disabled state 1`] = `
         />
       </button>
     </div>
-  </div>
-</div>
+  </td>
+</tr>
 `;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
@@ -49,110 +49,112 @@ exports[`Render component 1`] = `
   <div
     class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
-    <div
-      class="roleAssignmentsContainer"
+    <table
+      class="roleAssignments"
     >
-      <div
-        class="roleAssignmentContainer"
-      >
-        <div>
-          Role Name 5
-        </div>
-        <div>
-          Sulu
-        </div>
-        <div>
-          <div
-            class="select"
-          >
-            <button
-              class="displayValue default"
-              type="button"
+      <tbody>
+        <tr
+          class="roleAssignment"
+        >
+          <td>
+            Role Name 5
+          </td>
+          <td>
+            Sulu
+          </td>
+          <td>
+            <div
+              class="select"
             >
-              <div
-                aria-label="sulu_admin.all_selected"
-                class="croppedText"
-                title="sulu_admin.all_selected"
+              <button
+                class="displayValue default"
+                type="button"
               >
                 <div
-                  aria-hidden="true"
-                  class="front"
+                  aria-label="sulu_admin.all_selected"
+                  class="croppedText"
+                  title="sulu_admin.all_selected"
                 >
-                  sulu_admin.a
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    sulu_admin.a
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      ll_selected
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    sulu_admin.all_selected
+                  </div>
                 </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    ll_selected
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  sulu_admin.all_selected
-                </div>
-              </div>
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down toggle"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        class="roleAssignmentContainer"
-      >
-        <div>
-          Role Name 23
-        </div>
-        <div>
-          Sulu
-        </div>
-        <div>
-          <div
-            class="select"
-          >
-            <button
-              class="displayValue default"
-              type="button"
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="roleAssignment"
+        >
+          <td>
+            Role Name 23
+          </td>
+          <td>
+            Sulu
+          </td>
+          <td>
+            <div
+              class="select"
             >
-              <div
-                aria-label="de"
-                class="croppedText"
-                title="de"
+              <button
+                class="displayValue default"
+                type="button"
               >
                 <div
-                  aria-hidden="true"
-                  class="front"
+                  aria-label="de"
+                  class="croppedText"
+                  title="de"
                 >
-                  d
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    d
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      e
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    de
+                  </div>
                 </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    e
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  de
-                </div>
-              </div>
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down toggle"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -207,112 +209,114 @@ exports[`Render component in disabled state 1`] = `
   <div
     class="item colSpan colSpan-12 space-before-0 space-after-0"
   >
-    <div
-      class="roleAssignmentsContainer"
+    <table
+      class="roleAssignments"
     >
-      <div
-        class="roleAssignmentContainer disabled"
-      >
-        <div>
-          Role Name 5
-        </div>
-        <div>
-          Sulu
-        </div>
-        <div>
-          <div
-            class="select"
-          >
-            <button
-              class="displayValue default"
-              disabled=""
-              type="button"
+      <tbody>
+        <tr
+          class="roleAssignment disabled"
+        >
+          <td>
+            Role Name 5
+          </td>
+          <td>
+            Sulu
+          </td>
+          <td>
+            <div
+              class="select"
             >
-              <div
-                aria-label="sulu_admin.all_selected"
-                class="croppedText"
-                title="sulu_admin.all_selected"
+              <button
+                class="displayValue default"
+                disabled=""
+                type="button"
               >
                 <div
-                  aria-hidden="true"
-                  class="front"
+                  aria-label="sulu_admin.all_selected"
+                  class="croppedText"
+                  title="sulu_admin.all_selected"
                 >
-                  sulu_admin.a
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    sulu_admin.a
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      ll_selected
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    sulu_admin.all_selected
+                  </div>
                 </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    ll_selected
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  sulu_admin.all_selected
-                </div>
-              </div>
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down toggle"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        class="roleAssignmentContainer disabled"
-      >
-        <div>
-          Role Name 23
-        </div>
-        <div>
-          Sulu
-        </div>
-        <div>
-          <div
-            class="select"
-          >
-            <button
-              class="displayValue default"
-              disabled=""
-              type="button"
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="roleAssignment disabled"
+        >
+          <td>
+            Role Name 23
+          </td>
+          <td>
+            Sulu
+          </td>
+          <td>
+            <div
+              class="select"
             >
-              <div
-                aria-label="de"
-                class="croppedText"
-                title="de"
+              <button
+                class="displayValue default"
+                disabled=""
+                type="button"
               >
                 <div
-                  aria-hidden="true"
-                  class="front"
+                  aria-label="de"
+                  class="croppedText"
+                  title="de"
                 >
-                  d
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    d
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      e
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    de
+                  </div>
                 </div>
-                <div
-                  aria-hidden="true"
-                  class="back"
-                >
-                  <span>
-                    e
-                  </span>
-                </div>
-                <div
-                  class="whole"
-                >
-                  de
-                </div>
-              </div>
-              <span
-                aria-label="su-angle-down"
-                class="su-angle-down toggle"
-              />
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+                <span
+                  aria-label="su-angle-down"
+                  class="su-angle-down toggle"
+                />
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR replaces the divs in components that should actually be tables.

#### Why?

Because tables can and should still be used for table like representations.