### PR TITLE
Add mandatory condition to templates

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -72,6 +72,7 @@ class FormMetadataMapper
         $section->setColSpan($property->getColSpan());
         $section->setDisabledCondition($property->getDisabledCondition());
         $section->setVisibleCondition($property->getVisibleCondition());
+        $section->setMandatoryCondition($property->getMandatoryCondition());
 
         foreach ($property->getChildren() as $component) {
             if ($component instanceof BlockMetadata) {
@@ -126,6 +127,7 @@ class FormMetadataMapper
         $field->setLabel($property->getTitle($locale));
         $field->setDisabledCondition($property->getDisabledCondition());
         $field->setVisibleCondition($property->getVisibleCondition());
+        $field->setMandatoryCondition($property->getMandatoryCondition());
         $field->setDescription($property->getDescription($locale));
         $field->setType($property->getType());
         $field->setColSpan($property->getColSpan());

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
@@ -40,6 +40,11 @@ abstract class ItemMetadata
     /**
      * @var string
      */
+    protected $mandatoryCondition;
+
+    /**
+     * @var string
+     */
     protected $description;
 
     /**
@@ -90,6 +95,16 @@ abstract class ItemMetadata
     public function setVisibleCondition(?string $visibleCondition): void
     {
         $this->visibleCondition = $visibleCondition;
+    }
+
+    public function getMandatoryCondition(): ?string
+    {
+        return $this->mandatoryCondition;
+    }
+
+    public function setMandatoryCondition(?string $mandatoryCondition): void
+    {
+        $this->mandatoryCondition = $mandatoryCondition;
     }
 
     public function getDescription(): ?string

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -227,7 +227,7 @@ export default class AbstractFormStore {
     }
 
     updateFieldPathEvaluations = () => {
-        const {loading, rawSchema, jsonSchema} = this;
+        const {loading, rawSchema} = this;
         const locale = this.locale ? this.locale.get() : undefined;
 
         when(

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -1,10 +1,10 @@
 // @flow
-import { action, computed, observable, set, toJS, untracked, when } from 'mobx';
-import type { IObservableValue } from 'mobx';
+import {action, computed, observable, set, toJS, untracked, when} from 'mobx';
+import type {IObservableValue} from 'mobx';
 import jexl from 'jexl';
 import jsonpointer from 'json-pointer';
 import log from 'loglevel';
-import type { RawSchema, RawSchemaEntry, Schema, SchemaEntry } from '../types';
+import type {RawSchema, RawSchemaEntry, Schema, SchemaEntry} from '../types';
 
 const SECTION_TYPE = 'section';
 
@@ -59,7 +59,8 @@ function transformRawSchemaEntry(
         } else if (schemaEntryKey === 'mandatoryCondition' && rawSchemaEntry[schemaEntryKey]) {
             schemaEntry.required = jexl.evalSync(rawSchemaEntry[schemaEntryKey], evaluationData);
         } else if (schemaEntryKey === 'required') {
-            schemaEntry.required = schemaEntry.required === undefined ? rawSchemaEntry[schemaEntryKey] : schemaEntry[schemaEntryKey];
+            schemaEntry.required =
+                schemaEntry.required === undefined ? rawSchemaEntry[schemaEntryKey] : schemaEntry[schemaEntryKey];
         } else if (schemaEntryKey === 'items' && rawSchemaEntry.items) {
             schemaEntry.items = transformRawSchema(rawSchemaEntry.items, data, path);
         } else if (schemaEntryKey === 'types' && rawSchemaEntry.types) {
@@ -83,9 +84,10 @@ function transformRawSchemaEntry(
             schemaEntry[schemaEntryKey] = rawSchemaEntry[schemaEntryKey];
         }
 
-        if (schemaEntry['required'] === true && (schemaEntry['disabled'] === true || schemaEntry['visible'] === false)) {
+        if (schemaEntry['required'] === true &&
+            (schemaEntry['disabled'] === true || schemaEntry['visible'] === false)) {
             schemaEntry['required'] = false;
-            log.warn("Mandatory field has been disabled or hidden and is no longer mandatory!")
+            log.warn('Mandatory field has been disabled or hidden and is no longer mandatory!');
         }
 
         return schemaEntry;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -70,8 +70,8 @@ type BaseSchemaEntry = {
 export type RawSchemaEntry = BaseSchemaEntry & {
     disabledCondition?: string,
     items?: RawSchema,
-    types?: RawTypes,
     mandatoryCondition?: string,
+    types?: RawTypes,
     visibleCondition?: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -71,6 +71,7 @@ export type RawSchemaEntry = BaseSchemaEntry & {
     disabledCondition?: string,
     items?: RawSchema,
     types?: RawTypes,
+    mandatoryCondition?: string,
     visibleCondition?: string,
 };
 

--- a/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/forms/page_settings.xml
@@ -93,7 +93,7 @@
                         <title>sulu_page.link_title</title>
                     </meta>
                 </property>
-                <property name="internal_link" type="single_page_selection" visibleCondition="nodeType == 2">
+                <property name="internal_link" type="single_page_selection" visibleCondition="nodeType == 2" mandatory="true">
                     <meta>
                         <title>sulu_page.linked_content</title>
                     </meta>

--- a/src/Sulu/Component/Content/Metadata/ItemMetadata.php
+++ b/src/Sulu/Component/Content/Metadata/ItemMetadata.php
@@ -83,6 +83,11 @@ abstract class ItemMetadata
     protected $visibleCondition = null;
 
     /**
+     * @var string
+     */
+    protected $mandatoryCondition = null;
+
+    /**
      * @param mixed $name
      */
     public function __construct($name = null)
@@ -374,6 +379,18 @@ abstract class ItemMetadata
     public function setVisibleCondition(?string $visibleCondition): self
     {
         $this->visibleCondition = $visibleCondition;
+
+        return $this;
+    }
+
+    public function getMandatoryCondition(): ?string
+    {
+        return $this->mandatoryCondition;
+    }
+
+    public function setMandatoryCondition(?string $mandatoryCondition): self
+    {
+        $this->mandatoryCondition = $mandatoryCondition;
 
         return $this;
     }

--- a/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
+++ b/src/Sulu/Component/Content/Metadata/Loader/schema/properties-1.0.xsd
@@ -75,6 +75,7 @@
         <xs:attribute type="xs:integer" name="colspan" use="optional" default="12"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
+        <xs:attribute type="xs:string" name="mandatoryCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 
@@ -104,6 +105,7 @@
         <xs:attribute type="xs:integer" name="spaceAfter" use="optional"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
+        <xs:attribute type="xs:string" name="mandatoryCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 
@@ -124,6 +126,7 @@
         <xs:attribute type="xs:integer" name="colspan" use="optional" default="12"/>
         <xs:attribute type="xs:string" name="disabledCondition" use="optional"/>
         <xs:attribute type="xs:string" name="visibleCondition" use="optional"/>
+        <xs:attribute type="xs:string" name="mandatoryCondition" use="optional"/>
         <xs:attributeGroup ref="defaultAttributes"/>
     </xs:complexType>
 

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -399,7 +399,7 @@ class PropertiesXmlParser
             $section->setVisibleCondition($data['visibleCondition']);
         }
 
-        if(isset($data['mandatoryCondition'])) {
+        if (isset($data['mandatoryCondition'])) {
             $section->setMandatoryCondition($data['mandatoryCondition']);
         }
 

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -93,6 +93,7 @@ class PropertiesXmlParser
                 'spaceAfter',
                 'disabledCondition',
                 'visibleCondition',
+                'mandatoryCondition',
             ]
         );
 
