### PR TITLE
Fix search button dropdown in firefox

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/searchField.scss
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/searchField.scss
@@ -28,6 +28,7 @@ $searchFieldHintColor: $gray;
     text-align: left;
     padding: 0 10px;
     cursor: pointer;
+    align-items: center;
 }
 
 .index {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix search button dropdown in firefox.

#### Why?

Before:

![Bildschirmfoto 2019-07-16 um 17 55 58](https://user-images.githubusercontent.com/1698337/61309779-2ae43080-a7f3-11e9-8756-6f437c11ff32.png)

After:

![Bildschirmfoto 2019-07-16 um 17 57 35](https://user-images.githubusercontent.com/1698337/61309790-359ec580-a7f3-11e9-8db8-249b4afeb8c0.png)

