### PR TITLE
Add loader to MediaCard while image is loading

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -211,11 +211,7 @@ class MediaCard extends React.Component<Props> {
                     {image
                         ? (
                             <Fragment>
-                                <img
-                                    alt={title}
-                                    onLoad={this.handleImageLoad}
-                                    src={this.image.src}
-                                />
+                                <img alt={title} src={this.image.src} />
                                 {this.imageLoading && <Loader />}
                             </Fragment>
                         )

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/MediaCard.js
@@ -1,10 +1,10 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import type {ElementRef} from 'react';
 import classNames from 'classnames';
 import {observer} from 'mobx-react';
 import {action, observable} from 'mobx';
-import {Icon, Checkbox, CroppedText} from 'sulu-admin-bundle/components';
+import {Loader, Icon, Checkbox, CroppedText} from 'sulu-admin-bundle/components';
 import MimeTypeIndicator from '../MimeTypeIndicator';
 import DownloadList from './DownloadList';
 import mediaCardStyles from './mediaCard.scss';
@@ -38,9 +38,27 @@ class MediaCard extends React.Component<Props> {
         showCover: false,
     };
 
+    image: Image;
+
     @observable downloadButtonRef: ?ElementRef<'button'>;
 
     @observable downloadListOpen: boolean = false;
+
+    @observable imageLoading: boolean = true;
+
+    constructor(props: Props) {
+        super(props);
+
+        const {image: src} = this.props;
+
+        if (src) {
+            this.image = new Image();
+            this.image.onload = this.handleImageLoad;
+            this.image.src = src;
+        } else {
+            this.handleImageLoad();
+        }
+    }
 
     @action setDownloadButtonRef = (ref: ?ElementRef<'button'>) => {
         this.downloadButtonRef = ref;
@@ -95,6 +113,10 @@ class MediaCard extends React.Component<Props> {
         }
     };
 
+    @action handleImageLoad = () => {
+        this.imageLoading = false;
+    };
+
     render() {
         const {
             downloadCopyText,
@@ -111,6 +133,7 @@ class MediaCard extends React.Component<Props> {
             title,
             showCover,
         } = this.props;
+
         const mediaCardClass = classNames(
             mediaCardStyles.mediaCard,
             {
@@ -186,7 +209,16 @@ class MediaCard extends React.Component<Props> {
                     role="button"
                 >
                     {image
-                        ? <img alt={title} src={image} />
+                        ? (
+                            <Fragment>
+                                <img
+                                    alt={title}
+                                    onLoad={this.handleImageLoad}
+                                    src={this.image.src}
+                                />
+                                {this.imageLoading && <Loader />}
+                            </Fragment>
+                        )
                         : <MimeTypeIndicator height={200} mimeType={mimeType} />
                     }
                     <div className={mediaCardStyles.cover}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/mediaCard.scss
@@ -131,6 +131,7 @@ $downloadButtonBorderColorActive: $shakespeare;
     position: absolute;
     top: 0;
     left: 0;
+    z-index: 2;
     width: 100%;
     height: 100%;
     opacity: 0;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/MediaCard.test.js
@@ -1,28 +1,59 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
-import {mount, render} from 'enzyme';
-import pretty from 'pretty';
+// @flow
+import {mount} from 'enzyme';
 import React from 'react';
 import MediaCard from '../MediaCard';
 
 test('Render a MediaCard component', () => {
-    expect(render(
+    const mediaCard = mount(
         <MediaCard
+            downloadText=""
+            downloadUrl=""
+            id="test"
             image="http://lorempixel.com/300/200"
             meta="Test/Test"
+            mimeType="image/jpeg"
             title="Test"
         />
-    )).toMatchSnapshot();
+    );
+
+    mediaCard.instance().image.onload();
+
+    expect(mediaCard.render()).toMatchSnapshot();
+});
+
+test('Render a MediaCard component with loader if image has not been loaded yet', () => {
+    const mediaCard = mount(
+        <MediaCard
+            downloadText=""
+            downloadUrl=""
+            id="test"
+            image="http://lorempixel.com/300/200"
+            meta="Test/Test"
+            mimeType="image/jpeg"
+            title="Test"
+        />
+    );
+
+    expect(mediaCard.render()).toMatchSnapshot();
 });
 
 test('Render a MediaCard component with a checkbox for selection', () => {
-    expect(render(
+    const mediaCard = mount(
         <MediaCard
+            downloadText=""
+            downloadUrl=""
+            id="test"
             image="http://lorempixel.com/300/200"
             meta="Test/Test"
+            mimeType="image/jpeg"
             onSelectionChange={jest.fn()}
             title="Test"
         />
-    )).toMatchSnapshot();
+    );
+
+    mediaCard.instance().image.onload();
+
+    expect(mediaCard.render()).toMatchSnapshot();
 });
 
 test('Render a MediaCard with download list', () => {
@@ -41,20 +72,23 @@ test('Render a MediaCard with download list', () => {
         },
     ];
 
-    const masonry = mount(
+    const mediaCard = mount(
         <MediaCard
             downloadCopyText="Copy URL"
             downloadText="Direct download"
             downloadUrl="http://lorempixel.com/300/200"
+            id="test"
             image="http://lorempixel.com/300/200"
             imageSizes={imageSizes}
             meta="Test/Test"
+            mimeType="image/jpeg"
             title="Test"
         />
     );
 
-    masonry.instance().openDownloadList();
-    expect(pretty(document.body.innerHTML)).toMatchSnapshot();
+    mediaCard.instance().openDownloadList();
+    mediaCard.update();
+    expect(mediaCard.find('DownloadList Popover').render()).toMatchSnapshot();
 });
 
 test('Clicking on an item should call the responsible handler on the MediaCard component', () => {
@@ -64,9 +98,12 @@ test('Clicking on an item should call the responsible handler on the MediaCard c
 
     const mediaCard = mount(
         <MediaCard
+            downloadText=""
+            downloadUrl=""
             id={itemId}
             image="http://lorempixel.com/300/200"
             meta="Test/Test"
+            mimeType="image/jpeg"
             onClick={clickSpy}
             onSelectionChange={selectionSpy}
             title="Test"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MediaCard/tests/__snapshots__/MediaCard.test.js.snap
@@ -112,6 +112,7 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
           >
             <input
               type="checkbox"
+              value="test"
             />
             <span />
           </span>
@@ -194,19 +195,198 @@ exports[`Render a MediaCard component with a checkbox for selection 1`] = `
 </div>
 `;
 
-exports[`Render a MediaCard with download list 1`] = `
-"<div>
-  <div class=\\"backdrop fixed\\" role=\\"button\\"></div>
-</div>
-<div>
-  <div class=\\"container\\">
-    <ul class=\\"menu\\" style=\\"top: 10px; left: 10px; position: fixed; pointer-events: auto;\\">
-      <li class=\\"item\\"><button><span class=\\"content\\">Direct download<span class=\\"copyText\\"></span></span></button></li>
-      <li class=\\"divider\\"></li>
-      <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/300/200\\"><span class=\\"content\\">300/200<span class=\\"copyText\\">Copy URL</span></span></button></li>
-      <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/600/300\\"><span class=\\"content\\">600/300<span class=\\"copyText\\">Copy URL</span></span></button></li>
-      <li class=\\"item\\"><button type=\\"button\\" class=\\"\\" data-clipboard-text=\\"http://lorempixel.com/150/200\\"><span class=\\"content\\">150/200<span class=\\"copyText\\">Copy URL</span></span></button></li>
-    </ul>
+exports[`Render a MediaCard component with loader if image has not been loaded yet 1`] = `
+<div
+  class="mediaCard noDownloadList"
+>
+  <div
+    class="header"
+  >
+    <div
+      class="description"
+      role="button"
+    >
+      <div
+        class="title"
+      >
+        <div
+          class="titleText"
+        >
+          <div
+            aria-label="Test"
+            class="croppedText"
+            title="Test"
+          >
+            <div
+              aria-hidden="true"
+              class="front"
+            >
+              Te
+            </div>
+            <div
+              aria-hidden="true"
+              class="back"
+            >
+              <span>
+                st
+              </span>
+            </div>
+            <div
+              class="whole"
+            >
+              Test
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="meta"
+      >
+        <div
+          aria-label="Test/Test"
+          class="croppedText"
+          title="Test/Test"
+        >
+          <div
+            aria-hidden="true"
+            class="front"
+          >
+            Test/
+          </div>
+          <div
+            aria-hidden="true"
+            class="back"
+          >
+            <span>
+              Test
+            </span>
+          </div>
+          <div
+            class="whole"
+          >
+            Test/Test
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-</div>"
+  <div
+    class="media"
+    role="button"
+  >
+    <img
+      alt="Test"
+      src="http://lorempixel.com/300/200"
+    />
+    <div
+      class="spinner"
+      style="width: 40px; height: 40px;"
+    >
+      <div
+        class="doubleBounce1"
+      />
+      <div
+        class="doubleBounce2"
+      />
+    </div>
+    <div
+      class="cover"
+    />
+  </div>
+</div>
+`;
+
+exports[`Render a MediaCard with download list 1`] = `
+Array [
+  <div
+    class="backdrop fixed"
+    role="button"
+  />,
+  <div
+    class="container"
+  >
+    <ul
+      class="menu"
+      style="top: 10px; left: 10px; position: fixed; pointer-events: auto;"
+    >
+      <li
+        class="item"
+      >
+        <button>
+          <span
+            class="content"
+          >
+            Direct download
+            <span
+              class="copyText"
+            />
+          </span>
+        </button>
+      </li>
+      <li
+        class="divider"
+      />
+      <li
+        class="item"
+      >
+        <button
+          class=""
+          data-clipboard-text="http://lorempixel.com/300/200"
+          type="button"
+        >
+          <span
+            class="content"
+          >
+            300/200
+            <span
+              class="copyText"
+            >
+              Copy URL
+            </span>
+          </span>
+        </button>
+      </li>
+      <li
+        class="item"
+      >
+        <button
+          class=""
+          data-clipboard-text="http://lorempixel.com/600/300"
+          type="button"
+        >
+          <span
+            class="content"
+          >
+            600/300
+            <span
+              class="copyText"
+            >
+              Copy URL
+            </span>
+          </span>
+        </button>
+      </li>
+      <li
+        class="item"
+      >
+        <button
+          class=""
+          data-clipboard-text="http://lorempixel.com/150/200"
+          type="button"
+        >
+          <span
+            class="content"
+          >
+            150/200
+            <span
+              class="copyText"
+            >
+              Copy URL
+            </span>
+          </span>
+        </button>
+      </li>
+    </ul>
+  </div>,
+]
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/SingleMediaDropzone.js
@@ -1,10 +1,10 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import {observer} from 'mobx-react';
 import {observable, action} from 'mobx';
 import classNames from 'classnames';
 import Dropzone from 'react-dropzone';
-import {CircularProgressbar, Icon} from 'sulu-admin-bundle/components';
+import {CircularProgressbar, Icon, Loader} from 'sulu-admin-bundle/components';
 import MimeTypeIndicator from '../MimeTypeIndicator';
 import singleMediaDropzoneStyles from './singleMediaDropzone.scss';
 
@@ -33,7 +33,38 @@ class SingleMediaDropzone extends React.Component<Props> {
         uploading: false,
     };
 
+    image: Image;
+
     @observable uploadIndicatorVisibility: boolean;
+    @observable imageLoading: boolean = false;
+
+    componentDidMount() {
+        this.preloadImage();
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.image !== prevProps.image) {
+            this.preloadImage();
+        }
+    }
+
+    @action preloadImage() {
+        const {image: src} = this.props;
+
+        if (src) {
+            this.imageLoading = true;
+
+            this.image = new Image();
+            this.image.onload = this.handleImageLoad;
+            this.image.src = src;
+        } else {
+            this.handleImageLoad();
+        }
+    }
+
+    @action handleImageLoad = () => {
+        this.imageLoading = false;
+    };
 
     @action setUploadIndicatorVisibility(visibility: boolean) {
         this.uploadIndicatorVisibility = visibility;
@@ -86,7 +117,10 @@ class SingleMediaDropzone extends React.Component<Props> {
                 onDrop={this.handleDrop}
             >
                 {image &&
-                    <img className={singleMediaDropzoneStyles.thumbnail} key={image} src={image} />
+                    <Fragment>
+                        <img className={singleMediaDropzoneStyles.thumbnail} key={image} src={image} />
+                        {this.imageLoading && <Loader />}
+                    </Fragment>
                 }
                 {!image && mimeType &&
                     <div className={singleMediaDropzoneStyles.mimeTypeIndicator}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/SingleMediaDropzone.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {shallow, render} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
 import React from 'react';
 import SingleMediaDropzone from '../SingleMediaDropzone';
 
@@ -20,6 +20,19 @@ test('Render a SingleMediaDropzone with the default empty icon', () => {
 
 test('Render a SingleMediaDropzone with the passed empty icon', () => {
     expect(render(<SingleMediaDropzone emptyIcon="su-user" image={undefined} onDrop={jest.fn()} />)).toMatchSnapshot();
+});
+
+test('Render a SingleMediaDropzone with a loader if image has not been loaded yet', () => {
+    const singleMediaDropzone = mount(<SingleMediaDropzone emptyIcon="su-user" image="test.jpg" onDrop={jest.fn()} />);
+    expect(singleMediaDropzone.render()).toMatchSnapshot();
+});
+
+test('Render a SingleMediaDropzone without a loader if image has been loaded yet', () => {
+    const singleMediaDropzone = mount(<SingleMediaDropzone emptyIcon="su-user" image="test.jpg" onDrop={jest.fn()} />);
+
+    singleMediaDropzone.instance().image.onload();
+
+    expect(singleMediaDropzone.render()).toMatchSnapshot();
 });
 
 test('Render a SingleMediaDropzone in disabled state', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/SingleMediaDropzone/tests/__snapshots__/SingleMediaDropzone.test.js.snap
@@ -129,6 +129,49 @@ exports[`Render a SingleMediaDropzone while uploading 1`] = `
 </div>
 `;
 
+exports[`Render a SingleMediaDropzone with a loader if image has not been loaded yet 1`] = `
+<div
+  aria-disabled="false"
+  class="mediaContainer default"
+  style="position: relative;"
+>
+  <img
+    class="thumbnail"
+    src="test.jpg"
+  />
+  <div
+    class="spinner"
+    style="width: 40px; height: 40px;"
+  >
+    <div
+      class="doubleBounce1"
+    />
+    <div
+      class="doubleBounce2"
+    />
+  </div>
+  <div
+    class="uploadIndicatorContainer"
+  >
+    <div
+      class="uploadIndicator"
+    >
+      <div>
+        <span
+          aria-label="fa-cloud-upload"
+          class="fa fa-cloud-upload uploadIcon"
+        />
+      </div>
+    </div>
+  </div>
+  <input
+    autocomplete="off"
+    style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;"
+    type="file"
+  />
+</div>
+`;
+
 exports[`Render a SingleMediaDropzone with the default empty icon 1`] = `
 <div
   aria-disabled="false"
@@ -228,6 +271,38 @@ exports[`Render a SingleMediaDropzone with the round skin 1`] = `
   <input
     autocomplete="off"
     style="position:absolute;top:0;right:0;bottom:0;left:0;opacity:0.00001;pointer-events:none"
+    type="file"
+  />
+</div>
+`;
+
+exports[`Render a SingleMediaDropzone without a loader if image has been loaded yet 1`] = `
+<div
+  aria-disabled="false"
+  class="mediaContainer default"
+  style="position: relative;"
+>
+  <img
+    class="thumbnail"
+    src="test.jpg"
+  />
+  <div
+    class="uploadIndicatorContainer"
+  >
+    <div
+      class="uploadIndicator"
+    >
+      <div>
+        <span
+          aria-label="fa-cloud-upload"
+          class="fa fa-cloud-upload uploadIcon"
+        />
+      </div>
+    </div>
+  </div>
+  <input
+    autocomplete="off"
+    style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; opacity: 0.00001; pointer-events: none;"
     type="file"
   />
 </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardAdapter.test.js.snap
@@ -117,6 +117,17 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
               src="http://lorempixel.com/240/100"
             />
             <div
+              class="spinner"
+              style="width:40px;height:40px"
+            >
+              <div
+                class="doubleBounce1"
+              />
+              <div
+                class="doubleBounce2"
+              />
+            </div>
+            <div
               class="cover"
             >
               <span
@@ -237,6 +248,17 @@ exports[`Render a basic Masonry view with MediaCards 1`] = `
               alt="Title 1"
               src="http://lorempixel.com/240/100"
             />
+            <div
+              class="spinner"
+              style="width:40px;height:40px"
+            >
+              <div
+                class="doubleBounce1"
+              />
+              <div
+                class="doubleBounce2"
+              />
+            </div>
             <div
               class="cover"
             >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/__snapshots__/MediaCardOverviewAdapter.test.js.snap
@@ -117,6 +117,17 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
               src="http://lorempixel.com/240/100"
             />
             <div
+              class="spinner"
+              style="width:40px;height:40px"
+            >
+              <div
+                class="doubleBounce1"
+              />
+              <div
+                class="doubleBounce2"
+              />
+            </div>
+            <div
               class="cover"
             >
               <span
@@ -237,6 +248,17 @@ exports[`Render a basic Masonry view with the MediaCardOverviewAdapter 1`] = `
               alt="Title 1"
               src="http://lorempixel.com/240/100"
             />
+            <div
+              class="spinner"
+              style="width:40px;height:40px"
+            >
+              <div
+                class="doubleBounce1"
+              />
+              <div
+                class="doubleBounce2"
+              />
+            </div>
             <div
               class="cover"
             >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -384,6 +384,17 @@ exports[`Render the MediaCollection 1`] = `
                       src="http://lorempixel.com/240/100"
                     />
                     <div
+                      class="spinner"
+                      style="width:40px;height:40px"
+                    >
+                      <div
+                        class="doubleBounce1"
+                      />
+                      <div
+                        class="doubleBounce2"
+                      />
+                    </div>
+                    <div
                       class="cover"
                     >
                       <span
@@ -504,6 +515,17 @@ exports[`Render the MediaCollection 1`] = `
                       alt="Title 1"
                       src="http://lorempixel.com/240/100"
                     />
+                    <div
+                      class="spinner"
+                      style="width:40px;height:40px"
+                    >
+                      <div
+                        class="doubleBounce1"
+                      />
+                      <div
+                        class="doubleBounce2"
+                      />
+                    </div>
                     <div
                       class="cover"
                     >
@@ -895,6 +917,17 @@ exports[`Render the MediaCollection for all media 1`] = `
                       src="http://lorempixel.com/240/100"
                     />
                     <div
+                      class="spinner"
+                      style="width:40px;height:40px"
+                    >
+                      <div
+                        class="doubleBounce1"
+                      />
+                      <div
+                        class="doubleBounce2"
+                      />
+                    </div>
+                    <div
                       class="cover"
                     >
                       <span
@@ -1015,6 +1048,17 @@ exports[`Render the MediaCollection for all media 1`] = `
                       alt="Title 1"
                       src="http://lorempixel.com/240/100"
                     />
+                    <div
+                      class="spinner"
+                      style="width:40px;height:40px"
+                    >
+                      <div
+                        class="doubleBounce1"
+                      />
+                      <div
+                        class="doubleBounce2"
+                      />
+                    </div>
                     <div
                       class="cover"
                     >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -415,6 +415,17 @@ Array [
                                   src="http://lorempixel.com/240/100"
                                 />
                                 <div
+                                  class="spinner"
+                                  style="width: 40px; height: 40px;"
+                                >
+                                  <div
+                                    class="doubleBounce1"
+                                  />
+                                  <div
+                                    class="doubleBounce2"
+                                  />
+                                </div>
+                                <div
                                   class="cover"
                                 >
                                   <span
@@ -535,6 +546,17 @@ Array [
                                   alt="Title 2"
                                   src="http://lorempixel.com/240/100"
                                 />
+                                <div
+                                  class="spinner"
+                                  style="width: 40px; height: 40px;"
+                                >
+                                  <div
+                                    class="doubleBounce1"
+                                  />
+                                  <div
+                                    class="doubleBounce2"
+                                  />
+                                </div>
                                 <div
                                   class="cover"
                                 >
@@ -1012,6 +1034,17 @@ Array [
                                   src="http://lorempixel.com/240/100"
                                 />
                                 <div
+                                  class="spinner"
+                                  style="width: 40px; height: 40px;"
+                                >
+                                  <div
+                                    class="doubleBounce1"
+                                  />
+                                  <div
+                                    class="doubleBounce2"
+                                  />
+                                </div>
+                                <div
                                   class="cover"
                                 >
                                   <span
@@ -1132,6 +1165,17 @@ Array [
                                   alt="Title 2"
                                   src="http://lorempixel.com/240/100"
                                 />
+                                <div
+                                  class="spinner"
+                                  style="width: 40px; height: 40px;"
+                                >
+                                  <div
+                                    class="doubleBounce1"
+                                  />
+                                  <div
+                                    class="doubleBounce2"
+                                  />
+                                </div>
                                 <div
                                   class="cover"
                                 >

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/package.json
@@ -14,7 +14,6 @@
     },
     "devDependencies": {
         "enzyme": "^3.3.0",
-        "pretty": "^2.0.0",
         "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js",
         "sulu-page-bundle": "file:../../../PageBundle/Resources/js"
     },

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -425,6 +425,17 @@ exports[`Render a simple MediaOverview 1`] = `
                         src="http://lorempixel.com/240/100"
                       />
                       <div
+                        class="spinner"
+                        style="width:40px;height:40px"
+                      >
+                        <div
+                          class="doubleBounce1"
+                        />
+                        <div
+                          class="doubleBounce2"
+                        />
+                      </div>
+                      <div
                         class="cover"
                       >
                         <span
@@ -545,6 +556,17 @@ exports[`Render a simple MediaOverview 1`] = `
                         alt="Title 1"
                         src="http://lorempixel.com/240/100"
                       />
+                      <div
+                        class="spinner"
+                        style="width:40px;height:40px"
+                      >
+                        <div
+                          class="doubleBounce1"
+                        />
+                        <div
+                          class="doubleBounce2"
+                        />
+                      </div>
                       <div
                         class="cover"
                       >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds a loader while the image is loading in the `MediaCard` component.

#### Why?

Because in some environments it might take a while until the image is readily converted to the desired format, and in the mean time it looks like an error.