### PR TITLE
Extend WebsiteController from AbstractController instead of deprecated Controller class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,22 @@
 When upgrading also have a look at the changes in the
 [sulu skeleton](https://github.com/sulu/skeleton/compare/2.0.0-RC3...2.0.0).
 
+### WebsiteController and DefaultController changed
+
+The WebsiteController and DefaultController does not longer extend the basic Symfony Controller instead
+it extends the new Symfony [AbstractController](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php).
+If you extend from this Controllers you need to inject services you need over `getSubscribedServices` method:
+
+```php
+public static function getSubscribedServices()
+{
+    $subscribedServices = parent::getSubscribedServices();
+    $subscribedServices['app.custom_service'] = CustomService::class;
+
+    return $subscribedServices;
+}
+```
+
 ### Symfony 3.4 support dropped
 
 To fix current deprecations in symfony packages we needed to drop symfony 3.4 support and go on the newest minor version of symfony (4.3).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,11 +5,12 @@
 When upgrading also have a look at the changes in the
 [sulu skeleton](https://github.com/sulu/skeleton/compare/2.0.0-RC3...2.0.0).
 
-### WebsiteController and DefaultController changed
+### Refactor WebsiteController and DefaultController
 
-The WebsiteController and DefaultController does not longer extend the basic Symfony Controller instead
-it extends the new Symfony [AbstractController](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php).
-If you extend from this Controllers you need to inject services you need over `getSubscribedServices` method:
+The WebsiteController and DefaultController were refactored to not extend the deprecated Symfony Controller class.
+The controllers now use the new Symfony [AbstractController](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php) class as base class.
+
+If you extend from one of these Controllers, you need to define your service dependencies in the `getSubscribedServices` method:
 
 ```php
 public static function getSubscribedServices()

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -8,6 +8,8 @@
             <argument type="service" id="request_stack"/>
             <argument type="collection"/>
         </service>
+        <service id="Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface" alias="sulu_core.webspace.request_analyzer" />
+
         <service id="sulu_core.request_processor.parameter"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\ParameterRequestProcessor">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-lifetime-enhancer.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-lifetime-enhancer.xml
@@ -10,5 +10,8 @@
             <argument>%sulu_http_cache.cache.max_age%</argument>
             <argument>%sulu_http_cache.cache.shared_max_age%</argument>
         </service>
+
+        <service id="Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancerInterface"
+                 alias="sulu_http_cache.cache_lifetime.enhancer"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -12,18 +12,20 @@
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer;
+use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancerInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
+use Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use Twig\Template;
 
 /**
  * Basic class to render Website from phpcr content.
  */
-abstract class WebsiteController extends Controller
+abstract class WebsiteController extends AbstractController
 {
     /**
      * Returns a rendered structure.
@@ -110,8 +112,7 @@ abstract class WebsiteController extends Controller
         $twig = $this->get('twig');
         $attributes = $twig->mergeGlobals($attributes);
 
-        /** @var Template $template */
-        $template = $twig->loadTemplate($template);
+        $template = $twig->load($template);
 
         $level = ob_get_level();
         ob_start();
@@ -160,5 +161,18 @@ abstract class WebsiteController extends Controller
         }
 
         return $this->get('sulu_http_cache.cache_lifetime.enhancer');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedServices()
+    {
+        $subscribedServices = parent::getSubscribedServices();
+        // $subscribedServices['sulu_website.resolver.parameter'] = ParameterResolverInterface::class;
+        // $subscribedServices['sulu_core.webspace.request_analyzer'] = RequestAnalyzerInterface::class;
+        // $subscribedServices['sulu_http_cache.cache_lifetime.enhancer'] = '?'.CacheLifetimeEnhancerInterface::class;
+
+        return $subscribedServices;
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -169,9 +169,9 @@ abstract class WebsiteController extends AbstractController
     public static function getSubscribedServices()
     {
         $subscribedServices = parent::getSubscribedServices();
-        // $subscribedServices['sulu_website.resolver.parameter'] = ParameterResolverInterface::class;
-        // $subscribedServices['sulu_core.webspace.request_analyzer'] = RequestAnalyzerInterface::class;
-        // $subscribedServices['sulu_http_cache.cache_lifetime.enhancer'] = '?'.CacheLifetimeEnhancerInterface::class;
+        $subscribedServices['sulu_website.resolver.parameter'] = ParameterResolverInterface::class;
+        $subscribedServices['sulu_core.webspace.request_analyzer'] = RequestAnalyzerInterface::class;
+        $subscribedServices['sulu_http_cache.cache_lifetime.enhancer'] = '?' . CacheLifetimeEnhancerInterface::class;
 
         return $subscribedServices;
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -31,11 +31,12 @@
         <service id="sulu_website.default_controller" class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController">
             <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
+            <tag name="sulu.context" context="website" />
             <call method="setContainer">
                 <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
         </service>
-        <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller" />
+        <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller"/>
 
         <!-- website admin -->
         <service id="sulu_website.admin" class="%sulu_website.admin.class%">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -31,6 +31,9 @@
         <service id="sulu_website.default_controller" class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController">
             <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
+            <call method="setContainer">
+                <argument type="service" id="Psr\Container\ContainerInterface" />
+            </call>
         </service>
         <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller" />
 
@@ -180,6 +183,9 @@
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>
         </service>
+
+        <service id="Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolverInterface"
+                 alias="sulu_website.resolver.parameter"/>
 
         <service id="sulu_website.routing.request_listener" class="Sulu\Bundle\WebsiteBundle\Routing\RequestListener">
             <argument type="service" id="router"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -28,6 +28,11 @@
     </parameters>
 
     <services>
+        <service id="sulu_website.default_controller" class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController">
+            <tag name="container.service_subscriber" />
+        </service>
+        <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller" />
+
         <!-- website admin -->
         <service id="sulu_website.admin" class="%sulu_website.admin.class%">
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\Routing\RouteBuilderFactoryInterface"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -30,6 +30,7 @@
     <services>
         <service id="sulu_website.default_controller" class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController">
             <tag name="container.service_subscriber" />
+            <tag name="controller.service_arguments" />
         </service>
         <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller" />
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts our default `WebsiteController` to extend the new `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` class instead of the deprecated `Symfony\Bundle\FrameworkBundle\Controller\Controller` class.

This means that we need to configure the controller as a service from now on.

#### Why?

Because the `Symfony\Bundle\FrameworkBundle\Controller\Controller` class is deprecated and will be removed in the future.

#### BC Breaks/Deprecations

* `WebsiteController` extends `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` now
