### PR TITLE
Fix smart-content with empty data-source and jackrabbit

### DIFF
--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -239,6 +239,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
         $emptyFilterResult = [[], false];
 
         if (!array_key_exists('dataSource', $filters)
+            || null === $filters['dataSource']
             || '' === $filters['dataSource']
             || (null !== $limit && $limit < 1)
         ) {

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -514,4 +514,34 @@ class PageDataProviderTest extends TestCase
         $this->assertTrue($result->getHasNextPage());
         $this->assertEquals(['123-456-789', '123-123-123', '123-123-456'], $referenceStore->getAll());
     }
+
+    public function testResolveResourceItemsNullDataSource()
+    {
+        $referenceStore = new ReferenceStore();
+        $provider = new PageDataProvider(
+            $this->getContentQueryBuilder(),
+            $this->getContentQueryExecutor(),
+            $this->getDocumentManager(),
+            $this->getProxyFactory(),
+            $this->getSession(),
+            $referenceStore,
+            true
+        );
+
+        $result = $provider->resolveResourceItems(
+            ['dataSource' => null],
+            [
+                'properties' => new PropertyParameter('properties', ['my-properties' => true], 'collection'),
+                'exclude_duplicates' => new PropertyParameter('exclude_duplicates', true),
+            ],
+            ['webspaceKey' => 'sulu_io', 'locale' => 'en'],
+            5,
+            1,
+            2
+        );
+
+        $this->assertInstanceOf(DataProviderResult::class, $result);
+
+        $this->assertEquals([], $result->getItems());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes smart-content without dataSource and jackrabbit.