### PR TITLE
Resolve various deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
         "symfony/security": "^4.3",
         "symfony/security-bundle": "^4.3",
         "symfony/swiftmailer-bundle": "^3.1.4",
-        "symfony/templating": "^3.4 || ^4.0",
         "symfony/translation": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "symfony/web-link": "^4.3",
         "symfony/yaml": "^4.3",
         "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0",
-        "twig/twig": "^1.35 || ^2.0"
+        "twig/twig": "^1.41 || ^2.0"
     },
     "require-dev": {
         "google/cloud-storage": "^1.0",

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -211,7 +211,7 @@ class AdminController
             'routing' => $this->urlGenerator->generate('fos_js_routing_js'),
         ];
 
-        return $this->engine->renderResponse(
+        return new Response($this->engine->render(
             '@SuluAdmin\Admin\main.html.twig',
             [
                 'translations' => $this->translations,
@@ -220,7 +220,7 @@ class AdminController
                 'sulu_version' => $this->suluVersion,
                 'app_version' => $this->appVersion,
             ]
-        );
+        ));
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -25,13 +25,13 @@ use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Component\SmartContent\DataProviderInterface;
 use Sulu\Component\SmartContent\DataProviderPoolInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use Twig\Environment;
 
 class AdminController
 {
@@ -63,7 +63,7 @@ class AdminController
     private $viewHandler;
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     private $engine;
 
@@ -153,7 +153,7 @@ class AdminController
         AdminPool $adminPool,
         SerializerInterface $serializer,
         ViewHandlerInterface $viewHandler,
-        EngineInterface $engine,
+        Environment $engine,
         TranslatorBagInterface $translatorBag,
         MetadataProviderRegistry $metadataProviderRegistry,
         RouteRegistry $routeRegistry,

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -26,9 +26,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('sulu_admin');
 
-        $treeBuilder->root('sulu_admin')
+        $treeBuilder->getRootNode()
             ->children()
                 ->scalarNode('name')->defaultValue('Sulu Admin')->end()
                 ->scalarNode('email')->isRequired()->end()

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -12,7 +12,7 @@
             <argument type="service" id="sulu_admin.admin_pool"/>
             <argument type="service" id="jms_serializer"/>
             <argument type="service" id="fos_rest.view_handler"/>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="translator.default"/>
             <argument type="service" id="sulu_admin.metadata_provider_registry"/>
             <argument type="service" id="sulu_admin.route_registry"/>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -32,7 +32,6 @@ use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\SmartContent\DataProviderPoolInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -40,6 +39,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use Twig\Environment;
 
 class AdminControllerTest extends TestCase
 {
@@ -79,7 +79,7 @@ class AdminControllerTest extends TestCase
     private $viewHandler;
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     private $engine;
 
@@ -178,7 +178,7 @@ class AdminControllerTest extends TestCase
         $this->adminPool = $this->prophesize(AdminPool::class);
         $this->serializer = $this->prophesize(SerializerInterface::class);
         $this->viewHandler = $this->prophesize(ViewHandlerInterface::class);
-        $this->engine = $this->prophesize(EngineInterface::class);
+        $this->engine = $this->prophesize(Environment::class);
         $this->translatorBag = $this->prophesize(TranslatorBagInterface::class);
         $this->metadataProviderRegistry = $this->prophesize(MetadataProviderRegistry::class);
         $this->routeRegistry = $this->prophesize(RouteRegistry::class);

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
@@ -34,8 +34,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_audience_targeting');
+        $treeBuilder = new TreeBuilder('sulu_audience_targeting');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -152,7 +152,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
     private function setTargetGroupCookie(Response $response, Request $request)
     {
         $response->headers->setCookie(
-            new Cookie(
+            Cookie::create(
                 static::TARGET_GROUP_COOKIE,
                 $request->headers->get(static::TARGET_GROUP_HEADER),
                 static::TARGET_GROUP_COOKIE_LIFETIME
@@ -160,7 +160,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
         );
 
         $response->headers->setCookie(
-            new Cookie(
+            Cookie::create(
                 static::VISITOR_SESSION_COOKIE,
                 time()
             )

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -221,7 +221,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
         $response = $event->getResponse();
 
         $response->headers->setCookie(
-            new Cookie(
+            Cookie::create(
                 $this->targetGroupCookie,
                 $this->targetGroupStore->getTargetGroupId(true),
                 AudienceTargetingCacheListener::TARGET_GROUP_COOKIE_LIFETIME
@@ -229,7 +229,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
         );
 
         $response->headers->setCookie(
-            new Cookie(
+            Cookie::create(
                 $this->visitorSessionCookie,
                 time()
             )

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_website.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_website.yml
@@ -1,7 +1,7 @@
 sulu_category_api:
     path: "/"
     defaults:
-        _controller: FrameworkBundle:Template:template
+        _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
         _requestAnalyzer: false
         template: "empty.html.twig"
         maxAge: 60

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
@@ -21,7 +21,7 @@ use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupWebspaceRepositoryInte
 use Sulu\Bundle\AudienceTargetingBundle\Tests\Application\AppCache;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\HttpKernel\SuluKernel;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -37,7 +37,7 @@ class CachingTest extends SuluTestCase
         $this->purgeDatabase();
         $cacheKernel = new AppCache(self::bootKernel());
         $cookieJar = new CookieJar();
-        $client = new Client($cacheKernel, [], null, $cookieJar);
+        $client = new KernelBrowser($cacheKernel, [], null, $cookieJar);
 
         $client->request('PURGE', '/');
 
@@ -112,7 +112,7 @@ class CachingTest extends SuluTestCase
      */
     public function testRequestWithoutSessionCookieTriggersNoRules($arguments)
     {
-        /** @var Client $client */
+        /** @var KernelBrowser $client */
         /** @var CookieJar $cookieJar */
         list($client, $cookieJar) = $arguments;
 
@@ -137,7 +137,7 @@ class CachingTest extends SuluTestCase
      */
     public function testRequestWithoutSessionCookieTriggersARule($arguments)
     {
-        /** @var Client $client */
+        /** @var KernelBrowser $client */
         /** @var CookieJar $cookieJar */
         list($client, $cookieJar) = $arguments;
 

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
@@ -27,8 +27,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_category');
+        $treeBuilder = new TreeBuilder('sulu_category');
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addObjectsSection($rootNode);
 

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\AdminBundle\Admin\Routing\RouteCollection;
 use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Intl;
 
 class ContactAdmin extends Admin
@@ -313,7 +314,7 @@ class ContactAdmin extends Admin
     {
         return [
             'addressTypes' => $this->managerRegistry->getRepository('SuluContactBundle:AddressType')->findAll(),
-            'countries' => Intl::getRegionBundle()->getCountryNames(),
+            'countries' => Countries::getNames(),
             'emailTypes' => $this->managerRegistry->getRepository('SuluContactBundle:EmailType')->findAll(),
             'faxTypes' => $this->managerRegistry->getRepository('SuluContactBundle:FaxType')->findAll(),
             'phoneTypes' => $this->managerRegistry->getRepository('SuluContactBundle:PhoneType')->findAll(),

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -21,7 +21,6 @@ use Sulu\Bundle\AdminBundle\Admin\Routing\ToolbarAction;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Symfony\Component\Intl\Countries;
-use Symfony\Component\Intl\Intl;
 
 class ContactAdmin extends Admin
 {

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -29,8 +29,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_contact');
+        $treeBuilder = new TreeBuilder('sulu_contact');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sulu/Bundle/ContactBundle/Entity/Country.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Country.php
@@ -15,7 +15,6 @@ use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
 use Symfony\Component\Intl\Countries;
-use Symfony\Component\Intl\Intl;
 
 /**
  * @ExclusionPolicy("all")

--- a/src/Sulu/Bundle/ContactBundle/Entity/Country.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Country.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\ContactBundle\Entity;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Intl;
 
 /**
@@ -46,6 +47,6 @@ class Country
      */
     public function getName(?string $displayLocale = null): string
     {
-        return Intl::getRegionBundle()->getCountryName($this->code, $displayLocale);
+        return Countries::getName($this->code, $displayLocale);
     }
 }

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -27,8 +27,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_core');
+        $treeBuilder = new TreeBuilder('sulu_core');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode->addDefaultsIfNotSet();
 
         $children = $rootNode->children();

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_document_manager');
+        $treeBuilder = new TreeBuilder('sulu_document_manager');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode
             ->children()
                 ->scalarNode('default_session')->end()

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
@@ -34,8 +34,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('sulu_http_cache');
+        $treeBuilder = new TreeBuilder('sulu_http_cache');
+        $root = $treeBuilder->getRootNode();
 
         $root
             ->children()

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('sulu_location')
+        $treeBuilder = new TreeBuilder('sulu_location');
+        $treeBuilder->getRootNode()
             ->children()
                 ->enumNode('geolocator')
                     ->values(['nominatim', 'google'])

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -28,8 +28,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_media');
+        $treeBuilder = new TreeBuilder('sulu_media');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode->children()
             ->scalarNode('adobe_creative_key')->defaultNull()->end()
             ->scalarNode('adapter')

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Persistence\Model\AuditableTrait;
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+use Symfony\Component\Mime\MimeTypes;
 
 /**
  * FileVersion.
@@ -272,7 +272,7 @@ class FileVersion implements AuditableInterface
     public function getExtension()
     {
         $pathInfo = pathinfo($this->getName());
-        $extension = ExtensionGuesser::getInstance()->guess($this->getMimeType());
+        $extension = MimeTypes::getDefault()->getExtensions($this->getMimeType())[0] ?? null;
         if ($extension) {
             return $extension;
         } elseif (isset($pathInfo['extension'])) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 sulu_media.redirect:
     path: /redirect/media/{id}
-    defaults: { _controller: SuluMediaBundle:MediaRedirect:redirect }
+    defaults: { _controller: Sulu\Bundle\MediaBundle\Controller\MediaRedirectController::redirectAction }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yml
@@ -1,7 +1,7 @@
 sulu_media.website.image.proxy:
     path: "%sulu_media.format_cache.media_proxy_path%"
     defaults:
-        _controller: SuluMediaBundle:MediaStream:getImage
+        _controller: Sulu\Bundle\MediaBundle\Controller\MediaStreamController::getImageAction
         _requestAnalyzer: false
     requirements:
         slug: .*
@@ -9,7 +9,7 @@ sulu_media.website.image.proxy:
 sulu_media.website.media.download:
     path: "%sulu_media.media_manager.media_download_path%"
     defaults:
-        _controller: SuluMediaBundle:MediaStream:download
+        _controller: Sulu\Bundle\MediaBundle\Controller\MediaStreamController::downloadAction
         _requestAnalyzer: false
     requirements:
         slug: .*

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -1016,7 +1016,7 @@ class MediaControllerTest extends SuluTestCase
 
         $filePath = $this->getFilePath();
         $this->assertTrue(file_exists($filePath));
-        $photo = new UploadedFile($filePath, 'small.txt', 'text/plain', 0);
+        $photo = new UploadedFile($filePath, 'small.txt', 'text/plain');
 
         $client->request(
             'POST',

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -132,7 +132,7 @@ class MediaStreamControllerTest extends SuluTestCase
 
     private function createUploadedFile($path)
     {
-        return new UploadedFile($path, basename($path), mime_content_type($path), filesize($path));
+        return new UploadedFile($path, basename($path), mime_content_type($path));
     }
 
     private function createCollection($title = 'Test')

--- a/src/Sulu/Bundle/PageBundle/Command/ContentTypesDumpCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ContentTypesDumpCommand.php
@@ -36,7 +36,6 @@ class ContentTypesDumpCommand extends Command
         $arguments = [
             'command' => 'debug:container',
             '--tag' => 'sulu.content.type',
-            '--show-private' => true,
             '--format' => $input->getOption('format'),
         ];
 

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_page');
+        $treeBuilder = new TreeBuilder('sulu_page');
+        $rootNode = $treeBuilder->getRootNode();
 
         // add config preview interval
         $rootNode

--- a/src/Sulu/Bundle/PageBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/export.xml
@@ -15,7 +15,7 @@
 
         <!-- Webspace export -->
         <service id="sulu_page.export.webspace" class="Sulu\Component\Content\Export\WebspaceExport" public="true">
-            <argument type="service" id="templating" />
+            <argument type="service" id="twig" />
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu.content.structure_manager" />

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -13,7 +13,7 @@ namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
 use PHPCR\SessionInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
  * @group webtest
@@ -26,7 +26,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
     private $session;
 
     /**
-     * @var Client
+     * @var KernelBrowser
      */
     protected $client;
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
@@ -12,12 +12,12 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class ResourcelocatorControllerTest extends SuluTestCase
 {
     /**
-     * @var Client
+     * @var KernelBrowser
      */
     protected $client;
 

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Configuration.php
@@ -24,8 +24,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_persistence');
+        $treeBuilder = new TreeBuilder('sulu_persistence');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_preview');
+        $treeBuilder = new TreeBuilder('sulu_preview');
+        $rootNode = $treeBuilder->getRootNode();
 
         // add config preview interval
         $rootNode

--- a/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/DependencyInjection/Configuration.php
@@ -69,8 +69,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addBasicProviderNode($name)
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root($name);
+        $builder = new TreeBuilder($name);
+        $node = $builder->getRootNode();
 
         return $node;
     }
@@ -82,8 +82,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addFileSystemNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('file_system');
+        $builder = new TreeBuilder('file_system');
+        $node = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -103,8 +103,8 @@ class Configuration implements ConfigurationInterface
      */
     private function addRedisNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('redis');
+        $builder = new TreeBuilder('redis');
+        $node = $builder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
@@ -27,8 +27,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_route');
+        $treeBuilder = new TreeBuilder('sulu_route');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('sulu_search')
+        $treeBuilder = new TreeBuilder('sulu_search');
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('indexes')
                     ->useAttributeAsKey('index_name')

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_security');
+        $treeBuilder = new TreeBuilder('sulu_security');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -18,12 +18,11 @@ use JMS\Serializer\Annotation\Groups;
 use Sulu\Component\Persistence\Model\AuditableTrait;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\RoleSettingInterface;
-use Symfony\Component\Security\Core\Role\Role as SymfonyRole;
 
 /**
  * Role.
  */
-class Role extends SymfonyRole implements RoleInterface
+class Role implements RoleInterface
 {
     use AuditableTrait;
 
@@ -82,8 +81,6 @@ class Role extends SymfonyRole implements RoleInterface
         $this->userRoles = new ArrayCollection();
         $this->groups = new ArrayCollection();
         $this->settings = new ArrayCollection();
-
-        parent::__construct('');
     }
 
     /**

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/routing.yml
@@ -1,18 +1,18 @@
 sulu_security.reset_password.email:
     path: reset/email
     defaults:
-        _controller: SuluSecurityBundle:Resetting:sendEmail
+        _controller: Sulu\Bundle\SecurityBundle\Controller\ResettingController::sendEmailAction
 
 sulu_security.reset_password.email.resend:
     path: reset/email/resend
     defaults:
-        _controller: SuluSecurityBundle:Resetting:sendEmail
+        _controller: Sulu\Bundle\SecurityBundle\Controller\ResettingController::sendEmailAction
         generateNewKey: false
 
 sulu_security.reset_password.reset:
     path: reset
     defaults:
-        _controller: SuluSecurityBundle:Resetting:reset
+        _controller: Sulu\Bundle\SecurityBundle\Controller\ResettingController::resetAction
 
 sulu_security.contexts:
     type: rest

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('sulu_snippet')
+        $treeBuilder = new TreeBuilder('sulu_snippet');
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('types')
                     ->addDefaultsIfNotSet()

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/export.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/export.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="sulu_snippet.export.snippet" class="Sulu\Component\Snippet\Export\SnippetExport" public="true">
-            <argument type="service" id="templating" />
+            <argument type="service" id="twig" />
             <argument type="service" id="sulu_snippet.repository" />
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_document_manager.document_inspector" />

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -18,12 +18,12 @@ use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class SnippetControllerTest extends SuluTestCase
 {
     /**
-     * @var Client
+     * @var KernelBrowser
      */
     protected $client;
 

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/Configuration.php
@@ -26,8 +26,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('sulu_tag')
+        $treeBuilder = new TreeBuilder('sulu_tag');
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('objects')
                     ->addDefaultsIfNotSet()

--- a/src/Sulu/Bundle/TestBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TestBundle/DependencyInjection/Configuration.php
@@ -26,8 +26,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_test');
+        $treeBuilder = new TreeBuilder('sulu_test');
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode->children()
             ->booleanNode('enable_test_user_provider')->defaultFalse()->end()
         ->end();

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/context_admin.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/context_admin.yml
@@ -18,7 +18,6 @@ security:
 
     firewalls:
         test:
-            logout_on_user_change: true
             http_basic:
 
 sulu_security:

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -26,8 +26,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sulu_website');
+        $treeBuilder = new TreeBuilder('sulu_website');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode->children()
             ->arrayNode('analytics')

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -137,7 +137,7 @@ class AppendAnalyticsListener
         foreach (array_keys(self::$positions) as $position) {
             $template = 'SuluWebsiteBundle:Analytics:' . $analytics->getType() . '/' . $position . '.html.twig';
 
-            if (!$this->engine->exists($template)) {
+            if (!$this->engine->getLoader()->exists($template)) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -15,7 +15,7 @@ use Sulu\Bundle\WebsiteBundle\Entity\Analytics;
 use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsRepository;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Appends analytics scripts into body.
@@ -42,7 +42,7 @@ class AppendAnalyticsListener
     ];
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     private $engine;
 
@@ -67,18 +67,18 @@ class AppendAnalyticsListener
     private $preview;
 
     /**
-     * @param EngineInterface $engine
+     * @param Environment $engine
      * @param RequestAnalyzerInterface $requestAnalyzer
      * @param AnalyticsRepository $analyticsRepository
      * @param $environment
      * @param bool $preview
      */
     public function __construct(
-        EngineInterface $engine,
+        Environment $engine,
         RequestAnalyzerInterface $requestAnalyzer,
         AnalyticsRepository $analyticsRepository,
         $environment,
-        $preview = false
+        bool $preview = false
     ) {
         $this->engine = $engine;
         $this->requestAnalyzer = $requestAnalyzer;

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/analytics.xml
@@ -31,7 +31,7 @@
 
         <service id="sulu_website.analytics.response_listener"
                  class="Sulu\Bundle\WebsiteBundle\EventListener\AppendAnalyticsListener">
-            <argument type="service" id="templating"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
             <argument type="service" id="sulu_website.analytics.repository"/>
             <argument>%kernel.environment%</argument>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 sulu_website.cache.remove:
     path: /cache
-    defaults: { _controller: SuluWebsiteBundle:Cache:clear }
+    defaults: { _controller: Sulu\Bundle\WebsiteBundle\Controller\CacheController::clearAction }
     methods: [DELETE]

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_website.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_website.yml
@@ -1,12 +1,12 @@
 sulu_website.sitemap_index:
     path:      /sitemap.xml
-    defaults:  { _controller: SuluWebsiteBundle:Sitemap:index }
+    defaults:  { _controller: Sulu\Bundle\WebsiteBundle\Controller\SitemapController::indexAction }
 
 sulu_website.paginated_sitemap:
     path:      /sitemaps/{alias}-{page}.xml
-    defaults:  { _controller: SuluWebsiteBundle:Sitemap:sitemapPaginated }
+    defaults:  { _controller: Sulu\Bundle\WebsiteBundle\Controller\SitemapController::sitemapPaginatedAction }
     requirements: {page: \d+}
 
 sulu_website.sitemap:
     path:      /sitemaps/{alias}.xml
-    defaults:  { _controller: SuluWebsiteBundle:Sitemap:sitemap }
+    defaults:  { _controller: Sulu\Bundle\WebsiteBundle\Controller\SitemapController::sitemapAction }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
@@ -17,7 +17,7 @@
 
         <service id="sulu_website.sitemap.xml_renderer" class="Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapRenderer" public="true">
             <argument type="service" id="sulu_website.sitemap.pool"/>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="twig"/>
         </service>
 
         <service id="sulu_website.sitemap.xml_dumper" class="Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapDumper" public="true">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -1,4 +1,4 @@
-{% spaceless %}
+{% apply spaceless %}
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xhtml="http://www.w3.org/1999/xhtml" {% block namespaces %}xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"{% endblock %}>
     {% set registrableDomain = sulu_util_domain_info(domain).registrableDomain %}
@@ -42,4 +42,4 @@
         {% endif %}
     {% endfor %}
 </urlset>
-{% endspaceless %}
+{% endapply %}

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRenderer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRenderer.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Sitemap;
 
 use Sulu\Component\Webspace\Portal;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Render sitemap in xml-format.
@@ -25,17 +25,17 @@ class XmlSitemapRenderer implements XmlSitemapRendererInterface
     private $sitemapProviderPool;
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     private $engine;
 
     /**
      * @param SitemapProviderPoolInterface $sitemapProviderPool
-     * @param EngineInterface $engine
+     * @param Environment $engine
      */
     public function __construct(
         SitemapProviderPoolInterface $sitemapProviderPool,
-        EngineInterface $engine
+        Environment $engine
     ) {
         $this->sitemapProviderPool = $sitemapProviderPool;
         $this->engine = $engine;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -23,7 +23,8 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
 
 class AppendAnalyticsListenerTest extends TestCase
 {
@@ -39,7 +40,7 @@ class AppendAnalyticsListenerTest extends TestCase
      */
     public function testAppendFormatNoEffect($format)
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $listener = new AppendAnalyticsListener(
@@ -67,7 +68,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testBinaryFileResponse()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $listener = new AppendAnalyticsListener(
@@ -95,7 +96,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testAppendFormat()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $analytics = $this->prophesize(Analytics::class);
@@ -125,19 +126,22 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader = $this->prophesize(LoaderInterface::class);
+        $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
+
+        $loader->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google/head-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:google/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google/body-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
@@ -150,7 +154,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testAppendWildcard()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $analytics = $this->prophesize(Analytics::class);
@@ -182,19 +186,22 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader = $this->prophesize(LoaderInterface::class);
+        $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
+
+        $loader->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google/head-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:google/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google/body-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
@@ -208,7 +215,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testAppendGoogleTagManager()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $analytics = $this->prophesize(Analytics::class);
@@ -238,19 +245,22 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader = $this->prophesize(LoaderInterface::class);
+        $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
+
+        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-open.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/head-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-close.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/head-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google_tag_manager/body-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/body-open.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/body-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<noscript><div>Blabla</div></noscript>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:google_tag_manager/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/body-close.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
@@ -264,7 +274,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testAppendPiwik()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $analytics = $this->prophesize(Analytics::class);
@@ -294,19 +304,22 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $engine->exists('SuluWebsiteBundle:Analytics:piwik/head-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader = $this->prophesize(LoaderInterface::class);
+        $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
+
+        $loader->exists('SuluWebsiteBundle:Analytics:piwik/head-open.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:piwik/head-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $engine->exists('SuluWebsiteBundle:Analytics:piwik/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:piwik/head-close.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:piwik/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:piwik/body-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:piwik/body-open.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:piwik/body-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<noscript><div>Blabla</div></noscript>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:piwik/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $loader->exists('SuluWebsiteBundle:Analytics:piwik/body-close.html.twig')->shouldBeCalled()->willReturn(false);
         $engine->render('SuluWebsiteBundle:Analytics:piwik/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
@@ -320,7 +333,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testAppendCustom()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
         $analytics = $this->prophesize(Analytics::class);
@@ -350,19 +363,22 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $engine->exists('SuluWebsiteBundle:Analytics:custom/head-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader = $this->prophesize(LoaderInterface::class);
+        $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
+
+        $loader->exists('SuluWebsiteBundle:Analytics:custom/head-open.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:custom/head-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var nice_var = false;</script>');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:custom/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:custom/head-close.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:custom/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:custom/body-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:custom/body-open.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:custom/body-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('');
 
-        $engine->exists('SuluWebsiteBundle:Analytics:custom/body-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $loader->exists('SuluWebsiteBundle:Analytics:custom/body-close.html.twig')->shouldBeCalled()->willReturn(true);
         $engine->render('SuluWebsiteBundle:Analytics:custom/body-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('');
 
@@ -376,7 +392,7 @@ class AppendAnalyticsListenerTest extends TestCase
 
     public function testAppendPreview()
     {
-        $engine = $this->prophesize(EngineInterface::class);
+        $engine = $this->prophesize(Environment::class);
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $analyticsRepository = $this->prophesize(AnalyticsRepository::class);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Twig\Environment;
-use Twig\Loader\LoaderInterface;
+use Twig\Loader\FilesystemLoader;
 
 class AppendAnalyticsListenerTest extends TestCase
 {
@@ -126,7 +126,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $loader = $this->prophesize(LoaderInterface::class);
+        $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
         $loader->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
@@ -186,7 +186,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $loader = $this->prophesize(LoaderInterface::class);
+        $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
         $loader->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
@@ -245,7 +245,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $loader = $this->prophesize(LoaderInterface::class);
+        $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
         $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-open.html.twig')->shouldBeCalled()->willReturn(true);
@@ -304,7 +304,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $loader = $this->prophesize(LoaderInterface::class);
+        $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
         $loader->exists('SuluWebsiteBundle:Analytics:piwik/head-open.html.twig')->shouldBeCalled()->willReturn(false);
@@ -363,7 +363,7 @@ class AppendAnalyticsListenerTest extends TestCase
         $response->reveal()->headers = new ParameterBag(['Content-Type' => 'text/html']);
         $event->getResponse()->willReturn($response->reveal());
 
-        $loader = $this->prophesize(LoaderInterface::class);
+        $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
         $loader->exists('SuluWebsiteBundle:Analytics:custom/head-open.html.twig')->shouldBeCalled()->willReturn(true);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapRenderer;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Environment;
 
 class XmlSitemapRendererTest extends TestCase
 {
@@ -30,7 +30,7 @@ class XmlSitemapRendererTest extends TestCase
     protected $providerPoolInterface;
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     protected $engine;
 
@@ -45,7 +45,7 @@ class XmlSitemapRendererTest extends TestCase
     public function setUp(): void
     {
         $this->providerPoolInterface = $this->prophesize(SitemapProviderPoolInterface::class);
-        $this->engine = $this->prophesize(EngineInterface::class);
+        $this->engine = $this->prophesize(Environment::class);
 
         $this->renderer = new XmlSitemapRenderer($this->providerPoolInterface->reveal(), $this->engine->reveal(), '/');
     }

--- a/src/Sulu/Component/Content/Export/WebspaceExport.php
+++ b/src/Sulu/Component/Content/Export/WebspaceExport.php
@@ -24,7 +24,7 @@ use Sulu\Component\Export\Manager\ExportManagerInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Export Content by given locale to xliff file.
@@ -47,7 +47,7 @@ class WebspaceExport extends Export implements WebspaceExportInterface
     protected $output;
 
     public function __construct(
-        EngineInterface $templating,
+        Environment $templating,
         DocumentManagerInterface $documentManager,
         DocumentInspector $documentInspector,
         StructureManagerInterface $structureManager,

--- a/src/Sulu/Component/Export/Export.php
+++ b/src/Sulu/Component/Export/Export.php
@@ -19,7 +19,7 @@ use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\Export\Manager\ExportManagerInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Base export for sulu documents.
@@ -27,7 +27,7 @@ use Symfony\Component\Templating\EngineInterface;
 class Export
 {
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     protected $templating;
 
@@ -62,7 +62,7 @@ class Export
     protected $format = '1.2.xliff';
 
     public function __construct(
-        EngineInterface $templating,
+        Environment $templating,
         DocumentManagerInterface $documentManager,
         DocumentInspector $documentInspector,
         ExportManagerInterface $exportManager,

--- a/src/Sulu/Component/Snippet/Export/SnippetExport.php
+++ b/src/Sulu/Component/Snippet/Export/SnippetExport.php
@@ -21,7 +21,7 @@ use Sulu\Component\Export\Manager\ExportManagerInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 
 /**
  * Export Snippet by given locale to xliff file.
@@ -39,7 +39,7 @@ class SnippetExport extends Export implements SnippetExportInterface
     protected $output;
 
     public function __construct(
-        EngineInterface $templating,
+        Environment $templating,
         SnippetRepository $snippetManager,
         DocumentManager $documentManager,
         DocumentInspector $documentInspector,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR contains various changes to resolve existing deprecation warnings.
* Replace useages of Templating\EngineInterface with Twig\Environment
* Use Cookie::create instead of using constructor
* User Countries class instead of deprecated Intl class
* Adjust format of controller references in routing files
* Set root name of TreeBuilder in constructor instead of calling root method
* Use KernelBrowser instead of Client
* Remove deprecated 4th parameter when constructing UploadedFile
* Use MimeTypes class instead of deprecated ExtensionGuesser class
* Replace deprecated spaceless tag with spaceless filter

#### Why?

Because we probably want to resolve as many warnings as possible before releasing a new major version 🙂 

