### PR TITLE
Reuse the $navigation variable

### DIFF
--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -583,7 +583,7 @@ class Webspace implements ArrayableInterface
         $res['navigation'] = [];
         $res['navigation']['contexts'] = [];
         if ($navigation = $this->getNavigation()) {
-            foreach ($this->getNavigation()->getContexts() as $context) {
+            foreach ($navigation->getContexts() as $context) {
                 $res['navigation']['contexts'][] = [
                     'key' => $context->getKey(),
                     'metadata' => $context->getMetadata(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR reuses the `$navigation` variable to remove some duplicate code.

#### Why?

The code can be reused as the result of `getNavigation()`is already stored.

#### Example Usage

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
