### PR TITLE
Fix container build with unused media environment parameters

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -236,7 +236,7 @@ class Configuration implements ConfigurationInterface
         }
 
         $node->children()
-                ->enumNode('storage')->values($storages)->defaultValue('local')->end()
+                ->scalarNode('storage')->defaultValue('local')->end()
             ->end();
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix container build with unused media environment parameters

#### Why?

Sometimes when you use S3 storage but want to run it local under `prod` environment you want to use local storage. Currently this ends up with following error:

>   Environment variables "S3_KEY", "S3_SECRET", "S3_REGION", "S3_BUCKET_NAME", "S3_ENDPOINT" are never used. Please, check your container's configuration.

#### Example Usage

~~~yaml
# config/packages/sulu_media.yaml
sulu_media:
    storage: '%env(SULU_MEDIA_STORAGE)%'
    storages:
        s3:
            key: '%env(S3_KEY)%'
            secret: '%env(S3_SECRET)%'
            region: '%env(S3_REGION)%'
            bucket_name: '%env(S3_BUCKET_NAME)%'
            endpoint: '%env(S3_ENDPOINT)%'
~~~

```.env
# .env
SULU_MEDIA_STORAGE=local
S3_KEY=
S3_SECRET=
S3_REGION=
S3_ENDPOINT=
S3_BUCKET_NAME=
```