### PR TITLE
Fix target entity of target-group association of FileVersion

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/EventListener/MediaAudienceTargetingSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/MediaAudienceTargetingSubscriber.php
@@ -15,7 +15,6 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 
 /**
@@ -23,6 +22,16 @@ use Sulu\Bundle\MediaBundle\Entity\FileVersion;
  */
 class MediaAudienceTargetingSubscriber implements EventSubscriber
 {
+    /**
+     * @var string
+     */
+    private $targetGroupClass;
+
+    public function __construct($targetGroupClass)
+    {
+        $this->targetGroupClass = $targetGroupClass;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -45,7 +54,7 @@ class MediaAudienceTargetingSubscriber implements EventSubscriber
         if ($reflection && FileVersion::class === $reflection->getName()) {
             $metadata->mapManyToMany([
                 'fieldName' => 'targetGroups',
-                'targetEntity' => TargetGroupInterface::class,
+                'targetEntity' => $this->targetGroupClass,
                 'joinTable' => [
                     'name' => 'me_file_version_target_groups',
                     'joinColumns' => [

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/audience_targeting.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/audience_targeting.xml
@@ -3,6 +3,7 @@
     <services>
         <service id="sulu_media.media_audience_targeting_subscriber"
                  class="Sulu\Bundle\MediaBundle\EventListener\MediaAudienceTargetingSubscriber">
+            <argument>%sulu.model.target_group.class%</argument>
             <tag name="doctrine.event_subscriber"/>
         </service>
     </services>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `MediaAudienceTargetingSubscriber` to set the `targetEntity` of the `targetGroups` association of the `FileVersion` to the configured `TargetGroup` class.

#### Why?

Setting the `targetEntity` of the association to `TargetGroupInterface` will cause the following error on `bin/console doctrine:schema:validate`:

```
The entity-class Sulu\Bundle\MediaBundle\Entity\FileVersion mapping is invalid:
 * The target entity 'Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface' specified on Sulu\Bundle\MediaBundle\Entity\FileVersion#targetGroups is unknown or not an entity.
```