### PR TITLE
Fix assertHttpStatusCode phpunit 7 compatibility

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php
@@ -222,7 +222,7 @@ abstract class KernelTestCase extends \PHPUnit\Framework\TestCase
     {
         $httpCode = $response->getStatusCode();
 
-        $message = null;
+        $message = '';
         if ($code !== $httpCode) {
             $message = $response->getContent();
 
@@ -242,6 +242,6 @@ abstract class KernelTestCase extends \PHPUnit\Framework\TestCase
             }
         }
 
-        $this->assertEquals($code, $httpCode, $message);
+        $this->assertSame($code, $httpCode, $message);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Set the default message to empty string instead of null in assertHttpStatusCode.

#### Why?

The message need to be a string in phpunit >=7 and can't be null anymore.