### PR TITLE
 Fix sulu document init routes generation 

### DIFF
--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -123,13 +123,24 @@ class WebspaceInitializer implements InitializerInterface
 
             $this->documentManager->persist($homeDocument, $webspaceLocale, $persistOptions);
             $this->documentManager->publish($homeDocument, $webspaceLocale);
+        }
 
+        foreach ($webspaceLocales as $webspaceLocale) {
             $routePath = $routesPath . '/' . $webspaceLocale;
 
             try {
                 $routeDocument = $this->documentManager->find($routePath);
+
+                if ($routeDocument->getTargetDocument()
+                    && $routeDocument->getTargetDocument()->getUuid() === $homeDocument->getUuid()
+                ) {
+                    $output->writeln(sprintf('  [ ] <info>homepage</info>: %s (%s)', $routePath, $webspaceLocale));
+
+                    continue;
+                }
             } catch (DocumentNotFoundException $e) {
                 $routeDocument = $this->documentManager->create('route');
+                $output->writeln(sprintf('  [+] <info>homepage</info>: %s (%s)', $routePath, $webspaceLocale));
             }
 
             $routeDocument->setTargetDocument($homeDocument);

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -140,8 +140,9 @@ class WebspaceInitializer implements InitializerInterface
                 }
             } catch (DocumentNotFoundException $e) {
                 $routeDocument = $this->documentManager->create('route');
-                $output->writeln(sprintf('  [+] <info>homepage</info>: %s (%s)', $routePath, $webspaceLocale));
             }
+
+            $output->writeln(sprintf('  [+] <info>homepage</info>: %s (%s)', $routePath, $webspaceLocale));
 
             $routeDocument->setTargetDocument($homeDocument);
             $this->documentManager->persist($routeDocument, $webspaceLocale, [

--- a/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
+++ b/src/Sulu/Component/Webspace/Document/Initializer/WebspaceInitializer.php
@@ -134,7 +134,7 @@ class WebspaceInitializer implements InitializerInterface
                 if ($routeDocument->getTargetDocument()
                     && $routeDocument->getTargetDocument()->getUuid() === $homeDocument->getUuid()
                 ) {
-                    $output->writeln(sprintf('  [ ] <info>homepage</info>: %s (%s)', $routePath, $webspaceLocale));
+                    $output->writeln(sprintf('  [ ] <info>route</info>: %s (%s)', $routePath, $webspaceLocale));
 
                     continue;
                 }
@@ -142,7 +142,7 @@ class WebspaceInitializer implements InitializerInterface
                 $routeDocument = $this->documentManager->create('route');
             }
 
-            $output->writeln(sprintf('  [+] <info>homepage</info>: %s (%s)', $routePath, $webspaceLocale));
+            $output->writeln(sprintf('  [+] <info>route</info>: %s (%s)', $routePath, $webspaceLocale));
 
             $routeDocument->setTargetDocument($homeDocument);
             $this->documentManager->persist($routeDocument, $webspaceLocale, [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3990
| Related issues/PRs | 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix sulu document init routes generation.

#### Why?

When you did forget to run sulu:document:init the route nodes where never created and it was hard to fix this manually.

#### Example Usage

1. Run sulu document init
2. Add a new language to the webspace
3. Go into the webspace and save the homepage in the new language
4. Try to create a page in the new language
5. Run `sulu:document:init` (should create new route node (this wasn't the case before))
6. Now you should be able to create new pages

#### BC Breaks/Deprecations

--

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
