### PR TITLE
Add profile and security contexts rest routes to api endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,9 @@ before_script:
   - composer update -o $COMPOSER_FLAGS
 
 script:
-  - if [[ $PHPSTAN = true ]]; then bin/adminconsole cache:clear --env=dev; ./vendor/bin/phpstan analyze; fi
+  - bin/adminconsole cache:clear --env=dev
+  - bin/websiteconsole cache:clear --env=dev
+  - if [[ $PHPSTAN = true ]]; then ./vendor/bin/phpstan analyze; fi
   - time ./bin/runtests -i -a
 
 notifications:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,13 @@ public static function getSubscribedServices()
 }
 ```
 
+### Security Profile and Conexts routes changed
+
+The endpoints for the profile and security contexts apis changed:
+
+ - `/admin/security/contexts` -> `/admin/api/security-contexts`
+ - `/admin/security/profile` -> `/admin/api/profile`
+
 ### Symfony 3.4 support dropped
 
 To fix current deprecations in symfony packages we needed to drop symfony 3.4 support and go on the newest minor version of symfony (4.3).

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -237,7 +237,7 @@ class AdminControllerTest extends TestCase
         $this->urlGenerator->generate('sulu_preview.update')->willReturn('/preview/update');
         $this->urlGenerator->generate('sulu_preview.update-context')->willReturn('/preview/update-context');
         $this->urlGenerator->generate('sulu_preview.stop')->willReturn('/preview/stop');
-        $this->urlGenerator->generate('sulu_security.cget_contexts')->willReturn('/security/contexts');
+        $this->urlGenerator->generate('sulu_security.cget_security-contexts')->willReturn('/api/security-contexts');
         $this->urlGenerator->generate('sulu_website.cache.remove')->willReturn('/admin/website/cache');
         $this->urlGenerator->generate('sulu_media.redirect', ['id' => ':id'])->willReturn('/media/redirect');
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
@@ -23,6 +23,11 @@ sulu_security:
     resource: "@SuluSecurityBundle/Resources/config/routing.yml"
     prefix: /admin
 
+sulu_security_api:
+    type: rest
+    resource: "@SuluSecurityBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
 sulu_website:
     type: rest
     resource: "@SuluWebsiteBundle/Resources/config/routing.yml"

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -214,7 +214,7 @@ class SecurityAdmin extends Admin
     {
         return [
             'endpoints' => [
-                'contexts' => $this->urlGenerator->generate('sulu_security.cget_contexts'),
+                'contexts' => $this->urlGenerator->generate('sulu_security.cget_security-contexts'),
             ],
             'resourceKeySecurityContextMapping' => array_filter(array_map(function(array $resource) {
                 return $resource['security_context'] ?? null;

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ContextsController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ContextsController.php
@@ -11,12 +11,16 @@
 
 namespace Sulu\Bundle\SecurityBundle\Controller;
 
+use FOS\RestBundle\Controller\Annotations\RouteResource;
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
 use Sulu\Component\Rest\AbstractRestController;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @RouteResource("security-contexts")
+ */
 class ContextsController extends AbstractRestController implements ClassResourceInterface
 {
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/routing.yml
@@ -13,13 +13,3 @@ sulu_security.reset_password.reset:
     path: reset
     defaults:
         _controller: sulu_security.resetting_controller:resetAction
-
-sulu_security.contexts:
-    type: rest
-    name_prefix: sulu_security.
-    resource: sulu_security.contexts_controller
-
-sulu_security.profile:
-    type: rest
-    name_prefix: sulu_security.
-    resource: sulu_security.profile_controller

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/routing_api.yml
@@ -29,3 +29,13 @@ sulu_security.permissions:
     type: rest
     name_prefix: sulu_security.
     resource: sulu_security.permission_controller
+
+sulu_security.contexts:
+    type: rest
+    name_prefix: sulu_security.
+    resource: sulu_security.contexts_controller
+
+sulu_security.profile:
+    type: rest
+    name_prefix: sulu_security.
+    resource: sulu_security.profile_controller

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
@@ -25,7 +25,7 @@ class ProfileControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'PATCH',
-            '/security/profile/settings',
+            '/api/profile/settings',
             ['setting-key' => 'setting-value']
         );
 
@@ -44,7 +44,7 @@ class ProfileControllerTest extends SuluTestCase
     {
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', '/security/profile');
+        $client->request('GET', '/api/profile');
 
         $response = json_decode($client->getResponse()->getContent());
 
@@ -63,7 +63,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -89,7 +89,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -114,7 +114,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -139,7 +139,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'lastName' => 'Mustermann',
                 'username' => 'hansi',
@@ -163,7 +163,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'username' => 'hansi',
@@ -188,7 +188,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -213,7 +213,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -238,7 +238,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -263,7 +263,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'PUT',
-            '/security/profile',
+            '/api/profile',
             [
                 'firstName' => 'Hans',
                 'lastName' => 'Mustermann',
@@ -283,7 +283,7 @@ class ProfileControllerTest extends SuluTestCase
         $client = $this->createAuthenticatedClient();
         $client->request(
             'PATCH',
-            '/security/profile/settings',
+            '/api/profile/settings',
             ['setting-key' => 'setting-value']
         );
 
@@ -299,7 +299,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $client->request(
             'DELETE',
-            '/security/profile/settings',
+            '/api/profile/settings',
             ['key' => 'setting-key']
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add rest routes to api endpoint

#### Why?

Rest endpoints should be all under `/admin/api` and the current definition in the `routing.yml` website does not work for older symfony version without the name_prefix and break currently when the container is build thats why in the travis ci I added the container build for both contexts.