### PR TITLE
Check Preview token and generate one if not exist

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/Controller/PreviewController.php
@@ -63,10 +63,16 @@ class PreviewController
 
     public function renderAction(Request $request): Response
     {
+        $provider = $this->getRequestParameter($request, 'provider', true);
+        $id = $this->getRequestParameter($request, 'id', true);
         $token = $this->getRequestParameter($request, 'token', true);
         $webspace = $this->getRequestParameter($request, 'webspace', true, null);
         $locale = $this->getRequestParameter($request, 'locale', true, null);
         $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
+
+        if (!$this->preview->exists($token)) {
+            $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
+        }
 
         $content = $this->preview->render($token, $webspace, $locale, $targetGroup);
 
@@ -77,10 +83,17 @@ class PreviewController
 
     public function updateAction(Request $request): Response
     {
+        $provider = $this->getRequestParameter($request, 'provider', true);
+        $id = $this->getRequestParameter($request, 'id', true);
         $token = $this->getRequestParameter($request, 'token', true);
         $data = $this->getRequestParameter($request, 'data', true);
+        $locale = $this->getRequestParameter($request, 'locale', true, null);
         $webspace = $this->getRequestParameter($request, 'webspace', true);
         $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
+
+        if (!$this->preview->exists($token)) {
+            $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
+        }
 
         $content = $this->preview->update($token, $webspace, $data, $targetGroup);
 
@@ -89,10 +102,17 @@ class PreviewController
 
     public function updateContextAction(Request $request): Response
     {
+        $id = $this->getRequestParameter($request, 'id', true);
+        $provider = $this->getRequestParameter($request, 'provider', true);
         $token = $this->getRequestParameter($request, 'token', true);
         $context = $this->getRequestParameter($request, 'context', true);
+        $locale = $this->getRequestParameter($request, 'locale', true, null);
         $webspace = $this->getRequestParameter($request, 'webspace', true);
         $targetGroup = $this->getRequestParameter($request, 'targetGroup', false, null);
+
+        if (!$this->preview->exists($token)) {
+            $token = $this->preview->start($provider, $id, $locale, $this->getUserId());
+        }
 
         $content = $this->preview->updateContext($token, $webspace, $context, $targetGroup);
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/stores/PreviewStore.js
@@ -38,6 +38,8 @@ export default class PreviewStore {
     @computed get renderRoute() {
         return generateRoute('render', {
             webspace: this.webspace,
+            provider: this.resourceKey,
+            id: this.id,
             locale: this.locale,
             token: this.token,
             targetGroup: this.targetGroup,
@@ -59,8 +61,8 @@ export default class PreviewStore {
     start(): Promise<*> {
         const route = generateRoute('start', {
             provider: this.resourceKey,
-            locale: this.locale,
             id: this.id,
+            locale: this.locale,
             targetGroup: this.targetGroup,
         });
 
@@ -74,6 +76,8 @@ export default class PreviewStore {
             locale: this.locale,
             webspace: this.webspace,
             token: this.token,
+            provider: this.resourceKey,
+            id: this.id,
             targetGroup: this.targetGroup,
         });
 
@@ -86,6 +90,9 @@ export default class PreviewStore {
         const route = generateRoute('update-context', {
             webspace: this.webspace,
             token: this.token,
+            locale: this.locale,
+            provider: this.resourceKey,
+            id: this.id,
             targetGroup: this.targetGroup,
         });
 

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/stores/PreviewStore.test.js
@@ -57,7 +57,7 @@ test('Should request server on update preview', () => {
 
     return postPromise.then(() => {
         expect(Requester.post).toBeCalledWith(
-            '/update?locale=en&targetGroup=-1&webspace=sulu_io',
+            '/update?id=123-123-123&locale=en&provider=pages&targetGroup=-1&webspace=sulu_io',
             {data: {title: 'Sulu is aswesome'}}
         );
     });
@@ -79,7 +79,7 @@ test('Should request server on update preview with target group', () => {
 
     return postPromise.then(() => {
         expect(Requester.post).toBeCalledWith(
-            '/update?locale=en&targetGroup=2&webspace=sulu_io',
+            '/update?id=123-123-123&locale=en&provider=pages&targetGroup=2&webspace=sulu_io',
             {data: {title: 'Sulu is aswesome'}}
         );
     });
@@ -100,7 +100,10 @@ test('Should request server on update-context preview', () => {
 
     return postPromise.then(() => {
         expect(Requester.post)
-            .toBeCalledWith('/update-context?targetGroup=-1&webspace=sulu_io', {context: {template: 'default'}});
+            .toBeCalledWith(
+                '/update-context?id=123-123-123&locale=en&provider=pages&targetGroup=-1&webspace=sulu_io',
+                {context: {template: 'default'}}
+            );
     });
 });
 
@@ -120,7 +123,10 @@ test('Should request server on update-context preview with target group', () => 
 
     return postPromise.then(() => {
         expect(Requester.post)
-            .toBeCalledWith('/update-context?targetGroup=6&webspace=sulu_io', {context: {template: 'default'}});
+            .toBeCalledWith(
+                '/update-context?id=123-123-123&locale=en&provider=pages&targetGroup=6&webspace=sulu_io',
+                {context: {template: 'default'}}
+            );
     });
 });
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Controller/PreviewControllerTest.php
@@ -77,8 +77,38 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('webspace', null)->willReturn('sulu_io');
         $request->get('locale', null)->willReturn('de');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
         $request->get('targetGroup', null)->willReturn(1);
 
+        $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
+        $this->preview->render('test-token', 'sulu_io', 'de', 1)
+            ->shouldBeCalled()
+            ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
+
+        $response = $this->previewController->renderAction($request->reveal());
+        $this->assertEquals('<html><body><h1>SULU is awesome</h1></body></html>', $response->getContent());
+    }
+
+    public function testRenderInvalidToken()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->get('token', null)->willReturn('test-token');
+        $request->get('webspace', null)->willReturn('sulu_io');
+        $request->get('locale', null)->willReturn('de');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
+        $request->get('targetGroup', null)->willReturn(1);
+
+        $token = $this->prophesize(TokenInterface::class);
+        $user = $this->prophesize(UserInterface::class);
+        $this->tokenStorage->getToken()->willReturn($token->reveal());
+        $token->getUser()->willReturn($user->reveal());
+        $user->getId()->willReturn(42);
+
+        $this->preview->exists('test-token')->willReturn(false)->shouldBeCalled();
+        $this->preview->start('test-provider', '123-123-123', 'de', 42)
+            ->willReturn('test-token');
         $this->preview->render('test-token', 'sulu_io', 'de', 1)
             ->shouldBeCalled()
             ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
@@ -93,8 +123,11 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('webspace', null)->willReturn('sulu_io');
         $request->get('locale', null)->willReturn('de');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
         $request->get('targetGroup', null)->willReturn(1);
 
+        $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->render('test-token', 'sulu_io', 'de', 1)
             ->shouldBeCalled()
             ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
@@ -109,8 +142,12 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('data', null)->willReturn(['title' => 'Sulu is awesome']);
         $request->get('webspace', null)->willReturn('sulu_io');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
+        $request->get('locale', null)->willReturn('de');
         $request->get('targetGroup', null)->willReturn(1);
 
+        $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->update('test-token', 'sulu_io', ['title' => 'Sulu is awesome'], 1)
             ->shouldBeCalled()
             ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
@@ -129,8 +166,12 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('data', null)->willReturn(['title' => 'Sulu is awesome']);
         $request->get('webspace', null)->willReturn('sulu_io');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
+        $request->get('locale', null)->willReturn('de');
         $request->get('targetGroup', null)->willReturn(1);
 
+        $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->update('test-token', 'sulu_io', ['title' => 'Sulu is awesome'], 1)
             ->shouldBeCalled()
             ->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');
@@ -151,8 +192,12 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('context', null)->willReturn(['template' => 'default']);
         $request->get('webspace', null)->willReturn('sulu_io');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
+        $request->get('locale', null)->willReturn('de');
         $request->get('targetGroup', null)->willReturn(1);
 
+        $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1)
             ->shouldBeCalled()
             ->willReturn('<html><body><h1>SULU is awesome</h1></body></html>');
@@ -170,8 +215,12 @@ class PreviewControllerTest extends TestCase
         $request->get('token', null)->willReturn('test-token');
         $request->get('context', null)->willReturn(['template' => 'default']);
         $request->get('webspace', null)->willReturn('sulu_io');
+        $request->get('id', null)->willReturn('123-123-123');
+        $request->get('provider', null)->willReturn('test-provider');
+        $request->get('locale', null)->willReturn('de');
         $request->get('targetGroup', null)->willReturn(1);
 
+        $this->preview->exists('test-token')->willReturn(true)->shouldBeCalled();
         $this->preview->updateContext('test-token', 'sulu_io', ['template' => 'default'], 1)
             ->shouldBeCalled()
             ->willReturn('<html><body><a href="/test">SULU is awesome</a></body></html>');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #4662
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Check Preview token and generate one if not exist.

#### Why?

First I wanted to remove the whole preview cache but there is not only the HTML cached also the loading of the provided object I think. So currently the best to avoid a central store is to check for exist of a token and else generate a new one.

