### PR TITLE
Fix link in upgrade for skeleton

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,7 +3,7 @@
 ## 2.0.0-RC3
 
 When upgrading also have a look at the changes in the
-[sulu skeleton](https://github.com/sulu/sulu-minimal/compare/2.0.0-RC2...2.0.0-RC3).
+[sulu skeleton](https://github.com/sulu/skeleton/compare/f08ac00c57756f38cbf5166c2a3d09782f34fcb3...2.0.0-RC3).
 
 ### Country Table ('co_countries') was replace with Symfony Intl Regionbundle
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix link in upgrade for skeleton

#### Why?

2.0.0-RC2 was in sulu-minimal repository and the new tag in sulu/skeleton so this link need a fix commit id and should show to the new repository.