### PR TITLE
Support multiple list metadata loaders

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilder.php
@@ -147,6 +147,13 @@ class ListRouteBuilder implements ListRouteBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToListMetadata(array $routerAttributesToListMetadata): ListRouteBuilderInterface
+    {
+        $this->addRouterAttributesToListMetadataToRoute($this->route, $routerAttributesToListMetadata);
+
+        return $this;
+    }
+
     public function addResourceStorePropertiesToListStore(array $resourceStorePropertiesToListStore): ListRouteBuilderInterface
     {
         $this->addResourceStorePropertiesToListStoreToRoute($this->route, $resourceStorePropertiesToListStore);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderInterface.php
@@ -59,7 +59,6 @@ interface ListRouteBuilderInterface
      */
     public function addRouterAttributesToListStore(array $routerAttributesToListStore): self;
 
-
     /**
      * @param string[] $routerAttributesToListMetadata
      */

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderInterface.php
@@ -59,6 +59,12 @@ interface ListRouteBuilderInterface
      */
     public function addRouterAttributesToListStore(array $routerAttributesToListStore): self;
 
+
+    /**
+     * @param string[] $routerAttributesToListMetadata
+     */
+    public function addRouterAttributesToListMetadata(array $routerAttributesToListMetadata): self;
+
     /**
      * @param string[] $resourceStorePropertiesToListStore
      */

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ListRouteBuilderTrait.php
@@ -72,6 +72,16 @@ trait ListRouteBuilderTrait
         $route->setOption('routerAttributesToListStore', $newRouterAttributesToListStore);
     }
 
+    private function addRouterAttributesToListMetadataToRoute(Route $route, array $routerAttributesToListMetadata): void
+    {
+        $oldRouterAttributesToListMetadata = $route->getOption('routerAttributesToListMetadata');
+        $newRouterAttributesToListMetadata = $oldRouterAttributesToListMetadata
+            ? array_merge($oldRouterAttributesToListMetadata, $routerAttributesToListMetadata)
+            : $routerAttributesToListMetadata;
+
+        $route->setOption('routerAttributesToListMetadata', $newRouterAttributesToListMetadata);
+    }
+
     private function addLocalesToRoute(Route $route, array $locales): void
     {
         $oldLocales = $route->getOption('locales');

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -275,12 +275,18 @@ class AdminController
         $user = $this->tokenStorage->getToken()->getUser();
 
         $metadataOptions = $request->query->all();
-
+        $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)->getMetadata($key, $user->getLocale(), $metadataOptions);
         $view = View::create(
-            $this->metadataProviderRegistry->getMetadataProvider($type)->getMetadata($key, $user->getLocale(), $metadataOptions)
+            $metadata
         );
         $view->setFormat('json');
 
-        return $this->viewHandler->handle($view);
+        $response = $this->viewHandler->handle($view);
+
+        if (!$metadata->isCacheable()) {
+            $response->headers->addCacheControlDirective('no-store', !$metadata->isCacheable());
+        }
+
+        return $response;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -278,9 +278,7 @@ class AdminController
         $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
             ->getMetadata($key, $user->getLocale(), $metadataOptions);
 
