### PR TITLE
Delete page which is linked on another page

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
@@ -74,6 +74,10 @@ $transitionDuration: 300ms;
         overflow: auto;
         padding: 0 30px 30px;
         text-align: center;
+
+        ul {
+            text-align: left;
+        }
     }
 
     footer {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -117,8 +117,8 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         });
     }
 
-    delete(): Promise<Object> {
-        return this.resourceStore.delete(this.options);
+    delete(options: Object): Promise<Object> {
+        return this.resourceStore.delete({...this.options, ...options});
     }
 
     copyFromLocale(locale: string) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -820,9 +820,9 @@ test('Delete should delegate the call to resourceStore with options', () => {
     resourceStore.delete.mockReturnValue(deletePromise);
 
     const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets', {webspace: 'sulu_io'});
-    const returnedDeletePromise = resourceFormStore.delete();
+    const returnedDeletePromise = resourceFormStore.delete({force: true});
 
-    expect(resourceStore.delete).toBeCalledWith({webspace: 'sulu_io'});
+    expect(resourceStore.delete).toBeCalledWith({force: true, webspace: 'sulu_io'});
     expect(returnedDeletePromise).toBe(deletePromise);
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -71,6 +71,7 @@ class List extends React.Component<Props> {
     @observable showOrderDialog: boolean = false;
     @observable adapterOptionsOpen: boolean = false;
     @observable columnOptionsOpen: boolean = false;
+    @observable referencingItemsForDelete: Array<Object> = [];
     resolveCopy: ?(ResolveCopyArgument) => void;
     resolveDelete: ?(ResolveDeleteArgument) => void;
     resolveMove: ?(ResolveMoveArgument) => void;
@@ -168,21 +169,25 @@ class List extends React.Component<Props> {
 
                     this.showDeleteDialog = false;
                     this.showDeleteLinkedDialog = true;
+                    response.json().then(action((data) => {
+                        this.referencingItemsForDelete.splice(0, this.referencingItemsForDelete.length);
+                        this.referencingItemsForDelete.push(...data.items);
 
-                    const deleteLinkedPromise: Promise<ResolveDeleteArgument> = new Promise(
-                        (resolve) => this.resolveDelete = resolve
-                    );
+                        const deleteLinkedPromise: Promise<ResolveDeleteArgument> = new Promise(
+                            (resolve) => this.resolveDelete = resolve
+                        );
 
-                    deleteLinkedPromise.then(action((response) => {
-                        if (!response.deleted) {
-                            this.showDeleteDialog = this.showDeleteLinkedDialog = false;
-                            return response;
-                        }
+                        deleteLinkedPromise.then(action((response) => {
+                            if (!response.deleted) {
+                                this.showDeleteDialog = this.showDeleteLinkedDialog = false;
+                                return response;
+                            }
 
-                        this.props.store.delete(id, {force: true})
-                            .then(action(() => {
-                                this.showDeleteLinkedDialog = false;
-                            }));
+                            this.props.store.delete(id, {force: true})
+                                .then(action(() => {
+                                    this.showDeleteLinkedDialog = false;
+                                }));
+                        }));
                     }));
                 }));
 
@@ -563,6 +568,11 @@ class List extends React.Component<Props> {
                             title={translate('sulu_admin.delete_linked_warning_title')}
                         >
                             {translate('sulu_admin.delete_linked_warning_text')}
+                            <ul>
+                                {this.referencingItemsForDelete.map((referencingItem, index) => (
+                                    <li key={index}>{referencingItem.name}</li>
+                                ))}
+                            </ul>
                         </Dialog>
                     </Fragment>
                 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -340,10 +340,10 @@ export default class ListStore {
         return this.structureStrategy.findById(id);
     }
 
-    delete = (id: string | number): Promise<Object> => {
+    delete = (id: string | number, options: Object): Promise<Object> => {
         this.deleting = true;
 
-        return ResourceRequester.delete(this.resourceKey, {...this.queryOptions, id})
+        return ResourceRequester.delete(this.resourceKey, {...this.queryOptions, ...options, id})
             .then(action(() => {
                 this.deleting = false;
                 this.deselectById(id);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -348,6 +348,10 @@ export default class ListStore {
                 this.deleting = false;
                 this.deselectById(id);
                 this.remove(id);
+            }))
+            .catch(action((error) => {
+                this.deleting = false;
+                throw error;
             }));
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -792,7 +792,11 @@ test('ListStore should delete item when onRequestItemDelete callback is called a
 });
 
 test('ListStore should delete linked item when onRequestItemDelete callback is is confirmed twice', (done) => {
-    const deletePromise = Promise.reject({status: 409});
+    const jsonDeletePromise = Promise.resolve({items: [{name: 'Item 1'}, {name: 'Item 2'}]});
+    const deletePromise = Promise.reject({
+        json: jest.fn().mockReturnValue(jsonDeletePromise),
+        status: 409,
+    });
 
     listAdapterRegistry.get.mockReturnValue(TableAdapter);
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
@@ -835,7 +839,11 @@ test('ListStore should delete linked item when onRequestItemDelete callback is i
 });
 
 test('ListStore should not delete linked item when onRequestItemDelete callback is is confirmed once', (done) => {
-    const deletePromise = Promise.reject({status: 409});
+    const jsonDeletePromise = Promise.resolve({items: [{name: 'Item 1'}, {name: 'Item 2'}]});
+    const deletePromise = Promise.reject({
+        json: jest.fn().mockReturnValue(jsonDeletePromise),
+        status: 409,
+    });
 
     listAdapterRegistry.get.mockReturnValue(TableAdapter);
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
@@ -862,6 +870,9 @@ test('ListStore should not delete linked item when onRequestItemDelete callback 
             list.update();
             expect(list.find('Dialog').at(1).prop('open')).toEqual(false);
             expect(list.find('Dialog').at(2).prop('open')).toEqual(true);
+            expect(list.find('Dialog').at(2).find('li')).toHaveLength(2);
+            expect(list.find('Dialog').at(2).find('li').at(0).prop('children')).toEqual('Item 1');
+            expect(list.find('Dialog').at(2).find('li').at(1).prop('children')).toEqual('Item 2');
 
             const deletePromise = Promise.resolve();
             // $FlowFixMe

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1711,9 +1711,9 @@ test('Should delete the item with the given ID and options', () => {
     listStore.updateLoadingStrategy(loadingStrategy);
     listStore.updateStructureStrategy(structureStrategy);
 
-    listStore.delete(5);
+    listStore.delete(5, {force: true});
 
-    expect(ResourceRequester.delete).toBeCalledWith('snippets', {id: 5, locale: 'en', webspace: 'sulu'});
+    expect(ResourceRequester.delete).toBeCalledWith('snippets', {force: true, id: 5, locale: 'en', webspace: 'sulu'});
 
     return deletePromise.then(() => {
         expect(structureStrategy.remove).toBeCalledWith(5);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -180,8 +180,9 @@ export default class ResourceStore {
 
                 this.destroy();
             }))
-            .catch(action(() => {
+            .catch(action((error) => {
                 this.deleting = false;
+                throw error;
             }));
     }
 
@@ -204,8 +205,9 @@ export default class ResourceStore {
             .then(action(() => {
                 this.moving = false;
             }))
-            .catch(action(() => {
+            .catch(action((error) => {
                 this.moving = false;
+                throw error;
             }));
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -81,7 +81,7 @@ test('Return item config with correct disabled, loading, icon, type and value an
     }));
     expect(element.at(1).instance().props).toEqual(expect.objectContaining({
         cancelText: 'sulu_admin.cancel',
-        children: 'sulu_admin.delete_linked_warning_text',
+        children: expect.arrayContaining(['sulu_admin.delete_linked_warning_text']),
         confirmText: 'sulu_admin.ok',
         open: false,
         title: 'sulu_admin.delete_linked_warning_title',
@@ -184,7 +184,11 @@ test('Call delete with force when dialog is confirmed twice', (done) => {
     deleteToolbarAction.resourceFormStore.resourceStore.id = 3;
     deleteToolbarAction.router.route.options.backRoute = 'sulu_test.list';
 
-    const deletePromise = Promise.reject({status: 409});
+    const jsonDeletePromise = Promise.resolve({items: [{name: 'Item 1'}, {name: 'Item 2'}]});
+    const deletePromise = Promise.reject({
+        json: jest.fn().mockReturnValue(jsonDeletePromise),
+        status: 409,
+    });
     deleteToolbarAction.resourceFormStore.delete.mockReturnValueOnce(deletePromise);
 
     const toolbarItemConfig = deleteToolbarAction.getToolbarItemConfig();
@@ -204,12 +208,11 @@ test('Call delete with force when dialog is confirmed twice', (done) => {
     setTimeout(() => {
         element = mount(deleteToolbarAction.getNode());
         expect(deleteToolbarAction.router.navigate).toBeCalledTimes(0);
-        expect(element.at(0).instance().props).toEqual(expect.objectContaining({
-            open: false,
-        }));
-        expect(element.at(1).instance().props).toEqual(expect.objectContaining({
-            open: true,
-        }));
+        expect(element.at(0).prop('open')).toEqual(false);
+        expect(element.at(1).prop('open')).toEqual(true);
+        expect(element.at(1).find('li')).toHaveLength(2);
+        expect(element.at(1).find('li').at(0).prop('children')).toEqual('Item 1');
+        expect(element.at(1).find('li').at(1).prop('children')).toEqual('Item 2');
 
         const deletePromise = Promise.resolve({});
         deleteToolbarAction.resourceFormStore.delete.mockReturnValueOnce(deletePromise);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -7,8 +7,9 @@ import {translate} from '../../../utils/Translator';
 import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class DeleteToolbarAction extends AbstractFormToolbarAction {
-    @observable showDialog = false;
-    @observable showLinkedDialog = false;
+    @observable showDialog: boolean = false;
+    @observable showLinkedDialog: boolean = false;
+    @observable referencingItems: Array<Object> = [];
 
     getNode() {
         return (
@@ -34,6 +35,11 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
                     title={translate('sulu_admin.delete_linked_warning_title')}
                 >
                     {translate('sulu_admin.delete_linked_warning_text')}
+                    <ul>
+                        {this.referencingItems.map((referencingItem, index) => (
+                            <li key={index}>{referencingItem.name}</li>
+                        ))}
+                    </ul>
                 </Dialog>
             </Fragment>
         );
@@ -82,6 +88,10 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
 
                 this.showDialog = false;
                 this.showLinkedDialog = true;
+                response.json().then(action((data) => {
+                    this.referencingItems.splice(0, this.referencingItems.length);
+                    this.referencingItems.push(...data.items);
+                }));
             }));
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import {action, observable} from 'mobx';
 import jexl from 'jexl';
 import Dialog from '../../../components/Dialog';
@@ -8,21 +8,34 @@ import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 
 export default class DeleteToolbarAction extends AbstractFormToolbarAction {
     @observable showDialog = false;
+    @observable showLinkedDialog = false;
 
     getNode() {
         return (
-            <Dialog
-                cancelText={translate('sulu_admin.cancel')}
-                confirmLoading={this.resourceFormStore.deleting}
-                confirmText={translate('sulu_admin.ok')}
-                key="sulu_admin.delete"
-                onCancel={this.handleCancel}
-                onConfirm={this.handleConfirm}
-                open={this.showDialog}
-                title={translate('sulu_admin.delete_warning_title')}
-            >
-                {translate('sulu_admin.delete_warning_text')}
-            </Dialog>
+            <Fragment key="sulu_admin.delete">
+                <Dialog
+                    cancelText={translate('sulu_admin.cancel')}
+                    confirmLoading={this.resourceFormStore.deleting}
+                    confirmText={translate('sulu_admin.ok')}
+                    onCancel={this.handleCancel}
+                    onConfirm={this.handleConfirm}
+                    open={this.showDialog}
+                    title={translate('sulu_admin.delete_warning_title')}
+                >
+                    {translate('sulu_admin.delete_warning_text')}
+                </Dialog>
+                <Dialog
+                    cancelText={translate('sulu_admin.cancel')}
+                    confirmLoading={this.resourceFormStore.deleting}
+                    confirmText={translate('sulu_admin.ok')}
+                    onCancel={this.handleLinkCancel}
+                    onConfirm={this.handleLinkConfirm}
+                    open={this.showLinkedDialog}
+                    title={translate('sulu_admin.delete_linked_warning_title')}
+                >
+                    {translate('sulu_admin.delete_linked_warning_text')}
+                </Dialog>
+            </Fragment>
         );
     }
 
@@ -46,18 +59,41 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
         };
     }
 
+    navigateBack = () => {
+        const {backRoute} = this.router.route.options;
+        const {locale} = this.resourceFormStore;
+        this.router.navigate(backRoute, {locale: locale ? locale.get() : undefined});
+    };
+
     @action handleCancel = () => {
         this.showDialog = false;
     };
 
     @action handleConfirm = () => {
-        const {backRoute} = this.router.route.options;
-        const {locale} = this.resourceFormStore;
-
         this.resourceFormStore.delete()
             .then(action(() => {
                 this.showDialog = false;
-                this.router.navigate(backRoute, {locale: locale ? locale.get() : undefined});
+                this.navigateBack();
+            }))
+            .catch(action((response) => {
+                if (response.status !== 409) {
+                    throw response;
+                }
+
+                this.showDialog = false;
+                this.showLinkedDialog = true;
+            }));
+    };
+
+    @action handleLinkCancel = () => {
+        this.showLinkedDialog = false;
+    };
+
+    @action handleLinkConfirm = () => {
+        this.resourceFormStore.delete({force: true})
+            .then(action(() => {
+                this.showLinkedDialog = false;
+                this.navigateBack();
             }));
     };
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -57,6 +57,8 @@
     "sulu_admin.authored": "Verfasst am",
     "sulu_admin.delete_warning_title": "Löschen?",
     "sulu_admin.delete_warning_text": "Diese Operation löscht Daten und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
+    "sulu_admin.delete_linked_warning_title": "Löschen bestätigen",
+    "sulu_admin.delete_linked_warning_text": "Dieser Eintrag wird von folgenden anderen Einträgen referenziert, sind Sie sich sicher, dass sie diesen Eintrag löschen wollen?",
     "sulu_admin.delete_selection_warning_text": "Diese Operation löscht {count} {count, plural, =1 {Datensatz} other {Datensätze}} und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
     "sulu_admin.ghost_dialog_title": "Sprachvariante kopieren?",
     "sulu_admin.ghost_dialog_description": "Diese Seite existiert nicht in dieser Sprache. Wollen Sie den Inhalt aus einer anderen Sprache kopieren?",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -57,6 +57,8 @@
     "sulu_admin.authored": "Authored on",
     "sulu_admin.delete_warning_title": "Delete?",
     "sulu_admin.delete_warning_text": "This operation deletes data and cannot be undone. Do you really wish to proceed?",
+    "sulu_admin.delete_linked_warning_title": "Confirm deletion",
+    "sulu_admin.delete_linked_warning_text": "This item is referenced by the following items, are you sure you want to delete it?",
     "sulu_admin.delete_selection_warning_text": "This operation deletes {count} {count, plural, =1 {item} other {items}} and cannot be undone. Do you really wish to proceed?",
     "sulu_admin.ghost_dialog_title": "Copy language?",
     "sulu_admin.ghost_dialog_description": "This page does not exist in this language. Do you want to copy content from another language?",

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -354,11 +354,11 @@ test('Should delete selected items when delete button is clicked', () => {
     mediaListStore.selectionIds.push(1, 4, 6);
 
     mediaOverview.update();
-    expect(mediaOverview.find('Dialog').at(4).prop('open')).toEqual(false);
+    expect(mediaOverview.find('Dialog').at(5).prop('open')).toEqual(false);
 
     getDeleteItem().onClick();
     mediaOverview.update();
-    expect(mediaOverview.find('Dialog').at(4).prop('open')).toEqual(true);
+    expect(mediaOverview.find('Dialog').at(5).prop('open')).toEqual(true);
 });
 
 test('Upload button should be disabled if nothing is selected', () => {

--- a/src/Sulu/Bundle/PageBundle/Controller/NodeController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/NodeController.php
@@ -534,8 +534,7 @@ class NodeController extends RestController implements ClassResourceInterface
 
             if (count($references) > 0) {
                 $data = [
-                    'structures' => [],
-                    'other' => [],
+                    'items' => [],
                 ];
 
                 foreach ($references as $reference) {
@@ -545,7 +544,8 @@ class NodeController extends RestController implements ClassResourceInterface
                         $locale,
                         true
                     );
-                    $data['structures'][] = $content->toArray();
+
+                    $data['items'][] = ['name' => $content->getTitle()];
                 }
 
                 return $this->handleView($this->view($data, 409));

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/NodeControllerTest.php
@@ -574,6 +574,9 @@ class NodeControllerTest extends SuluTestCase
 
         $client->request('DELETE', '/api/nodes/' . $linkedDocument->getUuid() . '?webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(409, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent(), true);
+        $this->assertCount(1, $response['items'][0]);
+        $this->assertEquals('test2', $response['items'][0]['name']);
 
         $client->request('DELETE', '/api/nodes/' . $linkedDocument->getUuid() . '?webspace=sulu_io&language=en&force=true');
         $this->assertHttpStatusCode(204, $client->getResponse());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR will allow to delete pages which are linked to other pages. This does currently not work, because the server returns a 409 response, which is not handled in our application.

#### Why?

Because it should not fail as it does now.

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [x] Fix delete dialog of `List` container component when 409 is returned
- [x] Show which pages are linked in the confirmation dialog