### PR TITLE
Fix PageList in Safari

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/application.scss
@@ -41,6 +41,8 @@
 }
 
 .view-container {
+    display: flex;
+    flex-direction: column;
     flex-grow: 1;
     overflow-y: auto;
     padding: $viewPadding;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
@@ -8,6 +8,7 @@ $permissionHintColor: $gray;
     display: flex;
     flex-direction: column;
     height: 100%;
+    flex-grow: 1;
 }
 
 .list {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/pageList.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/pageList.scss
@@ -2,6 +2,9 @@
 @import 'sulu-page-bundle/views/WebspaceTabs/variables.scss';
 
 .page-list {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
     height: calc(100% - $tabMenuHeight - 8px);
     margin-top: calc(-$webspaceTabsWebspaceSelectMargin - 38px);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds some more flexbox css statements.

#### Why?

Because without them the `PageList´ component is not shown in Safari.