### PR TITLE
Make repositories lazy

### DIFF
--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
@@ -55,10 +55,9 @@ trait PersistenceExtensionTrait
             if (array_key_exists('model', $services)) {
                 $repositoryDefinition = $this->getRepositoryDefinition($object, $services, $container);
 
-                $container->setDefinition(
-                    $this->getContainerKey('repository', $object),
-                    $repositoryDefinition
-                )->setPublic(true);
+                $container->setDefinition($this->getContainerKey('repository', $object), $repositoryDefinition)
+                    ->setPublic(true)
+                    ->setLazy(true);
             }
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | built upon #4697
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR makes all repositories lazy services.

#### Why?

This is a part of the problem that doctrine tries to connect to the database on `cache:warmup`.
