### PR TITLE
Remove loader in settings tab when versioning is deactivated

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -65,18 +65,25 @@ class PageAdmin extends Admin
      */
     private $teaserProviderPool;
 
+    /**
+     * @var bool
+     */
+    private $versioningEnabled;
+
     public function __construct(
         RouteBuilderFactoryInterface $routeBuilderFactory,
         WebspaceManagerInterface $webspaceManager,
         SecurityCheckerInterface $securityChecker,
         SessionManagerInterface $sessionManager,
-        TeaserProviderPoolInterface $teaserProviderPool
+        TeaserProviderPoolInterface $teaserProviderPool,
+        bool $versioningEnabled
     ) {
         $this->routeBuilderFactory = $routeBuilderFactory;
         $this->webspaceManager = $webspaceManager;
         $this->securityChecker = $securityChecker;
         $this->sessionManager = $sessionManager;
         $this->teaserProviderPool = $teaserProviderPool;
+        $this->versioningEnabled = $versioningEnabled;
     }
 
     public function getNavigation(): Navigation
@@ -267,6 +274,7 @@ class PageAdmin extends Admin
     {
         return [
             'teaser' => $this->teaserProviderPool->getConfiguration(),
+            'versioning' => $this->versioningEnabled,
         ];
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
@@ -157,7 +157,7 @@
                         <title>sulu_page.changelog</title>
                     </meta>
                 </property>
-                <property name="versions" type="page_settings_versions" />
+                <property name="versions" type="page_settings_versions" onInvalid="ignore" />
             </properties>
         </section>
     </properties>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_page.teaser.provider_pool" />
+            <argument>%sulu_document_manager.versioning.enabled%</argument>
         </service>
 
         <!-- content -->

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -25,9 +25,12 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
 
     fieldRegistry.add('page_settings_navigation_select', PageSettingsNavigationSelect);
     fieldRegistry.add('page_settings_shadow_locale_select', PageSettingsShadowLocaleSelect);
-    fieldRegistry.add('page_settings_versions', PageSettingsVersions);
     fieldRegistry.add('search_result', SearchResult);
     fieldRegistry.add('teaser_selection', TeaserSelection);
+
+    if (config.versioning) {
+        fieldRegistry.add('page_settings_versions', PageSettingsVersions);
+    }
 
     formToolbarActionRegistry.add('sulu_page.edit', EditToolbarAction);
     formToolbarActionRegistry.add('sulu_page.templates', TemplateToolbarAction);

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -84,7 +84,8 @@ class PageAdminTest extends TestCase
             $this->webspaceManager->reveal(),
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
-            $this->teaserProviderPool->reveal()
+            $this->teaserProviderPool->reveal(),
+            false
         );
 
         $route = $admin->getRoutes()[0];
@@ -98,5 +99,37 @@ class PageAdminTest extends TestCase
         $this->assertAttributeEquals([
             'locale' => 'de',
         ], 'attributeDefaults', $route);
+    }
+
+    public function testGetConfigWithVersioning()
+    {
+        $admin = new PageAdmin(
+            $this->routeBuilderFactory,
+            $this->webspaceManager->reveal(),
+            $this->securityChecker->reveal(),
+            $this->sessionManager->reveal(),
+            $this->teaserProviderPool->reveal(),
+            true
+        );
+
+        $config = $admin->getConfig();
+
+        $this->assertEquals(true, $config['versioning']);
+    }
+
+    public function testGetConfigWithoutVersioning()
+    {
+        $admin = new PageAdmin(
+            $this->routeBuilderFactory,
+            $this->webspaceManager->reveal(),
+            $this->securityChecker->reveal(),
+            $this->sessionManager->reveal(),
+            $this->teaserProviderPool->reveal(),
+            false
+        );
+
+        $config = $admin->getConfig();
+
+        $this->assertEquals(false, $config['versioning']);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the infinite loader under the changelog line in the settings tab of the pages, when the versioning is deactivated.

#### Why?

Because loaders are confusing and power-consuming if they are infinite.