### PR TITLE
Fix controller validation definition as fcqn

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -340,9 +340,12 @@ class ValidateWebspacesCommand extends Command
      */
     private function validateControllerAction($controllerAction)
     {
-        $result = $this->controllerNameConverter->parse($controllerAction);
+        try {
+            $controllerAction = $this->controllerNameConverter->parse($controllerAction);
+        } catch (\InvalidArgumentException $e) {
+        }
 
-        list($class, $method) = explode('::', $result);
+        list($class, $method) = explode('::', $controllerAction);
 
         if (!method_exists($class, $method)) {
             $reflector = new \ReflectionClass($class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #4579
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix controller reference validation with FQCN.

#### Why?

Its recommended way to reference controllers and the bundle syntax is deprecated now.

#### Example Usage

~~~xml
<controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
~~~

