### PR TITLE
Fix permissions in page list for roles without any permission

### DIFF
--- a/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContentBundle/Resources/config/services.xml
@@ -129,6 +129,7 @@
             <argument type="service" id="sulu.content.localization_finder"/>
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.util.node_helper"/>
+            <argument>%sulu_security.permissions%</argument>
         </service>
         <service id="sulu_content.content_repository.event_subscriber"
                  class="Sulu\Component\Content\Repository\Serializer\SerializerEventListener">

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -763,6 +763,11 @@ class ContentRepositoryTest extends SuluTestCase
 
     public function testFindWithPermissionsNotGranted()
     {
+        $packageVersion = $this->getPackageVersion('jackalope/jackalope');
+        if (version_compare($packageVersion, '1.3.0') < 0) {
+            $this->markTestSkipped('The jackalope/jackalope version below 1.3.0 has a bug causing this test to fail');
+        }
+
         $role1 = $this->prophesize(RoleInterface::class);
         $role1->getId()->willReturn(1);
         $role1->getIdentifier()->willReturn('ROLE_SULU_ROLE 1');
@@ -1212,5 +1217,18 @@ class ContentRepositoryTest extends SuluTestCase
         $this->documentManager->flush();
 
         return $document;
+    }
+
+    private function getPackageVersion(string $packageName)
+    {
+        $this->composerLock = json_decode(
+            file_get_contents($this->getContainer()->getParameter('kernel.root_dir') . '/../../composer.lock')
+        );
+
+        foreach ($this->composerLock->packages as $package) {
+            if ($package->name === $packageName) {
+                return $package->version;
+            }
+        }
     }
 }

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -99,7 +99,8 @@ class ContentRepositoryTest extends SuluTestCase
             $this->webspaceManager,
             $this->localizationFinder,
             $this->structureManager,
-            $this->nodeHelper
+            $this->nodeHelper,
+            ['view' => 64, 'add' => 32, 'edit' => 16, 'delete' => 8]
         );
 
         $this->initPhpcr();
@@ -719,7 +720,84 @@ class ContentRepositoryTest extends SuluTestCase
         );
 
         $this->assertEquals(
-            [1 => ['edit' => true], 2 => ['view' => true, 'archive' => true]],
+            [
+                1 => ['view' => false, 'add' => false, 'delete' => false, 'edit' => true],
+                2 => ['view' => true, 'add' => false, 'edit' => false, 'delete' => false, 'archive' => true]
+            ],
+            $result->getPermissions()
+        );
+    }
+
+    public function testFindWithoutPermissions()
+    {
+        $role1 = $this->prophesize(RoleInterface::class);
+        $role1->getId()->willReturn(1);
+        $role1->getIdentifier()->willReturn('ROLE_SULU_ROLE 1');
+        $role2 = $this->prophesize(RoleInterface::class);
+        $role2->getId()->willReturn(2);
+        $role2->getIdentifier()->willReturn('ROLE_SULU_ROLE-2');
+
+        $user = $this->prophesize(UserInterface::class);
+        $user->getRoleObjects()->willReturn([$role1->reveal(), $role2->reveal()]);
+
+        $page = $this->createPage(
+            'test-1',
+            'de',
+            [],
+            null
+        );
+
+        $result = $this->contentRepository->find(
+            $page->getUuid(),
+            'de',
+            'sulu_io',
+            MappingBuilder::create()->getMapping(),
+            $user->reveal()
+        );
+
+        $this->assertEquals(
+            [],
+            $result->getPermissions()
+        );
+    }
+
+    public function testFindWithPermissionsNotGranted()
+    {
+        $role1 = $this->prophesize(RoleInterface::class);
+        $role1->getId()->willReturn(1);
+        $role1->getIdentifier()->willReturn('ROLE_SULU_ROLE 1');
+        $role2 = $this->prophesize(RoleInterface::class);
+        $role2->getId()->willReturn(2);
+        $role2->getIdentifier()->willReturn('ROLE_SULU_ROLE-2');
+
+        $user = $this->prophesize(UserInterface::class);
+        $user->getRoleObjects()->willReturn([$role1->reveal(), $role2->reveal()]);
+
+        $page = $this->createPage(
+            'test-1',
+            'de',
+            [],
+            null,
+            [
+                1 => ['edit' => false],
+                2 => ['view' => false, 'archive' => false],
+                3 => ['add' => false],
+            ]
+        );
+
+        $result = $this->contentRepository->find(
+            $page->getUuid(),
+            'de',
+            'sulu_io',
+            MappingBuilder::create()->getMapping(),
+            $user->reveal()
+        );
+
+        $this->assertEquals(
+            [
+                1 => ['view' => false, 'add' => false, 'delete' => false, 'edit' => false],
+                2 => ['view' => false, 'add' => false, 'edit' => false, 'delete' => false]
+            ],
             $result->getPermissions()
         );
     }
