### PR TITLE
Hide UI elements with missing permission

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,11 +27,6 @@
         "flowtype",
         "jsx-a11y"
     ],
-    "settings": {
-        "react": {
-            "version": "detect"
-        }
-    },
     "rules": {
         "indent": [
             "error",

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
@@ -102,7 +102,6 @@ class ColumnList extends React.Component<Props> {
             return;
         }
 
-        // TODO don't set if it is the same
         this.activeColumnIndex = index;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
@@ -102,6 +102,7 @@ class ColumnList extends React.Component<Props> {
             return;
         }
 
+        // TODO don't set if it is the same
         this.activeColumnIndex = index;
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import ArrowMenu from '../../components/ArrowMenu';
 import Button from '../../components/Button';
 import Dialog from '../../components/Dialog';
+import Icon from '../../components/Icon';
 import Loader from '../../components/Loader';
 import SingleListOverlay from '../SingleListOverlay';
 import {translate} from '../../utils/Translator';
@@ -435,6 +436,17 @@ class List extends React.Component<Props> {
         );
 
         const searchable = this.props.searchable && Adapter.searchable;
+
+        if (store.forbidden) {
+            return (
+                <div className={listStyles.permissionHint}>
+                    <div className={listStyles.permissionIcon}>
+                        <Icon name="su-lock" />
+                    </div>
+                    {translate('sulu_admin.no_permissions')}
+                </div>
+            );
+        }
 
         return (
             <div className={listStyles.listContainer}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -182,6 +182,7 @@ class ColumnListAdapter extends AbstractAdapter {
         const {
             _permissions: {
                 add: parentAddPermission = true,
+                edit: parentEditPermission = true,
             } = {},
         } = parentItem || {};
 
@@ -261,6 +262,7 @@ class ColumnListAdapter extends AbstractAdapter {
 
         if (onRequestItemOrder) {
             settingOptions.push({
+                disabled: !parentEditPermission,
                 label: translate('sulu_admin.order'),
                 onClick: action(() => {
                     this.orderColumn = index;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -179,8 +179,13 @@ class ColumnListAdapter extends AbstractAdapter {
         const toolbarItems = [];
         const parentColumn = data[index - 1];
         const parentItem = parentColumn ? parentColumn.find((item) => item.id === activeItems[index]) : undefined;
+        const {
+            _permissions: {
+                add: parentAddPermission = true,
+            } = {},
+        } = parentItem || {};
 
-        if (onItemAdd && (!parentItem || !parentItem._permissions || parentItem._permissions.add)) {
+        if (onItemAdd && parentAddPermission) {
             toolbarItems.push({
                 icon: 'su-plus-circle',
                 type: 'button',
@@ -192,12 +197,20 @@ class ColumnListAdapter extends AbstractAdapter {
             });
         }
 
-        const hasActiveItem = activeItems[index + 1] === undefined;
+        const hasActiveItem = activeItems[index + 1] !== undefined;
+        const column = data[index];
+        const item = column ? column.find((item) => item.id === activeItems[index + 1]) : undefined;
+        const {
+            _permissions: {
+                delete: deletePermission = true,
+                edit: editPermission = true,
+            } = {},
+        } = item || {};
 
         const settingOptions = [];
         if (onRequestItemDelete) {
             settingOptions.push({
-                disabled: hasActiveItem,
+                disabled: !hasActiveItem || !deletePermission,
                 label: translate('sulu_admin.delete'),
                 onClick: () => {
                     const itemId = activeItems[index + 1];
@@ -214,7 +227,7 @@ class ColumnListAdapter extends AbstractAdapter {
 
         if (onRequestItemMove) {
             settingOptions.push({
-                disabled: hasActiveItem,
+                disabled: !hasActiveItem || !editPermission,
                 label: translate('sulu_admin.move'),
                 onClick: () => {
                     const itemId = activeItems[index + 1];
@@ -231,7 +244,7 @@ class ColumnListAdapter extends AbstractAdapter {
 
         if (onRequestItemCopy) {
             settingOptions.push({
-                disabled: hasActiveItem,
+                disabled: !hasActiveItem || !editPermission,
                 label: translate('sulu_admin.copy'),
                 onClick: () => {
                     const itemId = activeItems[index + 1];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -149,12 +149,20 @@ class ColumnListAdapter extends AbstractAdapter {
     getToolbarItems = (index: number) => {
         const {
             activeItems,
+            data,
             onItemAdd,
             onRequestItemCopy,
             onRequestItemDelete,
             onRequestItemMove,
             onRequestItemOrder,
         } = this.props;
+
+        if (!activeItems) {
+            throw new Error(
+                'The ColumnListAdapter does not work without activeItems. '
+                + 'This error should not happen and is likely a bug.'
+            );
+        }
 
         if (this.orderColumn === index) {
             return [
@@ -169,8 +177,10 @@ class ColumnListAdapter extends AbstractAdapter {
         }
 
         const toolbarItems = [];
+        const parentColumn = data[index - 1];
+        const parentItem = parentColumn ? parentColumn.find((item) => item.id === activeItems[index]) : undefined;
 
-        if (onItemAdd) {
+        if (onItemAdd && (!parentItem || !parentItem._permissions || parentItem._permissions.add)) {
             toolbarItems.push({
                 icon: 'su-plus-circle',
                 type: 'button',
@@ -182,13 +192,6 @@ class ColumnListAdapter extends AbstractAdapter {
             });
         }
 
-        if (!activeItems) {
-            throw new Error(
-                'The ColumnListAdapter does not work without activeItems. '
-                + 'This error should not happen and is likely a bug.'
-            );
-        }
-
         const hasActiveItem = activeItems[index + 1] === undefined;
 
         const settingOptions = [];
@@ -197,7 +200,14 @@ class ColumnListAdapter extends AbstractAdapter {
                 disabled: hasActiveItem,
                 label: translate('sulu_admin.delete'),
                 onClick: () => {
-                    onRequestItemDelete(activeItems[index + 1]);
+                    const itemId = activeItems[index + 1];
+                    if (!itemId) {
+                        throw new Error(
+                            'An undefined itemId cannot be deleted! This should not happen and is likely a bug.'
+                        );
+                    }
+
+                    onRequestItemDelete(itemId);
                 },
             });
         }
@@ -207,7 +217,14 @@ class ColumnListAdapter extends AbstractAdapter {
                 disabled: hasActiveItem,
                 label: translate('sulu_admin.move'),
                 onClick: () => {
-                    onRequestItemMove(activeItems[index + 1]);
+                    const itemId = activeItems[index + 1];
+                    if (!itemId) {
+                        throw new Error(
+                            'An undefined itemId cannot be deleted! This should not happen and is likely a bug.'
+                        );
+                    }
+
+                    onRequestItemMove(itemId);
                 },
             });
         }
@@ -217,7 +234,14 @@ class ColumnListAdapter extends AbstractAdapter {
                 disabled: hasActiveItem,
                 label: translate('sulu_admin.copy'),
                 onClick: () => {
-                    onRequestItemCopy(activeItems[index + 1]);
+                    const itemId = activeItems[index + 1];
+                    if (!itemId) {
+                        throw new Error(
+                            'An undefined itemId cannot be deleted! This should not happen and is likely a bug.'
+                        );
+                    }
+
+                    onRequestItemCopy(itemId);
                 },
             });
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
@@ -1,5 +1,8 @@
+@import 'sulu-admin-bundle/containers/Application/colors.scss';
+
 $listToolbarHeight: 30px;
 $listHeaderMarginBottom: 40px;
+$permissionHintColor: $gray;
 
 .list-container {
     display: flex;
@@ -43,4 +46,16 @@ $listHeaderMarginBottom: 40px;
             margin-right: 0;
         }
     }
+}
+
+.permission-hint {
+    font-size: 18px;
+    font-weight: bold;
+    color: $permissionHintColor;
+    width: 100%;
+    text-align: center;
+}
+
+.permission-icon {
+    font-size: 32px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -37,6 +37,7 @@ export default class ListStore {
     @observable structureStrategy: StructureStrategyInterface;
     @observable options: Object;
     @observable schema: Schema;
+    @observable forbidden: boolean;
     active: IObservableValue<?string | number> = observable.box();
     sortColumn: IObservableValue<string> = observable.box();
     sortOrder: IObservableValue<SortOrder> = observable.box();
@@ -445,6 +446,7 @@ export default class ListStore {
         }
 
         this.setDataLoading(true);
+        this.setForbidden(false);
 
         const active = this.active.get();
         const options = {...observableOptions, ...this.options};
@@ -500,12 +502,23 @@ export default class ListStore {
                 // need to set the user setting to null manually, because the autorun runs too late
                 ListStore.setActiveSetting(this.listKey, this.userSettingsKey, undefined);
                 this.setActive(undefined);
+                return;
             }
+
+            if (response.status === 403) {
+                this.setForbidden(true);
+            }
+
+            this.setDataLoading(false);
         });
     };
 
     @action setDataLoading(dataLoading: boolean) {
         this.dataLoading = dataLoading;
+    }
+
+    @action setForbidden(forbidden: boolean) {
+        this.forbidden = forbidden;
     }
 
     @action setShouldReload(shouldReload: boolean) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -157,6 +157,16 @@ test('Render Loader instead of Adapter if nothing was loaded yet', () => {
     expect(render(<List adapters={['table']} store={listStore} />)).toMatchSnapshot();
 });
 
+test('Render permission hint if permissions are missing', () => {
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    // $FlowFixMe
+    listStore.loading = true;
+    listStore.pageCount = 0;
+    listStore.forbidden = true;
+
+    expect(render(<List adapters={['table']} store={listStore} />)).toMatchSnapshot();
+});
+
 test('Do not render Loader instead of Adapter if no page count is given', () => {
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
     // $FlowFixMe

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/List.test.js.snap
@@ -88,6 +88,21 @@ exports[`Render Loader instead of Adapter if nothing was loaded yet 1`] = `
 </div>
 `;
 
+exports[`Render permission hint if permissions are missing 1`] = `
+<div
+  class="permissionHint"
+>
+  <div
+    class="permissionIcon"
+  >
+    <span
+      aria-label="su-lock"
+      class="su-lock"
+    />
+  </div>
+</div>
+`;
+
 exports[`Render the adapter in disabled state 1`] = `
 <div
   class="listContainer"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -239,6 +239,53 @@ test('Render with add button in toolbar when onItemAdd callback is given', () =>
     expect(columnListAdapter).toMatchSnapshot();
 });
 
+test('Render without add button in toolbar when onItemAdd callback is given but permission is not granted', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+            },
+            {
+                id: 2,
+                title: 'Page 2',
+                hasChildren: false,
+            },
+        ],
+        [
+            {
+                id: 3,
+                title: 'Page 1.1',
+                hasChildren: true,
+            },
+            {
+                id: 4,
+                title: 'Page 1.2',
+                hasChildren: false,
+                _permissions: {
+                    add: false,
+                },
+            },
+        ],
+        [],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined, 1, 4]}
+            data={data}
+            onItemAdd={jest.fn()}
+            onRequestItemDelete={jest.fn()}
+        />
+    );
+
+    columnListAdapter.find('Column').at(2).find('div').simulate('mouseEnter');
+    columnListAdapter.update();
+    expect(columnListAdapter.find('Toolbar ToolbarButton[icon="su-plus-circle"]')).toHaveLength(0);
+});
+
 test('Render data with loading column', () => {
     const data = [
         [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -457,6 +457,50 @@ test('Disable move and copy button if permission is missing', () => {
     expect(columnListAdapter.find('Toolbar Action').at(3).prop('disabled')).toEqual(false);
 });
 
+test('Disable sort button if edit permission on parent is missing', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+                _permissions: {
+                    edit: false,
+                },
+            },
+        ],
+        [
+            {
+                id: 2,
+                title: 'Page 1.1',
+                hasChildren: true,
+            },
+        ],
+        [],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined, 1, 2]}
+            data={data}
+            onRequestItemCopy={jest.fn()}
+            onRequestItemDelete={jest.fn()}
+            onRequestItemMove={jest.fn()}
+            onRequestItemOrder={jest.fn()}
+        />
+    );
+
+    columnListAdapter.find('Column > div').at(1).simulate('mouseEnter');
+    columnListAdapter.find('Toolbar ToolbarDropdown').simulate('click');
+    columnListAdapter.update();
+
+    expect(columnListAdapter.find('Toolbar Action').at(0).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(1).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(2).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(3).prop('disabled')).toEqual(true);
+});
+
 test('Do not show order button if onRequestItemOrder callback is undefined', () => {
     const data = [
         [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -355,6 +355,108 @@ test('Execute onItemActivate callback when an item is clicked with the correct p
     expect(itemActivateSpy).toBeCalledWith(2);
 });
 
+test('Show all setting buttons', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+            },
+        ],
+        [],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined, 1]}
+            data={data}
+            onRequestItemCopy={jest.fn()}
+            onRequestItemDelete={jest.fn()}
+            onRequestItemMove={jest.fn()}
+            onRequestItemOrder={jest.fn()}
+        />
+    );
+
+    columnListAdapter.find('Toolbar ToolbarDropdown').simulate('click');
+    columnListAdapter.update();
+    expect(columnListAdapter.find('Toolbar Action').at(0).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(1).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(2).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(3).prop('disabled')).toEqual(false);
+});
+
+test('Disable delete button if permission is missing', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+                _permissions: {
+                    delete: false,
+                },
+            },
+        ],
+        [],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined, 1]}
+            data={data}
+            onRequestItemCopy={jest.fn()}
+            onRequestItemDelete={jest.fn()}
+            onRequestItemMove={jest.fn()}
+            onRequestItemOrder={jest.fn()}
+        />
+    );
+
+    columnListAdapter.find('Toolbar ToolbarDropdown').simulate('click');
+    columnListAdapter.update();
+    expect(columnListAdapter.find('Toolbar Action').at(0).prop('disabled')).toEqual(true);
+    expect(columnListAdapter.find('Toolbar Action').at(1).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(2).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(3).prop('disabled')).toEqual(false);
+});
+
+test('Disable move and copy button if permission is missing', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+                _permissions: {
+                    edit: false,
+                },
+            },
+        ],
+        [],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined, 1]}
+            data={data}
+            onRequestItemCopy={jest.fn()}
+            onRequestItemDelete={jest.fn()}
+            onRequestItemMove={jest.fn()}
+            onRequestItemOrder={jest.fn()}
+        />
+    );
+
+    columnListAdapter.find('Toolbar ToolbarDropdown').simulate('click');
+    columnListAdapter.update();
+    expect(columnListAdapter.find('Toolbar Action').at(0).prop('disabled')).toEqual(false);
+    expect(columnListAdapter.find('Toolbar Action').at(1).prop('disabled')).toEqual(true);
+    expect(columnListAdapter.find('Toolbar Action').at(2).prop('disabled')).toEqual(true);
+    expect(columnListAdapter.find('Toolbar Action').at(3).prop('disabled')).toEqual(false);
+});
+
 test('Do not show order button if onRequestItemOrder callback is undefined', () => {
     const data = [
         [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -795,6 +795,28 @@ test('Set loading flag to false after request', (done) => {
     });
 });
 
+test('Set forbidden flag to true if the response returned a 403', (done) => {
+    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
+    listStore.schema = {};
+    const promise = Promise.reject({
+        status: 403,
+    });
+
+    const loadingStrategy = new LoadingStrategy();
+    loadingStrategy.load.mockReturnValue(promise);
+    const structureStrategy = new StructureStrategy();
+    listStore.updateLoadingStrategy(loadingStrategy);
+    listStore.updateStructureStrategy(structureStrategy);
+
+    listStore.sendRequest();
+    expect(listStore.forbidden).toEqual(false);
+
+    setTimeout(() => {
+        expect(listStore.forbidden).toEqual(true);
+        done();
+    });
+});
+
 test('Set active to undefined if the response returned a 404', (done) => {
     const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
     listStore.schema = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -31,7 +31,7 @@ export type Action = {|
 export type ListAdapterProps = {
     actions?: Array<Action>,
     active: ?string | number,
-    activeItems: ?Array<string | number>,
+    activeItems: ?Array<?string | number>,
     data: Array<*>,
     disabledIds: Array<string | number>,
     limit: number,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import React from 'react';
 import {observable} from 'mobx';
 import {mount, render} from 'enzyme';
@@ -10,21 +10,22 @@ jest.mock('../stores/ToolbarStorePool', () => ({
 }));
 
 test('Pass props to rendered component', () => {
-    const Component = class Component extends React.Component {
+    const Component = class Component extends React.Component<*> {
         render() {
             return <h1>{this.props.title}</h1>;
         }
     };
 
-    const ComponentWithToolbar = withToolbar(Component, () => {});
+    const ComponentWithToolbar = withToolbar(Component, () => ({}));
 
     expect(render(<ComponentWithToolbar title="Test" />)).toMatchSnapshot();
 });
 
 test('Bind toolbar method to component instance', () => {
     const storeKey = 'testKey';
+    const clickSpy = jest.fn();
 
-    const Component = class Component extends React.Component {
+    const Component = class Component extends React.Component<*> {
         test = true;
 
         render() {
@@ -36,9 +37,11 @@ test('Bind toolbar method to component instance', () => {
         return {
             items: [
                 {
-                    label: 'Save',
-                    icon: 'su-save',
                     disabled: this.test,
+                    icon: 'su-save',
+                    label: 'Save',
+                    onClick: clickSpy,
+                    type: 'button',
                 },
             ],
         };
@@ -51,18 +54,20 @@ test('Bind toolbar method to component instance', () => {
                 label: 'Save',
                 icon: 'su-save',
                 disabled: true,
+                onClick: clickSpy,
+                type: 'button',
             },
         ],
     });
 });
 
 test('Call life-cycle events of rendered component', () => {
-    const Component = class Component extends React.Component {
+    const Component = class Component extends React.Component<*> {
         componentWillUnmount = jest.fn();
         render = jest.fn();
     };
 
-    const ComponentWithToolbar = withToolbar(Component, () => {});
+    const ComponentWithToolbar = withToolbar(Component, () => ({}));
 
     const component = mount(<ComponentWithToolbar />);
     expect(component.instance().render).toBeCalled();
@@ -72,8 +77,25 @@ test('Call life-cycle events of rendered component', () => {
     expect(componentWillUnmount).toBeCalled();
 });
 
+test('Reset config of toolbarStore when component is unmounted', () => {
+    const Component = class Component extends React.Component<*> {
+        render = jest.fn();
+    };
+
+    const config = {
+        items: [],
+    };
+    const ComponentWithToolbar = withToolbar(Component, () => config, 'default');
+
+    const component = mount(<ComponentWithToolbar />);
+    expect(toolbarStorePool.setToolbarConfig).toBeCalledWith('default', config);
+
+    component.unmount();
+    expect(toolbarStorePool.setToolbarConfig).toHaveBeenLastCalledWith('default', {});
+});
+
 test('Recall toolbar-function when changing observable', () => {
-    const Component = class Component extends React.Component {
+    const Component = class Component extends React.Component<*> {
         @observable test = true;
 
         render() {
@@ -102,7 +124,7 @@ test('Throw error when component has property toolbarDisposer', () => {
     // until better solution is availble
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const Component = class Component extends React.Component {
+    const Component = class Component extends React.Component<*> {
         toolbarDisposer = true;
 
         componentDidCatch() {}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js
@@ -105,7 +105,7 @@ test('Reset config of toolbarStore when component is unmounted', () => {
     expect(toolbarStorePool.setToolbarConfig).toBeCalledWith('default', config);
 
     component.unmount();
-    expect(updateRouteHookDisposer).toBeCalled();
+    expect(updateRouteHookDisposer).toBeCalledWith();
     expect(toolbarStorePool.setToolbarConfig).toHaveBeenLastCalledWith('default', {});
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/withToolbar.js
@@ -33,6 +33,8 @@ export default function withToolbar<P, C: Class<Component<P>>>(
             }
 
             this.toolbarDisposer();
+
+            toolbarStorePool.setToolbarConfig(toolbarStoreKey, {});
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import type {Element} from 'react';
 import {observer} from 'mobx-react';
-import {sidebarStore} from '../Sidebar';
 import Router, {getViewKeyFromRoute} from '../../services/Router';
 import type {Route} from '../../services/Router';
 import viewRegistry from './registries/ViewRegistry';
@@ -16,14 +15,8 @@ const UPDATE_ROUTE_HOOK_PRIORITY = 1024;
 
 @observer
 class ViewRenderer extends React.Component<Props> {
-    componentDidUpdate() {
-        this.clearSidebarConfig();
-    }
-
     componentDidMount() {
         const {router} = this.props;
-
-        this.clearSidebarConfig();
 
         router.addUpdateRouteHook((newRoute, newAttributes) => {
             const {attributes: oldAttributes, route: oldRoute} = router;
@@ -33,31 +26,6 @@ class ViewRenderer extends React.Component<Props> {
 
             return true;
         }, UPDATE_ROUTE_HOOK_PRIORITY);
-    }
-
-    clearSidebarConfig() {
-        if (!this.hasSidebar()) {
-            sidebarStore.clearConfig();
-        }
-    }
-
-    hasSidebar(route: ?Route): boolean {
-        route = route ? route : this.props.router.route;
-        const View = this.getView(route);
-
-        // $FlowFixMe
-        if (View.hasSidebar) {
-            return true;
-        }
-
-        if (route.parent) {
-            if (this.hasSidebar(route.parent)) {
-                return true;
-            }
-        }
-
-        // no sidebar found
-        return false;
     }
 
     getView = (route: Route): View => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/ViewRenderer.js
@@ -3,8 +3,8 @@ import React from 'react';
 import type {Element} from 'react';
 import {observer} from 'mobx-react';
 import {sidebarStore} from '../Sidebar';
-import Router from '../../services/Router';
-import type {AttributeMap, Route} from '../../services/Router';
+import Router, {getViewKeyFromRoute} from '../../services/Router';
+import type {Route} from '../../services/Router';
 import viewRegistry from './registries/ViewRegistry';
 import type {View} from './types';
 
@@ -27,7 +27,7 @@ class ViewRenderer extends React.Component<Props> {
 
         router.addUpdateRouteHook((newRoute, newAttributes) => {
             const {attributes: oldAttributes, route: oldRoute} = router;
-            if (this.getKey(newRoute, newAttributes) !== this.getKey(oldRoute, oldAttributes)) {
+            if (getViewKeyFromRoute(newRoute, newAttributes) !== getViewKeyFromRoute(oldRoute, oldAttributes)) {
                 router.clearBindings();
             }
 
@@ -60,24 +60,6 @@ class ViewRenderer extends React.Component<Props> {
         return false;
     }
 
-    getKey = (route: ?Route, attributes: ?AttributeMap) => {
-        if (!route) {
-            return null;
-        }
-
-        const rerenderAttributeValues = [];
-
-        if (route.rerenderAttributes) {
-            route.rerenderAttributes.forEach((rerenderAttribute) => {
-                if (attributes && attributes.hasOwnProperty(rerenderAttribute)) {
-                    rerenderAttributeValues.push(attributes[rerenderAttribute]);
-                }
-            });
-        }
-
-        return route.name + (rerenderAttributeValues.length > 0 ? '-' + rerenderAttributeValues.join('__') : '');
-    };
-
     getView = (route: Route): View => {
         const View = viewRegistry.get(route.view);
 
@@ -93,7 +75,7 @@ class ViewRenderer extends React.Component<Props> {
         const View = this.getView(route);
 
         const element = (
-            <View key={this.getKey(route, router.attributes)} route={route} router={router}>
+            <View key={getViewKeyFromRoute(route, router.attributes)} route={route} router={router}>
                 {(props) => child ? React.cloneElement(child, props) : null}
             </View>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -3,14 +3,9 @@ import React from 'react';
 import {mount, render, shallow} from 'enzyme';
 import ViewRenderer from '../ViewRenderer';
 import viewRegistry from '../registries/ViewRegistry';
-import sidebarStore from '../../Sidebar/stores/SidebarStore';
 
 jest.mock('../registries/ViewRegistry', () => ({
     get: jest.fn(),
-}));
-
-jest.mock('../../Sidebar/stores/SidebarStore', () => ({
-    clearConfig: jest.fn(),
 }));
 
 test('Render view returned from ViewRegistry', () => {
@@ -22,7 +17,6 @@ test('Render view returned from ViewRegistry', () => {
     const view = mount(<ViewRenderer router={router} />);
     expect(render(view)).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
-    expect(sidebarStore.clearConfig).toBeCalled();
 });
 
 test('Render view returned from ViewRegistry with passed router', () => {
@@ -287,72 +281,9 @@ test('Render view with route that has more than one rerenderAttributes', () => {
     expect(viewRenderer.key()).toBe('route-test__de');
 });
 
-test('Render view and not clear the sidebarstore when component has sidebar', () => {
-    const router = {
-        addUpdateRouteHook: jest.fn(),
-        route: {view: 'test'},
-    };
-    const Component = class Component extends React.Component {
-        static hasSidebar = true;
-
-        render() {
-            return <h1>{this.props.title}</h1>;
-        }
-    };
-
-    viewRegistry.get.mockReturnValue(Component);
-    const view = mount(<ViewRenderer router={router} />);
-    expect(render(view)).toMatchSnapshot();
-    expect(viewRegistry.get).toBeCalledWith('test');
-    expect(sidebarStore.clearConfig).not.toBeCalled();
-});
-
-test('Render view and not clear the sidebarstore when one of the parent component has sidebar', () => {
-    const route = {
-        view: 'test',
-        parent: {
-            view: 'parent',
-        },
-    };
-
-    const router = {
-        addUpdateRouteHook: jest.fn(),
-        route,
-    };
-
-    const Component = class Component extends React.Component {
-        static hasSidebar = false;
-
-        render() {
-            return <h1>{this.props.title}</h1>;
-        }
-    };
-
-    const ParentComponent = class Component extends React.Component {
-        static hasSidebar = true;
-
-        render() {
-            return <h1>{this.props.title}</h1>;
-        }
-    };
-
-    viewRegistry.get.mockImplementation((view) => {
-        switch (view) {
-            case 'test':
-                return Component;
-            case 'parent':
-                return ParentComponent;
-        }
-    });
-
-    const view = mount(<ViewRenderer router={router} />);
-    expect(render(view)).toMatchSnapshot();
-    expect(viewRegistry.get).toBeCalledWith('test');
-    expect(viewRegistry.get).toBeCalledWith('parent');
-    expect(sidebarStore.clearConfig).not.toBeCalled();
-});
-
 test('Clear bindings of router everytime a new view is rendered', () => {
+    viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
+
     const route1 = {
         name: 'test1',
         view: 'test',
@@ -382,6 +313,8 @@ test('Clear bindings of router everytime a new view is rendered', () => {
 });
 
 test('Clear bindings of router when same view with a different rerender attribute is rendered', () => {
+    viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
+
     const route = {
         name: 'test1',
         view: 'test',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Render view and not clear the sidebarstore when component has sidebar 1`] = `<h1 />`;
-
-exports[`Render view and not clear the sidebarstore when one of the parent component has sidebar 1`] = `<h1 />`;
-
 exports[`Render view returned from ViewRegistry 1`] = `
 <h1>
   Test

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/getViewKeyFromRoute.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/getViewKeyFromRoute.js
@@ -1,0 +1,20 @@
+// @flow
+import type {Route, AttributeMap} from './types';
+
+export default function getViewKeyFromRoute(route: ?Route, attributes: ?AttributeMap) {
+    if (!route) {
+        return null;
+    }
+
+    const rerenderAttributeValues = [];
+
+    if (route.rerenderAttributes) {
+        route.rerenderAttributes.forEach((rerenderAttribute) => {
+            if (attributes && attributes.hasOwnProperty(rerenderAttribute)) {
+                rerenderAttributeValues.push(attributes[rerenderAttribute]);
+            }
+        });
+    }
+
+    return route.name + (rerenderAttributeValues.length > 0 ? '-' + rerenderAttributeValues.join('__') : '');
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/index.js
@@ -1,8 +1,9 @@
 // @flow
 import Router from './Router';
+import getViewKeyFromRoute from './getViewKeyFromRoute';
 import routeRegistry from './registries/RouteRegistry';
 import type {AttributeMap, Route} from './types';
 
 export default Router;
-export {routeRegistry};
+export {getViewKeyFromRoute, routeRegistry};
 export type {AttributeMap, Route};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/getViewKeyFromRoute.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/tests/getViewKeyFromRoute.test.js
@@ -1,0 +1,46 @@
+// @flow
+import getViewKeyFromRoute from '../getViewKeyFromRoute';
+
+test('Return just the route name if no rerender attributes are given', () => {
+    const route = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {},
+        parent: undefined,
+        path: '/route1',
+        rerenderAttributes: [],
+        view: 'view1',
+    };
+    expect(getViewKeyFromRoute(route, {})).toEqual('route1');
+});
+
+test('Return the route name rerender attributes are not given', () => {
+    const route = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {},
+        parent: undefined,
+        path: '/route1',
+        rerenderAttributes: ['webspace', 'locale'],
+        view: 'view1',
+    };
+
+    expect(getViewKeyFromRoute(route, {})).toEqual('route1');
+});
+
+test('Return the route name with the value of the rerender attributes', () => {
+    const route = {
+        attributeDefaults: {},
+        children: [],
+        name: 'route1',
+        options: {},
+        parent: undefined,
+        path: '/route1',
+        rerenderAttributes: ['webspace', 'locale'],
+        view: 'view1',
+    };
+
+    expect(getViewKeyFromRoute(route, {webspace: 'sulu', locale: 'de'})).toEqual('route1-sulu__de');
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -133,5 +133,6 @@
     "sulu_admin.resource_locator_history_delete_warning": "Die URL wird für alle Entwurfs- und Live-Versionen gelöscht, und kann nicht wieder hergestellt werden. Wollen Sie wirklich fortfahren?",
     "sulu_admin.has_changed_warning_dialog_title": "Inhalte werden überschrieben!",
     "sulu_admin.has_changed_warning_dialog_text": "Dieser Inhalt wurde zwischenzeitlich von einem anderen Benutzer geändert. Wenn der Inhalt gespeichert wird, gehen diese Daten verloren.",
-    "sulu_admin.edit_profile": "Profil bearbeiten"
+    "sulu_admin.edit_profile": "Profil bearbeiten",
+    "sulu_admin.no_permissions": "Keine Berechtigung"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -133,5 +133,6 @@
     "sulu_admin.resource_locator_history_delete_warning": "The URL will be deleted for all draft and live versions. This cannot be undone. Do you wish to proceed?",
     "sulu_admin.has_changed_warning_dialog_title": "Content will be overwritten!",
     "sulu_admin.has_changed_warning_dialog_text": "This content has been edited by another user. When you save the content this data will get lost.",
-    "sulu_admin.edit_profile": "Edit profile"
+    "sulu_admin.edit_profile": "Edit profile",
+    "sulu_admin.no_permissions": "No permissions"
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -64,7 +64,7 @@ class AudienceTargetingAdmin extends Admin
 
         $settings = Admin::getNavigationItemSettings();
 
-        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $targetGroups = new NavigationItem('sulu_audience_targeting.target_groups');
             $targetGroups->setPosition(10);
             $targetGroups->setMainRoute(static::LIST_ROUTE);
@@ -80,19 +80,29 @@ class AudienceTargetingAdmin extends Admin
 
     public function getRoutes(): array
     {
-        $listToolbarActions = [
-            'sulu_admin.add',
-            'sulu_admin.delete',
-            'sulu_admin.export',
-        ];
+        $listToolbarActions = [];
+        $formToolbarActions = [];
 
-        $formToolbarActions = [
-            'sulu_admin.save',
-            'sulu_admin.delete',
-        ];
+        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+            $listToolbarActions[] = 'sulu_admin.add';
+        }
 
-        return [
-            $this->routeBuilderFactory->createListRouteBuilder(static::LIST_ROUTE, '/target-groups')
+        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $formToolbarActions[] = 'sulu_admin.save';
+        }
+
+        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+            $listToolbarActions[] = 'sulu_admin.delete';
+            $formToolbarActions[] = 'sulu_admin.delete';
+        }
+
+        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+            $listToolbarActions[] = 'sulu_admin.export';
+        }
+
+        $routes = [];
+        if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $routes[] = $this->routeBuilderFactory->createListRouteBuilder(static::LIST_ROUTE, '/target-groups')
                 ->setResourceKey('target_groups')
                 ->setListKey('target_groups')
                 ->setTitle('sulu_audience_targeting.target_groups')
@@ -100,32 +110,38 @@ class AudienceTargetingAdmin extends Admin
                 ->setAddRoute(static::ADD_FORM_ROUTE)
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
                 ->addToolbarActions($listToolbarActions)
-                ->getRoute(),
-            $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/target-groups/add')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory
+                ->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/target-groups/add')
                 ->setResourceKey('target_groups')
                 ->setBackRoute(static::LIST_ROUTE)
-                ->getRoute(),
-            $this->routeBuilderFactory->createFormRouteBuilder('sulu_audience_targeting.add_form.details', '/details')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory
+                ->createFormRouteBuilder('sulu_audience_targeting.add_form.details', '/details')
                 ->setResourceKey('target_groups')
                 ->setFormKey('target_group_details')
                 ->setTabTitle('sulu_admin.details')
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::ADD_FORM_ROUTE)
-                ->getRoute(),
-            $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/target-groups/:id')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory
+                ->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/target-groups/:id')
                 ->setResourceKey('target_groups')
                 ->setBackRoute(static::LIST_ROUTE)
                 ->setTitleProperty('title')
-                ->getRoute(),
-            $this->routeBuilderFactory->createFormRouteBuilder('sulu_audience_targeting.edit_form.details', '/details')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory
+                ->createFormRouteBuilder('sulu_audience_targeting.edit_form.details', '/details')
                 ->setResourceKey('target_groups')
                 ->setFormKey('target_group_details')
                 ->setTabTitle('sulu_admin.details')
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::EDIT_FORM_ROUTE)
-                ->getRoute(),
-        ];
+                ->getRoute();
+        }
+
+        return $routes;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -101,7 +101,16 @@ class ContactAdmin extends Admin
 
     public function getRoutes(): array
     {
-        $routes = [];
+        $routes = [
+            // This route has to be registered even if permissions for contacts are missing
+            // Otherwise the application breaks when other bundles try to add child routes to this one
+            $this->routeBuilderFactory
+                ->createResourceTabRouteBuilder(static::CONTACT_EDIT_FORM_ROUTE, '/contacts/:id')
+                ->setResourceKey('contacts')
+                ->setBackRoute(static::CONTACT_LIST_ROUTE)
+                ->setTitleProperty('fullName')
+                ->getRoute(),
+        ];
 
         if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $contactFormToolbarActions = [];
@@ -149,12 +158,6 @@ class ContactAdmin extends Admin
                 ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
                 ->addToolbarActions($contactFormToolbarActions)
                 ->setParent(static::CONTACT_ADD_FORM_ROUTE)
-                ->getRoute();
-            $routes[] = $this->routeBuilderFactory
-                ->createResourceTabRouteBuilder(static::CONTACT_EDIT_FORM_ROUTE, '/contacts/:id')
-                ->setResourceKey('contacts')
-                ->setBackRoute(static::CONTACT_LIST_ROUTE)
-                ->setTitleProperty('fullName')
                 ->getRoute();
             $routes[] = $this->routeBuilderFactory
                 ->createFormRouteBuilder('sulu_contact.contact_edit_form.details', '/details')

--- a/src/Sulu/Bundle/CustomUrlBundle/Resources/config/admin.xml
+++ b/src/Sulu/Bundle/CustomUrlBundle/Resources/config/admin.xml
@@ -7,6 +7,7 @@
         <service id="sulu_custom_urls.admin" class="Sulu\Bundle\CustomUrlBundle\Admin\CustomUrlAdmin">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface"/>
+            <argument type="service" id="sulu_security.security_checker"/>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -25,6 +25,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class MediaAdmin extends Admin
 {
+    const SECURITY_CONTEXT = 'sulu.media.collections';
+
     const MEDIA_OVERVIEW_ROUTE = 'sulu_media.overview';
 
     const EDIT_FORM_ROUTE = 'sulu_media.form';
@@ -71,7 +73,7 @@ class MediaAdmin extends Admin
     {
         $rootNavigationItem = $this->getNavigationItemRoot();
 
-        if ($this->securityChecker->hasPermission('sulu.media.collections', PermissionTypes::VIEW)) {
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $media = new NavigationItem('sulu_media.media');
             $media->setPosition(30);
             $media->setIcon('su-image');
@@ -101,21 +103,34 @@ class MediaAdmin extends Admin
             )
         );
 
-        $toolbarActions = [
-            'sulu_admin.save',
-            'sulu_admin.delete',
-        ];
+        $toolbarActions = [];
 
-        return [
-            (new Route(static::MEDIA_OVERVIEW_ROUTE, '/collections/:locale/:id?', 'sulu_media.overview'))
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $toolbarActions[] = 'sulu_admin.save';
+        }
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+            $toolbarActions[] = 'sulu_admin.delete';
+        }
+
+        $routes = [];
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $routes[] = (new Route(static::MEDIA_OVERVIEW_ROUTE, '/collections/:locale/:id?', 'sulu_media.overview'))
                 ->setOption('locales', $mediaLocales)
-                ->setAttributeDefault('locale', $mediaLocales[0]),
-            $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/media/:locale/:id')
+                ->setOption('permissions', [
+                    'add' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD),
+                    'delete' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE),
+                    'edit' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT),
+                ])
+                ->setAttributeDefault('locale', $mediaLocales[0]);
+            $routes[] = $this->routeBuilderFactory
+                ->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/media/:locale/:id')
                 ->setResourceKey('media')
                 ->addLocales($mediaLocales)
                 ->setTitleProperty('title')
-                ->getRoute(),
-            $this->routeBuilderFactory->createFormRouteBuilder(static::EDIT_FORM_DETAILS_ROUTE, '/details')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory->createFormRouteBuilder(static::EDIT_FORM_DETAILS_ROUTE, '/details')
                 ->setResourceKey('media')
                 ->setFormKey('media_details')
                 ->setTabTitle('sulu_media.information_taxonomy')
@@ -123,14 +138,16 @@ class MediaAdmin extends Admin
                 ->addToolbarActions($toolbarActions)
                 ->setParent(static::EDIT_FORM_ROUTE)
                 ->setBackRoute(static::MEDIA_OVERVIEW_ROUTE)
-                ->getRoute(),
-            (new Route(static::EDIT_FORM_FORMATS_ROUTE, '/formats', 'sulu_media.formats'))
+                ->getRoute();
+            $routes[] = (new Route(static::EDIT_FORM_FORMATS_ROUTE, '/formats', 'sulu_media.formats'))
                 ->setOption('tabTitle', 'sulu_media.formats')
-                ->setParent(static::EDIT_FORM_ROUTE),
-            (new Route(static::EDIT_FORM_HISTORY_ROUTE, '/history', 'sulu_media.history'))
+                ->setParent(static::EDIT_FORM_ROUTE);
+            $routes[] = (new Route(static::EDIT_FORM_HISTORY_ROUTE, '/history', 'sulu_media.history'))
                 ->setOption('tabTitle', 'sulu_media.history')
-                ->setParent(static::EDIT_FORM_ROUTE),
-        ];
+                ->setParent(static::EDIT_FORM_ROUTE);
+        }
+
+        return $routes;
     }
 
     public function getSecurityContexts()
@@ -138,7 +155,7 @@ class MediaAdmin extends Admin
         return [
             'Sulu' => [
                 'Media' => [
-                    'sulu.media.collections' => [
+                    static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,
                         PermissionTypes::ADD,
                         PermissionTypes::EDIT,
@@ -167,6 +184,11 @@ class MediaAdmin extends Admin
                     ['id' => ':id']
                 ),
             ],
+            'media_permissions' => [
+                'add' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD),
+                'delete' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE),
+                'edit' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT),
+            ]
         ];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -188,7 +188,7 @@ class MediaAdmin extends Admin
                 'add' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD),
                 'delete' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE),
                 'edit' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT),
-            ]
+            ],
         ];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -15,6 +15,9 @@ import collectionSectionStyles from './collectionSection.scss';
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 
 type Props = {
+    addable: boolean,
+    deletable: boolean,
+    editable: boolean,
     listStore: ListStore,
     locale: IObservableValue<string>,
     onCollectionNavigate: (collectionId: ?string | number) => void,
@@ -145,6 +148,9 @@ class CollectionSection extends React.Component<Props> {
 
     render() {
         const {
+            addable,
+            deletable,
+            editable,
             listStore,
             locale,
             overlayType,
@@ -164,32 +170,40 @@ class CollectionSection extends React.Component<Props> {
                             />
                             {resourceStore.id &&
                                 <div className={collectionSectionStyles.icons}>
-                                    <Icon
-                                        className={collectionSectionStyles.icon}
-                                        name="su-pen"
-                                        onClick={this.handleEditCollectionClick}
-                                    />
-                                    <Icon
-                                        className={collectionSectionStyles.icon}
-                                        name="su-trash-alt"
-                                        onClick={this.handleRemoveCollectionClick}
-                                    />
-                                    <Icon
-                                        className={collectionSectionStyles.icon}
-                                        name="su-arrows-alt"
-                                        onClick={this.handleMoveCollectionClick}
-                                    />
+                                    {editable &&
+                                        <Icon
+                                            className={collectionSectionStyles.icon}
+                                            name="su-pen"
+                                            onClick={this.handleEditCollectionClick}
+                                        />
+                                    }
+                                    {deletable &&
+                                        <Icon
+                                            className={collectionSectionStyles.icon}
+                                            name="su-trash-alt"
+                                            onClick={this.handleRemoveCollectionClick}
+                                        />
+                                    }
+                                    {editable &&
+                                        <Icon
+                                            className={collectionSectionStyles.icon}
+                                            name="su-arrows-alt"
+                                            onClick={this.handleMoveCollectionClick}
+                                        />
+                                    }
                                 </div>
                             }
                         </div>
 
-                        <div className={collectionSectionStyles.right}>
-                            <ButtonGroup>
-                                <Button onClick={this.handleAddCollectionClick}>
-                                    <Icon name="su-plus" />
-                                </Button>
-                            </ButtonGroup>
-                        </div>
+                        {addable &&
+                            <div className={collectionSectionStyles.right}>
+                                <ButtonGroup>
+                                    <Button onClick={this.handleAddCollectionClick}>
+                                        <Icon name="su-plus" />
+                                    </Button>
+                                </ButtonGroup>
+                            </div>
+                        }
                     </div>
                 }
                 <List

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -33,6 +33,10 @@ class MediaCollection extends React.Component<Props> {
         overlayType: 'overlay',
     };
 
+    static addable: boolean = true;
+    static deletable: boolean = true;
+    static editable: boolean = true;
+
     handleMediaClick = (mediaId: string | number) => {
         const {onMediaNavigate} = this.props;
 
@@ -73,7 +77,7 @@ class MediaCollection extends React.Component<Props> {
 
         return (
             <MultiMediaDropzone
-                collectionId={collectionStore.id}
+                collectionId={MediaCollection.addable ? collectionStore.id : undefined}
                 locale={locale}
                 onClose={onUploadOverlayClose}
                 onOpen={onUploadOverlayOpen}
@@ -81,6 +85,9 @@ class MediaCollection extends React.Component<Props> {
                 open={uploadOverlayOpen}
             >
                 <CollectionSection
+                    addable={MediaCollection.addable}
+                    deletable={MediaCollection.deletable}
+                    editable={MediaCollection.editable}
                     listStore={collectionListStore}
                     locale={locale}
                     onCollectionNavigate={this.handleCollectionNavigate}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -4,7 +4,6 @@ import {mount, render} from 'enzyme';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import MediaCollection from '../MediaCollection';
 import MediaCardOverviewAdapter from '../../List/adapters/MediaCardOverviewAdapter';
-
 const MEDIA_RESOURCE_KEY = 'media';
 const COLLECTIONS_RESOURCE_KEY = 'collections';
 const SETTINGS_KEY = 'media_collection_test';
@@ -227,6 +226,10 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
 jest.mock('sulu-admin-bundle/containers/SingleListOverlay', () => jest.fn(() => null));
 
 beforeEach(() => {
+    MediaCollection.addable = true;
+    MediaCollection.deletable = true;
+    MediaCollection.editable = true;
+
     const listAdapterRegistry = require('sulu-admin-bundle/containers/List/registries/ListAdapterRegistry');
 
     // $FlowFixMe
@@ -285,6 +288,156 @@ test('Render the MediaCollection', () => {
         />
     );
     expect(mediaCollection).toMatchSnapshot();
+});
+
+test('Render the MediaCollection without add button when permission is missing', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const collectionNavigateSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    MediaCollection.addable = false;
+    MediaCollection.deletable = true;
+    MediaCollection.editable = true;
+
+    const mediaCollection = mount(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={collectionNavigateSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(mediaCollection.find('CollectionSection Icon[name="su-plus"]')).toHaveLength(0);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-trash-alt"]')).toHaveLength(1);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-pen"]')).toHaveLength(1);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-arrows-alt"]')).toHaveLength(1);
+});
+
+test('Render the MediaCollection without delete button when permission is missing', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const collectionNavigateSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    MediaCollection.addable = true;
+    MediaCollection.deletable = false;
+    MediaCollection.editable = true;
+
+    const mediaCollection = mount(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={collectionNavigateSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(mediaCollection.find('CollectionSection Icon[name="su-plus"]')).toHaveLength(1);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-trash-alt"]')).toHaveLength(0);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-pen"]')).toHaveLength(1);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-arrows-alt"]')).toHaveLength(1);
+});
+
+test('Render the MediaCollection without edit buttons when permission is missing', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const collectionNavigateSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    MediaCollection.addable = true;
+    MediaCollection.deletable = true;
+    MediaCollection.editable = false;
+
+    const mediaCollection = mount(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={collectionNavigateSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(mediaCollection.find('CollectionSection Icon[name="su-plus"]')).toHaveLength(1);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-trash-alt"]')).toHaveLength(1);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-pen"]')).toHaveLength(0);
+    expect(mediaCollection.find('CollectionSection Icon[name="su-arrows-alt"]')).toHaveLength(0);
 });
 
 test('Render the MediaCollection for all media', () => {
@@ -374,6 +527,53 @@ test('Pass correct options to SingleListOverlay', () => {
     expect(mediaCollection.find(SingleListOverlay).prop('listKey')).toEqual('collections');
     expect(mediaCollection.find(SingleListOverlay).prop('resourceKey')).toEqual('collections');
     expect(mediaCollection.find(SingleListOverlay).prop('reloadOnOpen')).toEqual(true);
+});
+
+test('Deactive dropzone by passing no collectionId if dropzone should not be shown', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const collectionNavigateSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    MediaCollection.addable = false;
+    MediaCollection.deletable = true;
+    MediaCollection.editable = true;
+
+    const mediaCollection = mount(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={collectionNavigateSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(mediaCollection.find('MultiMediaDropzone').prop('collectionId')).toEqual(undefined);
 });
 
 test('Should send a request to add a new collection via the overlay', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -17,6 +17,7 @@ import {
     MediaSelectionBlockPreviewTransformer,
     SingleMediaSelectionBlockPreviewTransformer,
 } from './containers/FieldBlocks';
+import MediaCollection from './containers/MediaCollection';
 import MediaOverview from './views/MediaOverview';
 import MediaHistory from './views/MediaHistory';
 import MediaFormats from './views/MediaFormats';
@@ -25,6 +26,12 @@ const FIELD_TYPE_MEDIA_SELECTION = 'media_selection';
 const FIELD_TYPE_SINGLE_MEDIA_SELECTION = 'single_media_selection';
 
 initializer.addUpdateConfigHook('sulu_media', (config: Object, initialized: boolean) => {
+    const {media_permissions: mediaPermissions} = config;
+
+    MediaCollection.addable = mediaPermissions.add;
+    MediaCollection.deletable = mediaPermissions.delete;
+    MediaCollection.editable = mediaPermissions.edit;
+
     if (initialized) {
         return;
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -217,6 +217,11 @@ export default withToolbar(MediaOverview, function() {
         route: {
             options: {
                 locales,
+                permissions: {
+                    add: addPermission,
+                    delete: deletePermission,
+                    edit: editPermission,
+                },
             },
         },
     } = this.props.router;
@@ -233,6 +238,43 @@ export default withToolbar(MediaOverview, function() {
             })),
         }
         : undefined;
+
+    const items = [];
+
+    if (addPermission) {
+        items.push({
+            disabled: !this.collectionId.get(),
+            icon: 'su-upload',
+            label: translate('sulu_media.upload'),
+            onClick: action(() => {
+                this.showMediaUploadOverlay = true;
+            }),
+            type: 'button',
+        });
+    }
+
+    if (deletePermission) {
+        items.push({
+            disabled: this.mediaListStore.selectionIds.length === 0,
+            icon: 'su-trash-alt',
+            label: translate('sulu_admin.delete'),
+            loading: this.mediaListStore.deletingSelection,
+            onClick: this.mediaList.requestSelectionDelete,
+            type: 'button',
+        });
+    }
+
+    if (editPermission) {
+        items.push({
+            disabled: this.mediaListStore.selectionIds.length === 0,
+            icon: 'su-arrows-alt',
+            label: translate('sulu_admin.move_selected'),
+            onClick: action(() => {
+                this.showMediaMoveOverlay = true;
+            }),
+            type: 'button',
+        });
+    }
 
     return {
         locale,
@@ -252,33 +294,6 @@ export default withToolbar(MediaOverview, function() {
                 },
             }
             : undefined,
-        items: [
-            {
-                disabled: !this.collectionId.get(),
-                icon: 'su-upload',
-                label: translate('sulu_media.upload'),
-                onClick: action(() => {
-                    this.showMediaUploadOverlay = true;
-                }),
-                type: 'button',
-            },
-            {
-                disabled: this.mediaListStore.selectionIds.length === 0,
-                icon: 'su-trash-alt',
-                label: translate('sulu_admin.delete'),
-                loading: this.mediaListStore.deletingSelection,
-                onClick: this.mediaList.requestSelectionDelete,
-                type: 'button',
-            },
-            {
-                disabled: this.mediaListStore.selectionIds.length === 0,
-                icon: 'su-arrows-alt',
-                label: translate('sulu_admin.move_selected'),
-                onClick: action(() => {
-                    this.showMediaMoveOverlay = true;
-                }),
-                type: 'button',
-            },
-        ],
+        items,
     };
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -156,8 +156,17 @@ beforeEach(() => {
 test('Render a simple MediaOverview', () => {
     const MediaOverview = require('../MediaOverview').default;
     const router = {
-        bind: jest.fn(),
         attributes: {},
+        bind: jest.fn(),
+        route: {
+            options: {
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
+            },
+        },
     };
 
     const mediaOverview = render(<MediaOverview router={router} />);
@@ -167,8 +176,17 @@ test('Render a simple MediaOverview', () => {
 test('Destroy all stores on unmount', () => {
     const MediaOverview = require('../MediaOverview').default;
     const router = {
-        bind: jest.fn(),
         attributes: {},
+        bind: jest.fn(),
+        route: {
+            options: {
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
+            },
+        },
     };
 
     const mediaOverview = mount(<MediaOverview router={router} />);
@@ -206,6 +224,11 @@ test('Should navigate to defined route on back button click', () => {
         route: {
             options: {
                 locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {
@@ -238,6 +261,11 @@ test('Router navigate should be called when a media was clicked', () => {
         route: {
             options: {
                 locales: [locale],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {
@@ -264,6 +292,11 @@ test('The collectionId should be update along with the content when a collection
         route: {
             options: {
                 locales: [locale],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {
@@ -300,7 +333,11 @@ test('Should delete selected items when delete button is clicked', () => {
         bind: jest.fn(),
         route: {
             options: {
-
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
     };
@@ -328,6 +365,11 @@ test('Upload button should be disabled if nothing is selected', () => {
         route: {
             options: {
                 locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
     };
@@ -350,6 +392,11 @@ test('Upload overlay should be opened and closed as it requests', () => {
         route: {
             options: {
                 locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {
@@ -368,6 +415,35 @@ test('Upload overlay should be opened and closed as it requests', () => {
     expect(mediaOverview.find('MediaCollection').prop('uploadOverlayOpen')).toEqual(false);
 });
 
+test('Toolbar buttons should disappear when permissions are missing', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+                permissions: {
+                    add: false,
+                    delete: false,
+                    edit: false,
+                },
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />).at(0).instance();
+    mediaOverview.collectionId.set(4);
+    mediaOverview.locale.set('de');
+
+    expect(toolbarFunction.call(mediaOverview).items).toHaveLength(0);
+});
+
 test('Move overlay button should be disabled if nothing is selected', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
     const MediaOverview = require('../MediaOverview').default;
@@ -379,6 +455,11 @@ test('Move overlay button should be disabled if nothing is selected', () => {
         route: {
             options: {
                 locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {
@@ -408,6 +489,11 @@ test('Move overlay should disappear when overlay is closed', () => {
         route: {
             options: {
                 locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {
@@ -444,6 +530,11 @@ test('Media should be moved when overlay is confirmed', () => {
         route: {
             options: {
                 locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
             },
         },
         attributes: {

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -212,6 +212,7 @@ class PageAdmin extends Admin
                 ->setResourceKey('permissions')
                 ->setFormKey('permission_details')
                 ->setApiOptions(['resourceKey' => 'pages'])
+                ->setTabCondition('_permissions.security')
                 ->setTabTitle('sulu_security.permissions')
                 ->addToolbarActions(['sulu_admin.save'])
                 ->addRouterAttributesToFormStore(['webspace'])

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -60,6 +60,8 @@ class PageAdminTest extends TestCase
 
     public function testGetRoutes()
     {
+        $this->securityChecker->hasPermission('sulu.webspaces.test-1', 'edit')->willReturn(true);
+
         $localization1 = new Localization('de');
 
         $webspace1 = new Webspace();

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -134,6 +134,8 @@ class SecurityAdmin extends Admin
             $listToolbarActions[] = 'sulu_admin.export';
         }
 
+        $routes = [];
+
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $routes[] = $this->routeBuilderFactory->createListRouteBuilder(static::LIST_ROUTE, '/roles')
                 ->setResourceKey('roles')

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -63,6 +63,11 @@ class SnippetAdminTest extends TestCase
             'Test'
         );
 
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'add')->willReturn(true);
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'edit')->willReturn(true);
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'delete')->willReturn(true);
+        $this->securityChecker->hasPermission('sulu.global.snippets', 'view')->willReturn(true);
+
         $this->webspaceManager->getAllLocalizations()->willReturn(array_map(function($localization) {
             return new Localization($localization);
         }, $locales));

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -20,6 +20,8 @@ use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
 class TagAdmin extends Admin
 {
+    const SECURITY_CONTEXT = 'sulu.settings.tags';
+
     const LIST_ROUTE = 'sulu_tag.list';
 
     const ADD_FORM_ROUTE = 'sulu_tag.add_form';
@@ -50,7 +52,7 @@ class TagAdmin extends Admin
 
         $settings = Admin::getNavigationItemSettings();
 
-        if ($this->securityChecker->hasPermission('sulu.settings.tags', 'view')) {
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $roles = new NavigationItem('sulu_tag.tags', $settings);
             $roles->setPosition(30);
             $roles->setMainRoute(static::LIST_ROUTE);
@@ -65,19 +67,30 @@ class TagAdmin extends Admin
 
     public function getRoutes(): array
     {
-        $formToolbarActions = [
-            'sulu_admin.save',
-            'sulu_admin.delete',
-        ];
+        $formToolbarActions = [];
+        $listToolbarActions = [];
 
-        $listToolbarActions = [
-            'sulu_admin.add',
-            'sulu_admin.delete',
-            'sulu_admin.export',
-        ];
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+            $listToolbarActions[] = 'sulu_admin.add';
+        }
 
-        return [
-            $this->routeBuilderFactory->createListRouteBuilder(static::LIST_ROUTE, '/tags')
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $formToolbarActions[] = 'sulu_admin.save';
+        }
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+            $formToolbarActions[] = 'sulu_admin.delete';
+            $listToolbarActions[] = 'sulu_admin.delete';
+        }
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+            $listToolbarActions[] = 'sulu_admin.export';
+        }
+
+        $routes = [];
+
+        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            $routes[] = $this->routeBuilderFactory->createListRouteBuilder(static::LIST_ROUTE, '/tags')
                 ->setResourceKey('tags')
                 ->setListKey('tags')
                 ->setTitle('sulu_tag.tags')
@@ -85,32 +98,34 @@ class TagAdmin extends Admin
                 ->setAddRoute(static::ADD_FORM_ROUTE)
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
                 ->addToolbarActions($listToolbarActions)
-                ->getRoute(),
-            $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/tags/add')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory->createResourceTabRouteBuilder(static::ADD_FORM_ROUTE, '/tags/add')
                 ->setResourceKey('tags')
                 ->setBackRoute(static::LIST_ROUTE)
-                ->getRoute(),
-            $this->routeBuilderFactory->createFormRouteBuilder('sulu_tag.add_form.details', '/details')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory->createFormRouteBuilder('sulu_tag.add_form.details', '/details')
                 ->setResourceKey('tags')
                 ->setFormKey('tag_details')
                 ->setTabTitle('sulu_admin.details')
                 ->setEditRoute(static::EDIT_FORM_ROUTE)
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::ADD_FORM_ROUTE)
-                ->getRoute(),
-            $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/tags/:id')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory->createResourceTabRouteBuilder(static::EDIT_FORM_ROUTE, '/tags/:id')
                 ->setResourceKey('tags')
                 ->setBackRoute(static::LIST_ROUTE)
                 ->setTitleProperty('name')
-                ->getRoute(),
-            $this->routeBuilderFactory->createFormRouteBuilder('sulu_tag.edit_form.details', '/details')
+                ->getRoute();
+            $routes[] = $this->routeBuilderFactory->createFormRouteBuilder('sulu_tag.edit_form.details', '/details')
                 ->setResourceKey('tags')
                 ->setFormKey('tag_details')
                 ->setTabTitle('sulu_admin.details')
                 ->addToolbarActions($formToolbarActions)
                 ->setParent(static::EDIT_FORM_ROUTE)
-                ->getRoute(),
-        ];
+                ->getRoute();
+        }
+
+        return $routes;
     }
 
     /**
@@ -121,7 +136,7 @@ class TagAdmin extends Admin
         return [
             'Sulu' => [
                 'Settings' => [
-                    'sulu.settings.tags' => [
+                    static::SECURITY_CONTEXT => [
                         PermissionTypes::VIEW,
                         PermissionTypes::ADD,
                         PermissionTypes::EDIT,

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -73,8 +73,10 @@ class WebsiteAdmin extends Admin
             'sulu_admin.delete',
         ];
 
-        return [
-            $this->routeBuilderFactory
+        $routes = [];
+
+        if ($this->hasSomeWebspaceAnalyticsPermission()) {
+            $routes[] = $this->routeBuilderFactory
                 ->createFormOverlayListRouteBuilder('sulu_webspace.analytics_list', '/analytics')
                 ->setResourceKey('analytics')
                 ->setListKey('analytics')
@@ -88,8 +90,10 @@ class WebsiteAdmin extends Admin
                 ->addToolbarActions($listToolbarActions)
                 ->setParent(PageAdmin::WEBSPACE_TABS_ROUTE)
                 ->addRerenderAttribute('webspace')
-                ->getRoute(),
-        ];
+                ->getRoute();
+        }
+
+        return $routes;
     }
 
     /**
@@ -144,5 +148,21 @@ class WebsiteAdmin extends Admin
                 'clearCache' => $this->urlGenerator->generate('sulu_website.cache.remove'),
             ],
         ];
+    }
+
+    private function hasSomeWebspaceAnalyticsPermission(): bool
+    {
+        foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
+            $hasWebspaceAnalyticsPermission = $this->securityChecker->hasPermission(
+                self::getAnalyticsSecurityContext($webspace->getKey()),
+                PermissionTypes::EDIT
+            );
+
+            if ($hasWebspaceAnalyticsPermission) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -15,7 +15,6 @@ use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Config\Resource\FileResource;
-use Traversable;
 
 /**
  * A collection of all webspaces and portals in a specific sulu installation.

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -132,15 +132,6 @@ class WebspaceCollection implements \IteratorAggregate
         return count($this->webspaces);
     }
 
-    /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
-     * Retrieve an external iterator.
-     *
-     * @see http://php.net/manual/en/iteratoraggregate.getiterator.php
-     *
-     * @return Traversable An instance of an object implementing <b>Iterator</b> or
-     *                     <b>Traversable</b>
-     */
     public function getIterator()
     {
         return new \ArrayIterator($this->webspaces);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR hides UI elements, if the user has not been granted these permissions.

#### Why?

Because it is a better UX, than receiving an error on every click.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Avoid infinite loaders when 403 are returned