### PR TITLE
Fixed video thumbnail generation

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -134,11 +134,13 @@ class MediaImageExtractor implements MediaImageExtractorInterface
      */
     private function convertVideoToImage($resource)
     {
-        $temporaryFilePath = $this->createTemporaryFile($resource);
-        $this->videoThumbnail->generate($temporaryFilePath, '00:00:02:01', $temporaryFilePath);
+        $source = $this->createTemporaryFile($resource);
+        $destination = tempnam(sys_get_temp_dir(), 'media');
+        $this->videoThumbnail->generate($source, '00:00:02:01', $destination);
 
-        $extractedImage = file_get_contents($temporaryFilePath);
-        unlink($temporaryFilePath);
+        $extractedImage = file_get_contents($destination);
+        unlink($source);
+        unlink($destination);
 
         return $this->createTemporaryResource($extractedImage);
     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/ffmpeg.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/ffmpeg.xml
@@ -8,7 +8,7 @@
             <factory class="FFMpeg\FFMpeg" method="create"/>
             <argument type="collection">
                 <argument key="ffmpeg.binaries">%sulu_media.ffmpeg.binary%</argument>
-                <argument key="ffprobe.binaries">%sulu_media.ffmpeg.binary%</argument>
+                <argument key="ffprobe.binaries">%sulu_media.ffprobe.binary%</argument>
                 <argument key="timeout">%sulu_media.ffmpeg.binary_timeout%</argument>
                 <argument key="ffmpeg.threads">%sulu_media.ffmpeg.threads_count%</argument>
             </argument>
@@ -19,7 +19,7 @@
             <factory class="FFMpeg\FFProbe" method="create"/>
             <argument type="collection">
                 <argument key="ffmpeg.binaries">%sulu_media.ffmpeg.binary%</argument>
-                <argument key="ffprobe.binaries">%sulu_media.ffmpeg.binary%</argument>
+                <argument key="ffprobe.binaries">%sulu_media.ffprobe.binary%</argument>
             </argument>
             <argument id="logger" type="service" on-invalid="null"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no

#### What's in this PR?

Fixes the generation of video thumbnails.

#### Why?

The wrong binary was used for `ffprobe` and the thumbnail generation for the newest FFmpeg version didn't work.

Errors that happened:
- `Unable to save frame` 
- `FFmpeg cannot edit existing files in-place.`
