### PR TITLE
Use permissions from security context if no object security has been set

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/RolePermissions.js
@@ -22,6 +22,9 @@ class RolePermissions extends React.Component<Props> {
         disabled: false,
     };
 
+    // TODO Could be removed by using resourceKey for security as well instead of separate security context
+    static resourceKeyMapping: {[resourceKey: string]: string};
+
     @observable roles: ?Array<Role>;
     @observable actions: ?Array<string>;
 
@@ -38,15 +41,19 @@ class RolePermissions extends React.Component<Props> {
     }
 
     @computed get defaultValue() {
+        const {resourceKey} = this.props;
         const {actions, roles} = this;
 
         if (!actions || ! roles) {
             return {};
         }
 
+        const securityContext = RolePermissions.resourceKeyMapping[resourceKey];
+
         return roles.reduce((value, role) => {
+            const rolePermission = role.permissions.find((permission) => permission.context === securityContext);
             value[role.id] = actions.reduce((actionValue, action) => {
-                actionValue[action] = true;
+                actionValue[action] = rolePermission ? rolePermission.permissions[action] : true;
 
                 return actionValue;
             }, {});

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/RolePermissions.test.js.snap
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/__snapshots__/RolePermissions.test.js.snap
@@ -167,6 +167,141 @@ exports[`Render matrix with correct all values selected if not given 2`] = `
 </table>
 `;
 
+exports[`Render matrix with correct default values from roles 1`] = `
+<table
+  class="matrix"
+>
+  <tbody>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
+      >
+        Admin
+      </td>
+      <td
+        class="items"
+      >
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Security"
+        >
+          <span
+            aria-label="su-lock"
+            class="su-lock"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          sulu_admin.deactivate_all
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="row"
+    >
+      <td
+        class="name"
+      >
+        Contact Manager
+      </td>
+      <td
+        class="items"
+      >
+        <div
+          class="item selected"
+          title="View"
+        >
+          <span
+            aria-label="su-eye"
+            class="su-eye"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Add"
+        >
+          <span
+            aria-label="su-plus-circle"
+            class="su-plus-circle"
+          />
+        </div>
+        <div
+          class="item"
+          title="Edit"
+        >
+          <span
+            aria-label="su-pen"
+            class="su-pen"
+          />
+        </div>
+        <div
+          class="item"
+          title="Delete"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </div>
+        <div
+          class="item selected"
+          title="Security"
+        >
+          <span
+            aria-label="su-lock"
+            class="su-lock"
+          />
+        </div>
+        <button
+          class="rowButton"
+        >
+          sulu_admin.deactivate_all
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`Render matrix with correct given values 1`] = `
 <div
   class="spinner"

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/index.js
@@ -3,6 +3,7 @@ import {initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry} from 'sulu-admin-bundle/containers';
 import {formToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import {Permissions, RoleAssignments, RolePermissions} from './containers/Form';
+import RolePermissionsContainer from './containers/RolePermissions';
 import securityContextStore from './stores/SecurityContextStore';
 import EnableUserToolbarAction from './views/Form/toolbarActions/EnableUserToolbarAction';
 
@@ -14,5 +15,7 @@ formToolbarActionRegistry.add('sulu_security.enable_user', EnableUserToolbarActi
 
 initializer.addUpdateConfigHook('sulu_security', (config: Object) => {
     securityContextStore.endpoint = config.endpoints.contexts;
+    // TODO resourceKeyMapping could be removed by using resourceKey instead of separate security context
     securityContextStore.resourceKeyMapping = config.resourceKeySecurityContextMapping;
+    RolePermissionsContainer.resourceKeyMapping = config.resourceKeySecurityContextMapping;
 });

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/SecurityContextStore.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/stores/SecurityContextStore/SecurityContextStore.js
@@ -5,6 +5,8 @@ import type {SecurityContextGroups, Systems} from './types';
 class SecurityContextStore {
     endpoint: string;
     promise: Promise<Systems>;
+
+    // TODO Could be removed by using resourceKey for security as well instead of separate security key
     resourceKeyMapping: {[resourceKey: string]: string};
 
     sendRequest(): Promise<Systems> {

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/types.js
@@ -1,8 +1,14 @@
 // @flow
 
+type Permission = {|
+    context: string,
+    permissions: {[key: string]: boolean},
+|};
+
 export type Role = {|
     id: number,
     identifier: string,
     name: string,
+    permissions: Array<Permission>,
     system: string,
 |};

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -89,7 +89,7 @@ class AccessControlManager implements AccessControlManagerInterface
         }
 
         $objectPermissions = $this->getUserObjectPermission($securityCondition, $user);
-        $checkPermissionType = empty($objectPermissions);
+        $checkPermissionType = $objectPermissions === null;
 
         $securityContextPermissions = $this->getUserSecurityContextPermissions(
             $securityCondition->getLocale(),
@@ -111,7 +111,7 @@ class AccessControlManager implements AccessControlManagerInterface
     public function getUserPermissionByArray($locale, $securityContext, $objectPermissionsByRole, UserInterface $user)
     {
         $objectPermissions = $this->getUserObjectPermissionByArray($objectPermissionsByRole, $user);
-        $checkPermissionType = empty($objectPermissions);
+        $checkPermissionType = $objectPermissions === null;
 
         $securityContextPermissions = $this->getUserSecurityContextPermissions(
             $locale,
@@ -163,7 +163,7 @@ class AccessControlManager implements AccessControlManagerInterface
     private function getUserObjectPermissionByArray($permissions, UserInterface $user)
     {
         if (empty($permissions)) {
-            return [];
+            return null;
         }
 
         $userPermission = [];

--- a/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/AccessControlManager.php
@@ -89,7 +89,7 @@ class AccessControlManager implements AccessControlManagerInterface
         }
 
         $objectPermissions = $this->getUserObjectPermission($securityCondition, $user);
-        $checkPermissionType = $objectPermissions === null;
+        $checkPermissionType = null === $objectPermissions;
 
         $securityContextPermissions = $this->getUserSecurityContextPermissions(
             $securityCondition->getLocale(),
@@ -111,7 +111,7 @@ class AccessControlManager implements AccessControlManagerInterface
     public function getUserPermissionByArray($locale, $securityContext, $objectPermissionsByRole, UserInterface $user)
     {
         $objectPermissions = $this->getUserObjectPermissionByArray($objectPermissionsByRole, $user);
-        $checkPermissionType = $objectPermissions === null;
+        $checkPermissionType = null === $objectPermissions;
 
         $securityContextPermissions = $this->getUserSecurityContextPermissions(
             $locale,

--- a/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
+++ b/src/Sulu/Component/Security/Tests/Unit/Authorization/AccessControl/AccessControlManagerTest.php
@@ -157,7 +157,8 @@ class AccessControlManagerTest extends TestCase
         $this->assertEquals($result, $permissions);
     }
 
-    public function testGetUserPermissionsWithMissingRole() {
+    public function testGetUserPermissionsWithMissingRole()
+    {
         $this->maskConverter->convertPermissionsToArray(0)->willReturn(['view' => false, 'edit' => false]);
         $this->maskConverter->convertPermissionsToArray(64)->willReturn(['view' => true, 'edit' => false]);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses the permissions from the security context for the permissions if no permission on the object has been set. It also fixes the bug causing wrong behavior when a role has been created after object permission has been set.