### PR TITLE
Hide buttons in column list if view permissions for pages is missing

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/Item.js
@@ -98,7 +98,7 @@ class Item extends React.Component<Props> {
             const key = `button-${index}`;
 
             return (
-                <ItemButton config={button} id={id} key={key} />
+                <ItemButton {...button} id={id} key={key} />
             );
         });
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ItemButton.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/ItemButton.js
@@ -1,28 +1,44 @@
 // @flow
 import React from 'react';
+import classNames from 'classnames';
 import Icon from '../Icon';
-import type {ItemButtonConfig} from './types';
 import itemStyles from './item.scss';
 
 type Props = {|
-    config: ItemButtonConfig,
+    icon: string,
     id: string | number,
+    onClick: (id: string | number) => void,
+    visible: boolean,
 |};
 
 export default class ItemButton extends React.Component<Props> {
-    handleClick = () => {
-        const {id, config} = this.props;
+    static defaultProps = {
+        visible: true,
+    };
 
-        if (!config.onClick) {
+    handleClick = () => {
+        const {id, onClick} = this.props;
+
+        if (!onClick) {
             return;
         }
 
-        config.onClick(id);
+        onClick(id);
     };
 
     render() {
+        const {
+            icon,
+            visible,
+        } = this.props;
+
+        const iconClass = classNames({
+            [itemStyles.button]: true,
+            [itemStyles.visible]: visible,
+        });
+
         return (
-            <Icon className={itemStyles.button} name={this.props.config.icon} onClick={this.handleClick} />
+            <Icon className={iconClass} name={icon} onClick={this.handleClick} />
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/item.scss
@@ -50,6 +50,11 @@ $itemHeight: 40px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    visibility: inherit;
+
+    &:not(.visible) {
+        visibility: hidden;
+    }
 }
 
 .buttons {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/ColumnList.test.js
@@ -57,6 +57,7 @@ test('The ColumnList component should render without ', () => {
         {
             icon: 'fa-pencil',
             onClick: () => {},
+            visible: false,
         },
     ];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/tests/__snapshots__/ColumnList.test.js.snap
@@ -757,7 +757,7 @@ exports[`The ColumnList component should render without  1`] = `
           >
             <span
               aria-label="fa-heart"
-              class="fa fa-heart clickable button"
+              class="fa fa-heart clickable button visible"
               role="button"
               tabindex="0"
             />
@@ -810,7 +810,7 @@ exports[`The ColumnList component should render without  1`] = `
           >
             <span
               aria-label="fa-heart"
-              class="fa fa-heart clickable button"
+              class="fa fa-heart clickable button visible"
               role="button"
               tabindex="0"
             />
@@ -913,7 +913,7 @@ exports[`The ColumnList component should render without  1`] = `
           >
             <span
               aria-label="fa-heart"
-              class="fa fa-heart clickable button"
+              class="fa fa-heart clickable button visible"
               role="button"
               tabindex="0"
             />
@@ -966,7 +966,7 @@ exports[`The ColumnList component should render without  1`] = `
           >
             <span
               aria-label="fa-heart"
-              class="fa fa-heart clickable button"
+              class="fa fa-heart clickable button visible"
               role="button"
               tabindex="0"
             />
@@ -1029,7 +1029,7 @@ exports[`The ColumnList component should render without  1`] = `
           >
             <span
               aria-label="fa-heart"
-              class="fa fa-heart clickable button"
+              class="fa fa-heart clickable button visible"
               role="button"
               tabindex="0"
             />
@@ -1082,7 +1082,7 @@ exports[`The ColumnList component should render without  1`] = `
           >
             <span
               aria-label="fa-heart"
-              class="fa fa-heart clickable button"
+              class="fa fa-heart clickable button visible"
               role="button"
               tabindex="0"
             />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ColumnList/types.js
@@ -2,6 +2,7 @@
 export type ItemButtonConfig = {
     icon: string,
     onClick: (string | number) => void,
+    visible?: boolean,
 };
 
 export type ToolbarDropdownOptionConfig = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -109,16 +109,25 @@ class ColumnListAdapter extends AbstractAdapter {
         const isGhost = item.type && item.type.name === 'ghost';
 
         const buttons = [];
+
+        const {
+            _permissions: {
+                view: viewPermission = true,
+            } = {},
+        } = item;
+
         if (onItemClick) {
             if (isGhost) {
                 buttons.push({
                     icon: 'su-plus-circle',
                     onClick: onItemClick,
+                    visible: viewPermission,
                 });
             } else {
                 buttons.push({
                     icon: 'su-pen',
                     onClick: onItemClick,
+                    visible: viewPermission,
                 });
             }
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -99,6 +99,9 @@ test('Render different kind of data with edit button', () => {
                 type: {
                     name: 'shadow',
                 },
+                _permissions: {
+                    view: false,
+                },
             },
         ],
         [],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/__snapshots__/ColumnListAdapter.test.js.snap
@@ -47,7 +47,7 @@ exports[`Render data with disabled items 1`] = `
             >
               <span
                 aria-label="su-check"
-                class="su-check clickable button"
+                class="su-check clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -107,7 +107,7 @@ exports[`Render data with disabled items 1`] = `
             >
               <span
                 aria-label="su-check"
-                class="su-check clickable button"
+                class="su-check clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -429,7 +429,7 @@ exports[`Render data with selection 1`] = `
             >
               <span
                 aria-label="su-check"
-                class="su-check clickable button"
+                class="su-check clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -630,7 +630,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -689,7 +689,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -746,7 +746,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -811,7 +811,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -871,7 +871,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-plus-circle"
-                class="su-plus-circle clickable button"
+                class="su-plus-circle clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -932,7 +932,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-plus-circle"
-                class="su-plus-circle clickable button"
+                class="su-plus-circle clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -993,7 +993,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -1058,7 +1058,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />
@@ -1118,7 +1118,7 @@ exports[`Render different kind of data with edit button 1`] = `
             >
               <span
                 aria-label="su-pen"
-                class="su-pen clickable button"
+                class="su-pen clickable button visible"
                 role="button"
                 tabindex="0"
               />

--- a/src/Sulu/Bundle/PageBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/NodeController.php
@@ -35,9 +35,7 @@ use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Rest\RestController;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
-use Sulu\Component\Security\SecuredControllerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -556,25 +554,25 @@ class NodeController extends RestController implements ClassResourceInterface
 
         $view = $this->responseDelete(
             $id,
-            function($id) use ($webspace, $request) {
-                    try {
-                        $document = $this->getDocumentManager()->find($id);
+            function($id) use ($request) {
+                try {
+                    $document = $this->getDocumentManager()->find($id);
 
-                        $this->get('sulu_security.security_checker')->checkPermission(
+                    $this->get('sulu_security.security_checker')->checkPermission(
                             $this->getSecurityCondition($request, $document),
                             'delete'
                         );
 
-                        $this->getDocumentManager()->remove($document);
-                        $this->getDocumentManager()->flush();
-                    } catch (DocumentNotFoundException $ex) {
-                        throw new EntityNotFoundException('Content', $id);
-                    }
+                    $this->getDocumentManager()->remove($document);
+                    $this->getDocumentManager()->flush();
+                } catch (DocumentNotFoundException $ex) {
+                    throw new EntityNotFoundException('Content', $id);
                 }
+            }
             );
 
-            return $this->handleView($view);
-        }
+        return $this->handleView($view);
+    }
 
     /**
      * trigger a action for given node specified over get-action parameter

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -229,15 +229,6 @@ class NodeRepository implements NodeRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteNode($uuid, $webspaceKey)
-    {
-        // TODO remove third parameter, and ask in UI if referenced node should be deleted
-        $this->getMapper()->delete($uuid, $webspaceKey, true);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getReferences($uuid)
     {
         $session = $this->sessionManager->getSession();

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepositoryInterface.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepositoryInterface.php
@@ -123,14 +123,6 @@ interface NodeRepositoryInterface
     public function getIndexNode($webspaceKey, $languageCode);
 
     /**
-     * removes given node.
-     *
-     * @param string $uuid
-     * @param string $webspaceKey
-     */
-    public function deleteNode($uuid, $webspaceKey);
-
-    /**
      * Return the nodes which refer to the structure with the
      * given UUID.
      *

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerFieldsTest.php
@@ -195,25 +195,6 @@ class NodeControllerFieldsTest extends SuluTestCase
         $this->assertEquals('test-3', $items[0]['title']);
     }
 
-    public function testGet()
-    {
-        $page1 = $this->createPage('test-1', 'de');
-        $this->createPage('test-1-1', 'de', [], $page1);
-
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
-            'GET',
-            sprintf('/api/nodes/%s', $page1->getUuid()),
-            ['webspace' => 'sulu_io', 'language' => 'de', 'fields' => 'title']
-        );
-        $result = json_decode($client->getResponse()->getContent(), true);
-
-        $this->assertEquals($page1->getUuid(), $result['id']);
-        $this->assertTrue($result['hasChildren']);
-        $this->assertEmpty($result['_embedded']['pages']);
-    }
-
     public function testGetTree()
     {
         $page1 = $this->createPage('test-1', 'de');
@@ -306,23 +287,6 @@ class NodeControllerFieldsTest extends SuluTestCase
         $result = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertEquals('external', $result['linked']);
-    }
-
-    public function testTypeGhost()
-    {
-        $page = $this->createPage('test-2', 'en');
-
-        $client = $this->createAuthenticatedClient();
-
-        $client->request(
-            'GET',
-            sprintf('/api/nodes/%s', $page->getUuid()),
-            ['webspace' => 'sulu_io', 'language' => 'de', 'fields' => 'title']
-        );
-        $result = json_decode($client->getResponse()->getContent(), true);
-
-        $this->assertEquals('ghost', $result['type']['name']);
-        $this->assertEquals('en', $result['type']['value']);
     }
 
     public function testTypeShadow()

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -119,8 +119,14 @@ class NodeControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
         $client = $this->createAuthenticatedClient();
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data1);
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data1
+        );
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
         $uuid = $response->id;
@@ -172,7 +178,13 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
 
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent());
@@ -220,10 +232,20 @@ class NodeControllerTest extends SuluTestCase
             'article' => 'Test',
         ];
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
         $this->assertHttpStatusCode(200, $client->getResponse());
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data);
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
         $this->assertHttpStatusCode(409, $client->getResponse());
     }
 
@@ -552,7 +574,13 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data
+        );
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $client->request(
@@ -687,7 +715,9 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request('POST', '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en', $data);
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $data = [
@@ -773,7 +803,13 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data
+        );
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $client->request('PUT', '/api/nodes/' . $response['id'] . '?webspace=sulu_io&language=de', $data);
@@ -864,7 +900,9 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request('POST', '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en', $data);
         $response = json_decode($client->getResponse()->getContent(), true);
 
         $client->request('GET', '/api/nodes/' . $response['id'] . '?language=en', $data);
@@ -889,7 +927,13 @@ class NodeControllerTest extends SuluTestCase
 
         $client = $this->createAuthenticatedClient();
 
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data
+        );
         $response = json_decode($client->getResponse()->getContent(), true);
         $id = $response['id'];
 
@@ -921,11 +965,25 @@ class NodeControllerTest extends SuluTestCase
             'template' => 'default',
             'url' => '/test',
         ];
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
         $this->assertHttpStatusCode(200, $client->getResponse());
 
         $data['url'] = '/test2';
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
         $this->assertHttpStatusCode(200, $client->getResponse());
         $response = json_decode($client->getResponse()->getContent(), true);
 
@@ -1355,7 +1413,14 @@ class NodeControllerTest extends SuluTestCase
             'url' => '/a1',
             'article' => 'Test',
         ];
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', $data);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            $data
+        );
         $response = json_decode($client->getResponse()->getContent(), true);
         $uuid = $response['id'];
         $data = [
@@ -1823,8 +1888,14 @@ class NodeControllerTest extends SuluTestCase
             ],
         ];
 
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
         $client = $this->createAuthenticatedClient();
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data[0]);
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data[0]
+        );
         $data[0] = json_decode($client->getResponse()->getContent(), true);
 
         $client->request(
@@ -1850,7 +1921,14 @@ class NodeControllerTest extends SuluTestCase
             'article' => 'Test',
             'navContexts' => ['main', 'footer'],
         ];
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data
+        );
         $data = json_decode($client->getResponse()->getContent(), true);
 
         $this->assertArrayHasKey('id', $data);
@@ -1890,7 +1968,14 @@ class NodeControllerTest extends SuluTestCase
             'url' => '/test1',
             'article' => 'Test',
         ];
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data
+        );
         $data = json_decode($client->getResponse()->getContent(), true);
 
         $client->request(
@@ -1921,7 +2006,14 @@ class NodeControllerTest extends SuluTestCase
             'url' => '/test1',
             'article' => 'Test',
         ];
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data
+        );
         $data = json_decode($client->getResponse()->getContent(), true);
 
         $client->request(
@@ -2069,7 +2161,14 @@ class NodeControllerTest extends SuluTestCase
         ];
 
         $client = $this->createAuthenticatedClient();
-        $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data[0]);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+            $data[0]
+        );
         $data[0] = json_decode($client->getResponse()->getContent(), true);
         $client->request('POST', '/api/nodes?webspace=sulu_io&language=en&parentId=' . $data[0]['id'], $data[1]);
         $data[1] = json_decode($client->getResponse()->getContent(), true);
@@ -2136,8 +2235,14 @@ class NodeControllerTest extends SuluTestCase
     {
         $client = $this->createAuthenticatedClient();
 
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
         for ($i = 0; $i < count($data); ++$i) {
-            $client->request('POST', '/api/nodes?webspace=sulu_io&language=en', $data[$i]);
+            $client->request(
+                'POST',
+                '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en',
+                $data[$i]
+            );
             $data[$i] = (array) json_decode($client->getResponse()->getContent(), true);
         }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -38,6 +38,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
     protected function setUp()
     {
         $this->session = $this->getContainer()->get('doctrine')->getConnection();
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->purgeDatabase();
         $this->initPhpcr();
         $this->data = $this->prepareRepositoryContent();
@@ -112,15 +113,26 @@ class PageResourcelocatorControllerTest extends SuluTestCase
                 'PHP_AUTH_PW' => 'test',
             ]
         );
-        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish', $data[0]);
+
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&locale=en&action=publish',
+            $data[0]
+        );
         $data[0] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish', $data[1]);
+        $client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&locale=en&action=publish',
+            $data[1]
+        );
         $data[1] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parent=' . $data[1]['id'], $data[2]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parentId=' . $data[1]['id'], $data[2]);
         $data[2] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parent=' . $data[1]['id'], $data[3]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parentId=' . $data[1]['id'], $data[3]);
         $data[3] = (array) json_decode($client->getResponse()->getContent(), true);
-        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parent=' . $data[3]['id'], $data[4]);
+        $client->request('POST', '/api/nodes?webspace=sulu_io&locale=en&action=publish&parentId=' . $data[3]['id'], $data[4]);
         $data[4] = (array) json_decode($client->getResponse()->getContent(), true);
 
         return $data;

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
@@ -32,6 +32,8 @@ class ResourcelocatorControllerTest extends SuluTestCase
                 'PHP_AUTH_PW' => 'test',
             ]
         );
+
+        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
     }
 
     public function testGenerate()
@@ -48,9 +50,11 @@ class ResourcelocatorControllerTest extends SuluTestCase
 
     public function testGenerateWithParent()
     {
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
         $this->client->request(
             'POST',
-            '/api/nodes?webspace=sulu_io&language=en&action=publish',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&locale=en&action=publish',
             [
                 'title' => 'Produkte',
                 'template' => 'default',
@@ -72,11 +76,17 @@ class ResourcelocatorControllerTest extends SuluTestCase
 
     public function testGenerateWithConflict()
     {
-        $this->client->request('POST', '/api/nodes?webspace=sulu_io&language=en&action=publish', [
-            'title' => 'Test',
-            'template' => 'default',
-            'url' => '/test',
-        ]);
+        $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
+
+        $this->client->request(
+            'POST',
+            '/api/nodes?parentId=' . $homeDocument->getUuid() . '&webspace=sulu_io&language=en&action=publish',
+            [
+                'title' => 'Test',
+                'template' => 'default',
+                'url' => '/test',
+            ]
+        );
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->client->request('POST', '/api/resourcelocators?action=generate', [

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -101,16 +101,6 @@ class NodeRepositoryTest extends SuluTestCase
         $this->assertEquals($document->getStructure()->getProperty('url')->getValue(), $result['url']);
     }
 
-    public function testDelete()
-    {
-        $structure = $this->prepareGetTestData();
-
-        $this->nodeRepository->deleteNode($structure->getUuid(), 'sulu_io');
-
-        $this->expectException(DocumentNotFoundException::class);
-        $this->nodeRepository->getNode($structure->getUuid(), 'sulu_io', 'en');
-    }
-
     public function testGetWebspaceNode()
     {
         $result = $this->nodeRepository->getWebspaceNode('sulu_io', 'en');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR hides the edit button for pages in the column list if the view permission is missing.

#### Why?

Because if the permission is missing the API won't return any information, leading to an error.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
