### PR TITLE
Implement permission tab to be used in page form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormOverlayListRouteBuilder.php
@@ -55,6 +55,13 @@ class FormOverlayListRouteBuilder implements FormOverlayListRouteBuilderInterfac
         return $this;
     }
 
+    public function setApiOptions(array $apiOptions): FormOverlayListRouteBuilderInterface
+    {
+        $this->setApiOptionsToRoute($this->route, $apiOptions);
+
+        return $this;
+    }
+
     public function setTitle(string $title): FormOverlayListRouteBuilderInterface
     {
         $this->setTitleToRoute($this->route, $title);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilder.php
@@ -42,6 +42,13 @@ class FormRouteBuilder implements FormRouteBuilderInterface
         return $this;
     }
 
+    public function setApiOptions(array $apiOptions): FormRouteBuilderInterface
+    {
+        $this->setApiOptionsToRoute($this->route, $apiOptions);
+
+        return $this;
+    }
+
     public function addLocales(array $locales): FormRouteBuilderInterface
     {
         $this->addLocalesToRoute($this->route, $locales);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/FormRouteBuilderTrait.php
@@ -23,6 +23,11 @@ trait FormRouteBuilderTrait
         $route->setOption('formKey', $formKey);
     }
 
+    private function setApiOptionsToRoute(Route $route, array $apiOptions): void
+    {
+        $route->setOption('apiOptions', $apiOptions);
+    }
+
     private function setBackRouteToRoute(Route $route, string $backRoute): void
     {
         $route->setOption('backRoute', $backRoute);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/PreviewFormRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/PreviewFormRouteBuilder.php
@@ -42,6 +42,13 @@ class PreviewFormRouteBuilder implements PreviewFormRouteBuilderInterface
         return $this;
     }
 
+    public function setApiOptions(array $apiOptions): PreviewFormRouteBuilderInterface
+    {
+        $this->setApiOptionsToRoute($this->route, $apiOptions);
+
+        return $this;
+    }
+
     public function addLocales(array $locales): PreviewFormRouteBuilderInterface
     {
         $this->addLocalesToRoute($this->route, $locales);

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -43,6 +43,8 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('detail')->end()
                                 ->end()
                             ->end()
+                            ->scalarNode('security_context')->end()
+                            ->scalarNode('security_class')->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Matrix/Matrix.js
@@ -45,7 +45,7 @@ export default class Matrix extends React.PureComponent<Props> {
                 disabled: disabled,
                 key: `matrix-row-${index}`,
                 onChange: this.handleChange,
-                values: values[row.props.name],
+                values: values.hasOwnProperty(row.props.name) ? values[row.props.name] : {},
             }
         ));
     };

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
@@ -62,6 +62,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
                 'sulu_category.add_category',
                 'sulu_category.edit_category',
                 'small',
+                ['test1' => 'value1'],
             ],
             [
                 'sulu_tag.list',
@@ -74,6 +75,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
                 'sulu_tag.add_tag',
                 'sulu_tag.edit_tag',
                 'large',
+                ['test2' => 'value2'],
             ],
         ];
     }
@@ -91,7 +93,8 @@ class FormOverlayListRouteBuilderTest extends TestCase
         array $listAdapters,
         string $addOverlayTitle,
         string $editOverlayTitle,
-        string $overlaySize
+        string $overlaySize,
+        array $apiOptions
     ) {
         $route = (new FormOverlayListRouteBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -102,6 +105,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
             ->setAddOverlayTitle($addOverlayTitle)
             ->setEditOverlayTitle($editOverlayTitle)
             ->setOverlaySize($overlaySize)
+            ->setApiOptions($apiOptions)
             ->getRoute();
 
         $this->assertEquals($name, $route->getName());
@@ -114,6 +118,7 @@ class FormOverlayListRouteBuilderTest extends TestCase
         $this->assertEquals($addOverlayTitle, $route->getOption('addOverlayTitle'));
         $this->assertEquals($editOverlayTitle, $route->getOption('editOverlayTitle'));
         $this->assertEquals($overlaySize, $route->getOption('overlaySize'));
+        $this->assertEquals($apiOptions, $route->getOption('apiOptions'));
         $this->assertEquals('sulu_admin.form_overlay_list', $route->getView());
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormRouteBuilderTest.php
@@ -48,12 +48,18 @@ class FormRouteBuilderTest extends TestCase
                 512,
                 'sulu_category.edit_form',
                 'sulu_category.list',
+                null,
+                null,
+                ['test1' => 'value1'],
             ],
             [
                 'sulu_tag.edit_form',
                 '/tags/:id',
                 'tags',
                 'tags',
+                null,
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -74,6 +80,7 @@ class FormRouteBuilderTest extends TestCase
                 'sulu_category.list',
                 ['webspace'],
                 true,
+                null,
             ],
             [
                 'sulu_category.add_form',
@@ -88,6 +95,7 @@ class FormRouteBuilderTest extends TestCase
                 'sulu_category.list',
                 ['webspace', 'id' => 'active'],
                 false,
+                null,
             ],
         ];
     }
@@ -106,8 +114,9 @@ class FormRouteBuilderTest extends TestCase
         ?int $tabPriority,
         ?string $editRoute,
         ?string $backRoute,
