### PR TITLE
Fix optional ffmpeg configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,6 @@
         "league/flysystem-aws-s3-v3": "^1.0.1",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "php-ffmpeg/php-ffmpeg": "^0.13 || ^0.14",
         "phpcr/phpcr-shell": "^1.0",
         "phpspec/prophecy": "^1.7",
         "phpstan/phpstan": "^0.11.5",

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
         "league/flysystem-aws-s3-v3": "^1.0.1",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "php-ffmpeg/php-ffmpeg": "^0.13 || ^0.14",
         "phpcr/phpcr-shell": "^1.0",
         "phpspec/prophecy": "^1.7",
         "phpstan/phpstan": "^0.11.5",

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -277,7 +277,15 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
             $loader->load('audience_targeting.xml');
         }
 
-        if (array_key_exists('ffmpeg', $config)) {
+        $ffmpegBinary = $config['ffmpeg']['ffmpeg_binary'] ?? null;
+        $ffprobeBinary = $config['ffmpeg']['ffprobe_binary'] ?? null;
+
+        if (method_exists($container, 'resolveEnvPlaceholders')) {
+            $ffmpegBinary = $container->resolveEnvPlaceholders($ffmpegBinary, true);
+            $ffprobeBinary = $container->resolveEnvPlaceholders($ffprobeBinary, true);
+        }
+
+        if ($ffmpegBinary || $ffprobeBinary) {
             if (!class_exists(FFMpeg::class)) {
                 throw new InvalidConfigurationException(
                     'The "php-ffmpeg/php-ffmpeg" need to be installed to use ffmpeg.'

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/config.yml
@@ -9,6 +9,9 @@ sulu_media:
             Expires: "+1 month"
     image_format_files:
         - "%kernel.root_dir%/config/image-formats.xml"
+    ffmpeg:
+        ffmpeg_binary: '/usr/local/bin/ffmpeg'
+        ffprobe_binary: '/usr/local/bin/ffmprobe'
 
 framework:
     assets: ~

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -54,11 +54,6 @@ jms_serializer:
     metadata:
         debug: '%kernel.debug%'
 
-sulu_media:
-    ffmpeg:
-        ffmpeg_binary: '/usr/local/bin/ffmpeg'
-        ffprobe_binary: '/usr/local/bin/ffmprobe'
-
 swiftmailer:
     url: 'null://localhost'
     spool: { type: 'memory' }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Removes the php-ffmpeg config from the TestKernel and adds it to the MediaBundle test configuration.

#### Why?

Because the dependency is only used in the MediaBundle and should not be required in all the other bundles.