### PR TITLE
Adjust listed field in page tree table view to avoid showing id

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/config/lists/pages.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/lists/pages.xml
@@ -5,7 +5,7 @@
     <properties>
         <property
             name="id"
-            visibility="always"
+            visibility="no"
             sortable="false"
             translation="sulu_admin.id"
         />
@@ -15,15 +15,10 @@
             translation="sulu_admin.title"
         />
         <property
-            name="order"
-            visibility="always"
-            translation="sulu_page.order"
-        />
-        <property
             name="published"
             type="datetime"
-            visibility="always"
-            translation="sulu_page.published"
+            visibility="yes"
+            translation="sulu_admin.published"
         />
     </properties>
 </list>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR prevents the page id from being displayed by default.

#### Why?

Because this value is not really useful.