### PR TITLE
Fixed construct type for activeTheme in validate webspace command

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -78,7 +78,7 @@ class ValidateWebspacesCommand extends Command
         StructureManagerInterface $structureManager,
         WebspaceStructureProvider $structureProvider,
         WebspaceManagerInterface $webspaceManager,
-        ?string $activeTheme = null
+        $activeTheme = null
     ) {
         $this->twig = $twig;
         $this->structureMetadataFactory = $structureMetadataFactory;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

Removes the `?string` type hint in the `ValidateWebspaceCommand.php` file to remove a warning caused by PHP 7.3.

The warning happens only after the installation of the sulu/theme-bundle: https://github.com/sulu/SuluThemeBundle/pull/11

```
In ValidateWebspacesCommand.php line 74:

  Argument 7 passed to Sulu\Bundle\PageBundle\Command\ValidateWebspacesComman
  d::__construct() must be of the type string or null, object given, called i
  n /Users/thomas.duenser/Development/websites/boneco.lo/sulu/var/cache/admin
  /dev/ContainerCLYMCtY/getConsole_Command_PublicAlias_SuluPage_Command_Valid
  ateWebspacesService.php on line 12
```
