### PR TITLE
Fix types in 'KernelTestCase::assertHttpStatusCode'

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/KernelTestCase.php
@@ -222,7 +222,7 @@ abstract class KernelTestCase extends \PHPUnit\Framework\TestCase
     {
         $httpCode = $response->getStatusCode();
 
-        $message = null;
+        $message = '';
         if ($code !== $httpCode) {
             $message = $response->getContent();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

For new phpunit the message of assertEquals cannot be null. It has to be a string.