### PR TITLE
Fix migration of teaser with other properties

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201905071542.php
+++ b/src/Sulu/Bundle/PageBundle/Resources/phpcr-migrations/Version201905071542.php
@@ -55,6 +55,7 @@ class Version201905071542 implements VersionInterface, ContainerAwareInterface
                 if (is_string($property->getValue())) {
                     $propertyValue = json_decode($property->getValue(), true);
                     if ($propertyValue
+                        && is_array($propertyValue)
                         && array_key_exists('items', $propertyValue)
                         && array_key_exists('displayOption', $propertyValue)
                     ) {
@@ -86,6 +87,7 @@ class Version201905071542 implements VersionInterface, ContainerAwareInterface
                 if (is_string($property->getValue())) {
                     $propertyValue = json_decode($property->getValue(), true);
                     if ($propertyValue
+                        && is_array($propertyValue)
                         && array_key_exists('items', $propertyValue)
                     ) {
                         $propertyValue['displayOption'] = 'top';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Check in the migration for teaser that the property which is changed is an array.

#### Why?

Else properties like:

```
"i18n:en-homeBlocks-length"
5
```

will error with:

> In Version201905071542.php line 58:
> Warning: array_key_exists() expects parameter 2 to be array, int given

#### Example Usage

~~~php
bin/adminconsole phpcr:migrations:migrate
~~~
