### PR TITLE
Add toolbar-action for locking users to permission-tab of contact form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -15,7 +15,7 @@ jest.mock('../../../containers/SingleListOverlay', () => jest.fn(function() {
     return <div />;
 }));
 
-jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(function() {}));
+jest.mock('../../../containers/List/stores/ListStore', () => jest.fn());
 
 jest.mock('../../../stores/SingleSelectionStore', () => jest.fn(function() {
     this.set = jest.fn((item) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
@@ -9,7 +9,7 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-jest.mock('../../../../stores/ResourceStore', () => jest.fn(function() {}));
+jest.mock('../../../../stores/ResourceStore', () => jest.fn());
 
 jest.mock('../../../../containers/Form', () => ({
     ResourceFormStore: class {
@@ -28,7 +28,7 @@ jest.mock('../../../../containers/Form', () => ({
     },
 }));
 
-jest.mock('../../../../services/Router', () => jest.fn(function() {}));
+jest.mock('../../../../services/Router', () => jest.fn());
 
 jest.mock('../../../../views/Form', () => jest.fn(function() {
     this.submit = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithPublishingToolbarAction.test.js
@@ -34,7 +34,7 @@ jest.mock('../../../../containers/Form', () => ({
     },
 }));
 
-jest.mock('../../../../services/Router', () => jest.fn(function() {}));
+jest.mock('../../../../services/Router', () => jest.fn());
 
 jest.mock('../../../../views/Form', () => jest.fn(function() {
     this.submit = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -9,7 +9,7 @@ jest.mock('../../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
-jest.mock('../../../../stores/ResourceStore', () => jest.fn(function() {}));
+jest.mock('../../../../stores/ResourceStore', () => jest.fn());
 
 jest.mock('../../../../containers/Form', () => ({
     ResourceFormStore: class {
@@ -30,7 +30,7 @@ jest.mock('../../../../containers/Form', () => ({
     },
 }));
 
-jest.mock('../../../../services/Router', () => jest.fn(function() {}));
+jest.mock('../../../../services/Router', () => jest.fn());
 
 jest.mock('../../../../views/Form', () => jest.fn(function() {
     this.submit = jest.fn();

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/TemplateToolbarAction.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/Form/tests/toolbarActions/TemplateToolbarAction.test.js
@@ -30,7 +30,7 @@ jest.mock('sulu-admin-bundle/containers', () => ({
 }));
 
 jest.mock('sulu-admin-bundle/services', () => ({
-    Router: jest.fn(function() {}),
+    Router: jest.fn(),
 }));
 
 jest.mock('sulu-admin-bundle/views', () => ({

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -157,7 +157,7 @@ class SecurityAdmin extends Admin
                 ->setResourceKey('users')
                 ->setFormKey('user_details')
                 ->setTabTitle('sulu_security.permissions')
-                ->addToolbarActions(['sulu_admin.save', 'sulu_security.enable_user'])
+                ->addToolbarActions(['sulu_admin.save', 'sulu_security.enable_user', 'sulu_security.lock_user'])
                 ->setIdQueryParameter('contactId')
                 ->setTitleVisible(true)
                 ->setTabOrder(3072)

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -147,15 +147,20 @@ class UserController extends RestController implements ClassResourceInterface, S
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function postEnableUserAction($id, Request $request)
+    public function postTriggerAction($id, Request $request)
     {
         $action = $request->get('action');
 
         try {
             switch ($action) {
                 case 'enable':
-                    // call repository method
                     $user = $this->getUserManager()->enableUser($id);
+                    break;
+                case 'lock':
+                    $user = $this->getUserManager()->lockUser($id);
+                    break;
+                case 'unlock':
+                    $user = $this->getUserManager()->unlockUser($id);
                     break;
                 default:
                     throw new RestException('Unrecognized action: ' . $action);

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
@@ -5,12 +5,14 @@ import {formToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import {Permissions, RoleAssignments, RolePermissions} from './containers/Form';
 import securityContextStore from './stores/SecurityContextStore';
 import EnableUserToolbarAction from './views/Form/toolbarActions/EnableUserToolbarAction';
+import LockUserToolbarAction from './views/Form/toolbarActions/LockUserToolbarAction';
 
 fieldRegistry.add('permissions', Permissions);
 fieldRegistry.add('role_assignments', RoleAssignments);
 fieldRegistry.add('role_permissions', RolePermissions);
 
 formToolbarActionRegistry.add('sulu_security.enable_user', EnableUserToolbarAction);
+formToolbarActionRegistry.add('sulu_security.lock_user', LockUserToolbarAction);
 
 initializer.addUpdateConfigHook('sulu_security', (config: Object) => {
     securityContextStore.endpoint = config.endpoints.contexts;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
@@ -112,8 +112,8 @@ test('Return null as item config when user is already enabled', () => {
 });
 
 test('Call ResourceRequester with correct parameters when button is clicked', () => {
-    const deleteDraftPromise = Promise.resolve({enabled: true});
-    ResourceRequester.post.mockReturnValue(deleteDraftPromise);
+    const enableUserPromise = Promise.resolve({enabled: true});
+    ResourceRequester.post.mockReturnValue(enableUserPromise);
 
     const toolbarAction = createEnableUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = false;
@@ -136,8 +136,8 @@ test('Call ResourceRequester with correct parameters when button is clicked', ()
 });
 
 test('Return item config with loading button during request', () => {
-    const deleteDraftPromise = Promise.resolve({enabled: true});
-    ResourceRequester.post.mockReturnValue(deleteDraftPromise);
+    const enableUserPromise = Promise.resolve({enabled: true});
+    ResourceRequester.post.mockReturnValue(enableUserPromise);
 
     const toolbarAction = createEnableUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = false;
@@ -158,7 +158,7 @@ test('Return item config with loading button during request', () => {
         loading: true,
     }));
 
-    return deleteDraftPromise.then(() => {
+    return enableUserPromise.then(() => {
         expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
             loading: false,
         }));
@@ -166,8 +166,8 @@ test('Return item config with loading button during request', () => {
 });
 
 test('Set new enabled value to ResourceFormStore and show success-snackbar on successful request', () => {
-    const deleteDraftPromise = Promise.resolve({enabled: true});
-    ResourceRequester.post.mockReturnValue(deleteDraftPromise);
+    const enableUserPromise = Promise.resolve({enabled: true});
+    ResourceRequester.post.mockReturnValue(enableUserPromise);
 
     const toolbarAction = createEnableUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = false;
@@ -180,15 +180,15 @@ test('Set new enabled value to ResourceFormStore and show success-snackbar on su
     }
     toolbarItemConfig.onClick();
 
-    return deleteDraftPromise.then(() => {
+    return enableUserPromise.then(() => {
         expect(toolbarAction.resourceFormStore.set).toBeCalledWith('enabled', true);
         expect(toolbarAction.form.showSuccessSnackbar).toBeCalled();
     });
 });
 
 test('Push error to form view on failed request', (done) => {
-    const deleteDraftPromise = Promise.reject();
-    ResourceRequester.post.mockReturnValue(deleteDraftPromise);
+    const enableUserPromise = Promise.reject();
+    ResourceRequester.post.mockReturnValue(enableUserPromise);
 
     const toolbarAction = createEnableUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = false;

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/EnableUserToolbarAction.test.js
@@ -42,7 +42,7 @@ jest.mock('sulu-admin-bundle/containers/Form', () => ({
     },
 }));
 
-jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function() {}));
+jest.mock('sulu-admin-bundle/services/Router', () => jest.fn());
 
 jest.mock('sulu-admin-bundle/views/Form/Form', () => jest.fn(function() {
     this.errors = [];

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
@@ -146,8 +146,9 @@ test('Call ResourceRequester with correct parameters when user is not locked and
     toolbarAction.resourceFormStore.resourceStore.locale = 'de';
 
     const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
-    expect(toolbarItemConfig).not.toBeFalsy();
-    // $FlowFixMe
+    if (!toolbarItemConfig) {
+        throw new Error('The ToolbarItemConfig should not be undefined or null');
+    }
     toolbarItemConfig.onClick();
 
     expect(ResourceRequester.post).toBeCalledWith(
@@ -170,8 +171,9 @@ test('Call ResourceRequester with correct parameters when user is already locked
     toolbarAction.resourceFormStore.resourceStore.locale = 'de';
 
     const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
-    expect(toolbarItemConfig).not.toBeFalsy();
-    // $FlowFixMe
+    if (!toolbarItemConfig) {
+        throw new Error('The ToolbarItemConfig should not be undefined or null');
+    }
     toolbarItemConfig.onClick();
 
     expect(ResourceRequester.post).toBeCalledWith(
@@ -196,8 +198,9 @@ test('Return item config with loading button during request', () => {
     }));
 
     const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
-    expect(toolbarItemConfig).not.toBeFalsy();
-    // $FlowFixMe
+    if (!toolbarItemConfig) {
+        throw new Error('The ToolbarItemConfig should not be undefined or null');
+    }
     toolbarItemConfig.onClick();
 
     expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
@@ -222,8 +225,9 @@ test('Set new locked value to ResourceFormStore and show success-snackbar on suc
     toolbarAction.resourceFormStore.resourceStore.data.locked = false;
 
     const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
-    expect(toolbarItemConfig).not.toBeFalsy();
-    // $FlowFixMe
+    if (!toolbarItemConfig) {
+        throw new Error('The ToolbarItemConfig should not be undefined or null');
+    }
     toolbarItemConfig.onClick();
 
     return lockUserPromise.then(() => {
@@ -245,8 +249,9 @@ test('Push error to form view on failed request', (done) => {
     expect(toolbarAction.form.errors).toHaveLength(0);
 
     const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
-    expect(toolbarItemConfig).not.toBeFalsy();
-    // $FlowFixMe
+    if (!toolbarItemConfig) {
+        throw new Error('The ToolbarItemConfig should not be undefined or null');
+    }
     toolbarItemConfig.onClick();
 
     setTimeout(() => {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
@@ -70,7 +70,7 @@ function createLockUserToolbarAction() {
     return new LockUserToolbarAction(resourceFormStore, form, router);
 }
 
-test('Return item config with correct disabled, loading, icon, type and label', () => {
+test('Return item config with correct type, label, loading and value', () => {
     const toolbarAction = createLockUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = false;
     toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
@@ -79,13 +79,13 @@ test('Return item config with correct disabled, loading, icon, type and label', 
 
     expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         type: 'toggler',
-        label: 'sulu_security.lock_user',
+        label: 'sulu_security.user_locked',
         loading: false,
         value: false,
     }));
 });
 
-test('Return correct label and value when user is already locked', () => {
+test('Return correct value when user is already locked', () => {
     const toolbarAction = createLockUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = false;
     toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
@@ -93,7 +93,6 @@ test('Return correct label and value when user is already locked', () => {
     toolbarAction.resourceFormStore.resourceStore.data.locked = true;
 
     expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
-        label: 'sulu_security.user_locked',
         value: true,
     }));
 });
@@ -178,7 +177,7 @@ test('Call ResourceRequester with correct parameters when user is already locked
     );
 });
 
-test('Return item config with loading button during request', () => {
+test('Return item config with loading toggler during request', () => {
     const lockUserPromise = Promise.resolve({locked: true});
     ResourceRequester.post.mockReturnValue(lockUserPromise);
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
@@ -42,7 +42,7 @@ jest.mock('sulu-admin-bundle/containers/Form', () => ({
     },
 }));
 
-jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function() {}));
+jest.mock('sulu-admin-bundle/services/Router', () => jest.fn());
 
 jest.mock('sulu-admin-bundle/views/Form/Form', () => jest.fn(function() {
     this.errors = [];

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
@@ -79,7 +79,6 @@ test('Return item config with correct disabled, loading, icon, type and label', 
 
     expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         type: 'toggler',
-        disabled: false,
         label: 'sulu_security.lock_user',
         loading: false,
         value: false,
@@ -88,8 +87,8 @@ test('Return item config with correct disabled, loading, icon, type and label', 
 
 test('Return correct label and value when user is already locked', () => {
     const toolbarAction = createLockUserToolbarAction();
-    toolbarAction.resourceFormStore.resourceStore.loading = true;
-    toolbarAction.resourceFormStore.resourceStore.data.id = null;
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
     toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
     toolbarAction.resourceFormStore.resourceStore.data.locked = true;
 
@@ -99,28 +98,24 @@ test('Return correct label and value when user is already locked', () => {
     }));
 });
 
-test('Return item config with disabled button when resource store is loading', () => {
+test('Return null as item config when resource store is loading', () => {
     const toolbarAction = createLockUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = true;
     toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
     toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
     toolbarAction.resourceFormStore.resourceStore.data.locked = false;
 
-    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
-        disabled: true,
-    }));
+    expect(toolbarAction.getToolbarItemConfig()).toBeFalsy();
 });
 
-test('Return item config with disabled button when user has no id yet', () => {
+test('Return null as item config when user has no id yet', () => {
     const toolbarAction = createLockUserToolbarAction();
     toolbarAction.resourceFormStore.resourceStore.loading = true;
     toolbarAction.resourceFormStore.resourceStore.data.id = null;
     toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
     toolbarAction.resourceFormStore.resourceStore.data.locked = false;
 
-    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
-        disabled: true,
-    }));
+    expect(toolbarAction.getToolbarItemConfig()).toBeFalsy();
 });
 
 test('Return null as item config when user is not enabled yet', () => {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/tests/toolbarActions/LockUserToolbarAction.test.js
@@ -1,0 +1,256 @@
+// @flow
+import ResourceStore from 'sulu-admin-bundle/stores/ResourceStore';
+import Router from 'sulu-admin-bundle/services/Router';
+import Form from 'sulu-admin-bundle/views/Form/Form';
+import {ResourceFormStore} from 'sulu-admin-bundle/containers/Form';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import LockUserToolbarAction from '../../toolbarActions/LockUserToolbarAction';
+
+jest.mock('sulu-admin-bundle/utils', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function() {
+    this.data = {};
+}));
+
+jest.mock('sulu-admin-bundle/containers/Form', () => ({
+    ResourceFormStore: class {
+        resourceStore;
+
+        set = jest.fn();
+
+        constructor(resourceStore) {
+            this.resourceStore = resourceStore;
+        }
+
+        get id() {
+            return this.resourceStore.id;
+        }
+
+        get data() {
+            return this.resourceStore.data;
+        }
+
+        get locale() {
+            return this.resourceStore.locale;
+        }
+
+        get loading() {
+            return this.resourceStore.loading;
+        }
+    },
+}));
+
+jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function() {}));
+
+jest.mock('sulu-admin-bundle/views/Form/Form', () => jest.fn(function() {
+    this.errors = [];
+    this.showSuccessSnackbar = jest.fn();
+    this.submit = jest.fn();
+}));
+
+jest.mock('sulu-admin-bundle/services', () => ({
+    ResourceRequester: {
+        post: jest.fn(),
+    },
+}));
+
+function createLockUserToolbarAction() {
+    const resourceStore = new ResourceStore('test');
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'test');
+    const router = new Router({});
+    const form = new Form({
+        locales: [],
+        resourceStore,
+        route: router.route,
+        router,
+    });
+
+    return new LockUserToolbarAction(resourceFormStore, form, router);
+}
+
+test('Return item config with correct disabled, loading, icon, type and label', () => {
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        type: 'toggler',
+        disabled: false,
+        label: 'sulu_security.lock_user',
+        loading: false,
+        value: false,
+    }));
+});
+
+test('Return correct label and value when user is already locked', () => {
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = true;
+    toolbarAction.resourceFormStore.resourceStore.data.id = null;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = true;
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        label: 'sulu_security.user_locked',
+        value: true,
+    }));
+});
+
+test('Return item config with disabled button when resource store is loading', () => {
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = true;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
+test('Return item config with disabled button when user has no id yet', () => {
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = true;
+    toolbarAction.resourceFormStore.resourceStore.data.id = null;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
+test('Return null as item config when user is not enabled yet', () => {
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = true;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = false;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    expect(toolbarAction.getToolbarItemConfig()).toBeFalsy();
+});
+
+test('Call ResourceRequester with correct parameters when user is not locked and toggler is clicked', () => {
+    const lockUserPromise = Promise.resolve({locked: true});
+    ResourceRequester.post.mockReturnValue(lockUserPromise);
+
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+    // $FlowFixMe
+    toolbarAction.resourceFormStore.resourceStore.locale = 'de';
+
+    const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).not.toBeFalsy();
+    // $FlowFixMe
+    toolbarItemConfig.onClick();
+
+    expect(ResourceRequester.post).toBeCalledWith(
+        'users',
+        undefined,
+        {action: 'lock', id: 1234, locale: 'de'}
+    );
+});
+
+test('Call ResourceRequester with correct parameters when user is already locked and toggler is clicked', () => {
+    const unlockUserPromise = Promise.resolve({locked: false});
+    ResourceRequester.post.mockReturnValue(unlockUserPromise);
+
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = true;
+    // $FlowFixMe
+    toolbarAction.resourceFormStore.resourceStore.locale = 'de';
+
+    const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).not.toBeFalsy();
+    // $FlowFixMe
+    toolbarItemConfig.onClick();
+
+    expect(ResourceRequester.post).toBeCalledWith(
+        'users',
+        undefined,
+        {action: 'unlock', id: 1234, locale: 'de'}
+    );
+});
+
+test('Return item config with loading button during request', () => {
+    const lockUserPromise = Promise.resolve({locked: true});
+    ResourceRequester.post.mockReturnValue(lockUserPromise);
+
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        loading: false,
+    }));
+
+    const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).not.toBeFalsy();
+    // $FlowFixMe
+    toolbarItemConfig.onClick();
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        loading: true,
+    }));
+
+    return lockUserPromise.then(() => {
+        expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+            loading: false,
+        }));
+    });
+});
+
+test('Set new locked value to ResourceFormStore and show success-snackbar on successful request', () => {
+    const lockUserPromise = Promise.resolve({locked: true});
+    ResourceRequester.post.mockReturnValue(lockUserPromise);
+
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).not.toBeFalsy();
+    // $FlowFixMe
+    toolbarItemConfig.onClick();
+
+    return lockUserPromise.then(() => {
+        expect(toolbarAction.resourceFormStore.set).toBeCalledWith('locked', true);
+        expect(toolbarAction.form.showSuccessSnackbar).toBeCalled();
+    });
+});
+
+test('Push error to form view on failed request', (done) => {
+    const lockUserPromise = Promise.reject();
+    ResourceRequester.post.mockReturnValue(lockUserPromise);
+
+    const toolbarAction = createLockUserToolbarAction();
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.enabled = true;
+    toolbarAction.resourceFormStore.resourceStore.data.locked = false;
+
+    expect(toolbarAction.form.errors).toHaveLength(0);
+
+    const toolbarItemConfig = toolbarAction.getToolbarItemConfig();
+    expect(toolbarItemConfig).not.toBeFalsy();
+    // $FlowFixMe
+    toolbarItemConfig.onClick();
+
+    setTimeout(() => {
+        expect(toolbarAction.form.errors).toHaveLength(1);
+        done();
+    });
+});

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/LockUserToolbarAction.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/LockUserToolbarAction.js
@@ -12,14 +12,13 @@ export default class LockUserToolbarAction extends AbstractFormToolbarAction {
     }
 
     getToolbarItemConfig() {
-        if (!this.resourceFormStore.data.enabled) {
+        if (this.resourceFormStore.loading || !this.resourceFormStore.data.id || !this.resourceFormStore.data.enabled) {
             return null;
         }
 
         return {
             type: 'toggler',
             onClick: this.handleLockUserTogglerClick,
-            disabled: this.resourceFormStore.loading || !this.resourceFormStore.data.id,
             label: translate(this.userIsLocked ? 'sulu_security.user_locked' : 'sulu_security.lock_user'),
             loading: this.loading,
             value: this.userIsLocked,

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/LockUserToolbarAction.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/LockUserToolbarAction.js
@@ -19,7 +19,7 @@ export default class LockUserToolbarAction extends AbstractFormToolbarAction {
         return {
             type: 'toggler',
             onClick: this.handleLockUserTogglerClick,
-            label: translate(this.userIsLocked ? 'sulu_security.user_locked' : 'sulu_security.lock_user'),
+            label: translate('sulu_security.user_locked'),
             loading: this.loading,
             value: this.userIsLocked,
         };

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/LockUserToolbarAction.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/views/Form/toolbarActions/LockUserToolbarAction.js
@@ -1,0 +1,55 @@
+// @flow
+import {action, computed, observable} from 'mobx';
+import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
+import {translate} from 'sulu-admin-bundle/utils';
+
+export default class LockUserToolbarAction extends AbstractFormToolbarAction {
+    @observable loading: boolean = false;
+
+    @computed get userIsLocked() {
+        return this.resourceFormStore.data.locked;
+    }
+
+    getToolbarItemConfig() {
+        if (!this.resourceFormStore.data.enabled) {
+            return null;
+        }
+
+        return {
+            type: 'toggler',
+            onClick: this.handleLockUserTogglerClick,
+            disabled: this.resourceFormStore.loading || !this.resourceFormStore.data.id,
+            label: translate(this.userIsLocked ? 'sulu_security.user_locked' : 'sulu_security.lock_user'),
+            loading: this.loading,
+            value: this.userIsLocked,
+        };
+    }
+
+    @action handleLockUserTogglerClick = () => {
+        const {
+            locale,
+            data: {
+                id,
+            },
+        } = this.resourceFormStore;
+
+        this.loading = true;
+        ResourceRequester.post(
+            'users',
+            undefined,
+            {
+                action: this.userIsLocked ? 'unlock' : 'lock',
+                locale,
+                id,
+            }
+        ).then(action((response) => {
+            this.resourceFormStore.set('locked', response.locked);
+            this.loading = false;
+            this.form.showSuccessSnackbar();
+        })).catch(action((error) => {
+            this.form.errors.push(error);
+            this.loading = false;
+        }));
+    };
+}

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
@@ -2,6 +2,8 @@
     "sulu_security.roles": "Benutzerrollen",
     "sulu_security.user_name": "Username",
     "sulu_security.enable_user": "Benutzer aktivieren",
+    "sulu_security.lock_user": "Benutzer sperren",
+    "sulu_security.user_locked": "Benutzer gesperrt",
     "sulu_security.permissions": "Berechtigungen",
     "sulu_security.password": "Passwort",
     "sulu_security.email": "Email",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.de.json
@@ -2,7 +2,6 @@
     "sulu_security.roles": "Benutzerrollen",
     "sulu_security.user_name": "Username",
     "sulu_security.enable_user": "Benutzer aktivieren",
-    "sulu_security.lock_user": "Benutzer sperren",
     "sulu_security.user_locked": "Benutzer gesperrt",
     "sulu_security.permissions": "Berechtigungen",
     "sulu_security.password": "Passwort",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
@@ -2,6 +2,8 @@
     "sulu_security.roles": "User roles",
     "sulu_security.user_name": "Username",
     "sulu_security.enable_user": "Enable User",
+    "sulu_security.lock_user": "Lock User",
+    "sulu_security.user_locked": "User locked",
     "sulu_security.permissions": "Permissions",
     "sulu_security.password": "Password",
     "sulu_security.email": "Email",

--- a/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/translations/admin.en.json
@@ -2,7 +2,6 @@
     "sulu_security.roles": "User roles",
     "sulu_security.user_name": "Username",
     "sulu_security.enable_user": "Enable User",
-    "sulu_security.lock_user": "Lock User",
     "sulu_security.user_locked": "User locked",
     "sulu_security.permissions": "Permissions",
     "sulu_security.password": "Password",

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -329,6 +329,38 @@ class UserManager implements UserManagerInterface
     }
 
     /**
+     * @param int $id
+     *
+     * @return UserInterface
+     */
+    public function lockUser($id)
+    {
+        /** @var UserInterface $user */
+        $user = $this->userRepository->findUserById($id);
+        $user->setLocked(true);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return UserInterface
+     */
+    public function unlockUser($id)
+    {
+        /** @var UserInterface $user */
+        $user = $this->userRepository->findUserById($id);
+        $user->setLocked(false);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        return $user;
+    }
+
+    /**
      * Checks if the given password is a valid one.
      *
      * @param string $password The password to check


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

Builds upon: #4641 

#### What's in this PR?

This PR adds a toggler toolbar-action that allows to lock and unlock the current user to the Permissions tab of the Contact form.

#### Why?

Because we do not want to manually modify the database every time we need to lock a user 😉 

