### PR TITLE
Fix deprecated RestController viewHandler

### DIFF
--- a/src/Sulu/Component/Rest/AbstractRestController.php
+++ b/src/Sulu/Component/Rest/AbstractRestController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Rest;
 
+use FOS\RestBundle\Controller\ControllerTrait;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -19,6 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 abstract class AbstractRestController
 {
+    use ControllerTrait;
     use RestControllerTrait;
 
     /**

--- a/src/Sulu/Component/Rest/RestControllerTrait.php
+++ b/src/Sulu/Component/Rest/RestControllerTrait.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Rest;
 
-use FOS\RestBundle\Controller\ControllerTrait;
 use FOS\RestBundle\View\View;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntity;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
@@ -20,8 +19,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 trait RestControllerTrait
 {
-    use ControllerTrait;
-
     /**
      * The type of the entity, which is handled by the concrete controller.
      *


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Fix deprecated RestController viewHandler.

#### Why?

The Trait is included by the RestController extends itself included it in the trait overwrite the methods / variables of the other trait and so in this class the viewHandler is not set and will currently error when a controller is extending the old RestController.