### PR TITLE
Fix jumping width of RoleAssignment

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/RoleAssignment.js
@@ -40,7 +40,7 @@ class RoleAssignment extends React.Component<Props> {
             <tr className={roleAssignmentClass}>
                 <td>{value.role.name}</td>
                 <td>{value.role.system}</td>
-                <td>
+                <td className={roleAssignmentStyle.locale}>
                     <MultiSelect
                         disabled={disabled}
                         onChange={this.handleChange}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignment.scss
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/roleAssignment.scss
@@ -20,3 +20,7 @@ $roleAssignmentBorderColor: $silver;
         opacity: .5;
     }
 }
+
+.locale {
+    width: 50%;
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignment.test.js.snap
@@ -10,7 +10,9 @@ exports[`Render component 1`] = `
   <td>
     Sulu
   </td>
-  <td>
+  <td
+    class="locale"
+  >
     <div
       class="select"
     >
@@ -63,7 +65,9 @@ exports[`Render component in disabled state 1`] = `
   <td>
     Sulu
   </td>
-  <td>
+  <td
+    class="locale"
+  >
     <div
       class="select"
     >

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/__snapshots__/RoleAssignments.test.js.snap
@@ -62,7 +62,9 @@ exports[`Render component 1`] = `
           <td>
             Sulu
           </td>
-          <td>
+          <td
+            class="locale"
+          >
             <div
               class="select"
             >
@@ -112,7 +114,9 @@ exports[`Render component 1`] = `
           <td>
             Sulu
           </td>
-          <td>
+          <td
+            class="locale"
+          >
             <div
               class="select"
             >
@@ -222,7 +226,9 @@ exports[`Render component in disabled state 1`] = `
           <td>
             Sulu
           </td>
-          <td>
+          <td
+            class="locale"
+          >
             <div
               class="select"
             >
@@ -273,7 +279,9 @@ exports[`Render component in disabled state 1`] = `
           <td>
             Sulu
           </td>
-          <td>
+          <td
+            class="locale"
+          >
             <div
               class="select"
             >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the with of the last column in the `RoleAssignment` table.

#### Why?

Because then it stops changing its width when the content of the localization select is changed.