### PR TITLE
Detach file and file version in delete of media manager

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -719,7 +719,9 @@ class MediaManager implements MediaManagerInterface
                     // this will trigger massive-search deindex
                     $this->em->remove($fileVersionMeta);
                 }
+                $this->em->detach($fileVersion);
             }
+            $this->em->detach($file);
         }
 
         $this->em->remove($mediaEntity);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -278,7 +278,8 @@ class MediaManagerTest extends TestCase
         )->shouldBeCalled();
 
         $this->storage->remove(['segment' => '01', 'fileName' => 'test.jpg'])->shouldBeCalled();
-
+        $this->em->detach($fileVersion->reveal())->shouldBeCalled();
+        $this->em->detach($file->reveal())->shouldBeCalled();
         $this->em->remove($media->reveal())->shouldBeCalled();
         $this->em->remove($fileVersionMeta->reveal())->shouldBeCalled();
         $this->em->flush()->shouldBeCalled();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

This PR detachs the file and file version in the delete method of the media manager. 

#### Why?

Currently an error occurs in the form bundle if the delete method of the media manager is called, followed by another remove call to the entity manager with another entity. The error message says that _a new entity was found through the relationship Sulu\Bundle\MediaBundle\Entity\File#media that was not configured to cascade persist operations for entity_.
