### PR TITLE
Fix loading custom url list if creator has been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 CHANGELOG for Sulu
 ==================
 
-* 1.6.28 (2019-07-23)
+* dev-master
+    * BUGFIX      #4644  [CustomUrlBundle]      Fix loading custom url list if creator has been deleted
     * BUGFIX      #4627  [WebsiteBundle]        Fix Routing when no prefix is Provided.
     * BUGFIX      #4633  [AudienceTargetingBundle] Fixed conditions saving for Audience Targeting.
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/UserManager/UserManagerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/UserManager/UserManagerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\UserManager;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
+use Sulu\Component\Security\Authentication\UserRepositoryInterface;
+
+class UserManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UserManager
+     */
+    private $userManager;
+
+    /**
+     * @var UserRepositoryInterface
+     */
+    private $userRepository;
+
+    public function setUp()
+    {
+        $this->objectManager = $this->prophesize(ObjectManager::class);
+        $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
+
+        $this->userManager = new UserManager(
+            $this->objectManager->reveal(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            $this->userRepository->reveal()
+        );
+    }
+
+    public function testGetFullNameByUserIdForNonExistingUser()
+    {
+        $this->assertNull($this->userManager->getFullNameByUserId(0));
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -259,7 +259,13 @@ class UserManager implements UserManagerInterface
      */
     public function getFullNameByUserId($id)
     {
-        return $this->getUserById($id)->getFullName();
+        $user = $this->getUserById($id);
+
+        if (!$user) {
+            return null;
+        }
+
+        return $user->getFullName();
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4447 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the `getFullNameByUserId` method of the `UserManager` not fail anymore, if a not existing User ID is given.

#### Why?

Because this function was called when the CustomURLs for the datagrid are loaded. That means that if a user has created a Custom URL, and this user was deleted later, then the response for the list returned a 500 error code.