### PR TITLE
Check permissions before saving information from permission tab

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -207,6 +207,7 @@ class PageAdmin extends Admin
                 ->setApiOptions(['resourceKey' => 'pages'])
                 ->setTabTitle('sulu_security.permissions')
                 ->addToolbarActions(['sulu_admin.save'])
+                ->addRouterAttributesToFormStore(['webspace'])
                 ->setTitleVisible(true)
                 ->setTabOrder(5120)
                 ->setParent(static::EDIT_FORM_ROUTE)

--- a/src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
@@ -102,10 +102,13 @@ class PermissionController implements ClassResourceInterface
     public function cputAction(Request $request)
     {
         try {
-            $identifier = $request->get('id');
             $resourceKey = $request->get('resourceKey');
+            $identifier = $request->get('id');
             $permissions = $request->get('permissions');
-            $securityContext = $request->get('securityContext'); // TODO don't rely on securityContext passed in request
+            $webspace = $request->get('webspace');
+
+            $rawSecurityContext = $this->resources[$resourceKey]['security_context'] ?? null;
+            $securityContext = $rawSecurityContext ? str_replace('#webspace#', $webspace, $rawSecurityContext) : null;
 
             if (!$identifier) {
                 throw new MissingParameterException(static::class, 'id');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR checks the permission for changing the security before saving the permission tab.

#### Why?

Because if a user is missing the security permission, they should not be allowed to save the permission tab.