### PR TITLE
Fix height of list under WebspaceTabs

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/list.scss
@@ -7,7 +7,6 @@ $permissionHintColor: $gray;
 .list-container {
     display: flex;
     flex-direction: column;
-    height: 100%;
     flex-grow: 1;
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/listOverlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/listOverlay.scss
@@ -2,6 +2,7 @@
 @import '../../components/ColumnList/variables.scss';
 
 .list {
+    display: flex;
     padding: 30px 60px 60px;
 }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | #4710
| License | MIT
| Documentation PR | ---

#### What's in this PR?

While fixing the column list for safari in #4710 another regression was introduced. The lists for analytics and custom URLs are currently always scrolling, even if the lists are empty, and there is just empty space.

This PR fixes this issue.

#### Why?

Because if there is nothing to see, the user should not be able to scroll.