### PR TITLE
Avoid linebreak with long template titles in toolbar dropdown

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/button.scss
@@ -54,6 +54,7 @@ $primaryBackgroundColor: $shakespeare;
     background-color: transparent;
     font-size: 12px;
     cursor: pointer;
+    white-space: nowrap;
 
     &:disabled {
         cursor: default;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This title avoid line-breaks in the toolbar buttons.

#### Why?

Because if you had a long title for a template, then the dropdown in the toolbar of the Page form looked strange.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
