### PR TITLE
Remember last selected Adapter

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -37,6 +37,8 @@ class MediaOverview extends React.Component<ViewProps> {
         return {
             collectionLimit: ListStore.getLimitSetting(COLLECTIONS_RESOURCE_KEY, USER_SETTINGS_KEY),
             mediaLimit: ListStore.getLimitSetting(MEDIA_RESOURCE_KEY, USER_SETTINGS_KEY),
+            mediaSortColumn: ListStore.getSortColumnSetting(MEDIA_RESOURCE_KEY, USER_SETTINGS_KEY),
+            mediaSortOrder: ListStore.getSortOrderSetting(MEDIA_RESOURCE_KEY, USER_SETTINGS_KEY),
         };
     }
 
@@ -60,6 +62,8 @@ class MediaOverview extends React.Component<ViewProps> {
         router.bind('search', this.mediaListStore.searchTerm);
         router.bind('collectionLimit', this.collectionListStore.limit, 10);
         router.bind('mediaLimit', this.mediaListStore.limit, 10);
+        router.bind('mediaSortColumn', this.mediaListStore.sortColumn);
+        router.bind('mediaSortOrder', this.mediaListStore.sortOrder);
     }
 
     componentWillUnmount() {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -203,6 +203,8 @@ test('Destroy all stores on unmount', () => {
     const locale = router.bind.mock.calls[2][1];
     const collectionLimit = router.bind.mock.calls[5][1];
     const mediaLimit = router.bind.mock.calls[6][1];
+    const mediaSortColumn = router.bind.mock.calls[7][1];
+    const mediaSortOrder = router.bind.mock.calls[8][1];
 
     expect(mediaOverviewInstance.collectionListStore.sort).toBeCalledWith('title', 'asc');
     expect(collectionPage.get()).toBe(undefined);
@@ -213,6 +215,8 @@ test('Destroy all stores on unmount', () => {
     expect(router.bind).toBeCalledWith('locale', locale);
     expect(router.bind).toBeCalledWith('collectionLimit', collectionLimit, 10);
     expect(router.bind).toBeCalledWith('mediaLimit', mediaLimit, 10);
+    expect(router.bind).toBeCalledWith('mediaSortColumn', mediaSortColumn);
+    expect(router.bind).toBeCalledWith('mediaSortOrder', mediaSortOrder);
 
     mediaOverview.unmount();
     expect(mediaOverviewInstance.mediaListStore.destroy).toBeCalled();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes the `List` component remember its last selected `Adapter`.

#### Why?

Because it is more comfortable for the user.

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
- [x] Check if everyting is working for the `MediaOverview` as well