### PR TITLE
Upgrade DoctrineFixturesBundle to newest verison

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/dbal": "^2.6",
         "doctrine/doctrine-bundle": "^1.10",
         "doctrine/doctrine-cache-bundle": "^1.3.1",
-        "doctrine/doctrine-fixtures-bundle": "^2.4",
+        "doctrine/doctrine-fixtures-bundle": "^2.4 || ^3.0",
         "doctrine/inflector": "^1.3",
         "doctrine/orm": "^2.5.3",
         "doctrine/phpcr-bundle": "^1.3.5 || ^2.0",

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -93,5 +93,8 @@
             <tag name="doctrine.event_listener" event="postUpdate"/>
             <tag name="doctrine.event_listener" event="preRemove"/>
         </service>
+        <service id="sulu_contact.fixtures.default_types" class="Sulu\Bundle\ContactBundle\DataFixtures\ORM\LoadDefaultTypes">
+            <tag name="doctrine.fixture.orm"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -284,5 +284,13 @@
 
             <tag name="console.command"/>
         </service>
+
+        <service id="sulu_media.fixtures.collection_types" class="Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes">
+            <tag name="doctrine.fixture.orm"/>
+        </service>
+
+        <service id="sulu_media.fixtures.media_types" class="Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadMediaTypes">
+            <tag name="doctrine.fixture.orm"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -186,5 +186,9 @@
             <tag name="kernel.event_listener" event="kernel.request" method="copyUserLocaleToRequest"/>
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <service id="sulu_security.fixtures.security_types" class="Sulu\Bundle\SecurityBundle\DataFixtures\ORM\LoadSecurityTypes">
+            <tag name="doctrine.fixture.orm"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateRoleCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateRoleCommandTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
 
-use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
 use Sulu\Bundle\SecurityBundle\Command\CreateRoleCommand;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -26,12 +25,8 @@ class CreateRoleCommandTest extends SuluTestCase
 
     public function setUp(): void
     {
+        $this->purgeDatabase();
         $application = new Application($this->getContainer()->get('kernel'));
-
-        $loadFixturesCommand = new LoadDataFixturesDoctrineCommand();
-        $loadFixturesCommand->setApplication($application);
-        $loadFixturesCommandTester = new CommandTester($loadFixturesCommand);
-        $loadFixturesCommandTester->execute([], ['interactive' => false]);
 
         $createUserCommand = new CreateRoleCommand(
             $this->getContainer()->get('doctrine.orm.entity_manager'),

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/CreateUserCommandTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
 
-use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
 use Sulu\Bundle\SecurityBundle\Command\CreateUserCommand;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -32,12 +31,8 @@ class CreateUserCommandTest extends SuluTestCase
 
     public function setUp(): void
     {
+        $this->purgeDatabase();
         $application = new Application($this->getContainer()->get('kernel'));
-
-        $loadFixturesCommand = new LoadDataFixturesDoctrineCommand();
-        $loadFixturesCommand->setApplication($application);
-        $loadFixturesCommandTester = new CommandTester($loadFixturesCommand);
-        $loadFixturesCommandTester->execute([], ['interactive' => false]);
 
         $this->command = new CreateUserCommand(
             $this->getContainer()->get('doctrine.orm.entity_manager'),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #4758
| License | MIT
| Documentation PR | -

#### What's in this PR?

Upgrade DoctrineFixturesBundle to newest verison

#### Why?

To avoid outdated dependencies in our dependency tree.

#### Example Usage

~~~xml
<service id="sulu_media.fixtures.media_types" class="Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadMediaTypes">
    <tag name="doctrine.fixture.orm"/>
</service>
~~~
