### PR TITLE
Refactor deprecated controllers to use constructor injection for its dependencies

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
@@ -12,17 +12,29 @@
 namespace Sulu\Bundle\MediaBundle\Controller;
 
 use Sulu\Bundle\MediaBundle\Api\Media;
+use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * This controller provides an easy redirect to media-formats by redirecting.
  */
-class MediaRedirectController extends Controller
+class MediaRedirectController
 {
     use RequestParametersTrait;
+
+    /**
+     * @var MediaManagerInterface
+     */
+    private $mediaManager;
+
+    public function __construct(
+        MediaManagerInterface $mediaManager
+    ) {
+        $this->mediaManager = $mediaManager;
+    }
 
     /**
      * Redirects to format or original url.
@@ -38,16 +50,16 @@ class MediaRedirectController extends Controller
         $format = $this->getRequestParameter($request, 'format');
 
         /** @var Media $media */
-        $media = $this->container->get('sulu_media.media_manager')->getById($id, $locale);
+        $media = $this->mediaManager->getById($id, $locale);
 
         if (null === $format) {
-            return $this->redirect($media->getUrl());
+            return new RedirectResponse($media->getUrl());
         }
 
         if (!array_key_exists($format, $media->getFormats())) {
-            throw $this->createNotFoundException();
+            throw new NotFoundHttpException();
         }
 
-        return $this->redirect($media->getFormats()[$format]);
+        return new RedirectResponse($media->getFormats()[$format]);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 sulu_media.redirect:
     path: /redirect/media/{id}
-    defaults: { _controller: Sulu\Bundle\MediaBundle\Controller\MediaRedirectController::redirectAction }
+    defaults: { _controller: sulu_media.media_redirect_controller:redirectAction }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -27,6 +27,13 @@
     </parameters>
 
     <services>
+        <service id="sulu_media.media_redirect_controller" class="Sulu\Bundle\MediaBundle\Controller\MediaRedirectController">
+            <argument type="service" id="sulu_media.media_manager" />
+
+            <tag name="controller.service_arguments" />
+            <tag name="sulu.context" context="admin"/>
+        </service>
+
         <service id="sulu_media.admin" class="%sulu_media.admin.class%">
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -27,10 +27,13 @@
     </parameters>
 
     <services>
-        <service id="sulu_media.media_redirect_controller" class="Sulu\Bundle\MediaBundle\Controller\MediaRedirectController">
+        <service
+            id="sulu_media.media_redirect_controller"
+            class="Sulu\Bundle\MediaBundle\Controller\MediaRedirectController"
+            public="true"
+        >
             <argument type="service" id="sulu_media.media_manager" />
 
-            <tag name="controller.service_arguments" />
             <tag name="sulu.context" context="admin"/>
         </service>
 

--- a/src/Sulu/Bundle/SnippetBundle/Controller/LanguageController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/LanguageController.php
@@ -15,14 +15,24 @@ use FOS\RestBundle\Routing\ClassResourceInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * handles languages for snippet ui.
  */
-class LanguageController extends Controller implements ClassResourceInterface
+class LanguageController implements ClassResourceInterface
 {
+    /**
+     * @var WebspaceManagerInterface
+     */
+    private $webspaceManager;
+
+    public function __construct(
+        WebspaceManagerInterface $webspaceManager
+    ) {
+        $this->webspaceManager = $webspaceManager;
+    }
+
     /**
      * Returns all languages in admin.
      *
@@ -30,14 +40,11 @@ class LanguageController extends Controller implements ClassResourceInterface
      */
     public function cgetAction()
     {
-        /** @var WebspaceManagerInterface $webspaceManager */
-        $webspaceManager = $this->get('sulu_core.webspace.webspace_manager');
-
         $localizations = [];
         $locales = [];
 
         /** @var Webspace $webspace */
-        foreach ($webspaceManager->getWebspaceCollection() as $webspace) {
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             $i = 0;
             foreach ($webspace->getAllLocalizations() as $localization) {
                 if (!in_array($localization->getLocale(), $locales)) {

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/routing_api.yml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/routing_api.yml
@@ -18,4 +18,4 @@ sulu_snippet.snippet-areas:
 sulu_snippet.languages:
     type: rest
     name_prefix: sulu_snippet.
-    resource: Sulu\Bundle\SnippetBundle\Controller\LanguageController
+    resource: sulu_snippet.language_controller

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -13,10 +13,13 @@
     </parameters>
 
     <services>
-        <service id="sulu_snippet.language_controller" class="Sulu\Bundle\SnippetBundle\Controller\LanguageController">
+        <service
+            id="sulu_snippet.language_controller"
+            class="Sulu\Bundle\SnippetBundle\Controller\LanguageController"
+            public="true"
+        >
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
 
-            <tag name="controller.service_arguments" />
             <tag name="sulu.context" context="admin"/>
         </service>
 

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/snippet.xml
@@ -13,6 +13,13 @@
     </parameters>
 
     <services>
+        <service id="sulu_snippet.language_controller" class="Sulu\Bundle\SnippetBundle\Controller\LanguageController">
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
+
+            <tag name="controller.service_arguments" />
+            <tag name="sulu.context" context="admin"/>
+        </service>
+
         <service id="sulu_snippet.repository" class="%sulu_snippet.repository.class%" public="true">
             <argument type="service" id="sulu.phpcr.session" />
             <argument type="service" id="sulu.content.mapper" />

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yml
@@ -1,4 +1,4 @@
 sulu_website.cache.remove:
     path: /cache
-    defaults: { _controller: Sulu\Bundle\WebsiteBundle\Controller\CacheController::clearAction }
+    defaults: { _controller: sulu_website.cache_controller:clearAction }
     methods: [DELETE]

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -28,6 +28,7 @@
     </parameters>
 
     <services>
+        <!-- controllers -->
         <service id="sulu_website.default_controller" class="Sulu\Bundle\WebsiteBundle\Controller\DefaultController">
             <tag name="container.service_subscriber" />
             <tag name="controller.service_arguments" />
@@ -37,6 +38,15 @@
             </call>
         </service>
         <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller"/>
+
+        <service id="sulu_website.cache_controller" class="Sulu\Bundle\WebsiteBundle\Controller\CacheController">
+            <argument type="service" id="sulu_website.http_cache.clearer" />
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
+            <argument type="service" id="sulu_security.security_checker"/>
+
+            <tag name="controller.service_arguments" />
+            <tag name="sulu.context" context="admin"/>
+        </service>
 
         <!-- website admin -->
         <service id="sulu_website.admin" class="%sulu_website.admin.class%">

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -39,12 +39,15 @@
         </service>
         <service id="Sulu\Bundle\WebsiteBundle\Controller\DefaultController" alias="sulu_website.default_controller"/>
 
-        <service id="sulu_website.cache_controller" class="Sulu\Bundle\WebsiteBundle\Controller\CacheController">
+        <service
+            id="sulu_website.cache_controller"
+            class="Sulu\Bundle\WebsiteBundle\Controller\CacheController"
+            public="true"
+        >
             <argument type="service" id="sulu_website.http_cache.clearer" />
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="sulu_security.security_checker"/>
 
-            <tag name="controller.service_arguments" />
             <tag name="sulu.context" context="admin"/>
         </service>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | Builds upon https://github.com/sulu/sulu/pull/4762
| License | MIT

#### What's in this PR?

This PR refactors multiple controllers to use constructor injection instead of extending the deprecated `Symfony\Bundle\FrameworkBundle\Controller\Controller` class.

#### Why?

Because the `Symfony\Bundle\FrameworkBundle\Controller\Controller` class is deprecated and constructor injection is the preferred method for injecting dependencies now.
