### PR TITLE
Cleanup TwigExtensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "symfony/web-link": "^3.4 || ^4.0",
         "symfony/yaml": "^3.4 || ^4.0",
         "toflar/psr6-symfony-http-cache-store": "^1.1",
-        "twig/twig": "^1.11 || ^2.0",
+        "twig/twig": "^1.35 || ^2.0",
         "willdurand/hateoas-bundle": "^1.1"
     },
     "require-dev": {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -21,11 +21,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Twig\Environment;
 
 class TargetGroupSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -90,11 +91,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
     private $visitorSessionCookie;
 
     /**
-     * @param \Twig_Environment $twig
      * @param bool $preview
-     * @param TargetGroupStoreInterface $targetGroupStore
-     * @param TargetGroupEvaluatorInterface $targetGroupEvaluator
-     * @param TargetGroupRepositoryInterface $targetGroupRepository
      * @param string $targetGroupUrl
      * @param string $targetGroupHitUrl
      * @param string $urlHeader
@@ -105,7 +102,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
      * @param string $visitorSessionCookie
      */
     public function __construct(
-        \Twig_Environment $twig,
+        Environment $twig,
         $preview,
         TargetGroupStoreInterface $targetGroupStore,
         TargetGroupEvaluatorInterface $targetGroupEvaluator,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -25,11 +25,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Twig\Environment;
 
 class TargetGroupSubscriberTest extends TestCase
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -50,7 +51,7 @@ class TargetGroupSubscriberTest extends TestCase
 
     public function setUp()
     {
-        $this->twig = $this->prophesize(\Twig_Environment::class);
+        $this->twig = $this->prophesize(Environment::class);
         $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
         $this->targetGroupEvaluator = $this->prophesize(TargetGroupEvaluatorInterface::class);
         $this->targetGroupRepository = $this->prophesize(TargetGroupRepositoryInterface::class);

--- a/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/Twig/CategoryTwigExtension.php
@@ -16,11 +16,13 @@ use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides functionality to handle categories in twig templates.
  */
-class CategoryTwigExtension extends \Twig_Extension
+class CategoryTwigExtension extends AbstractExtension
 {
     /**
      * @var CategoryManagerInterface
@@ -60,10 +62,10 @@ class CategoryTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_categories', [$this, 'getCategoriesFunction']),
-            new \Twig_SimpleFunction('sulu_category_url', [$this, 'setCategoryUrlFunction']),
-            new \Twig_SimpleFunction('sulu_category_url_append', [$this, 'appendCategoryUrlFunction']),
-            new \Twig_SimpleFunction('sulu_category_url_clear', [$this, 'clearCategoryUrlFunction']),
+            new TwigFunction('sulu_categories', [$this, 'getCategoriesFunction']),
+            new TwigFunction('sulu_category_url', [$this, 'setCategoryUrlFunction']),
+            new TwigFunction('sulu_category_url_append', [$this, 'appendCategoryUrlFunction']),
+            new TwigFunction('sulu_category_url_clear', [$this, 'clearCategoryUrlFunction']),
         ];
     }
 
@@ -128,13 +130,5 @@ class CategoryTwigExtension extends \Twig_Extension
     public function clearCategoryUrlFunction($categoriesParameter = 'categories')
     {
         return $this->categoryRequestHandler->removeCategoriesFromUrl($categoriesParameter);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_category';
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -14,11 +14,13 @@ namespace Sulu\Bundle\ContactBundle\Twig;
 use Doctrine\Common\Cache\Cache;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Extension to handle contacts in frontend.
  */
-class ContactTwigExtension extends \Twig_Extension
+class ContactTwigExtension extends AbstractExtension
 {
     /**
      * @var ContactRepository
@@ -36,19 +38,14 @@ class ContactTwigExtension extends \Twig_Extension
         $this->contactRepository = $contactRepository;
     }
 
-    /**
-     * @return array
-     */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_resolve_contact', [$this, 'resolveContactFunction']),
+            new TwigFunction('sulu_resolve_contact', [$this, 'resolveContactFunction']),
         ];
     }
 
     /**
-     * resolves user id to user data.
-     *
      * @param int $id id to resolve
      *
      * @return Contact
@@ -67,15 +64,5 @@ class ContactTwigExtension extends \Twig_Extension
         $this->cache->save($id, $contact);
 
         return $contact;
-    }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'sulu_contact';
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Twig/DispositionTypeTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/DispositionTypeTwigExtension.php
@@ -13,11 +13,13 @@ namespace Sulu\Bundle\MediaBundle\Twig;
 
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Extension for content form generation.
  */
-class DispositionTypeTwigExtension extends \Twig_Extension
+class DispositionTypeTwigExtension extends AbstractExtension
 {
     /**
      * Returns an array of possible function in this extension.
@@ -27,7 +29,7 @@ class DispositionTypeTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_get_media_url', [$this, 'getMediaUrl']),
+            new TwigFunction('sulu_get_media_url', [$this, 'getMediaUrl']),
         ];
     }
 
@@ -50,15 +52,5 @@ class DispositionTypeTwigExtension extends \Twig_Extension
         }
 
         return $url;
-    }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'media_disposition_type';
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -15,11 +15,13 @@ use Sulu\Bundle\MediaBundle\Api\Media as MediaApi;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Extension to handle medias in frontend.
  */
-class MediaTwigExtension extends \Twig_Extension
+class MediaTwigExtension extends AbstractExtension
 {
     /**
      * @var MediaManagerInterface
@@ -40,8 +42,8 @@ class MediaTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_resolve_media', [$this, 'resolveMediaFunction']),
-            new \Twig_SimpleFunction('sulu_resolve_medias', [$this, 'resolveMediasFunction']),
+            new TwigFunction('sulu_resolve_media', [$this, 'resolveMediaFunction']),
+            new TwigFunction('sulu_resolve_medias', [$this, 'resolveMediasFunction']),
         ];
     }
 
@@ -121,13 +123,5 @@ class MediaTwigExtension extends \Twig_Extension
         }
 
         return;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_media';
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidateWebspacesCommand.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Twig\Environment;
 
 class ValidateWebspacesCommand extends Command
 {
@@ -31,7 +32,7 @@ class ValidateWebspacesCommand extends Command
     private $output;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -71,7 +72,7 @@ class ValidateWebspacesCommand extends Command
     private $webspaceManager;
 
     public function __construct(
-        \Twig_Environment $twig,
+        Environment $twig,
         StructureMetadataFactoryInterface $structureMetadataFactory,
         ControllerNameParser $controllerNameConverter,
         StructureManagerInterface $structureManager,

--- a/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
@@ -12,11 +12,13 @@
 namespace Sulu\Bundle\PageBundle\Twig;
 
 use Sulu\Component\Export\Manager\ExportManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Twig extensions for the Webspace export.
  */
-class ExportTwigExtension extends \Twig_Extension
+class ExportTwigExtension extends AbstractExtension
 {
     /**
      * @var ExportManagerInterface
@@ -44,8 +46,8 @@ class ExportTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_content_type_export_escape', [$this, 'escapeXmlContent']),
-            new \Twig_SimpleFunction('sulu_content_type_export_counter', [$this, 'counter']),
+            new TwigFunction('sulu_content_type_export_escape', [$this, 'escapeXmlContent']),
+            new TwigFunction('sulu_content_type_export_counter', [$this, 'counter']),
         ];
     }
 
@@ -77,15 +79,5 @@ class ExportTwigExtension extends \Twig_Extension
         }
 
         return $content;
-    }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'content_export';
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TwigException.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Exception/TwigException.php
@@ -11,19 +11,20 @@
 
 namespace Sulu\Bundle\PreviewBundle\Preview\Exception;
 
+use Twig\Error\Error;
+
 /**
  * This exception will be thrown when preview rendering fails.
  */
 class TwigException extends PreviewRendererException
 {
     /**
-     * @param \Twig_Error $exception
      * @param int $object
      * @param mixed $id
      * @param string $webspaceKey
      * @param string $locale
      */
-    public function __construct(\Twig_Error $exception, $object, $id, $webspaceKey, $locale)
+    public function __construct(Error $exception, $object, $id, $webspaceKey, $locale)
     {
         parent::__construct(
             $exception->getMessage(),

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Twig\Error\Error;
 
 /**
  * Renders preview responses.
@@ -188,7 +189,7 @@ class PreviewRenderer implements PreviewRendererInterface
 
         try {
             $response = $this->handle($request);
-        } catch (\Twig_Error $e) {
+        } catch (Error $e) {
             // dev/test only: display also the file and line which was causing the error
             // for better debugging and faster development
             if (in_array($this->environment, ['dev', 'test'])) {

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/Renderer/PreviewRendererTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Twig\Error\RuntimeError;
 
 class PreviewRendererTest extends TestCase
 {
@@ -393,7 +394,7 @@ class PreviewRendererTest extends TestCase
             ->shouldBeCalled();
 
         $this->httpKernel->handle(Argument::type(Request::class), HttpKernelInterface::MASTER_REQUEST, false)
-            ->shouldBeCalled()->willThrow(new \Twig_Error_Runtime('Test error'));
+            ->shouldBeCalled()->willThrow(new RuntimeError('Test error'));
 
         $request = new Request();
         $this->requestStack->getCurrentRequest()->willReturn($request);

--- a/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Controller/WebsiteSearchController.php
@@ -18,6 +18,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
 
 /**
  * This controller handles the search for the website.
@@ -42,21 +43,15 @@ class WebsiteSearchController
     private $parameterResolver;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
-    /**
-     * @param SearchManagerInterface $searchManager
-     * @param RequestAnalyzerInterface $requestAnalyzer
-     * @param ParameterResolverInterface $parameterResolver
-     * @param \Twig_Environment $twig
-     */
     public function __construct(
         SearchManagerInterface $searchManager,
         RequestAnalyzerInterface $requestAnalyzer,
         ParameterResolverInterface $parameterResolver,
-        \Twig_Environment $twig
+        Environment $twig
     ) {
         $this->searchManager = $searchManager;
         $this->requestAnalyzer = $requestAnalyzer;

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Controller/WebsiteSearchControllerTest.php
@@ -22,6 +22,8 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class WebsiteSearchControllerTest extends TestCase
 {
@@ -41,12 +43,12 @@ class WebsiteSearchControllerTest extends TestCase
     private $parameterResolver;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
     /**
-     * @var \Twig_LoaderInterface
+     * @var FilesystemLoader
      */
     private $twigLoader;
 
@@ -60,8 +62,8 @@ class WebsiteSearchControllerTest extends TestCase
         $this->searchManager = $this->prophesize(SearchManagerInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
-        $this->twig = $this->prophesize(\Twig_Environment::class);
-        $this->twigLoader = $this->prophesize(\Twig_Loader_Filesystem::class);
+        $this->twig = $this->prophesize(Environment::class);
+        $this->twigLoader = $this->prophesize(FilesystemLoader::class);
         $this->twig->getLoader()->willReturn($this->twigLoader->reveal());
 
         $this->websiteSearchController = new WebsiteSearchController(

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -14,11 +14,13 @@ namespace Sulu\Bundle\SecurityBundle\Twig;
 use Doctrine\Common\Cache\Cache;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Extension to handle users in frontend.
  */
-class UserTwigExtension extends \Twig_Extension
+class UserTwigExtension extends AbstractExtension
 {
     /**
      * @var UserRepository
@@ -42,7 +44,7 @@ class UserTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_resolve_user', [$this, 'resolveUserFunction']),
+            new TwigFunction('sulu_resolve_user', [$this, 'resolveUserFunction']),
         ];
     }
 
@@ -67,13 +69,5 @@ class UserTwigExtension extends \Twig_Extension
         $this->cache->save($id, $user);
 
         return $user;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_user';
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/DefaultSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/DefaultSnippetTwigExtension.php
@@ -14,6 +14,8 @@ namespace Sulu\Bundle\SnippetBundle\Twig;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * @deprecated
@@ -23,7 +25,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
  *
  * Provides default snippets.
  */
-class DefaultSnippetTwigExtension extends \Twig_Extension
+class DefaultSnippetTwigExtension extends AbstractExtension
 {
     /**
      * @var DefaultSnippetManagerInterface
@@ -56,7 +58,7 @@ class DefaultSnippetTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_snippet_load_default', [$this, 'getDefault']),
+            new TwigFunction('sulu_snippet_load_default', [$this, 'getDefault']),
         ];
     }
 
@@ -79,13 +81,5 @@ class DefaultSnippetTwigExtension extends \Twig_Extension
         $ids = array_filter($ids);
 
         return $this->snippetResolver->resolve($ids, $webspaceKey, $locale);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_snippet.default';
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/MemoizedSnippetTwigExtension.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\SnippetBundle\Twig;
 
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Provides memoized Twig functions to handle snippets.
  */
-class MemoizedSnippetTwigExtension extends \Twig_Extension
+class MemoizedSnippetTwigExtension extends AbstractExtension
 {
     use MemoizeTwigExtensionTrait;
 
@@ -31,13 +32,5 @@ class MemoizedSnippetTwigExtension extends \Twig_Extension
         $this->extension = $extension;
         $this->memoizeCache = $memoizeCache;
         $this->lifeTime = $lifeTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return $this->extension->getName();
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -16,11 +16,13 @@ use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolverInterface;
 use Sulu\Bundle\SnippetBundle\Snippet\WrongSnippetTypeException;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides snippets by area.
  */
-class SnippetAreaTwigExtension extends \Twig_Extension
+class SnippetAreaTwigExtension extends AbstractExtension
 {
     /**
      * @var DefaultSnippetManagerInterface
@@ -53,7 +55,7 @@ class SnippetAreaTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_snippet_load_by_area', [$this, 'loadByArea']),
+            new TwigFunction('sulu_snippet_load_by_area', [$this, 'loadByArea']),
         ];
     }
 
@@ -94,13 +96,5 @@ class SnippetAreaTwigExtension extends \Twig_Extension
         }
 
         return $snippets[0];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_snippet.area';
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtension.php
@@ -15,11 +15,13 @@ use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides Twig functions to handle snippets.
  */
-class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensionInterface
+class SnippetTwigExtension extends AbstractExtension implements SnippetTwigExtensionInterface
 {
     /**
      * @var ContentMapperInterface
@@ -55,7 +57,7 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_snippet_load', [$this, 'loadSnippet']),
+            new TwigFunction('sulu_snippet_load', [$this, 'loadSnippet']),
         ];
     }
 
@@ -75,13 +77,5 @@ class SnippetTwigExtension extends \Twig_Extension implements SnippetTwigExtensi
         } catch (DocumentNotFoundException $ex) {
             return;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_snippet';
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetTwigExtensionInterface.php
@@ -11,10 +11,12 @@
 
 namespace Sulu\Bundle\SnippetBundle\Twig;
 
+use Twig\Extension\ExtensionInterface;
+
 /**
  * Provides Twig functions to handle snippets.
  */
-interface SnippetTwigExtensionInterface extends \Twig_ExtensionInterface
+interface SnippetTwigExtensionInterface extends ExtensionInterface
 {
     /**
      * Returns snippet.

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -16,8 +16,10 @@ use JMS\Serializer\SerializerInterface;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class TagTwigExtension extends \Twig_Extension
+class TagTwigExtension extends AbstractExtension
 {
     /**
      * @var TagManagerInterface
@@ -57,10 +59,10 @@ class TagTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_tags', [$this, 'getTagsFunction']),
-            new \Twig_SimpleFunction('sulu_tag_url', [$this, 'setTagUrlFunction']),
-            new \Twig_SimpleFunction('sulu_tag_url_append', [$this, 'appendTagUrlFunction']),
-            new \Twig_SimpleFunction('sulu_tag_url_clear', [$this, 'clearTagUrlFunction']),
+            new TwigFunction('sulu_tags', [$this, 'getTagsFunction']),
+            new TwigFunction('sulu_tag_url', [$this, 'setTagUrlFunction']),
+            new TwigFunction('sulu_tag_url_append', [$this, 'appendTagUrlFunction']),
+            new TwigFunction('sulu_tag_url_clear', [$this, 'clearTagUrlFunction']),
         ];
     }
 
@@ -120,13 +122,5 @@ class TagTwigExtension extends \Twig_Extension
     public function clearTagUrlFunction($tagsParameter = 'tags')
     {
         return $this->tagRequestHandler->removeTagsFromUrl($tagsParameter);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_tag';
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
@@ -18,6 +18,7 @@ use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Twig\Environment;
 
 /**
  * Custom exception controller.
@@ -40,7 +41,7 @@ class ExceptionController
     private $parameterResolver;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
@@ -50,17 +51,13 @@ class ExceptionController
     private $debug;
 
     /**
-     * @param BaseExceptionController $exceptionController
-     * @param RequestAnalyzerInterface $requestAnalyzer
-     * @param ParameterResolverInterface $parameterResolver
-     * @param \Twig_Environment $twig
      * @param bool $debug
      */
     public function __construct(
         BaseExceptionController $exceptionController,
         RequestAnalyzerInterface $requestAnalyzer,
         ParameterResolverInterface $parameterResolver,
-        \Twig_Environment $twig,
+        Environment $twig,
         $debug
     ) {
         $this->exceptionController = $exceptionController;

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Twig\Template;
 
 /**
  * Basic class to render Website from phpcr content.
@@ -109,7 +110,7 @@ abstract class WebsiteController extends Controller
         $twig = $this->get('twig');
         $attributes = $twig->mergeGlobals($attributes);
 
-        /** @var \Twig_Template $template */
+        /** @var Template $template */
         $template = $twig->loadTemplate($template);
 
         $level = ob_get_level();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
@@ -20,6 +20,8 @@ use Sulu\Component\Webspace\Webspace;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class ExceptionControllerTest extends TestCase
 {
@@ -34,17 +36,12 @@ class ExceptionControllerTest extends TestCase
     private $innerExceptionController;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twig;
 
     /**
-     * @var \Twig_LoaderInterface
-     */
-    private $twigLoader;
-
-    /**
-     * @var \Twig_ExistsLoaderInterface
+     * @var FilesystemLoader
      */
     private $loader;
 
@@ -60,8 +57,8 @@ class ExceptionControllerTest extends TestCase
 
     public function setUp()
     {
-        $this->twig = $this->prophesize(\Twig_Environment::class);
-        $this->loader = $this->prophesize(\Twig_ExistsLoaderInterface::class);
+        $this->twig = $this->prophesize(Environment::class);
+        $this->loader = $this->prophesize(FilesystemLoader::class);
         $this->twig->getLoader()->willReturn($this->loader->reveal());
 
         $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/DefaultControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Controller/DefaultControllerTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class DefaultControllerTest extends TestCase
 {
@@ -48,8 +50,8 @@ class DefaultControllerTest extends TestCase
         $this->request = $this->prophesize(Request::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
         $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
-        $this->twig = $this->prophesize(\Twig_Environment::class);
-        $this->twigLoader = $this->prophesize(\Twig_Loader_Filesystem::class);
+        $this->twig = $this->prophesize(Environment::class);
+        $this->twigLoader = $this->prophesize(FilesystemLoader::class);
         $this->twig->getLoader()->willReturn($this->twigLoader->reveal());
         $this->parameterResolver = $this->prophesize(ParameterResolverInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtensionTest.php
@@ -20,6 +20,7 @@ use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\TwigFunction;
 
 class SeoTwigExtensionTest extends TestCase
 {
@@ -72,7 +73,7 @@ class SeoTwigExtensionTest extends TestCase
         $result = $this->seoTwigExtension->getFunctions();
 
         $this->assertEquals(
-            new \Twig_SimpleFunction('sulu_seo', [$this->seoTwigExtension, 'renderSeoTags'], ['needs_environment' => true]),
+            new TwigFunction('sulu_seo', [$this->seoTwigExtension, 'renderSeoTags'], ['needs_environment' => true]),
             $result[0]
         );
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentPathTwigExtension.php
@@ -13,11 +13,13 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * provides the content_path function to generate real urls for frontend.
  */
-class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInterface
+class ContentPathTwigExtension extends AbstractExtension implements ContentPathInterface
 {
     /**
      * @var RequestAnalyzerInterface
@@ -50,8 +52,8 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_content_path', [$this, 'getContentPath']),
-            new \Twig_SimpleFunction('sulu_content_root_path', [$this, 'getContentRootPath']),
+            new TwigFunction('sulu_content_path', [$this, 'getContentPath']),
+            new TwigFunction('sulu_content_root_path', [$this, 'getContentRootPath']),
         ];
     }
 
@@ -114,13 +116,5 @@ class ContentPathTwigExtension extends \Twig_Extension implements ContentPathInt
     public function getContentRootPath($full = false)
     {
         return $this->getContentPath('/');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_website_content_path';
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtension.php
@@ -19,11 +19,13 @@ use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides Interface to load content.
  */
-class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensionInterface
+class ContentTwigExtension extends AbstractExtension implements ContentTwigExtensionInterface
 {
     /**
      * @var ContentMapperInterface
@@ -73,8 +75,8 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_content_load', [$this, 'load']),
-            new \Twig_SimpleFunction('sulu_content_load_parent', [$this, 'loadParent']),
+            new TwigFunction('sulu_content_load', [$this, 'load']),
+            new TwigFunction('sulu_content_load_parent', [$this, 'loadParent']),
         ];
     }
 
@@ -116,13 +118,5 @@ class ContentTwigExtension extends \Twig_Extension implements ContentTwigExtensi
         }
 
         return $this->load($node->getParent()->getIdentifier());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_website_content';
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/ContentTwigExtensionInterface.php
@@ -12,11 +12,12 @@
 namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
 use Sulu\Bundle\WebsiteBundle\Twig\Exception\ParentNotFoundException;
+use Twig\Extension\ExtensionInterface;
 
 /**
  * Provide Interface to load content.
  */
-interface ContentTwigExtensionInterface extends \Twig_ExtensionInterface
+interface ContentTwigExtensionInterface extends ExtensionInterface
 {
     /**
      * Returns resolved content for parent of given uuid.

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Content/MemoizedContentTwigExtension.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Content;
 
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Provides memoized Interface to load content.
  */
-class MemoizedContentTwigExtension extends \Twig_Extension
+class MemoizedContentTwigExtension extends AbstractExtension
 {
     use MemoizeTwigExtensionTrait;
 
@@ -31,13 +32,5 @@ class MemoizedContentTwigExtension extends \Twig_Extension
         $this->extension = $extension;
         $this->memoizeCache = $memoizeCache;
         $this->lifeTime = $lifeTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return $this->extension->getName();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Core/UtilTwigExtension.php
@@ -11,29 +11,25 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Core;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
 /**
  * Twig extension providing generally useful utilities which are available
  * in the Sulu\Component\Util namespace.
  */
-class UtilTwigExtension extends \Twig_Extension
+class UtilTwigExtension extends AbstractExtension
 {
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'sulu_util';
-    }
-
     /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sulu_util_multisort', 'Sulu\Component\Util\SortUtils::multisort'),
-            new \Twig_SimpleFilter('sulu_util_filter', 'Sulu\Component\Util\ArrayUtils::filter'),
-            new \Twig_SimpleFilter('sulu_util_domain_info', 'tld_extract'),
+            new TwigFilter('sulu_util_multisort', 'Sulu\Component\Util\SortUtils::multisort'),
+            new TwigFilter('sulu_util_filter', 'Sulu\Component\Util\ArrayUtils::filter'),
+            new TwigFilter('sulu_util_domain_info', 'tld_extract'),
         ];
     }
 
@@ -43,7 +39,7 @@ class UtilTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_util_domain_info', 'tld_extract'),
+            new TwigFunction('sulu_util_domain_info', 'tld_extract'),
         ];
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Meta/MetaTwigExtension.php
@@ -13,13 +13,15 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Meta;
 
 use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides helper function to generate meta tags.
  *
  * @deprecated will be removed in 1.2
  */
-class MetaTwigExtension extends \Twig_Extension
+class MetaTwigExtension extends AbstractExtension
 {
     /**
      * @var RequestAnalyzerInterface
@@ -43,19 +45,11 @@ class MetaTwigExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'sulu_website_meta';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_meta_alternate', [$this, 'getAlternateLinks']),
-            new \Twig_SimpleFunction('sulu_meta_seo', [$this, 'getSeoMetaTags']),
+            new TwigFunction('sulu_meta_alternate', [$this, 'getAlternateLinks']),
+            new TwigFunction('sulu_meta_seo', [$this, 'getSeoMetaTags']),
         ];
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/MemoizedNavigationTwigExtension.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Navigation;
 
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Provides memoized navigation functions.
  */
-class MemoizedNavigationTwigExtension extends \Twig_Extension
+class MemoizedNavigationTwigExtension extends AbstractExtension
 {
     use MemoizeTwigExtensionTrait;
 
@@ -31,13 +32,5 @@ class MemoizedNavigationTwigExtension extends \Twig_Extension
         $this->extension = $extension;
         $this->memoizeCache = $memoizeCache;
         $this->lifeTime = $lifeTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return $this->extension->getName();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtension.php
@@ -15,11 +15,13 @@ use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides the navigation functions.
  */
-class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigExtensionInterface
+class NavigationTwigExtension extends AbstractExtension implements NavigationTwigExtensionInterface
 {
     /**
      * @var ContentMapperInterface
@@ -52,12 +54,12 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_navigation_root_flat', [$this, 'flatRootNavigationFunction']),
-            new \Twig_SimpleFunction('sulu_navigation_root_tree', [$this, 'treeRootNavigationFunction']),
-            new \Twig_SimpleFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
-            new \Twig_SimpleFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
-            new \Twig_SimpleFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
-            new \Twig_SimpleFunction('sulu_navigation_is_active', [$this, 'navigationIsActiveFunction']),
+            new TwigFunction('sulu_navigation_root_flat', [$this, 'flatRootNavigationFunction']),
+            new TwigFunction('sulu_navigation_root_tree', [$this, 'treeRootNavigationFunction']),
+            new TwigFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
+            new TwigFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
+            new TwigFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
+            new TwigFunction('sulu_navigation_is_active', [$this, 'navigationIsActiveFunction']),
         ];
     }
 
@@ -179,13 +181,5 @@ class NavigationTwigExtension extends \Twig_Extension implements NavigationTwigE
         }
 
         return preg_match(sprintf('/%s([\/]|$)/', preg_quote($itemPath, '/')), $requestPath);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_website_navigation';
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Navigation/NavigationTwigExtensionInterface.php
@@ -12,11 +12,12 @@
 namespace Sulu\Bundle\WebsiteBundle\Twig\Navigation;
 
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem;
+use Twig\Extension\ExtensionInterface;
 
 /**
  * provides the navigation function.
  */
-interface NavigationTwigExtensionInterface extends \Twig_ExtensionInterface
+interface NavigationTwigExtensionInterface extends ExtensionInterface
 {
     /**
      * Returns a flat navigation of first layer.

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -14,11 +14,14 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Seo;
 use Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * This twig extension provides support for the SEO functionality provided by Sulu.
  */
-class SeoTwigExtension extends \Twig_Extension
+class SeoTwigExtension extends AbstractExtension
 {
     /**
      * @var RequestAnalyzerInterface
@@ -50,18 +53,10 @@ class SeoTwigExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return 'sulu_seo';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_seo', [$this, 'renderSeoTags'], ['needs_environment' => true]),
+            new TwigFunction('sulu_seo', [$this, 'renderSeoTags'], ['needs_environment' => true]),
         ];
     }
 
@@ -72,7 +67,7 @@ class SeoTwigExtension extends \Twig_Extension
      * @deprecated use the twig include function to render the seo
      */
     public function renderSeoTags(
-        \Twig_Environment $twig,
+        Environment $twig,
         array $seoExtension,
         array $content,
         array $urls,

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/MemoizedSitemapTwigExtension.php
@@ -13,11 +13,12 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Sitemap;
 
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Provides memoized twig functions for sitemap.
  */
-class MemoizedSitemapTwigExtension extends \Twig_Extension
+class MemoizedSitemapTwigExtension extends AbstractExtension
 {
     use MemoizeTwigExtensionTrait;
 
@@ -31,13 +32,5 @@ class MemoizedSitemapTwigExtension extends \Twig_Extension
         $this->extension = $extension;
         $this->memoizeCache = $memoizeCache;
         $this->lifeTime = $lifeTime;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return $this->extension->getName();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
@@ -14,11 +14,13 @@ namespace Sulu\Bundle\WebsiteBundle\Twig\Sitemap;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGeneratorInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides twig functions for sitemap.
  */
-class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensionInterface
+class SitemapTwigExtension extends AbstractExtension implements SitemapTwigExtensionInterface
 {
     /**
      * @var WebspaceManagerInterface
@@ -58,8 +60,8 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sulu_sitemap_url', [$this, 'sitemapUrlFunction']),
-            new \Twig_SimpleFunction('sulu_sitemap', [$this, 'sitemapFunction']),
+            new TwigFunction('sulu_sitemap_url', [$this, 'sitemapUrlFunction']),
+            new TwigFunction('sulu_sitemap', [$this, 'sitemapFunction']),
         ];
     }
 
@@ -98,13 +100,5 @@ class SitemapTwigExtension extends \Twig_Extension implements SitemapTwigExtensi
         }
 
         return $this->sitemapGenerator->generate($webspaceKey, $locale)->getSitemap();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sulu_website_sitemap';
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
@@ -11,10 +11,12 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Twig\Sitemap;
 
+use Twig\Extension\ExtensionInterface;
+
 /**
  * Provides twig functions for sitemap.
  */
-interface SitemapTwigExtensionInterface extends \Twig_ExtensionInterface
+interface SitemapTwigExtensionInterface extends ExtensionInterface
 {
     /**
      * Returns prefixed resourcelocator with the url and locale.

--- a/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
+++ b/src/Sulu/Component/Cache/MemoizeTwigExtensionTrait.php
@@ -11,13 +11,16 @@
 
 namespace Sulu\Component\Cache;
 
+use Twig\Extension\ExtensionInterface;
+use Twig\TwigFunction;
+
 /**
  * Provides functionality to convert twig functions.
  */
 trait MemoizeTwigExtensionTrait
 {
     /**
-     * @var \Twig_ExtensionInterface
+     * @var ExtensionInterface
      */
     protected $extension;
 
@@ -31,9 +34,6 @@ trait MemoizeTwigExtensionTrait
      */
     protected $lifeTime;
 
-    /**
-     * {@see \Twig_Extension::getFunctions}.
-     */
     public function getFunctions()
     {
         $result = [];
@@ -41,7 +41,7 @@ trait MemoizeTwigExtensionTrait
             $callable = $function->getCallable();
             $name = $function->getName();
 
-            $result[] = new \Twig_SimpleFunction(
+            $result[] = new TwigFunction(
                 $name,
                 function() use ($callable, $name) {
                     return $this->memoizeCache->memoizeById($name, func_get_args(), $callable, $this->lifeTime);

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Cache\MemoizeTwigExtensionTrait;
+use Twig\Extension\ExtensionInterface;
+use Twig\TwigFunction;
 
 class MemoizeTwigExtensionTraitTest extends TestCase
 {
@@ -24,7 +26,7 @@ class MemoizeTwigExtensionTraitTest extends TestCase
     protected $trait;
 
     /**
-     * @var \Twig_ExtensionInterface
+     * @var ExtensionInterface
      */
     protected $extension;
 
@@ -56,7 +58,7 @@ class MemoizeTwigExtensionTraitTest extends TestCase
     protected function setUp()
     {
         $this->memoizeCache = $this->prophesize(MemoizeInterface::class);
-        $this->extension = $this->prophesize(\Twig_ExtensionInterface::class);
+        $this->extension = $this->prophesize(ExtensionInterface::class);
 
         $this->trait = $this->getMockForTrait(MemoizeTwigExtensionTrait::class);
 
@@ -76,13 +78,13 @@ class MemoizeTwigExtensionTraitTest extends TestCase
     public function testGetFunctions()
     {
         $before = [
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'sulu_content_load',
                 function() {
                     return 1;
                 }
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'sulu_content_load_parent',
                 function() {
                     return 2;
@@ -104,13 +106,13 @@ class MemoizeTwigExtensionTraitTest extends TestCase
                 }
             );
 
-        /** @var \Twig_SimpleFunction[] $result */
+        /** @var TwigFunction[] $result */
         $result = $this->trait->getFunctions();
 
-        $this->assertInstanceOf(\Twig_SimpleFunction::class, $result[0]);
+        $this->assertInstanceOf(TwigFunction::class, $result[0]);
         $this->assertEquals('sulu_content_load', $result[0]->getName());
 
-        $this->assertInstanceOf(\Twig_SimpleFunction::class, $result[1]);
+        $this->assertInstanceOf(TwigFunction::class, $result[1]);
         $this->assertEquals('sulu_content_load_parent', $result[1]->getName());
 
         $this->assertEquals(1, call_user_func($result[0]->getCallable()));

--- a/src/Sulu/Component/Webspace/Manager/Dumper/WebspaceCollectionDumper.php
+++ b/src/Sulu/Component/Webspace/Manager/Dumper/WebspaceCollectionDumper.php
@@ -11,12 +11,15 @@
 
 namespace Sulu\Component\Webspace\Manager\Dumper;
 
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
 class WebspaceCollectionDumper
 {
     protected function render($template, $parameters)
     {
         //TODO set path in a more elegant way
-        $twig = new \Twig_Environment(new \Twig_Loader_Filesystem(__DIR__ . '/../../Resources/skeleton/'));
+        $twig = new Environment(new FilesystemLoader(__DIR__ . '/../../Resources/skeleton/'));
 
         return $twig->render($template, $parameters);
     }

--- a/src/Sulu/Component/Webspace/StructureProvider/WebspaceStructureProvider.php
+++ b/src/Sulu/Component/Webspace/StructureProvider/WebspaceStructureProvider.php
@@ -14,6 +14,8 @@ namespace Sulu\Component\Webspace\StructureProvider;
 use Doctrine\Common\Cache\Cache;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
 
 /**
  * Provide templates which are implemented in a single webspace.
@@ -21,7 +23,7 @@ use Sulu\Component\Content\Compat\StructureManagerInterface;
 class WebspaceStructureProvider implements WebspaceStructureProviderInterface
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $twig;
 
@@ -35,13 +37,8 @@ class WebspaceStructureProvider implements WebspaceStructureProviderInterface
      */
     protected $cache;
 
-    /**
-     * @param \Twig_Environment $twig
-     * @param StructureManagerInterface $structureManager
-     * @param Cache $cache
-     */
     public function __construct(
-        \Twig_Environment $twig,
+        Environment $twig,
         StructureManagerInterface $structureManager,
         Cache $cache
     ) {
@@ -50,9 +47,6 @@ class WebspaceStructureProvider implements WebspaceStructureProviderInterface
         $this->cache = $cache;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getStructures($webspaceKey)
     {
         if (!$this->cache->contains($webspaceKey)) {
@@ -112,7 +106,7 @@ class WebspaceStructureProvider implements WebspaceStructureProviderInterface
             // cast possible TemplateReferenceInterface to string because the
             // EngineInterface supports them but Twig_LoaderInterface does not
             $loader->getSource($template)->getCode();
-        } catch (\Twig_Error_Loader $e) {
+        } catch (LoaderError $e) {
             return false;
         }
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/StructureProvider/WebspaceStructureProviderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/StructureProvider/WebspaceStructureProviderTest.php
@@ -18,6 +18,8 @@ use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider;
 use Sulu\Component\Webspace\Webspace;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class WebspaceStructureProviderTest extends TestCase
 {
@@ -34,12 +36,12 @@ class WebspaceStructureProviderTest extends TestCase
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getTheme()->willReturn('test');
 
-        $twigLoader = $this->prophesize(\Twig_ExistsLoaderInterface::class);
+        $twigLoader = $this->prophesize(FilesystemLoader::class);
         $twigLoader->exists('MyBundle:default:t1.html.twig')->willReturn(false);
         $twigLoader->exists('MyBundle:default:t2.html.twig')->shouldBeCalled()->willReturn(true);
         $twigLoader->exists('MyBundle:default:t3.html.twig')->willReturn(false);
 
-        $twig = $this->prophesize('\Twig_Environment');
+        $twig = $this->prophesize(Environment::class);
         $twig->getLoader()->willReturn($twigLoader->reveal());
 
         $structureManager = $this->prophesize(StructureManagerInterface::class);
@@ -71,7 +73,7 @@ class WebspaceStructureProviderTest extends TestCase
             $this->generateStructure('t3', 'MyBundle:default:t3'),
         ];
 
-        $twig = $this->prophesize(\Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
         $twig->getLoader()->shouldNotBeCalled();
 
         $structureManager = $this->prophesize(StructureManagerInterface::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | build upon https://github.com/sulu/sulu/pull/4688
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR cleanup twig extensions and fixes a part of the problem that `cache:warmup` triggers the database.

#### Why?

This is a part of the problem that doctrine tries to connect to the database on cache:warmup.
