### PR TITLE
Disallow editing of resource locator on homepage

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -8,6 +8,8 @@ import resourceLocatorStyles from './resourceLocator.scss';
 
 const PART_TAG = 'sulu.rlp.part';
 
+const HOMEPAGE_RESOURCE_LOCATOR = '/';
+
 export default class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
     constructor(props: FieldTypeProps<?string>) {
         super(props);
@@ -22,6 +24,10 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
 
         if (typeof generationUrl !== 'string') {
             throw new Error('The "generationUrl" fieldTypeOption must be a string!');
+        }
+
+        if (value === HOMEPAGE_RESOURCE_LOCATOR) {
+            return;
         }
 
         formInspector.addFinishFieldHandler((finishedFieldDataPath, finishedFieldSchemaPath) => {
@@ -95,6 +101,10 @@ export default class ResourceLocator extends React.Component<FieldTypeProps<?str
 
         if (mode !== 'leaf' && mode !== 'full') {
             throw new Error('The "mode" schema option must be either "leaf" or "full"!');
+        }
+
+        if (value === HOMEPAGE_RESOURCE_LOCATOR) {
+            return '/';
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -54,13 +54,39 @@ test('Pass props correctly to ResourceLocator', () => {
             }}
             formInspector={formInspector}
             schemaOptions={schemaOptions}
+            value="/url"
+        />
+    );
+
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('value')).toBe('/url');
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
+    expect(resourceLocator.find(ResourceLocatorComponent).prop('disabled')).toBe(true);
+});
+
+test('Render just slash instead of ResourceLocatorComponent if used on the homepage', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const schemaOptions = {
+        mode: {
+            value: 'full',
+        },
+    };
+
+    const resourceLocator = shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
             value="/"
         />
     );
 
-    expect(resourceLocator.find(ResourceLocatorComponent).prop('value')).toBe('/');
-    expect(resourceLocator.find(ResourceLocatorComponent).prop('mode')).toBe('full');
-    expect(resourceLocator.find(ResourceLocatorComponent).prop('disabled')).toBe(true);
+    expect(resourceLocator.find(ResourceLocatorComponent)).toHaveLength(0);
+    expect(resourceLocator.text()).toEqual('/');
 });
 
 test('Do not render history link if new entity is created', () => {
@@ -170,6 +196,24 @@ test('Do not add an addFinishFieldHandler for URL generation if no generationUrl
                 historyResourceKey: 'page_resourcelocators',
             }}
             formInspector={formInspector}
+        />
+    );
+
+    expect(formInspector.addFinishFieldHandler).not.toBeCalled();
+});
+
+test('Do not add an addFinishFieldHandler for URL generation if used on the homepage', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+            }}
+            formInspector={formInspector}
+            value="/"
         />
     );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR replaces the `ResourceLocator` field with a simple '/' on the homepage.

#### Why?

Because the URL of the homepage should not be editable, since it should always be the entry point of the website. 