### PR TITLE
Fix missing occurs properties in forms

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -132,6 +132,8 @@ class FormMetadataMapper
         $field->setRequired($property->isRequired());
         $field->setOnInvalid($property->getOnInvalid());
         $field->setSpaceAfter($property->getSpaceAfter());
+        $field->setMinOccurs($property->getMinOccurs());
+        $field->setMaxOccurs($property->getMaxOccurs());
 
         foreach ($property->getParameters() as $parameter) {
             $field->addOption($this->mapOption($parameter, $locale));

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -39,6 +39,16 @@ class FieldMetadata extends ItemMetadata
     protected $spaceAfter;
 
     /**
+     * @var null|int
+     */
+    protected $minOccurs;
+
+    /**
+     * @var null|int
+     */
+    protected $maxOccurs;
+
+    /**
      * @var string
      */
     protected $onInvalid;
@@ -104,6 +114,26 @@ class FieldMetadata extends ItemMetadata
     public function setSpaceAfter(int $spaceAfter = null): void
     {
         $this->spaceAfter = $spaceAfter;
+    }
+
+    public function setMinOccurs(int $minOccurs = null): void
+    {
+        $this->minOccurs = $minOccurs;
+    }
+
+    public function getMinOccurs(): ?int
+    {
+        return $this->minOccurs;
+    }
+
+    public function setMaxOccurs(int $maxOccurs = null): void
+    {
+        $this->maxOccurs = $maxOccurs;
+    }
+
+    public function getMaxOccurs(): ?int
+    {
+        return $this->maxOccurs;
     }
 
     public function setOnInvalid(string $onInvalid = null): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -199,6 +199,8 @@ class FormMetadataMapperTest extends TestCase
         $this->assertInstanceOf(FieldMetadata::class, $block);
         $this->assertEquals('block', $block->getType());
         $this->assertEquals('component1', $block->getDefaultType());
+        $this->assertEquals(1, $block->getMinOccurs());
+        $this->assertEquals(2, $block->getMaxOccurs());
 
         $this->assertEquals('component1', $block->getTypes()['component1']->getName());
         $this->assertEquals('First Component', $block->getTypes()['component1']->getTitle());
@@ -227,6 +229,8 @@ class FormMetadataMapperTest extends TestCase
         $this->assertInstanceOf(FieldMetadata::class, $block);
         $this->assertEquals('block', $block->getType());
         $this->assertEquals('component1', $block->getDefaultType());
+        $this->assertEquals(1, $block->getMinOccurs());
+        $this->assertEquals(2, $block->getMaxOccurs());
 
         $this->assertEquals('component1', $block->getTypes()['component1']->getName());
         $this->assertEquals('Erste Komponente', $block->getTypes()['component1']->getTitle());
@@ -396,6 +400,8 @@ class FormMetadataMapperTest extends TestCase
 
         $block->addComponent($component1);
         $block->addComponent($component2);
+        $block->setMinOccurs(1);
+        $block->setMaxOccurs(2);
         $block->defaultComponentName = 'component1';
         $block->setType('block');
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/blocks.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/blocks.xml
@@ -79,7 +79,6 @@
                                 <title lang="en">Lines</title>
                             </meta>
                         </property>
-
                     </properties>
                 </type>
             </types>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -58,9 +58,9 @@ class AdminControllerTest extends SuluTestCase
 
         $types = $response->types;
 
-        // check for both types
         $this->assertObjectHasAttribute('default', $types);
         $this->assertObjectHasAttribute('overview', $types);
+        $this->assertObjectHasAttribute('blocks', $types);
 
         $defaultType = $types->default;
         $this->assertObjectHasAttribute('name', $defaultType);
@@ -72,7 +72,6 @@ class AdminControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('url', $defaultType->form);
         $this->assertEquals('sulu.rlp.part', $defaultType->form->title->tags[0]->name);
         $this->assertEquals(1, $defaultType->form->title->tags[0]->priority);
-
         $this->assertObjectHasAttribute('schema', $defaultType);
         $this->assertEquals(['title'], $defaultType->schema->required);
 
@@ -87,8 +86,13 @@ class AdminControllerTest extends SuluTestCase
         $this->assertObjectHasAttribute('url', $overviewType->form);
         $this->assertObjectHasAttribute('article', $overviewType->form);
         $this->assertObjectHasAttribute('schema', $overviewType);
-
         $this->assertEquals(['required' => []], (array) $overviewType->schema);
+
+        $blocksType = $types->blocks;
+        $this->assertEquals(1, $blocksType->form->block->minOccurs);
+        $this->assertEquals(5, $blocksType->form->block->maxOccurs);
+        $this->assertEquals(2, $blocksType->form->block->types->article->form->lines->minOccurs);
+        $this->assertEquals(2, $blocksType->form->block->types->article->form->lines->maxOccurs);
     }
 
     public function testPageSeoFormMetadataAction()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the transformation of the `minOccurs` and `maxOccurs` properties from the XML files.

#### Why?

Because it seems like for quite a while the `minOccurs` and `maxOccurs` properties in the form XML have no impact on the frontend.

#### Example Usage

~~~xml
        <block name="blocks" default-type="editor" minOccurs="1" maxOccurs="2">
            <types>
                <type name="editor">
                    <properties>
                        <property name="editor" type="text_editor" />
                    </properties>
                </type>
            </types>
        </block>
~~~