### PR TITLE
Add class for ToolbarAction

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,7 @@ sulu_admin_api:
     resource: "@SuluAdminBundle/Resources/config/routing_api.yml"
     type: rest
     prefix: /admin/api
+```
 
 ### ToolbarActions
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,84 @@ sulu_admin_api:
     resource: "@SuluAdminBundle/Resources/config/routing_api.yml"
     type: rest
     prefix: /admin/api
+
+### ToolbarActions
+
+The `addToolbarActions` method of different `RouteBuilder` do not accept simple arrays anymore, but arrays of the new
+`ToolbarAction` class. The `ToolbarAction` class takes the type of the `ToolbarAction` and an array of additional
+options. There are special `ToolbarAction` classes for the `sulu_admin.dropdown` (`DropdownToolbarAction`) and
+`sulu_admin.toggler` (`TogglerToolbarAction`) type, because they contain translatable values.
+
+```php
+<?php
+// before
+$formToolbarActionsWithType = [
+    'sulu_admin.save_with_publishing' => [
+        'publish_display_condition' => '(!_permissions || _permissions.live)',
+        'save_display_condition' => '(!_permissions || _permissions.edit)',
+    ],
+    'sulu_page.templates',
+    'sulu_admin.delete' => [
+        'display_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+    ],
+    'sulu_admin.dropdown' => [
+        'label' => $this->translator->trans('sulu_admin.edit', [], 'admin'),
+        'icon' => 'su-pen',
+        'actions' => [
+            'sulu_admin.copy_locale' => [
+                'display_condition' => '(!_permissions || _permissions.edit)',
+            ],
+            'sulu_admin.delete_draft' => [
+                'display_condition' => $publishDisplayCondition,
+            ],
+            'sulu_admin.set_unpublished' => [
+                'display_condition' => $publishDisplayCondition,
+            ],
+        ],
+    ],
+];
+
+// after
+$formToolbarActionsWithType = [
+    new ToolbarAction(
+        'sulu_admin.save_with_publishing',
+        [
+            'publish_display_condition' => '(!_permissions || _permissions.live)',
+            'save_display_condition' => '(!_permissions || _permissions.edit)',
+        ]
+    ),
+    new ToolbarAction('sulu_page.templates'),
+    new ToolbarAction(
+        'sulu_admin.delete',
+        [
+            'display_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+        ]
+    ),
+    new DropdownToolbarAction(
+        'sulu_admin.edit',
+        'su-pen',
+        [
+            new ToolbarAction(
+                'sulu_admin.copy_locale',
+                [
+                    'display_condition' => '(!_permissions || _permissions.edit)',
+                ]
+            ),
+            new ToolbarAction(
+                'sulu_admin.delete_draft',
+                [
+                    'display_condition' => $publishDisplayCondition,
+                ]
+            ),
+            new ToolbarAction(
+                'sulu_admin.set_unpublished',
+                [
+                    'display_condition' => $publishDisplayCondition,
+                ]
+            ),
+        ]
+    ),
+];
 ```
 
 ## 2.0.0-RC2

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DropdownToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DropdownToolbarAction.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Routing;
+
+class DropdownToolbarAction extends ToolbarAction
+{
+    public function __construct(string $label, string $icon, array $actions)
+    {
+        parent::__construct(
+            'sulu_admin.dropdown',
+            [
+                'label' => $label,
+                'icon' => $icon,
+                'actions' => $actions,
+            ]
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/DropdownToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/DropdownToolbarAction.php
@@ -13,14 +13,17 @@ namespace Sulu\Bundle\AdminBundle\Admin\Routing;
 
 class DropdownToolbarAction extends ToolbarAction
 {
-    public function __construct(string $label, string $icon, array $actions)
+    /**
+     * @param ToolbarAction[] $toolbarActions
+     */
+    public function __construct(string $label, string $icon, array $toolbarActions)
     {
         parent::__construct(
             'sulu_admin.dropdown',
             [
                 'label' => $label,
                 'icon' => $icon,
-                'actions' => $actions,
+                'toolbarActions' => $toolbarActions,
             ]
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/TogglerToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/TogglerToolbarAction.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Routing;
+
+class TogglerToolbarAction extends ToolbarAction
+{
+    public function __construct(string $label, string $property, string $activateAction, string $deactivateAction)
+    {
+        parent::__construct(
+            'sulu_admin.toggler',
+            [
+                'label' => $label,
+                'property' => $property,
+                'activate' => $activateAction,
+                'deactivate' => $deactivateAction,
+            ]
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ToolbarAction.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\Routing;
+
+use JMS\Serializer\Annotation\Groups;
+
+class ToolbarAction
+{
+    /**
+     * @var string
+     * @Groups({"frontend"})
+     */
+    private $type;
+
+    /**
+     * @var array
+     * @Groups({"frontend"})
+     */
+    private $options;
+
+    public function __construct(string $type, array $options = [])
+    {
+        $this->type = $type;
+        $this->options = $options;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ToolbarAction.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ToolbarAction.php
@@ -32,4 +32,9 @@ class ToolbarAction
         $this->type = $type;
         $this->options = $options;
     }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/ToolbarActionsRouteBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/ToolbarActionsRouteBuilderTrait.php
@@ -13,30 +13,15 @@ namespace Sulu\Bundle\AdminBundle\Admin\Routing;
 
 trait ToolbarActionsRouteBuilderTrait
 {
+    /**
+     * @param ToolbarAction[] $toolbarActions
+     */
     private function addToolbarActionsToRoute(Route $route, array $toolbarActions): void
     {
-        $transformedToolbarActions = [];
-        foreach ($toolbarActions as $toolbarActionKey => $toolbarActionOptions) {
-            if (is_string($toolbarActionKey) && is_array($toolbarActionOptions)) {
-                $transformedToolbarActions[$toolbarActionKey] = $toolbarActionOptions;
-                continue;
-            }
-
-            if (is_numeric($toolbarActionKey) && is_string($toolbarActionOptions)) {
-                $transformedToolbarActions[$toolbarActionOptions] = [];
-                continue;
-            }
-
-            throw new \DomainException(
-                'The definition of a toolbarAction is either a string key with an options array '
-                . 'or a numeric key with a string value!'
-            );
-        }
-
         $oldToolbarActions = $route->getOption('toolbarActions');
         $newToolbarActions = $oldToolbarActions
-            ? array_merge($oldToolbarActions, $transformedToolbarActions)
-            : $transformedToolbarActions;
+            ? array_merge($oldToolbarActions, $toolbarActions)
+            : $toolbarActions;
         $route->setOption('toolbarActions', $newToolbarActions);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -119,10 +119,6 @@
             class="Sulu\Bundle\AdminBundle\FieldType\FieldTypeOptionRegistry"
         />
 
-        <service id="sulu_admin.schema_handler" class="Sulu\Bundle\AdminBundle\Serializer\Handler\SchemaHandler">
-            <tag name="jms_serializer.subscribing_handler"/>
-        </service>
-
         <service
             id="sulu_admin.collaboration_controller"
             class="Sulu\Bundle\AdminBundle\Controller\CollaborationController"
@@ -143,14 +139,18 @@
             <argument>%sulu_admin.collaboration_threshold%</argument>
         </service>
 
-        <service id="sulu_admin.dropdown_toolbar_action_handler"
+        <service id="sulu_admin.schema_handler" class="Sulu\Bundle\AdminBundle\Serializer\Handler\SchemaHandler">
+            <tag name="jms_serializer.subscribing_handler"/>
+        </service>
+
+        <service id="sulu_admin.dropdown_toolbar_action_subscriber"
             class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
-        <service id="sulu_admin.toggler_toolbar_action_handler"
+        <service id="sulu_admin.toggler_toolbar_action_subscriber"
             class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
         >
             <argument type="service" id="translator"/>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -142,5 +142,19 @@
             <argument type="service" id="sulu_admin.collaboration_cache"/>
             <argument>%sulu_admin.collaboration_threshold%</argument>
         </service>
+
+        <service id="sulu_admin.dropdown_toolbar_action_handler"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber"
+        >
+            <argument type="service" id="translator"/>
+            <tag name="jms_serializer.event_subscriber"/>
+        </service>
+
+        <service id="sulu_admin.toggler_toolbar_action_handler"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\TogglerToolbarActionSubscriber"
+        >
+            <argument type="service" id="translator"/>
+            <tag name="jms_serializer.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -2,7 +2,7 @@
 import type {ElementRef} from 'react';
 import React from 'react';
 import type {IObservableValue} from 'mobx';
-import {action, computed, toJS, isObservableArray, isObservableObject, observable} from 'mobx';
+import {action, computed, toJS, isObservableArray, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import equals from 'fast-deep-equal';
 import Dialog from '../../components/Dialog';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -197,31 +197,27 @@ class Form extends React.Component<Props> {
         if (
             !Array.isArray(rawToolbarActions)
             && !isObservableArray(rawToolbarActions)
-            && typeof rawToolbarActions !== 'object'
-            && !isObservableObject(rawToolbarActions)
         ) {
             throw new Error('The view "Form" needs some defined toolbarActions to work properly!');
         }
 
         const toolbarActions = toJS(rawToolbarActions);
 
-        Object.keys(toolbarActions).forEach((toolbarActionKey) => {
-            const toolbarActionValue = toolbarActions[toolbarActionKey];
-            if (typeof toolbarActionValue !== 'object') {
+        toolbarActions.forEach((toolbarAction) => {
+            if (typeof toolbarAction !== 'object') {
                 throw new Error(
-                    'The value of the toolbarAction entry "' + toolbarActionKey + '" must be an object, '
-                    + 'but ' + typeof toolbarActionValue + ' was given!'
+                    'The value of a toolbarAction entry must be an object, but ' + typeof toolbarAction + ' was given!'
                 );
             }
         });
 
-        this.toolbarActions = Object.keys(toolbarActions)
-            .map((toolbarActionKey): AbstractFormToolbarAction => new (formToolbarActionRegistry.get(toolbarActionKey))(
+        this.toolbarActions = toolbarActions
+            .map((toolbarAction): AbstractFormToolbarAction => new (formToolbarActionRegistry.get(toolbarAction.type))(
                 this.resourceFormStore,
                 this,
                 router,
                 this.locales,
-                toolbarActions[toolbarActionKey]
+                toolbarAction.options
             ));
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -399,7 +399,20 @@ test('Should add items defined in ToolbarActions to Toolbar with options', () =>
     const route = {
         options: {
             formKey: 'snippets',
-            toolbarActions: {'save': {test1: 'value1'}, 'delete': {test2: 'value2'}, 'edit': {}},
+            toolbarActions: [
+                {
+                    type: 'save',
+                    options: {test1: 'value1'},
+                },
+                {
+                    type: 'delete',
+                    options: {test2: 'value2'},
+                },
+                {
+                    type: 'edit',
+                    options: {},
+                },
+            ],
         },
     };
     const router = {
@@ -602,7 +615,7 @@ test('Should set and update locales defined in ToolbarActions', () => {
     const route = {
         options: {
             formKey: 'snippets',
-            toolbarActions: {save: {}},
+            toolbarActions: [{type: 'save', options: []}],
         },
     };
     const router = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
@@ -90,9 +90,9 @@ test('Return item config with an option for every action in array and skip undef
         icon: 'su-edit',
         label: 'edit',
         actions: [
-            'sulu_admin.delete',
-            'sulu_admin.copy',
-            'sulu_admin.nothing',
+            {type: 'sulu_admin.delete', options: {}},
+            {type: 'sulu_admin.copy', options: {}},
+            {type: 'sulu_admin.nothing', options: {}},
         ],
     });
 
@@ -152,14 +152,10 @@ test('Return item config with options passed to child ToolbarActions', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: {
-            'sulu_admin.delete': {
-                label: 'Delete',
-            },
-            'sulu_admin.copy': {
-                title: 'Copy',
-            },
-        },
+        actions: [
+            {type: 'sulu_admin.delete', options: {label: 'Delete'}},
+            {type: 'sulu_admin.copy', options: {title: 'Copy'}},
+        ],
     });
 
     expect(dropdownToolbarAction.getToolbarItemConfig()).toEqual({
@@ -194,14 +190,10 @@ test('Return no item config if all child ToolbarActions return nothing', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: {
-            'sulu_admin.delete': {
-                label: 'Delete',
-            },
-            'sulu_admin.copy': {
-                title: 'Copy',
-            },
-        },
+        actions: [
+            {type: 'sulu_admin.delete', options: {label: 'Delete'}},
+            {type: 'sulu_admin.copy', options: {title: 'Copy'}},
+        ],
     });
 
     expect(dropdownToolbarAction.getToolbarItemConfig()).toEqual(undefined);
@@ -226,7 +218,7 @@ test('Throw error if child ToolbarAction is a dropdown', () => {
         icon: 'su-edit',
         label: 'edit',
         actions: [
-            'sulu_admin.delete',
+            {type: 'sulu_admin.delete', options: {}},
         ],
     });
     expect(() => dropdownToolbarAction.getToolbarItemConfig()).toThrow(/not being a dropdown/);
@@ -250,7 +242,7 @@ test('Throw error if child ToolbarAction has no onClick handler', () => {
         icon: 'su-edit',
         label: 'edit',
         actions: [
-            'sulu_admin.delete',
+            {type: 'sulu_admin.delete', options: {}},
         ],
     });
     expect(() => dropdownToolbarAction.getToolbarItemConfig()).toThrow(/onClick/);
@@ -273,7 +265,7 @@ test('Throw error if child Toolbaraction has no label', () => {
         icon: 'su-edit',
         label: 'edit',
         actions: [
-            'sulu_admin.delete',
+            {type: 'sulu_admin.delete', options: {}},
         ],
     });
     expect(() => dropdownToolbarAction.getToolbarItemConfig()).toThrow(/label/);
@@ -305,9 +297,9 @@ test('Return JSX for all child ToolbarActions', () => {
         icon: 'su-edit',
         label: 'edit',
         actions: [
-            'sulu_admin.delete',
-            'sulu_admin.copy',
-            'sulu_admin.nothing',
+            {type: 'sulu_admin.delete', options: {}},
+            {type: 'sulu_admin.copy', options: {}},
+            {type: 'sulu_admin.nothing', options: {}},
         ],
     });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js
@@ -89,7 +89,7 @@ test('Return item config with an option for every action in array and skip undef
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {}},
             {type: 'sulu_admin.copy', options: {}},
             {type: 'sulu_admin.nothing', options: {}},
@@ -152,7 +152,7 @@ test('Return item config with options passed to child ToolbarActions', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {label: 'Delete'}},
             {type: 'sulu_admin.copy', options: {title: 'Copy'}},
         ],
@@ -190,7 +190,7 @@ test('Return no item config if all child ToolbarActions return nothing', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {label: 'Delete'}},
             {type: 'sulu_admin.copy', options: {title: 'Copy'}},
         ],
@@ -217,7 +217,7 @@ test('Throw error if child ToolbarAction is a dropdown', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {}},
         ],
     });
@@ -241,7 +241,7 @@ test('Throw error if child ToolbarAction has no onClick handler', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {}},
         ],
     });
@@ -264,7 +264,7 @@ test('Throw error if child Toolbaraction has no label', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {}},
         ],
     });
@@ -296,7 +296,7 @@ test('Return JSX for all child ToolbarActions', () => {
     const dropdownToolbarAction = createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: [
+        toolbarActions: [
             {type: 'sulu_admin.delete', options: {}},
             {type: 'sulu_admin.copy', options: {}},
             {type: 'sulu_admin.nothing', options: {}},
@@ -306,10 +306,10 @@ test('Return JSX for all child ToolbarActions', () => {
     expect(render(dropdownToolbarAction.getNode())).toMatchSnapshot();
 });
 
-test('Throw error if actions are neither an object nor an array', () => {
+test('Throw error if toolbarActions are neither an object nor an array', () => {
     expect(() => createDropdownToolbarAction({
         icon: 'su-edit',
         label: 'edit',
-        actions: false,
-    })).toThrow(/actions/);
+        toolbarActions: false,
+    })).toThrow(/toolbarActions/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -27,33 +27,34 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
 
         const {actions} = this.options;
 
-        if (typeof actions !== 'object' || actions === null) {
+        if (!Array.isArray(actions)) {
             throw new Error('The passed "actions" option must be of type object or array');
         }
 
-        const transformedActions = Object.keys(actions).reduce((transformedActions, actionKey) => {
-            if (isNaN(actionKey)) {
-                transformedActions[actionKey] = actions[actionKey];
-                return transformedActions;
-            }
+        this.toolbarActions = actions
+            .map((action) => {
+                if (action === null || typeof action !== 'object') {
+                    throw new Error('The passed entries in the "actions" option must be objects');
+                }
 
-            if (typeof actions[actionKey] !== 'string') {
-                throw new Error('If the "actionKey" is not numeric, the value at actionKey must be a string');
-            }
+                const {type, options} = action;
 
-            transformedActions[actions[actionKey]] = {};
+                if (typeof type !== 'string') {
+                    throw new Error('The "type" of each entry in the "actions" options must be a string');
+                }
 
-            return transformedActions;
-        }, {});
+                if (options === null || typeof options !== 'object') {
+                    throw new Error('The "options" of each entry in the "actions" options must be a string');
+                }
 
-        this.toolbarActions = Object.keys(transformedActions)
-            .map((actionKey) => new (formToolbarActionRegistry.get(actionKey))(
-                this.resourceFormStore,
-                this.form,
-                router,
-                this.locales,
-                transformedActions[actionKey]
-            ));
+                return new (formToolbarActionRegistry.get(type))(
+                    this.resourceFormStore,
+                    this.form,
+                    router,
+                    this.locales,
+                    ((options: any): {[key: string]: mixed})
+                );
+            });
     }
 
     getNode() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DropdownToolbarAction.js
@@ -25,13 +25,13 @@ export default class DropdownToolbarAction extends AbstractFormToolbarAction {
             options
         );
 
-        const {actions} = this.options;
+        const {toolbarActions} = this.options;
 
-        if (!Array.isArray(actions)) {
-            throw new Error('The passed "actions" option must be of type object or array');
+        if (!Array.isArray(toolbarActions)) {
+            throw new Error('The passed "toolbarActions" option must be of type object or array');
         }
 
-        this.toolbarActions = actions
+        this.toolbarActions = toolbarActions
             .map((action) => {
                 if (action === null || typeof action !== 'object') {
                     throw new Error('The passed entries in the "actions" option must be objects');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -192,24 +192,22 @@ class List extends React.Component<Props> {
             return;
         }
 
-        Object.keys(toolbarActions).forEach((toolbarActionKey) => {
-            const toolbarActionValue = toolbarActions[toolbarActionKey];
-            if (typeof toolbarActionValue !== 'object') {
+        toolbarActions.forEach((toolbarAction) => {
+            if (typeof toolbarAction !== 'object') {
                 throw new Error(
-                    'The value of the toolbarAction entry "' + toolbarActionKey + '" must be an object, '
-                    + 'but ' + typeof toolbarActionValue + ' was given!'
+                    'The value of a toolbarAction entry must be an object, but ' + typeof toolbarAction + ' was given!'
                 );
             }
         });
 
-        this.toolbarActions = Object.keys(toolbarActions)
-            .map((toolbarActionKey): AbstractListToolbarAction => new (listToolbarActionRegistry.get(toolbarActionKey))(
+        this.toolbarActions = toolbarActions
+            .map((toolbarAction): AbstractListToolbarAction => new (listToolbarActionRegistry.get(toolbarAction.type))(
                 this.listStore,
                 this,
                 router,
                 locales,
                 resourceStore,
-                toolbarActions[toolbarActionKey]
+                toolbarAction.options
             ));
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -1301,7 +1301,7 @@ test('Should make move overlay disappear if cancel is clicked', () => {
                 resourceKey: 'test',
                 toolbarActions: [
                     {type: 'sulu_admin.move', options: {}},
-                ]
+                ],
             },
         },
     };
@@ -1342,7 +1342,7 @@ test('Should move items after move overlay was confirmed', () => {
                 resourceKey: 'test',
                 toolbarActions: [
                     {type: 'sulu_admin.move', options: {}},
-                ]
+                ],
             },
         },
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -228,7 +228,16 @@ test('Pass correct arguments to ToolbarActions', () => {
                 listKey: 'snippets_list',
                 locales,
                 resourceKey: 'snippets',
-                toolbarActions: {'mock1': {'test1': 'value1'}, 'mock2': {'test2': 'value2'}},
+                toolbarActions: [
+                    {
+                        type: 'mock1',
+                        options: {'test1': 'value1'},
+                    },
+                    {
+                        type: 'mock2',
+                        options: {'test2': 'value2'},
+                    },
+                ],
             },
         },
     };
@@ -305,7 +314,9 @@ test('Pass correct arguments with passed ResourceStore to ToolbarActions', () =>
                 listKey: 'snippets_list',
                 locales,
                 resourceKey: 'snippets',
-                toolbarActions: {'mock1': {}},
+                toolbarActions: [
+                    {type: 'mock1', options: {}},
+                ],
             },
         },
     };
@@ -336,7 +347,9 @@ test('Should pass correct props to move list overlay', () => {
                 listKey: 'snippets_list',
                 resourceKey: 'snippets',
                 title: 'sulu_snippet.snippets',
-                toolbarActions: {'sulu_admin.move': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.move', options: {}},
+                ],
             },
         },
     };
@@ -417,7 +430,9 @@ test('Should render the list with the add icon if a addRoute has been passed', (
                 addRoute: 'addRoute',
                 listKey: 'snippets',
                 resourceKey: 'snippets',
-                toolbarActions: {'sulu_admin.add': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.add', options: {}},
+                ],
             },
         },
     };
@@ -439,7 +454,9 @@ test('Should render the list with the add icon if onItemAdd prop is set', () => 
                 adapters: ['tree_table'],
                 listKey: 'snippets',
                 resourceKey: 'snippets',
-                toolbarActions: {'sulu_admin.add': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.add', options: {}},
+                ],
             },
         },
     };
@@ -661,7 +678,9 @@ test('Should render the add button in the toolbar only if an addRoute has been p
                 addRoute: 'addRoute',
                 listKey: 'test',
                 resourceKey: 'test',
-                toolbarActions: {'sulu_admin.add': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.add', options: {}},
+                ],
             },
         },
     };
@@ -695,7 +714,9 @@ test('Should navigate when add button is clicked and locales have been passed in
                 locales: ['de', 'en'],
                 listKey: 'test',
                 resourceKey: 'test',
-                toolbarActions: {'sulu_admin.add': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.add', options: {}},
+                ],
             },
         },
     };
@@ -729,7 +750,9 @@ test('Should navigate without locale when add button is clicked', () => {
                 addRoute: 'addRoute',
                 listKey: 'test',
                 resourceKey: 'test',
-                toolbarActions: {'sulu_admin.add': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.add', options: {}},
+                ],
             },
         },
     };
@@ -758,7 +781,9 @@ test('Should fire callback instead of navigate when onItemAdd prop is set and ad
                 addRoute: 'addRoute',
                 listKey: 'test',
                 resourceKey: 'test',
-                toolbarActions: {'sulu_admin.add': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.add', options: {}},
+                ],
             },
         },
     };
@@ -948,10 +973,12 @@ test('Should render the delete item enabled only if something is selected', () =
         bind: jest.fn(),
         route: {
             options: {
-                toolbarActions: {'sulu_admin.delete': {}},
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',
+                toolbarActions: [
+                    {type: 'sulu_admin.delete', options: {}},
+                ],
             },
         },
     };
@@ -1232,10 +1259,12 @@ test('Should delete selected items when delete button is clicked', () => {
         bind: jest.fn(),
         route: {
             options: {
-                toolbarActions: {'sulu_admin.delete': {}},
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',
+                toolbarActions: [
+                    {type: 'sulu_admin.delete', options: {}},
+                ],
             },
         },
     };
@@ -1270,7 +1299,9 @@ test('Should make move overlay disappear if cancel is clicked', () => {
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',
-                toolbarActions: {'sulu_admin.move': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.move', options: {}},
+                ]
             },
         },
     };
@@ -1309,7 +1340,9 @@ test('Should move items after move overlay was confirmed', () => {
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',
-                toolbarActions: {'sulu_admin.move': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.move', options: {}},
+                ]
             },
         },
     };
@@ -1358,7 +1391,9 @@ test('Export dialog should open when the button is pressed', () => {
         bind: jest.fn(),
         route: {
             options: {
-                toolbarActions: {'sulu_admin.export': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.export', options: {}},
+                ],
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',
@@ -1394,7 +1429,9 @@ test('Render export dialog', () => {
         bind: jest.fn(),
         route: {
             options: {
-                toolbarActions: {'sulu_admin.export': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.export', options: {}},
+                ],
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',
@@ -1432,7 +1469,9 @@ test('Export method should be called when the export-button is pressed', () => {
         bind: jest.fn(),
         route: {
             options: {
-                toolbarActions: {'sulu_admin.export': {}},
+                toolbarActions: [
+                    {type: 'sulu_admin.export', options: {}},
+                ],
                 adapters: ['table'],
                 listKey: 'test',
                 resourceKey: 'test',

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/DropdownToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/DropdownToolbarActionSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Serializer\Subscriber;
+
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\JsonSerializationVisitor;
+use Sulu\Bundle\AdminBundle\Admin\Routing\DropdownToolbarAction;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class DropdownToolbarActionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerialize',
+                'class' => DropdownToolbarAction::class,
+            ],
+        ];
+    }
+
+    public function onPostSerialize(ObjectEvent $event)
+    {
+        $dropdownToolbarAction = $event->getObject();
+        $visitor = $event->getVisitor();
+
+        $options = $dropdownToolbarAction->getOptions();
+        $options['label'] = $this->translator->trans($options['label'], [], 'admin');
+        $serializedOptions = $visitor->visitArray($options, [], $event->getContext());
+        $visitor->setData('options', $serializedOptions);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/DropdownToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/DropdownToolbarActionSubscriber.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\AdminBundle\Serializer\Subscriber;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\JsonSerializationVisitor;
 use Sulu\Bundle\AdminBundle\Admin\Routing\DropdownToolbarAction;
 use Symfony\Component\Translation\TranslatorInterface;
 

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/TogglerToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/TogglerToolbarActionSubscriber.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\AdminBundle\Serializer\Subscriber;
 use JMS\Serializer\EventDispatcher\Events;
 use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
-use JMS\Serializer\JsonSerializationVisitor;
 use Sulu\Bundle\AdminBundle\Admin\Routing\TogglerToolbarAction;
 use Symfony\Component\Translation\TranslatorInterface;
 

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/TogglerToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/TogglerToolbarActionSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Serializer\Subscriber;
+
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\JsonSerializationVisitor;
+use Sulu\Bundle\AdminBundle\Admin\Routing\TogglerToolbarAction;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class TogglerToolbarActionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerialize',
+                'class' => TogglerToolbarAction::class,
+            ],
+        ];
+    }
+
+    public function onPostSerialize(ObjectEvent $event)
+    {
+        $dropdownToolbarAction = $event->getObject();
+        $visitor = $event->getVisitor();
+
+        $options = $dropdownToolbarAction->getOptions();
+        $options['label'] = $this->translator->trans($options['label'], [], 'admin');
+        $serializedOptions = $visitor->visitArray($options, [], $event->getContext());
+        $visitor->setData('options', $serializedOptions);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormOverlayListRouteBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\Routing\FormOverlayListRouteBuilder;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 
 class FormOverlayListRouteBuilderTest extends TestCase
 {
@@ -380,17 +381,21 @@ class FormOverlayListRouteBuilderTest extends TestCase
 
     public function testBuildAddToolbarActions()
     {
+        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
+        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
+        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+
         $route = (new FormOverlayListRouteBuilder('sulu_role.list', '/roles'))
             ->setResourceKey('roles')
             ->setListKey('roles')
             ->setFormKey('role_details')
             ->addListAdapters(['tree'])
-            ->addToolbarActions(['sulu_admin.add', 'sulu_admin.move'])
-            ->addToolbarActions(['sulu_admin.delete'])
+            ->addToolbarActions([$saveToolbarAction, $typesToolbarAction])
+            ->addToolbarActions([$deleteToolbarAction])
             ->getRoute();
 
         $this->assertEquals(
-            ['sulu_admin.add' => [], 'sulu_admin.move' => [], 'sulu_admin.delete' => []],
+            [$saveToolbarAction, $typesToolbarAction, $deleteToolbarAction],
             $route->getOption('toolbarActions')
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/FormRouteBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\Routing\FormRouteBuilder;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 
 class FormRouteBuilderTest extends TestCase
 {
@@ -179,15 +180,19 @@ class FormRouteBuilderTest extends TestCase
 
     public function testBuildFormWithToolbarActions()
     {
+        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
+        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
+        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+
         $route = (new FormRouteBuilder('sulu_role.add_form', '/roles'))
             ->setResourceKey('roles')
             ->setFormKey('roles')
-            ->addToolbarActions(['sulu_admin.save', 'sulu_admin.types'])
-            ->addToolbarActions(['sulu_admin.delete'])
+            ->addToolbarActions([$saveToolbarAction, $typesToolbarAction])
+            ->addToolbarActions([$deleteToolbarAction])
             ->getRoute();
 
         $this->assertSame(
-            ['sulu_admin.save' => [], 'sulu_admin.types' => [], 'sulu_admin.delete' => []],
+            [$saveToolbarAction, $typesToolbarAction, $deleteToolbarAction],
             $route->getOption('toolbarActions')
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ListRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/ListRouteBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\Routing\ListRouteBuilder;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
 
 class ListRouteBuilderTest extends TestCase
@@ -335,16 +336,20 @@ class ListRouteBuilderTest extends TestCase
 
     public function testBuildAddToolbarActions()
     {
+        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
+        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
+        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+
         $route = (new ListRouteBuilder('sulu_role.list', '/roles'))
             ->setResourceKey('roles')
             ->setListKey('roles')
             ->addListAdapters(['tree'])
-            ->addToolbarActions(['sulu_admin.add', 'sulu_admin.move'])
-            ->addToolbarActions(['sulu_admin.delete'])
+            ->addToolbarActions([$saveToolbarAction, $typesToolbarAction])
+            ->addToolbarActions([$deleteToolbarAction])
             ->getRoute();
 
         $this->assertSame(
-            ['sulu_admin.add' => [], 'sulu_admin.move' => [], 'sulu_admin.delete' => []],
+            [$saveToolbarAction, $typesToolbarAction, $deleteToolbarAction],
             $route->getOption('toolbarActions')
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/PreviewFormRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/PreviewFormRouteBuilderTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\Routing\PreviewFormRouteBuilder;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 
 class PreviewFormRouteBuilderTest extends TestCase
 {
@@ -141,15 +142,19 @@ class PreviewFormRouteBuilderTest extends TestCase
 
     public function testBuildFormWithToolbarActions()
     {
+        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
+        $typesToolbarAction = new ToolbarAction('sulu_admin.types');
+        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+
         $route = (new PreviewFormRouteBuilder('sulu_role.add_form', '/roles'))
             ->setResourceKey('roles')
             ->setFormKey('roles')
-            ->addToolbarActions(['sulu_admin.save', 'sulu_admin.types'])
-            ->addToolbarActions(['sulu_admin.delete'])
+            ->addToolbarActions([$saveToolbarAction, $typesToolbarAction])
+            ->addToolbarActions([$deleteToolbarAction])
             ->getRoute();
 
         $this->assertSame(
-            ['sulu_admin.save' => [], 'sulu_admin.types' => [], 'sulu_admin.delete' => []],
+            [$saveToolbarAction, $typesToolbarAction, $deleteToolbarAction],
             $route->getOption('toolbarActions')
         );
     }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Admin/AudienceTargetingAdmin.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleCollectionInterface;
 use Sulu\Bundle\AudienceTargetingBundle\Rule\RuleInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -76,20 +77,20 @@ class AudienceTargetingAdmin extends Admin
         $formToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = 'sulu_admin.add';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = 'sulu_admin.save';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $listToolbarActions[] = 'sulu_admin.delete';
-            $formToolbarActions[] = 'sulu_admin.delete';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = 'sulu_admin.export';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
+++ b/src/Sulu/Bundle/CategoryBundle/Admin/CategoryAdmin.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -74,21 +75,21 @@ class CategoryAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = 'sulu_admin.add';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = 'sulu_admin.save';
-            $listToolbarActions[] = 'sulu_admin.move';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.move');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActions[] = 'sulu_admin.delete';
-            $listToolbarActions[] = 'sulu_admin.delete';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = 'sulu_admin.export';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
         if ($this->securityChecker->hasPermission(self::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
@@ -152,7 +153,7 @@ class CategoryAdmin extends Admin
                     ->setFormKey('category_keywords')
                     ->addRouterAttributesToFormStore(['id' => 'categoryId'])
                     ->setTabTitle('sulu_category.keywords')
-                    ->addToolbarActions(['sulu_admin.add', 'sulu_admin.delete'])
+                    ->addToolbarActions([new ToolbarAction('sulu_admin.add'), new ToolbarAction('sulu_admin.delete')])
                     ->setParent(static::EDIT_FORM_ROUTE)
             );
         }

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -256,7 +256,7 @@ class ContactAdmin extends Admin
                     ->addRouterAttributesToListStore(['id'])
                     ->addToolbarActions([
                         new ToolbarAction('sulu_contact.add_contact'),
-                        new ToolbarAction('sulu_admin.delete')
+                        new ToolbarAction('sulu_admin.delete'),
                     ])
                     ->addRouterAttributesToListStore(['id' => 'accountId'])
                     ->setTabOrder(2048)

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
@@ -102,22 +103,22 @@ class ContactAdmin extends Admin
             $contactDocumentsToolbarAction = [];
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::ADD)) {
-                $contactListToolbarActions[] = 'sulu_admin.add';
+                $contactListToolbarActions[] = new ToolbarAction('sulu_admin.add');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-                $contactFormToolbarActions[] = 'sulu_admin.save';
-                $contactDocumentsToolbarAction[] = 'sulu_contact.add_media';
-                $contactDocumentsToolbarAction[] = 'sulu_contact.delete_media';
+                $contactFormToolbarActions[] = new ToolbarAction('sulu_admin.save');
+                $contactDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.add_media');
+                $contactDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.delete_media');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-                $contactFormToolbarActions[] = 'sulu_admin.delete';
-                $contactListToolbarActions[] = 'sulu_admin.delete';
+                $contactFormToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+                $contactListToolbarActions[] = new ToolbarAction('sulu_admin.delete');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-                $contactListToolbarActions[] = 'sulu_admin.export';
+                $contactListToolbarActions[] = new ToolbarAction('sulu_admin.export');
             }
 
             $routeCollection->add(
@@ -182,22 +183,22 @@ class ContactAdmin extends Admin
             $accountDocumentsToolbarAction = [];
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::ADD)) {
-                $accountListToolbarActions[] = 'sulu_admin.add';
+                $accountListToolbarActions[] = new ToolbarAction('sulu_admin.add');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-                $accountFormToolbarActions[] = 'sulu_admin.save';
-                $accountDocumentsToolbarAction[] = 'sulu_contact.add_media';
-                $accountDocumentsToolbarAction[] = 'sulu_contact.delete_media';
+                $accountFormToolbarActions[] = new ToolbarAction('sulu_admin.save');
+                $accountDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.add_media');
+                $accountDocumentsToolbarAction[] = new ToolbarAction('sulu_contact.delete_media');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-                $accountFormToolbarActions[] = 'sulu_admin.delete';
-                $accountListToolbarActions[] = 'sulu_admin.delete';
+                $accountFormToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+                $accountListToolbarActions[] = new ToolbarAction('sulu_admin.delete');
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-                $accountListToolbarActions[] = 'sulu_admin.export';
+                $accountListToolbarActions[] = new ToolbarAction('sulu_admin.export');
             }
 
             $routeCollection->add(
@@ -253,7 +254,10 @@ class ContactAdmin extends Admin
                     ->addListAdapters(['table'])
                     ->setEditRoute(static::CONTACT_EDIT_FORM_ROUTE)
                     ->addRouterAttributesToListStore(['id'])
-                    ->addToolbarActions(['sulu_contact.add_contact', 'sulu_admin.delete'])
+                    ->addToolbarActions([
+                        new ToolbarAction('sulu_contact.add_contact'),
+                        new ToolbarAction('sulu_admin.delete')
+                    ])
                     ->addRouterAttributesToListStore(['id' => 'accountId'])
                     ->setTabOrder(2048)
                     ->setParent(static::ACCOUNT_EDIT_FORM_ROUTE)

--- a/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Admin/CustomUrlAdmin.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CustomUrlBundle\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -65,8 +66,8 @@ class CustomUrlAdmin extends Admin
     public function configureRoutes(RouteCollection $routeCollection): void
     {
         $listToolbarActions = [
-            'sulu_admin.add',
-            'sulu_admin.delete',
+            new ToolbarAction('sulu_admin.add'),
+            new ToolbarAction('sulu_admin.delete'),
         ];
 
         $routes = [];

--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Component\Localization\Manager\LocalizationManager;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -94,11 +95,11 @@ class MediaAdmin extends Admin
         $toolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $toolbarActions[] = 'sulu_admin.save';
+            $toolbarActions[] = new ToolbarAction('sulu_admin.save');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $toolbarActions[] = 'sulu_admin.delete';
+            $toolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
         $routes = [];

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -14,10 +14,10 @@ namespace Sulu\Bundle\PageBundle\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\Routing\Route;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
-use Sulu\Bundle\AdminBundle\Admin\Routing\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPoolInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -25,7 +25,6 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class PageAdmin extends Admin
 {

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -17,6 +17,8 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\Route;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\DropdownToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPoolInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -68,11 +70,6 @@ class PageAdmin extends Admin
     private $teaserProviderPool;
 
     /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
      * @var bool
      */
     private $versioningEnabled;
@@ -83,7 +80,6 @@ class PageAdmin extends Admin
         SecurityCheckerInterface $securityChecker,
         SessionManagerInterface $sessionManager,
         TeaserProviderPoolInterface $teaserProviderPool,
-        TranslatorInterface $translator,
         bool $versioningEnabled
     ) {
         $this->routeBuilderFactory = $routeBuilderFactory;
@@ -91,7 +87,6 @@ class PageAdmin extends Admin
         $this->securityChecker = $securityChecker;
         $this->sessionManager = $sessionManager;
         $this->teaserProviderPool = $teaserProviderPool;
-        $this->translator = $translator;
         $this->versioningEnabled = $versioningEnabled;
     }
 
@@ -117,33 +112,48 @@ class PageAdmin extends Admin
         $publishDisplayCondition = '(!_permissions || _permissions.live)';
 
         $formToolbarActionsWithType = [
-            'sulu_admin.save_with_publishing' => [
-                'publish_display_condition' => '(!_permissions || _permissions.live)',
-                'save_display_condition' => '(!_permissions || _permissions.edit)',
-            ],
-            'sulu_page.templates',
-            'sulu_admin.delete' => [
-                'display_condition' => '(!_permissions || _permissions.delete) && url != "/"',
-            ],
-            'sulu_admin.dropdown' => [
-                'label' => $this->translator->trans('sulu_admin.edit', [], 'admin'),
-                'icon' => 'su-pen',
-                'actions' => [
-                    'sulu_admin.copy_locale' => [
-                        'display_condition' => '(!_permissions || _permissions.edit)',
-                    ],
-                    'sulu_admin.delete_draft' => [
-                        'display_condition' => $publishDisplayCondition,
-                    ],
-                    'sulu_admin.set_unpublished' => [
-                        'display_condition' => $publishDisplayCondition,
-                    ],
-                ],
-            ],
+            new ToolbarAction(
+                'sulu_admin.save_with_publishing',
+                [
+                    'publish_display_condition' => '(!_permissions || _permissions.live)',
+                    'save_display_condition' => '(!_permissions || _permissions.edit)',
+                ]
+            ),
+            new ToolbarAction('sulu_page.templates'),
+            new ToolbarAction(
+                'sulu_admin.delete',
+                [
+                    'display_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                ]
+            ),
+            new DropdownToolbarAction(
+                'sulu_admin.edit',
+                'su-pen',
+                [
+                    new ToolbarAction(
+                        'sulu_admin.copy_locale',
+                        [
+                            'display_condition' => '(!_permissions || _permissions.edit)',
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.delete_draft',
+                        [
+                            'display_condition' => $publishDisplayCondition,
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.set_unpublished',
+                        [
+                            'display_condition' => $publishDisplayCondition,
+                        ]
+                    ),
+                ]
+            ),
         ];
 
         $formToolbarActionsWithoutType = [
-            'sulu_admin.save_with_publishing',
+            new ToolbarAction('sulu_admin.save_with_publishing'),
         ];
 
         $routerAttributesToFormStore = ['parentId', 'webspace'];
@@ -265,7 +275,7 @@ class PageAdmin extends Admin
                     ->setApiOptions(['resourceKey' => 'pages'])
                     ->setTabCondition('_permissions.security')
                     ->setTabTitle('sulu_security.permissions')
-                    ->addToolbarActions(['sulu_admin.save'])
+                    ->addToolbarActions([new ToolbarAction('sulu_admin.save')])
                     ->addRouterAttributesToFormStore(['webspace'])
                     ->setTitleVisible(true)
                     ->setTabOrder(5120)

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -18,7 +18,6 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_page.teaser.provider_pool" />
-            <argument type="service" id="translator"/>
             <argument>%sulu_document_manager.versioning.enabled%</argument>
         </service>
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -27,7 +27,7 @@ class AdminControllerTest extends SuluTestCase
 
         $formRoute = null;
         foreach ($routeConfig as $route) {
-            if ($route->name === 'sulu_page.page_add_form.details') {
+            if ('sulu_page.page_add_form.details' === $route->name) {
                 $formRoute = $route;
                 break;
             }

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -15,6 +15,27 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class AdminControllerTest extends SuluTestCase
 {
+    public function testRouteConfig()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/admin/config');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $routeConfig = $response->sulu_admin->routes;
+
+        $formRoute = null;
+        foreach ($routeConfig as $route) {
+            if ($route->name === 'sulu_page.page_add_form.details') {
+                $formRoute = $route;
+                break;
+            }
+        }
+
+        $this->assertEquals('Edit', $formRoute->options->toolbarActions[3]->options->label);
+    }
+
     public function testTeaserConfig()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Admin/PageAdminTest.php
@@ -22,7 +22,6 @@ use Sulu\Component\Security\Authorization\SecurityChecker;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class PageAdminTest extends TestCase
 {
@@ -51,11 +50,6 @@ class PageAdminTest extends TestCase
      */
     private $teaserProviderPool;
 
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
     public function setUp(): void
     {
         $this->routeBuilderFactory = new RouteBuilderFactory();
@@ -63,7 +57,6 @@ class PageAdminTest extends TestCase
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->sessionManager = $this->prophesize(SessionManagerInterface::class);
         $this->teaserProviderPool = $this->prophesize(TeaserProviderPoolInterface::class);
-        $this->translator = $this->prophesize(TranslatorInterface::class);
     }
 
     public function testGetRoutes()
@@ -95,7 +88,6 @@ class PageAdminTest extends TestCase
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
             $this->teaserProviderPool->reveal(),
-            $this->translator->reveal(),
             false
         );
 
@@ -120,7 +112,6 @@ class PageAdminTest extends TestCase
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
             $this->teaserProviderPool->reveal(),
-            $this->translator->reveal(),
             true
         );
 
@@ -137,7 +128,6 @@ class PageAdminTest extends TestCase
             $this->securityChecker->reveal(),
             $this->sessionManager->reveal(),
             $this->teaserProviderPool->reveal(),
-            $this->translator->reveal(),
             false
         );
 

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -16,6 +16,8 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\TogglerToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -119,20 +121,20 @@ class SecurityAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = 'sulu_admin.add';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = 'sulu_admin.save';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActions[] = 'sulu_admin.delete';
-            $listToolbarActions[] = 'sulu_admin.delete';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = 'sulu_admin.export';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
         if ($this->securityChecker->hasPermission(static::ROLE_SECURITY_CONTEXT, PermissionTypes::EDIT)) {
@@ -186,14 +188,14 @@ class SecurityAdmin extends Admin
                     ->setFormKey('user_details')
                     ->setTabTitle('sulu_security.permissions')
                     ->addToolbarActions([
-                        'sulu_admin.save',
-                        'sulu_security.enable_user',
-                        'sulu_admin.toggler' => [
-                            'label' => $this->translator->trans('sulu_security.user_locked', [], 'admin'),
-                            'property' => 'locked',
-                            'activate' => 'lock',
-                            'deactivate' => 'unlock',
-                        ],
+                        new ToolbarAction('sulu_admin.save'),
+                        new ToolbarAction('sulu_security.enable_user'),
+                        new TogglerToolbarAction(
+                            'sulu_security.user_locked',
+                            'locked',
+                            'lock',
+                            'unlock'
+                        ),
                     ])
                     ->setIdQueryParameter('contactId')
                     ->setTitleVisible(true)

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
@@ -11,3 +11,19 @@ sulu_security_api:
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"
     prefix: /admin
+
+# The following route are necessary to get AdminController::configAction work.
+# Can be removed once its content is not hardcoded anymore.
+sulu_preview:
+    type: rest
+    resource: "@SuluPreviewBundle/Resources/config/routing.yml"
+    prefix: /admin
+
+sulu_website:
+    type: rest
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    prefix: /admin
+
+sulu_media:
+    resource: "@SuluMediaBundle/Resources/config/routing.yml"
+    prefix: /admin/media

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
@@ -15,6 +15,26 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class AdminControllerTest extends SuluTestCase
 {
+    public function testRouteConfigWithTranslation()
+    {
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/admin/config');
+
+        $this->assertHttpStatusCode(200, $client->getResponse());
+        $response = json_decode($client->getResponse()->getContent());
+
+        $routeConfig = $response->sulu_admin->routes;
+
+        $formRoute = null;
+        foreach ($routeConfig as $route) {
+            if ($route->name === 'sulu_security.form.permissions') {
+                $formRoute = $route;
+                break;
+            }
+        }
+
+        $this->assertEquals('User locked', $formRoute->options->toolbarActions[2]->options->label);
+    }
     public function testUserMetadataAction()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
@@ -27,7 +27,7 @@ class AdminControllerTest extends SuluTestCase
 
         $formRoute = null;
         foreach ($routeConfig as $route) {
-            if ($route->name === 'sulu_security.form.permissions') {
+            if ('sulu_security.form.permissions' === $route->name) {
                 $formRoute = $route;
                 break;
             }
@@ -35,6 +35,7 @@ class AdminControllerTest extends SuluTestCase
 
         $this->assertEquals('User locked', $formRoute->options->toolbarActions[2]->options->label);
     }
+
     public function testUserMetadataAction()
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -103,22 +104,22 @@ class SnippetAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = 'sulu_admin.add';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActionsWithoutType[] = 'sulu_admin.save';
-            $formToolbarActionsWithType[] = 'sulu_admin.save';
-            $formToolbarActionsWithType[] = 'sulu_admin.type';
+            $formToolbarActionsWithoutType[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.save');
+            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.type');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActionsWithType[] = 'sulu_admin.delete';
-            $listToolbarActions[] = 'sulu_admin.delete';
+            $formToolbarActionsWithType[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = 'sulu_admin.export';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Admin/SnippetAdminTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Admin;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\SnippetBundle\Admin\SnippetAdmin;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
 use Sulu\Component\Security\Authorization\SecurityChecker;
@@ -85,7 +86,11 @@ class SnippetAdminTest extends TestCase
         $this->assertEquals('sulu_snippet.list', $listRoute->getName());
         $this->assertEquals([
             'title' => 'sulu_snippet.snippets',
-            'toolbarActions' => ['sulu_admin.add' => [], 'sulu_admin.delete' => [], 'sulu_admin.export' => []],
+            'toolbarActions' => [
+                new ToolbarAction('sulu_admin.add'),
+                new ToolbarAction('sulu_admin.delete'),
+                new ToolbarAction('sulu_admin.export'),
+            ],
             'resourceKey' => 'snippets',
             'listKey' => 'snippets',
             'adapters' => ['table'],
@@ -107,9 +112,9 @@ class SnippetAdminTest extends TestCase
             'formKey' => 'snippet',
             'editRoute' => 'sulu_snippet.edit_form',
             'toolbarActions' => [
-                'sulu_admin.save' => [],
-                'sulu_admin.type' => [],
-                'sulu_admin.delete' => [],
+                new Toolbaraction('sulu_admin.save'),
+                new Toolbaraction('sulu_admin.type'),
+                new Toolbaraction('sulu_admin.delete'),
             ],
         ], $this->readObjectAttribute($addDetailRoute, 'options'));
         $this->assertEquals('sulu_snippet.edit_form', $editFormRoute->getName());
@@ -126,9 +131,9 @@ class SnippetAdminTest extends TestCase
             'tabTitle' => 'sulu_admin.details',
             'formKey' => 'snippet',
             'toolbarActions' => [
-                'sulu_admin.save' => [],
-                'sulu_admin.type' => [],
-                'sulu_admin.delete' => [],
+                new Toolbaraction('sulu_admin.save'),
+                new Toolbaraction('sulu_admin.type'),
+                new Toolbaraction('sulu_admin.delete'),
             ],
         ], $this->readObjectAttribute($editDetailRoute, 'options'));
     }

--- a/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
+++ b/src/Sulu/Bundle/TagBundle/Admin/TagAdmin.php
@@ -16,6 +16,7 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 
@@ -64,20 +65,20 @@ class TagAdmin extends Admin
         $listToolbarActions = [];
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = 'sulu_admin.add';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $formToolbarActions[] = 'sulu_admin.save';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.save');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $formToolbarActions[] = 'sulu_admin.delete';
-            $listToolbarActions[] = 'sulu_admin.delete';
+            $formToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = 'sulu_admin.export';
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
         if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\WebsiteBundle\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
+use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -70,8 +71,8 @@ class WebsiteAdmin extends Admin
     public function configureRoutes(RouteCollection $routeCollection): void
     {
         $listToolbarActions = [
-            'sulu_admin.add',
-            'sulu_admin.delete',
+            new ToolbarAction('sulu_admin.add'),
+            new ToolbarAction('sulu_admin.delete'),
         ];
 
         if ($this->hasSomeWebspaceAnalyticsPermission()) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces a `ToolbarAction` class, which solves two problems:

* They can be serialized, and in the serialization process we can translate some translation keys, so that it is not necessary to translate stuff in the `Admin` class
* The type can be handled separately (the `ToolbarAction` class has a type and options)

#### Why?

Because we don't want to have the `translator` in every `Admin` class and the current array does not work when we want to have different `ToolbarAction`s be shown multiple times, because the key is used as the type, and if we add a second key it would override the value of the first one.
#### BC Breaks/Deprecations

Instead of an array you have to pass an array of `ToolbarAction` classes to the `addToolbarActions` method of the `RouteBuilder`s.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
