### PR TITLE
Fix generation of URL for child pages

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -42,7 +42,11 @@ export default class ResourceLocator extends React.PureComponent<Props> {
     }
 
     handleChange = (value: ?string) => {
-        const {onChange} = this.props;
+        const {mode, onChange} = this.props;
+
+        if (value && mode === 'leaf' && value.endsWith('/')) {
+            return;
+        }
 
         onChange(value ? this.fixed + value : undefined);
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {computed} from 'mobx';
+import {action, computed, observable} from 'mobx';
+import {observer} from 'mobx-react';
 import Input from '../Input';
 import resourceLocatorStyles from './resourceLocator.scss';
 
@@ -13,16 +14,27 @@ type Props = {|
     value: ?string,
 |};
 
-export default class ResourceLocator extends React.PureComponent<Props> {
+@observer
+export default class ResourceLocator extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
 
-    fixed: string = '/';
+    @observable fixed: string = '/';
 
     constructor(props: Props) {
         super(props);
 
+        this.splitLeafValue();
+    }
+
+    @action componentDidUpdate(prevProps: Props) {
+        if (this.props.value !== prevProps.value) {
+            this.splitLeafValue();
+        }
+    }
+
+    splitLeafValue() {
         const {value, mode} = this.props;
 
         if (mode === 'leaf' && value) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -36,6 +36,20 @@ test('ResourceLocator should render when disabled', () => {
         .toMatchSnapshot();
 });
 
+test('ResourceLocator should update the split leaf representation when value changes', () => {
+    const resourceLocator = mount(
+        <ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={jest.fn()} value="/child" />
+    );
+
+    expect(resourceLocator.find('.fixed').prop('children')).toEqual('/');
+    expect(resourceLocator.find('Input').prop('value')).toEqual('child');
+
+    resourceLocator.setProps({value: '/child/test'});
+    resourceLocator.update();
+    expect(resourceLocator.find('.fixed').prop('children')).toEqual('/child/');
+    expect(resourceLocator.find('Input').prop('value')).toEqual('test');
+});
+
 test('ResourceLocator should call the onChange callback when the input changes with type full', () => {
     const onChange = jest.fn();
     const value = '/parent';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -56,6 +56,26 @@ test('ResourceLocator should call the onChange callback when the input changes w
     expect(onChange).toHaveBeenCalledWith('/parent/child-new');
 });
 
+test('ResourceLocator should not call the onChange callback when a slash is typed in leaf mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const resourceLocator = mount(
+        <ResourceLocator mode="leaf" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('/parent/child/');
+    expect(onChange).not.toBeCalled();
+});
+
+test('ResourceLocator should call the onChange callback when a slash is typed in full mode', () => {
+    const onChange = jest.fn();
+    const value = '/parent/child';
+    const resourceLocator = mount(
+        <ResourceLocator mode="full" onBlur={jest.fn()} onChange={onChange} value={value} />
+    );
+    resourceLocator.find('Input').props().onChange('parent/child/');
+    expect(onChange).toBeCalledWith('/parent/child/');
+});
+
 test('ResourceLocator should call the onChange callback with undefined if no input is given', () => {
     const onChange = jest.fn();
     const resourceLocator = mount(<ResourceLocator mode="leaf" onChange={onChange} value="/url" />);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR splits the URL used by the `ResourceLocator` component into pieces also after updating the URL.

#### Why?

Because the old behavior resulted in a strange behavior, when a page is created as child of another page (so that the leaf resourcelocator would generate a URL with a slash).