### PR TITLE
Fix smart-content sorting

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/SmartContentItemController.php
@@ -47,7 +47,7 @@ class SmartContentItemController extends RestController
             $filters['tags'] = explode(',', $this->getRequestParameter($request, 'tags'));
         }
         if (isset($filters['sortBy'])) {
-            $filters['sortBy'] = explode(',', $this->getRequestParameter($request, 'sortBy'));
+            $filters['sortBy'] = $this->getRequestParameter($request, 'sortBy');
         }
         $filters = array_filter($filters);
         $options = [

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -305,7 +305,7 @@ class NodeRepositoryTest extends SuluTestCase
         }
 
         $nodes = $this->nodeRepository->getFilteredNodes(
-            ['sortBy' => ['published'], 'sortMethod' => 'asc'],
+            ['sortBy' => 'published', 'sortMethod' => 'asc'],
             'en',
             'sulu_io'
         );
@@ -314,7 +314,7 @@ class NodeRepositoryTest extends SuluTestCase
         $this->assertEquals('Testtitle2', $nodes[1]['title']);
 
         $nodes = $this->nodeRepository->getFilteredNodes(
-            ['sortBy' => ['published'], 'sortMethod' => 'desc'],
+            ['sortBy' => 'published', 'sortMethod' => 'desc'],
             'en',
             'sulu_io'
         );
@@ -371,7 +371,7 @@ class NodeRepositoryTest extends SuluTestCase
         }
 
         $nodes = $this->nodeRepository->getFilteredNodes(
-            ['sortBy' => ['title'], 'sortMethod' => 'asc'],
+            ['sortBy' => 'title', 'sortMethod' => 'asc'],
             'en',
             'sulu_io'
         );
@@ -381,7 +381,7 @@ class NodeRepositoryTest extends SuluTestCase
         $this->assertEquals('Test', $nodes[2]['title']);
 
         $nodes = $this->nodeRepository->getFilteredNodes(
-            ['sortBy' => ['title'], 'sortMethod' => 'desc'],
+            ['sortBy' => 'title', 'sortMethod' => 'desc'],
             'en',
             'sulu_io'
         );

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/SmartContent/SmartContentQueryBuilderTest.php
@@ -1003,7 +1003,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
 
         // order by title
         $builder->init(
-            ['config' => ['dataSource' => $root->getIdentifier(), 'sortBy' => ['title']]]
+            ['config' => ['dataSource' => $root->getIdentifier(), 'sortBy' => 'title']]
         );
         $result = $this->contentQuery->execute('sulu_io', ['en'], $builder);
 
@@ -1017,7 +1017,7 @@ class SmartContentQueryBuilderTest extends SuluTestCase
             [
                 'config' => [
                     'dataSource' => $root->getIdentifier(),
-                    'sortBy' => ['title'],
+                    'sortBy' => 'title',
                     'sortMethod' => 'desc',
                 ],
             ]

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -180,16 +180,14 @@ class QueryBuilder extends ContentQueryBuilder
         $sql2Order = [];
         $sortBy = $this->getConfig('sortBy', []);
 
-        if (!empty($sortBy) && is_array($sortBy)) {
-            foreach ($sortBy as $sortColumn) {
-                // TODO implement more generic
-                $order = 'page.[i18n:' . $locale . '-' . $sortColumn . '] ';
-                if (!in_array($sortColumn, ['published', 'created', 'changed', 'authored'])) {
-                    $order = sprintf('lower(%s)', $order);
-                }
-
-                $sql2Order[] = $order . ' ' . $sortOrder;
+        if (!empty($sortBy)) {
+            // TODO implement more generic
+            $order = 'page.[i18n:' . $locale . '-' . $sortBy . '] ';
+            if (!in_array($sortBy, ['published', 'created', 'changed', 'authored'])) {
+                $order = sprintf('lower(%s)', $order);
             }
+
+            $sql2Order[] = $order . ' ' . $sortOrder;
         } else {
             $sql2Order[] = 'page.[sulu:order] ' . $sortOrder;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix for the sorting function of the smart-content type. The `QueryBuilder` for smart-content anticipated a `sortBy` array, but from the website-view only a `string` was given. Thus the orderBy defaulted to `sulu:order`.

#### Why?

Previously the sorting function was only working in the admin view but not on the website.
