### PR TITLE
Catch NotFoundHttpException in the AudienceTargetingCacheListener

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/AudienceTargetingCacheListenerTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class AudienceTargetingCacheListenerTest extends TestCase
 {
@@ -127,7 +128,11 @@ class AudienceTargetingCacheListenerTest extends TestCase
         $targetGroupResponse->headers = $responseHeaderBag->reveal();
 
         $httpCache = $this->prophesize(SuluHttpCache::class);
-        $httpCache->handle(Argument::any())->willReturn($targetGroupResponse->reveal());
+        $httpCache->handle(
+            Argument::any(),
+            HttpKernelInterface::MASTER_REQUEST,
+            false
+        )->willReturn($targetGroupResponse->reveal());
 
         return $httpCache->reveal();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the `AudienceTargetingCacheListener` to catch `NotFoundHttpException`s  that may happen during the `targetGroupRequest`. 

#### Why?

Because in the admin-context there is no route configured for the `/_sulu_target_group` url. Furthermore, the `AudienceTargetingCacheListener` is called on every `ConsoleEvents::TERMINATE` event. 

Therefore, right now, the `targetGroupRequest` will throw an `NotFoundHttpException` at the end of every command that is executed in the admin-context in the prod-environment.
