### PR TITLE
Add locked toggler to user tab

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/user_details.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/forms/user_details.xml
@@ -12,6 +12,7 @@
                     <property name="id" mandatory="true" />
                 </properties>
             </schema>
+
             <schema>
                 <properties>
                     <property name="password" mandatory="true" />
@@ -43,12 +44,23 @@
             <meta>
                 <title>sulu_security.system_language</title>
             </meta>
+
             <params>
                 <param
                     name="values"
                     type="expression"
                     value="service('sulu_security.system_language_select_helper').getValues()"
                 />
+            </params>
+        </property>
+
+        <property name="locked" type="checkbox" colspan="6">
+            <meta>
+                <title>sulu_security.locked</title>
+            </meta>
+
+            <params>
+                <param name="type" value="toggler"/>
             </params>
         </property>
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
@@ -15,5 +15,6 @@
     "sulu_security.edit": "Bearbeiten",
     "sulu_security.delete": "Löschen",
     "sulu_security.live": "Live",
-    "sulu_security.security": "Sicherheit"
+    "sulu_security.security": "Sicherheit",
+    "sulu_security.locked": "Gesperrt"
 }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
@@ -15,5 +15,6 @@
     "sulu_security.edit": "Edit",
     "sulu_security.delete": "Delete",
     "sulu_security.live": "Live",
-    "sulu_security.security": "Security"
+    "sulu_security.security": "Security",
+    "sulu_security.locked": "Locked"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add locked toggler to user tab.

#### Why?

To make it possible to lock a user over the UI.

![Bildschirmfoto 2019-07-11 um 13 17 57](https://user-images.githubusercontent.com/1698337/61047137-0ba66700-a3df-11e9-8070-ce361bbb4c5e.png)

