### PR TITLE
Fix nested properties within block

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -1,4 +1,5 @@
 // @flow
+import jsonpointer from 'json-pointer';
 import React, {Fragment} from 'react';
 import {toJS} from 'mobx';
 import BlockCollection from '../../components/BlockCollection';
@@ -20,7 +21,7 @@ export default class FieldBlocks extends React.Component<FieldTypeProps<Array<Bl
         }
 
         const newValues = toJS(oldValues);
-        newValues[index][name] = value;
+        jsonpointer.set(newValues[index], '/' + name, value);
 
         onChange(newValues);
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -650,6 +650,50 @@ test('Should call onFinish when a field from the child renderer has finished edi
     expect(finishSpy).toBeCalledWith();
 });
 
+test ('Should set nested properties in handleBlockChange and call onChange with new values', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text: {
+                    label: 'Text',
+                    type: 'text_line',
+                    visible: true,
+                },
+            },
+        },
+    };
+    const value = [{__id: 1, type: 'default'}];
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const changeSpy = jest.fn();
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            dataPath=""
+            defaultType="editor"
+            fieldTypeOptions={{}}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaPath=""
+            types={types}
+            value={value}
+        />
+    );
+
+    fieldBlocks.find('Block').simulate('click');
+    fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'options/test1', 'value1');
+
+    const expectedArray1 = [{__id: 1, type: 'default', options: {test1: 'value1'}}];
+    expect(changeSpy).toBeCalledWith(expectedArray1);
+
+    fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'options/test2/test3', 'value2');
+    const expectedArray2 = [{__id: 1, type: 'default', options: {test1: 'value1', test2: {test3: 'value2'}}}];
+    expect(changeSpy).toBeCalledWith(expectedArray2);
+});
+
 test('Should call onFinish when the order of the blocks has changed', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const types = {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4628
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Allow mapping between form properties within a block element and nested JSON data.

#### Why?

Previously it was not possible to map data from a nested JSON object to a form property within a block element.

