### PR TITLE
Make webspace manager environment variable optional

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,11 @@
 When upgrading also have a look at the changes in the
 [sulu skeleton](https://github.com/sulu/skeleton/compare/2.0.0-RC3...2.0.0).
 
+### WebspaceMangerInterface changed
+
+The `WebspaceManagerInterface` changed that in all methods the `$environment` variable is nullable
+and will use in the implementation the current `kernel.environment`.
+
 ### Ugrading JMS Serializer dependency
 
 See [JMS/Serializer](https://github.com/schmittjoh/serializer/blob/master/UPGRADING.md)

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -39,6 +39,7 @@
                 <argument key="cache_class">%sulu_core.webspace.cache_class%</argument>
                 <argument key="base_class">%sulu_core.webspace.base_class%</argument>
             </argument>
+            <argument>%kernel.environment%</argument>
 
             <tag name="sulu.localization_provider"/>
         </service>

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -47,14 +47,21 @@ class WebspaceManager implements WebspaceManagerInterface
      */
     private $urlReplacer;
 
+    /**
+     * @var string
+     */
+    private $environment;
+
     public function __construct(
         LoaderInterface $loader,
         ReplacerInterface $urlReplacer,
-        array $options = []
+        array $options,
+        string $environment
     ) {
         $this->loader = $loader;
         $this->urlReplacer = $urlReplacer;
         $this->setOptions($options);
+        $this->environment = $environment;
     }
 
     public function findWebspaceByKey(?string $key): ?Webspace
@@ -75,8 +82,12 @@ class WebspaceManager implements WebspaceManagerInterface
         return $this->getWebspaceCollection()->getPortal($key);
     }
 
-    public function findPortalInformationByUrl(string $url, string $environment): ?PortalInformation
+    public function findPortalInformationByUrl(string $url, ?string $environment = null): ?PortalInformation
     {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         $portalInformations = $this->getWebspaceCollection()->getPortalInformations($environment);
         foreach ($portalInformations as $portalInformation) {
             if ($this->matchUrl($url, $portalInformation->getUrl())) {
@@ -87,8 +98,12 @@ class WebspaceManager implements WebspaceManagerInterface
         return null;
     }
 
-    public function findPortalInformationsByUrl(string $url, string $environment): array
+    public function findPortalInformationsByUrl(string $url, ?string $environment = null): array
     {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         return array_filter(
             $this->getWebspaceCollection()->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($url) {
@@ -100,8 +115,12 @@ class WebspaceManager implements WebspaceManagerInterface
     public function findPortalInformationsByWebspaceKeyAndLocale(
         string $webspaceKey,
         string $locale,
-        string $environment
+        ?string $environment = null
     ): array {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         return array_filter(
             $this->getWebspaceCollection()->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($webspaceKey, $locale) {
@@ -114,8 +133,12 @@ class WebspaceManager implements WebspaceManagerInterface
     public function findPortalInformationsByPortalKeyAndLocale(
         string $portalKey,
         string $locale,
-        string $environment
+        ?string $environment = null
     ): array {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         return array_filter(
             $this->getWebspaceCollection()->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($portalKey, $locale) {
@@ -128,12 +151,16 @@ class WebspaceManager implements WebspaceManagerInterface
 
     public function findUrlsByResourceLocator(
         string $resourceLocator,
-        string $environment,
+        ?string $environment,
         string $languageCode,
         ?string $webspaceKey = null,
         ?string $domain = null,
         string $scheme = 'http'
     ): array {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         $urls = [];
         $portals = $this->getWebspaceCollection()->getPortalInformations(
             $environment,
@@ -153,12 +180,16 @@ class WebspaceManager implements WebspaceManagerInterface
 
     public function findUrlByResourceLocator(
         ?string $resourceLocator,
-        string $environment,
+        ?string $environment,
         string $languageCode,
         ?string $webspaceKey = null,
         ?string $domain = null,
         string $scheme = 'http'
     ): ?string {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         $urls = [];
         $portals = $this->getWebspaceCollection()->getPortalInformations(
             $environment,
@@ -192,8 +223,12 @@ class WebspaceManager implements WebspaceManagerInterface
         return $this->getWebspaceCollection()->getPortals();
     }
 
-    public function getUrls(string $environment): array
+    public function getUrls(?string $environment = null): array
     {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         $urls = [];
 
         foreach ($this->getWebspaceCollection()->getPortalInformations($environment) as $portalInformation) {
@@ -206,13 +241,21 @@ class WebspaceManager implements WebspaceManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getPortalInformations(string $environment): array
+    public function getPortalInformations(?string $environment = null): array
     {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         return $this->getWebspaceCollection()->getPortalInformations($environment);
     }
 
-    public function getPortalInformationsByWebspaceKey(string $environment, string $webspaceKey): array
+    public function getPortalInformationsByWebspaceKey(?string $environment = null, string $webspaceKey): array
     {
+        if (null === $environment) {
+            $environment = $this->environment;
+        }
+
         return array_filter(
             $this->getWebspaceCollection()->getPortalInformations($environment),
             function(PortalInformation $portal) use ($webspaceKey) {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManagerInterface.php
@@ -26,14 +26,14 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
     /**
      * Returns the portal with the given url (which has not necessarily to be the main url).
      */
-    public function findPortalInformationByUrl(string $url, string $environment): ?PortalInformation;
+    public function findPortalInformationByUrl(string $url, ?string $environment = null): ?PortalInformation;
 
     /**
      * Returns all portal which matches the given url (which has not necessarily to be the main url).
      *
      * @return PortalInformation[]
      */
-    public function findPortalInformationsByUrl(string $url, string $environment): array;
+    public function findPortalInformationsByUrl(string $url, ?string $environment = null): array;
 
     /**
      * Returns all portal which matches the given webspace-key and locale.
@@ -43,7 +43,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
     public function findPortalInformationsByWebspaceKeyAndLocale(
         string $webspaceKey,
         string $locale,
-        string $environment
+        ?string $environment = null
     ): array;
 
     /**
@@ -54,7 +54,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
     public function findPortalInformationsByPortalKeyAndLocale(
         string $portalKey,
         string $locale,
-        string $environment
+        ?string $environment = null
     ): array;
 
     /**
@@ -64,7 +64,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
      */
     public function findUrlsByResourceLocator(
         string $resourceLocator,
-        string $environment,
+        ?string $environment,
         string $languageCode,
         ?string $webspaceKey = null,
         ?string $domain = null,
@@ -76,7 +76,7 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
      */
     public function findUrlByResourceLocator(
         ?string $resourceLocator,
-        string $environment,
+        ?string $environment,
         string $languageCode,
         ?string $webspaceKey = null,
         ?string $domain = null,
@@ -91,17 +91,17 @@ interface WebspaceManagerInterface extends LocalizationProviderInterface
     /**
      * @return string[]
      */
-    public function getUrls(string $environment): array;
+    public function getUrls(?string $environment = null): array;
 
     /**
      * @return PortalInformation[]
      */
-    public function getPortalInformations(string $environment): array;
+    public function getPortalInformations(?string $environment = null): array;
 
     /**
      * @return PortalInformation[]
      */
-    public function getPortalInformationsByWebspaceKey(string $environment, string $webspaceKey): array;
+    public function getPortalInformationsByWebspaceKey(?string $environment, string $webspaceKey): array;
 
     public function getWebspaceCollection(): WebspaceCollection;
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -68,7 +68,8 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_dir' => $this->cacheDirectory,
                 'config_dir' => $this->getResourceDirectory() . '/DataFixtures/Webspace/valid',
                 'cache_class' => 'WebspaceCollectionCache' . uniqid(),
-            ]
+            ],
+            'test'
         );
     }
 
@@ -561,7 +562,8 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_dir' => $this->getResourceDirectory() . '/cache',
                 'config_dir' => $this->getResourceDirectory() . '/DataFixtures/Webspace/multiple',
                 'cache_class' => 'WebspaceCollectionCache' . uniqid(),
-            ]
+            ],
+            'test'
         );
 
         $webspaces = $this->webspaceManager->getWebspaceCollection();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | related to #188
| License | MIT
| Documentation PR | -

#### What's in this PR?

Make webspace manager environment variable in functions optional.

#### Why?

Avoid that the developer needs to inject the current environment as services should not depend on environments. 