@@ -157,6 +158,7 @@ class PropertiesXmlParser
                 'cssClass',
                 'disabledCondition',
                 'visibleCondition',
+                'mandatoryCondition',
             ]
         );
 
@@ -178,7 +180,7 @@ class PropertiesXmlParser
         $result = $this->loadValues(
             $xpath,
             $node,
-            ['name', 'colspan', 'cssClass', 'disabledCondition', 'visibleCondition']
+            ['name', 'colspan', 'cssClass', 'disabledCondition', 'visibleCondition', 'mandatoryCondition']
         );
 
         $result['type'] = 'section';
@@ -397,6 +399,10 @@ class PropertiesXmlParser
             $section->setVisibleCondition($data['visibleCondition']);
         }
 
+        if(isset($data['mandatoryCondition'])) {
+            $section->setMandatoryCondition($data['mandatoryCondition']);
+        }
+
         foreach ($data['properties'] as $name => $property) {
             $section->addChild($this->createProperty($name, $property));
         }
@@ -416,6 +422,10 @@ class PropertiesXmlParser
 
         if (isset($data['visibleCondition'])) {
             $blockProperty->setVisibleCondition($data['visibleCondition']);
+        }
+
+        if (isset($data['mandatoryCondition'])) {
+            $blockProperty->setMandatoryCondition($data['mandatoryCondition']);
         }
 
         if (isset($data['meta']['title'])) {
@@ -470,6 +480,9 @@ class PropertiesXmlParser
         );
         $property->setVisibleCondition(
             array_key_exists('visibleCondition', $data) ? $data['visibleCondition'] : null
+        );
+        $property->setMandatoryCondition(
+            array_key_exists('mandatoryCondition', $data) ? $data['mandatoryCondition'] : null
         );
         $property->setParameters($data['params']);
         $property->setOnInvalid(array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| Fixes issue | fixes #4609
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?
Disable the mandatory property, when the field is hidden or disabled.
Add a mandatory condition to xml templates.

#### Why?
If a mandatory field is hidden, the form fails to validate and the user doesn't get a proper error message.

#### Example Usage

~~~xml
<property name="article" type="text_line" mandatoryCondition="title == 'testTitle">
        <meta>
            <title lang="en">Article</title>
        </meta>
</property>
~~~

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
