### PR TITLE
Fix rendering contact add form

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -101,16 +101,12 @@ class ContactAdmin extends Admin
 
     public function getRoutes(): array
     {
-        $routes = [
-            // This route has to be registered even if permissions for contacts are missing
-            // Otherwise the application breaks when other bundles try to add child routes to this one
-            $this->routeBuilderFactory
-                ->createResourceTabRouteBuilder(static::CONTACT_EDIT_FORM_ROUTE, '/contacts/:id')
-                ->setResourceKey('contacts')
-                ->setBackRoute(static::CONTACT_LIST_ROUTE)
-                ->setTitleProperty('fullName')
-                ->getRoute(),
-        ];
+        $contactEditFormRoute = $this->routeBuilderFactory
+            ->createResourceTabRouteBuilder(static::CONTACT_EDIT_FORM_ROUTE, '/contacts/:id')
+            ->setResourceKey('contacts')
+            ->setBackRoute(static::CONTACT_LIST_ROUTE)
+            ->setTitleProperty('fullName')
+            ->getRoute();
 
         if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $contactFormToolbarActions = [];
@@ -150,6 +146,7 @@ class ContactAdmin extends Admin
                 ->setResourceKey('contacts')
                 ->setBackRoute(static::CONTACT_LIST_ROUTE)
                 ->getRoute();
+            $routes[] = $contactEditFormRoute;
             $routes[] = $this->routeBuilderFactory
                 ->createFormRouteBuilder('sulu_contact.contact_add_form.details', '/details')
                 ->setResourceKey('contacts')
@@ -180,6 +177,10 @@ class ContactAdmin extends Admin
                 ->setTabOrder(2048)
                 ->setParent(static::CONTACT_EDIT_FORM_ROUTE)
                 ->getRoute();
+        } else {
+            // This route has to be registered even if permissions for contacts are missing
+            // Otherwise the application breaks when other bundles try to add child routes to this one
+            $routes[] = $contactEditFormRoute;
         }
 
         if ($this->securityChecker->hasPermission(static::ACCOUNT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR moves the edit form router for the contacts after the contacts add form.

#### Why?

Because if the edit form is listed first, then the `/contacts/add` route will be recognized as edit route, with "add" being the id. This results in a request being sent to the server with "add" as an id, which will fail.