-        $view = View::create(
-            $metadata
-        );
+        $view = View::create($metadata);
         $view->setFormat('json');
 
         $response = $this->viewHandler->handle($view);

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -224,12 +224,6 @@ class AdminController
 
         $config = [
             'sulu_admin' => [
-                'endpoints' => [
-                    'metadata' => $this->urlGenerator->generate(
-                        'sulu_admin.metadata',
-                        ['type' => ':type', 'key' => ':key']
-                    ),
-                ],
                 'fieldTypeOptions' => $this->fieldTypeOptionRegistry->toArray(),
                 'internalLinkTypes' => $this->linkProviderPool->getConfiguration(),
                 'navigation' => $this->navigationRegistry->getNavigation()->getChildrenAsArray(),
@@ -276,12 +270,17 @@ class AdminController
         return new JsonResponse($translations);
     }
 
-    public function metadataAction(string $type, string $key): Response
+    public function metadataAction(string $type, string $key, Request $request): Response
     {
         $user = $this->tokenStorage->getToken()->getUser();
 
+        $metadataOptions = [];
+        if ($request->query->get('metadataOptions')) {
+            $metadataOptions = $request->query->get('metadataOptions');
+        }
+
         $view = View::create(
-            $this->metadataProviderRegistry->getMetadataProvider($type)->getMetadata($key, $user->getLocale())
+            $this->metadataProviderRegistry->getMetadataProvider($type)->getMetadata($key, $user->getLocale(), $metadataOptions)
         );
         $view->setFormat('json');
 

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -274,10 +274,7 @@ class AdminController
     {
         $user = $this->tokenStorage->getToken()->getUser();
 
-        $metadataOptions = [];
-        if ($request->query->get('metadataOptions')) {
-            $metadataOptions = $request->query->get('metadataOptions');
-        }
+        $metadataOptions = $request->query->all();
 
         $view = View::create(
             $this->metadataProviderRegistry->getMetadataProvider($type)->getMetadata($key, $user->getLocale(), $metadataOptions)

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -275,7 +275,9 @@ class AdminController
         $user = $this->tokenStorage->getToken()->getUser();
 
         $metadataOptions = $request->query->all();
-        $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)->getMetadata($key, $user->getLocale(), $metadataOptions);
+        $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
+            ->getMetadata($key, $user->getLocale(), $metadataOptions);
+
         $view = View::create(
             $metadata
         );
@@ -284,7 +286,7 @@ class AdminController
         $response = $this->viewHandler->handle($view);
 
         if (!$metadata->isCacheable()) {
-            $response->headers->addCacheControlDirective('no-store', !$metadata->isCacheable());
+            $response->headers->addCacheControlDirective('no-store', true);
         }
 
         return $response;

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -99,6 +99,7 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                 [
                     'routes_to_expose' => [
                         'c?get_.*',
+                        'sulu_admin.metadata',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/AdminBundle/Metadata/AbstractMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/AbstractMetadata.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata;
+
+use JMS\Serializer\Annotation as Serializer;
+
+abstract class AbstractMetadata
+{
+    /**
+     * @var bool
+     *
+     * @Serializer\Exclude()
+     */
+    protected $cacheable = true;
+
+    public function isCacheable(): bool
+    {
+        return $this->cacheable;
+    }
+
+    public function setCacheable(bool $cacheable): void
+    {
+        $this->cacheable = $cacheable;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/AbstractMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/AbstractMetadata.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 use JMS\Serializer\Annotation as Serializer;
 
-abstract class AbstractMetadata
+abstract class AbstractMetadata implements MetadataInterface
 {
     /**
      * @var bool

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -12,9 +12,10 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Sulu\Bundle\AdminBundle\Metadata\AbstractMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
-class FormMetadata
+class FormMetadata extends AbstractMetadata
 {
     /**
      * @var string

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataLoaderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataLoaderInterface.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
+
 interface FormMetadataLoaderInterface
 {
-    public function getMetadata(string $key, string $locale, array $metadataOptions);
+    public function getMetadata(string $key, string $locale, array $metadataOptions): ?MetadataInterface;
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataLoaderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataLoaderInterface.php
@@ -13,5 +13,5 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 interface FormMetadataLoaderInterface
 {
-    public function getMetadata(string $key, string $locale);
+    public function getMetadata(string $key, string $locale, array $metadataOptions);
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -38,11 +38,11 @@ class FormMetadataProvider implements MetadataProviderInterface
     /**
      * @return FormMetadata|TypedFormMetadata
      */
-    public function getMetadata(string $key, string $locale, array $metadataOptions)
+    public function getMetadata(string $key, string $locale, array $metadataOptions = [])
     {
         $form = null;
         foreach ($this->formMetadataLoaders as $metadataLoader) {
-            $form = $metadataLoader->getMetadata($key, $locale);
+            $form = $metadataLoader->getMetadata($key, $locale, $metadataOptions);
             if ($form) {
                 break;
             }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -38,7 +38,7 @@ class FormMetadataProvider implements MetadataProviderInterface
     /**
      * @return FormMetadata|TypedFormMetadata
      */
-    public function getMetadata(string $key, string $locale)
+    public function getMetadata(string $key, string $locale, array $metadataOptions)
     {
         $form = null;
         foreach ($this->formMetadataLoaders as $metadataLoader) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\Exception\MetadataNotFoundException;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
@@ -35,10 +36,7 @@ class FormMetadataProvider implements MetadataProviderInterface
         $this->formMetadataLoaders = $formMetadataLoaders;
     }
 
-    /**
-     * @return FormMetadata|TypedFormMetadata
-     */
-    public function getMetadata(string $key, string $locale, array $metadataOptions = [])
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
     {
         $form = null;
         foreach ($this->formMetadataLoaders as $metadataLoader) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactory;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata as ContentStructureMetadata;
@@ -60,7 +61,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         $this->debug = $debug;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?TypedFormMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?MetadataInterface
     {
         $configCache = $this->getConfigCache($key, $locale);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -60,7 +60,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         $this->debug = $debug;
     }
 
-    public function getMetadata(string $key, string $locale): ?TypedFormMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?TypedFormMetadata
     {
         $configCache = $this->getConfigCache($key, $locale);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TypedFormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TypedFormMetadata.php
@@ -12,8 +12,9 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Sulu\Bundle\AdminBundle\Metadata\AbstractMetadata;
 
-class TypedFormMetadata
+class TypedFormMetadata extends AbstractMetadata
 {
     /**
      * @var FormMetadata[]

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -51,7 +51,7 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         $this->debug = $debug;
     }
 
-    public function getMetadata(string $key, string $locale): ?FormMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?FormMetadata
     {
         $configCache = $this->getConfigCache($key, $locale);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\FormMetadata\FormXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
@@ -51,7 +52,7 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         $this->debug = $debug;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?FormMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?MetadataInterface
     {
         $configCache = $this->getConfigCache($key, $locale);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadata.php
@@ -12,8 +12,9 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
 
 use JMS\Serializer\Annotation as Serializer;
+use Sulu\Bundle\AdminBundle\Metadata\AbstractMetadata;
 
-class ListMetadata
+class ListMetadata extends AbstractMetadata
 {
     /**
      * @var FieldMetadata[]

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataLoaderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataLoaderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
+
+interface ListMetadataLoaderInterface
+{
+    public function getMetadata(string $key, string $locale, array $metadataOptions);
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataLoaderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataLoaderInterface.php
@@ -11,7 +11,9 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
 
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
+
 interface ListMetadataLoaderInterface
 {
-    public function getMetadata(string $key, string $locale, array $metadataOptions);
+    public function getMetadata(string $key, string $locale, array $metadataOptions): ?MetadataInterface;
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
@@ -13,47 +13,31 @@ namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
 
 use Sulu\Bundle\AdminBundle\Exception\MetadataNotFoundException;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
-use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class ListMetadataProvider implements MetadataProviderInterface
 {
     /**
-     * @var FieldDescriptorFactoryInterface
+     * @var ListMetadataLoaderInterface[]
      */
-    private $fieldDescriptorFactory;
+    private $listMetadataLoaders;
 
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    public function __construct(
-        FieldDescriptorFactoryInterface $fieldDescriptorFactory,
-        TranslatorInterface $translator
-    ) {
-        $this->fieldDescriptorFactory = $fieldDescriptorFactory;
-        $this->translator = $translator;
+    public function __construct(iterable $listMetadataLoaders)
+    {
+        $this->listMetadataLoaders = $listMetadataLoaders;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions)
+    public function getMetadata(string $key, string $locale, array $metadataOptions): ?ListMetadata
     {
-        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($key);
-
-        if (!$fieldDescriptors) {
-            throw new MetadataNotFoundException('list', $key);
+        $list = null;
+        foreach ($this->listMetadataLoaders as $listMetadataLoader) {
+            $list = $listMetadataLoader->getMetadata($key, $locale, $metadataOptions);
+            if ($list) {
+                break;
+            }
         }
 
-        $list = new ListMetadata();
-        foreach ($fieldDescriptors as $fieldDescriptor) {
-            $field = new FieldMetadata($fieldDescriptor->getName());
-
-            $field->setLabel($this->translator->trans($fieldDescriptor->getTranslation(), [], 'admin', $locale));
-            $field->setType($fieldDescriptor->getType());
-            $field->setVisibility($fieldDescriptor->getVisibility());
-            $field->setSortable($fieldDescriptor->getSortable());
-
-            $list->addField($field);
+        if (!$list) {
+            throw new MetadataNotFoundException('list', $key);
         }
 
         return $list;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
 
 use Sulu\Bundle\AdminBundle\Exception\MetadataNotFoundException;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 
 class ListMetadataProvider implements MetadataProviderInterface
@@ -26,7 +27,7 @@ class ListMetadataProvider implements MetadataProviderInterface
         $this->listMetadataLoaders = $listMetadataLoaders;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?ListMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
     {
         $list = null;
         foreach ($this->listMetadataLoaders as $listMetadataLoader) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
@@ -36,7 +36,7 @@ class ListMetadataProvider implements MetadataProviderInterface
         $this->translator = $translator;
     }
 
-    public function getMetadata(string $key, string $locale)
+    public function getMetadata(string $key, string $locale, array $metadataOptions)
     {
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($key);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
@@ -26,7 +26,7 @@ class ListMetadataProvider implements MetadataProviderInterface
         $this->listMetadataLoaders = $listMetadataLoaders;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions): ?ListMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?ListMetadata
     {
         $list = null;
         foreach ($this->listMetadataLoaders as $listMetadataLoader) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
+
+use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class XmlListMetadataLoader implements ListMetadataLoaderInterface
+{
+    /**
+     * @var FieldDescriptorFactoryInterface
+     */
+    private $fieldDescriptorFactory;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        FieldDescriptorFactoryInterface $fieldDescriptorFactory,
+        TranslatorInterface $translator
+    ) {
+        $this->fieldDescriptorFactory = $fieldDescriptorFactory;
+        $this->translator = $translator;
+    }
+
+    public function getMetadata(string $key, string $locale, array $metadataOptions): ?ListMetadata
+    {
+        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($key);
+
+        if (!$fieldDescriptors) {
+            return null;
+        }
+
+        $list = new ListMetadata();
+        foreach ($fieldDescriptors as $fieldDescriptor) {
+            $field = new FieldMetadata($fieldDescriptor->getName());
+
+            $field->setLabel($this->translator->trans($fieldDescriptor->getTranslation(), [], 'admin', $locale));
+            $field->setType($fieldDescriptor->getType());
+            $field->setVisibility($fieldDescriptor->getVisibility());
+            $field->setSortable($fieldDescriptor->getSortable());
+
+            $list->addField($field);
+        }
+
+        return $list;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
@@ -34,7 +34,7 @@ class XmlListMetadataLoader implements ListMetadataLoaderInterface
         $this->translator = $translator;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions): ?ListMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?ListMetadata
     {
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($key);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/XmlListMetadataLoader.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
 
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -34,7 +35,7 @@ class XmlListMetadataLoader implements ListMetadataLoaderInterface
         $this->translator = $translator;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?ListMetadata
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?MetadataInterface
     {
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($key);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataInterface.php
@@ -1,8 +1,15 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace Sulu\Bundle\AdminBundle\Metadata;
-
 
 interface MetadataInterface
 {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Sulu\Bundle\AdminBundle\Metadata;
+
+
+interface MetadataInterface
+{
+    public function isCacheable(): bool;
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
@@ -13,5 +13,5 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 interface MetadataProviderInterface
 {
-    public function getMetadata(string $key, string $locale, array $metadataOptions);
+    public function getMetadata(string $key, string $locale, array $metadataOptions): MetadataInterface;
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
@@ -13,5 +13,5 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 interface MetadataProviderInterface
 {
-    public function getMetadata(string $key, string $locale);
+    public function getMetadata(string $key, string $locale, array $metadataOptions);
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
@@ -17,7 +17,7 @@ class MetadataProviderRegistry
 {
     private $metadataProviders = [];
 
-    public function getMetadataProvider(string $type)
+    public function getMetadataProvider(string $type): MetadataProviderInterface
     {
         if (!array_key_exists($type, $this->metadataProviders)) {
             throw new MetadataProviderNotFoundException($type);

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -63,9 +63,17 @@
             id="sulu_admin.list_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider"
         >
+            <argument type="tagged" tag="sulu_admin.list_metadata_loader"></argument>
+            <tag name="sulu_admin.metadata_provider" type="list" />
+        </service>
+
+        <service
+            id="sulu_admin.xml_list_metadata_loader"
+            class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\XmlListMetadataLoader"
+        >
             <argument type="service" id="sulu_core.list_builder.field_descriptor_factory" />
             <argument type="service" id="translator.default"/>
-            <tag name="sulu_admin.metadata_provider" type="list" />
+            <tag name="sulu_admin.list_metadata_loader"/>
         </service>
 
         <service id="sulu_admin.route_factory" class="Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactory" />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -533,6 +533,7 @@ class List extends React.Component<Props> {
                         disabledIds={this.moveId ? [this.moveId] : []}
                         listKey={store.listKey}
                         locale={store.observableOptions.locale}
+                        metadataOptions={store.metadataOptions}
                         onClose={this.handleMoveOverlayClose}
                         onConfirm={this.handleMoveOverlayConfirmClick}
                         open={this.showMoveOverlay}
@@ -549,6 +550,7 @@ class List extends React.Component<Props> {
                         confirmLoading={store.copying}
                         listKey={store.listKey}
                         locale={store.observableOptions.locale}
+                        metadataOptions={store.metadataOptions}
                         onClose={this.handleCopyOverlayClose}
                         onConfirm={this.handleCopyOverlayConfirmClick}
                         open={this.showCopyOverlay}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -55,6 +55,7 @@ export default class ListStore {
     activeSettingDisposer: () => void;
     sendRequestDisposer: () => void;
     initialSelectionIds: ?Array<string | number>;
+    metadataOptions: ?Object;
 
     static getActiveSetting(listKey: string, userSettingsKey: string): string {
         const key = [USER_SETTING_PREFIX, listKey, userSettingsKey, USER_SETTING_ACTIVE].join('.');
@@ -121,6 +122,7 @@ export default class ListStore {
         userSettingsKey: string,
         observableOptions: ObservableOptions,
         options: Object = {},
+        metadataOptions: ?Object,
         selectionIds: ?Array<string | number>
     ) {
         this.resourceKey = resourceKey;
@@ -128,6 +130,7 @@ export default class ListStore {
         this.userSettingsKey = userSettingsKey;
         this.observableOptions = observableOptions;
         this.options = options;
+        this.metadataOptions = metadataOptions;
         this.initialSelectionIds = selectionIds;
 
         this.sendRequestDisposer = autorun(() => {
@@ -181,7 +184,7 @@ export default class ListStore {
             return change;
         });
 
-        metadataStore.getSchema(this.listKey)
+        metadataStore.getSchema(this.listKey, this.metadataOptions)
             .then(action((schema) => {
                 this.schema = schema;
                 this.schemaLoading = false;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/MetadataStore.js
@@ -5,7 +5,7 @@ import type {Schema} from '../types';
 const LIST_TYPE = 'list';
 
 class MetadataStore {
-    getSchema(listKey: string, metadataOptions?: ?Object): Promise<Schema> {
+    getSchema(listKey: string, metadataOptions: ?Object): Promise<Schema> {
         return metadataStore.loadMetadata(LIST_TYPE, listKey, metadataOptions);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/MetadataStore.js
@@ -5,8 +5,8 @@ import type {Schema} from '../types';
 const LIST_TYPE = 'list';
 
 class MetadataStore {
-    getSchema(listKey: string): Promise<Schema> {
-        return metadataStore.loadMetadata(LIST_TYPE, listKey);
+    getSchema(listKey: string, metadataOptions?: ?Object): Promise<Schema> {
+        return metadataStore.loadMetadata(LIST_TYPE, listKey, metadataOptions);
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -26,7 +26,6 @@ jest.mock('../stores/ListStore', () => {
     ) {
         this.resourceKey = resourceKey;
         this.listKey = listKey;
-        this.options = options;
         this.userSettingsKey = userSettingsKey;
         this.observableOptions = observableOptions;
         this.options = options;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -15,69 +15,83 @@ import StringFieldTransformer from '../fieldTransformers/StringFieldTransformer'
 
 let mockStructureStrategyData;
 
-jest.mock('../stores/ListStore', () => jest.fn(function(resourceKey, listKey, observableOptions = {}) {
-    this.resourceKey = resourceKey;
-    this.listKey = listKey;
-    this.observableOptions = observableOptions;
-    this.setPage = jest.fn();
-    this.setActive = jest.fn();
-    this.activeItems = [];
-    this.activate = jest.fn();
-    this.active = {
-        get: jest.fn(),
-    };
-    this.deactivate = jest.fn();
-    this.delete = jest.fn();
-    this.deleteSelection = jest.fn();
-    this.order = jest.fn();
-    this.sort = jest.fn();
-    this.sortColumn = {
-        get: jest.fn(),
-    };
-    this.sortOrder = {
-        get: jest.fn(),
-    };
-    this.searchTerm = {
-        get: jest.fn(),
-    };
-    this.limit = {
-        get: jest.fn().mockReturnValue(10),
-    };
-    this.setLimit = jest.fn();
-    this.updateLoadingStrategy = jest.fn();
-    this.updateStructureStrategy = jest.fn();
-    this.getPage = jest.fn().mockReturnValue(4);
-    this.pageCount = 7;
-    this.selections = [];
-    this.selectionIds = [];
-    this.loading = false;
-    this.userSchema = {
-        title: {
-            type: 'string',
-            sortable: true,
-            visibility: 'yes',
-            label: 'Title',
-        },
-    };
-    this.findById = jest.fn();
-    this.select = jest.fn();
-    this.deselect = jest.fn();
-    this.selectVisibleItems = jest.fn();
-    this.deselectVisibleItems = jest.fn();
-    this.updateLoadingStrategy = jest.fn();
-    this.structureStrategy = {
-        data: mockStructureStrategyData,
-    };
-    this.data = this.structureStrategy.data;
-    this.search = jest.fn();
-    this.move = jest.fn();
-    this.copy = jest.fn();
+jest.mock('../stores/ListStore', () => {
+    return jest.fn(function(
+        resourceKey,
+        listKey,
+        userSettingsKey,
+        observableOptions = {},
+        options = {},
+        metadataOptions = {}
+    ) {
+        this.resourceKey = resourceKey;
+        this.listKey = listKey;
+        this.options = options;
+        this.userSettingsKey = userSettingsKey;
+        this.observableOptions = observableOptions;
+        this.options = options;
+        this.metadataOptions = metadataOptions;
 
-    mockExtendObservable(this, {
-        copying: false,
-        ordering: false,
+        this.setPage = jest.fn();
+        this.setActive = jest.fn();
+        this.activeItems = [];
+        this.activate = jest.fn();
+        this.active = {
+            get: jest.fn(),
+        };
+        this.deactivate = jest.fn();
+        this.delete = jest.fn();
+        this.deleteSelection = jest.fn();
+        this.order = jest.fn();
+        this.sort = jest.fn();
+        this.sortColumn = {
+            get: jest.fn(),
+        };
+        this.sortOrder = {
+            get: jest.fn(),
+        };
+        this.searchTerm = {
+            get: jest.fn(),
+        };
+        this.limit = {
+            get: jest.fn().mockReturnValue(10),
+        };
+        this.setLimit = jest.fn();
+        this.updateLoadingStrategy = jest.fn();
+        this.updateStructureStrategy = jest.fn();
+        this.getPage = jest.fn().mockReturnValue(4);
+        this.pageCount = 7;
+        this.selections = [];
+        this.selectionIds = [];
+        this.loading = false;
+        this.userSchema = {
+            title: {
+                type: 'string',
+                sortable: true,
+                visibility: 'yes',
+                label: 'Title',
+            },
+        };
+        this.findById = jest.fn();
+        this.select = jest.fn();
+        this.deselect = jest.fn();
+        this.selectVisibleItems = jest.fn();
+        this.deselectVisibleItems = jest.fn();
+        this.updateLoadingStrategy = jest.fn();
+        this.structureStrategy = {
+            data: mockStructureStrategyData,
+        };
+        this.data = this.structureStrategy.data;
+        this.search = jest.fn();
+        this.move = jest.fn();
+        this.copy = jest.fn();
+
+        mockExtendObservable(this, {
+            copying: false,
+            ordering: false,
+        });
     });
-}));
+});
 
 jest.mock('../registries/ListAdapterRegistry', () => ({
     add: jest.fn(),
@@ -374,13 +388,19 @@ test('Pass options to adapter', () => {
     }));
 });
 
-test('Pass correct options to SingleListOverlays', () => {
-    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+test('Pass correct options and metadataOptions to SingleListOverlays', () => {
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)}, {option: 'test'}, {id: 1});
 
     const list = shallow(<List adapters={['test']} store={listStore} />);
 
     expect(list.find(SingleListOverlay).at(0).prop('reloadOnOpen')).toEqual(true);
     expect(list.find(SingleListOverlay).at(1).prop('reloadOnOpen')).toEqual(true);
+
+    expect(list.find(SingleListOverlay).at(0).prop('options')).toEqual({option: 'test'});
+    expect(list.find(SingleListOverlay).at(1).prop('options')).toEqual({option: 'test'});
+
+    expect(list.find(SingleListOverlay).at(0).prop('metadataOptions')).toEqual({id: 1});
+    expect(list.find(SingleListOverlay).at(1).prop('metadataOptions')).toEqual({id: 1});
 });
 
 test('Selecting and deselecting items should update store', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -184,8 +184,13 @@ test('The user store should be called correctly when changing the schema', () =>
         },
         {
             test: 'value',
+        },
+        {
+            id: 1,
         }
     );
+
+    expect((metadataStore).getSchema).toBeCalledWith('tests', {id: 1});
 
     return schemaPromise.then(() => {
         const newSchema = {
@@ -261,7 +266,8 @@ test('The loading strategy should be called with a different resourceKey when a 
         },
         {
             test: 'value',
-        }
+        },
+        undefined
     );
     listStore.schema = {};
 
@@ -819,7 +825,7 @@ test('Set forbidden flag to true if the response returned a 403', (done) => {
 });
 
 test('Set active to undefined if the response returned a 404', (done) => {
-    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
+    const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()}, undefined);
     listStore.schema = {};
     const promise = Promise.reject({
         status: 404,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -620,6 +620,7 @@ test('The loading strategy should be called with expandedIds if some items are a
             page,
         },
         {},
+        {},
         [1, 5, 10]
     );
     listStore.schema = {};
@@ -886,7 +887,7 @@ test('Get schema from MetadataStore for correct resourceKey', () => {
     });
     listStore.updateLoadingStrategy(new LoadingStrategy());
     listStore.updateStructureStrategy(new StructureStrategy());
-    expect(metadataStore.getSchema).toBeCalledWith('tests');
+    expect(metadataStore.getSchema).toBeCalledWith('tests', undefined);
     return schemaPromise.then(() => {
         expect(listStore.schema).toEqual(schema);
         listStore.destroy();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/MetadataStore.test.js
@@ -10,12 +10,16 @@ test('Return list fields for given resourceKey from MetadataStore', () => {
     const promise = Promise.resolve();
     generalMetadataStore.loadMetadata.mockReturnValue(promise);
 
-    const snippetPromise = metadataStore.getSchema('snippets');
-    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'snippets', undefined);
+    const snippetPromise = metadataStore.getSchema('snippets', {id: 10});
+    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'snippets', {id: 10});
 
     const contactPromise = metadataStore.getSchema('contacts');
     expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'contacts', undefined);
 
+    const contactPromise2 = metadataStore.getSchema('contacts', undefined);
+    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'contacts', undefined);
+
     expect(snippetPromise).toEqual(promise);
     expect(contactPromise).toEqual(promise);
+    expect(contactPromise2).toEqual(promise);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/MetadataStore.test.js
@@ -11,10 +11,10 @@ test('Return list fields for given resourceKey from MetadataStore', () => {
     generalMetadataStore.loadMetadata.mockReturnValue(promise);
 
     const snippetPromise = metadataStore.getSchema('snippets');
-    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'snippets');
+    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'snippets', undefined);
 
     const contactPromise = metadataStore.getSchema('contacts');
-    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'contacts');
+    expect(generalMetadataStore.loadMetadata).toHaveBeenLastCalledWith('list', 'contacts', undefined);
 
     expect(snippetPromise).toEqual(promise);
     expect(contactPromise).toEqual(promise);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/SingleListOverlay.js
@@ -18,6 +18,7 @@ type Props = {|
     excludedIds: Array<string | number>,
     listKey: string,
     locale?: ?IObservableValue<string>,
+    metadataOptions?: ?Object,
     onClose: () => void,
     onConfirm: (selectedItem: Object) => void,
     open: boolean,
@@ -49,7 +50,7 @@ class SingleListOverlay extends React.Component<Props> {
         const excludedIds = computed(() => this.props.excludedIds.length ? this.props.excludedIds : undefined);
         this.excludedIdsDisposer = excludedIds.observe(() => this.listStore.clear());
 
-        const {listKey, locale, options, preSelectedItem, resourceKey} = this.props;
+        const {listKey, locale, metadataOptions, options, preSelectedItem, resourceKey} = this.props;
         const observableOptions = {};
         observableOptions.page = this.page;
         observableOptions.excludedIds = excludedIds;
@@ -68,6 +69,7 @@ class SingleListOverlay extends React.Component<Props> {
             USER_SETTINGS_KEY,
             observableOptions,
             options,
+            metadataOptions,
             initialSelectionIds
         );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js
@@ -15,11 +15,12 @@ jest.mock('../../../containers/ListOverlay', () => jest.fn(function ListOverlay(
 }));
 
 jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
-    function(resourceKey, listKey, userSettingsKey, observableOptions, options) {
+    function(resourceKey, listKey, userSettingsKey, observableOptions, options, metadataOptions) {
         this.resourceKey = resourceKey;
         this.listKey = listKey;
         this.userSettingsKey = userSettingsKey;
         this.options = options;
+        this.metadataOptions = metadataOptions;
         this.observableOptions = observableOptions;
         this.select = jest.fn();
 
@@ -33,9 +34,10 @@ jest.mock('../../../containers/List/stores/ListStore', () => jest.fn(
     }
 ));
 
-test('Should instantiate the ListStore with locale, excluded-ids and options', () => {
+test('Should instantiate the ListStore with locale, excluded-ids, options and metadataOptions', () => {
     const locale = observable.box('en');
     const options = {};
+    const metadataOptions = {id: 2};
 
     const singleListOverlay = shallow(
         <SingleListOverlay
@@ -43,6 +45,7 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
             excludedIds={['id-1', 'id-2']}
             listKey="snippets_list"
             locale={locale}
+            metadataOptions={metadataOptions}
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={false}
@@ -57,9 +60,10 @@ test('Should instantiate the ListStore with locale, excluded-ids and options', (
     expect(singleListOverlay.instance().listStore.observableOptions.locale.get()).toEqual('en');
     expect(singleListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(['id-1', 'id-2']);
     expect(singleListOverlay.instance().listStore.options).toBe(options);
+    expect(singleListOverlay.instance().listStore.metadataOptions).toBe(metadataOptions);
 });
 
-test('Should instantiate the ListStore without locale, excluded-ids and options', () => {
+test('Should instantiate the ListStore without locale, excluded-ids, options and metadataOptions', () => {
     const singleListOverlay = shallow(
         <SingleListOverlay
             adapter="table"
@@ -74,6 +78,8 @@ test('Should instantiate the ListStore without locale, excluded-ids and options'
 
     expect(singleListOverlay.instance().listStore.observableOptions.locale).toEqual(undefined);
     expect(singleListOverlay.instance().listStore.observableOptions.excludedIds.get()).toEqual(undefined);
+    expect(singleListOverlay.instance().listStore.options).toEqual(undefined);
+    expect(singleListOverlay.instance().listStore.metadataOptions).toEqual(undefined);
 });
 
 test('Should pass overlayType overlay by default', () => {
@@ -234,6 +240,7 @@ test('Should pass the id from the preSelectedItems to the ListStore', () => {
         <SingleListOverlay
             adapter="table"
             listKey="snippets"
+            metadataOptions={undefined}
             onClose={jest.fn()}
             onConfirm={jest.fn()}
             open={true}
@@ -248,6 +255,7 @@ test('Should pass the id from the preSelectedItems to the ListStore', () => {
         'snippets',
         'single_list_overlay',
         expect.anything(),
+        undefined,
         undefined,
         [1]
     );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -10,7 +10,6 @@ import Requester from './services/Requester';
 import Router, {routeRegistry} from './services/Router';
 import Application from './containers/Application';
 import {updateRouterAttributesFromView, viewRegistry} from './containers/ViewRenderer';
-import metadataStore from './stores/MetadataStore';
 import userStore, {logoutOnUnauthorizedResponse} from './stores/UserStore';
 import {Config, resourceRouteRegistry} from './services';
 import initializer from './services/Initializer';
@@ -271,7 +270,6 @@ function processConfig(config: Object) {
     resourceRouteRegistry.clear();
 
     routeRegistry.addCollection(config.routes);
-    metadataStore.endpoint = config.endpoints.metadata;
     navigationRegistry.set(config.navigation);
     resourceRouteRegistry.setEndpoints(config.resources);
     smartContentConfigStore.setConfig(config.smartContent);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
@@ -5,15 +5,12 @@ import {Requester} from '../../services';
 class MetadataStore {
     metadataPromises: {[string]: {[string]: Promise<Object>}} = {};
 
-    loadMetadata(type: string, key: string, metadataOptions: Object): Promise<Object> {
+    loadMetadata(type: string, key: string, metadataOptions: Object = {}): Promise<Object> {
         const parameters = {
             type: type,
             key: key,
-            metadataOptions: {},
+            ...metadataOptions,
         };
-        if (metadataOptions) {
-            parameters.metadataOptions = metadataOptions;
-        }
 
         if (!this.metadataPromises[type]) {
             this.metadataPromises[type] = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
@@ -1,20 +1,27 @@
 // @flow
+import symfonyRouting from 'fos-jsrouting/router';
 import {Requester} from '../../services';
 
 class MetadataStore {
-    endpoint: string;
     metadataPromises: {[string]: {[string]: Promise<Object>}} = {};
 
-    loadMetadata(type: string, key: string): Promise<Object> {
+    loadMetadata(type: string, key: string, metadataOptions: Object): Promise<Object> {
+        const parameters = {
+            type: type,
+            key: key,
+            metadataOptions: {},
+        };
+        if (metadataOptions) {
+            parameters.metadataOptions = metadataOptions;
+        }
+
         if (!this.metadataPromises[type]) {
             this.metadataPromises[type] = {};
         }
 
         if (!this.metadataPromises[type][key]) {
             this.metadataPromises[type][key] = Requester.get(
-                this.endpoint
-                    .replace(':type', type)
-                    .replace(':key', key)
+                symfonyRouting.generate('sulu_admin.metadata', parameters)
             );
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
@@ -23,10 +23,7 @@ class MetadataStore {
         if (!this.metadataPromises[type]) {
             this.metadataPromises[type] = {};
         }
-        const keyWithOptions = buildQueryString({
-            key: key,
-            ...metadataOptions,
-        });
+        const keyWithOptions = key + buildQueryString(metadataOptions);
 
         if (!this.metadataPromises[type][keyWithOptions]) {
             const url = symfonyRouting.generate('sulu_admin.metadata', parameters);
@@ -36,23 +33,16 @@ class MetadataStore {
                     return Promise.reject(response);
                 }
 
-                if (response.status === 204) {
-                    this.metadataPromises[type][keyWithOptions] = undefined;
-                    return Promise.resolve({});
-                }
-
                 const cacheControl = response.headers.get('cache-control');
                 if (cacheControl && cacheControl.includes('no-store')) {
                     this.metadataPromises[type][keyWithOptions] = undefined;
                 }
 
-                return response.json()
-                    .then((data) => {
-                        return data;
-                    });
+                return response.json();
             });
 
             this.metadataPromises[type][keyWithOptions] = response;
+
             return response;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/MetadataStore.js
@@ -32,10 +32,12 @@ class MetadataStore {
             const url = symfonyRouting.generate('sulu_admin.metadata', parameters);
             const response = fetch(url, defaultOptions).then((response) => {
                 if (!response.ok) {
+                    this.metadataPromises[type][keyWithOptions] = undefined;
                     return Promise.reject(response);
                 }
 
                 if (response.status === 204) {
+                    this.metadataPromises[type][keyWithOptions] = undefined;
                     return Promise.resolve({});
                 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/tests/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/tests/MetadataStore.test.js
@@ -1,4 +1,5 @@
 // @flow
+import SymfonyRouting from 'fos-jsrouting/router';
 import metadataStore from '../MetadataStore';
 import Requester from '../../../services/Requester';
 
@@ -7,8 +8,6 @@ jest.mock('../../../services/Requester', () => ({
 }));
 
 test('Load metadata for given type and key', () => {
-    metadataStore.endpoint = '/metadata/:type/:key';
-
     const snippetMetadata = {
         form: {
             title: {
@@ -37,6 +36,10 @@ test('Load metadata for given type and key', () => {
 
     const snippetPromise = Promise.resolve(snippetMetadata);
     const tagPromise = Promise.resolve(tagMetadata);
+
+    SymfonyRouting.generate.mockImplementation((routeName, value) => {
+        return '/metadata/' + value.type + '/' + value.key;
+    });
 
     Requester.get.mockImplementation((key) => {
         switch (key) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/tests/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MetadataStore/tests/MetadataStore.test.js
@@ -193,17 +193,3 @@ test('Load metadata should reject with response when the response contains error
 
     expect(metadataStore.loadMetadata('form', 'reject')).rejects.toEqual(response);
 });
-
-test('Load metadata should return empty object if status code was 204', () => {
-    const promise = Promise.resolve({
-        ok: true,
-        status: 204,
-    });
-
-    window.fetch = jest.fn();
-    window.fetch.mockReturnValue(promise);
-
-    return metadataStore.loadMetadata('form', 'empty').then((data) => {
-        expect(data).toEqual({});
-    });
-});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -70,6 +70,7 @@ class List extends React.Component<Props> {
                     routerAttributesToListStore = {},
                     resourceStorePropertiesToListStore = {},
                     userSettingsKey = DEFAULT_USER_SETTINGS_KEY,
+                    routerAttributesToListMetadata = {},
                 },
             },
         } = router;
@@ -106,12 +107,18 @@ class List extends React.Component<Props> {
             props.resourceStore
         );
 
+        const metadataOptions = this.buildMetadataOptions(
+            attributes,
+            routerAttributesToListMetadata
+        );
+
         this.listStore = new ListStore(
             resourceKey,
             listKey,
             userSettingsKey,
             observableOptions,
-            listStoreOptions
+            listStoreOptions,
+            metadataOptions
         );
 
         router.bind('active', this.listStore.active);
@@ -119,6 +126,22 @@ class List extends React.Component<Props> {
         router.bind('sortOrder', this.listStore.sortOrder);
         router.bind('search', this.listStore.searchTerm);
         router.bind('limit', this.listStore.limit, DEFAULT_LIMIT);
+    }
+    buildMetadataOptions(
+        attributes: Object,
+        routerAttributesToListMetadata: {[string | number]: string}
+    ) {
+        const metadataOptions = {};
+        routerAttributesToListMetadata = toJS(routerAttributesToListMetadata);
+
+        Object.keys(routerAttributesToListMetadata).forEach((key) => {
+            const listOptionKey = routerAttributesToListMetadata[key];
+            const attributeName = isNaN(key) ? key : routerAttributesToListMetadata[key];
+
+            metadataOptions[listOptionKey] = attributes[attributeName];
+        });
+
+        return metadataOptions;
     }
 
     buildListStoreOptions(
@@ -129,7 +152,6 @@ class List extends React.Component<Props> {
         resourceStore: ?ResourceStore
     ) {
         const listStoreOptions = apiOptions ? apiOptions : {};
-
         routerAttributesToListStore = toJS(routerAttributesToListStore);
         Object.keys(routerAttributesToListStore).forEach((key) => {
             const listOptionKey = routerAttributesToListStore[key];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -1123,7 +1123,7 @@ test('Should pass router attributes array from router to the ListStore metadataO
                 listKey: 'test',
                 locales: ['en', 'de'],
                 resourceKey: 'test',
-                routerAttributesToListMetadata: ['locale', 'title', 'id'],
+                routerAttributesToListMetadata: ['locale', 'id'],
             },
         },
     };
@@ -1133,7 +1133,7 @@ test('Should pass router attributes array from router to the ListStore metadataO
 
     expect(listStore.metadataOptions.locale).toEqual('en');
     expect(listStore.metadataOptions.id).toEqual('123-123-123');
-    expect(listStore.metadataOptions.title).toEqual('Sulu is awesome');
+    expect(listStore.metadataOptions.title).toBeUndefined();
 });
 
 test('Should pass locale and page observables to the ListStore', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -26,12 +26,13 @@ jest.mock('../../../stores/UserStore', () => ({
 
 jest.mock(
     '../../../containers/List/stores/ListStore',
-    () => jest.fn(function(resourceKey, listKey, userSettingsKey, observableOptions, options) {
+    () => jest.fn(function(resourceKey, listKey, userSettingsKey, observableOptions, options, metadataOptions) {
         this.resourceKey = resourceKey;
         this.listKey = listKey;
         this.userSettingsKey = userSettingsKey;
         this.observableOptions = observableOptions;
         this.options = options;
+        this.metadataOptions = metadataOptions;
         this.loading = false;
         this.pageCount = 3;
         this.active = {
@@ -1104,6 +1105,35 @@ test('Should pass router attributes array from router to the ListStore', () => {
     expect(listStore.options.locale).toEqual('en');
     expect(listStore.options.id).toEqual('123-123-123');
     expect(listStore.options.title).toEqual('Sulu is awesome');
+});
+
+test('Should pass router attributes array from router to the ListStore metadataOptions', () => {
+    const List = require('../List').default;
+    const router = {
+        bind: jest.fn(),
+        attributes: {
+            id: '123-123-123',
+            locale: 'en',
+            title: 'Sulu is awesome',
+        },
+        route: {
+            options: {
+                adapters: ['table'],
+                apiOptions: {},
+                listKey: 'test',
+                locales: ['en', 'de'],
+                resourceKey: 'test',
+                routerAttributesToListMetadata: ['locale', 'title', 'id'],
+            },
+        },
+    };
+
+    const list = mount(<List router={router} />);
+    const listStore = list.instance().listStore;
+
+    expect(listStore.metadataOptions.locale).toEqual('en');
+    expect(listStore.metadataOptions.id).toEqual('123-123-123');
+    expect(listStore.metadataOptions.title).toEqual('Sulu is awesome');
 });
 
 test('Should pass locale and page observables to the ListStore', () => {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -32,12 +32,12 @@ class FormMetadataProviderTest extends KernelTestCase
     public function testMetadataNotFound()
     {
         $this->expectException(MetadataNotFoundException::class);
-        $this->formMetadataProvider->getMetadata('form_without_metadata', 'en');
+        $this->formMetadataProvider->getMetadata('form_without_metadata', 'en', []);
     }
 
     public function testGetMetadataFromFormMetadataXmlLoader()
     {
-        $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'en');
+        $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'en', []);
         $this->assertInstanceOf(FormMetadata::class, $form);
         $this->assertCount(3, $form->getItems());
         $schema = $form->getSchema()->toJsonSchema();
@@ -46,7 +46,7 @@ class FormMetadataProviderTest extends KernelTestCase
 
     public function testGetMetadataFromStructureLoader()
     {
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'en');
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'en', []);
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(2, $typedForm->getForms());
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -32,12 +32,12 @@ class FormMetadataProviderTest extends KernelTestCase
     public function testMetadataNotFound()
     {
         $this->expectException(MetadataNotFoundException::class);
-        $this->formMetadataProvider->getMetadata('form_without_metadata', 'en', []);
+        $this->formMetadataProvider->getMetadata('form_without_metadata', 'en');
     }
 
     public function testGetMetadataFromFormMetadataXmlLoader()
     {
-        $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'en', []);
+        $form = $this->formMetadataProvider->getMetadata('form_with_schema', 'en');
         $this->assertInstanceOf(FormMetadata::class, $form);
         $this->assertCount(3, $form->getItems());
         $schema = $form->getSchema()->toJsonSchema();
@@ -46,7 +46,7 @@ class FormMetadataProviderTest extends KernelTestCase
 
     public function testGetMetadataFromStructureLoader()
     {
-        $typedForm = $this->formMetadataProvider->getMetadata('page', 'en', []);
+        $typedForm = $this->formMetadataProvider->getMetadata('page', 'en');
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
         $this->assertCount(2, $typedForm->getForms());
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ListRouteBuilderTest.php
@@ -226,6 +226,22 @@ class ListRouteBuilderTest extends TestCase
         );
     }
 
+    public function testBuildListWithRouterAttributesToListMetadata()
+    {
+        $route = (new ListRouteBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey('roles')
+            ->setListKey('roles')
+            ->addListAdapters(['tree'])
+            ->addRouterAttributesToListMetadata(['webspace' => 'webspaceId', 'parent' => 'parentId', 'id' => 1])
+            ->addRouterAttributesToListMetadata(['locale'])
+            ->getRoute();
+
+        $this->assertSame(
+            ['webspace' => 'webspaceId', 'parent' => 'parentId', 'id' => 1, 'locale'],
+            $route->getOption('routerAttributesToListMetadata')
+        );
+    }
+
     public function testBuildListWithResourceStorePropertiesToListStore()
     {
         $route = (new ListRouteBuilder('sulu_role.datagrid', '/roles'))

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -295,14 +295,14 @@ class AdminControllerTest extends TestCase
         $this->user->getLocale()->willReturn('en');
 
         $metadataProvider = $this->prophesize(MetadataProviderInterface::class);
-        $metadataProvider->getMetadata('pages', 'en')->willReturn($form);
+        $metadataProvider->getMetadata('pages', 'en', [])->willReturn($form);
         $this->metadataProviderRegistry->getMetadataProvider('form')->willReturn($metadataProvider);
 
         $this->viewHandler->handle(Argument::that(function(View $view) use ($form) {
             return $form === $view->getData();
         }))->shouldBeCalled()->willReturn(new Response());
 
-        $this->adminController->metadataAction('form', 'pages');
+        $this->adminController->metadataAction('form', 'pages', new Request());
     }
 
     public function provideTranslationsAction()

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -305,6 +305,25 @@ class AdminControllerTest extends TestCase
         $this->adminController->metadataAction('form', 'pages', new Request());
     }
 
+    public function testMetadataActionWithOptions()
+    {
+        $form = new FormMetadata();
+
+        $this->user->getLocale()->willReturn('en');
+
+        $metadataProvider = $this->prophesize(MetadataProviderInterface::class);
+        $metadataProvider->getMetadata('pages', 'en', ['id' => 1])->willReturn($form);
+        $this->metadataProviderRegistry->getMetadataProvider('form')->willReturn($metadataProvider);
+
+        $this->viewHandler->handle(Argument::that(function(View $view) use ($form) {
+            return $form === $view->getData();
+        }))->shouldBeCalled()->willReturn(new Response());
+
+        $request = new Request();
+        $request->query->add(['id' => 1]);
+        $this->adminController->metadataAction('form', 'pages', $request);
+    }
+
     public function provideTranslationsAction()
     {
         return [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/ListMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/ListMetadataProviderTest.php
@@ -55,7 +55,7 @@ class ListMetadataProviderTest extends TestCase
         $this->xmlListMetadataLoader1->getMetadata('list1', 'en', [])->willReturn($listMetadata);
         $this->xmlListMetadataLoader2->getMetadata('list1', 'en', [])->willReturn(null);
 
-        $metadata = $this->listMetadataProvider->getMetadata('list1', 'en', []);
+        $metadata = $this->listMetadataProvider->getMetadata('list1', 'en');
         $this->assertEquals($listMetadata, $metadata);
     }
 
@@ -69,7 +69,7 @@ class ListMetadataProviderTest extends TestCase
         $this->xmlListMetadataLoader1->getMetadata('list1', 'en', [])->willReturn(null);
         $this->xmlListMetadataLoader2->getMetadata('list1', 'en', [])->willReturn($listMetadata);
 
-        $metadata = $this->listMetadataProvider->getMetadata('list1', 'en', []);
+        $metadata = $this->listMetadataProvider->getMetadata('list1', 'en');
         $this->assertEquals($listMetadata, $metadata);
     }
 
@@ -79,6 +79,6 @@ class ListMetadataProviderTest extends TestCase
         $this->xmlListMetadataLoader2->getMetadata('list1', 'en', [])->willReturn(null);
 
         $this->expectException(MetadataNotFoundException::class);
-        $this->listMetadataProvider->getMetadata('list1', 'en', []);
+        $this->listMetadataProvider->getMetadata('list1', 'en');
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/ListMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/ListMetadataProviderTest.php
@@ -84,7 +84,7 @@ class ListMetadataProviderTest extends TestCase
             ]
         );
 
-        $contactListMetadata = $this->listMetadataProvider->getMetadata('contact', 'de');
+        $contactListMetadata = $this->listMetadataProvider->getMetadata('contact', 'de', []);
         $contactListFields = $contactListMetadata->getFields();
 
         $this->assertEquals('firstName', $contactListFields['firstName']->getName());
@@ -104,7 +104,7 @@ class ListMetadataProviderTest extends TestCase
             $contactListFields['lastName']->getVisibility()
         );
 
-        $accountListMetadata = $this->listMetadataProvider->getMetadata('account', 'en');
+        $accountListMetadata = $this->listMetadataProvider->getMetadata('account', 'en', []);
         $accountListFields = $accountListMetadata->getFields();
 
         $this->assertEquals('name', $accountListFields['name']->getName());
@@ -121,6 +121,6 @@ class ListMetadataProviderTest extends TestCase
     {
         $this->expectException(MetadataNotFoundException::class);
 
-        $this->listMetadataProvider->getMetadata('not-existing', 'de');
+        $this->listMetadataProvider->getMetadata('not-existing', 'de', []);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/ListMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/ListMetadataProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\ListMetadata;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Exception\MetadataNotFoundException;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataLoaderInterface;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\XmlListMetadataLoader;
+
+class ListMetadataProviderTest extends TestCase
+{
+    /**
+     * @var ListMetadataProvider
+     */
+    private $listMetadataProvider;
+
+    /**
+     * @var XmlListMetadataLoader
+     */
+    private $xmlListMetadataLoader1;
+
+    /**
+     * @var XmlListMetadataLoader
+     */
+    private $xmlListMetadataLoader2;
+
+    public function setUp()
+    {
+        $this->xmlListMetadataLoader1 = $this->prophesize(ListMetadataLoaderInterface::class);
+        $this->xmlListMetadataLoader2 = $this->prophesize(ListMetadataLoaderInterface::class);
+
+        $loaders = [$this->xmlListMetadataLoader1->reveal(), $this->xmlListMetadataLoader2->reveal()];
+        $this->listMetadataProvider = new ListMetadataProvider($loaders);
+    }
+
+    public function testGetMetadataFromLoader1()
+    {
+        $listMetadata = new ListMetadata();
+        $listMetadata->addField(new FieldMetadata('field1'));
+        $listMetadata->addField(new FieldMetadata('field2'));
+        $listMetadata->addField(new FieldMetadata('field3'));
+
+        $this->xmlListMetadataLoader1->getMetadata('list1', 'en', [])->willReturn($listMetadata);
+        $this->xmlListMetadataLoader2->getMetadata('list1', 'en', [])->willReturn(null);
+
+        $metadata = $this->listMetadataProvider->getMetadata('list1', 'en', []);
+        $this->assertEquals($listMetadata, $metadata);
+    }
+
+    public function testGetMetadataFromLoader2()
+    {
+        $listMetadata = new ListMetadata();
+        $listMetadata->addField(new FieldMetadata('field1'));
+        $listMetadata->addField(new FieldMetadata('field2'));
+        $listMetadata->addField(new FieldMetadata('field3'));
+
+        $this->xmlListMetadataLoader1->getMetadata('list1', 'en', [])->willReturn(null);
+        $this->xmlListMetadataLoader2->getMetadata('list1', 'en', [])->willReturn($listMetadata);
+
+        $metadata = $this->listMetadataProvider->getMetadata('list1', 'en', []);
+        $this->assertEquals($listMetadata, $metadata);
+    }
+
+    public function testGetMetadataNotExisting()
+    {
+        $this->xmlListMetadataLoader1->getMetadata('list1', 'en', [])->willReturn(null);
+        $this->xmlListMetadataLoader2->getMetadata('list1', 'en', [])->willReturn(null);
+
+        $this->expectException(MetadataNotFoundException::class);
+        $this->listMetadataProvider->getMetadata('list1', 'en', []);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
@@ -83,7 +83,7 @@ class XmlListMetadataLoaderTest extends TestCase
             ]
         );
 
-        $contactListMetadata = $this->xmlListMetadataLoader->getMetadata('contact', 'de', []);
+        $contactListMetadata = $this->xmlListMetadataLoader->getMetadata('contact', 'de');
         $contactListFields = $contactListMetadata->getFields();
 
         $this->assertEquals('firstName', $contactListFields['firstName']->getName());
@@ -103,7 +103,7 @@ class XmlListMetadataLoaderTest extends TestCase
             $contactListFields['lastName']->getVisibility()
         );
 
-        $accountListMetadata = $this->xmlListMetadataLoader->getMetadata('account', 'en', []);
+        $accountListMetadata = $this->xmlListMetadataLoader->getMetadata('account', 'en');
         $accountListFields = $accountListMetadata->getFields();
 
         $this->assertEquals('name', $accountListFields['name']->getName());
@@ -118,7 +118,7 @@ class XmlListMetadataLoaderTest extends TestCase
 
     public function testGetMetadataNotExisting()
     {
-        $notExistingMetadata = $this->xmlListMetadataLoader->getMetadata('not-existing', 'de', []);
+        $notExistingMetadata = $this->xmlListMetadataLoader->getMetadata('not-existing', 'de');
         $this->assertNull($notExistingMetadata);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/ListMetadata/XmlListMetadataLoaderTest.php
@@ -12,19 +12,18 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\ListMetadata;
 
 use PHPUnit\Framework\TestCase;
-use Sulu\Bundle\AdminBundle\Exception\MetadataNotFoundException;
-use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\XmlListMetadataLoader;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class ListMetadataProviderTest extends TestCase
+class XmlListMetadataLoaderTest extends TestCase
 {
     /**
-     * @var ListMetadataProvider
+     * @var XmlListMetadataLoader
      */
-    private $listMetadataProvider;
+    private $xmlListMetadataLoader;
 
     /**
      * @var TranslatorInterface
@@ -40,7 +39,7 @@ class ListMetadataProviderTest extends TestCase
     {
         $this->fieldDescriptorFactory = $this->prophesize(FieldDescriptorFactoryInterface::class);
         $this->translator = $this->prophesize(TranslatorInterface::class);
-        $this->listMetadataProvider = new ListMetadataProvider(
+        $this->xmlListMetadataLoader = new XmlListMetadataLoader(
             $this->fieldDescriptorFactory->reveal(),
             $this->translator->reveal()
         );
@@ -84,7 +83,7 @@ class ListMetadataProviderTest extends TestCase
             ]
         );
 
-        $contactListMetadata = $this->listMetadataProvider->getMetadata('contact', 'de', []);
+        $contactListMetadata = $this->xmlListMetadataLoader->getMetadata('contact', 'de', []);
         $contactListFields = $contactListMetadata->getFields();
 
         $this->assertEquals('firstName', $contactListFields['firstName']->getName());
@@ -104,7 +103,7 @@ class ListMetadataProviderTest extends TestCase
             $contactListFields['lastName']->getVisibility()
         );
 
-        $accountListMetadata = $this->listMetadataProvider->getMetadata('account', 'en', []);
+        $accountListMetadata = $this->xmlListMetadataLoader->getMetadata('account', 'en', []);
         $accountListFields = $accountListMetadata->getFields();
 
         $this->assertEquals('name', $accountListFields['name']->getName());
@@ -119,8 +118,7 @@ class ListMetadataProviderTest extends TestCase
 
     public function testGetMetadataNotExisting()
     {
-        $this->expectException(MetadataNotFoundException::class);
-
-        $this->listMetadataProvider->getMetadata('not-existing', 'de', []);
+        $notExistingMetadata = $this->xmlListMetadataLoader->getMetadata('not-existing', 'de', []);
+        $this->assertNull($notExistingMetadata);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | https://github.com/sulu/SuluFormBundle/pull/197
| License | MIT
| Documentation PR | 

#### What's in this PR?

This PR adds the support for multiple list metadata loaders. The different `ListMetadataLoader` classes can be tagged in the associated `services.xml` files as **sulu_admin.list_metadata_loader** in order to get injected automatically in the `ListMetadataProvider`. The different `ListMetadataLoader` classes must implement the interface `ListMetadataLoaderInterface`.

The `ListRouteBuilder` has now a method `addRouterAttributesToListMetadata` that allows to add metadata options to the metadata request.

This PR also adds the abstract class `AbstractMetadata` which defines a property **cacheable** that allows to define whether this metadata instance should be cached or not. When cacheable is set to false, the `AdminController` adds the header **Cache-Control: no-store** to the response.
 
By checking this cache-control header the JS class `MetadataStore` can then decide if the metadata information should be cached or not.

#### Why?

Enable to use a custom list metadata loader provided from the form bundle (see https://github.com/sulu/SuluFormBundle/pull/197). The functionality can also be useful for other bundles that want to provide their own list metadata loader.

#### Example Usage

Add a custom list loader that implements the `ListMetadataLoaderInterface`. Tag this loader in the `services.xml` file as **sulu_admin.list_metadata_loader**.

~~~xml
<service id="sulu_form.metadata.dynamic_list_metadata_loader" class="Sulu\Bundle\FormBundle\Metadata\DynamicListMetadataLoader">
            <argument type="service" id="sulu_form.dynamic.form_field_type_pool"/>
            <argument type="service" id="translator"/>
            <argument type="service" id="sulu_form.manager.form"/>
            <tag name="sulu_admin.list_metadata_loader"/>
</service>
~~~

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
