### PR TITLE
Fix double route redirects and polluted history when clicking on navigation item showing a list

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1833,9 +1833,6 @@ test('Should call all disposers if destroy is called', () => {
     listStore.sortOrderDisposer = jest.fn();
     listStore.limitDisposer = jest.fn();
     listStore.activeSettingDisposer = jest.fn();
-    listStore.limitSettingDisposer = jest.fn();
-    listStore.sortColumnSettingDisposer = jest.fn();
-    listStore.sortOrderSettingDisposer = jest.fn();
 
     listStore.destroy();
 
@@ -1846,7 +1843,4 @@ test('Should call all disposers if destroy is called', () => {
     expect(listStore.sortOrderDisposer).toBeCalledWith();
     expect(listStore.limitDisposer).toBeCalledWith();
     expect(listStore.activeSettingDisposer).toBeCalledWith();
-    expect(listStore.limitSettingDisposer).toBeCalledWith();
-    expect(listStore.sortColumnSettingDisposer).toBeCalledWith();
-    expect(listStore.sortOrderSettingDisposer).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -15,6 +15,7 @@ import toolbarActionRegistry from './registries/ToolbarActionRegistry';
 import listStyles from './list.scss';
 
 const DEFAULT_USER_SETTINGS_KEY = 'list';
+const DEFAULT_LIMIT = 10;
 
 type Props = ViewProps & {
     locale?: IObservableValue<string>,
@@ -42,11 +43,13 @@ class List extends React.Component<Props> {
             },
         } = route;
 
+        const limit = ListStore.getLimitSetting(listKey, userSettingsKey);
+
         return {
             active: ListStore.getActiveSetting(listKey, userSettingsKey),
             sortColumn: ListStore.getSortColumnSetting(listKey, userSettingsKey),
             sortOrder: ListStore.getSortOrderSetting(listKey, userSettingsKey),
-            limit: ListStore.getLimitSetting(listKey, userSettingsKey),
+            limit: limit === DEFAULT_LIMIT ? undefined : limit,
         };
     }
 
@@ -114,7 +117,7 @@ class List extends React.Component<Props> {
         router.bind('sortColumn', this.listStore.sortColumn);
         router.bind('sortOrder', this.listStore.sortOrder);
         router.bind('search', this.listStore.searchTerm);
-        router.bind('limit', this.listStore.limit, 10);
+        router.bind('limit', this.listStore.limit, DEFAULT_LIMIT);
     }
 
     buildListStoreOptions(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -829,6 +829,37 @@ test('Should load the route attributes from the ListStore', () => {
     expect(ListStore.getLimitSetting).toBeCalledWith('list_test', 'list');
 });
 
+test('Should return the limit route attributes as undefined if ListStore is set to default value', () => {
+    const List = require('../List').default;
+    const ListStore = require('../../../containers/List').ListStore;
+    ListStore.getActiveSetting = jest.fn();
+    ListStore.getSortColumnSetting = jest.fn();
+    ListStore.getSortOrderSetting = jest.fn();
+    ListStore.getLimitSetting = jest.fn();
+
+    ListStore.getActiveSetting.mockReturnValueOnce('some-uuid');
+    ListStore.getSortColumnSetting.mockReturnValueOnce('title');
+    ListStore.getSortOrderSetting.mockReturnValueOnce('desc');
+    ListStore.getLimitSetting.mockReturnValueOnce(10);
+
+    expect(List.getDerivedRouteAttributes({
+        options: {
+            listKey: 'list_test',
+            resourceKey: 'test',
+        },
+    })).toEqual({
+        active: 'some-uuid',
+        limit: undefined,
+        sortColumn: 'title',
+        sortOrder: 'desc',
+    });
+
+    expect(ListStore.getActiveSetting).toBeCalledWith('list_test', 'list');
+    expect(ListStore.getSortColumnSetting).toBeCalledWith('list_test', 'list');
+    expect(ListStore.getSortOrderSetting).toBeCalledWith('list_test', 'list');
+    expect(ListStore.getLimitSetting).toBeCalledWith('list_test', 'list');
+});
+
 test('Should load the route attributes from the ListStore using the passed userSettingsKey', () => {
     const List = require('../List').default;
     const ListStore = require('../../../containers/List').ListStore;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR writes the list store settings to the user settings before the actual change is written on the observable (that means it is done using an `intercept` call instead of an `autorun`).

#### Why?

Because otherwise this setting will be reset by the router again.

This can be tested when clicking on a navigation item. If the default limit is selected, then there are two entries in the history. That means that e.g. clicking the history back button of the browser had no effect unless changing the parameters of the current URL.