### PR TITLE
Add webspace and target group selection to preview

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/Routing/PreviewFormRouteBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Routing/PreviewFormRouteBuilder.php
@@ -24,6 +24,13 @@ class PreviewFormRouteBuilder implements PreviewFormRouteBuilderInterface
         $this->route = new Route($name, $path, static::VIEW);
     }
 
+    public function disablePreviewWebspaceChooser(): PreviewFormRouteBuilderInterface
+    {
+        $this->route->setOption('previewWebspaceChooser', false);
+
+        return $this;
+    }
+
     public function setResourceKey(string $resourceKey): PreviewFormRouteBuilderInterface
     {
         $this->setResourceKeyToRoute($this->route, $resourceKey);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -59,6 +59,7 @@ export default class Selection extends React.Component<Props> {
                 USER_SETTINGS_KEY,
                 {locale: this.locale, page: observable.box()},
                 {},
+                undefined,
                 value
             );
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -14,7 +14,15 @@ import ResourceFormStore from '../../stores/ResourceFormStore';
 jest.mock('../../../List', () => jest.fn(() => null));
 
 jest.mock('../../../List/stores/ListStore',
-    () => function(resourceKey, listKey, userSettingsKey, observableOptions = {}, options, initialSelectionIds) {
+    () => function(
+        resourceKey,
+        listKey,
+        userSettingsKey,
+        observableOptions = {},
+        options,
+        metadataOptions,
+        initialSelectionIds
+    ) {
         this.resourceKey = resourceKey;
         this.listKey = listKey;
         this.userSettingsKey = userSettingsKey;
@@ -37,11 +45,13 @@ jest.mock('../../FormInspector', () => jest.fn(function(formStore) {
     this.resourceKey = formStore.resourceKey;
     this.locale = formStore.locale;
 }));
+
 jest.mock('../../stores/ResourceFormStore', () => jest.fn(function(resourceStore) {
     this.id = resourceStore.id;
     this.resourceKey = resourceStore.resourceKey;
     this.locale = resourceStore.locale;
 }));
+
 jest.mock('../../../../stores/ResourceStore', () => jest.fn(function(resourceKey, id, options) {
     this.id = id;
     this.resourceKey = resourceKey;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/index.js
@@ -2,11 +2,13 @@
 import localizationStore from './localizationStore';
 import type {Localization} from './localizationStore/types';
 import MultiSelectionStore from './MultiSelectionStore';
+import ResourceListStore from './ResourceListStore';
 import ResourceStore from './ResourceStore';
 import userStore from './userStore';
 
 export {
     MultiSelectionStore,
+    ResourceListStore,
     ResourceStore,
     localizationStore,
     userStore,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/PreviewFormRouteBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/Routing/PreviewFormRouteBuilderTest.php
@@ -51,6 +51,7 @@ class PreviewFormRouteBuilderTest extends TestCase
                 'sulu_category.list',
                 false,
                 ['test1' => 'value1'],
+                true,
             ],
             [
                 'sulu_tag.edit_form',
@@ -65,6 +66,7 @@ class PreviewFormRouteBuilderTest extends TestCase
                 null,
                 true,
                 null,
+                false,
             ],
         ];
     }
@@ -84,7 +86,8 @@ class PreviewFormRouteBuilderTest extends TestCase
         ?string $editRoute,
         ?string $backRoute,
         ?bool $titleVisible,
-        ?array $apiOptions
+        ?array $apiOptions,
+        bool $disablePreviewWebspaceChooser
     ) {
         $routeBuilder = (new PreviewFormRouteBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -122,6 +125,10 @@ class PreviewFormRouteBuilderTest extends TestCase
             $routeBuilder->setApiOptions($apiOptions);
         }
 
+        if ($disablePreviewWebspaceChooser) {
+            $routeBuilder->disablePreviewWebspaceChooser();
+        }
+
         $route = $routeBuilder->getRoute();
 
         $this->assertSame($name, $route->getName());
@@ -138,6 +145,12 @@ class PreviewFormRouteBuilderTest extends TestCase
         $this->assertSame($apiOptions, $route->getOption('apiOptions'));
         $this->assertNull($route->getParent());
         $this->assertSame('sulu_admin.preview_form', $route->getView());
+
+        if ($disablePreviewWebspaceChooser) {
+            $this->assertFalse($route->getOption('previewWebspaceChooser'));
+        } else {
+            $this->assertNull($route->getOption('previewWebspaceChooser'));
+        }
     }
 
     public function testBuildFormWithToolbarActions()

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.de.json
@@ -1,5 +1,6 @@
 {
     "sulu_audience_targeting.target_groups": "Zielgruppen",
+    "sulu_audience_targeting.no_target_group": "Keine Zielgruppe",
     "sulu_audience_targeting.active": "Aktiv",
     "sulu_audience_targeting.priority": "Priorität",
     "sulu_audience_targeting.rules": "Regeln",

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.en.json
@@ -1,5 +1,6 @@
 {
     "sulu_audience_targeting.target_groups": "Target groups",
+    "sulu_audience_targeting.no_target_group": "No target group",
     "sulu_audience_targeting.active": "Active",
     "sulu_audience_targeting.priority": "Priority",
     "sulu_audience_targeting.rules": "Rules",

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -213,6 +213,7 @@ class PageAdmin extends Admin
             $routeCollection->add(
                 $this->routeBuilderFactory
                     ->createPreviewFormRouteBuilder('sulu_page.page_edit_form.details', '/details')
+                    ->disablePreviewWebspaceChooser()
                     ->setResourceKey('pages')
                     ->setFormKey('page')
                     ->setTabTitle('sulu_admin.details')
@@ -227,6 +228,7 @@ class PageAdmin extends Admin
             $routeCollection->add(
                 $this->routeBuilderFactory
                     ->createPreviewFormRouteBuilder('sulu_page.page_edit_form.seo', '/seo')
+                    ->disablePreviewWebspaceChooser()
                     ->setResourceKey('pages')
                     ->setFormKey('page_seo')
                     ->setTabTitle('sulu_page.seo')
@@ -241,6 +243,7 @@ class PageAdmin extends Admin
             $routeCollection->add(
                 $this->routeBuilderFactory
                     ->createPreviewFormRouteBuilder('sulu_page.page_edit_form.excerpt', '/excerpt')
+                    ->disablePreviewWebspaceChooser()
                     ->setResourceKey('pages')
                     ->setFormKey('page_excerpt')
                     ->setTabTitle('sulu_page.excerpt')
@@ -255,6 +258,7 @@ class PageAdmin extends Admin
             $routeCollection->add(
                 $this->routeBuilderFactory
                     ->createPreviewFormRouteBuilder('sulu_page.page_edit_form.settings', '/settings')
+                    ->disablePreviewWebspaceChooser()
                     ->setResourceKey('pages')
                     ->setFormKey('page_settings')
                     ->setTabTitle('sulu_page.settings')

--- a/src/Sulu/Bundle/PreviewBundle/Admin/PreviewAdmin.php
+++ b/src/Sulu/Bundle/PreviewBundle/Admin/PreviewAdmin.php
@@ -31,14 +31,21 @@ class PreviewAdmin extends Admin
      */
     private $previewMode;
 
+    /**
+     * @var array
+     */
+    private $bundles;
+
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
         int $previewDelay,
-        string $previewMode
+        string $previewMode,
+        array $bundles
     ) {
         $this->urlGenerator = $urlGenerator;
         $this->previewDelay = $previewDelay;
         $this->previewMode = $previewMode;
+        $this->bundles = $bundles;
     }
 
     public function getConfigKey(): ?string
@@ -58,6 +65,7 @@ class PreviewAdmin extends Admin
             ],
             'debounceDelay' => $this->previewDelay,
             'mode' => $this->previewMode,
+            'audienceTargeting' => array_key_exists('SuluAudienceTargetingBundle', $this->bundles),
         ];
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -66,7 +66,7 @@ class PreviewController
         $token = $this->getRequestParameter($request, 'token', true);
         $webspace = $this->getRequestParameter($request, 'webspace', true, null);
         $locale = $this->getRequestParameter($request, 'locale', true, null);
-        $targetGroup = $this->getRequestParameter($request, 'target-group', false, null);
+        $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
 
         $content = $this->preview->render($token, $webspace, $locale, $targetGroup);
 
@@ -80,7 +80,7 @@ class PreviewController
         $token = $this->getRequestParameter($request, 'token', true);
         $data = $this->getRequestParameter($request, 'data', true);
         $webspace = $this->getRequestParameter($request, 'webspace', true);
-        $targetGroup = $this->getRequestParameter($request, 'target-group', false, null);
+        $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
 
         $content = $this->preview->update($token, $webspace, $data, $targetGroup);
 
@@ -92,7 +92,7 @@ class PreviewController
         $token = $this->getRequestParameter($request, 'token', true);
         $context = $this->getRequestParameter($request, 'context', true);
         $webspace = $this->getRequestParameter($request, 'webspace', true);
-        $targetGroup = $this->getRequestParameter($request, 'target-group', false, null);
+        $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
 
         $content = $this->preview->updateContext($token, $webspace, $context, $targetGroup);
 

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -159,6 +159,20 @@ class PreviewRenderer implements PreviewRendererInterface
         $attributes = $this->routeDefaultsProvider->getByEntity(get_class($object), $id, $locale, $object);
         $attributes['preview'] = true;
         $attributes['partial'] = $partial;
+        $attributes['_sulu'] = new RequestAttributes(
+            [
+                'webspace' => $webspace,
+                'locale' => $locale,
+                'localization' => $localization,
+                'portal' => $portalInformation->getPortal(),
+                'portalUrl' => $portalInformation->getUrl(),
+                'resourceLocatorPrefix' => $portalInformation->getPrefix(),
+                'getParameters' => $query,
+                'postParameters' => $request,
+                'portalInformation' => $portalInformation,
+                'scheme' => $currentRequest->getScheme(),
+            ]
+        );
 
         // get server parameters
         $server = $this->createServerAttributes($portalInformation, $currentRequest);
@@ -172,19 +186,7 @@ class PreviewRenderer implements PreviewRendererInterface
 
         // TODO Remove this event in 2.0 as it is not longer needed to set the correct theme.
         $this->eventDispatcher->dispatch(Events::PRE_RENDER, new PreRenderEvent(
-            new RequestAttributes(
-                [
-                    'webspace' => $webspace,
-                    'locale' => $locale,
-                    'localization' => $localization,
-                    'portal' => $portalInformation->getPortal(),
-                    'portalUrl' => $portalInformation->getUrl(),
-                    'resourceLocatorPrefix' => $portalInformation->getPrefix(),
-                    'getParameters' => $query,
-                    'postParameters' => $request,
-                    'portalInformation' => $portalInformation,
-                ]
-            )
+            $attributes['_sulu']
         ));
 
         try {

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -185,9 +185,7 @@ class PreviewRenderer implements PreviewRendererInterface
         }
 
         // TODO Remove this event in 2.0 as it is not longer needed to set the correct theme.
-        $this->eventDispatcher->dispatch(Events::PRE_RENDER, new PreRenderEvent(
-            $attributes['_sulu']
-        ));
+        $this->eventDispatcher->dispatch(Events::PRE_RENDER, new PreRenderEvent($attributes['_sulu']));
 
         try {
             $response = $this->handle($request);

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="router"/>
             <argument>%sulu_preview.delay%</argument>
             <argument>%sulu_preview.mode%</argument>
+            <argument>%kernel.bundles%</argument>
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>
@@ -49,5 +50,4 @@
             <argument type="service" id="profiler" on-invalid="null"/>
         </service>
     </services>
-
 </container>

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -19,7 +19,7 @@ export default class PreviewStore {
     resourceKey: string;
     id: ?string | number;
     locale: string;
-    webspace: string;
+    @observable webspace: string;
 
     @observable token: ?string;
 
@@ -44,6 +44,10 @@ export default class PreviewStore {
 
     @action setToken = (token: ?string) => {
         this.token = token;
+    };
+
+    @action setWebspace = (webspace: string) => {
+        this.webspace = webspace;
     };
 
     start(): Promise<*> {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -20,6 +20,7 @@ export default class PreviewStore {
     id: ?string | number;
     locale: string;
     @observable webspace: string;
+    @observable targetGroup: number = -1;
 
     @observable token: ?string;
 
@@ -39,6 +40,7 @@ export default class PreviewStore {
             webspace: this.webspace,
             locale: this.locale,
             token: this.token,
+            targetGroup: this.targetGroup,
         });
     }
 
@@ -50,11 +52,16 @@ export default class PreviewStore {
         this.webspace = webspace;
     };
 
+    @action setTargetGroup = (targetGroup: number) => {
+        this.targetGroup = targetGroup;
+    };
+
     start(): Promise<*> {
         const route = generateRoute('start', {
             provider: this.resourceKey,
             locale: this.locale,
             id: this.id,
+            targetGroup: this.targetGroup,
         });
 
         return Requester.get(route).then((response) => {
@@ -67,9 +74,10 @@ export default class PreviewStore {
             locale: this.locale,
             webspace: this.webspace,
             token: this.token,
+            targetGroup: this.targetGroup,
         });
 
-        return Requester.post(route, {data: data}).then((response) => {
+        return Requester.post(route, {data}).then((response) => {
             return response.content;
         });
     }
@@ -78,6 +86,7 @@ export default class PreviewStore {
         const route = generateRoute('update-context', {
             webspace: this.webspace,
             token: this.token,
+            targetGroup: this.targetGroup,
         });
 
         return Requester.post(route, {context: {template: type}}).then((response) => {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react';
 import {observable} from 'mobx';
-import {mount, render, shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import ResourceStore from 'sulu-admin-bundle/stores/ResourceStore';
 import ResourceFormStore from 'sulu-admin-bundle/containers/Form/stores/ResourceFormStore';
 import Router from 'sulu-admin-bundle/services/Router';
+import PreviewStore from '../stores/PreviewStore';
 import Preview from '../Preview';
 
 window.open = jest.fn().mockReturnValue({addEventListener: jest.fn()});
@@ -16,6 +17,7 @@ jest.mock('../stores/PreviewStore', () => jest.fn(function() {
     this.update = jest.fn().mockReturnValue(Promise.resolve());
     this.updateContext = jest.fn().mockReturnValue(Promise.resolve());
     this.stop = jest.fn().mockReturnValue(Promise.resolve());
+    this.setWebspace = jest.fn();
 
     this.renderRoute = '/render';
 }));
@@ -29,15 +31,18 @@ jest.mock('sulu-admin-bundle/services/Requester', () => ({
     post: jest.fn().mockReturnValue(Promise.resolve()),
 }));
 
-jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn(function() {
-}));
+jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => jest.fn());
 
-jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn(function() {
+jest.mock('sulu-admin-bundle/stores/ResourceStore', () => jest.fn());
+
+jest.mock('sulu-page-bundle/stores/webspaceStore', () => ({
+    loadWebspaces: jest.fn().mockReturnValue(Promise.resolve([{key: 'sulu_io'}, {key: 'example'}])),
 }));
 
 jest.mock('sulu-admin-bundle/services/Router', () => jest.fn(function(history) {
     this.history = history;
     this.attributes = {locale: 'de'};
+    this.route = {options: {}};
 }));
 
 jest.mock('sulu-admin-bundle/utils', () => ({
@@ -50,34 +55,42 @@ beforeEach(() => {
     Preview.mode = 'on_request';
 });
 
-test('Render correct preview', () => {
+test('Render correct preview', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
     const router = new Router({});
 
     const preview = shallow(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.starting = false;
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    return startPromise.then(() => {
-        expect(preview).toMatchSnapshot();
+        return startPromise.then(() => {
+            expect(preview.render()).toMatchSnapshot();
+            done();
+        });
     });
 });
 
-test('Render button to start preview', () => {
+test('Render button to start preview', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
     const router = new Router({});
 
-    expect(render(<Preview formStore={formStore} router={router} />)).toMatchSnapshot();
+    const preview = mount(<Preview formStore={formStore} router={router} />);
+
+    setTimeout(() => {
+        expect(preview.render()).toMatchSnapshot();
+        done();
+    });
 });
 
-test('Render nothing if separate window is opened and rerender if it is closed', () => {
+test('Render nothing if separate window is opened and rerender if it is closed', (done) => {
     const previewWindow = {addEventListener: jest.fn()};
     window.open.mockReturnValue(previewWindow);
 
@@ -87,65 +100,99 @@ test('Render nothing if separate window is opened and rerender if it is closed',
 
     const preview = shallow(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.starting = false;
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    return startPromise.then(() => {
-        expect(preview).toMatchSnapshot();
-        preview.find('Button[icon="su-link"]').simulate('click');
-        expect(preview.html()).toEqual(null);
+        return startPromise.then(() => {
+            expect(preview.render()).toMatchSnapshot();
+            preview.find('Button[icon="su-link"]').simulate('click');
+            expect(preview.html()).toEqual(null);
 
-        expect(previewWindow.addEventListener).toBeCalledWith('beforeunload', expect.anything());
-        previewWindow.addEventListener.mock.calls[0][1]();
-        expect(preview).toMatchSnapshot();
+            expect(previewWindow.addEventListener).toBeCalledWith('beforeunload', expect.anything());
+            previewWindow.addEventListener.mock.calls[0][1]();
+            expect(preview.render()).toMatchSnapshot();
+
+            done();
+        });
     });
 });
 
-test('Change css class when selection of device has changed', () => {
+test('Change css class when selection of device has changed', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
     const router = new Router({});
 
     const preview = shallow(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.starting = false;
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    return startPromise.then(() => {
-        expect(preview.find('.auto')).toHaveLength(1);
-        expect(preview.find('.desktop')).toHaveLength(0);
-        expect(preview.find('.tablet')).toHaveLength(0);
-        expect(preview.find('.smartphone')).toHaveLength(0);
+        return startPromise.then(() => {
+            expect(preview.find('.auto')).toHaveLength(1);
+            expect(preview.find('.desktop')).toHaveLength(0);
+            expect(preview.find('.tablet')).toHaveLength(0);
+            expect(preview.find('.smartphone')).toHaveLength(0);
 
-        preview.find('Select').prop('onChange')('tablet');
-        expect(preview.find('.auto')).toHaveLength(0);
-        expect(preview.find('.desktop')).toHaveLength(0);
-        expect(preview.find('.tablet')).toHaveLength(1);
-        expect(preview.find('.smartphone')).toHaveLength(0);
+            preview.find('Select').at(0).prop('onChange')('tablet');
+            expect(preview.find('.auto')).toHaveLength(0);
+            expect(preview.find('.desktop')).toHaveLength(0);
+            expect(preview.find('.tablet')).toHaveLength(1);
+            expect(preview.find('.smartphone')).toHaveLength(0);
 
-        preview.find('Select').prop('onChange')('desktop');
-        expect(preview.find('.auto')).toHaveLength(0);
-        expect(preview.find('.desktop')).toHaveLength(1);
-        expect(preview.find('.tablet')).toHaveLength(0);
-        expect(preview.find('.smartphone')).toHaveLength(0);
+            preview.find('Select').at(0).prop('onChange')('desktop');
+            expect(preview.find('.auto')).toHaveLength(0);
+            expect(preview.find('.desktop')).toHaveLength(1);
+            expect(preview.find('.tablet')).toHaveLength(0);
+            expect(preview.find('.smartphone')).toHaveLength(0);
 
-        preview.find('Select').prop('onChange')('smartphone');
-        expect(preview.find('.auto')).toHaveLength(0);
-        expect(preview.find('.desktop')).toHaveLength(0);
-        expect(preview.find('.tablet')).toHaveLength(0);
-        expect(preview.find('.smartphone')).toHaveLength(1);
+            preview.find('Select').at(0).prop('onChange')('smartphone');
+            expect(preview.find('.auto')).toHaveLength(0);
+            expect(preview.find('.desktop')).toHaveLength(0);
+            expect(preview.find('.tablet')).toHaveLength(0);
+            expect(preview.find('.smartphone')).toHaveLength(1);
+
+            done();
+        });
     });
 });
 
-test('React and update preview when data is changed', () => {
+test('Change webspace in PreviewStore when selection of webspace has changed', (done) => {
+    const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
+    const formStore = new ResourceFormStore(resourceStore, 'pages');
+    const router = new Router({});
+
+    const preview = shallow(<Preview formStore={formStore} router={router} />);
+
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.starting = false;
+
+        preview.instance().handleStartClick();
+
+        return startPromise.then(() => {
+            expect(PreviewStore).toBeCalledWith(undefined, undefined, 'de', 'sulu_io');
+
+            preview.find('Select').at(1).prop('onChange')('example');
+            expect(previewStore.setWebspace).toBeCalledWith('example');
+
+            done();
+        });
+    });
+});
+
+test('React and update preview when data is changed', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
 
@@ -159,26 +206,30 @@ test('React and update preview when data is changed', () => {
     const router = new Router({});
     const preview = mount(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
 
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.update.mockReturnValue(updatePromise);
-    previewStore.starting = false;
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.update.mockReturnValue(updatePromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    formStore.data.set('title', 'New Test');
+        formStore.data.set('title', 'New Test');
 
-    return startPromise.then(() => {
-        expect(previewStore.update).toBeCalledWith({title: 'New Test'});
+        return startPromise.then(() => {
+            preview.update();
+            expect(previewStore.update).toBeCalledWith({title: 'New Test'});
 
-        expect(preview).toMatchSnapshot();
+            expect(preview.render()).toMatchSnapshot();
+            done();
+        });
     });
 });
 
-test('React and update preview in external window when data is changed', () => {
+test('React and update preview in external window when data is changed', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
 
@@ -202,32 +253,37 @@ test('React and update preview in external window when data is changed', () => {
     const router = new Router({});
     const preview = mount(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
 
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.update.mockReturnValue(updatePromise);
-    previewStore.starting = false;
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.update.mockReturnValue(updatePromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
-    preview.update();
-    preview.find('Button[icon="su-link"]').prop('onClick')();
-    preview.update();
+        preview.instance().handleStartClick();
+        preview.update();
+        preview.find('Button[icon="su-link"]').prop('onClick')();
+        preview.update();
 
-    formStore.data.set('title', 'New Test');
+        formStore.data.set('title', 'New Test');
 
-    return startPromise.then(() => {
-        expect(previewStore.update).toBeCalledWith({title: 'New Test'});
+        return startPromise.then(() => {
+            preview.update();
+            expect(previewStore.update).toBeCalledWith({title: 'New Test'});
 
-        expect(preview).toMatchSnapshot();
-        expect(previewWindow.document.open).toBeCalledWith();
-        expect(previewWindow.document.write).toBeCalledWith('<h1>Sulu is awesome</h1>');
-        expect(previewWindow.document.close).toBeCalledWith();
+            expect(preview.render()).toMatchSnapshot();
+            expect(previewWindow.document.open).toBeCalledWith();
+            expect(previewWindow.document.write).toBeCalledWith('<h1>Sulu is awesome</h1>');
+            expect(previewWindow.document.close).toBeCalledWith();
+
+            done();
+        });
     });
 });
 
-test('Dont react or update preview when data is changed during formstore is loading', () => {
+test('Dont react or update preview when data is changed during formstore is loading', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
 
@@ -241,26 +297,30 @@ test('Dont react or update preview when data is changed during formstore is load
     const router = new Router({});
     const preview = mount(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
 
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.update.mockReturnValue(updatePromise);
-    previewStore.starting = false;
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.update.mockReturnValue(updatePromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    formStore.data.set('title', 'New Test');
+        formStore.data.set('title', 'New Test');
 
-    return startPromise.then(() => {
-        expect(previewStore.update).not.toBeCalled();
+        return startPromise.then(() => {
+            preview.update();
+            expect(previewStore.update).not.toBeCalled();
 
-        expect(preview).toMatchSnapshot();
+            expect(preview.render()).toMatchSnapshot();
+            done();
+        });
     });
 });
 
-test('Dont react or update preview when data is changed during preview-store is starting', () => {
+test('Dont react or update preview when data is changed during preview-store is starting', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
 
@@ -274,26 +334,30 @@ test('Dont react or update preview when data is changed during preview-store is 
     const router = new Router({});
     const preview = mount(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const updatePromise = Promise.resolve('<h1>Sulu is awesome</h1>');
 
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.update.mockReturnValue(updatePromise);
-    previewStore.starting = true;
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.update.mockReturnValue(updatePromise);
+        previewStore.starting = true;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    formStore.data.set('title', 'New Test');
+        formStore.data.set('title', 'New Test');
 
-    return startPromise.then(() => {
-        expect(previewStore.update).not.toBeCalled();
+        return startPromise.then(() => {
+            preview.update();
+            expect(previewStore.update).not.toBeCalled();
 
-        expect(preview).toMatchSnapshot();
+            expect(preview.render()).toMatchSnapshot();
+            done();
+        });
     });
 });
 
-test('React and update-context when type is changed', () => {
+test('React and update-context when type is changed', (done) => {
     const resourceStore = new ResourceStore('pages', 1, {title: 'Test'});
     const formStore = new ResourceFormStore(resourceStore, 'pages');
 
@@ -307,20 +371,23 @@ test('React and update-context when type is changed', () => {
     const router = new Router({});
     const preview = mount(<Preview formStore={formStore} router={router} />);
 
-    const startPromise = Promise.resolve();
-    const updateContextPromise = Promise.resolve('<h1>Sulu is awesome</h1>');
+    setTimeout(() => {
+        const startPromise = Promise.resolve();
+        const updateContextPromise = Promise.resolve('<h1>Sulu is awesome</h1>');
 
-    const previewStore = preview.instance().previewStore;
-    previewStore.start.mockReturnValue(startPromise);
-    previewStore.updateContext.mockReturnValue(updateContextPromise);
-    previewStore.starting = false;
+        const previewStore = preview.instance().previewStore;
+        previewStore.start.mockReturnValue(startPromise);
+        previewStore.updateContext.mockReturnValue(updateContextPromise);
+        previewStore.starting = false;
 
-    preview.instance().handleStartClick();
+        preview.instance().handleStartClick();
 
-    // $FlowFixMe
-    formStore.type.set('homepage');
+        // $FlowFixMe
+        formStore.type.set('homepage');
 
-    return startPromise.then(() => {
-        expect(previewStore.updateContext).toBeCalledWith('homepage');
+        return startPromise.then(() => {
+            expect(previewStore.updateContext).toBeCalledWith('homepage');
+            done();
+        });
     });
 });

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
@@ -1,377 +1,596 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dont react or update preview when data is changed during formstore is loading 1`] = `
-<Preview
-  formStore={
-    mockConstructor {
-      "data": Object {
-        "title": "New Test",
-      },
-      "loading": true,
-      "type": "default",
-    }
-  }
-  router={
-    mockConstructor {
-      "attributes": Object {
-        "locale": "de",
-      },
-      "history": Object {},
-    }
-  }
->
-  <button
-    onClick={[Function]}
-  >
-    Start
-  </button>
-</Preview>
-`;
-
-exports[`Dont react or update preview when data is changed during preview-store is starting 1`] = `
-<Preview
-  formStore={
-    mockConstructor {
-      "data": Object {
-        "title": "New Test",
-      },
-      "loading": false,
-      "type": "default",
-    }
-  }
-  router={
-    mockConstructor {
-      "attributes": Object {
-        "locale": "de",
-      },
-      "history": Object {},
-    }
-  }
->
-  <button
-    onClick={[Function]}
-  >
-    Start
-  </button>
-</Preview>
-`;
-
-exports[`React and update preview in external window when data is changed 1`] = `
-<Preview
-  formStore={
-    mockConstructor {
-      "data": Object {
-        "title": "New Test",
-      },
-      "loading": false,
-      "type": "default",
-    }
-  }
-  router={
-    mockConstructor {
-      "attributes": Object {
-        "locale": "de",
-      },
-      "history": Object {},
-    }
-  }
-/>
-`;
-
-exports[`React and update preview when data is changed 1`] = `
-<Preview
-  formStore={
-    mockConstructor {
-      "data": Object {
-        "title": "New Test",
-      },
-      "loading": false,
-      "type": "default",
-    }
-  }
-  router={
-    mockConstructor {
-      "attributes": Object {
-        "locale": "de",
-      },
-      "history": Object {},
-    }
-  }
->
-  <button
-    onClick={[Function]}
-  >
-    Start
-  </button>
-</Preview>
-`;
-
-exports[`Render button to start preview 1`] = `
-<button>
-  Start
-</button>
-`;
-
-exports[`Render correct preview 1`] = `
 <div
-  className="container auto"
+  class="container auto"
 >
   <div
-    className="previewContainer"
+    class="previewContainer"
   >
     <div
-      className="iframeContainer"
+      class="iframeContainer"
     >
       <iframe
-        className="iframe"
+        class="iframe"
         src="/render"
       />
     </div>
   </div>
-  <Toolbar
-    skin="dark"
+  <nav
+    class="toolbar dark"
   >
-    <Controls
-      grow={false}
-      skin="light"
+    <div
+      class="controls dark"
     >
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-arrow-right"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
-      />
-      <Select
-        icon="su-expand"
-        onChange={[Function]}
-        options={
-          Array [
-            Object {
-              "label": "sulu_preview.auto",
-              "value": "auto",
-            },
-            Object {
-              "label": "sulu_preview.desktop",
-              "value": "desktop",
-            },
-            Object {
-              "label": "sulu_preview.tablet",
-              "value": "tablet",
-            },
-            Object {
-              "label": "sulu_preview.smartphone",
-              "value": "smartphone",
-            },
-          ]
-        }
-        showText={true}
-        value="auto"
-      />
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-sync"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
+      <button
+        class="button dark"
       >
-        sulu_preview.reload
-      </Button>
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-link"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
       >
-        sulu_preview.open_in_window
-      </Button>
-    </Controls>
-  </Toolbar>
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`Dont react or update preview when data is changed during preview-store is starting 1`] = `
+<div
+  class="container auto"
+>
+  <div
+    class="loaderContainer"
+  >
+    <div
+      class="spinner"
+      style="width: 40px; height: 40px;"
+    >
+      <div
+        class="doubleBounce1"
+      />
+      <div
+        class="doubleBounce2"
+      />
+    </div>
+  </div>
+  <nav
+    class="toolbar dark"
+  >
+    <div
+      class="controls dark"
+    >
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`React and update preview in external window when data is changed 1`] = `null`;
+
+exports[`React and update preview when data is changed 1`] = `
+<div
+  class="container auto"
+>
+  <div
+    class="previewContainer"
+  >
+    <div
+      class="iframeContainer"
+    >
+      <iframe
+        class="iframe"
+        src="/render"
+      />
+    </div>
+  </div>
+  <nav
+    class="toolbar dark"
+  >
+    <div
+      class="controls dark"
+    >
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`Render button to start preview 1`] = `null`;
+
+exports[`Render correct preview 1`] = `
+<div
+  class="container auto"
+>
+  <div
+    class="previewContainer"
+  >
+    <div
+      class="iframeContainer"
+    >
+      <iframe
+        class="iframe"
+        src="/render"
+      />
+    </div>
+  </div>
+  <nav
+    class="toolbar dark"
+  >
+    <div
+      class="controls dark"
+    >
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
 </div>
 `;
 
 exports[`Render nothing if separate window is opened and rerender if it is closed 1`] = `
 <div
-  className="container auto"
+  class="container auto"
 >
   <div
-    className="previewContainer"
+    class="previewContainer"
   >
     <div
-      className="iframeContainer"
+      class="iframeContainer"
     >
       <iframe
-        className="iframe"
+        class="iframe"
         src="/render"
       />
     </div>
   </div>
-  <Toolbar
-    skin="dark"
+  <nav
+    class="toolbar dark"
   >
-    <Controls
-      grow={false}
-      skin="light"
+    <div
+      class="controls dark"
     >
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-arrow-right"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
-      />
-      <Select
-        icon="su-expand"
-        onChange={[Function]}
-        options={
-          Array [
-            Object {
-              "label": "sulu_preview.auto",
-              "value": "auto",
-            },
-            Object {
-              "label": "sulu_preview.desktop",
-              "value": "desktop",
-            },
-            Object {
-              "label": "sulu_preview.tablet",
-              "value": "tablet",
-            },
-            Object {
-              "label": "sulu_preview.smartphone",
-              "value": "smartphone",
-            },
-          ]
-        }
-        showText={true}
-        value="auto"
-      />
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-sync"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
+      <button
+        class="button dark"
       >
-        sulu_preview.reload
-      </Button>
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-link"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
       >
-        sulu_preview.open_in_window
-      </Button>
-    </Controls>
-  </Toolbar>
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
 </div>
 `;
 
 exports[`Render nothing if separate window is opened and rerender if it is closed 2`] = `
 <div
-  className="container auto"
+  class="container auto"
 >
   <div
-    className="previewContainer"
+    class="previewContainer"
   >
     <div
-      className="iframeContainer"
+      class="iframeContainer"
     >
       <iframe
-        className="iframe"
+        class="iframe"
         src="/render"
       />
     </div>
   </div>
-  <Toolbar
-    skin="dark"
+  <nav
+    class="toolbar dark"
   >
-    <Controls
-      grow={false}
-      skin="light"
+    <div
+      class="controls dark"
     >
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-arrow-right"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
-      />
-      <Select
-        icon="su-expand"
-        onChange={[Function]}
-        options={
-          Array [
-            Object {
-              "label": "sulu_preview.auto",
-              "value": "auto",
-            },
-            Object {
-              "label": "sulu_preview.desktop",
-              "value": "desktop",
-            },
-            Object {
-              "label": "sulu_preview.tablet",
-              "value": "tablet",
-            },
-            Object {
-              "label": "sulu_preview.smartphone",
-              "value": "smartphone",
-            },
-          ]
-        }
-        showText={true}
-        value="auto"
-      />
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-sync"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
+      <button
+        class="button dark"
       >
-        sulu_preview.reload
-      </Button>
-      <Button
-        active={false}
-        disabled={false}
-        hasOptions={false}
-        icon="su-link"
-        onClick={[Function]}
-        primary={false}
-        showText={true}
-        success={false}
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
       >
-        sulu_preview.open_in_window
-      </Button>
-    </Controls>
-  </Toolbar>
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
 </div>
 `;

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/__snapshots__/Preview.test.js.snap
@@ -399,6 +399,120 @@ exports[`Render correct preview 1`] = `
 </div>
 `;
 
+exports[`Render correct preview with target groups 1`] = `
+<div
+  class="container auto"
+>
+  <div
+    class="previewContainer"
+  >
+    <div
+      class="iframeContainer"
+    >
+      <iframe
+        class="iframe"
+        src="/render"
+      />
+    </div>
+  </div>
+  <nav
+    class="toolbar dark"
+  >
+    <div
+      class="controls dark"
+    >
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-arrow-right"
+          class="su-arrow-right icon"
+        />
+      </button>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-expand"
+            class="su-expand icon"
+          />
+          <span
+            class="label"
+          >
+            sulu_preview.auto
+          </span>
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-webspace"
+            class="su-webspace icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="select dark"
+      >
+        <button
+          class="button dark"
+        >
+          <span
+            aria-label="su-user"
+            class="su-user icon"
+          />
+          <span
+            aria-label="su-angle-down"
+            class="su-angle-down dropdownIcon"
+          />
+        </button>
+      </div>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-sync"
+          class="su-sync icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.reload
+        </span>
+      </button>
+      <button
+        class="button dark"
+      >
+        <span
+          aria-label="su-link"
+          class="su-link icon"
+        />
+        <span
+          class="label"
+        >
+          sulu_preview.open_in_window
+        </span>
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
 exports[`Render nothing if separate window is opened and rerender if it is closed 1`] = `
 <div
   class="container auto"

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -24,7 +24,21 @@ test('Should request server on start preview', () => {
     previewStore.start();
 
     return requestPromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages');
+        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
+    });
+});
+
+test('Should request server on start preview with target group', () => {
+    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+
+    const requestPromise = Promise.resolve({token: '123-123-123'});
+    Requester.get.mockReturnValue(requestPromise);
+
+    previewStore.setTargetGroup(3);
+    previewStore.start();
+
+    return requestPromise.then(() => {
+        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=3');
     });
 });
 
@@ -43,7 +57,29 @@ test('Should request server on update preview', () => {
 
     return postPromise.then(() => {
         expect(Requester.post).toBeCalledWith(
-            '/update?locale=en&webspace=sulu_io',
+            '/update?locale=en&targetGroup=-1&webspace=sulu_io',
+            {data: {title: 'Sulu is aswesome'}}
+        );
+    });
+});
+
+test('Should request server on update preview with target group', () => {
+    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+
+    const getPromise = Promise.resolve({token: '123-123-123'});
+    const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
+    Requester.get.mockReturnValue(getPromise);
+    Requester.post.mockReturnValue(postPromise);
+
+    previewStore.setTargetGroup(2);
+    previewStore.start();
+    previewStore.update({title: 'Sulu is aswesome'}).then((content) => {
+        expect(content).toEqual('<h1>Sulu is awesome</h1>');
+    });
+
+    return postPromise.then(() => {
+        expect(Requester.post).toBeCalledWith(
+            '/update?locale=en&targetGroup=2&webspace=sulu_io',
             {data: {title: 'Sulu is aswesome'}}
         );
     });
@@ -63,7 +99,28 @@ test('Should request server on update-context preview', () => {
     });
 
     return postPromise.then(() => {
-        expect(Requester.post).toBeCalledWith('/update-context?webspace=sulu_io', {context: {template: 'default'}});
+        expect(Requester.post)
+            .toBeCalledWith('/update-context?targetGroup=-1&webspace=sulu_io', {context: {template: 'default'}});
+    });
+});
+
+test('Should request server on update-context preview with target group', () => {
+    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+
+    const getPromise = Promise.resolve({token: '123-123-123'});
+    const postPromise = Promise.resolve({content: '<h1>Sulu is awesome</h1>'});
+    Requester.get.mockReturnValue(getPromise);
+    Requester.post.mockReturnValue(postPromise);
+
+    previewStore.setTargetGroup(6);
+    previewStore.start();
+    previewStore.updateContext('default').then((content) => {
+        expect(content).toEqual('<h1>Sulu is awesome</h1>');
+    });
+
+    return postPromise.then(() => {
+        expect(Requester.post)
+            .toBeCalledWith('/update-context?targetGroup=6&webspace=sulu_io', {context: {template: 'default'}});
     });
 });
 
@@ -78,7 +135,7 @@ test('Should request server on stop preview', () => {
     previewStore.stop();
 
     return postPromise.then(() => {
-        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages');
+        expect(Requester.get).toBeCalledWith('/start?id=123-123-123&locale=en&provider=pages&targetGroup=-1');
         expect(Requester.get).toBeCalledWith('/stop');
     });
 });

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -82,3 +82,11 @@ test('Should request server on stop preview', () => {
         expect(Requester.get).toBeCalledWith('/stop');
     });
 });
+
+test('Should set webspace', () => {
+    const previewStore = new PreviewStore('pages', '123-123-123', 'en', 'sulu_io');
+    expect(previewStore.webspace).toEqual('sulu_io');
+
+    previewStore.setWebspace('example');
+    expect(previewStore.webspace).toEqual('example');
+});

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/index.js
@@ -7,6 +7,7 @@ initializer.addUpdateConfigHook('sulu_preview', (config: Object) => {
     PreviewStore.endpoints = config.endpoints;
     Preview.debounceDelay = config.debounceDelay;
     Preview.mode = config.mode;
+    Preview.audienceTargeting = config.audienceTargeting;
 
     if (config.mode === 'off') {
         sidebarRegistry.disable('sulu_preview.preview');

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/package.json
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/package.json
@@ -11,13 +11,15 @@
     "devDependencies": {
         "enzyme": "^3.3.0",
         "pretty": "^2.0.0",
-        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js"
+        "sulu-admin-bundle": "file:../../../AdminBundle/Resources/js",
+        "sulu-page-bundle": "file:../../../PageBundle/Resources/js"
     },
     "peerDependencies": {
         "mobx": "^4.0.0",
         "mobx-react": "^5.0.0",
         "react": "^16.2.0",
         "react-dom": "^16.2.0",
-        "sulu-admin-bundle": "*"
+        "sulu-admin-bundle": "*",
+        "sulu-page-bundle": "*"
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -77,7 +77,7 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('webspace', null)->willReturn('sulu_io');
         $request->get('locale', null)->willReturn('de');
-        $request->get('target-group', null)->willReturn(1);
+        $request->get('targetGroup', null)->willReturn(1);
 
         $this->preview->render('test-token', 'sulu_io', 'de', 1)
             ->shouldBeCalled()
@@ -93,7 +93,7 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('webspace', null)->willReturn('sulu_io');
         $request->get('locale', null)->willReturn('de');
-        $request->get('target-group', null)->willReturn(1);
+        $request->get('targetGroup', null)->willReturn(1);
 
         $this->preview->render('test-token', 'sulu_io', 'de', 1)
             ->shouldBeCalled()
@@ -109,7 +109,7 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('data', null)->willReturn(['title' => 'Sulu is awesome']);
         $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('target-group', null)->willReturn(1);
+        $request->get('targetGroup', null)->willReturn(1);
 
         $this->preview->update('test-token', 'sulu_io', ['title' => 'Sulu is awesome'], 1)
             ->shouldBeCalled()
@@ -129,7 +129,7 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('data', null)->willReturn(['title' => 'Sulu is awesome']);
         $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('target-group', null)->willReturn(1);
+        $request->get('targetGroup', null)->willReturn(1);
 
         $this->preview->update('test-token', 'sulu_io', ['title' => 'Sulu is awesome'], 1)
             ->shouldBeCalled()
@@ -151,7 +151,7 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('context', null)->willReturn(['template' => 'default']);
         $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('target-group', null)->willReturn(1);
+        $request->get('targetGroup', null)->willReturn(1);
 
         $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1)
             ->shouldBeCalled()
@@ -170,7 +170,7 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('context', null)->willReturn(['template' => 'default']);
         $request->get('webspace', null)->willReturn('sulu_io');
-        $request->get('target-group', null)->willReturn(1);
+        $request->get('targetGroup', null)->willReturn(1);
 
         $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1)
             ->shouldBeCalled()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds two more selects in the preview toolbar, in order to change the webspace and target group.

#### Why?

Because it was already possible in the old UI.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
