### PR TITLE
Make AdapterSwitch in PageList clickable

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/webspaceTabs.scss
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/webspaceTabs.scss
@@ -5,4 +5,5 @@
     z-index: 2;
     display: inline-block;
     margin-bottom: $webspaceTabsWebspaceSelectMargin;
+    width: 0;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | probably #4710 
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the HTML container for the `WebspaceSelect` take only as much width as it needs.

#### Why?

Because the container component lies over the `AdapterSwitch` of the `List`, making it impossible to switch to the tree view.