### PR TITLE
Fix some static types issues with EntityNotFoundException and WebspaceManager

### DIFF
--- a/src/Sulu/Component/Rest/Exception/EntityNotFoundException.php
+++ b/src/Sulu/Component/Rest/Exception/EntityNotFoundException.php
@@ -26,13 +26,13 @@ class EntityNotFoundException extends RestException
     /**
      * The id of the entity, which was not found.
      *
-     * @var int
+     * @var int|string
      */
     protected $id;
 
     /**
      * @param string $entity The type of the entity, which was not found
-     * @param int $id The id of the entity, which was not found
+     * @param int|string $id The id of the entity, which was not found
      */
     public function __construct($entity, $id, $previous = null)
     {
@@ -55,7 +55,7 @@ class EntityNotFoundException extends RestException
     /**
      * Returns the id of the entity, which was not found.
      *
-     * @return int
+     * @return int|string
      */
     public function getId()
     {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -76,7 +76,7 @@ class WebspaceCollection implements \IteratorAggregate
      *
      * @param $key string The index of the portal
      *
-     * @return Portal
+     * @return Portal|null
      */
     public function getPortal($key)
     {
@@ -115,7 +115,7 @@ class WebspaceCollection implements \IteratorAggregate
      *
      * @param $key string The key of the webspace
      *
-     * @return Webspace
+     * @return Webspace|null
      */
     public function getWebspace($key)
     {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -61,7 +61,7 @@ class WebspaceManager implements WebspaceManagerInterface
      *
      * @param $key string The key to search for
      *
-     * @return Webspace
+     * @return Webspace|null
      */
     public function findWebspaceByKey($key)
     {
@@ -73,7 +73,7 @@ class WebspaceManager implements WebspaceManagerInterface
      *
      * @param string $key The key to search for
      *
-     * @return Portal
+     * @return Portal|null
      */
     public function findPortalByKey($key)
     {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -26,7 +26,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
      *
      * @param $key string The key to search for
      *
-     * @return Webspace
+     * @return Webspace|null
      */
     public function findWebspaceByKey($key);
 
@@ -35,7 +35,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
      *
      * @param string $key The key to search for
      *
-     * @return Portal
+     * @return Portal|null
      */
     public function findPortalByKey($key);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/SuluRedirectBundle/pull/32
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Allow id in EntityNotFoundException to be a string.

#### Why?

For phpstan static analyizer in RedirectBundle the id is a uuid and so a string.