-        ?array $routerAttributesToBackRoute = null,
-        ?bool $titleVisible = null
+        ?array $routerAttributesToBackRoute,
+        ?bool $titleVisible,
+        ?array $apiOptions
     ) {
         $routeBuilder = (new FormRouteBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -145,6 +154,10 @@ class FormRouteBuilderTest extends TestCase
             $routeBuilder->setTitleVisible($titleVisible);
         }
 
+        if ($apiOptions) {
+            $routeBuilder->setApiOptions($apiOptions);
+        }
+
         $route = $routeBuilder->getRoute();
 
         $this->assertSame($name, $route->getName());
@@ -159,6 +172,7 @@ class FormRouteBuilderTest extends TestCase
         $this->assertSame($backRoute, $route->getOption('backRoute'));
         $this->assertSame($routerAttributesToBackRoute, $route->getOption('routerAttributesToBackRoute'));
         $this->assertSame($titleVisible, $route->getOption('titleVisible'));
+        $this->assertSame($apiOptions, $route->getOption('apiOptions'));
         $this->assertNull($route->getParent());
         $this->assertSame('sulu_admin.form', $route->getView());
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/PreviewFormRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/PreviewFormRouteBuilderTest.php
@@ -49,6 +49,7 @@ class PreviewFormRouteBuilderTest extends TestCase
                 'sulu_category.edit_form',
                 'sulu_category.list',
                 false,
+                ['test1' => 'value1'],
             ],
             [
                 'sulu_tag.edit_form',
@@ -62,6 +63,7 @@ class PreviewFormRouteBuilderTest extends TestCase
                 null,
                 null,
                 true,
+                null,
             ],
         ];
     }
@@ -80,7 +82,8 @@ class PreviewFormRouteBuilderTest extends TestCase
         ?int $tabPriority,
         ?string $editRoute,
         ?string $backRoute,
-        ?bool $titleVisible = null
+        ?bool $titleVisible,
+        ?array $apiOptions
     ) {
         $routeBuilder = (new PreviewFormRouteBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -114,6 +117,10 @@ class PreviewFormRouteBuilderTest extends TestCase
             $routeBuilder->setTitleVisible($titleVisible);
         }
 
+        if ($apiOptions) {
+            $routeBuilder->setApiOptions($apiOptions);
+        }
+
         $route = $routeBuilder->getRoute();
 
         $this->assertSame($name, $route->getName());
@@ -127,6 +134,7 @@ class PreviewFormRouteBuilderTest extends TestCase
         $this->assertSame($editRoute, $route->getOption('editRoute'));
         $this->assertSame($backRoute, $route->getOption('backRoute'));
         $this->assertSame($titleVisible, $route->getOption('titleVisible'));
+        $this->assertSame($apiOptions, $route->getOption('apiOptions'));
         $this->assertNull($route->getParent());
         $this->assertSame('sulu_admin.preview_form', $route->getView());
     }

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 use Sulu\Bundle\AdminBundle\Navigation\NavigationItem;
 use Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPoolInterface;
-use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Navigation\Navigation;
 use Sulu\Bundle\AdminBundle\Navigation\NavigationItem;
 use Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPoolInterface;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -201,6 +202,19 @@ class PageAdmin extends Admin
                 ->setTabOrder(4096)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
+            // TODO maybe even build a separate builder?
+            $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_edit_form.permissions', '/permissions')
+                ->setResourceKey('permissions')
+                ->setFormKey('permission_details')
+                ->setTabTitle('sulu_security.permissions')
+                ->addToolbarActions(['sulu_admin.save'])
+                ->setTitleVisible(true)
+                ->setTabOrder(5120)
+                ->setParent(static::EDIT_FORM_ROUTE)
+                ->getRoute()
+                // TODO replace with call to FormRouteBuilder
+                // TODO replacing with resourceKey requires API change, but allows loading available actions for Matrix
+                ->setOption('apiOptions', ['type' => SecurityBehavior::class]),
         ];
     }
 

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -206,7 +206,7 @@ class PageAdmin extends Admin
                 ->setResourceKey('permissions')
                 ->setFormKey('permission_details')
                 // TODO replacing with resourceKey requires API change, but allows loading available actions for Matrix
-                ->setApiOptions(['type' => SecurityBehavior::class])
+                ->setApiOptions(['resourceKey' => 'pages'])
                 ->setTabTitle('sulu_security.permissions')
                 ->addToolbarActions(['sulu_admin.save'])
                 ->setTitleVisible(true)

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -204,7 +204,6 @@ class PageAdmin extends Admin
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_edit_form.permissions', '/permissions')
                 ->setResourceKey('permissions')
                 ->setFormKey('permission_details')
-                // TODO replacing with resourceKey requires API change, but allows loading available actions for Matrix
                 ->setApiOptions(['resourceKey' => 'pages'])
                 ->setTabTitle('sulu_security.permissions')
                 ->addToolbarActions(['sulu_admin.save'])

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -202,19 +202,17 @@ class PageAdmin extends Admin
                 ->setTabOrder(4096)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
-            // TODO maybe even build a separate builder?
             $this->routeBuilderFactory->createFormRouteBuilder('sulu_page.page_edit_form.permissions', '/permissions')
                 ->setResourceKey('permissions')
                 ->setFormKey('permission_details')
