### PR TITLE
Remove React deprecations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -118,7 +118,7 @@
         "import/no-absolute-path": "error",
         "import/named": "error",
         "import/default": "error",
-        "react/no-deprecated": "warn",
+        "react/no-deprecated": "error",
         "react/jsx-curly-brace-presence": [
             "error",
             "never"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/DatePicker.js
@@ -62,12 +62,12 @@ class DatePicker extends React.Component<Props> {
         this.setValue(this.props.value);
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        if (this.value && !nextProps.value) {
+    componentDidUpdate() {
+        if (this.value && !this.props.value) {
             return;
         }
 
-        this.setValue(nextProps.value);
+        this.setValue(this.props.value);
     }
 
     handleChange = (date: ?Date) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/DatePicker/README.md
@@ -24,6 +24,8 @@ const onChange = (newValue) => {
 <div>
     <div style={{paddingBottom: '50px'}}>Current value: {state.value ? state.value.toLocaleDateString() : 'null'}</div>
     <DatePicker value={state.value} onChange={onChange} />
+
+    <button onClick={() => onChange(new Date('2017-03-10'))}>Test</button>
 </div>
 ```
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/README.md
@@ -19,7 +19,7 @@ const handleChange = (selection) => {
 
 <div style={{width: 500, height: 500, background: '#e8e8e8'}}>
     <ImageRectangleSelection
-        image="https://unsplash.it/1920/1080"
+        image="https://picsum.photos/1920/1080"
         onChange={handleChange}
         value={state.selection}
     />
@@ -39,7 +39,7 @@ const handleChange = (selection) => {
 <div>
     <div style={{width: 800, height: 300, background: '#e8e8e8'}}>
         <ImageRectangleSelection
-            image="https://unsplash.it/1920/1080"
+            image="https://picsum.photos/1920/1080"
             initialSelection={{width: 1500, height: 800, top: 200, left: 300}}
             minWidth={100}
             minHeight={60}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/README.md
@@ -23,6 +23,7 @@ const handleNavigationClick = (value) => {
         title="sulu.io"
         username="John Travolta"
         userImage={'http://lorempixel.com/200/200'}
+        onItemClick={handleNavigationClick}
         onLogoutClick={handleLogoutClick}
         onProfileClick={handleProfileClick}
         suluVersion="2.0.0-RC1"
@@ -30,20 +31,20 @@ const handleNavigationClick = (value) => {
         appVersion="1.0.0"
         appVersionLink="http://link.com"
     >
-        <Navigation.Item value="search" title="Search" icon="su-search" onClick={handleNavigationClick} />
-        <Navigation.Item value="webspaces" title="Webspaces" icon="su-webspace" onClick={handleNavigationClick} />
-        <Navigation.Item value="media" title="Media" icon="fa-image" onClick={handleNavigationClick} />
-        <Navigation.Item value="articles" title="Article" icon="fa-newspaper-o" onClick={handleNavigationClick} />
-        <Navigation.Item value="snippets" title="Snippets" icon="fa-sticky-note-o" onClick={handleNavigationClick} />
+        <Navigation.Item value="search" title="Search" icon="su-search" />
+        <Navigation.Item value="webspaces" title="Webspaces" icon="su-webspace" />
+        <Navigation.Item value="media" title="Media" icon="fa-image" />
+        <Navigation.Item value="articles" title="Article" icon="fa-newspaper-o" />
+        <Navigation.Item value="snippets" title="Snippets" icon="fa-sticky-note-o" />
         <Navigation.Item value="contact" title="Contact" icon="fa-user">
-            <Navigation.Item value="contact_1" onClick={handleNavigationClick} title="Contact 1" />
-            <Navigation.Item value="contact_2" onClick={handleNavigationClick} title="Contact 2" active={true} />
-            <Navigation.Item value="contact_3" onClick={handleNavigationClick} title="Contact 3" />
+            <Navigation.Item value="contact_1" title="Contact 1" />
+            <Navigation.Item value="contact_2" title="Contact 2" active={true} />
+            <Navigation.Item value="contact_3" title="Contact 3" />
         </Navigation.Item>
         <Navigation.Item value="settings" title="Settings" icon="fa-gear">
-            <Navigation.Item value="setting_1" onClick={handleNavigationClick} title="Setting 1" />
-            <Navigation.Item value="setting_2" onClick={handleNavigationClick} title="Setting 2" />
-            <Navigation.Item value="setting_3" onClick={handleNavigationClick} title="Setting 3" />
+            <Navigation.Item value="setting_1" title="Setting 1" />
+            <Navigation.Item value="setting_2" title="Setting 2" />
+            <Navigation.Item value="setting_3" title="Setting 3" />
         </Navigation.Item>
     </Navigation>
 </div>
@@ -69,15 +70,16 @@ const handleNavigationClick = (value) => {
 
 <div style={{height: '500px'}}>
     <Navigation
-        title="sulu.io"
-        username="John Terence Maximilian Travolta"
+        onItemClick={handleNavigationClick}
         onLogoutClick={handleLogoutClick}
         onProfileClick={handleProfileClick}
         suluVersion="2.0.0-RC1"
         suluVersionLink="http://link.com"
+        title="sulu.io"
+        username="John Terence Maximilian Travolta"
     >
-        <Navigation.Item value="search" title="Search" icon="su-search" onClick={handleNavigationClick} />
-        <Navigation.Item value="webspaces" title="Webspaces" icon="su-webspace" onClick={handleNavigationClick} />
+        <Navigation.Item value="search" title="Search" icon="su-search" />
+        <Navigation.Item value="webspaces" title="Webspaces" icon="su-webspace" />
     </Navigation>
 </div>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/tests/Navigation.test.js
@@ -10,6 +10,7 @@ test('The component should render and handle clicks correctly', () => {
 
     const navigation = mount(
         <Navigation
+            onItemClick={jest.fn()}
             onLogoutClick={handleLogoutClick}
             onProfileClick={handleProfileClick}
             suluVersion="2.0.0-RC1"
@@ -41,35 +42,35 @@ test('The component should render with all available props and handle clicks cor
         <Navigation
             appVersion="1.0.0"
             appVersionLink="http://link.com"
-            isPinned={false}
+            onItemClick={handleNavigationClick}
             onLogoutClick={handleLogoutClick}
             onPinToggle={handlePinClick}
             onProfileClick={handleProfileClick}
+            pinned={false}
             suluVersion="2.0.0-RC1"
             suluVersionLink="http://link.com"
             title="sulu.io"
             userImage="http://lorempixel.com/200/200"
             username="John Travolta"
         >
-            <Navigation.Item icon="su-search" onClick={handleNavigationClick} title="Search" value="search" />
-            <Navigation.Item icon="su-webspace" onClick={handleNavigationClick} title="Webspaces" value="webspaces" />
-            <Navigation.Item icon="fa-image" onClick={handleNavigationClick} title="Media" value="media" />
-            <Navigation.Item icon="fa-newspaper-o" onClick={handleNavigationClick} title="Article" value="articles" />
+            <Navigation.Item icon="su-search" title="Search" value="search" />
+            <Navigation.Item icon="su-webspace" title="Webspaces" value="webspaces" />
+            <Navigation.Item icon="fa-image" title="Media" value="media" />
+            <Navigation.Item icon="fa-newspaper-o" title="Article" value="articles" />
             <Navigation.Item
                 icon="fa-sticky-note-o"
-                onClick={handleNavigationClick}
                 title="Snippets"
                 value="snippets"
             />
             <Navigation.Item icon="su-user-1" title="Contact" value="contact">
-                <Navigation.Item onClick={handleNavigationClick} title="Contact 1" value="contact_1" />
-                <Navigation.Item active={true} onClick={handleNavigationClick} title="Contact 2" value="contact_2" />
-                <Navigation.Item onClick={handleNavigationClick} title="Contact 3" value="contact_3" />
+                <Navigation.Item title="Contact 1" value="contact_1" />
+                <Navigation.Item active={true} title="Contact 2" value="contact_2" />
+                <Navigation.Item title="Contact 3" value="contact_3" />
             </Navigation.Item>
             <Navigation.Item icon="fa-gear" title="Settings" value="settings">
-                <Navigation.Item onClick={handleNavigationClick} title="Setting 1" value="setting_1" />
-                <Navigation.Item onClick={handleNavigationClick} title="Setting 2" value="setting_2" />
-                <Navigation.Item onClick={handleNavigationClick} title="Setting 3" value="setting_3" />
+                <Navigation.Item title="Setting 1" value="setting_1" />
+                <Navigation.Item title="Setting 2" value="setting_2" />
+                <Navigation.Item title="Setting 3" value="setting_3" />
             </Navigation.Item>
         </Navigation>
     );
@@ -95,6 +96,7 @@ test('The expanded prop should be set correct automatically', () => {
         <Navigation
             appVersion="1.0.0"
             appVersionLink="http://link.com"
+            onItemClick={handleNavigationClick}
             onLogoutClick={handleLogoutClick}
             onProfileClick={handleProfileClick}
             suluVersion="2.0.0-RC1"
@@ -103,25 +105,15 @@ test('The expanded prop should be set correct automatically', () => {
             userImage="http://lorempixel.com/200/200"
             username="John Travolta"
         >
-            <Navigation.Item icon="su-search" onClick={handleNavigationClick} title="Search" value="search" />
-            <Navigation.Item icon="su-webspace" onClick={handleNavigationClick} title="Webspaces" value="webspaces" />
-            <Navigation.Item icon="fa-image" onClick={handleNavigationClick} title="Media" value="media" />
-            <Navigation.Item icon="fa-newspaper-o" onClick={handleNavigationClick} title="Article" value="articles" />
-            <Navigation.Item
-                icon="fa-sticky-note-o"
-                onClick={handleNavigationClick}
-                title="Snippets"
-                value="snippets"
-            />
             <Navigation.Item icon="su-user-1" title="Contact" value="contact">
-                <Navigation.Item onClick={handleNavigationClick} title="Contact 1" value="contact_1" />
-                <Navigation.Item active={true} onClick={handleNavigationClick} title="Contact 2" value="contact_2" />
-                <Navigation.Item onClick={handleNavigationClick} title="Contact 3" value="contact_3" />
+                <Navigation.Item title="Contact 1" value="contact_1" />
+                <Navigation.Item active={true} title="Contact 2" value="contact_2" />
+                <Navigation.Item title="Contact 3" value="contact_3" />
             </Navigation.Item>
             <Navigation.Item icon="fa-gear" title="Settings" value="settings">
-                <Navigation.Item onClick={handleNavigationClick} title="Setting 1" value="setting_1" />
-                <Navigation.Item onClick={handleNavigationClick} title="Setting 2" value="setting_2" />
-                <Navigation.Item onClick={handleNavigationClick} title="Setting 3" value="setting_3" />
+                <Navigation.Item title="Setting 1" value="setting_1" />
+                <Navigation.Item title="Setting 2" value="setting_2" />
+                <Navigation.Item title="Setting 3" value="setting_3" />
             </Navigation.Item>
         </Navigation>
     );
@@ -130,6 +122,59 @@ test('The expanded prop should be set correct automatically', () => {
     expect(navigation.find('Item[value="settings"]').instance().props.expanded).toBe(false);
 
     navigation.find('Item[value="settings"] .title').simulate('click');
+    expect(navigation.find('Item[value="contact"]').instance().props.expanded).toBe(false);
+    expect(navigation.find('Item[value="settings"]').instance().props.expanded).toBe(true);
+});
+
+test('The expanded prop should be set correct automatically when children change', () => {
+    const handleNavigationClick = jest.fn();
+    const handleLogoutClick = jest.fn();
+    const handleProfileClick = jest.fn();
+
+    const navigation = mount(
+        <Navigation
+            appVersion="1.0.0"
+            appVersionLink="http://link.com"
+            onItemClick={handleNavigationClick}
+            onLogoutClick={handleLogoutClick}
+            onProfileClick={handleProfileClick}
+            suluVersion="2.0.0-RC1"
+            suluVersionLink="http://link.com"
+            title="sulu.io"
+            userImage="http://lorempixel.com/200/200"
+            username="John Travolta"
+        >
+            <Navigation.Item icon="su-user-1" title="Contact" value="contact">
+                <Navigation.Item title="Contact 1" value="contact_1" />
+                <Navigation.Item active={true} title="Contact 2" value="contact_2" />
+                <Navigation.Item title="Contact 3" value="contact_3" />
+            </Navigation.Item>
+            <Navigation.Item icon="fa-gear" title="Settings" value="settings">
+                <Navigation.Item title="Setting 1" value="setting_1" />
+                <Navigation.Item title="Setting 2" value="setting_2" />
+                <Navigation.Item title="Setting 3" value="setting_3" />
+            </Navigation.Item>
+        </Navigation>
+    );
+
+    expect(navigation.find('Item[value="contact"]').instance().props.expanded).toBe(true);
+    expect(navigation.find('Item[value="settings"]').instance().props.expanded).toBe(false);
+
+    navigation.setProps({
+        children: [
+            <Navigation.Item icon="su-user-1" key="1" title="Contact" value="contact">
+                <Navigation.Item title="Contact 1" value="contact_1" />
+                <Navigation.Item title="Contact 2" value="contact_2" />
+                <Navigation.Item title="Contact 3" value="contact_3" />
+            </Navigation.Item>,
+            <Navigation.Item icon="fa-gear" key="2" title="Settings" value="settings">
+                <Navigation.Item title="Setting 1" value="setting_1" />
+                <Navigation.Item active={true} title="Setting 2" value="setting_2" />
+                <Navigation.Item title="Setting 3" value="setting_3" />
+            </Navigation.Item>,
+        ],
+    });
+
     expect(navigation.find('Item[value="contact"]').instance().props.expanded).toBe(false);
     expect(navigation.find('Item[value="settings"]').instance().props.expanded).toBe(true);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/RectangleSelection.js
@@ -65,8 +65,8 @@ class RectangleSelection extends React.Component<Props> {
         this.normalizers = RectangleSelection.createNormalizers(this.props);
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        this.normalizers = RectangleSelection.createNormalizers(nextProps);
+    componentDidUpdate() {
+        this.normalizers = RectangleSelection.createNormalizers(this.props);
     }
 
     normalize(selection: SelectionData): SelectionData {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Toolbar/Select.js
@@ -40,13 +40,13 @@ class Select extends React.Component<SelectProps> {
         });
     }
 
-    componentWillReceiveProps = (nextProps: SelectProps) => {
-        const {disabled} = nextProps;
+    componentDidUpdate() {
+        const {disabled} = this.props;
 
         if (disabled) {
             this.close();
         }
-    };
+    }
 
     handleButtonClick = () => {
         this.toggle();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -42,6 +42,10 @@ class Navigation extends React.Component<Props> {
     handleNavigationItemClick = (value: string) => {
         const navigationItem = navigationRegistry.get(value);
 
+        if (!navigationItem.mainRoute) {
+            return;
+        }
+
         this.props.router.navigate(navigationItem.mainRoute);
         this.props.onNavigate(navigationItem.mainRoute);
     };
@@ -72,6 +76,7 @@ class Navigation extends React.Component<Props> {
         return (
             <NavigationComponent
                 appVersion={appVersion}
+                onItemClick={this.handleNavigationItemClick}
                 onLogoutClick={this.props.onLogout}
                 onPinToggle={this.handlePinToggle}
                 onProfileClick={this.handleProfileEditClick}
@@ -87,7 +92,6 @@ class Navigation extends React.Component<Props> {
                         active={this.isItemActive(navigationItem)}
                         icon={navigationItem.icon}
                         key={navigationItem.id}
-                        onClick={this.handleNavigationItemClick}
                         title={navigationItem.label}
                         value={navigationItem.id}
                     >
@@ -96,7 +100,6 @@ class Navigation extends React.Component<Props> {
                                 <NavigationComponent.Item
                                     active={this.isItemActive(subNavigationItem)}
                                     key={subNavigationItem.id}
-                                    onClick={this.handleNavigationItemClick}
                                     title={subNavigationItem.label}
                                     value={subNavigationItem.id}
                                 />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the deprecated `componentWillReceiveProps` lifecycle hook from some React components.

#### Why?

Because if we don't do that, then some React version will stop working.

#### To Do

- [x] Also remove that lifecycle hook from the `Navigation` component