### PR TITLE
Rename security column of se_roles table to securitySystem for MySQL 8.0 compatibility

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,15 @@
 
 Instead of `sulu:webspaces:init` or `sulu:phpcr:init` use `sulu:document:initialize`.
 
+### Rename system column of se_roles table to securitySystem for MySQL 8 compatibility
+
+The `system` column of the `se_roles` table was renamed to `securitySystem` to make Sulu compatible with MySQL 8.0.
+This is necessary because `SYTEM` is a SQL keyword since MySQL 8.0.3.
+
+```sql
+ALTER TABLE se_roles CHANGE system securitySystem VARCHAR(60) NOT NULL;
+```
+
 ### Rename ToolbarActionRegistry and AbstractToolbarAction javscript classes
 
 **This change only affects you if you have used a 2.0.0 release before**

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,7 +9,7 @@ Instead of `sulu:webspaces:init` or `sulu:phpcr:init` use `sulu:document:initial
 ### Rename system column of se_roles table to securitySystem for MySQL 8 compatibility
 
 The `system` column of the `se_roles` table was renamed to `securitySystem` to make Sulu compatible with MySQL 8.0.
-This is necessary because `SYTEM` is a SQL keyword since MySQL 8.0.3.
+This is necessary because `SYSTEM` is a SQL keyword since MySQL 8.0.3.
 
 ```sql
 ALTER TABLE se_roles CHANGE system securitySystem VARCHAR(60) NOT NULL;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,15 +9,13 @@ environment:
   MAILER_URL: null://localhost
   SULU_ADMIN_EMAIL:
   PHPCR_TRANSPORT: doctrinedbal
-  DATABASE_URL: mysql://root:Password12!@127.0.0.1/sulu_test
+  DATABASE_URL: mysql://root:root@127.0.0.1/sulu_test
   DATABASE_CHARSET: utf8mb4
   DATABASE_COLLATE: utf8mb4_unicode_ci
   SYMFONY_DEPRECATIONS_HELPER: weak
+  MYSQL_VERSION: 8.0.17
   matrix:
    - PHP_VERSION: 7.2.4
-
-services:
-  - mysql
 
 hosts:
   localhost: 127.0.0.1
@@ -37,15 +35,20 @@ install:
   # disable wuauserv service
   - ps: Set-Service wuauserv -StartupType Manual
 
+  # install configured mysql version and set authentication-plugin for root
+  - choco install mysql --version %MYSQL_VERSION%
+  - cd C:\tools\mysql\current\bin
+  - mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
+
   # install composer
   - IF NOT EXIST C:\tools\composer.phar (
         cd C:\tools
         && appveyor DownloadFile https://getcomposer.org/composer.phar
     )
 
-  # install php
+  # install configured php version
   - IF NOT EXIST C:\tools\php (
-        cinst --yes --allow-empty-checksums php --version %PHP_VERSION% --params '/InstallDir:C:\tools\php'
+        choco install --yes --allow-empty-checksums php --version %PHP_VERSION% --params '/InstallDir:C:\tools\php'
     )
 
   # configure PHP and enable extensions.

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/BaseRole.orm.xml
@@ -8,7 +8,7 @@
         </id>
 
         <field name="name" type="string" column="name" length="60" unique="true"/>
-        <field name="system" type="string" column="system" length="60"/>
+        <field name="system" type="string" column="securitySystem" length="60"/>
 
         <many-to-one field="securityType" target-entity="Sulu\Bundle\SecurityBundle\Entity\SecurityType"
                      inversed-by="roles">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | https://github.com/sulu/sulu/issues/4658
| License | MIT

#### What's in this PR?

This PR renames the `security` column of the `se_roles` table to `securitySystem` to make Sulu compatible with MySQL 8.0.

#### Why?

Because `SYSTEM` is a keyword since MySQL 8.0.3. See: https://dev.mysql.com/doc/refman/8.0/en/keywords.html