+                // TODO replacing with resourceKey requires API change, but allows loading available actions for Matrix
+                ->setApiOptions(['type' => SecurityBehavior::class])
                 ->setTabTitle('sulu_security.permissions')
                 ->addToolbarActions(['sulu_admin.save'])
                 ->setTitleVisible(true)
                 ->setTabOrder(5120)
                 ->setParent(static::EDIT_FORM_ROUTE)
-                ->getRoute()
-                // TODO replace with call to FormRouteBuilder
-                // TODO replacing with resourceKey requires API change, but allows loading available actions for Matrix
-                ->setOption('apiOptions', ['type' => SecurityBehavior::class]),
+                ->getRoute(),
         ];
     }
 

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
@@ -11,12 +11,14 @@
 
 namespace Sulu\Bundle\PageBundle\DependencyInjection;
 
+use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\PageBundle\Document\RouteDocument;
 use Sulu\Bundle\PageBundle\Form\Type\HomeDocumentType;
 use Sulu\Bundle\PageBundle\Form\Type\PageDocumentType;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
+use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -54,6 +56,8 @@ class SuluPageExtension extends Extension implements PrependExtensionInterface
                                 'list' => 'get_pages',
                                 'detail' => 'get_page',
                             ],
+                            'security_context' => PageAdmin::SECURITY_CONTEXT_PREFIX . '#webspace#',
+                            'security_class' => SecurityBehavior::class,
                         ],
                         'page_versions' => [
                             'routes' => [

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -43,14 +43,21 @@ class SecurityAdmin extends Admin
      */
     private $urlGenerator;
 
+    /**
+     * @var array
+     */
+    private $resources;
+
     public function __construct(
         RouteBuilderFactoryInterface $routeBuilderFactory,
         SecurityCheckerInterface $securityChecker,
-        UrlGeneratorInterface $urlGenerator
+        UrlGeneratorInterface $urlGenerator,
+        array $resources
     ) {
         $this->routeBuilderFactory = $routeBuilderFactory;
         $this->securityChecker = $securityChecker;
         $this->urlGenerator = $urlGenerator;
+        $this->resources = $resources;
     }
 
     public function getNavigation(): Navigation
@@ -170,6 +177,9 @@ class SecurityAdmin extends Admin
             'endpoints' => [
                 'contexts' => $this->urlGenerator->generate('cget_contexts'),
             ],
+            'resourceKeySecurityContextMapping' => array_filter(array_map(function(array $resource) {
+                return $resource['security_context'] ?? null;
+            }, $this->resources)),
         ];
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
@@ -77,8 +77,6 @@ class PermissionController implements ClassResourceInterface
 
             return $this->viewHandler->handle(View::create(
                 [
-                    'id' => $identifier,
-                    'type' => $type,
                     'permissions' => $permissions,
                 ]
             ));
@@ -87,7 +85,7 @@ class PermissionController implements ClassResourceInterface
         }
     }
 
-    public function postAction(Request $request)
+    public function cputAction(Request $request)
     {
         try {
             $identifier = $request->get('id');
@@ -125,8 +123,6 @@ class PermissionController implements ClassResourceInterface
             );
 
             return $this->viewHandler->handle(View::create([
-                'id' => $identifier,
-                'type' => $type,
                 'permissions' => $permissions,
             ]));
         } catch (RestException $exc) {

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -97,6 +97,11 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
                         ],
                     ],
                     'resources' => [
+                        'permissions' => [
+                            'routes' => [
+                                'detail' => 'get_permissions',
+                            ],
+                        ],
                         'roles' => [
                             'routes' => [
                                 'list' => 'get_roles',

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/permission_details.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/permission_details.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>permission_details</key>
+
+    <properties>
+        <property name="permissions" type="role_permissions" />
+    </properties>
+</form>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -43,6 +43,7 @@
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="router"/>
+            <argument>%sulu_admin.resources%</argument>
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>
         </service>
@@ -112,6 +113,7 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.repository.role"/>
             <argument type="service" id="fos_rest.view_handler"/>
+            <argument>%sulu_admin.resources%</argument>
             <tag name="sulu.context" context="admin"/>
         </service>
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
@@ -1,0 +1,28 @@
+// @flow
+import React from 'react';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+import RolePermissionsContainer from '../../RolePermissions';
+import type {RolePermissions as RolePermissionsType} from '../../RolePermissions/types';
+
+class RolePermissions extends React.Component<FieldTypeProps<RolePermissionsType>> {
+    handleChange = (value: RolePermissionsType) => {
+        const {onChange, onFinish} = this.props;
+
+        onChange(value);
+        onFinish();
+    };
+
+    render() {
+        const {disabled, value} = this.props;
+
+        return (
+            <RolePermissionsContainer
+                disabled={disabled || undefined}
+                onChange={this.handleChange}
+                value={value ? value : {}}
+            />
+        );
+    }
+}
+
+export default RolePermissions;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/fields/RolePermissions.js
@@ -13,12 +13,17 @@ class RolePermissions extends React.Component<FieldTypeProps<RolePermissionsType
     };
 
     render() {
-        const {disabled, value} = this.props;
+        const {disabled, formInspector, value} = this.props;
+
+        if (!formInspector.options.resourceKey) {
+            throw new Error('The "resourceKey" must be available in order to load the available permissions!');
+        }
 
         return (
             <RolePermissionsContainer
                 disabled={disabled || undefined}
                 onChange={this.handleChange}
+                resourceKey={formInspector.options.resourceKey}
                 value={value ? value : {}}
             />
         );

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/index.js
@@ -1,8 +1,10 @@
 // @flow
 import Permissions from './fields/Permissions';
 import RoleAssignments from './fields/RoleAssignments';
+import RolePermissions from './fields/RolePermissions';
 
 export {
     Permissions,
     RoleAssignments,
+    RolePermissions,
 };

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js
@@ -1,0 +1,63 @@
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import {FormInspector, ResourceFormStore} from 'sulu-admin-bundle/containers';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {fieldTypeDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
+import RolePermissions from '../../fields/RolePermissions';
+
+jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn());
+jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn());
+jest.mock('sulu-admin-bundle/containers/Form/FormInspector', () => jest.fn());
+
+test('Pass props correctly to component', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const value = {};
+
+    const rolePermissions = shallow(
+        <RolePermissions
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            value={value}
+        />
+    );
+
+    expect(rolePermissions.find('RolePermissions').prop('disabled')).toEqual(false);
+    expect(rolePermissions.find('RolePermissions').prop('value')).toBe(value);
+});
+
+test('Pass disabled prop correctly to component', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+
+    const rolePermissions = shallow(
+        <RolePermissions
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+        />
+    );
+
+    expect(rolePermissions.find('RolePermissions').prop('disabled')).toEqual(true);
+    expect(rolePermissions.find('RolePermissions').prop('value')).toEqual({});
+});
+
+test('Pass disabled prop correctly to component', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const changeSpy = jest.fn();
+    const finishSpy = jest.fn();
+
+    const rolePermissions = shallow(
+        <RolePermissions
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            onFinish={finishSpy}
+        />
+    );
+
+    rolePermissions.find('RolePermissions').prop('onChange')({});
+
+    expect(changeSpy).toBeCalledWith({});
+    expect(finishSpy).toBeCalledWith();
+});

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js
@@ -7,11 +7,23 @@ import {fieldTypeDefaultProps} from 'sulu-admin-bundle/utils/TestHelper';
 import RolePermissions from '../../fields/RolePermissions';
 
 jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn());
-jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn());
-jest.mock('sulu-admin-bundle/containers/Form/FormInspector', () => jest.fn());
+jest.mock(
+    'sulu-admin-bundle/containers/Form/stores/ResourceFormStore',
+    () => jest.fn(function(resourceStore, formKey, options) {
+        this.options = options;
+    })
+);
+jest.mock('sulu-admin-bundle/containers/Form/FormInspector', () => jest.fn(function(formStore) {
+    this.options = formStore.options;
+}));
 
 test('Pass props correctly to component', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test'), 'snippets', {resourceKey: 'snippets'}
+        )
+    );
+
     const value = {};
 
     const rolePermissions = shallow(
@@ -23,11 +35,16 @@ test('Pass props correctly to component', () => {
     );
 
     expect(rolePermissions.find('RolePermissions').prop('disabled')).toEqual(false);
+    expect(rolePermissions.find('RolePermissions').prop('resourceKey')).toEqual('snippets');
     expect(rolePermissions.find('RolePermissions').prop('value')).toBe(value);
 });
 
 test('Pass disabled prop correctly to component', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test'), 'snippets', {resourceKey: 'snippets'}
+        )
+    );
 
     const rolePermissions = shallow(
         <RolePermissions
@@ -42,7 +59,12 @@ test('Pass disabled prop correctly to component', () => {
 });
 
 test('Pass disabled prop correctly to component', () => {
-    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'snippets'));
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test'), 'snippets', {resourceKey: 'snippets'}
+        )
+    );
+
     const changeSpy = jest.fn();
     const finishSpy = jest.fn();
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/PermissionMatrix.js
@@ -2,10 +2,11 @@
 import React from 'react';
 import {toJS} from 'mobx';
 import {observer} from 'mobx-react';
-import Matrix from 'sulu-admin-bundle/components/Matrix';
+import {Matrix} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import type {MatrixValues} from 'sulu-admin-bundle/components/Matrix/types';
 import type {Actions, SecurityContexts} from '../../stores/SecurityContextStore/types';
+import {getActionIcon} from '../../utils/Permission';
 import type {ContextPermission} from './types';
 import permissionsStyle from './permissions.scss';
 
