### PR TITLE
Fix authentication handler redirect

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/config.yml
@@ -11,7 +11,6 @@ security:
             anonymous: ~
             entry_point: sulu_security.authentication_entry_point
             form_login:
-                login_path: sulu_admin.login
                 check_path: sulu_admin.login_check
                 success_handler: sulu_security.authentication_handler
                 failure_handler: sulu_security.authentication_handler

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/config.yml
@@ -11,7 +11,6 @@ security:
             anonymous: ~
             entry_point: sulu_security.authentication_entry_point
             form_login:
-                login_path: sulu_admin.login
                 check_path: sulu_admin.login_check
                 success_handler: sulu_security.authentication_handler
                 failure_handler: sulu_security.authentication_handler

--- a/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
+++ b/src/Sulu/Bundle/SecurityBundle/Security/AuthenticationHandler.php
@@ -96,7 +96,7 @@ class AuthenticationHandler implements AuthenticationSuccessHandlerInterface, Au
             // if form login
             // set authentication exception to session
             $this->session->set(Security::AUTHENTICATION_ERROR, $exception);
-            $response = new RedirectResponse($this->router->generate('sulu_admin.login'));
+            $response = new RedirectResponse($this->router->generate('sulu_admin'));
         }
 
         return $response;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/config.yml
@@ -6,4 +6,22 @@ swiftmailer:
     disable_delivery: true
     transport: "null"
 
-security: ~
+security:
+    access_control:
+        - { path: ^/admin/reset, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/admin/security/reset, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/admin/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/admin, roles: ROLE_USER }
+
+    firewalls:
+        test:
+            pattern: ^/
+            anonymous: ~
+            entry_point: sulu_security.authentication_entry_point
+            form_login:
+                check_path: sulu_admin.login_check
+                success_handler: sulu_security.authentication_handler
+                failure_handler: sulu_security.authentication_handler
+            logout:
+                path: /admin/logout
+                target: /admin/

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LoginControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LoginControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Functional\Controller;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class LoginControllerTest extends SuluTestCase
+{
+    public function testFalseLoginRedirect()
+    {
+        $client = $this->createClient();
+        $client->request('POST', '/admin/login', [
+            '_username' => 'FalseUser',
+            '_password' => 'FalsePassword',
+        ]);
+        $response = $client->getResponse();
+        $this->assertHttpStatusCode(302, $response);
+        $this->assertSame('/admin/', $response->getTargetUrl());
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationEntryPointTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationEntryPointTest.php
@@ -25,7 +25,7 @@ class AuthenticationEntryPointTest extends TestCase
         parent::setUp();
 
         $urlGenerator = $this->prophesize('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
-        $urlGenerator->generate('sulu_admin.login')->willReturn('/admin/login');
+        $urlGenerator->generate('sulu_admin')->willReturn('/admin');
         $this->authenticationEntryPoint = new AuthenticationEntryPoint($urlGenerator->reveal());
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
@@ -63,7 +63,7 @@ class AuthenticationHandlerTest extends TestCase
         $session->get('_security.admin.target_path')->willReturn('/admin/#target/path');
         $session->set(Security::AUTHENTICATION_ERROR, $this->exception->reveal())->willReturn(null);
         $router->generate('sulu_admin')->willReturn('/admin');
-        $router->generate('sulu_admin.login')->willReturn('/admin/login');
+        $router->generate('sulu_admin')->willReturn('/admin');
 
         $this->authenticationHandler = new AuthenticationHandler($router->reveal(), $session->reveal(), 'Sulu');
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Redirect to correct login page `/admin` when it fails.

#### Why?

The current route `sulu_admin.login` does not longer exist and the login form is shown on `/admin`.
