### PR TITLE
Avoid parallel generation of images

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -96,6 +96,7 @@ class Configuration implements ConfigurationInterface
                             'Expires' => '+1 month',
                             'Pragma' => 'public',
                             'Cache-Control' => 'public',
+                            'X-SULU-MEDIA-CACHE' => 'MISS',
                         ])
                     ->end()
                     ->arrayNode('default_imagine_options')

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
@@ -42,6 +42,7 @@ class SuluMediaExtensionTest extends AbstractExtensionTestCase
             'Expires' => '+1 month',
             'Pragma' => 'public',
             'Cache-Control' => 'public',
+            'X-SULU-MEDIA-CACHE' => 'MISS',
         ]);
         $this->assertContainerBuilderHasParameter('sulu_media.search.default_image_format', 'sulu-170x170');
         $this->assertContainerBuilderHasParameter('sulu_media.media.storage.local.path', '%kernel.project_dir%/var/uploads/media');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Avoid parallel generation of images by using the symfony lock component.

#### Why?

Image generation could end up in high memory usage if a image is currently requested parallel by different clients a server should just generate it once and not multiple times to avoid high memory usage.

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