@@ -22,25 +23,6 @@ type Props = {|
 class PermissionMatrix extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
-    };
-
-    getIcon = (action: string) => {
-        switch (action) {
-            case 'view':
-                return 'su-eye';
-            case 'add':
-                return 'su-plus-circle';
-            case 'edit':
-                return 'su-pen';
-            case 'delete':
-                return 'su-trash-alt';
-            case 'security':
-                return 'su-lock';
-            case 'live':
-                return 'fa-signal';
-            default:
-                throw new Error('No icon defined for "' + action + '"');
-        }
     };
 
     getMatrixValueFromContextPermission = (securityContextKey: string) => {
@@ -86,7 +68,7 @@ class PermissionMatrix extends React.Component<Props> {
             <Matrix.Row key={'row-' + rowIndex} name={securityContextKey} title={title}>
                 {actions.map((action, itemIndex) => (
                     <Matrix.Item
-                        icon={this.getIcon(action)}
+                        icon={getActionIcon(action)}
                         key={'item-' + itemIndex}
                         name={action}
                         title={translate('sulu_security.' + action)}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
@@ -1,0 +1,87 @@
+// @flow
+import React from 'react';
+import {action, computed, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import {Loader, Matrix} from 'sulu-admin-bundle/components';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import securityContextStore from '../../stores/SecurityContextStore';
+import {getActionIcon} from '../../utils/Permission';
+import type {Role} from '../../types';
+import type {RolePermissions as RolePermissionsType} from './types';
+
+type Props = {|
+    disabled: boolean,
+    onChange: (value: RolePermissionsType) => void,
+    value: RolePermissionsType,
+|};
+
+@observer
+class RolePermissions extends React.Component<Props> {
+    static defaultProps = {
+        disabled: false,
+    };
+
+    @observable roles: ?Array<Role>;
+    @observable actions: ?Array<string>;
+
+    componentDidMount() {
+        // TODO do not hardcode permission key, maybe even load based on resourceKey?
+        securityContextStore.loadAvailableActions('sulu.webspaces.#webspace#').then(action((actions) => {
+            this.actions = actions.filter((action) => action !== 'security');
+        }));
+
+        ResourceRequester.get('roles').then(action((response) => {
+            this.roles = response._embedded.roles;
+        }));
+    }
+
+    @computed get defaultValue() {
+        const {actions, roles} = this;
+
+        if (!actions || ! roles) {
+            return {};
+        }
+
+        return roles.reduce((value, role) => {
+            value[role.id] = actions.reduce((actionValue, action) => {
+                actionValue[action] = true;
+
+                return actionValue;
+            }, {});
+
+            return value;
+        }, {});
+    }
+
+    handleChange = (value: RolePermissionsType) => {
+        const {onChange} = this.props;
+        onChange(value);
+    };
+
+    render() {
+        const {actions, roles} = this;
+        const {disabled, value} = this.props;
+
+        if (!roles || !actions) {
+            return <Loader />;
+        }
+
+        return (
+            <Matrix
+                disabled={disabled}
+                onChange={this.handleChange}
+                values={Object.keys(value).length > 0 ? value : this.defaultValue}
+            >
+                {roles.map((role) => (
+                    <Matrix.Row key={role.id} name={role.id.toString()} title={role.name}>
+                        {actions.map((action) => (
+                            <Matrix.Item icon={getActionIcon(action)} key={action} name={action} />
+                        ))}
+                    </Matrix.Row>
+                ))}
+            </Matrix>
+        );
+    }
+}
+
+export default RolePermissions;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
@@ -12,6 +12,7 @@ import type {RolePermissions as RolePermissionsType} from './types';
 type Props = {|
     disabled: boolean,
     onChange: (value: RolePermissionsType) => void,
+    resourceKey: string,
     value: RolePermissionsType,
 |};
 
@@ -25,8 +26,9 @@ class RolePermissions extends React.Component<Props> {
     @observable actions: ?Array<string>;
 
     componentDidMount() {
-        // TODO do not hardcode permission key, maybe even load based on resourceKey?
-        securityContextStore.loadAvailableActions('sulu.webspaces.#webspace#').then(action((actions) => {
+        const {resourceKey} = this.props;
+
+        securityContextStore.loadAvailableActions(resourceKey).then(action((actions) => {
             this.actions = actions.filter((action) => action !== 'security');
         }));
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/index.js
@@ -1,0 +1,4 @@
+// @flow
+import RolePermissions from './RolePermissions';
+
+export default RolePermissions;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
@@ -34,7 +34,7 @@ test('Render matrix with correct all values selected if not given', () => {
     securityContextStore.loadAvailableActions.mockReturnValue(actionPromise);
 
     const value = {};
-    const rolePermissions = mount(<RolePermissions onChange={jest.fn()} value={value} />);
+    const rolePermissions = mount(<RolePermissions onChange={jest.fn()} resourceKey="snippets" value={value} />);
 
     expect(rolePermissions.render()).toMatchSnapshot();
 
@@ -74,7 +74,7 @@ test('Render matrix with correct given values', () => {
             delete: false,
         },
     };
-    const rolePermissions = mount(<RolePermissions onChange={jest.fn()} value={value} />);
+    const rolePermissions = mount(<RolePermissions onChange={jest.fn()} resourceKey="snippets" value={value} />);
 
     expect(rolePermissions.render()).toMatchSnapshot();
 
@@ -103,7 +103,9 @@ test('Render matrix with correct all values selected if not given', () => {
     securityContextStore.loadAvailableActions.mockReturnValue(actionPromise);
 
     const value = {};
-    const rolePermissions = shallow(<RolePermissions onChange={changeSpy} value={value} />);
+    const rolePermissions = shallow(<RolePermissions onChange={changeSpy} resourceKey="snippets" value={value} />);
+
+    expect(securityContextStore.loadAvailableActions).toBeCalledWith('snippets');
 
     return Promise.all([rolePromise, actionPromise]).then(() => {
         const newValue = {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js
@@ -1,0 +1,128 @@
+// @flow
+import React from 'react';
+import {mount, shallow} from 'enzyme';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import securityContextStore from '../../../stores/SecurityContextStore';
+import RolePermissions from '../RolePermissions';
+
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('sulu-admin-bundle/services/ResourceRequester', () => ({
+    get: jest.fn(),
+}));
+
+jest.mock('../../../stores/SecurityContextStore', () => ({
+    loadAvailableActions: jest.fn(),
+}));
+
+test('Render matrix with correct all values selected if not given', () => {
+    const rolePromise = Promise.resolve(
+        {
+            _embedded: {
+                roles: [
+                    {id: 1, name: 'Administrator'},
+                    {id: 2, name: 'Account Manager'},
+                ],
+            },
+        }
+    );
+    ResourceRequester.get.mockReturnValue(rolePromise);
+
+    const actionPromise = Promise.resolve(['view', 'add', 'edit', 'delete', 'live', 'security']);
+    securityContextStore.loadAvailableActions.mockReturnValue(actionPromise);
+
+    const value = {};
+    const rolePermissions = mount(<RolePermissions onChange={jest.fn()} value={value} />);
+
+    expect(rolePermissions.render()).toMatchSnapshot();
+
+    return Promise.all([rolePromise, actionPromise]).then(() => {
+        rolePermissions.update();
+        expect(rolePermissions.render()).toMatchSnapshot();
+    });
+});
+
+test('Render matrix with correct given values', () => {
+    const rolePromise = Promise.resolve(
+        {
+            _embedded: {
+                roles: [
+                    {id: 1, name: 'Admin'},
+                    {id: 2, name: 'Contact Manager'},
+                ],
+            },
+        }
+    );
+    ResourceRequester.get.mockReturnValue(rolePromise);
+
+    const actionPromise = Promise.resolve(['view', 'add', 'edit', 'delete', 'security']);
+    securityContextStore.loadAvailableActions.mockReturnValue(actionPromise);
+
+    const value = {
+        '1': {
+            view: true,
+            add: false,
+            edit: true,
+            delete: true,
+        },
+        '2': {
+            view: true,
+            add: true,
+            edit: true,
+            delete: false,
+        },
+    };
+    const rolePermissions = mount(<RolePermissions onChange={jest.fn()} value={value} />);
+
+    expect(rolePermissions.render()).toMatchSnapshot();
+
+    return Promise.all([rolePromise, actionPromise]).then(() => {
+        rolePermissions.update();
+        expect(rolePermissions.render()).toMatchSnapshot();
+    });
+});
+
+test('Render matrix with correct all values selected if not given', () => {
+    const changeSpy = jest.fn();
+
+    const rolePromise = Promise.resolve(
+        {
+            _embedded: {
+                roles: [
+                    {id: 1, name: 'Administrator'},
+                    {id: 2, name: 'Account Manager'},
+                ],
+            },
+        }
+    );
+    ResourceRequester.get.mockReturnValue(rolePromise);
+
+    const actionPromise = Promise.resolve(['view', 'add', 'edit', 'delete', 'live', 'security']);
+    securityContextStore.loadAvailableActions.mockReturnValue(actionPromise);
+
+    const value = {};
+    const rolePermissions = shallow(<RolePermissions onChange={changeSpy} value={value} />);
+
+    return Promise.all([rolePromise, actionPromise]).then(() => {
+        const newValue = {
+            '1': {
+                view: true,
+                add: false,
+                edit: true,
+                delete: true,
+            },
+            '2': {
+                view: true,
+                add: true,
+                edit: true,
+                delete: false,
+            },
+        };
+        rolePermissions.update();
+
+        rolePermissions.find('Matrix').prop('onChange')(newValue);
+        expect(changeSpy).toBeCalledWith(newValue);
+    });
+});

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/RolePermissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/RolePermissions.test.js.snap
@@ -1,0 +1,281 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Render matrix with correct all values selected if not given 1`] = `
+<div
+  class="spinner"
+  style="width: 40px; height: 40px;"
+>
+  <div
+    class="doubleBounce1"
+  />
+  <div
+    class="doubleBounce2"
+  />
+</div>
+`;
+
+exports[`Render matrix with correct all values selected if not given 2`] = `
+<table
+  class="matrix"
+>
+  <tbody>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
+      >
+        Administrator
+      </td>
+      <td
+        class="items"
+      >
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Live"
+        >
+          <span
+            aria-label="fa-signal"
+            class="fa fa-signal"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          sulu_admin.deactivate_all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
+      >
+        Account Manager
+      </td>
+      <td
+        class="items"
+      >
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Live"
+        >
+          <span
+            aria-label="fa-signal"
+            class="fa fa-signal"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          sulu_admin.deactivate_all
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Render matrix with correct given values 1`] = `
+<div
+  class="spinner"
+  style="width: 40px; height: 40px;"
+>
+  <div
+    class="doubleBounce1"
+  />
+  <div
+    class="doubleBounce2"
+  />
+</div>
+`;
+
+exports[`Render matrix with correct given values 2`] = `
+<table
+  class="matrix"
+>
+  <tbody>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
+      >
+        Admin
+      </td>
+      <td
+        class="items"
+      >
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item"
+          title="Add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          sulu_admin.deactivate_all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
+      >
+        Contact Manager
+      </td>
+      <td
+        class="items"
+      >
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          sulu_admin.deactivate_all
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/types.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/types.js
@@ -1,0 +1,4 @@
+// @flow
+export type RolePermissions = {
+    [string]: {[string]: boolean},
+};

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
@@ -10,4 +10,5 @@ fieldRegistry.add('role_permissions', RolePermissions);
 
 initializer.addUpdateConfigHook('sulu_security', (config: Object) => {
     securityContextStore.endpoint = config.endpoints.contexts;
+    securityContextStore.resourceKeyMapping = config.resourceKeySecurityContextMapping;
 });

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
@@ -1,11 +1,12 @@
 // @flow
 import {initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry} from 'sulu-admin-bundle/containers';
-import {Permissions, RoleAssignments} from './containers/Form';
+import {Permissions, RoleAssignments, RolePermissions} from './containers/Form';
 import securityContextStore from './stores/SecurityContextStore';
 
 fieldRegistry.add('permissions', Permissions);
 fieldRegistry.add('role_assignments', RoleAssignments);
+fieldRegistry.add('role_permissions', RolePermissions);
 
 initializer.addUpdateConfigHook('sulu_security', (config: Object) => {
     securityContextStore.endpoint = config.endpoints.contexts;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/SecurityContextStore.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/SecurityContextStore.js
@@ -5,6 +5,7 @@ import type {SecurityContextGroups, Systems} from './types';
 class SecurityContextStore {
     endpoint: string;
     promise: Promise<Systems>;
+    resourceKeyMapping: {[resourceKey: string]: string};
 
     sendRequest(): Promise<Systems> {
         if (!this.promise) {
@@ -20,14 +21,14 @@ class SecurityContextStore {
         });
     }
 
-    loadAvailableActions(searchPermissionKey: string) {
+    loadAvailableActions(resourceKey: string) {
         return this.sendRequest().then((systems: Systems) => {
             for (const systemKey in systems) {
                 const system = systems[systemKey];
                 for (const groupKey in system) {
                     const group = system[groupKey];
                     for (const permissionKey in group) {
-                        if (permissionKey === searchPermissionKey) {
+                        if (permissionKey === this.resourceKeyMapping[resourceKey]) {
                             return group[permissionKey];
                         }
                     }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/SecurityContextStore.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/SecurityContextStore.js
@@ -19,6 +19,22 @@ class SecurityContextStore {
             return response[system];
         });
     }
+
+    loadAvailableActions(searchPermissionKey: string) {
+        return this.sendRequest().then((systems: Systems) => {
+            for (const systemKey in systems) {
+                const system = systems[systemKey];
+                for (const groupKey in system) {
+                    const group = system[groupKey];
+                    for (const permissionKey in group) {
+                        if (permissionKey === searchPermissionKey) {
+                            return group[permissionKey];
+                        }
+                    }
+                }
+            }
+        });
+    }
 }
 
 export default new SecurityContextStore();

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/tests/SecurityContextStore.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/tests/SecurityContextStore.test.js
@@ -7,6 +7,10 @@ jest.mock('sulu-admin-bundle/services/Requester', () => ({
 }));
 
 test('Load available actions for permissions with given keys', () => {
+    securityContextStore.resourceKeyMapping = {
+        'test': 'sulu.test',
+    };
+
     Requester.get.mockReturnValue(Promise.resolve({
         'Sulu': {
             'Global': {
@@ -18,12 +22,16 @@ test('Load available actions for permissions with given keys', () => {
         },
     }));
 
-    return securityContextStore.loadAvailableActions('sulu.test').then((actions) => {
+    return securityContextStore.loadAvailableActions('test').then((actions) => {
         expect(actions).toEqual(['view', 'add', 'edit']);
     });
 });
 
 test('Load security contexts for entire system', () => {
+    securityContextStore.resourceKeyMapping = {
+        'test': 'sulu.test',
+    };
+
     const suluSecurityContexts = {
         'Global': {
             'sulu.snippets': ['view', 'add'],

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/tests/SecurityContextStore.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/tests/SecurityContextStore.test.js
@@ -1,0 +1,43 @@
+// @flow
+import {Requester} from 'sulu-admin-bundle/services';
+import securityContextStore from '../SecurityContextStore';
+
+jest.mock('sulu-admin-bundle/services/Requester', () => ({
+    get: jest.fn(),
+}));
+
+test('Load available actions for permissions with given keys', () => {
+    Requester.get.mockReturnValue(Promise.resolve({
+        'Sulu': {
+            'Global': {
+                'sulu.snippets': ['view', 'add'],
+            },
+            'Test': {
+                'sulu.test': ['view', 'add', 'edit'],
+            },
+        },
+    }));
+
+    return securityContextStore.loadAvailableActions('sulu.test').then((actions) => {
+        expect(actions).toEqual(['view', 'add', 'edit']);
+    });
+});
+
+test('Load security contexts for entire system', () => {
+    const suluSecurityContexts = {
+        'Global': {
+            'sulu.snippets': ['view', 'add'],
+        },
+        'Test': {
+            'sulu.test': ['view', 'add', 'edit'],
+        },
+    };
+
+    Requester.get.mockReturnValue(Promise.resolve({
+        'Sulu': suluSecurityContexts,
+    }));
+
+    return securityContextStore.loadSecurityContextGroups('Sulu').then((securityContexts) => {
+        expect(securityContexts).toEqual(suluSecurityContexts);
+    });
+});

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/types.js
@@ -1,0 +1,8 @@
+// @flow
+
+export type Role = {|
+    id: number,
+    identifier: string,
+    name: string,
+    system: string,
+|};

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/getActionIcon.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/getActionIcon.js
@@ -1,0 +1,20 @@
+// @flow
+
+export default function getActionIcon(action: string) {
+    switch (action) {
+        case 'view':
+            return 'su-eye';
+        case 'add':
+            return 'su-plus-circle';
+        case 'edit':
+            return 'su-pen';
+        case 'delete':
+            return 'su-trash-alt';
+        case 'security':
+            return 'su-lock';
+        case 'live':
+            return 'fa-signal';
+        default:
+            throw new Error('No icon defined for "' + action + '"');
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/index.js
@@ -1,0 +1,4 @@
+// @flow
+import getActionIcon from './getActionIcon';
+
+export {getActionIcon};

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
@@ -93,8 +93,6 @@ class PermissionControllerTest extends TestCase
         $this->viewHandler->handle(
             View::create(
                 [
-                    'id' => $id,
-                    'type' => $class,
                     'permissions' => [1 => $permissions],
                 ]
             )
@@ -106,13 +104,14 @@ class PermissionControllerTest extends TestCase
     /**
      * @dataProvider providePermissionData
      */
-    public function testPostAction($id, $class, $permissions)
+    public function testPutAction($id, $class, $permissions)
     {
         $request = new Request(
-            [],
             [
                 'id' => $id,
                 'type' => $class,
+            ],
+            [
                 'permissions' => [
                     1 => $permissions,
                 ],
@@ -129,8 +128,6 @@ class PermissionControllerTest extends TestCase
         $this->viewHandler->handle(
             View::create(
                 [
-                    'id' => $id,
-                    'type' => $class,
                     'permissions' => [
                         1 => $permissions,
                     ],
@@ -138,7 +135,7 @@ class PermissionControllerTest extends TestCase
             )
         )->shouldBeCalled();
 
-        $this->permissionController->postAction($request);
+        $this->permissionController->cputAction($request);
     }
 
     public function provideWrongPermissionData()
@@ -154,19 +151,20 @@ class PermissionControllerTest extends TestCase
     /**
      * @dataProvider provideWrongPermissionData
      */
-    public function testPostActionWithWrongData($id, $class, $permissions)
+    public function testPutActionWithWrongData($id, $class, $permissions)
     {
         $request = new Request(
-            [],
             [
                 'id' => $id,
                 'type' => $class,
+            ],
+            [
                 'permissions' => $permissions,
             ]
         );
 
         $this->accessControlManager->setPermissions(Argument::cetera())->shouldNotBeCalled();
 
-        $this->permissionController->postAction($request);
+        $this->permissionController->cputAction($request);
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
@@ -63,7 +63,7 @@ class PermissionControllerTest extends TestCase
             'example' => [
                 'security_context' => 'sulu_example.example',
                 'security_class' => 'Acme\Example',
-            ]
+            ],
         ];
 
         $this->permissionController = new PermissionController(

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Controller/PermissionControllerTest.php
@@ -48,18 +48,30 @@ class PermissionControllerTest extends TestCase
      */
     private $viewHandler;
 
+    /**
+     * @var array
+     */
+    private $resources;
+
     public function setUp()
     {
         $this->accessControlManager = $this->prophesize(AccessControlManagerInterface::class);
         $this->securityChecker = $this->prophesize(SecurityCheckerInterface::class);
         $this->roleRepository = $this->prophesize(RoleRepositoryInterface::class);
         $this->viewHandler = $this->prophesize(ViewHandlerInterface::class);
+        $this->resources = [
+            'example' => [
+                'security_context' => 'sulu_example.example',
+                'security_class' => 'Acme\Example',
+            ]
+        ];
 
         $this->permissionController = new PermissionController(
             $this->accessControlManager->reveal(),
             $this->securityChecker->reveal(),
             $this->roleRepository->reveal(),
-            $this->viewHandler->reveal()
+            $this->viewHandler->reveal(),
+            $this->resources
         );
     }
 
@@ -68,7 +80,7 @@ class PermissionControllerTest extends TestCase
         return [
             [
                 '1',
-                'Acme\Example',
+                'example',
                 [
                     'add' => 'true',
                     'view' => true,
@@ -85,10 +97,10 @@ class PermissionControllerTest extends TestCase
     /**
      * @dataProvider providePermissionData
      */
-    public function testGetAction($id, $class, $permissions)
+    public function testGetAction($id, $resourceKey, $permissions)
     {
-        $request = new Request(['id' => $id, 'type' => $class]);
-        $this->accessControlManager->getPermissions($class, $id)->willReturn([1 => $permissions]);
+        $request = new Request(['id' => $id, 'resourceKey' => $resourceKey]);
+        $this->accessControlManager->getPermissions($this->resources[$resourceKey]['security_class'], $id)->willReturn([1 => $permissions]);
 
         $this->viewHandler->handle(
             View::create(
@@ -104,12 +116,12 @@ class PermissionControllerTest extends TestCase
     /**
      * @dataProvider providePermissionData
      */
-    public function testPutAction($id, $class, $permissions)
+    public function testPutAction($id, $resourceKey, $permissions)
     {
         $request = new Request(
             [
                 'id' => $id,
-                'type' => $class,
+                'resourceKey' => $resourceKey,
             ],
             [
                 'permissions' => [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the permission tabs to the page form.

#### Why?

Because this functionality has already been there in the 1.x release.

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [ ] Fix limit of 10 in `ResourceSelect` for roles in Permission tab of contact