### PR TITLE
Avoid bc break in twig templates by provide uuid and id properties for pages

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -91,11 +91,11 @@ class PageControllerTest extends SuluTestCase
         $this->assertEquals('Homepage', $page1->title);
         $this->assertEquals('test_io', $page1->webspaceKey);
         $this->assertObjectHasAttribute('id', $page1);
-        $this->assertObjectNotHasAttribute('uuid', $page1);
+        $this->assertObjectHasAttribute('uuid', $page1);
         $this->assertEquals('Homepage', $page2->title);
         $this->assertEquals('sulu_io', $page2->webspaceKey);
         $this->assertObjectHasAttribute('id', $page2);
-        $this->assertObjectNotHasAttribute('uuid', $page2);
+        $this->assertObjectHasAttribute('uuid', $page2);
     }
 
     public function testPostTriggerAction()

--- a/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Navigation/NavigationItem.php
@@ -21,7 +21,7 @@ class NavigationItem
     /**
      * @var string
      */
-    private $uuid;
+    private $id;
 
     /**
      * @var string
@@ -48,14 +48,14 @@ class NavigationItem
      */
     private $excerpt;
 
-    public function __construct($title, $url, $excerpt, $children = [], $uuid = null, $nodeType = Structure::STATE_TEST)
+    public function __construct($title, $url, $excerpt, $children = [], $id = null, $nodeType = Structure::STATE_TEST)
     {
         $this->title = $title;
         $this->url = $url;
         $this->nodeType = $nodeType;
         $this->excerpt = $excerpt;
 
-        $this->uuid = (null === $uuid ? uniqid() : $uuid);
+        $this->id = (null === $id ? uniqid() : $id);
 
         $this->children = $children;
     }
@@ -71,9 +71,17 @@ class NavigationItem
     /**
      * @return string
      */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
     public function getUuid()
     {
-        return $this->uuid;
+        return $this->id;
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolver.php
@@ -54,6 +54,7 @@ class StructureResolver implements StructureResolverInterface
         $data = [
             'view' => [],
             'content' => [],
+            'id' => $structure->getUuid(),
             'uuid' => $structure->getUuid(),
             'creator' => $structure->getCreator(),
             'changer' => $structure->getChanger(),

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Resolver/StructureResolverTest.php
@@ -98,6 +98,7 @@ class StructureResolverTest extends TestCase
             'extension' => [
                 'excerpt' => ['test1' => 'test1'],
             ],
+            'id' => 'some-uuid',
             'uuid' => 'some-uuid',
             'view' => [
                 'property' => 'view',
@@ -161,6 +162,7 @@ class StructureResolverTest extends TestCase
         $document->getAuthor()->willReturn(1);
 
         $expected = [
+            'id' => 'some-uuid',
             'uuid' => 'some-uuid',
             'view' => [
                 'property' => 'view',

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -751,6 +751,7 @@ class ContentMapper implements ContentMapperInterface
 
         $documentData = [
             'id' => $originalDocument->getUuid(),
+            'uuid' => $originalDocument->getUuid(),
             'nodeType' => $redirectType,
             'path' => $shortPath,
             'changed' => $document->getChanged(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | 
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add uuid property to contentmapper besides the id.

#### Why?

Avoid twig developers to change all twig template which access uuid so introduce a bc layer with uuid.

Introduced in: https://github.com/sulu/sulu/pull/4550/files#diff-2a74d79cea8c966c3ad6a835206c6c3bL751

#### Example Usage

 - smart content
 - navigation twig extension
 - breadcrumb return uuid
 - page return uuid

#### To Do

- [ ] Create a documentation PR
- [ ] ~~Add breaking changes to UPGRADE.md~~
