### PR TITLE
Make array serializer service public

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/serializer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/serializer.xml
@@ -4,10 +4,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-
     <services>
-        <service id="sulu_core.array_serializer" class="Sulu\Component\Serializer\ArraySerializer">
+        <service id="sulu_core.array_serializer" class="Sulu\Component\Serializer\ArraySerializer" public="true">
             <argument type="service" id="jms_serializer"/>
         </service>
+
+        <service id="Sulu\Component\Serializer\ArraySerializerInterface" alias="sulu_core.array_serializer"/>
     </services>
 </container>

--- a/src/Sulu/Component/Serializer/ArraySerializer.php
+++ b/src/Sulu/Component/Serializer/ArraySerializer.php
@@ -28,6 +28,12 @@ class ArraySerializer implements ArraySerializerInterface
 
     public function serialize($data, ?SerializationContext $context = null): array
     {
+        if (!$context) {
+            $context = SerializationContext::create();
+        }
+
+        $context->setAttribute('array_serializer', true);
+
         return $this->serializer->toArray($data, $context);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Make array serializer service public.

#### Why?

At some places user want to get the array serializer over the container e.g. SuluArticleBundle https://github.com/sulu/SuluArticleBundle/blob/40bc58a247e86a1fa1a54ad1fca1d07425046bba/Controller/WebsiteArticleController.php#L127-L129.