### PR TITLE
Add permissions overlay to collections

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
@@ -16,12 +16,17 @@ type Props = {
     children: ChildrenArray<Element<*>>,
     onClose?: () => void,
     open: boolean,
+    refProp: string,
 };
 
 const VERTICAL_OFFSET = 20;
 
 @observer
 class ArrowMenu extends React.Component<Props> {
+    static defaultProps = {
+        refProp: 'ref',
+    };
+
     static Section = Section;
     static SingleItemSection = SingleItemSection;
     static Item = Item;
@@ -37,7 +42,7 @@ class ArrowMenu extends React.Component<Props> {
         return React.cloneElement(
             anchorElement,
             {
-                ref: this.setDisplayValueRef,
+                [this.props.refProp]: this.setDisplayValueRef,
             }
         );
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/ArrowMenu.js
@@ -13,7 +13,7 @@ import arrowMenuStyles from './arrowMenu.scss';
 
 type Props = {
     anchorElement: Element<*>,
-    children: ChildrenArray<Element<*>>,
+    children: ChildrenArray<Element<*> | false>,
     onClose?: () => void,
     open: boolean,
     refProp: string,
@@ -47,8 +47,12 @@ class ArrowMenu extends React.Component<Props> {
         );
     };
 
-    cloneChildren(children: ChildrenArray<Element<*>>) {
-        return React.Children.map(children, (child: any) => {
+    cloneChildren(children: ChildrenArray<Element<*> | false>) {
+        return React.Children.map(children, (child) => {
+            if (!child) {
+                return null;
+            }
+
             if (child.type === Section) {
                 return React.cloneElement(child, {
                     children: this.cloneSection(child),
@@ -60,8 +64,16 @@ class ArrowMenu extends React.Component<Props> {
     }
 
     cloneSection(section: Element<typeof Section>) {
+        if (!section) {
+            return null;
+        }
+
         if (section.props.children){
-            return React.Children.map(section.props.children, (child: any) => {
+            return React.Children.map(section.props.children, (child) => {
+                if (!child) {
+                    return null;
+                }
+
                 if (child.type === Action) {
                     return this.cloneAction(child);
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/Section.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/Section.js
@@ -4,7 +4,7 @@ import type {ChildrenArray, Element} from 'react';
 import sectionStyles from './section.scss';
 
 type Props = {
-    children?: ChildrenArray<Element<*>>,
+    children?: ChildrenArray<Element<*> | false>,
     title?: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/SingleItemSection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/SingleItemSection.js
@@ -5,7 +5,7 @@ import Item from './Item';
 import Section from './Section';
 
 type Props = {
-    children: ChildrenArray<Element<typeof Item>>,
+    children: ChildrenArray<Element<typeof Item> | false>,
     icon: string,
     onChange: (value: *) => void,
     title?: string,
@@ -21,10 +21,14 @@ export default class SingleItemSection extends React.PureComponent<Props> {
         this.props.onChange(value);
     };
 
-    cloneChildren = (items: ChildrenArray<Element<typeof Item>>) => {
+    cloneChildren = (items: ChildrenArray<Element<typeof Item> | false>) => {
         const {value, icon} = this.props;
 
         return React.Children.map(items, (item) => {
+            if (!item) {
+                return null;
+            }
+
             return React.cloneElement(
                 item,
                 {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
@@ -56,6 +56,22 @@ test('Render ArrowMenu closed', () => {
     expect(arrowMenu.find('Popover').prop('open')).toEqual(false);
 });
 
+test('Render ArrowMenu with non-HTML element as anchor', () => {
+    class Button extends React.Component<*> {
+        render() {
+            return <button ref={this.props.buttonRef} />;
+        }
+    }
+
+    const arrowMenu = mount(
+        <ArrowMenu anchorElement={<Button />} open={true} refProp="buttonRef">
+            <ArrowMenu.Item value="title">Title</ArrowMenu.Item>
+        </ArrowMenu>
+    );
+
+    expect(arrowMenu.render()).toMatchSnapshot();
+});
+
 test('Render ArrowMenu open', () => {
     const handleClose = jest.fn();
     const handleChangeSection1 = jest.fn();
@@ -102,7 +118,7 @@ test('Render ArrowMenu open', () => {
 
     expect(arrowMenu.find('Popover').children()).toHaveLength(2);
     expect(arrowMenu.find('Popover Backdrop').prop('open')).toEqual(true);
-    expect(arrowMenu.find('Popover > Portal').render()).toMatchSnapshot();
+    expect(arrowMenu.render()).toMatchSnapshot();
 });
 
 test('Render the correct item active with a value of undefined', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/ArrowMenu.test.js
@@ -121,6 +121,60 @@ test('Render ArrowMenu open', () => {
     expect(arrowMenu.render()).toMatchSnapshot();
 });
 
+test('Render ArrowMenu open with falsy values', () => {
+    const handleClose = jest.fn();
+    const handleChangeSection1 = jest.fn();
+    const handleChangeSection2 = jest.fn();
+    const open = true;
+    const button = (<button>Nice button</button>);
+    const value1 = 'sulu';
+    const value2 = undefined;
+
+    const arrowMenu = mount(
+        <ArrowMenu anchorElement={button} onClose={handleClose} open={open}>
+            <ArrowMenu.Section title="Search Section">
+                <input type="text" />
+                {false}
+            </ArrowMenu.Section>
+            <ArrowMenu.SingleItemSection
+                icon="su-webspace"
+                onChange={handleChangeSection1}
+                title="Webspaces"
+                value={value1}
+            >
+                <ArrowMenu.Item value="sulu">Sulu</ArrowMenu.Item>
+                <ArrowMenu.Item value="sulu_blog">Sulu Blog</ArrowMenu.Item>
+                <ArrowMenu.Item value="sulu_doc">Sulu Doc</ArrowMenu.Item>
+                {false}
+            </ArrowMenu.SingleItemSection>
+            <ArrowMenu.SingleItemSection
+                icon="su-check"
+                onChange={handleChangeSection2}
+                title="Columns"
+                value={value2}
+            >
+                <ArrowMenu.Item value="title">Title</ArrowMenu.Item>
+                <ArrowMenu.Item value="description">Description</ArrowMenu.Item>
+                {false}
+            </ArrowMenu.SingleItemSection>
+            <ArrowMenu.Section>
+                <ArrowMenu.Action onClick={jest.fn()}>Test Action 1</ArrowMenu.Action>
+                <ArrowMenu.Action onClick={jest.fn()}>Test Action 2</ArrowMenu.Action>
+                <ArrowMenu.Action onClick={jest.fn()}>Test Action 3</ArrowMenu.Action>
+                {false}
+            </ArrowMenu.Section>
+            {false}
+        </ArrowMenu>
+    );
+
+    expect(arrowMenu.children()).toHaveLength(2);
+    expect(arrowMenu.find('ArrowMenu > button').text()).toEqual('Nice button');
+
+    expect(arrowMenu.find('Popover').children()).toHaveLength(2);
+    expect(arrowMenu.find('Popover Backdrop').prop('open')).toEqual(true);
+    expect(arrowMenu.render()).toMatchSnapshot();
+});
+
 test('Render the correct item active with a value of undefined', () => {
     const button = (<button>Nice button</button>);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
@@ -148,6 +148,154 @@ Array [
 ]
 `;
 
+exports[`Render ArrowMenu open with falsy values 1`] = `
+Array [
+  <button>
+    Nice button
+  </button>,
+  <div
+    class="backdrop fixed"
+    role="button"
+  />,
+  <div
+    class="container"
+  >
+    <div
+      class="arrowMenuContainer"
+      style="top: 20px; left: 10px; position: fixed; pointer-events: auto;"
+    >
+      <div
+        class="arrow top right"
+      />
+      <div
+        class="arrowMenu"
+      >
+        <div
+          class="section"
+        >
+          <div
+            class="title"
+          >
+            Search Section
+          </div>
+          <div
+            class="children"
+          >
+            <input
+              type="text"
+            />
+          </div>
+        </div>
+        <div
+          class="section"
+        >
+          <div
+            class="title"
+          >
+            Webspaces
+          </div>
+          <div
+            class="children"
+          >
+            <button
+              class="item active"
+            >
+              <span
+                class="icon"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+              </span>
+              <span>
+                Sulu
+              </span>
+            </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Sulu Blog
+              </span>
+            </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Sulu Doc
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="section"
+        >
+          <div
+            class="title"
+          >
+            Columns
+          </div>
+          <div
+            class="children"
+          >
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Title
+              </span>
+            </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Description
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="section"
+        >
+          <div
+            class="children"
+          >
+            <button
+              class="action"
+            >
+              Test Action 1
+            </button>
+            <button
+              class="action"
+            >
+              Test Action 2
+            </button>
+            <button
+              class="action"
+            >
+              Test Action 3
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Render ArrowMenu with non-HTML element as anchor 1`] = `
 Array [
   <button />,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ArrowMenu/tests/__snapshots__/ArrowMenu.test.js.snap
@@ -1,140 +1,185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render ArrowMenu open 1`] = `
-<div
-  class="container"
->
+Array [
+  <button>
+    Nice button
+  </button>,
   <div
-    class="arrowMenuContainer"
-    style="top: 20px; left: 10px; position: fixed; pointer-events: auto;"
+    class="backdrop fixed"
+    role="button"
+  />,
+  <div
+    class="container"
   >
     <div
-      class="arrow top right"
-    />
-    <div
-      class="arrowMenu"
+      class="arrowMenuContainer"
+      style="top: 20px; left: 10px; position: fixed; pointer-events: auto;"
     >
       <div
-        class="section"
-      >
-        <div
-          class="title"
-        >
-          Search Section
-        </div>
-        <div
-          class="children"
-        >
-          <input
-            type="text"
-          />
-        </div>
-      </div>
+        class="arrow top right"
+      />
       <div
-        class="section"
+        class="arrowMenu"
       >
         <div
-          class="title"
+          class="section"
         >
-          Webspaces
+          <div
+            class="title"
+          >
+            Search Section
+          </div>
+          <div
+            class="children"
+          >
+            <input
+              type="text"
+            />
+          </div>
         </div>
         <div
-          class="children"
+          class="section"
         >
-          <button
-            class="item active"
+          <div
+            class="title"
           >
-            <span
-              class="icon"
+            Webspaces
+          </div>
+          <div
+            class="children"
+          >
+            <button
+              class="item active"
             >
               <span
-                aria-label="su-webspace"
-                class="su-webspace icon"
+                class="icon"
+              >
+                <span
+                  aria-label="su-webspace"
+                  class="su-webspace icon"
+                />
+              </span>
+              <span>
+                Sulu
+              </span>
+            </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
               />
-            </span>
-            <span>
-              Sulu
-            </span>
-          </button>
-          <button
-            class="item"
-          >
-            <span
-              class="icon"
-            />
-            <span>
-              Sulu Blog
-            </span>
-          </button>
-          <button
-            class="item"
-          >
-            <span
-              class="icon"
-            />
-            <span>
-              Sulu Doc
-            </span>
-          </button>
-        </div>
-      </div>
-      <div
-        class="section"
-      >
-        <div
-          class="title"
-        >
-          Columns
+              <span>
+                Sulu Blog
+              </span>
+            </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Sulu Doc
+              </span>
+            </button>
+          </div>
         </div>
         <div
-          class="children"
+          class="section"
         >
-          <button
-            class="item"
+          <div
+            class="title"
           >
-            <span
-              class="icon"
-            />
-            <span>
-              Title
-            </span>
-          </button>
-          <button
-            class="item"
+            Columns
+          </div>
+          <div
+            class="children"
           >
-            <span
-              class="icon"
-            />
-            <span>
-              Description
-            </span>
-          </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Title
+              </span>
+            </button>
+            <button
+              class="item"
+            >
+              <span
+                class="icon"
+              />
+              <span>
+                Description
+              </span>
+            </button>
+          </div>
         </div>
-      </div>
-      <div
-        class="section"
-      >
         <div
-          class="children"
+          class="section"
         >
-          <button
-            class="action"
+          <div
+            class="children"
           >
-            Test Action 1
-          </button>
-          <button
-            class="action"
-          >
-            Test Action 2
-          </button>
-          <button
-            class="action"
-          >
-            Test Action 3
-          </button>
+            <button
+              class="action"
+            >
+              Test Action 1
+            </button>
+            <button
+              class="action"
+            >
+              Test Action 2
+            </button>
+            <button
+              class="action"
+            >
+              Test Action 3
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
+`;
+
+exports[`Render ArrowMenu with non-HTML element as anchor 1`] = `
+Array [
+  <button />,
+  <div
+    class="backdrop fixed"
+    role="button"
+  />,
+  <div
+    class="container"
+  >
+    <div
+      class="arrowMenuContainer"
+      style="top: 20px; left: 10px; position: fixed; pointer-events: auto;"
+    >
+      <div
+        class="arrow top right"
+      />
+      <div
+        class="arrowMenu"
+      >
+        <button
+          class="item"
+        >
+          <span
+            class="icon"
+          />
+          <span>
+            Title
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/Button.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import type {Node} from 'react';
+import type {ElementRef, Node} from 'react';
 import classNames from 'classnames';
 import Icon from '../Icon';
 import Loader from '../Loader';
@@ -11,6 +11,7 @@ const LOADER_SIZE = 25;
 type Props<T> = {|
     active: boolean,
     activeClassName?: string,
+    buttonRef?: (ref: ?ElementRef<'button'>) => void,
     children?: Node,
     className?: string,
     disabled: boolean,
@@ -50,6 +51,7 @@ export default class Button<T> extends React.PureComponent<Props<T>> {
         const {
             active,
             activeClassName,
+            buttonRef,
             children,
             className,
             disabled,
@@ -82,6 +84,7 @@ export default class Button<T> extends React.PureComponent<Props<T>> {
                 className={buttonClass}
                 disabled={loading || disabled}
                 onClick={onClick ? this.handleClick : undefined}
+                ref={buttonRef}
                 type={type}
             >
                 {icon &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -3,6 +3,7 @@
 
 $borderRadius: 3px;
 $fontSize: 12px;
+$dropdownFontSize: 10px;
 
 $primaryBackground: $shakespeare;
 $primaryColor: $white;
@@ -23,6 +24,8 @@ $iconColorActive: $white;
 .button {
     position: relative;
     white-space: nowrap;
+    display: inline-flex;
+    justify-content: center;
 
     &:disabled {
         cursor: default;
@@ -56,6 +59,7 @@ $iconColorActive: $white;
     .dropdown-icon {
         left: auto;
         right: 10px;
+        font-size: $dropdownFontSize;
     }
 }
 
@@ -98,6 +102,7 @@ $iconColorActive: $white;
 
     .dropdown-icon {
         margin-left: 10px;
+        font-size: $dropdownFontSize;
     }
 }
 
@@ -132,6 +137,7 @@ $iconColorActive: $white;
 
     .dropdown-icon {
         margin-left: 5px;
+        font-size: $dropdownFontSize;
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/button.scss
@@ -15,7 +15,7 @@ $secondaryDisabledColor: $silver;
 
 $linkColor: $black;
 
-$iconFontSize: 18px;
+$iconFontSize: 14px;
 $iconBackgroundColorActive: $doveGray;
 $iconBackgroundColorHover: $mercury;
 $iconColorActive: $white;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Button/tests/Button.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {render, shallow} from 'enzyme';
+import {mount, render, shallow} from 'enzyme';
 import Button from '../Button';
 
 test('Should render the button with icon', () => {
@@ -54,4 +54,11 @@ test('Should call the callback on click', () => {
     button.find('button').simulate('click', {preventDefault: preventDefaultSpy});
     expect(preventDefaultSpy).toBeCalled();
     expect(onClick).toBeCalled();
+});
+
+test('Should call the buttonRef callback correctly', () => {
+    const buttonRefSpy = jest.fn();
+    const button = mount(<Button buttonRef={buttonRefSpy} />);
+
+    expect(buttonRefSpy).toBeCalledWith(button.find('button').instance());
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/ButtonGroup.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/ButtonGroup.js
@@ -3,10 +3,11 @@ import React from 'react';
 import classNames from 'classnames';
 import type {ChildrenArray, Element} from 'react';
 import Button from '../Button';
+import DropdownButton from '../DropdownButton';
 import buttonGroupStyles from './buttonGroup.scss';
 
 type Props = {
-    children: ChildrenArray<Element<typeof Button>>,
+    children: ChildrenArray<Element<typeof Button | typeof DropdownButton> | false>,
 };
 
 export default class ButtonGroup extends React.PureComponent<Props> {
@@ -14,6 +15,10 @@ export default class ButtonGroup extends React.PureComponent<Props> {
         const {children} = this.props;
 
         return React.Children.map(children, (child) => {
+            if (!child) {
+                return null;
+            }
+
             const buttonClass = classNames(
                 buttonGroupStyles.button,
                 child.props.className
@@ -31,7 +36,7 @@ export default class ButtonGroup extends React.PureComponent<Props> {
 
     render() {
         return (
-            <div>
+            <div className={buttonGroupStyles.buttonGroup}>
                 {this.cloneChildren()}
             </div>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/buttonGroup.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/buttonGroup.scss
@@ -1,8 +1,12 @@
 @import '../Button/variables.scss';
 
+.button-group {
+    display: flex;
+}
+
 .button {
     border-radius: 0;
-    width: 34px;
+    min-width: 34px;
 
     &:first-child {
         border-top-left-radius: $iconBorderRadius;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/tests/ButtonGroup.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/tests/ButtonGroup.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {render} from 'enzyme';
 import ButtonGroup from '../ButtonGroup';
 import Button from '../../Button';
+import DropdownButton from '../../DropdownButton';
 import Icon from '../../Icon';
 
 test('Should render one button', () => {
@@ -23,6 +24,20 @@ test('Should render two buttons', () => {
         <ButtonGroup>
             <Button onClick={handleClick}><Icon name="su-th-large" /></Button>
             <Button onClick={handleClick}><Icon name="su-align-justify" /></Button>
+        </ButtonGroup>
+    );
+    expect(render(buttonGroup)).toMatchSnapshot();
+});
+
+test('Should render a button and a dropdown button', () => {
+    const handleClick = jest.fn();
+
+    const buttonGroup = (
+        <ButtonGroup>
+            <Button onClick={handleClick}><Icon name="su-th-large" /></Button>
+            <DropdownButton>
+                <DropdownButton.Item onClick={jest.fn()}>Test</DropdownButton.Item>
+            </DropdownButton>
         </ButtonGroup>
     );
     expect(render(buttonGroup)).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/tests/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ButtonGroup/tests/__snapshots__/ButtonGroup.test.js.snap
@@ -1,7 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Should render a button and a dropdown button 1`] = `
+<div
+  class="buttonGroup"
+>
+  <button
+    class="button icon button"
+    type="button"
+  >
+    <span
+      class="text"
+    >
+      <span
+        aria-label="su-th-large"
+        class="su-th-large"
+      />
+    </span>
+  </button>
+  <button
+    class="button icon button"
+    type="button"
+  >
+    <span
+      aria-label="su-angle-down"
+      class="su-angle-down dropdownIcon"
+    />
+  </button>
+</div>
+`;
+
 exports[`Should render a button with a custom className 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon button test"
     type="button"
@@ -19,7 +50,9 @@ exports[`Should render a button with a custom className 1`] = `
 `;
 
 exports[`Should render more than two buttons 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon button"
     type="button"
@@ -76,7 +109,9 @@ exports[`Should render more than two buttons 1`] = `
 `;
 
 exports[`Should render one button 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon button"
     type="button"
@@ -94,7 +129,9 @@ exports[`Should render one button 1`] = `
 `;
 
 exports[`Should render one button with a custom className and another one without 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon button test"
     type="button"
@@ -125,7 +162,9 @@ exports[`Should render one button with a custom className and another one withou
 `;
 
 exports[`Should render two buttons 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon button"
     type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/DropdownButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/DropdownButton.js
@@ -7,7 +7,7 @@ import ArrowMenu from '../ArrowMenu';
 import Button from '../Button';
 
 type Props = {|
-    children: ChildrenArray<Element<typeof ArrowMenu.Action>>,
+    children: ChildrenArray<Element<typeof ArrowMenu.Action> | false>,
     className?: string,
     icon?: string,
     label?: string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/DropdownButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/DropdownButton.js
@@ -8,12 +8,18 @@ import Button from '../Button';
 
 type Props = {|
     children: ChildrenArray<Element<typeof ArrowMenu.Action>>,
+    className?: string,
     icon?: string,
-    label: string,
+    label?: string,
+    skin: 'primary' | 'secondary' | 'link' | 'icon',
 |};
 
 @observer
 class DropdownButton extends React.Component<Props> {
+    static defaultProps = {
+        skin: 'secondary',
+    };
+
     static Item = ArrowMenu.Action;
 
     @observable open: boolean = false;
@@ -27,18 +33,22 @@ class DropdownButton extends React.Component<Props> {
     };
 
     render() {
-        const {children, icon, label} = this.props;
+        const {children, className, icon, label, skin} = this.props;
 
         const button = (
-            <div>
-                <Button icon={icon} onClick={this.handleButtonClick} showDropdownIcon={true}>
-                    {label}
-                </Button>
-            </div>
+            <Button
+                className={className}
+                icon={icon}
+                onClick={this.handleButtonClick}
+                showDropdownIcon={true}
+                skin={skin}
+            >
+                {label}
+            </Button>
         );
 
         return (
-            <ArrowMenu anchorElement={button} onClose={this.handleArrowMenuClose} open={this.open}>
+            <ArrowMenu anchorElement={button} onClose={this.handleArrowMenuClose} open={this.open} refProp="buttonRef">
                 <ArrowMenu.Section>
                     {children}
                 </ArrowMenu.Section>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/README.md
@@ -14,3 +14,35 @@ const handleOption2Click = () => {
     <DropdownButton.Item onClick={handleOption2Click}>Option 2</DropdownButton.Item>
 </DropdownButton>
 ```
+
+The `DropdownButton` has the same skins available as the [Button component](#button).
+
+```javascript
+const handleOption1Click = () => {
+    alert('Option1 has been chosen');
+};
+
+const handleOption2Click = () => {
+    alert('Option2 has been chosen');
+};
+
+<DropdownButton icon="su-plus" label="Button" skin="primary">
+    <DropdownButton.Item onClick={handleOption1Click}>Option 1</DropdownButton.Item>
+    <DropdownButton.Item onClick={handleOption2Click}>Option 2</DropdownButton.Item>
+</DropdownButton>
+```
+
+```javascript
+const handleOption1Click = () => {
+    alert('Option1 has been chosen');
+};
+
+const handleOption2Click = () => {
+    alert('Option2 has been chosen');
+};
+
+<DropdownButton icon="su-plus" skin="icon">
+    <DropdownButton.Item onClick={handleOption1Click}>Option 1</DropdownButton.Item>
+    <DropdownButton.Item onClick={handleOption2Click}>Option 2</DropdownButton.Item>
+</DropdownButton>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/tests/__snapshots__/DropdownButton.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DropdownButton/tests/__snapshots__/DropdownButton.test.js.snap
@@ -1,24 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render dropdown button 1`] = `
-<div>
-  <button
-    class="button secondary"
-    type="button"
+<button
+  class="button secondary"
+  type="button"
+>
+  <span
+    aria-label="su-plus"
+    class="su-plus buttonIcon"
+  />
+  <span
+    class="text"
   >
-    <span
-      aria-label="su-plus"
-      class="su-plus buttonIcon"
-    />
-    <span
-      class="text"
-    >
-      Add
-    </span>
-    <span
-      aria-label="su-angle-down"
-      class="su-angle-down dropdownIcon"
-    />
-  </button>
-</div>
+    Add
+  </span>
+  <span
+    aria-label="su-angle-down"
+    class="su-angle-down dropdownIcon"
+  />
+</button>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/Pagination.js
@@ -2,7 +2,8 @@
 import React, {type Node} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import Icon from '../Icon';
+import Button from '../Button';
+import ButtonGroup from '../ButtonGroup';
 import Input from '../Input';
 import Loader from '../Loader';
 import SingleSelect from '../SingleSelect';
@@ -166,20 +167,18 @@ class Pagination extends React.Component<Props> {
                     <span className={paginationStyles.display}>
                         {translate('sulu_admin.of')} {totalPages}
                     </span>
-                    <button
-                        className={paginationStyles.previous}
-                        disabled={!this.hasPreviousPage()}
-                        onClick={this.handlePreviousClick}
-                    >
-                        <Icon name="su-angle-left" />
-                    </button>
-                    <button
-                        className={paginationStyles.next}
-                        disabled={!this.hasNextPage()}
-                        onClick={this.handleNextClick}
-                    >
-                        <Icon name="su-angle-right" />
-                    </button>
+                    <ButtonGroup>
+                        <Button
+                            disabled={!this.hasPreviousPage()}
+                            icon="su-angle-left"
+                            onClick={this.handlePreviousClick}
+                        />
+                        <Button
+                            disabled={!this.hasNextPage()}
+                            icon="su-angle-right"
+                            onClick={this.handleNextClick}
+                        />
+                    </ButtonGroup>
                 </nav>
             </section>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/pagination.scss
@@ -29,32 +29,3 @@ $buttonActiveColor: $blueZodiac;
     margin-right: 20px;
     width: 50px;
 }
-
-.next,
-.previous {
-    display: inline-block;
-    height: 30px;
-    width: $buttonWidth;
-    background-color: $buttonBackgroundColor;
-    border: 1px solid $buttonBorderColor;
-    text-align: center;
-    font-size: 12px;
-
-    &:not(:disabled) {
-        color: $buttonActiveColor;
-        cursor: pointer;
-    }
-
-    span {
-        line-height: 28px;
-    }
-}
-
-.previous {
-    border-radius: $borderRadius 0 0 $borderRadius;
-}
-
-.next {
-    border-radius: 0 $borderRadius $borderRadius 0;
-    border-left: none;
-}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
@@ -77,7 +77,9 @@ exports[`Render disabled next link if current page is last page 1`] = `
     >
       of 5
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"
@@ -179,7 +181,9 @@ exports[`Render disabled previous link current page is first page 1`] = `
     >
       of 5
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -293,7 +297,9 @@ exports[`Render pagination with loader 1`] = `
     >
       of 10
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"
@@ -394,7 +400,9 @@ exports[`Render pagination with page numbers 1`] = `
     >
       of 10
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Pagination/tests/__snapshots__/Pagination.test.js.snap
@@ -77,23 +77,27 @@ exports[`Render disabled next link if current page is last page 1`] = `
     >
       of 5
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -175,23 +179,27 @@ exports[`Render disabled previous link current page is first page 1`] = `
     >
       of 5
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -285,22 +293,26 @@ exports[`Render pagination with loader 1`] = `
     >
       of 10
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -382,22 +394,26 @@ exports[`Render pagination with page numbers 1`] = `
     >
       of 10
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/AdapterSwitch.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/__snapshots__/AdapterSwitch.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The component should render with current adapter "folder" 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon button"
     type="button"
@@ -32,7 +34,9 @@ exports[`The component should render with current adapter "folder" 1`] = `
 `;
 
 exports[`The component should render with current adapter "table" 1`] = `
-<div>
+<div
+  class="buttonGroup"
+>
   <button
     class="button icon active button"
     type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/FolderAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/FolderAdapter.test.js.snap
@@ -138,7 +138,9 @@ exports[`Render a basic Folder list with data 1`] = `
     >
        2
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/FolderAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/FolderAdapter.test.js.snap
@@ -138,23 +138,27 @@ exports[`Render a basic Folder list with data 1`] = `
     >
        2
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -130,7 +130,9 @@ exports[`Render column with ascending sort icon 1`] = `
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -285,7 +287,9 @@ exports[`Render column with descending sort icon 1`] = `
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -454,7 +458,9 @@ exports[`Render data with all different visibility types schema 1`] = `
     >
       of 5
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"
@@ -715,7 +721,9 @@ exports[`Render data with pencil button and given actions when onItemEdit callba
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -901,7 +909,9 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -1049,7 +1059,9 @@ exports[`Render data with schema 1`] = `
     >
       of 5
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"
@@ -1302,7 +1314,9 @@ exports[`Render data with schema and selections 1`] = `
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -1450,7 +1464,9 @@ exports[`Render data with schema in different order 1`] = `
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"
@@ -1569,7 +1585,9 @@ exports[`Render data with schema not containing all fields 1`] = `
     >
       of 3
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         disabled=""
@@ -1698,7 +1716,9 @@ exports[`Render data with skin 1`] = `
     >
       of 5
     </span>
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/TableAdapter.test.js.snap
@@ -130,23 +130,27 @@ exports[`Render column with ascending sort icon 1`] = `
     >
       of 3
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -281,23 +285,27 @@ exports[`Render column with descending sort icon 1`] = `
     >
       of 3
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -446,22 +454,26 @@ exports[`Render data with all different visibility types schema 1`] = `
     >
       of 5
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -703,23 +715,27 @@ exports[`Render data with pencil button and given actions when onItemEdit callba
     >
       of 3
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -885,23 +901,27 @@ exports[`Render data with pencil button when onItemEdit callback is passed 1`] =
     >
       of 3
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -1029,22 +1049,26 @@ exports[`Render data with schema 1`] = `
     >
       of 5
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -1278,23 +1302,27 @@ exports[`Render data with schema and selections 1`] = `
     >
       of 3
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -1422,22 +1450,26 @@ exports[`Render data with schema in different order 1`] = `
     >
       of 3
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -1537,23 +1569,27 @@ exports[`Render data with schema not containing all fields 1`] = `
     >
       of 3
     </span>
-    <button
-      class="previous"
-      disabled=""
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        disabled=""
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;
@@ -1662,22 +1698,26 @@ exports[`Render data with skin 1`] = `
     >
       of 5
     </span>
-    <button
-      class="previous"
-    >
-      <span
-        aria-label="su-angle-left"
-        class="su-angle-left"
-      />
-    </button>
-    <button
-      class="next"
-    >
-      <span
-        aria-label="su-angle-right"
-        class="su-angle-right"
-      />
-    </button>
+    <div>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-left"
+          class="su-angle-left buttonIcon"
+        />
+      </button>
+      <button
+        class="button icon button"
+        type="button"
+      >
+        <span
+          aria-label="su-angle-right"
+          class="su-angle-right buttonIcon"
+        />
+      </button>
+    </div>
   </nav>
 </section>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -486,22 +486,26 @@ exports[`Should render the list with a title 1`] = `
           >
             of 3
           </span>
-          <button
-            class="previous"
-          >
-            <span
-              aria-label="su-angle-left"
-              class="su-angle-left"
-            />
-          </button>
-          <button
-            class="next"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </button>
+          <div>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-left"
+                class="su-angle-left buttonIcon"
+              />
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right buttonIcon"
+              />
+            </button>
+          </div>
         </nav>
       </section>
     </div>
@@ -745,22 +749,26 @@ exports[`Should render the list with the correct resourceKey 1`] = `
           >
             of 3
           </span>
-          <button
-            class="previous"
-          >
-            <span
-              aria-label="su-angle-left"
-              class="su-angle-left"
-            />
-          </button>
-          <button
-            class="next"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </button>
+          <div>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-left"
+                class="su-angle-left buttonIcon"
+              />
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-angle-right"
+                class="su-angle-right buttonIcon"
+              />
+            </button>
+          </div>
         </nav>
       </section>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -486,7 +486,9 @@ exports[`Should render the list with a title 1`] = `
           >
             of 3
           </span>
-          <div>
+          <div
+            class="buttonGroup"
+          >
             <button
               class="button icon button"
               type="button"
@@ -749,7 +751,9 @@ exports[`Should render the list with the correct resourceKey 1`] = `
           >
             of 3
           </span>
-          <div>
+          <div
+            class="buttonGroup"
+          >
             <button
               class="button icon button"
               type="button"

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/TargetGroupRules.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/TargetGroupRules.test.js.snap
@@ -5,7 +5,9 @@ Array [
   <div
     class="buttons"
   >
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"
@@ -296,7 +298,9 @@ Array [
   <div
     class="buttons"
   >
-    <div>
+    <div
+      class="buttonGroup"
+    >
       <button
         class="button icon button"
         type="button"

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -250,7 +250,7 @@ class ContactAdmin extends Admin
                 ->createListRouteBuilder('sulu_contact.account_contacts_list', '/contacts')
                 ->setResourceKey('account_contacts')
                 ->setListKey('account_contacts')
-                ->setTabTitle(static::CONTACT_SECURITY_CONTEXT)
+                ->setTabTitle('sulu_contact.people')
                 ->addListAdapters(['table'])
                 ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
                 ->addRouterAttributesToListStore(['id'])

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
@@ -335,26 +335,24 @@ exports[`Render ContactDetails with data 1`] = `
       >
         sulu_contact.contact_details
       </label>
-      <div>
-        <button
-          class="button secondary"
-          type="button"
+      <button
+        class="button secondary"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="text"
         >
-          <span
-            aria-label="su-plus"
-            class="su-plus buttonIcon"
-          />
-          <span
-            class="text"
-          >
-            sulu_admin.add
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
+          sulu_admin.add
+        </span>
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down dropdownIcon"
+        />
+      </button>
       <label
         class="errorLabel"
       />
@@ -490,26 +488,24 @@ exports[`Render empty ContactDetails 1`] = `
       >
         sulu_contact.contact_details
       </label>
-      <div>
-        <button
-          class="button secondary"
-          type="button"
+      <button
+        class="button secondary"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="text"
         >
-          <span
-            aria-label="su-plus"
-            class="su-plus buttonIcon"
-          />
-          <span
-            class="text"
-          >
-            sulu_admin.add
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
+          sulu_admin.add
+        </span>
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down dropdownIcon"
+        />
+      </button>
       <label
         class="errorLabel"
       />
@@ -849,26 +845,24 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
       >
         sulu_contact.contact_details
       </label>
-      <div>
-        <button
-          class="button secondary"
-          type="button"
+      <button
+        class="button secondary"
+        type="button"
+      >
+        <span
+          aria-label="su-plus"
+          class="su-plus buttonIcon"
+        />
+        <span
+          class="text"
         >
-          <span
-            aria-label="su-plus"
-            class="su-plus buttonIcon"
-          />
-          <span
-            class="text"
-          >
-            sulu_admin.add
-          </span>
-          <span
-            aria-label="su-angle-down"
-            class="su-angle-down dropdownIcon"
-          />
-        </button>
-      </div>
+          sulu_admin.add
+        </span>
+        <span
+          aria-label="su-angle-down"
+          class="su-angle-down dropdownIcon"
+        />
+      </button>
       <label
         class="errorLabel"
       />

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -188,6 +188,10 @@ class MediaAdmin extends Admin
                 'add' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD),
                 'delete' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE),
                 'edit' => $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT),
+                'security' => $this->securityChecker->hasPermission(
+                    static::SECURITY_CONTEXT,
+                    PermissionTypes::SECURITY
+                ),
             ],
         ];
     }

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -128,6 +128,8 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
                                 'list' => 'cget_media',
                                 'detail' => 'get_media',
                             ],
+                            'security_context' => 'sulu.media.collections',
+                            'security_class' => Collection::class,
                         ],
                         'media_formats' => [
                             'routes' => [

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
@@ -42,8 +42,13 @@ class CollectionFormOverlay extends React.Component<Props> {
         }
 
         if (this.props.resourceStore !== prevProps.resourceStore) {
+            this.formStore.destroy();
             this.formStore = new ResourceFormStore(this.props.resourceStore, FORM_KEY);
         }
+    }
+
+    componentWillUnmount() {
+        this.formStore.destroy();
     }
 
     setFormRef = (formRef: ?Form) => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionFormOverlay.js
@@ -22,8 +22,7 @@ const FORM_KEY = 'collection_details';
 @observer
 class CollectionFormOverlay extends React.Component<Props> {
     formRef: ?Form;
-    title: string;
-    operationType: string;
+    @observable title: string;
     @observable formStore: ResourceFormStore;
 
     constructor(props: Props) {
@@ -33,8 +32,8 @@ class CollectionFormOverlay extends React.Component<Props> {
         this.formStore = new ResourceFormStore(resourceStore, FORM_KEY);
     }
 
-    @action componentWillReceiveProps(nextProps: Props) {
-        const {operationType} = nextProps;
+    @action componentDidUpdate(prevProps: Props) {
+        const {operationType} = this.props;
 
         if (operationType) {
             this.title = operationType === 'create'
@@ -42,8 +41,8 @@ class CollectionFormOverlay extends React.Component<Props> {
                 : translate('sulu_media.edit_collection');
         }
 
-        if (this.props.resourceStore !== nextProps.resourceStore) {
-            this.formStore = new ResourceFormStore(nextProps.resourceStore, FORM_KEY);
+        if (this.props.resourceStore !== prevProps.resourceStore) {
+            this.formStore = new ResourceFormStore(this.props.resourceStore, FORM_KEY);
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -192,7 +192,7 @@ class CollectionSection extends React.Component<Props> {
                                 {addable &&
                                     <Button icon="su-plus" onClick={this.handleAddCollectionClick} />
                                 }
-                                {!!resourceStore.id &&
+                                {!!resourceStore.id && (editable || deletable || editable || securable) &&
                                     <DropdownButton icon="su-cog">
                                         {editable &&
                                             <DropdownButton.Item onClick={this.handleEditCollectionClick}>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -9,6 +9,7 @@ import {translate} from 'sulu-admin-bundle/utils';
 import {Button, ButtonGroup, Dialog, DropdownButton} from 'sulu-admin-bundle/components';
 import CollectionFormOverlay from './CollectionFormOverlay';
 import CollectionBreadcrumb from './CollectionBreadcrumb';
+import PermissionFormOverlay from './PermissionFormOverlay';
 import type {OperationType, OverlayType} from './types';
 import collectionSectionStyles from './collectionSection.scss';
 
@@ -23,6 +24,7 @@ type Props = {
     onCollectionNavigate: (collectionId: ?string | number) => void,
     overlayType: OverlayType,
     resourceStore: ResourceStore,
+    securable: boolean,
 };
 
 @observer
@@ -88,6 +90,10 @@ class CollectionSection extends React.Component<Props> {
         this.openCollectionOperationOverlay('move');
     };
 
+    handlePermissionCollectionClick = () => {
+        this.openCollectionOperationOverlay('permissions');
+    };
+
     handleCollectionOverlayConfirm = (resourceStore: ResourceStore) => {
         const options = {};
         options.breadcrumb = true;
@@ -112,6 +118,16 @@ class CollectionSection extends React.Component<Props> {
     };
 
     handleCollectionOverlayClose = () => {
+        this.closeCollectionOperationOverlay();
+    };
+
+    handlePermissionOverlayClose = () => {
+        this.closeCollectionOperationOverlay();
+    };
+
+    handlePermissionOverlayConfirm = () => {
+        const {resourceStore} = this.props;
+        resourceStore.reload();
         this.closeCollectionOperationOverlay();
     };
 
@@ -155,6 +171,7 @@ class CollectionSection extends React.Component<Props> {
             locale,
             overlayType,
             resourceStore,
+            securable,
         } = this.props;
 
         const operationType = this.openedCollectionOperationOverlayType;
@@ -192,6 +209,11 @@ class CollectionSection extends React.Component<Props> {
                                                 {translate('sulu_admin.move')}
                                             </DropdownButton.Item>
                                         }
+                                        {securable &&
+                                            <DropdownButton.Item onClick={this.handlePermissionCollectionClick}>
+                                                {translate('sulu_security.permissions')}
+                                            </DropdownButton.Item>
+                                        }
                                     </DropdownButton>
                                 }
                             </ButtonGroup>
@@ -222,6 +244,12 @@ class CollectionSection extends React.Component<Props> {
                 >
                     {translate('sulu_media.remove_collection_warning')}
                 </Dialog>
+                <PermissionFormOverlay
+                    collectionId={this.collectionId}
+                    onClose={this.handlePermissionOverlayClose}
+                    onConfirm={this.handlePermissionOverlayConfirm}
+                    open={operationType === 'permissions'}
+                />
                 <SingleListOverlay
                     adapter="column_list"
                     allowActivateForDisabledItems={false}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/CollectionSection.js
@@ -6,7 +6,7 @@ import {observer} from 'mobx-react';
 import {List, ListStore, SingleListOverlay} from 'sulu-admin-bundle/containers';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import {translate} from 'sulu-admin-bundle/utils';
-import {Dialog, Icon, Button, ButtonGroup} from 'sulu-admin-bundle/components';
+import {Button, ButtonGroup, Dialog, DropdownButton} from 'sulu-admin-bundle/components';
 import CollectionFormOverlay from './CollectionFormOverlay';
 import CollectionBreadcrumb from './CollectionBreadcrumb';
 import type {OperationType, OverlayType} from './types';
@@ -168,42 +168,34 @@ class CollectionSection extends React.Component<Props> {
                                 onNavigate={this.handleBreadcrumbNavigate}
                                 resourceStore={resourceStore}
                             />
-                            {resourceStore.id &&
-                                <div className={collectionSectionStyles.icons}>
-                                    {editable &&
-                                        <Icon
-                                            className={collectionSectionStyles.icon}
-                                            name="su-pen"
-                                            onClick={this.handleEditCollectionClick}
-                                        />
-                                    }
-                                    {deletable &&
-                                        <Icon
-                                            className={collectionSectionStyles.icon}
-                                            name="su-trash-alt"
-                                            onClick={this.handleRemoveCollectionClick}
-                                        />
-                                    }
-                                    {editable &&
-                                        <Icon
-                                            className={collectionSectionStyles.icon}
-                                            name="su-arrows-alt"
-                                            onClick={this.handleMoveCollectionClick}
-                                        />
-                                    }
-                                </div>
-                            }
                         </div>
 
-                        {addable &&
-                            <div className={collectionSectionStyles.right}>
-                                <ButtonGroup>
-                                    <Button onClick={this.handleAddCollectionClick}>
-                                        <Icon name="su-plus" />
-                                    </Button>
-                                </ButtonGroup>
-                            </div>
-                        }
+                        <div className={collectionSectionStyles.right}>
+                            <ButtonGroup>
+                                {addable &&
+                                    <Button icon="su-plus" onClick={this.handleAddCollectionClick} />
+                                }
+                                {!!resourceStore.id &&
+                                    <DropdownButton icon="su-cog">
+                                        {editable &&
+                                            <DropdownButton.Item onClick={this.handleEditCollectionClick}>
+                                                {translate('sulu_admin.edit')}
+                                            </DropdownButton.Item>
+                                        }
+                                        {deletable &&
+                                            <DropdownButton.Item onClick={this.handleRemoveCollectionClick}>
+                                                {translate('sulu_admin.delete')}
+                                            </DropdownButton.Item>
+                                        }
+                                        {editable &&
+                                            <DropdownButton.Item onClick={this.handleMoveCollectionClick}>
+                                                {translate('sulu_admin.move')}
+                                            </DropdownButton.Item>
+                                        }
+                                    </DropdownButton>
+                                }
+                            </ButtonGroup>
+                        </div>
                     </div>
                 }
                 <List

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -76,9 +76,16 @@ class MediaCollection extends React.Component<Props> {
             uploadOverlayOpen,
         } = this.props;
 
+        const {permissions} = collectionStore;
+
+        const addable = permissions.add !== undefined ? permissions.add : MediaCollection.addable;
+        const editable = permissions.edit !== undefined ? permissions.edit : MediaCollection.editable;
+        const deletable = permissions.delete !== undefined ? permissions.delete : MediaCollection.deletable;
+        const securable = permissions.security !== undefined ? permissions.security : MediaCollection.securable;
+
         return (
             <MultiMediaDropzone
-                collectionId={MediaCollection.addable ? collectionStore.id : undefined}
+                collectionId={addable ? collectionStore.id : undefined}
                 locale={locale}
                 onClose={onUploadOverlayClose}
                 onOpen={onUploadOverlayOpen}
@@ -86,14 +93,15 @@ class MediaCollection extends React.Component<Props> {
                 open={uploadOverlayOpen}
             >
                 <CollectionSection
-                    addable={MediaCollection.addable}
-                    deletable={MediaCollection.deletable}
-                    editable={MediaCollection.editable}
+                    addable={addable}
+                    deletable={deletable}
+                    editable={editable}
                     listStore={collectionListStore}
                     locale={locale}
                     onCollectionNavigate={this.handleCollectionNavigate}
                     overlayType={overlayType}
                     resourceStore={collectionStore.resourceStore}
+                    securable={securable}
                 />
                 <Divider />
                 <div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/MediaCollection.js
@@ -36,6 +36,7 @@ class MediaCollection extends React.Component<Props> {
     static addable: boolean = true;
     static deletable: boolean = true;
     static editable: boolean = true;
+    static securable: boolean = true;
 
     handleMediaClick = (mediaId: string | number) => {
         const {onMediaNavigate} = this.props;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/PermissionFormOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/PermissionFormOverlay.js
@@ -1,0 +1,91 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import {Form, ResourceFormStore} from 'sulu-admin-bundle/containers';
+import {Overlay} from 'sulu-admin-bundle/components';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {translate} from 'sulu-admin-bundle/utils';
+import permissionFormOverlayStyles from './permissionFormOverlay.scss';
+
+type Props = {|
+    collectionId: ?number | string,
+    onClose: () => void,
+    onConfirm: () => void,
+    open: boolean,
+|};
+
+const API_OPTIONS = {resourceKey: 'media'};
+
+@observer
+export default class PermissionFormOverlay extends React.Component<Props> {
+    formRef: ?Form;
+    resourceStore: ResourceStore;
+    formStore: ResourceFormStore;
+
+    constructor(props: Props) {
+        super(props);
+
+        this.createFormStore();
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        const {collectionId} = this.props;
+
+        if (collectionId !== prevProps.collectionId) {
+            this.destroyFormStore();
+            this.createFormStore();
+        }
+    }
+
+    componentWillUnmount() {
+        this.destroyFormStore();
+    }
+
+    createFormStore() {
+        const {collectionId} = this.props;
+        this.resourceStore = new ResourceStore('permissions', collectionId, {}, API_OPTIONS);
+        this.formStore = new ResourceFormStore(this.resourceStore, 'permission_details', API_OPTIONS);
+    }
+
+    destroyFormStore() {
+        this.resourceStore.destroy();
+        this.formStore.destroy();
+    }
+
+    setFormRef = (formRef: ?Form) => {
+        this.formRef = formRef;
+    };
+
+    handleConfirm = () => {
+        if (this.formRef) {
+            this.formRef.submit();
+        }
+    };
+
+    handleSubmit = () => {
+        const {onConfirm} = this.props;
+
+        this.resourceStore.save(API_OPTIONS).then(() => onConfirm());
+    };
+
+    render() {
+        const {onClose, open} = this.props;
+
+        return (
+            <Overlay
+                cancelText={translate('sulu_admin.cancel')}
+                confirmLoading={this.resourceStore && this.resourceStore.saving}
+                confirmText={translate('sulu_admin.ok')}
+                onClose={onClose}
+                onConfirm={this.handleConfirm}
+                open={open}
+                size="small"
+                title={translate('sulu_security.permissions')}
+            >
+                <div className={permissionFormOverlayStyles.overlay}>
+                    <Form onSubmit={this.handleSubmit} ref={this.setFormRef} store={this.formStore} />
+                </div>
+            </Overlay>
+        );
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/collectionSection.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/collectionSection.scss
@@ -14,17 +14,6 @@
     }
 }
 
-.icons {
-    display: none;
-    font-size: 16px;
-    margin: 0 10px 30px 20px;
-}
-
-.icon {
-    margin-left: 5px;
-    margin-right: 5px;
-}
-
 .right {
     flex-grow: 1;
     margin-bottom: 30px;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/permissionFormOverlay.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/permissionFormOverlay.scss
@@ -1,0 +1,5 @@
+@import 'sulu-admin-bundle/containers/Application/variables.scss';
+
+.overlay {
+    padding: $viewPadding;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/CollectionFormOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/CollectionFormOverlay.test.js
@@ -1,6 +1,6 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 import CollectionFormOverlay from '../CollectionFormOverlay';
 
@@ -8,6 +8,7 @@ jest.mock('sulu-admin-bundle/services/Initializer', () => jest.fn());
 
 jest.mock('sulu-admin-bundle/containers', () => ({
     ResourceFormStore: jest.fn(),
+    // $FlowFixMe
     Form: require.requireActual('sulu-admin-bundle/containers').Form,
 }));
 
@@ -86,4 +87,24 @@ test('Keep title when closing overlay until new overlay opens', () => {
         open: false,
         title: 'sulu_media.edit_collection',
     }));
+});
+
+test('Call destroy of ResourceFormStore when unmounted', () => {
+    const resourceStore = new ResourceStore('test');
+    const collectionFormOverlay = mount(
+        <CollectionFormOverlay
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            operationType={null}
+            overlayType="overlay"
+            resourceStore={resourceStore}
+        />
+    );
+
+    const resourceFormStore = collectionFormOverlay.instance().formStore;
+    resourceFormStore.destroy = jest.fn();
+
+    collectionFormOverlay.unmount();
+
+    expect(resourceFormStore.destroy).toBeCalledWith();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -174,53 +174,11 @@ jest.mock('sulu-admin-bundle/stores', () => {
 });
 
 jest.mock('sulu-admin-bundle/utils', () => ({
-    translate: function(key) {
-        switch (key) {
-            case 'sulu_media.all_media':
-                return 'All Media';
-            case 'sulu_media.copy_url':
-                return 'Copy URL';
-            case 'sulu_media.download_masterfile':
-                return 'Download master file';
-            case 'sulu_media.copy_masterfile_url':
-                return 'Copy masterfile url';
-            case 'sulu_media.add_collection':
-                return 'Add collection';
-            case 'sulu_media.edit_collection':
-                return 'Edit collection';
-            case 'sulu_media.remove_collection':
-                return 'Remove collection';
-            case 'sulu_media.remove_collection_warning':
-                return 'Warning: Remove collection';
-            case 'sulu_admin.page':
-                return 'Page';
-            case 'sulu_admin.of':
-                return 'of';
-            case 'sulu_admin.object':
-                return 'Object';
-            case 'sulu_admin.objects':
-                return 'Objects';
-            case 'sulu_admin.ok':
-                return 'ok';
-            case 'sulu_admin.cancel':
-                return 'cancel';
-        }
-    },
+    translate: (key) => key,
 }));
 
 jest.mock('sulu-admin-bundle/utils/Translator', () => ({
-    translate: function(key) {
-        switch (key) {
-            case 'sulu_admin.page':
-                return 'Page';
-            case 'sulu_admin.of':
-                return 'of';
-            case 'sulu_admin.object':
-                return 'Object';
-            case 'sulu_admin.objects':
-                return 'Objects';
-        }
-    },
+    translate: (key) => key,
 }));
 
 jest.mock('sulu-admin-bundle/containers/SingleListOverlay', () => jest.fn(() => null));
@@ -334,10 +292,12 @@ test('Render the MediaCollection without add button when permission is missing',
         />
     );
 
-    expect(mediaCollection.find('CollectionSection Icon[name="su-plus"]')).toHaveLength(0);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-trash-alt"]')).toHaveLength(1);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-pen"]')).toHaveLength(1);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-arrows-alt"]')).toHaveLength(1);
+    mediaCollection.find('DropdownButton').simulate('click');
+
+    expect(mediaCollection.find('Button[icon="su-plus"]')).toHaveLength(0);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.delete'})).toHaveLength(1);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.edit'})).toHaveLength(1);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.move'})).toHaveLength(1);
 });
 
 test('Render the MediaCollection without delete button when permission is missing', () => {
@@ -384,10 +344,12 @@ test('Render the MediaCollection without delete button when permission is missin
         />
     );
 
-    expect(mediaCollection.find('CollectionSection Icon[name="su-plus"]')).toHaveLength(1);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-trash-alt"]')).toHaveLength(0);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-pen"]')).toHaveLength(1);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-arrows-alt"]')).toHaveLength(1);
+    mediaCollection.find('DropdownButton').simulate('click');
+
+    expect(mediaCollection.find('Button[icon="su-plus"]')).toHaveLength(1);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.delete'})).toHaveLength(0);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.edit'})).toHaveLength(1);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.move'})).toHaveLength(1);
 });
 
 test('Render the MediaCollection without edit buttons when permission is missing', () => {
@@ -434,10 +396,12 @@ test('Render the MediaCollection without edit buttons when permission is missing
         />
     );
 
-    expect(mediaCollection.find('CollectionSection Icon[name="su-plus"]')).toHaveLength(1);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-trash-alt"]')).toHaveLength(1);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-pen"]')).toHaveLength(0);
-    expect(mediaCollection.find('CollectionSection Icon[name="su-arrows-alt"]')).toHaveLength(0);
+    mediaCollection.find('DropdownButton').simulate('click');
+
+    expect(mediaCollection.find('Button[icon="su-plus"]')).toHaveLength(1);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.delete'})).toHaveLength(1);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.edit'})).toHaveLength(0);
+    expect(mediaCollection.find('Action').find({children: 'sulu_admin.move'})).toHaveLength(0);
 });
 
 test('Render the MediaCollection for all media', () => {
@@ -624,7 +588,8 @@ test('Should send a request to add a new collection via the overlay', () => {
         />
     );
 
-    mediaCollection.find('CollectionSection Icon[name="su-plus"]').simulate('click');
+    mediaCollection.find('Button[icon="su-plus"]').simulate('click');
+
     expect(collectionStore.resourceStore.clone).not.toBeCalled();
     expect(field.mock.calls[0][0].value).toEqual(undefined);
 
@@ -635,7 +600,7 @@ test('Should send a request to add a new collection via the overlay', () => {
     if (!header) {
         throw new Error('Header not found!');
     }
-    expect(header.outerHTML).toEqual(expect.stringContaining('Add collection'));
+    expect(header.outerHTML).toEqual(expect.stringContaining('sulu_media.add_collection'));
 
     const newResourceStore = mediaCollection.find('CollectionSection').instance().resourceStoreByOperationType;
     newResourceStore.save = jest.fn().mockReturnValue(promise);
@@ -703,7 +668,8 @@ test('Should send a request to update the collection via the overlay', () => {
         />
     );
 
-    mediaCollection.find('CollectionSection Icon[name="su-pen"]').simulate('click');
+    mediaCollection.find('DropdownButton').simulate('click');
+    mediaCollection.find('DropdownButton Action').find({children: 'sulu_admin.edit'}).simulate('click');
 
     // $FlowFixMe
     const resourceStoreInstances = ResourceStore.mock.instances;
@@ -719,7 +685,7 @@ test('Should send a request to update the collection via the overlay', () => {
     if (!header) {
         throw new Error('Header not found!');
     }
-    expect(header.outerHTML).toEqual(expect.stringContaining('Edit collection'));
+    expect(header.outerHTML).toEqual(expect.stringContaining('sulu_media.edit_collection'));
 
     // enzyme can't know about portals (rendered outside the react tree), so the document has to be used instead
     const button = document.querySelector('button.primary');
@@ -779,7 +745,8 @@ test('Confirming the delete dialog should delete the item', () => {
         />
     );
 
-    mediaCollection.find('Icon[name="su-trash-alt"]').simulate('click');
+    mediaCollection.find('DropdownButton').simulate('click');
+    mediaCollection.find('DropdownButton Action').find({children: 'sulu_admin.delete'}).simulate('click');
 
     expect(mediaCollection.find('CollectionSection > div > Dialog').prop('open')).toEqual(true);
     expect(mediaCollection.find('CollectionFormOverlay > Overlay').prop('open')).toEqual(false);
@@ -856,7 +823,8 @@ test('Confirming the delete dialog should delete the item and navigate to its pa
         />
     );
 
-    mediaCollection.find('Icon[name="su-trash-alt"]').simulate('click');
+    mediaCollection.find('DropdownButton').simulate('click');
+    mediaCollection.find('DropdownButton Action').find({children: 'sulu_admin.delete'}).simulate('click');
 
     // enzyme can't know about portals (rendered outside the react tree), so the document has to be used instead
     const button = document.querySelector('button.primary');
@@ -913,7 +881,8 @@ test('Confirming the move dialog should move the item', () => {
         />
     );
 
-    mediaCollection.find('Icon[name="su-arrows-alt"]').simulate('click');
+    mediaCollection.find('DropdownButton').simulate('click');
+    mediaCollection.find('DropdownButton Action').find({children: 'sulu_admin.move'}).simulate('click');
 
     expect(mediaCollection.find('CollectionSection > div > Dialog').prop('open')).toEqual(false);
     expect(mediaCollection.find('CollectionFormOverlay > Overlay').prop('open')).toEqual(false);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -114,6 +114,7 @@ jest.mock('sulu-admin-bundle/containers', () => {
             this.data = resourceStore.data;
             this.isFieldModified = jest.fn();
             this.validate = jest.fn().mockReturnValue(true);
+            this.destroy = jest.fn();
         }),
         InfiniteLoadingStrategy: require(
             'sulu-admin-bundle/containers/List/loadingStrategies/InfiniteLoadingStrategy'

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js
@@ -251,6 +251,55 @@ test('Render the MediaCollection', () => {
     expect(mediaCollection).toMatchSnapshot();
 });
 
+test('Render the MediaCollection without dropdown button when permissions are missing', () => {
+    const page = observable.box();
+    const locale = observable.box();
+    const collectionNavigateSpy = jest.fn();
+    const ListStore = require('sulu-admin-bundle/containers').ListStore;
+    const mediaListStore = new ListStore(
+        MEDIA_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const collectionListStore = new ListStore(
+        COLLECTIONS_RESOURCE_KEY,
+        SETTINGS_KEY,
+        USER_SETTINGS_KEY,
+        {
+            page,
+            locale,
+        }
+    );
+    const CollectionStore = require('../../../stores/CollectionStore').default;
+    const collectionStore = new CollectionStore(1, locale);
+
+    MediaCollection.addable = false;
+    MediaCollection.deletable = false;
+    MediaCollection.editable = false;
+    MediaCollection.securable = false;
+
+    const mediaCollection = mount(
+        <MediaCollection
+            collectionListStore={collectionListStore}
+            collectionStore={collectionStore}
+            locale={locale}
+            mediaListAdapters={['media_card_overview']}
+            mediaListStore={mediaListStore}
+            onCollectionNavigate={collectionNavigateSpy}
+            onUploadOverlayClose={jest.fn()}
+            onUploadOverlayOpen={jest.fn()}
+            uploadOverlayOpen={false}
+        />
+    );
+
+    expect(mediaCollection.find('Button[icon="su-plus"]')).toHaveLength(0);
+    expect(mediaCollection.find('DropdownButton')).toHaveLength(0);
+});
+
 test('Render the MediaCollection without add button when permission is missing', () => {
     const page = observable.box();
     const locale = observable.box();

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/PermissionFormOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/PermissionFormOverlay.test.js
@@ -1,0 +1,119 @@
+// @flow
+import React from 'react';
+import {extendObservable as mockExtendObservable} from 'mobx';
+import {mount, shallow} from 'enzyme';
+import {ResourceStore} from 'sulu-admin-bundle/stores';
+import {ResourceFormStore} from 'sulu-admin-bundle/containers';
+import PermissionFormOverlay from '../PermissionFormOverlay';
+
+jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function() {
+    this.destroy = jest.fn();
+    this.save = jest.fn();
+
+    mockExtendObservable(this, {
+        saving: false,
+    });
+}));
+
+jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn(function() {
+    this.destroy = jest.fn();
+    this.data = {};
+    this.schema = {};
+    this.validate = jest.fn().mockReturnValue(true);
+}));
+
+jest.mock('sulu-admin-bundle/utils/Translator', () => ({
+    translate: (key) => key,
+}));
+
+test('Create new ResourceFormStore when collectionId has changed', () => {
+    const permissionFormOverlay = shallow(
+        <PermissionFormOverlay collectionId={1} onClose={jest.fn()} onConfirm={jest.fn()} open={true} />
+    );
+
+    expect(ResourceStore).toHaveBeenLastCalledWith('permissions', 1, {}, {resourceKey: 'media'});
+    expect(ResourceFormStore).toHaveBeenLastCalledWith(
+        // $FlowFixMe
+        ResourceStore.mock.instances[0],
+        'permission_details',
+        {resourceKey: 'media'}
+    );
+
+    permissionFormOverlay.setProps({collectionId: 3});
+
+    // $FlowFixMe
+    expect(ResourceStore.mock.instances[0].destroy).toBeCalledWith();
+    // $FlowFixMe
+    expect(ResourceFormStore.mock.instances[0].destroy).toBeCalledWith();
+
+    expect(ResourceStore).toHaveBeenLastCalledWith('permissions', 3, {}, {resourceKey: 'media'});
+    expect(ResourceFormStore).toHaveBeenLastCalledWith(
+        // $FlowFixMe
+        ResourceStore.mock.instances[1],
+        'permission_details',
+        {resourceKey: 'media'}
+    );
+});
+
+test('Call destroy of created ResourceFormStore and ResourceStore', () => {
+    const permissionFormOverlay = shallow(
+        <PermissionFormOverlay collectionId={undefined} onClose={jest.fn()} onConfirm={jest.fn()} open={true} />
+    );
+
+    const formStore = permissionFormOverlay.instance().formStore;
+    const resourceStore = permissionFormOverlay.instance().resourceStore;
+    formStore.destroy = jest.fn();
+    resourceStore.destroy = jest.fn();
+
+    permissionFormOverlay.unmount();
+    expect(formStore.destroy).toBeCalledWith();
+    expect(resourceStore.destroy).toBeCalledWith();
+});
+
+test('Confirming dialog should save the current value', () => {
+    const confirmSpy = jest.fn();
+
+    const permissionFormOverlay = mount(
+        <PermissionFormOverlay collectionId={undefined} onClose={jest.fn()} onConfirm={confirmSpy} open={true} />
+    );
+
+    const savePromise = Promise.resolve();
+    permissionFormOverlay.instance().resourceStore.save.mockReturnValue(savePromise);
+
+    permissionFormOverlay.update();
+
+    permissionFormOverlay.find('Overlay').prop('onConfirm')();
+    permissionFormOverlay.update();
+    expect(permissionFormOverlay.instance().resourceStore.save).toBeCalledWith({resourceKey: 'media'});
+
+    expect(confirmSpy).not.toBeCalled();
+    return savePromise.then(() => {
+        permissionFormOverlay.update();
+        expect(confirmSpy).toBeCalledWith();
+    });
+});
+
+test.each([
+    [true],
+    [false],
+])('Pass saving prop of value "%s" to confirmLoading prop of Overlay', (saving) => {
+    const permissionFormOverlay = shallow(
+        <PermissionFormOverlay collectionId={1} onClose={jest.fn()} onConfirm={jest.fn()} open={true} />
+    );
+
+    permissionFormOverlay.instance().resourceStore.saving = saving;
+    permissionFormOverlay.update();
+
+    expect(permissionFormOverlay.find('Overlay').prop('confirmLoading')).toEqual(saving);
+});
+
+test.each([
+    [true],
+    [false],
+])('Pass open prop of value "%s" to open prop of Overlay', (open) => {
+    const permissionFormOverlay = shallow(
+        <PermissionFormOverlay collectionId={1} onClose={jest.fn()} onConfirm={jest.fn()} open={open} />
+    );
+
+    expect(permissionFormOverlay.find('Overlay').prop('open')).toEqual(open);
+});

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -21,49 +21,38 @@ exports[`Render the MediaCollection 1`] = `
               class="item"
               disabled=""
             >
-              All Media
+              sulu_media.all_media
             </button>
           </li>
         </ul>
-        <div
-          class="icons"
-        >
-          <span
-            aria-label="su-pen"
-            class="su-pen clickable icon"
-            role="button"
-            tabindex="0"
-          />
-          <span
-            aria-label="su-trash-alt"
-            class="su-trash-alt clickable icon"
-            role="button"
-            tabindex="0"
-          />
-          <span
-            aria-label="su-arrows-alt"
-            class="su-arrows-alt clickable icon"
-            role="button"
-            tabindex="0"
-          />
-        </div>
       </div>
       <div
         class="right"
       >
-        <div>
+        <div
+          class="buttonGroup"
+        >
           <button
             class="button icon button"
             type="button"
           >
             <span
-              class="text"
-            >
-              <span
-                aria-label="su-plus"
-                class="su-plus"
-              />
-            </span>
+              aria-label="su-plus"
+              class="su-plus buttonIcon"
+            />
+          </button>
+          <button
+            class="button icon button"
+            type="button"
+          >
+            <span
+              aria-label="su-cog"
+              class="su-cog buttonIcon"
+            />
+            <span
+              aria-label="su-angle-down"
+              class="su-angle-down dropdownIcon"
+            />
           </button>
         </div>
       </div>
@@ -103,7 +92,7 @@ exports[`Render the MediaCollection 1`] = `
                   <div
                     class="info"
                   >
-                    1 Object
+                    1 sulu_admin.object
                   </div>
                 </div>
               </div>
@@ -133,7 +122,7 @@ exports[`Render the MediaCollection 1`] = `
                   <div
                     class="info"
                   >
-                    0 Objects
+                    0 sulu_admin.objects
                   </div>
                 </div>
               </div>
@@ -145,7 +134,7 @@ exports[`Render the MediaCollection 1`] = `
             <span
               class="display"
             >
-              :
+              sulu_admin.per_page:
             </span>
             <span>
               <div
@@ -191,7 +180,7 @@ exports[`Render the MediaCollection 1`] = `
               class="loader"
             />
             <span>
-              Page:
+              sulu_admin.page:
             </span>
             <span
               class="inputContainer"
@@ -209,9 +198,11 @@ exports[`Render the MediaCollection 1`] = `
             <span
               class="display"
             >
-              of 3
+              sulu_admin.of 3
             </span>
-            <div>
+            <div
+              class="buttonGroup"
+            >
               <button
                 class="button icon button"
                 type="button"
@@ -263,6 +254,7 @@ exports[`Render the MediaCollection 1`] = `
               />
             </div>
             <input
+              placeholder="sulu_admin.list_search_placeholder"
               type="text"
               value=""
             />
@@ -580,7 +572,7 @@ exports[`Render the MediaCollection for all media 1`] = `
               class="item"
               disabled=""
             >
-              All Media
+              sulu_media.all_media
             </button>
           </li>
         </ul>
@@ -588,19 +580,17 @@ exports[`Render the MediaCollection for all media 1`] = `
       <div
         class="right"
       >
-        <div>
+        <div
+          class="buttonGroup"
+        >
           <button
             class="button icon button"
             type="button"
           >
             <span
-              class="text"
-            >
-              <span
-                aria-label="su-plus"
-                class="su-plus"
-              />
-            </span>
+              aria-label="su-plus"
+              class="su-plus buttonIcon"
+            />
           </button>
         </div>
       </div>
@@ -640,7 +630,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   <div
                     class="info"
                   >
-                    1 Object
+                    1 sulu_admin.object
                   </div>
                 </div>
               </div>
@@ -670,7 +660,7 @@ exports[`Render the MediaCollection for all media 1`] = `
                   <div
                     class="info"
                   >
-                    0 Objects
+                    0 sulu_admin.objects
                   </div>
                 </div>
               </div>
@@ -682,7 +672,7 @@ exports[`Render the MediaCollection for all media 1`] = `
             <span
               class="display"
             >
-              :
+              sulu_admin.per_page:
             </span>
             <span>
               <div
@@ -728,7 +718,7 @@ exports[`Render the MediaCollection for all media 1`] = `
               class="loader"
             />
             <span>
-              Page:
+              sulu_admin.page:
             </span>
             <span
               class="inputContainer"
@@ -746,9 +736,11 @@ exports[`Render the MediaCollection for all media 1`] = `
             <span
               class="display"
             >
-              of 3
+              sulu_admin.of 3
             </span>
-            <div>
+            <div
+              class="buttonGroup"
+            >
               <button
                 class="button icon button"
                 type="button"
@@ -800,6 +792,7 @@ exports[`Render the MediaCollection for all media 1`] = `
               />
             </div>
             <input
+              placeholder="sulu_admin.list_search_placeholder"
               type="text"
               value=""
             />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/__snapshots__/MediaCollection.test.js.snap
@@ -211,22 +211,26 @@ exports[`Render the MediaCollection 1`] = `
             >
               of 3
             </span>
-            <button
-              class="previous"
-            >
-              <span
-                aria-label="su-angle-left"
-                class="su-angle-left"
-              />
-            </button>
-            <button
-              class="next"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right"
-              />
-            </button>
+            <div>
+              <button
+                class="button icon button"
+                type="button"
+              >
+                <span
+                  aria-label="su-angle-left"
+                  class="su-angle-left buttonIcon"
+                />
+              </button>
+              <button
+                class="button icon button"
+                type="button"
+              >
+                <span
+                  aria-label="su-angle-right"
+                  class="su-angle-right buttonIcon"
+                />
+              </button>
+            </div>
           </nav>
         </section>
       </div>
@@ -744,22 +748,26 @@ exports[`Render the MediaCollection for all media 1`] = `
             >
               of 3
             </span>
-            <button
-              class="previous"
-            >
-              <span
-                aria-label="su-angle-left"
-                class="su-angle-left"
-              />
-            </button>
-            <button
-              class="next"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right"
-              />
-            </button>
+            <div>
+              <button
+                class="button icon button"
+                type="button"
+              >
+                <span
+                  aria-label="su-angle-left"
+                  class="su-angle-left buttonIcon"
+                />
+              </button>
+              <button
+                class="button icon button"
+                type="button"
+              >
+                <span
+                  aria-label="su-angle-right"
+                  class="su-angle-right buttonIcon"
+                />
+              </button>
+            </div>
           </nav>
         </section>
       </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/types.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/types.js
@@ -1,5 +1,5 @@
 // @flow
-export type OperationType = null | 'create' | 'update' | 'remove' | 'move';
+export type OperationType = null | 'create' | 'update' | 'remove' | 'move' | 'permissions';
 
 export type OverlayType = 'overlay' | 'dialog';
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js
@@ -68,7 +68,9 @@ jest.mock('sulu-admin-bundle/containers/List/stores/ListStore', () =>
     })
 );
 
-jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn());
+jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn(function() {
+    this.destroy = jest.fn();
+}));
 
 let collectionListStoreMock: ListStore;
 let mediaListStoreMock: ListStore;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js
@@ -14,6 +14,7 @@ jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function() {
     this.id = 1;
     this.data = {
         id: 1,
+        _permissions: {},
     };
 }));
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -240,22 +240,26 @@ Array [
                         >
                           sulu_admin.of 3
                         </span>
-                        <button
-                          class="previous"
-                        >
-                          <span
-                            aria-label="su-angle-left"
-                            class="su-angle-left"
-                          />
-                        </button>
-                        <button
-                          class="next"
-                        >
-                          <span
-                            aria-label="su-angle-right"
-                            class="su-angle-right"
-                          />
-                        </button>
+                        <div>
+                          <button
+                            class="button icon button"
+                            type="button"
+                          >
+                            <span
+                              aria-label="su-angle-left"
+                              class="su-angle-left buttonIcon"
+                            />
+                          </button>
+                          <button
+                            class="button icon button"
+                            type="button"
+                          >
+                            <span
+                              aria-label="su-angle-right"
+                              class="su-angle-right buttonIcon"
+                            />
+                          </button>
+                        </div>
                       </nav>
                     </section>
                   </div>
@@ -859,22 +863,26 @@ Array [
                         >
                           sulu_admin.of 3
                         </span>
-                        <button
-                          class="previous"
-                        >
-                          <span
-                            aria-label="su-angle-left"
-                            class="su-angle-left"
-                          />
-                        </button>
-                        <button
-                          class="next"
-                        >
-                          <span
-                            aria-label="su-angle-right"
-                            class="su-angle-right"
-                          />
-                        </button>
+                        <div>
+                          <button
+                            class="button icon button"
+                            type="button"
+                          >
+                            <span
+                              aria-label="su-angle-left"
+                              class="su-angle-left buttonIcon"
+                            />
+                          </button>
+                          <button
+                            class="button icon button"
+                            type="button"
+                          >
+                            <span
+                              aria-label="su-angle-right"
+                              class="su-angle-right buttonIcon"
+                            />
+                          </button>
+                        </div>
                       </nav>
                     </section>
                   </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/__snapshots__/MediaSelectionOverlay.test.js.snap
@@ -54,45 +54,34 @@ Array [
                         </button>
                       </li>
                     </ul>
-                    <div
-                      class="icons"
-                    >
-                      <span
-                        aria-label="su-pen"
-                        class="su-pen clickable icon"
-                        role="button"
-                        tabindex="0"
-                      />
-                      <span
-                        aria-label="su-trash-alt"
-                        class="su-trash-alt clickable icon"
-                        role="button"
-                        tabindex="0"
-                      />
-                      <span
-                        aria-label="su-arrows-alt"
-                        class="su-arrows-alt clickable icon"
-                        role="button"
-                        tabindex="0"
-                      />
-                    </div>
                   </div>
                   <div
                     class="right"
                   >
-                    <div>
+                    <div
+                      class="buttonGroup"
+                    >
                       <button
                         class="button icon button"
                         type="button"
                       >
                         <span
-                          class="text"
-                        >
-                          <span
-                            aria-label="su-plus"
-                            class="su-plus"
-                          />
-                        </span>
+                          aria-label="su-plus"
+                          class="su-plus buttonIcon"
+                        />
+                      </button>
+                      <button
+                        class="button icon button"
+                        type="button"
+                      >
+                        <span
+                          aria-label="su-cog"
+                          class="su-cog buttonIcon"
+                        />
+                        <span
+                          aria-label="su-angle-down"
+                          class="su-angle-down dropdownIcon"
+                        />
                       </button>
                     </div>
                   </div>
@@ -240,7 +229,9 @@ Array [
                         >
                           sulu_admin.of 3
                         </span>
-                        <div>
+                        <div
+                          class="buttonGroup"
+                        >
                           <button
                             class="button icon button"
                             type="button"
@@ -677,45 +668,34 @@ Array [
                         </button>
                       </li>
                     </ul>
-                    <div
-                      class="icons"
-                    >
-                      <span
-                        aria-label="su-pen"
-                        class="su-pen clickable icon"
-                        role="button"
-                        tabindex="0"
-                      />
-                      <span
-                        aria-label="su-trash-alt"
-                        class="su-trash-alt clickable icon"
-                        role="button"
-                        tabindex="0"
-                      />
-                      <span
-                        aria-label="su-arrows-alt"
-                        class="su-arrows-alt clickable icon"
-                        role="button"
-                        tabindex="0"
-                      />
-                    </div>
                   </div>
                   <div
                     class="right"
                   >
-                    <div>
+                    <div
+                      class="buttonGroup"
+                    >
                       <button
                         class="button icon button"
                         type="button"
                       >
                         <span
-                          class="text"
-                        >
-                          <span
-                            aria-label="su-plus"
-                            class="su-plus"
-                          />
-                        </span>
+                          aria-label="su-plus"
+                          class="su-plus buttonIcon"
+                        />
+                      </button>
+                      <button
+                        class="button icon button"
+                        type="button"
+                      >
+                        <span
+                          aria-label="su-cog"
+                          class="su-cog buttonIcon"
+                        />
+                        <span
+                          aria-label="su-angle-down"
+                          class="su-angle-down dropdownIcon"
+                        />
                       </button>
                     </div>
                   </div>
@@ -863,7 +843,9 @@ Array [
                         >
                           sulu_admin.of 3
                         </span>
-                        <div>
+                        <div
+                          class="buttonGroup"
+                        >
                           <button
                             class="button icon button"
                             type="button"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -31,6 +31,7 @@ initializer.addUpdateConfigHook('sulu_media', (config: Object, initialized: bool
     MediaCollection.addable = mediaPermissions.add;
     MediaCollection.deletable = mediaPermissions.delete;
     MediaCollection.editable = mediaPermissions.edit;
+    MediaCollection.securable = mediaPermissions.security;
 
     if (initialized) {
         return;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
@@ -1,6 +1,6 @@
 // @flow
 import {computed} from 'mobx';
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import type {IObservableValue} from 'mobx';
 import {ResourceStore} from 'sulu-admin-bundle/stores';
 
 const COLLECTIONS_RESOURCE_KEY = 'collections';
@@ -37,6 +37,10 @@ export default class CollectionStore {
 
     @computed get id(): ?string | number {
         return this.resourceStore.id;
+    }
+
+    @computed get permissions(): {[key: string]: boolean} {
+        return this.resourceStore.data._permissions;
     }
 
     @computed get parentId(): ?number {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/CollectionStore.js
@@ -40,6 +40,10 @@ export default class CollectionStore {
     }
 
     @computed get permissions(): {[key: string]: boolean} {
+        if (this.resourceStore.loading || !this.resourceStore.id) {
+            return {};
+        }
+
         return this.resourceStore.data._permissions;
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/tests/CollectionStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/tests/CollectionStore.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation */
+// @flow
 import {observable, when} from 'mobx';
 import ResourceRequester from 'sulu-admin-bundle/services/ResourceRequester';
 import CollectionStore from '../CollectionStore';
@@ -15,6 +15,7 @@ test('Do not send request without defined collectionId', () => {
 });
 
 test('After loading the collection info should be set', (done) => {
+    // $FlowFixMe
     const Promise = require.requireActual('promise');
 
     ResourceRequester.get.mockReturnValue(Promise.resolve({
@@ -25,6 +26,11 @@ test('After loading the collection info should be set', (done) => {
                 id: 1,
             },
         },
+        _permissions: {
+            view: true,
+            edit: false,
+            delete: false,
+        },
     }));
 
     const locale = observable.box('en');
@@ -33,7 +39,8 @@ test('After loading the collection info should be set', (done) => {
     when(
         () => !collectionStore.loading,
         () => {
-            expect(collectionStore.parentId).toBe(1);
+            expect(collectionStore.parentId).toEqual(1);
+            expect(collectionStore.permissions).toEqual({view: true, edit: false, delete: false});
             collectionStore.destroy();
             done();
         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/tests/CollectionStore.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/stores/CollectionStore/tests/CollectionStore.test.js
@@ -15,9 +15,6 @@ test('Do not send request without defined collectionId', () => {
 });
 
 test('After loading the collection info should be set', (done) => {
-    // $FlowFixMe
-    const Promise = require.requireActual('promise');
-
     ResourceRequester.get.mockReturnValue(Promise.resolve({
         id: 2,
         title: 'test',
@@ -45,4 +42,18 @@ test('After loading the collection info should be set', (done) => {
             done();
         }
     );
+});
+
+test('Should return an empty permission object if still loading', () => {
+    const collectionStore = new CollectionStore(1, observable.box('en'));
+
+    expect(collectionStore.permissions).toEqual({});
+});
+
+test('Should return an empty permission object if no id was given', () => {
+    const collectionStore = new CollectionStore(undefined, observable.box('en'));
+
+    expect(ResourceRequester.get).not.toBeCalled();
+    expect(collectionStore.loading).toEqual(false);
+    expect(collectionStore.permissions).toEqual({});
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -218,9 +218,9 @@ export default withToolbar(MediaOverview, function() {
             options: {
                 locales,
                 permissions: {
-                    add: addPermission,
-                    delete: deletePermission,
-                    edit: editPermission,
+                    add: routeAddPermission,
+                    delete: routeDeletePermission,
+                    edit: routeEditPermission,
                 },
             },
         },
@@ -240,6 +240,14 @@ export default withToolbar(MediaOverview, function() {
         : undefined;
 
     const items = [];
+
+    const {permissions: collectionPermissions = {}} = this.collectionStore;
+
+    const addPermission = collectionPermissions.add !== undefined ? collectionPermissions.add : routeAddPermission;
+    const deletePermission = collectionPermissions.delete !== undefined
+        ? collectionPermissions.delete
+        : routeDeletePermission;
+    const editPermission = collectionPermissions.edit !== undefined ? collectionPermissions.edit : routeEditPermission;
 
     if (addPermission) {
         items.push({

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -8,7 +8,9 @@ jest.mock('sulu-admin-bundle/containers', () => {
     return {
         withToolbar: jest.fn((Component) => Component),
         Form: jest.fn(() => null),
-        ResourceFormStore: jest.fn(),
+        ResourceFormStore: jest.fn(function() {
+            this.destroy = jest.fn();
+        }),
         AbstractAdapter: require('sulu-admin-bundle/containers/List/adapters/AbstractAdapter').default,
         List: require('sulu-admin-bundle/containers/List/List').default,
         ListStore: jest.fn(function(resourceKey, observableOptions) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
+import {extendObservable as mockExtendObservable} from 'mobx';
 import {mount, render} from 'enzyme';
 import {findWithHighOrderFunction} from 'sulu-admin-bundle/utils/TestHelper';
 import MediaCardOverviewAdapter from '../../../containers/List/adapters/MediaCardOverviewAdapter';
@@ -109,14 +110,18 @@ jest.mock('sulu-admin-bundle/stores', () => ({
         this.destroy = jest.fn();
         this.loading = false;
         this.id = 1;
-        this.data = {
-            id: 1,
-            _embedded: {
-                parent: {
-                    id: 1,
+
+        mockExtendObservable(this, {
+            data: {
+                id: 1,
+                _embedded: {
+                    parent: {
+                        id: 1,
+                    },
                 },
+                _permissions: {},
             },
-        };
+        });
     }),
 }));
 
@@ -444,6 +449,39 @@ test('Toolbar buttons should disappear when permissions are missing', () => {
     mediaOverview.locale.set('de');
 
     expect(toolbarFunction.call(mediaOverview).items).toHaveLength(0);
+});
+
+test('Toolbar buttons should disappear when permissions are missing on current collection', () => {
+    const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const MediaOverview = require('../MediaOverview').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, MediaOverview);
+
+    const router = {
+        restore: jest.fn(),
+        bind: jest.fn(),
+        route: {
+            options: {
+                locales: ['de'],
+                permissions: {
+                    add: true,
+                    delete: true,
+                    edit: true,
+                },
+            },
+        },
+        attributes: {
+            id: 4,
+        },
+    };
+    const mediaOverview = mount(<MediaOverview router={router} />);
+    mediaOverview.instance().collectionId.set(4);
+    mediaOverview.instance().locale.set('de');
+
+    mediaOverview.instance().collectionStore.resourceStore.data = {
+        _permissions: {add: false, delete: false, edit: false},
+    };
+
+    expect(toolbarFunction.call(mediaOverview.instance()).items).toHaveLength(0);
 });
 
 test('Move overlay button should be disabled if nothing is selected', () => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -223,22 +223,26 @@ exports[`Render a simple MediaOverview 1`] = `
               >
                 sulu_admin.of 3
               </span>
-              <button
-                class="previous"
-              >
-                <span
-                  aria-label="su-angle-left"
-                  class="su-angle-left"
-                />
-              </button>
-              <button
-                class="next"
-              >
-                <span
-                  aria-label="su-angle-right"
-                  class="su-angle-right"
-                />
-              </button>
+              <div>
+                <button
+                  class="button icon button"
+                  type="button"
+                >
+                  <span
+                    aria-label="su-angle-left"
+                    class="su-angle-left buttonIcon"
+                  />
+                </button>
+                <button
+                  class="button icon button"
+                  type="button"
+                >
+                  <span
+                    aria-label="su-angle-right"
+                    class="su-angle-right buttonIcon"
+                  />
+                </button>
+              </div>
             </nav>
           </section>
         </div>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/__snapshots__/MediaOverview.test.js.snap
@@ -37,45 +37,34 @@ exports[`Render a simple MediaOverview 1`] = `
               />
             </li>
           </ul>
-          <div
-            class="icons"
-          >
-            <span
-              aria-label="su-pen"
-              class="su-pen clickable icon"
-              role="button"
-              tabindex="0"
-            />
-            <span
-              aria-label="su-trash-alt"
-              class="su-trash-alt clickable icon"
-              role="button"
-              tabindex="0"
-            />
-            <span
-              aria-label="su-arrows-alt"
-              class="su-arrows-alt clickable icon"
-              role="button"
-              tabindex="0"
-            />
-          </div>
         </div>
         <div
           class="right"
         >
-          <div>
+          <div
+            class="buttonGroup"
+          >
             <button
               class="button icon button"
               type="button"
             >
               <span
-                class="text"
-              >
-                <span
-                  aria-label="su-plus"
-                  class="su-plus"
-                />
-              </span>
+                aria-label="su-plus"
+                class="su-plus buttonIcon"
+              />
+            </button>
+            <button
+              class="button icon button"
+              type="button"
+            >
+              <span
+                aria-label="su-cog"
+                class="su-cog buttonIcon"
+              />
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down dropdownIcon"
+              />
             </button>
           </div>
         </div>
@@ -223,7 +212,9 @@ exports[`Render a simple MediaOverview 1`] = `
               >
                 sulu_admin.of 3
               </span>
-              <div>
+              <div
+                class="buttonGroup"
+              >
                 <button
                   class="button icon button"
                   type="button"
@@ -280,7 +271,9 @@ exports[`Render a simple MediaOverview 1`] = `
                 value=""
               />
             </label>
-            <div>
+            <div
+              class="buttonGroup"
+            >
               <button
                 class="button icon active button"
                 type="button"

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
@@ -13,7 +13,9 @@ exports[`Render PageList 1`] = `
       <div
         class="toolbar"
       >
-        <div>
+        <div
+          class="buttonGroup"
+        >
           <button
             class="button icon active button"
             type="button"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds an option for opening a permission overlay for collections.

#### Why?

Because the user should be able to set different permissions on different collections.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Remove delete button in toolbar when permission is missing
- [x] Check why moving works without edit permission