### PR TITLE
Fix target group evaluator without webspace

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupEvaluator.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupEvaluator.php
@@ -55,7 +55,13 @@ class TargetGroupEvaluator implements TargetGroupEvaluatorInterface
         $maxFrequency = TargetGroupRuleInterface::FREQUENCY_VISITOR,
         TargetGroupInterface $currentTargetGroup = null
     ) {
-        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
+        $webspace = $this->requestAnalyzer->getWebspace();
+        if (!$webspace) {
+            return $currentTargetGroup;
+        }
+
+        $webspaceKey = $webspace->getKey();
+
         $considerableTargetGroups = $this->targetGroupRepository->findAllActiveForWebspaceOrderedByPriority(
             $webspaceKey,
             $maxFrequency

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Rule/TargetGroupEvaluatorTest.php
@@ -69,8 +69,11 @@ class TargetGroupEvaluatorTest extends \PHPUnit_Framework_TestCase
         $frequency = TargetGroupRuleInterface::FREQUENCY_SESSION,
         $currentTargetGroup = null
     ) {
-        $webspace = new Webspace();
-        $webspace->setKey($webspaceKey);
+        $webspace = null;
+        if ($webspaceKey) {
+            $webspace = new Webspace();
+            $webspace->setKey($webspaceKey);
+        }
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
         $rules = [];
@@ -154,6 +157,7 @@ class TargetGroupEvaluatorTest extends \PHPUnit_Framework_TestCase
 
         return [
             [[], [], 'sulu_io', null],
+            [[], [], null, null],
             [[$targetGroup1], [], 'sulu_io', null],
             [[$targetGroup2], ['rule1' => [['targetGroup2']]], 'sulu_io', $targetGroup2],
             [[$targetGroup2], ['rule1' => [['targetGroup2']]], 'test', $targetGroup2],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix target group evaluator without webspace.

#### Why?

If you have a `_requestAnalyer: false` route and AudienceTargeting activated the webspace is not set and will fail on that route.
