### PR TITLE
Add separate tab for handling category keywords

### DIFF
--- a/assets/admin/index.js
+++ b/assets/admin/index.js
@@ -13,6 +13,7 @@ import 'core-js/fn/symbol';
 
 // Bundles
 import {startAdmin} from 'sulu-admin-bundle';
+import 'sulu-category-bundle';
 import 'sulu-contact-bundle';
 import 'sulu-custom-url-bundle';
 import 'sulu-media-bundle';

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     },
     "dependencies": {
         "sulu-admin-bundle": "file:src/Sulu/Bundle/AdminBundle/Resources/js",
+        "sulu-category-bundle": "file:src/Sulu/Bundle/CategoryBundle/Resources/js",
         "sulu-contact-bundle": "file:src/Sulu/Bundle/ContactBundle/Resources/js",
         "sulu-custom-url-bundle": "file:src/Sulu/Bundle/CustomUrlBundle/Resources/js",
         "sulu-media-bundle": "file:src/Sulu/Bundle/MediaBundle/Resources/js",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/index.js
@@ -3,6 +3,7 @@ import {internalLinkTypeRegistry} from './CKEditor5';
 import List, {
     ListStore,
     listAdapterRegistry,
+    listFieldTransformerRegistry,
     AbstractAdapter,
     FlatStructureStrategy,
     InfiniteLoadingStrategy,
@@ -41,6 +42,7 @@ export {
     List,
     ListStore,
     listAdapterRegistry,
+    listFieldTransformerRegistry,
     fieldRegistry,
     FlatStructureStrategy,
     Form,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/types.js
@@ -5,11 +5,13 @@ import type {SelectionData} from './components/RectangleSelection/types';
 import type {FieldTypeProps} from './containers/Form/types';
 import type {InternalLinkTypeOverlayProps} from './containers/CKEditor5/types';
 import type {BlockPreviewTransformer} from './containers/FieldBlocks/types';
+import type {FieldTransformer} from './containers/List/types';
 import type {ToolbarItemConfig} from './containers/Toolbar/types';
 
 export type {
     BlockPreviewTransformer,
     ButtonOption,
+    FieldTransformer,
     FieldTypeProps,
     FormFieldTypes,
     InternalLinkTypeOverlayProps,

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -135,6 +135,18 @@ class CategoryAdmin extends Admin
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->getRoute(),
+            $this->routeBuilderFactory
+                ->createFormOverlayListRouteBuilder('sulu_category.edit_form.keywords', '/keywords')
+                ->setResourceKey('category_keywords')
+                ->setListKey('category_keywords')
+                ->addListAdapters(['table'])
+                ->addRouterAttributesToListStore(['id' => 'categoryId'])
+                ->setFormKey('category_keywords')
+                ->addRouterAttributesToFormStore(['id' => 'categoryId'])
+                ->setTabTitle('sulu_category.keywords')
+                ->addToolbarActions(['sulu_admin.add', 'sulu_admin.delete'])
+                ->setParent(static::EDIT_FORM_ROUTE)
+                ->getRoute(),
         ];
     }
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -43,7 +43,7 @@ class KeywordController extends RestController implements ClassResourceInterface
     /**
      * {@inheritdoc}
      */
-    protected static $entityKey = 'keywords';
+    protected static $entityKey = 'category_keywords';
 
     /**
      * Returns list of keywords filtered by the category.
@@ -118,21 +118,24 @@ class KeywordController extends RestController implements ClassResourceInterface
         return $this->handleView($this->view($keyword));
     }
 
+    public function getAction($categoryId, $id, Request $request)
+    {
+        $keyword = $this->getKeywordRepository()->findById($id);
+
+        if (!$keyword) {
+            return $this->handleView($this->view(null, 404));
+        }
+
+        return $this->handleView($this->view($keyword));
+    }
+
     /**
-     * Updates given keyword for given category.
-     *
-     * @param int $categoryId
-     * @param int $keywordId
-     * @param Request $request
-     *
-     * @return Response
-     *
      * @throws KeywordIsMultipleReferencedException
      * @throws KeywordNotUniqueException
      */
-    public function putAction($categoryId, $keywordId, Request $request)
+    public function putAction($categoryId, $id, Request $request)
     {
-        $keyword = $this->getKeywordRepository()->findById($keywordId);
+        $keyword = $this->getKeywordRepository()->findById($id);
 
         if (!$keyword) {
             return $this->handleView($this->view(null, 404));
@@ -158,9 +161,9 @@ class KeywordController extends RestController implements ClassResourceInterface
      *
      * @return Response
      */
-    public function deleteAction($categoryId, $keywordId)
+    public function deleteAction($categoryId, $id)
     {
-        $keyword = $this->getKeywordRepository()->findById($keywordId);
+        $keyword = $this->getKeywordRepository()->findById($id);
         $category = $this->getCategoryRepository()->findCategoryById($categoryId);
         $this->getKeywordManager()->delete($keyword, $category);
 
@@ -232,7 +235,7 @@ class KeywordController extends RestController implements ClassResourceInterface
     public function getFieldDescriptors()
     {
         return $this->get('sulu_core.list_builder.field_descriptor_factory')
-        ->getFieldDescriptors('keywords');
+        ->getFieldDescriptors('category_keywords');
     }
 
     /**

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -98,6 +98,12 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
                                 'detail' => 'get_category',
                             ],
                         ],
+                        'category_keywords' => [
+                            'routes' => [
+                                'list' => 'get_category_keywords',
+                                'detail' => 'get_category_keyword',
+                            ],
+                        ],
                     ],
                     'field_type_options' => [
                         'selection' => [

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/forms/category_keywords.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/forms/category_keywords.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>category_keywords</key>
+
+    <properties>
+        <property name="keyword" type="text_line" mandatory="true">
+            <meta>
+                <title>sulu_category.keyword</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+        </property>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/lists/category_keywords.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/lists/category_keywords.xml
@@ -30,7 +30,12 @@
             </joins>
         </group-concat-property>
 
-        <count-property name="categoryTranslationCount" visibility="always" translation="sulu_category.multiple_usage">
+        <count-property
+            name="categoryTranslationCount"
+            visibility="always"
+            translation="sulu_category.multiple_usage"
+            type="category_keywords_multiple_usage"
+        >
             <field-name>id</field-name>
             <entity-name>%sulu.model.category_translation.class%</entity-name>
 

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/lists/category_keywords.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/lists/category_keywords.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <list xmlns="http://schemas.sulu.io/list-builder/list">
-    <key>keywords</key>
+    <key>category_keywords</key>
 
     <properties>
         <property name="id" translation="sulu_admin.id" visibility="no" type="string">

--- a/src/Sulu/Bundle/CategoryBundle/Resources/js/containers/List/fieldTransformers/CategoryKeywordsMultipleUsageTransformer.js
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/js/containers/List/fieldTransformers/CategoryKeywordsMultipleUsageTransformer.js
@@ -1,0 +1,11 @@
+// @flow
+import React from 'react';
+import type {Node} from 'react';
+import {Checkbox} from 'sulu-admin-bundle/components';
+import type {FieldTransformer} from 'sulu-admin-bundle/types';
+
+export default class CategoryKeywordsMultipleUsageTransformer implements FieldTransformer {
+    transform(value: *): Node {
+        return <Checkbox checked={value > 1} disabled={true} />;
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Resources/js/containers/List/tests/fieldTransformers/CategoryKeywordsMultipleUsageTransformer.test.js
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/js/containers/List/tests/fieldTransformers/CategoryKeywordsMultipleUsageTransformer.test.js
@@ -1,0 +1,20 @@
+// @flow
+import React from 'react';
+import {Checkbox} from 'sulu-admin-bundle/components';
+import CategoryKeywordsMultipleUsageTransformer from '../../fieldTransformers/CategoryKeywordsMultipleUsageTransformer';
+
+const categoryKeywordsMultipleUsageTransformer = new CategoryKeywordsMultipleUsageTransformer();
+
+test.each([
+    [undefined, false],
+    [0, false],
+    [1, false],
+    [2, true],
+    [100, true],
+    ['0', false],
+    ['1', false],
+    ['2', true],
+])('Transform %s', (value, checked) => {
+    expect(categoryKeywordsMultipleUsageTransformer.transform(value))
+        .toEqual(<Checkbox checked={checked} disabled={true} />);
+});

--- a/src/Sulu/Bundle/CategoryBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/js/index.js
@@ -1,0 +1,6 @@
+// @flow
+import {listFieldTransformerRegistry} from 'sulu-admin-bundle/containers';
+import CategoryKeywordsMultipleUsageTransformer
+    from './containers/List/fieldTransformers/CategoryKeywordsMultipleUsageTransformer';
+
+listFieldTransformerRegistry.add('category_keywords_multiple_usage', new CategoryKeywordsMultipleUsageTransformer());

--- a/src/Sulu/Bundle/CategoryBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/js/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "sulu-category-bundle",
+    "description": "Adds support for categories to Sulu",
+    "license": "MIT",
+    "repository": "https://github.com/sulu/sulu.git",
+    "devDependencies": {
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
+    },
+    "peerDependencies": {
+        "react": "^16.2.0",
+        "sulu-admin-bundle": "*"
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.de.json
@@ -2,7 +2,8 @@
     "sulu_category.categories": "Kategorien",
     "sulu_category.key": "Schlüssel",
     "sulu_category.name": "Name",
-    "sulu_category.key_word": "Schlüsselwort",
+    "sulu_category.keywords": "Schlüsselwörter",
+    "sulu_category.keyword": "Schlüsselwort",
     "sulu_category.multiple_usage": "Mehrfachverwendung",
     "sulu_category.all_categories": "Alle Kategorien"
 }

--- a/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/translations/admin.en.json
@@ -2,7 +2,8 @@
     "sulu_category.categories": "Categories",
     "sulu_category.key": "Key",
     "sulu_category.name": "Name",
-    "sulu_category.key_word": "Keywords",
+    "sulu_category.keywords": "Keywords",
+    "sulu_category.keyword": "Keyword",
     "sulu_category.multiple_usage": "Multiple Usage",
     "sulu_category.all_categories": "All categories"
 }

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
@@ -85,12 +85,40 @@ class KeywordControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
         $this->assertEquals(2, $response->total);
 
-        usort($response->_embedded->keywords, function($key1, $key2) {
+        usort($response->_embedded->category_keywords, function($key1, $key2) {
             return $key1->id > $key2->id;
         });
 
-        $this->assertEquals('keyword1', $response->_embedded->keywords[0]->keyword);
-        $this->assertEquals('keyword2', $response->_embedded->keywords[1]->keyword);
+        $this->assertEquals('keyword1', $response->_embedded->category_keywords[0]->keyword);
+        $this->assertEquals('keyword2', $response->_embedded->category_keywords[1]->keyword);
+    }
+
+    public function testGet()
+    {
+        $keyword = $this->testPost('keyword1', 'de', $this->category1->getId());
+
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/categories/' . $this->category1->getId() . '/keywords/' . $keyword['id'] . '?locale=de'
+        );
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertEquals('keyword1', $response->keyword);
+    }
+
+    public function testGetNotExisting()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            '/api/categories/' . $this->category1->getId() . '/keywords/1?locale=de'
+        );
+
+        $this->assertHttpStatusCode(404, $client->getResponse());
     }
 
     public function testPost($keyword = 'Test', $locale = 'de', $categoryId = null)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a new tab, which allows to add/delete/edit keywords attached to a category.

#### Why?

Because this feature existed already in the old UI.