### PR TITLE
Fix wrong session configuration

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -117,10 +117,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             $container->prependExtensionConfig(
                 'framework',
                 [
-                    'session' => [
-                        'handler_id' => 'session.handler.native_file',
-                        'save_path' => '%kernel.project_dir%/var/sessions/%sulu.context%/%kernel.environment%',
-                    ],
                     'templating' => [
                         'engines' => [
                             'twig',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | https://github.com/symfony/symfony/pull/31620
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the prepended configuration for sessions.

#### Why?

Because it was not working as intended anymore, and caused an error since Symfony 4.3.3 because of https://github.com/symfony/symfony/pull/31620.