### PR TITLE
Hide actions for the Homepage Column in the ColumnList

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ColumnList.js
@@ -13,7 +13,7 @@ import columnListStyles from './columnList.scss';
 type Props = {|
     children: ChildrenArray<Element<typeof Column>>,
     onItemClick: (id: string | number) => void,
-    toolbarItemsProvider: (index: number) => Array<ToolbarItemConfig>,
+    toolbarItemsProvider: (index: number) => ?Array<ToolbarItemConfig>,
 |};
 
 @observer
@@ -138,12 +138,14 @@ class ColumnList extends React.Component<Props> {
 
         return (
             <div className={columnListStyles.columnListToolbarContainer}>
-                {!!toolbarItems.length &&
+                {!!toolbarItems &&
                     <div className={columnListStyles.toolbarContainer} style={{marginLeft: toolbarPosition}}>
-                        <Toolbar
-                            toolbarItems={toolbarItems}
-                            toolbarRef={this.setToolbarRef}
-                        />
+                        {!!toolbarItems.length &&
+                            <Toolbar
+                                toolbarItems={toolbarItems}
+                                toolbarRef={this.setToolbarRef}
+                            />
+                        }
                     </div>
                 }
                 <div className={columnListContainerClass} ref={this.setContainerRef}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/README.md
@@ -93,11 +93,84 @@ const indicators = [
 </div>
 ```
 
-The `toolbarItems` prop is not optional, but it is possible to return an empty array to use the `ColumnList` with an
-no toolbar.
+The `toolbarItems` prop is not optional, but it is possible to return `undefined` to use the `ColumnList` with no
+toolbar.
 
 ```
-const toolbarItems = () => [];
+const toolbarItems = () => undefined;
+
+<div style={{height: '60vh'}}>
+    <ColumnList toolbarItemsProvider={toolbarItems}>
+        <ColumnList.Column>
+            <ColumnList.Item id="1">Google 1</ColumnList.Item>
+            <ColumnList.Item id="2" hasChildren="true">Apple 1</ColumnList.Item>
+            <ColumnList.Item id="3">Microsoft 1</ColumnList.Item>
+        </ColumnList.Column>
+        <ColumnList.Column>
+            <ColumnList.Item id="1-1">Item 1</ColumnList.Item>
+            <ColumnList.Item id="1-2" hasChildren="true">Item 1</ColumnList.Item>
+        </ColumnList.Column>
+        <ColumnList.Column>
+            <ColumnList.Item id="1-1-1">Item 1</ColumnList.Item>
+            <ColumnList.Item id="1-1-2">Item 1</ColumnList.Item>
+        </ColumnList.Column>
+        <ColumnList.Column />
+    </ColumnList>
+</div>
+```
+
+By returning an empty array you indicated that only this single column does not have a toolbar, while the others might
+return something.
+
+```
+const toolbarItems = (index) => {
+    if (index === 0) {
+        return [];
+    }
+
+    return [
+        {
+            icon: 'fa-plus',
+            type: 'button',
+            onClick: (index) => {
+                alert('Clicked plus button for item with index: ' + index);
+            },
+        },
+        {
+            icon: 'fa-search',
+            type: 'button',
+            skin: 'secondary',
+            onClick: (index) => {
+                alert('Clicked search button for column with index: ' + index);
+            },
+        },
+        {
+            icon: 'fa-gear',
+            type: 'dropdown',
+            options: [
+                {
+                    label: 'Option1 ',
+                    onClick: (index) => {
+                        alert('Clicked option1 for column with index: ' + index);
+                    },
+                },
+                {
+                    label: 'Option2 ',
+                    onClick: (index) => {
+                        alert('Clicked option2 for column with index: ' + index);
+                    },
+                },
+                {
+                    isDisabled: (index) => true,
+                    label: 'Option3 ',
+                    onClick: (index) => {
+                        alert('This alert will never be called, because the button is disabled...');
+                    },
+                },
+            ],
+        },
+    ];
+};
 
 <div style={{height: '60vh'}}>
     <ColumnList toolbarItemsProvider={toolbarItems}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/columnList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/columnList.scss
@@ -13,6 +13,10 @@ $columnListContainerTextColor: $black;
     overflow: hidden;
 }
 
+.toolbar-container {
+    height: $toolbarHeight;
+}
+
 .column-list-container {
     color: $columnListContainerTextColor;
     height: 100%;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
@@ -21,6 +21,34 @@ jest.mock('../columnList.scss', () => new Proxy({}, {
 test('The ColumnList component should render in a non-scrolling container', () => {
     const onItemClick = jest.fn();
 
+    const toolbarItemsProvider = jest.fn(() => undefined);
+
+    expect(render(
+        <ColumnList
+            onItemClick={onItemClick}
+            toolbarItemsProvider={toolbarItemsProvider}
+        >
+            <Column>
+                <Item id="1" selected={true}>Item 1</Item>
+                <Item hasChildren={true} id="2">Item 1</Item>
+                <Item id="3">Item 1</Item>
+            </Column>
+            <Column>
+                <Item id="1-1">Item 1</Item>
+                <Item hasChildren={true} id="1-2">Item 1</Item>
+            </Column>
+            <Column>
+                <Item id="1-1-1">Item 1</Item>
+                <Item id="1-1-2">Item 1</Item>
+            </Column>
+            <Column loading={true} />
+        </ColumnList>
+    )).toMatchSnapshot();
+});
+
+test('The ColumnList component should render without ', () => {
+    const onItemClick = jest.fn();
+
     const buttonsConfig = [
         {
             icon: 'fa-heart',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
@@ -5,6 +5,703 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
   class="columnListToolbarContainer"
 >
   <div
+    class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
+  >
+    <div
+      class="columnList"
+    >
+      <div
+        class="column"
+        role="button"
+      >
+        <div
+          class="item selected"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </span>
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+      </div>
+      <div
+        class="column"
+        role="button"
+      >
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="column"
+        role="button"
+      >
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+      </div>
+      <div
+        class="column"
+        role="button"
+      >
+        <div
+          class="loader"
+        >
+          <div
+            class="spinner"
+            style="width:40px;height:40px"
+          >
+            <div
+              class="doubleBounce1"
+            />
+            <div
+              class="doubleBounce2"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`The ColumnList component should render in a scrolling container 1`] = `
+<div
+  class="columnListToolbarContainer"
+>
+  <div
+    class="toolbarContainer"
+    style="margin-left: 520px;"
+  >
+    <div
+      class="toolbar"
+    >
+      <button
+        class="item primary"
+      >
+        <span
+          aria-label="fa-plus"
+          class="fa fa-plus"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="columnListContainer lastVisibleColumnActive"
+  >
+    <div
+      class="columnList"
+    >
+      <div
+        class="column scrolling"
+        role="button"
+      >
+        <div
+          class="item selected"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </span>
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+      </div>
+      <div
+        class="column scrolling"
+        role="button"
+      >
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          >
+            <span
+              aria-label="su-angle-right"
+              class="su-angle-right"
+            />
+          </span>
+        </div>
+      </div>
+      <div
+        class="column scrolling"
+        role="button"
+      >
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+        <div
+          class="item"
+          role="button"
+        >
+          <span
+            class="buttons"
+          />
+          <span
+            class="text"
+          >
+            <div
+              aria-label="Item 1"
+              class="croppedText"
+              title="Item 1"
+            >
+              <div
+                aria-hidden="true"
+                class="front"
+              >
+                Ite
+              </div>
+              <div
+                aria-hidden="true"
+                class="back"
+              >
+                <span>
+                  m 1
+                </span>
+              </div>
+              <div
+                class="whole"
+              >
+                Item 1
+              </div>
+            </div>
+          </span>
+          <span
+            class="children"
+          />
+        </div>
+      </div>
+      <div
+        class="column scrolling"
+        role="button"
+      >
+        <div
+          class="loader"
+        >
+          <div
+            class="spinner"
+            style="width: 40px; height: 40px;"
+          >
+            <div
+              class="doubleBounce1"
+            />
+            <div
+              class="doubleBounce2"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`The ColumnList component should render without  1`] = `
+<div
+  class="columnListToolbarContainer"
+>
+  <div
     class="toolbarContainer"
     style="margin-left:0"
   >
@@ -440,363 +1137,6 @@ exports[`The ColumnList component should render in a non-scrolling container 1`]
           <div
             class="spinner"
             style="width:40px;height:40px"
-          >
-            <div
-              class="doubleBounce1"
-            />
-            <div
-              class="doubleBounce2"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`The ColumnList component should render in a scrolling container 1`] = `
-<div
-  class="columnListToolbarContainer"
->
-  <div
-    class="toolbarContainer"
-    style="margin-left: 520px;"
-  >
-    <div
-      class="toolbar"
-    >
-      <button
-        class="item primary"
-      >
-        <span
-          aria-label="fa-plus"
-          class="fa fa-plus"
-        />
-      </button>
-    </div>
-  </div>
-  <div
-    class="columnListContainer lastVisibleColumnActive"
-  >
-    <div
-      class="columnList"
-    >
-      <div
-        class="column scrolling"
-        role="button"
-      >
-        <div
-          class="item selected"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-        <div
-          class="item"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </span>
-        </div>
-        <div
-          class="item"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-      </div>
-      <div
-        class="column scrolling"
-        role="button"
-      >
-        <div
-          class="item"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-        <div
-          class="item"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          >
-            <span
-              aria-label="su-angle-right"
-              class="su-angle-right"
-            />
-          </span>
-        </div>
-      </div>
-      <div
-        class="column scrolling"
-        role="button"
-      >
-        <div
-          class="item"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-        <div
-          class="item"
-          role="button"
-        >
-          <span
-            class="buttons"
-          />
-          <span
-            class="text"
-          >
-            <div
-              aria-label="Item 1"
-              class="croppedText"
-              title="Item 1"
-            >
-              <div
-                aria-hidden="true"
-                class="front"
-              >
-                Ite
-              </div>
-              <div
-                aria-hidden="true"
-                class="back"
-              >
-                <span>
-                  m 1
-                </span>
-              </div>
-              <div
-                class="whole"
-              >
-                Item 1
-              </div>
-            </div>
-          </span>
-          <span
-            class="children"
-          />
-        </div>
-      </div>
-      <div
-        class="column scrolling"
-        role="button"
-      >
-        <div
-          class="loader"
-        >
-          <div
-            class="spinner"
-            style="width: 40px; height: 40px;"
           >
             <div
               class="doubleBounce1"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -15,7 +15,7 @@ type Props = {|
 |};
 
 @observer
-export default class ResourceLocator extends React.Component<Props> {
+class ResourceLocator extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
     };
@@ -80,3 +80,5 @@ export default class ResourceLocator extends React.Component<Props> {
         );
     }
 }
+
+export default ResourceLocator;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -31,6 +31,7 @@ import ColumnOptionsOverlay from './ColumnOptionsOverlay';
 
 type Props = {|
     actions?: Array<Action>,
+    adapterOptions?: {[adapterKey: string]: {[key: string]: mixed}},
     adapters: Array<string>,
     allowActivateForDisabledItems: boolean,
     copyable: boolean,
@@ -39,7 +40,7 @@ type Props = {|
     disabledIds: Array<string | number>,
     header?: Node,
     movable: boolean,
-    onItemAdd?: (id: string | number) => void,
+    onItemAdd?: (id: ?string | number) => void,
     onItemClick?: (itemId: string | number) => void,
     orderable: boolean,
     searchable: boolean,
@@ -413,6 +414,7 @@ class List extends React.Component<Props> {
     render() {
         const {
             actions,
+            adapterOptions,
             adapters,
             copyable,
             deletable,
@@ -473,6 +475,7 @@ class List extends React.Component<Props> {
                             actions={actions}
                             active={store.active.get()}
                             activeItems={store.activeItems}
+                            adapterOptions={adapterOptions ? adapterOptions[this.currentAdapterKey] : undefined}
                             data={store.data}
                             disabledIds={disabledIds}
                             limit={store.limit.get()}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -137,6 +137,9 @@ class ColumnListAdapter extends AbstractAdapter {
     getToolbarItems = (index: number) => {
         const {
             activeItems,
+            adapterOptions: {
+                display_root_level_toolbar: displayRootLevelToolbar = true,
+            } = {},
             data,
             onItemAdd,
             onRequestItemCopy,
@@ -150,6 +153,10 @@ class ColumnListAdapter extends AbstractAdapter {
                 'The ColumnListAdapter does not work without activeItems. '
                 + 'This error should not happen and is likely a bug.'
             );
+        }
+
+        if (!displayRootLevelToolbar && !activeItems[index]) {
+            return [];
         }
 
         if (this.orderColumn === index) {
@@ -179,9 +186,7 @@ class ColumnListAdapter extends AbstractAdapter {
                 icon: 'su-plus-circle',
                 type: 'button',
                 onClick: () => {
-                    if (activeItems && activeItems[index]) {
-                        onItemAdd(activeItems[index]);
-                    }
+                    onItemAdd(activeItems[index]);
                 },
             });
         }
@@ -266,7 +271,7 @@ class ColumnListAdapter extends AbstractAdapter {
             });
         }
 
-        return toolbarItems;
+        return toolbarItems.length > 0 ? toolbarItems : undefined;
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -53,18 +53,6 @@ class ColumnListAdapter extends AbstractAdapter {
         }
     };
 
-    handleColumnAdd = (index?: string | number) => {
-        if (!index || typeof index !== 'number') {
-            return;
-        }
-
-        const {activeItems, onItemAdd} = this.props;
-
-        if (onItemAdd && activeItems && activeItems[index]) {
-            onItemAdd(activeItems[index]);
-        }
-    };
-
     handleOrderChange = (id: string | number, order: number) => {
         const {data, onRequestItemOrder} = this.props;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -331,6 +331,22 @@ test('Pass the ids to be disabled to the adapter', () => {
     expect(list.find('TestAdapter').prop('disabledIds')).toBe(disabledIds);
 });
 
+test('Pass adapterOptions to the adapter', () => {
+    const adapterOptions = {table: {option1: 'value1'}, test: {option2: 'value2'}};
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    const list = shallow(<List adapterOptions={adapterOptions} adapters={['test']} store={listStore} />);
+
+    expect(list.find('TestAdapter').prop('adapterOptions')).toEqual({option2: 'value2'});
+});
+
+test('Pass undefined as adapterOptions to the adapter if no options for current adapter are passed', () => {
+    const adapterOptions = {table: {option1: 'value1'}};
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    const list = shallow(<List adapterOptions={adapterOptions} adapters={['test']} store={listStore} />);
+
+    expect(list.find('TestAdapter').prop('adapterOptions')).toEqual(undefined);
+});
+
 test('Call activate on store if item is activated', () => {
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
     const list = shallow(<List adapters={['test']} store={listStore} />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -286,6 +286,80 @@ test('Render without add button in toolbar when onItemAdd callback is given but 
     expect(columnListAdapter.find('Toolbar ToolbarButton[icon="su-plus-circle"]')).toHaveLength(0);
 });
 
+test('Render without toolbar for first column if display_root_level_toolbar option is set', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+            },
+            {
+                id: 2,
+                title: 'Page 2',
+                hasChildren: false,
+            },
+        ],
+        [
+            {
+                id: 3,
+                title: 'Page 1.1',
+                hasChildren: true,
+            },
+            {
+                id: 4,
+                title: 'Page 1.2',
+                hasChildren: false,
+                _permissions: {
+                    add: false,
+                },
+            },
+        ],
+        [],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined, 1, 4]}
+            adapterOptions={{display_root_level_toolbar: false}}
+            data={data}
+            onItemAdd={jest.fn()}
+            onRequestItemDelete={jest.fn()}
+        />
+    );
+
+    columnListAdapter.find('Column').at(0).find('div').at(0).simulate('mouseEnter');
+    columnListAdapter.update();
+    expect(columnListAdapter.find('Toolbar').children()).toHaveLength(0);
+
+    columnListAdapter.find('Column').at(1).find('div').at(0).simulate('mouseEnter');
+    columnListAdapter.update();
+    expect(columnListAdapter.find('Toolbar').children()).toHaveLength(1);
+});
+
+test('Render without toolbar when all actions would be deactivated', () => {
+    const data = [
+        [
+            {
+                id: 1,
+                title: 'Page 1',
+                hasChildren: true,
+            },
+        ],
+    ];
+
+    const columnListAdapter = mount(
+        <ColumnListAdapter
+            {...listAdapterDefaultProps}
+            activeItems={[undefined]}
+            data={data}
+        />
+    );
+
+    expect(columnListAdapter.find('Toolbar')).toHaveLength(0);
+});
+
 test('Render data with loading column', () => {
     const data = [
         [

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -323,10 +323,6 @@ exports[`Render data with name as fallback for title 1`] = `
     class="columnListToolbarContainer"
   >
     <div
-      class="toolbarContainer"
-      style="margin-left:0"
-    />
-    <div
       class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
     >
       <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -323,6 +323,10 @@ exports[`Render data with name as fallback for title 1`] = `
     class="columnListToolbarContainer"
   >
     <div
+      class="toolbarContainer"
+      style="margin-left:0"
+    />
+    <div
       class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
     >
       <div

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -28,17 +28,18 @@ export type Action = {|
     onClick: ?(itemId: string | number, index: number) => void,
 |};
 
-export type ListAdapterProps = {
+export type ListAdapterProps = {|
     actions?: Array<Action>,
     active: ?string | number,
     activeItems: ?Array<?string | number>,
+    adapterOptions?: {[key: string]: mixed},
     data: Array<*>,
     disabledIds: Array<string | number>,
     limit: number,
     loading: boolean,
     onAllSelectionChange: ?(selected?: boolean) => void,
     onItemActivate: (itemId: string | number) => void,
-    onItemAdd: ?(id: string | number) => void,
+    onItemAdd: ?(id: ?string | number) => void,
     onItemClick: ?(itemId: string | number) => void,
     onItemDeactivate: (itemId: string | number) => void,
     onItemSelectionChange: ?(rowId: string | number, selected?: boolean) => void,
@@ -56,7 +57,7 @@ export type ListAdapterProps = {
     selections: Array<number | string>,
     sortColumn: ?string,
     sortOrder: ?SortOrder,
-};
+|};
 
 export type ObservableOptions = {
     locale?: ?IObservableValue<string>,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -20,7 +20,7 @@ const DEFAULT_LIMIT = 10;
 
 type Props = ViewProps & {
     locale?: IObservableValue<string>,
-    onItemAdd?: (parentId: string | number) => void,
+    onItemAdd?: (parentId: ?string | number) => void,
     onItemClick?: (itemId: string | number) => void,
     resourceStore?: ResourceStore,
     title?: string,
@@ -241,7 +241,7 @@ class List extends React.Component<Props> {
         this.listStore.destroy();
     }
 
-    addItem = (parentId: string | number) => {
+    addItem = (parentId: ?string | number) => {
         const {onItemAdd, router} = this.props;
         const {
             route: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -1,9 +1,9 @@
 // @flow
-import type {IObservableValue} from 'mobx'; // eslint-disable-line import/named
+import type {IObservableValue} from 'mobx';
 import {action, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import type {ElementRef} from 'react';
-import React from 'react';
+import React, {Fragment} from 'react';
 import equals from 'fast-deep-equal';
 import {default as ListContainer, ListStore} from '../../containers/List';
 import {withToolbar} from '../../containers/Toolbar';
@@ -314,7 +314,7 @@ class List extends React.Component<Props> {
         const title = routeTitle ? translate(routeTitle) : propTitle;
 
         return (
-            <div>
+            <Fragment>
                 <ListContainer
                     adapters={adapters}
                     header={title && <h1 className={listStyles.header}>{title}</h1>}
@@ -325,7 +325,7 @@ class List extends React.Component<Props> {
                     store={this.listStore}
                 />
                 {this.toolbarActions.map((toolbarAction) => toolbarAction.getNode())}
-            </div>
+            </Fragment>
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -251,531 +251,527 @@ Array [
 `;
 
 exports[`Should render the list with a title 1`] = `
-<div>
+<div
+  class="listContainer"
+>
   <div
-    class="listContainer"
+    class="headerContainer"
   >
-    <div
-      class="headerContainer"
+    <h1
+      class="header"
     >
-      <h1
-        class="header"
+      Snippets
+    </h1>
+    <div
+      class="toolbar"
+    >
+      <label
+        class="input dark left collapsed hasAppendIcon"
       >
-        Snippets
-      </h1>
-      <div
-        class="toolbar"
-      >
-        <label
-          class="input dark left collapsed hasAppendIcon"
+        <div
+          class="prependedContainer dark collapsed"
         >
-          <div
-            class="prependedContainer dark collapsed"
-          >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <input
-            type="text"
-            value=""
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
           />
-        </label>
-        <div>
+        </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <div>
+        <button
+          class="button icon"
+          type="button"
+        >
+          <span
+            aria-label="su-sort"
+            class="su-sort buttonIcon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="list"
+  >
+    <section>
+      <div
+        class="tableContainer dark"
+      >
+        <table
+          class="table"
+        >
+          <thead
+            class="header"
+          >
+            <tr>
+              <th
+                class="headerCell"
+              >
+                <span>
+                  <label
+                    class="label"
+                  >
+                    <span
+                      class="switch checkbox light"
+                    >
+                      <input
+                        type="checkbox"
+                      />
+                      <span />
+                    </span>
+                  </label>
+                </span>
+              </th>
+              <th
+                class="headerCell clickable"
+              >
+                <button>
+                  Description
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="row"
+            >
+              <td
+                class="cell small"
+              >
+                <div
+                  class="cellContent"
+                >
+                  <label
+                    class="label"
+                  >
+                    <span
+                      class="switch checkbox dark"
+                    >
+                      <input
+                        type="checkbox"
+                        value="1"
+                      />
+                      <span />
+                    </span>
+                  </label>
+                </div>
+              </td>
+              <td
+                class="cell"
+              >
+                <div
+                  class="cellContent"
+                >
+                  Description 1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="row"
+            >
+              <td
+                class="cell small"
+              >
+                <div
+                  class="cellContent"
+                >
+                  <label
+                    class="label"
+                  >
+                    <span
+                      class="switch checkbox dark"
+                    >
+                      <input
+                        type="checkbox"
+                        value="2"
+                      />
+                      <span />
+                    </span>
+                  </label>
+                </div>
+              </td>
+              <td
+                class="cell"
+              >
+                <div
+                  class="cellContent"
+                >
+                  Description 2
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <nav
+        class="pagination"
+      >
+        <span
+          class="display"
+        >
+          :
+        </span>
+        <span>
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue dark"
+              type="button"
+            >
+              <div
+                aria-label="10"
+                class="croppedText"
+                title="10"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  1
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    0
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  10
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </span>
+        <div
+          class="loader"
+        />
+        <span>
+          Page:
+        </span>
+        <span
+          class="inputContainer"
+        >
+          <label
+            class="input dark center"
+          >
+            <input
+              inputmode="numeric"
+              type="text"
+              value="1"
+            />
+          </label>
+        </span>
+        <span
+          class="display"
+        >
+          of 3
+        </span>
+        <div
+          class="buttonGroup"
+        >
           <button
-            class="button icon"
+            class="button icon button"
             type="button"
           >
             <span
-              aria-label="su-sort"
-              class="su-sort buttonIcon"
+              aria-label="su-angle-left"
+              class="su-angle-left buttonIcon"
             />
+          </button>
+          <button
+            class="button icon button"
+            type="button"
+          >
             <span
-              aria-label="su-angle-down"
-              class="su-angle-down dropdownIcon"
+              aria-label="su-angle-right"
+              class="su-angle-right buttonIcon"
             />
           </button>
         </div>
-      </div>
-    </div>
-    <div
-      class="list"
-    >
-      <section>
-        <div
-          class="tableContainer dark"
-        >
-          <table
-            class="table"
-          >
-            <thead
-              class="header"
-            >
-              <tr>
-                <th
-                  class="headerCell"
-                >
-                  <span>
-                    <label
-                      class="label"
-                    >
-                      <span
-                        class="switch checkbox light"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <span />
-                      </span>
-                    </label>
-                  </span>
-                </th>
-                <th
-                  class="headerCell clickable"
-                >
-                  <button>
-                    Description
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                class="row"
-              >
-                <td
-                  class="cell small"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    <label
-                      class="label"
-                    >
-                      <span
-                        class="switch checkbox dark"
-                      >
-                        <input
-                          type="checkbox"
-                          value="1"
-                        />
-                        <span />
-                      </span>
-                    </label>
-                  </div>
-                </td>
-                <td
-                  class="cell"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    Description 1
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class="row"
-              >
-                <td
-                  class="cell small"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    <label
-                      class="label"
-                    >
-                      <span
-                        class="switch checkbox dark"
-                      >
-                        <input
-                          type="checkbox"
-                          value="2"
-                        />
-                        <span />
-                      </span>
-                    </label>
-                  </div>
-                </td>
-                <td
-                  class="cell"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    Description 2
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <nav
-          class="pagination"
-        >
-          <span
-            class="display"
-          >
-            :
-          </span>
-          <span>
-            <div
-              class="select"
-            >
-              <button
-                class="displayValue dark"
-                type="button"
-              >
-                <div
-                  aria-label="10"
-                  class="croppedText"
-                  title="10"
-                >
-                  <div
-                    aria-hidden="true"
-                    class="front"
-                  >
-                    1
-                  </div>
-                  <div
-                    aria-hidden="true"
-                    class="back"
-                  >
-                    <span>
-                      0
-                    </span>
-                  </div>
-                  <div
-                    class="whole"
-                  >
-                    10
-                  </div>
-                </div>
-                <span
-                  aria-label="su-angle-down"
-                  class="su-angle-down toggle"
-                />
-              </button>
-            </div>
-          </span>
-          <div
-            class="loader"
-          />
-          <span>
-            Page:
-          </span>
-          <span
-            class="inputContainer"
-          >
-            <label
-              class="input dark center"
-            >
-              <input
-                inputmode="numeric"
-                type="text"
-                value="1"
-              />
-            </label>
-          </span>
-          <span
-            class="display"
-          >
-            of 3
-          </span>
-          <div
-            class="buttonGroup"
-          >
-            <button
-              class="button icon button"
-              type="button"
-            >
-              <span
-                aria-label="su-angle-left"
-                class="su-angle-left buttonIcon"
-              />
-            </button>
-            <button
-              class="button icon button"
-              type="button"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right buttonIcon"
-              />
-            </button>
-          </div>
-        </nav>
-      </section>
-    </div>
+      </nav>
+    </section>
   </div>
 </div>
 `;
 
 exports[`Should render the list with the correct resourceKey 1`] = `
-<div>
+<div
+  class="listContainer"
+>
   <div
-    class="listContainer"
+    class="headerContainer"
   >
-    <div
-      class="headerContainer"
+    <h1
+      class="header"
     >
-      <h1
-        class="header"
+      Test 1
+    </h1>
+    <div
+      class="toolbar"
+    >
+      <label
+        class="input dark left collapsed hasAppendIcon"
       >
-        Test 1
-      </h1>
-      <div
-        class="toolbar"
-      >
-        <label
-          class="input dark left collapsed hasAppendIcon"
+        <div
+          class="prependedContainer dark collapsed"
         >
-          <div
-            class="prependedContainer dark collapsed"
-          >
-            <span
-              aria-label="su-search"
-              class="su-search clickable icon dark iconClickable collapsed"
-              role="button"
-              tabindex="0"
-            />
-          </div>
-          <input
-            type="text"
-            value=""
+          <span
+            aria-label="su-search"
+            class="su-search clickable icon dark iconClickable collapsed"
+            role="button"
+            tabindex="0"
           />
-        </label>
-        <div>
+        </div>
+        <input
+          type="text"
+          value=""
+        />
+      </label>
+      <div>
+        <button
+          class="button icon"
+          type="button"
+        >
+          <span
+            aria-label="su-sort"
+            class="su-sort buttonIcon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="list"
+  >
+    <section>
+      <div
+        class="tableContainer dark"
+      >
+        <table
+          class="table"
+        >
+          <thead
+            class="header"
+          >
+            <tr>
+              <th
+                class="headerCell"
+              >
+                <span>
+                  <label
+                    class="label"
+                  >
+                    <span
+                      class="switch checkbox light"
+                    >
+                      <input
+                        type="checkbox"
+                      />
+                      <span />
+                    </span>
+                  </label>
+                </span>
+              </th>
+              <th
+                class="headerCell clickable"
+              >
+                <button>
+                  Description
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="row"
+            >
+              <td
+                class="cell small"
+              >
+                <div
+                  class="cellContent"
+                >
+                  <label
+                    class="label"
+                  >
+                    <span
+                      class="switch checkbox dark"
+                    >
+                      <input
+                        type="checkbox"
+                        value="1"
+                      />
+                      <span />
+                    </span>
+                  </label>
+                </div>
+              </td>
+              <td
+                class="cell"
+              >
+                <div
+                  class="cellContent"
+                >
+                  Description 1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="row"
+            >
+              <td
+                class="cell small"
+              >
+                <div
+                  class="cellContent"
+                >
+                  <label
+                    class="label"
+                  >
+                    <span
+                      class="switch checkbox dark"
+                    >
+                      <input
+                        type="checkbox"
+                        value="2"
+                      />
+                      <span />
+                    </span>
+                  </label>
+                </div>
+              </td>
+              <td
+                class="cell"
+              >
+                <div
+                  class="cellContent"
+                >
+                  Description 2
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <nav
+        class="pagination"
+      >
+        <span
+          class="display"
+        >
+          :
+        </span>
+        <span>
+          <div
+            class="select"
+          >
+            <button
+              class="displayValue dark"
+              type="button"
+            >
+              <div
+                aria-label="10"
+                class="croppedText"
+                title="10"
+              >
+                <div
+                  aria-hidden="true"
+                  class="front"
+                >
+                  1
+                </div>
+                <div
+                  aria-hidden="true"
+                  class="back"
+                >
+                  <span>
+                    0
+                  </span>
+                </div>
+                <div
+                  class="whole"
+                >
+                  10
+                </div>
+              </div>
+              <span
+                aria-label="su-angle-down"
+                class="su-angle-down toggle"
+              />
+            </button>
+          </div>
+        </span>
+        <div
+          class="loader"
+        />
+        <span>
+          Page:
+        </span>
+        <span
+          class="inputContainer"
+        >
+          <label
+            class="input dark center"
+          >
+            <input
+              inputmode="numeric"
+              type="text"
+              value="1"
+            />
+          </label>
+        </span>
+        <span
+          class="display"
+        >
+          of 3
+        </span>
+        <div
+          class="buttonGroup"
+        >
           <button
-            class="button icon"
+            class="button icon button"
             type="button"
           >
             <span
-              aria-label="su-sort"
-              class="su-sort buttonIcon"
+              aria-label="su-angle-left"
+              class="su-angle-left buttonIcon"
             />
+          </button>
+          <button
+            class="button icon button"
+            type="button"
+          >
             <span
-              aria-label="su-angle-down"
-              class="su-angle-down dropdownIcon"
+              aria-label="su-angle-right"
+              class="su-angle-right buttonIcon"
             />
           </button>
         </div>
-      </div>
-    </div>
-    <div
-      class="list"
-    >
-      <section>
-        <div
-          class="tableContainer dark"
-        >
-          <table
-            class="table"
-          >
-            <thead
-              class="header"
-            >
-              <tr>
-                <th
-                  class="headerCell"
-                >
-                  <span>
-                    <label
-                      class="label"
-                    >
-                      <span
-                        class="switch checkbox light"
-                      >
-                        <input
-                          type="checkbox"
-                        />
-                        <span />
-                      </span>
-                    </label>
-                  </span>
-                </th>
-                <th
-                  class="headerCell clickable"
-                >
-                  <button>
-                    Description
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                class="row"
-              >
-                <td
-                  class="cell small"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    <label
-                      class="label"
-                    >
-                      <span
-                        class="switch checkbox dark"
-                      >
-                        <input
-                          type="checkbox"
-                          value="1"
-                        />
-                        <span />
-                      </span>
-                    </label>
-                  </div>
-                </td>
-                <td
-                  class="cell"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    Description 1
-                  </div>
-                </td>
-              </tr>
-              <tr
-                class="row"
-              >
-                <td
-                  class="cell small"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    <label
-                      class="label"
-                    >
-                      <span
-                        class="switch checkbox dark"
-                      >
-                        <input
-                          type="checkbox"
-                          value="2"
-                        />
-                        <span />
-                      </span>
-                    </label>
-                  </div>
-                </td>
-                <td
-                  class="cell"
-                >
-                  <div
-                    class="cellContent"
-                  >
-                    Description 2
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <nav
-          class="pagination"
-        >
-          <span
-            class="display"
-          >
-            :
-          </span>
-          <span>
-            <div
-              class="select"
-            >
-              <button
-                class="displayValue dark"
-                type="button"
-              >
-                <div
-                  aria-label="10"
-                  class="croppedText"
-                  title="10"
-                >
-                  <div
-                    aria-hidden="true"
-                    class="front"
-                  >
-                    1
-                  </div>
-                  <div
-                    aria-hidden="true"
-                    class="back"
-                  >
-                    <span>
-                      0
-                    </span>
-                  </div>
-                  <div
-                    class="whole"
-                  >
-                    10
-                  </div>
-                </div>
-                <span
-                  aria-label="su-angle-down"
-                  class="su-angle-down toggle"
-                />
-              </button>
-            </div>
-          </span>
-          <div
-            class="loader"
-          />
-          <span>
-            Page:
-          </span>
-          <span
-            class="inputContainer"
-          >
-            <label
-              class="input dark center"
-            >
-              <input
-                inputmode="numeric"
-                type="text"
-                value="1"
-              />
-            </label>
-          </span>
-          <span
-            class="display"
-          >
-            of 3
-          </span>
-          <div
-            class="buttonGroup"
-          >
-            <button
-              class="button icon button"
-              type="button"
-            >
-              <span
-                aria-label="su-angle-left"
-                class="su-angle-left buttonIcon"
-              />
-            </button>
-            <button
-              class="button icon button"
-              type="button"
-            >
-              <span
-                aria-label="su-angle-right"
-                class="su-angle-right buttonIcon"
-              />
-            </button>
-          </div>
-        </nav>
-      </section>
-    </div>
+      </nav>
+    </section>
   </div>
 </div>
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/adapters/MediaCardAdapter.js
@@ -8,7 +8,8 @@ import MediaCard from '../../../components/MediaCard';
 
 const THUMBNAIL_SIZE = 'sulu-240x';
 
-type Props = ListAdapterProps & {
+type Props = {
+    ...ListAdapterProps,
     icon: string,
     showCoverWhenSelected?: boolean,
 };

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -141,7 +141,7 @@ class PageAdmin extends Admin
         ];
 
         if ($this->hasSomeWebspacePermission()) {
-            $routes[] = (new Route(static::PAGES_ROUTE, '/pages/:locale', 'sulu_page.webspace_overview'))
+            $routes[] = (new Route(static::PAGES_ROUTE, '/pages/:locale', 'sulu_page.page_list'))
                 ->setAttributeDefault('locale', $firstWebspace->getDefaultLocalization()->getLocale())
                 ->setOption('tabTitle', 'sulu_page.pages')
                 ->setOption('tabOrder', 0)

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -20,7 +20,7 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
     }
 
     viewRegistry.add('sulu_page.page_tabs', PageTabs);
-    viewRegistry.add('sulu_page.webspace_overview', PageList);
+    viewRegistry.add('sulu_page.page_list', PageList);
     viewRegistry.add('sulu_page.webspace_tabs', WebspaceTabs);
 
     fieldRegistry.add('page_settings_navigation_select', PageSettingsNavigationSelect);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/PageList.js
@@ -161,6 +161,11 @@ class PageList extends React.Component<Props> {
         return (
             <div className={pageListStyles.pageList}>
                 <List
+                    adapterOptions={{
+                        column_list: {
+                            display_root_level_toolbar: false,
+                        },
+                    }}
                     adapters={['column_list', 'tree_table']}
                     onItemAdd={this.handleItemAdd}
                     onItemClick={this.handleEditClick}

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/__snapshots__/PageList.test.js.snap
@@ -57,32 +57,7 @@ exports[`Render PageList 1`] = `
           <div
             class="toolbarContainer"
             style="margin-left: 0px;"
-          >
-            <div
-              class="toolbar"
-            >
-              <button
-                class="item primary"
-              >
-                <span
-                  aria-label="su-plus-circle"
-                  class="su-plus-circle"
-                />
-              </button>
-              <button
-                class="item primary"
-              >
-                <span
-                  aria-label="su-cog"
-                  class="su-cog"
-                />
-                <span
-                  aria-label="su-angle-down"
-                  class="su-angle-down buttonArrowIcon"
-                />
-              </button>
-            </div>
-          </div>
+          />
           <div
             class="columnListContainer firstVisibleColumnActive lastVisibleColumnActive"
           >


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR hides the actions for the first column in the ColumnList containing the Homepage.

#### Why?

Because it should not be possible to delete or add a homepage.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
