### PR TITLE
Prevent unnecessary config request if user is not logged in

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -279,7 +279,7 @@ function startAdmin() {
     const router = new Router(createHashHistory());
     router.addUpdateAttributesHook(updateRouterAttributesFromView);
 
-    initializer.initialize().then(() => {
+    initializer.initialize(Config.initialLoginState).then(() => {
         router.reload();
     });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Initializer/Initializer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Initializer/Initializer.js
@@ -83,8 +83,15 @@ class Initializer {
         });
     }
 
-    initialize() {
+    initialize(userIsLoggedIn: boolean) {
         this.setLoading(true);
+
+        // the config and the routes are accessible only for authenticated users
+        // if no user is logged in, we do not want to fetch this data to prevent unnecessary 401 responses
+        // a 401 response will reset cached basic auth credentials and lead to a second authentication prompt
+        if (!userIsLoggedIn) {
+            return this.initializeTranslations();
+        }
 
         const configPromise = Requester.get(Config.endpoints.config);
         const routePromise = this.initializeSymfonyRouting();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/UserStore.js
@@ -98,7 +98,7 @@ class UserStore {
                 }
 
                 this.setLoading(true);
-                return initializer.initialize().then(() => {
+                return initializer.initialize(true).then(() => {
                     this.setLoading(false);
                 });
             })

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/UserStore/tests/UserStore.test.js
@@ -168,7 +168,7 @@ test('Should login', () => {
 
     return loginPromise.then(() => {
         expect(Requester.post).toBeCalledWith('login_check_url', {username: 'test', password: 'password'});
-        expect(initializer.initialize).toBeCalled();
+        expect(initializer.initialize).toBeCalledWith(true);
 
         return initializePromise.then(() => {
             expect(userStore.loading).toBe(false);
@@ -209,7 +209,7 @@ test('Should login with initializing when it`s not the same user', () => {
             'login_check_url',
             {username: 'other-user-than-test', password: 'password'}
         );
-        expect(initializer.initialize).toBeCalled();
+        expect(initializer.initialize).toBeCalledWith(true);
         expect(userStore.loading).toBe(true);
         expect(userStore.loggedIn).toBe(false);
         expect(userStore.loginError).toBe(false);

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -12,7 +12,7 @@
         <script type="text/javascript">
             {% autoescape false %}
             const SULU_CONFIG = Object.freeze({
-                initialLoginState: {{ app.user ? 'true' : 'false' }},
+                initialLoginState: {{ is_granted('IS_AUTHENTICATED_REMEMBERED') ? 'true' : 'false' }},
                 translations: {{ translations|json_encode }},
                 fallbackLocale: '{{ fallback_locale }}',
                 endpoints: {{ endpoints|json_encode }},

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -12,6 +12,7 @@
         <script type="text/javascript">
             {% autoescape false %}
             const SULU_CONFIG = Object.freeze({
+                initialLoginState: {{ app.user ? 'true' : 'false' }},
                 translations: {{ translations|json_encode }},
                 fallbackLocale: '{{ fallback_locale }}',
                 endpoints: {{ endpoints|json_encode }},


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts `Initializer` javascript class to prevent unnecessary requests if no user is logged in.

#### Why?

To prevent unnecessary 401 responses that will reset cached Basic Authentication credentials.
Without this change, if the Sulu admin runs behind a webserver with enabled Basic Authentication, the user must provide Basic Authentication credentials **two times** before he is able to log in with his sulu credentials.

Right now, the following happens if the Sulu admin runs behind a webserver with enabled Basic Authentication:

- The browser will ask for Basic Authentication credentials on the initial `admin/` request and cache the given credentials
- The `Initializer` dispatches the `admin/config` request (to which the browser appends the cached credentials) which will lead to a 401 response because the user is not logged in into Sulu yet
- The 401 response triggers the browser to reset the cached Basic Authentication credentials
- The `Initializer` dispatches a `admin/api/localizations?flat=true` request. The browser will not attach any credentials and therefore will ask for Basic Authentication credentials **again**
- The user sees the loaded login screen