@@ -1035,7 +1113,7 @@ class ContentRepositoryTest extends SuluTestCase
      *
      * @return PageDocument
      */
-    private function createPage($title, $locale, $data = [], $parentDocument = null, array $permissions = [])
+    private function createPage($title, $locale, $data = [], $parentDocument = null, array $permissions = null)
     {
         /** @var PageDocument $document */
         $document = $this->documentManager->create('page');
@@ -1057,7 +1135,9 @@ class ContentRepositoryTest extends SuluTestCase
         $document->setRedirectType(RedirectType::NONE);
         $document->setShadowLocaleEnabled(false);
         $document->getStructure()->bind($data);
-        $document->setPermissions($permissions);
+        if ($permissions) {
+            $document->setPermissions($permissions);
+        }
         $this->documentManager->persist(
             $document,
             $locale,

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -1219,7 +1219,7 @@ class ContentRepositoryTest extends SuluTestCase
         return $document;
     }
 
-    private function getPackageVersion(string $packageName)
+    private function getPackageVersion($packageName)
     {
         $this->composerLock = json_decode(
             file_get_contents($this->getContainer()->getParameter('kernel.root_dir') . '/../../composer.lock')

--- a/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Functional/Repository/ContentRepositoryTest.php
@@ -722,7 +722,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals(
             [
                 1 => ['view' => false, 'add' => false, 'delete' => false, 'edit' => true],
-                2 => ['view' => true, 'add' => false, 'edit' => false, 'delete' => false, 'archive' => true]
+                2 => ['view' => true, 'add' => false, 'edit' => false, 'delete' => false, 'archive' => true],
             ],
             $result->getPermissions()
         );
@@ -801,7 +801,7 @@ class ContentRepositoryTest extends SuluTestCase
         $this->assertEquals(
             [
                 1 => ['view' => false, 'add' => false, 'delete' => false, 'edit' => false],
-                2 => ['view' => false, 'add' => false, 'edit' => false, 'delete' => false]
+                2 => ['view' => false, 'add' => false, 'edit' => false, 'delete' => false],
             ],
             $result->getPermissions()
         );

--- a/src/Sulu/Component/PHPCR/PathCleanup.php
+++ b/src/Sulu/Component/PHPCR/PathCleanup.php
@@ -74,7 +74,7 @@ class PathCleanup implements PathCleanupInterface
 
         // Inspired by ZOOLU
         // delete problematic characters
-        $clean = str_replace('%2F', '/', urlencode(preg_replace('/([^A-za-z0-9\s-_\/])/', '', $clean)));
+        $clean = str_replace('%2F', '/', urlencode(preg_replace('/([^A-za-z0-9\s\-_\/])/', '', $clean)));
 
         // replace multiple dash with one
         $clean = preg_replace('/([-]+)/', '-', $clean);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the `ContentRepository` return an empty array only if no permissions at all are set on the corresponding node. In case some permissions are set, empty arrays or missing information for a role will be interpreted as having no permissions at all.

#### Why?

Because an empty array will be interpreted as having all permissions in our security system.

That this behavior is not correct can be tested in the following way:

1. Create a role without the security permission for a webspace
2. Create a page in that webspace
3. Remove all permissions from the role of step 1
4. See that the page has an edit icon in the page list, even for user having only the role from step 1
5. If you click the edit icon you get an error message telling you that you don't have the required permissions

With this PR the edit icon from step 4 should not be visible.
