### PR TITLE
Fix switching between webspaces

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -12,7 +12,7 @@ type Props = {
     router: Router,
 };
 
-const UPDATE_ROUTE_HOOK_PRIORITY = -1024;
+const UPDATE_ROUTE_HOOK_PRIORITY = 1024;
 
 @observer
 class ViewRenderer extends React.Component<Props> {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -370,7 +370,7 @@ test('Clear bindings of router everytime a new view is rendered', () => {
     };
 
     shallow(<ViewRenderer router={router} />);
-    expect(router.addUpdateRouteHook).toBeCalledWith(expect.anything(), -1024);
+    expect(router.addUpdateRouteHook).toBeCalledWith(expect.anything(), 1024);
 
     const updateRouteHook = router.addUpdateRouteHook.mock.calls[0][0];
 
@@ -399,7 +399,7 @@ test('Clear bindings of router when same view with a different rerender attribut
     };
 
     shallow(<ViewRenderer router={router} />);
-    expect(router.addUpdateRouteHook).toBeCalledWith(expect.anything(), -1024);
+    expect(router.addUpdateRouteHook).toBeCalledWith(expect.anything(), 1024);
 
     const updateRouteHook = router.addUpdateRouteHook.mock.calls[0][0];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -22,7 +22,7 @@ type Props = ViewProps & {
     title?: string,
 };
 
-const FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY = 1024;
+const FORM_STORE_UPDATE_ROUTE_HOOK_PRIORITY = 2048;
 
 const HAS_CHANGED_ERROR_CODE = 1102;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1749,7 +1749,7 @@ test('Should add and remove the UpdateRouteHook on mounting and unmounting', () 
 
     const checkFormStoreDirtyStateBeforeNavigation = form.instance().checkFormStoreDirtyStateBeforeNavigation;
 
-    expect(router.addUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation, 1024);
+    expect(router.addUpdateRouteHook).toBeCalledWith(checkFormStoreDirtyStateBeforeNavigation, 2048);
     expect(checkFormStoreDirtyStateBeforeNavigationDisposerSpy).not.toBeCalledWith();
 
     form.unmount();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the order of the hooks being executed when a routing takes place.

#### Why?

Because after the first time switching the webspace in the `WebspaceTabs` switching the webspace does not work anymore.
