### PR TITLE
Remove the unused width value

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RatioNormalizer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/RectangleSelection/normalizers/RatioNormalizer.js
@@ -16,7 +16,7 @@ export default class RatioNormalizer implements Normalizer {
 
     normalize(data: SelectionData): SelectionData {
         let height = data.height;
-        let width = data.width;
+        let width;
         const calculatedWidth = height * (this.minWidth / this.minHeight);
 
         if (calculatedWidth > this.containerWidth) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

This PR removes the initial `width` value.

#### Why?

The initial value `data.width` is never used.

#### Example Usage

#### BC Breaks/Deprecations

Describe BC breaks/deprecations here. (remove this section if not needed)

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
