### PR TITLE
Remove obsolete fieldsActions

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -198,18 +198,6 @@ abstract class AbstractMediaController extends RestController
     }
 
     /**
-     * Returns the the media fields for the current entity.
-     *
-     * @param $entityName
-     *
-     * @return Response
-     */
-    protected function getFieldsView($entityName)
-    {
-        return $this->handleView($this->view(array_values($this->getFieldDescriptors($entityName, null)), 200));
-    }
-
-    /**
      * Returns the field-descriptors. Ensures that the descriptors get only instantiated once.
      *
      * @param $entityName

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountMediaController.php
@@ -45,11 +45,6 @@ class AccountMediaController extends AbstractMediaController implements ClassRes
         );
     }
 
-    public function fieldsAction()
-    {
-        return $this->getFieldsView($this->getAccountEntityName());
-    }
-
     private function getAccountEntityName()
     {
         return $this->container->getParameter('sulu.model.account.class');

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactMediaController.php
@@ -45,11 +45,6 @@ class ContactMediaController extends AbstractMediaController implements ClassRes
         );
     }
 
-    public function fieldsAction()
-    {
-        return $this->getFieldsView($this->getContactEntityName());
-    }
-
     private function getContactEntityName()
     {
         return $this->container->getParameter('sulu.model.contact.class');

--- a/src/Sulu/Bundle/ResourceBundle/Controller/FilterController.php
+++ b/src/Sulu/Bundle/ResourceBundle/Controller/FilterController.php
@@ -278,22 +278,6 @@ class FilterController extends RestController implements ClassResourceInterface
     }
 
     /**
-     * returns all fields that can be used by list.
-     *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     *
-     * @return mixed
-     */
-    public function fieldsAction(Request $request)
-    {
-        $locale = $this->getRequestParameter($request, 'locale', true);
-
-        return $this->handleView(
-            $this->view(array_values($this->getManager()->getFieldDescriptors($locale)), 200)
-        );
-    }
-
-    /**
      * Returns the manager for filters.
      *
      * @return FilterManagerInterface


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes all the `fieldsAction`s in the system, which have been necessary for the old datagrid in 1.x, but are obsolet now.

#### Why?

Because that's basically dead code.