### PR TITLE
Add posibility to change api-options and resource-key in resource-multi-select

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/ResourceMultiSelect.js
@@ -1,7 +1,9 @@
 // @flow
-import React from 'react';
 import type {Element} from 'react';
+import React from 'react';
+import {observable, action} from 'mobx';
 import {observer} from 'mobx-react';
+import equals from 'fast-deep-equal';
 import MultiSelectComponent from '../../components/MultiSelect';
 import ResourceListStore from '../../stores/ResourceListStore';
 import Loader from '../../components/Loader';
@@ -27,18 +29,33 @@ class ResourceMultiSelect<T: string | number> extends React.Component<Props<T>> 
         values: [],
     };
 
-    resourceListStore: ResourceListStore;
+    @observable resourceListStore: ResourceListStore;
 
     constructor(props: Props<T>) {
         super(props);
 
+        this.createResourceListStore();
+    }
+
+    componentDidUpdate(prevProps: Props<T>) {
+        const {
+            resourceKey,
+            apiOptions,
+        } = this.props;
+
+        if (!equals(prevProps.apiOptions, apiOptions) || prevProps.resourceKey !== resourceKey) {
+            this.createResourceListStore();
+        }
+    }
+
+    @action createResourceListStore = () => {
         const {
             resourceKey,
             apiOptions,
         } = this.props;
 
         this.resourceListStore = new ResourceListStore(resourceKey, apiOptions);
-    }
+    };
 
     // TODO: Remove explicit type annotation when flow bug is fixed
     // https://github.com/facebook/flow/issues/6978

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js
@@ -135,6 +135,87 @@ test('Render with data and apiOptions', () => {
     expect(resourceMultiSelect.render()).toMatchSnapshot();
 });
 
+test('Render with data and apiOptions when apiOptions props changed', () => {
+    // $FlowFixMe
+    ResourceListStore.mockImplementation(function() {
+        this.loading = false;
+        this.data = [
+            {
+                'id': 2,
+                'name': 'Test ABC',
+                'someOtherProperty': 'No no',
+            },
+        ];
+    });
+
+    const apiOptions1 = {};
+    const apiOptions2 = {'testOption': 'testValue'};
+
+    const resourceMultiSelect = mount(
+        <ResourceMultiSelect
+            apiOptions={apiOptions1}
+            displayProperty="name"
+            onChange={jest.fn()}
+            resourceKey="test"
+            values={undefined}
+        />
+    );
+
+    resourceMultiSelect.setProps({
+        apiOptions: apiOptions2,
+        displayProperty: 'name',
+        onChange: jest.fn(),
+        resourceKey: 'test',
+        values: undefined,
+    });
+
+    // $FlowFixMe
+    expect(ResourceListStore.mock.calls).toEqual([
+        ['test', apiOptions1],
+        ['test', apiOptions2],
+    ]);
+});
+
+test('Render with data and apiOptions when resourceKey props changed', () => {
+    // $FlowFixMe
+    ResourceListStore.mockImplementation(function() {
+        this.loading = false;
+        this.data = [
+            {
+                'id': 2,
+                'name': 'Test ABC',
+                'someOtherProperty': 'No no',
+            },
+        ];
+    });
+
+    const apiOptions = {};
+
+    const resourceMultiSelect = mount(
+        <ResourceMultiSelect
+            apiOptions={apiOptions}
+            displayProperty="name"
+            onChange={jest.fn()}
+            resourceKey="test1"
+            values={undefined}
+        />
+    );
+
+    resourceMultiSelect.setProps({
+        apiOptions: apiOptions,
+        displayProperty: 'name',
+        onChange: jest.fn(),
+        resourceKey: 'test2',
+        values: undefined,
+    });
+
+    // $FlowFixMe
+    expect(ResourceListStore.mock.calls).toEqual([
+        ['test1', apiOptions],
+        ['test2', apiOptions],
+    ]);
+});
+
 test('Render with values', () => {
     // $FlowFixMe
     ResourceListStore.mockImplementation(function() {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add posibility to change api-options and resource-key in resource-multi-select.

#### To Do

- [ ] Tests
