### PR TITLE
Correct styling of MultiItemSelection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/item.scss
@@ -14,6 +14,7 @@ $itemBackgroundColor: $white;
     justify-content: center;
     flex: 1;
     height: 100%;
+    overflow: hidden;
     margin: 0 20px 0 22px;
     font-size: 12px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/multiItemSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/MultiItemSelection/multiItemSelection.scss
@@ -1,5 +1,7 @@
 @import '../../containers/Application/colors.scss';
 
+$listBorderColor: $alto;
+$listBorderRadius: 3px;
 $listElementBackgroundColor: $white;
 $listElementBorderBottomColor: $silver;
 $listElementDragBoxShadowColor: rgba($black, .1);
@@ -16,6 +18,9 @@ $listElementDragBoxShadowColor: rgba($black, .1);
     padding: 0;
     max-height: 225px;
     overflow: auto;
+    border: 1px $listBorderColor solid;
+    border-top: 0;
+    border-radius: 0 0 $listBorderRadius $listBorderRadius;
 }
 
 .list-element {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -46,6 +46,7 @@
 }
 
 .main {
+    width: 100%;
     height: 100vh;
     flex: 2;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -24,9 +24,10 @@
 }
 
 .content {
+    display: flex;
     width: 100vw;
     min-height: 500px;
-    overflow: auto;
+    overflow: hidden;
     will-change: width;
     transition: width $navigationMoveAnimationDuration;
 
@@ -46,24 +47,30 @@
 }
 
 .main {
-    width: 100%;
+    width: 0;
+    max-width: 100%;
     height: 100vh;
-    flex: 2;
+    flex-basis: $viewMinWidth;
+    flex-grow: 1;
+    flex-shrink: 0;
 }
 
 .sidebar {
     transition: flex $sidebarShrinkAnimationDuration;
+    max-width: $sidebarMaxWidth;
 
     &.small {
-        flex: 1;
+        flex-basis: 30%;
     }
 
     &.medium {
-        flex: 2;
+        flex-basis: 50%;
     }
 
     &.large {
-        flex: 3;
+        flex-basis: $sidebarMaxWidth;
+        flex-grow: 0;
+        flex-shrink: 0;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/variables.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/variables.scss
@@ -4,3 +4,5 @@ $viewMaxWidth: 1140px;
 
 $sidebarShrinkAnimationDuration: 700ms;
 $navigationMoveAnimationDuration: 500ms;
+
+$sidebarMaxWidth: calc(100% - $viewMinWidth - 2 * $viewPadding);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/field.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/field.scss
@@ -13,6 +13,7 @@ $exceptionBorderColor: $persianRed;
 
 .field {
     flex: 1;
+    width: 100%;
 }
 
 .field-exception {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -4,7 +4,8 @@ import {action, observable, reaction, toJS} from 'mobx';
 import type {IObservableValue} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
-import {MultiItemSelection} from '../../components';
+import CroppedText from '../../components/CroppedText';
+import MultiItemSelection from '../../components/MultiItemSelection';
 import MultiSelectionStore from '../../stores/MultiSelectionStore';
 import MultiListOverlay from '../MultiListOverlay';
 import multiSelectionStyles from './multiSelection.scss';
@@ -140,7 +141,7 @@ class MultiSelection extends React.Component<Props> {
                                         key={displayProperty}
                                         style={{width: 100 / columns + '%'}}
                                     >
-                                        {item[displayProperty]}
+                                        <CroppedText>{item[displayProperty]}</CroppedText>
                                     </span>
                                 ))}
                             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/multiSelection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/multiSelection.scss
@@ -8,8 +8,12 @@ $multiSelectionColumnColor: $scorpion;
     display: inline-block;
     height: 40px;
     line-height: 40px;
+    white-space: nowrap;
+    overflow: hidden;
+    padding-left: 10px;
 
     &:first-child {
         color: $multiSelectionMainColumnColor;
+        padding-left: 0;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/__snapshots__/MultiSelection.test.js.snap
@@ -182,13 +182,59 @@ exports[`Show with passed values as items in right locale 1`] = `
               class="itemColumn"
               style="width:50%"
             >
-              1
+              <div
+                aria-label="1"
+                class="croppedText"
+                title="1"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  1
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span />
+                </div>
+                <div
+                  class="whole"
+                >
+                  1
+                </div>
+              </div>
             </span>
             <span
               class="itemColumn"
               style="width:50%"
             >
-              Title 1
+              <div
+                aria-label="Title 1"
+                class="croppedText"
+                title="Title 1"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Titl
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e 1
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Title 1
+                </div>
+              </div>
             </span>
           </div>
         </div>
@@ -234,13 +280,59 @@ exports[`Show with passed values as items in right locale 1`] = `
               class="itemColumn"
               style="width:50%"
             >
-              2
+              <div
+                aria-label="2"
+                class="croppedText"
+                title="2"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  2
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span />
+                </div>
+                <div
+                  class="whole"
+                >
+                  2
+                </div>
+              </div>
             </span>
             <span
               class="itemColumn"
               style="width:50%"
             >
-              Title 2
+              <div
+                aria-label="Title 2"
+                class="croppedText"
+                title="Title 2"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Titl
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e 2
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Title 2
+                </div>
+              </div>
             </span>
           </div>
         </div>
@@ -286,13 +378,59 @@ exports[`Show with passed values as items in right locale 1`] = `
               class="itemColumn"
               style="width:50%"
             >
-              5
+              <div
+                aria-label="5"
+                class="croppedText"
+                title="5"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  5
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span />
+                </div>
+                <div
+                  class="whole"
+                >
+                  5
+                </div>
+              </div>
             </span>
             <span
               class="itemColumn"
               style="width:50%"
             >
-              Title 5
+              <div
+                aria-label="Title 5"
+                class="croppedText"
+                title="Title 5"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  Titl
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    e 5
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  Title 5
+                </div>
+              </div>
             </span>
           </div>
         </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContentItem.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContentItem.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import CroppedText from '../../components/CroppedText';
 import PublishIndicator from '../../components/PublishIndicator';
 import smartContentItemStyles from './smartContentItem.scss';
 
@@ -35,11 +36,11 @@ export default class SmartContentItem extends React.Component<Props> {
                             />
                         </div>
                     }
-                    {title}
+                    <CroppedText>{title}</CroppedText>
                 </div>
                 {Object.keys(rest).map((key) => (
                     <div className={smartContentItemStyles.column} key={key}>
-                        {rest[key]}
+                        <CroppedText>{rest[key]}</CroppedText>
                     </div>
                 ))}
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/smartContentItem.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/smartContentItem.scss
@@ -29,6 +29,7 @@ $smartContentColumnColor: $scorpion;
     align-items: center;
     flex-basis: 0;
     flex-grow: 1;
+    overflow: hidden;
 }
 
 .column {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/SmartContentItem.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/__snapshots__/SmartContentItem.test.js.snap
@@ -7,17 +7,89 @@ exports[`Render item with additional columns except for id 1`] = `
   <div
     class="title"
   >
-    Title with URL
+    <div
+      aria-label="Title with URL"
+      class="croppedText"
+      title="Title with URL"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Title w
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          ith URL
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Title with URL
+      </div>
+    </div>
   </div>
   <div
     class="column"
   >
-    /url
+    <div
+      aria-label="/url"
+      class="croppedText"
+      title="/url"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        /u
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          rl
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        /url
+      </div>
+    </div>
   </div>
   <div
     class="column"
   >
-    Test
+    <div
+      aria-label="Test"
+      class="croppedText"
+      title="Test"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Te
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          st
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Test
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -29,7 +101,31 @@ exports[`Render item with only title 1`] = `
   <div
     class="title"
   >
-    Only title
+    <div
+      aria-label="Only title"
+      class="croppedText"
+      title="Only title"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Only 
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          title
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Only title
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -51,7 +147,31 @@ exports[`Render item with title and draft with published state 1`] = `
         class="draft"
       />
     </div>
-    Draft and published
+    <div
+      aria-label="Draft and published"
+      class="croppedText"
+      title="Draft and published"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Draft and 
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          published
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Draft and published
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -70,7 +190,31 @@ exports[`Render item with title and image 1`] = `
   <div
     class="title"
   >
-    Image
+    <div
+      aria-label="Image"
+      class="croppedText"
+      title="Image"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Ima
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          ge
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Image
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -82,7 +226,31 @@ exports[`Render item with title and published state 1`] = `
   <div
     class="title"
   >
-    Published
+    <div
+      aria-label="Published"
+      class="croppedText"
+      title="Published"
+    >
+      <div
+        aria-hidden="true"
+        class="front"
+      >
+        Publi
+      </div>
+      <div
+        aria-hidden="true"
+        class="back"
+      >
+        <span>
+          shed
+        </span>
+      </div>
+      <div
+        class="whole"
+      >
+        Published
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/MultiMediaSelection.js
@@ -3,7 +3,7 @@ import React, {Fragment} from 'react';
 import {action, toJS, observable, reaction} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
-import {MultiItemSelection} from 'sulu-admin-bundle/components';
+import {CroppedText, MultiItemSelection} from 'sulu-admin-bundle/components';
 import {translate} from 'sulu-admin-bundle/utils';
 import {MultiSelectionStore} from 'sulu-admin-bundle/stores';
 import type {IObservableValue} from 'mobx';
@@ -169,7 +169,9 @@ class MultiMediaSelection extends React.Component<Props> {
                                             width={25}
                                         />
                                     }
-                                    <div className={multiMediaSelectionStyle.mediaTitle}>{media.title}</div>
+                                    <div className={multiMediaSelectionStyle.mediaTitle}>
+                                        <CroppedText>{media.title}</CroppedText>
+                                    </div>
                                 </div>
                             </MultiItemSelection.Item>
                         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/multiMediaSelection.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/multiMediaSelection.scss
@@ -10,6 +10,7 @@
     }
 
     .media-title {
+        overflow: hidden;
         margin-left: 15px;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/__snapshots__/MultiMediaSelection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/__snapshots__/MultiMediaSelection.test.js.snap
@@ -59,7 +59,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 1
+                <div
+                  aria-label="Media 1"
+                  class="croppedText"
+                  title="Media 1"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 1
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 1
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -111,7 +135,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 2
+                <div
+                  aria-label="Media 2"
+                  class="croppedText"
+                  title="Media 2"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 2
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 2
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -163,7 +211,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 3
+                <div
+                  aria-label="Media 3"
+                  class="croppedText"
+                  title="Media 3"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 3
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 3
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -262,7 +334,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 1
+                <div
+                  aria-label="Media 1"
+                  class="croppedText"
+                  title="Media 1"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 1
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 1
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -361,7 +457,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 1
+                <div
+                  aria-label="Media 1"
+                  class="croppedText"
+                  title="Media 1"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 1
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 1
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -451,7 +571,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 1
+                <div
+                  aria-label="Media 1"
+                  class="croppedText"
+                  title="Media 1"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 1
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 1
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -507,7 +651,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 2
+                <div
+                  aria-label="Media 2"
+                  class="croppedText"
+                  title="Media 2"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 2
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 2
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -563,7 +731,31 @@ Array [
               <div
                 class="mediaTitle"
               >
-                Media 3
+                <div
+                  aria-label="Media 3"
+                  class="croppedText"
+                  title="Media 3"
+                >
+                  <div
+                    aria-hidden="true"
+                    class="front"
+                  >
+                    Medi
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="back"
+                  >
+                    <span>
+                      a 3
+                    </span>
+                  </div>
+                  <div
+                    class="whole"
+                  >
+                    Media 3
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the following styling issues:

* The width of the form was determined by its content, which meant that if something was very long, the width of the preview got smaller
* The texts in the components using the `MultiItemSelection` components are now cropped.

#### Why?

Because these issues lead to strange displaying when long titles were listed in the `MultiItemSelection`.