### PR TITLE
Add computed locales to list view

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -19,6 +19,7 @@ const DEFAULT_USER_SETTINGS_KEY = 'list';
 const DEFAULT_LIMIT = 10;
 
 type Props = ViewProps & {
+    locales?: Array<string>,
     locale?: IObservableValue<string>,
     onItemAdd?: (parentId: ?string | number) => void,
     onItemClick?: (itemId: string | number) => void,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -58,9 +58,11 @@ class List extends React.Component<Props> {
     @computed get locales() {
         const {
             locales: propsLocales,
-            route: {
-                options: {
-                    locales: routeLocales,
+            router: {
+                route: {
+                    options: {
+                        locales: routeLocales,
+                    },
                 },
             },
         } = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -1,6 +1,6 @@
 // @flow
 import type {IObservableValue} from 'mobx';
-import {action, observable, toJS} from 'mobx';
+import {action, computed, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import type {ElementRef} from 'react';
 import React, {Fragment} from 'react';
@@ -54,6 +54,19 @@ class List extends React.Component<Props> {
         };
     }
 
+    @computed get locales() {
+        const {
+            locales: propsLocales,
+            route: {
+                options: {
+                    locales: routeLocales,
+                },
+            },
+        } = this.props;
+
+        return routeLocales ? routeLocales : propsLocales;
+    }
+
     constructor(props: Props) {
         super(props);
 
@@ -65,7 +78,6 @@ class List extends React.Component<Props> {
                     adapters,
                     requestParameters = {},
                     listKey,
-                    locales,
                     resourceKey,
                     routerAttributesToListRequest = {},
                     resourceStorePropertiesToListRequest = {},
@@ -94,7 +106,7 @@ class List extends React.Component<Props> {
         router.bind('page', this.page, 1);
         observableOptions.page = this.page;
 
-        if (locales) {
+        if (this.locales) {
             router.bind('locale', this.locale);
             observableOptions.locale = this.locale;
         }
@@ -336,7 +348,6 @@ export default withToolbar(List, function() {
         route: {
             options: {
                 backView,
-                locales,
             },
         },
     } = router;
@@ -352,13 +363,13 @@ export default withToolbar(List, function() {
             },
         }
         : undefined;
-    const locale = locales
+    const locale = this.locales
         ? {
             value: this.locale.get(),
             onChange: action((locale) => {
                 this.locale.set(locale);
             }),
-            options: locales.map((locale) => ({
+            options: this.locales.map((locale) => ({
                 value: locale,
                 label: locale,
             })),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -19,8 +19,8 @@ const DEFAULT_USER_SETTINGS_KEY = 'list';
 const DEFAULT_LIMIT = 10;
 
 type Props = ViewProps & {
-    locales?: Array<string>,
     locale?: IObservableValue<string>,
+    locales?: Array<string>,
     onItemAdd?: (parentId: ?string | number) => void,
     onItemClick?: (itemId: string | number) => void,
     resourceStore?: ResourceStore,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -1028,6 +1028,36 @@ test('Should render the locale dropdown with the options from router', () => {
     ]);
 });
 
+test('Should render the locale dropdown with the options from props', () => {
+    const withToolbar = require('../../../containers/Toolbar/withToolbar');
+    const List = require('../List').default;
+    const toolbarFunction = findWithHighOrderFunction(withToolbar, List);
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                listKey: 'test',
+                resourceKey: 'test',
+            },
+        },
+    };
+
+    const list = mount(<List locales={['en', 'de']} router={router} />);
+    list.instance().locale = {
+        get: function() {
+            return 'de';
+        },
+    };
+
+    const toolbarConfig = toolbarFunction.call(list.instance());
+    expect(toolbarConfig.locale.value).toBe('de');
+    expect(toolbarConfig.locale.options).toEqual([
+        {value: 'en', label: 'en'},
+        {value: 'de', label: 'de'},
+    ]);
+});
+
 test('Should pass requestParameters from router to the ListStore', () => {
     const List = require('../List').default;
     const router = {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add computed method to get locales from the route and props.

#### Why?

Because the parent locales were not correctly inherited from the list view.

#### Example
        $formOverlayListViewBuilder = new FormOverlayListViewBuilder(static::LIST_VIEW, '/automation');
        $formOverlayListViewBuilder->setResourceKey(Task::RESOURCE_KEY)
            ->setListKey(Task::RESOURCE_KEY)
            ->setFormKey('task_details')
            ->setTabTitle('sulu_automation.automation')
            ->addToolbarActions($listToolbarActions)
            ->addListAdapters(['table'])
            ->setTabOrder(4096)
            ->addRouterAttributesToFormRequest(['id' => 'entity-id'])
            ->addRouterAttributesToListRequest(['id' => 'entity-id'])
            ->setParent(PageAdmin::EDIT_FORM_VIEW);