### PR TITLE
Simplify the count() check

### DIFF
--- a/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
+++ b/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
@@ -215,7 +215,7 @@ class ListQueryBuilder
 
         $fieldsWhere = array_merge($fieldsWhere, $this->searchTextFields, $this->searchNumberFields);
 
-        if (null != $fieldsWhere && count($fieldsWhere) >= 0) {
+        if (null != $fieldsWhere && count($fieldsWhere)) {
             foreach ($fieldsWhere as $field) {
                 $this->performSelectFromField($field, $prefix);
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR removes the wrong `count()` check and simplifies it. There is no need to check the values when count() === 0.

#### Why?

The previous check was not correct and can be simplified.

#### Example Usage

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
