### PR TITLE
Using alias so that every project can override template

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -233,7 +233,7 @@ class AdminController
         ];
 
         return $this->engine->renderResponse(
-            'SuluAdminBundle:Admin:main.html.twig',
+            '@SuluAdmin\Admin\main.html.twig',
             [
                 'translations' => $this->translations,
                 'fallback_locale' => $this->fallbackLocale,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

With this change in every project the admin base template is overridable and can be extended with project custom options.
