### PR TITLE
Add view data for the single media selection content type

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -61,6 +61,14 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
     /**
      * {@inheritdoc}
      */
+    public function getViewData(PropertyInterface $property)
+    {
+        return $property->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function preResolve(PropertyInterface $property)
     {
         $data = $property->getValue();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/SingleMediaSelectionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/SingleMediaSelectionTest.php
@@ -168,8 +168,7 @@ class SingleMediaSelectionTest extends TestCase
         $property = new Property('media', [], 'single_media_selection');
         $property->setValue(null);
 
-        $this->assertEquals(
-            [],
+        $this->assertNull(
             $this->singleMediaSelection->getViewData($property)
         );
     }
@@ -180,7 +179,7 @@ class SingleMediaSelectionTest extends TestCase
         $property->setValue(['id' => 11]);
 
         $this->assertEquals(
-            [],
+            ['id' => 11],
             $this->singleMediaSelection->getViewData($property)
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Implemented `getViewData` for the single media selection content type similar to the media selection content type.

#### Why?

To make view data like the display options available.
