### PR TITLE
Fix choosing correct language for custom url

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -138,19 +138,21 @@ class SingleSelection extends React.Component<Props> {
                         </div>
                     }
                 </SingleItemSelection>
-                <SingleListOverlay
-                    adapter={adapter}
-                    disabledIds={disabledIds}
-                    listKey={listKey}
-                    locale={locale}
-                    onClose={this.handleOverlayClose}
-                    onConfirm={this.handleOverlayConfirm}
-                    open={this.overlayOpen}
-                    options={listOptions}
-                    preSelectedItem={item}
-                    resourceKey={resourceKey}
-                    title={overlayTitle}
-                />
+                {!loading &&
+                    <SingleListOverlay
+                        adapter={adapter}
+                        disabledIds={disabledIds}
+                        listKey={listKey}
+                        locale={locale}
+                        onClose={this.handleOverlayClose}
+                        onConfirm={this.handleOverlayConfirm}
+                        open={this.overlayOpen}
+                        options={listOptions}
+                        preSelectedItem={item}
+                        resourceKey={resourceKey}
+                        title={overlayTitle}
+                    />
+                }
             </Fragment>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -432,4 +432,5 @@ test('Set loading prop of SingleItemSelection component if SingleSelectionStore 
     expect(singleSelection.find(SingleItemSelection).prop('loading')).toEqual(false);
     singleSelection.instance().singleSelectionStore.loading = true;
     expect(singleSelection.find(SingleItemSelection).prop('loading')).toEqual(true);
+    expect(singleSelection.find(SingleListOverlay)).toHaveLength(0);
 });

--- a/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
+++ b/src/Sulu/Component/CustomUrl/Manager/CustomUrlManager.php
@@ -182,9 +182,9 @@ class CustomUrlManager implements CustomUrlManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function findByUrl($url, $webspaceKey)
+    public function findByUrl($url, $webspaceKey, $locale = null)
     {
-        $routeDocument = $this->findRouteByUrl($url, $webspaceKey);
+        $routeDocument = $this->findRouteByUrl($url, $webspaceKey, $locale);
 
         if (null === $routeDocument) {
             return;
@@ -211,13 +211,13 @@ class CustomUrlManager implements CustomUrlManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function findRouteByUrl($url, $webspaceKey)
+    public function findRouteByUrl($url, $webspaceKey, $locale = null)
     {
         try {
             /** @var RouteDocument $routeDocument */
             $routeDocument = $this->documentManager->find(
                 sprintf('%s/%s', $this->getRoutesPath($webspaceKey), $url),
-                LOCALE,
+                $locale,
                 ['load_ghost_content' => true]
             );
         } catch (DocumentNotFoundException $ex) {

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
@@ -251,10 +251,10 @@ class CustomUrlManagerTest extends TestCase
         $this->pathBuilder->build(['%base%', 'sulu_io', '%custom_urls%', '%custom_urls_routes%'])
             ->willReturn('/cmf/sulu_io/custom_urls/routes');
 
-        $this->documentManager->find('/cmf/sulu_io/custom_urls/routes/sulu.io/test', 'en', ['load_ghost_content' => true])
+        $this->documentManager->find('/cmf/sulu_io/custom_urls/routes/sulu.io/test', 'de', ['load_ghost_content' => true])
             ->willReturn($routeDocument->reveal());
 
-        $result = $this->manager->findByUrl('sulu.io/test', 'sulu_io');
+        $result = $this->manager->findByUrl('sulu.io/test', 'sulu_io', 'de');
 
         $this->assertEquals($customUrlDocument->reveal(), $result);
     }
@@ -269,7 +269,7 @@ class CustomUrlManagerTest extends TestCase
         $this->documentManager->find('/cmf/sulu_io/custom_urls/routes/sulu.io/test', 'en', ['load_ghost_content' => true])
             ->willReturn($routeDocument->reveal());
 
-        $result = $this->manager->findRouteByUrl('sulu.io/test', 'sulu_io');
+        $result = $this->manager->findRouteByUrl('sulu.io/test', 'sulu_io', 'en');
 
         $this->assertEquals($routeDocument->reveal(), $result);
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the correct language to load resp. redirect to the correct page.

#### Why?

Because currently it is always referring to the english version of a page.