### PR TITLE
Fix account interface function types

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,27 @@
 
 ## dev-release/2.0
 
+### Fix AccountInterface nullable setters/getter
+
+Setters and getter of nullable fields on the Account entity were fixed.
+For some function on the AccountInterface need to be changed to the following:
+
+```php
+// Before
+public function setExternalId(string $externalId): AccountInterface;
+public function setNumber(string $number): AccountInterface;
+public function setRegisterNumber(string $registerNumber): AccountInterface;
+public function setPlaceOfJurisdiction(string $placeOfJurisdiction): AccountInterface;
+public function addNote(Note $note): AccountInterface;
+
+// After
+public function setExternalId(?string $externalId): AccountInterface;
+public function setNumber(?string $number): AccountInterface;
+public function setRegisterNumber(?string $registerNumber): AccountInterface;
+public function setPlaceOfJurisdiction(?string $placeOfJurisdiction): AccountInterface;
+public function setNote(?string $note): AccountInterface;
+```
+
 ### Sitemap Provider changed
 
 As a sitemap is always domain specific and a domain can have multiple webspaces and portal

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -616,13 +616,8 @@ class AccountController extends AbstractRestController implements ClassResourceI
         $account->setCorporation($request->get('corporation'));
         $accountManager = $this->accountManager;
 
-        if (null !== $request->get('uid')) {
-            $account->setUid($request->get('uid'));
-        }
-
-        if (null !== $request->get('note')) {
-            $account->setNote($request->get('note'));
-        }
+        $account->setUid($request->get('uid'));
+        $account->setNote($request->get('note'));
 
         $logo = $request->get('logo', []);
         if ($logo && array_key_exists('id', $logo)) {

--- a/src/Sulu/Bundle/ContactBundle/Entity/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Account.php
@@ -342,7 +342,7 @@ class Account implements AccountInterface
         return $this->emails;
     }
 
-    public function setNote(?string $note): self
+    public function setNote(?string $note): AccountInterface
     {
         $this->note = $note;
 
@@ -651,7 +651,7 @@ class Account implements AccountInterface
         return $this->name;
     }
 
-    public function setExternalId(string $externalId): AccountInterface
+    public function setExternalId(?string $externalId): AccountInterface
     {
         $this->externalId = $externalId;
 
@@ -663,7 +663,7 @@ class Account implements AccountInterface
         return $this->externalId;
     }
 
-    public function setNumber(string $number): AccountInterface
+    public function setNumber(?string $number): AccountInterface
     {
         $this->number = $number;
 
@@ -687,7 +687,7 @@ class Account implements AccountInterface
         return $this->corporation;
     }
 
-    public function setUid(string $uid): AccountInterface
+    public function setUid(?string $uid): AccountInterface
     {
         $this->uid = $uid;
 
@@ -699,7 +699,7 @@ class Account implements AccountInterface
         return $this->uid;
     }
 
-    public function setRegisterNumber(string $registerNumber): AccountInterface
+    public function setRegisterNumber(?string $registerNumber): AccountInterface
     {
         $this->registerNumber = $registerNumber;
 
@@ -711,7 +711,7 @@ class Account implements AccountInterface
         return $this->registerNumber;
     }
 
-    public function setPlaceOfJurisdiction(string $placeOfJurisdiction): AccountInterface
+    public function setPlaceOfJurisdiction(?string $placeOfJurisdiction): AccountInterface
     {
         $this->placeOfJurisdiction = $placeOfJurisdiction;
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/AccountInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AccountInterface.php
@@ -26,11 +26,11 @@ interface AccountInterface extends AuditableInterface
 
     public function getName(): string;
 
-    public function setExternalId(string $externalId): self;
+    public function setExternalId(?string $externalId): self;
 
     public function getExternalId(): ?string;
 
-    public function setNumber(string $number): self;
+    public function setNumber(?string $number): self;
 
     public function getNumber(): ?string;
 
@@ -38,15 +38,15 @@ interface AccountInterface extends AuditableInterface
 
     public function getCorporation(): ?string;
 
-    public function setUid(string $uid): self;
+    public function setUid(?string $uid): self;
 
     public function getUid(): ?string;
 
-    public function setRegisterNumber(string $registerNumber): self;
+    public function setRegisterNumber(?string $registerNumber): self;
 
     public function getRegisterNumber(): ?string;
 
-    public function setPlaceOfJurisdiction(string $placeOfJurisdiction): self;
+    public function setPlaceOfJurisdiction(?string $placeOfJurisdiction): self;
 
     public function getPlaceOfJurisdiction(): ?string;
 
@@ -95,6 +95,10 @@ interface AccountInterface extends AuditableInterface
     public function addUrl(Url $url): self;
 
     public function removeUrl(Url $url): self;
+
+    public function getNote(): ?string;
+
+    public function setNote(?string $note): self;
 
     /**
      * @return Collection|Url[]

--- a/src/Sulu/Bundle/ContactBundle/Entity/AccountInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AccountInterface.php
@@ -123,15 +123,6 @@ interface AccountInterface extends AuditableInterface
      */
     public function getEmails(): Collection;
 
-    public function addNote(Note $note): self;
-
-    public function removeNote(Note $note): self;
-
-    /**
-     * @return Collection|Note[]
-     */
-    public function getNotes(): Collection;
-
     /**
      * @return Collection|AccountInterface[]
      */

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1075,6 +1075,8 @@ class AccountControllerTest extends SuluTestCase
         );
         $note = $this->createNote('Note');
         $account = $this->createAccount('Company', null, $url, $address, $email, $phone, $fax, $note);
+        $account->setUid('Test Uuid');
+        $account->setNote('Test Note');
 
         $this->em->flush();
 
@@ -1099,6 +1101,8 @@ class AccountControllerTest extends SuluTestCase
         $response = json_decode($client->getResponse()->getContent());
 
         $this->assertEquals('ExampleCompany', $response->name);
+        $this->assertEquals(null, $response->uid);
+        $this->assertEquals(null, $response->note);
         $this->assertEquals(0, count($response->contactDetails->websites));
         $this->assertEquals(0, count($response->contactDetails->emails));
         $this->assertEquals(0, count($response->contactDetails->phones));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/3942
| License | MIT
| Documentation PR | -

#### What's in this PR?

Allow set null of some fields on the AccounterInterface and remove the deprecated notes function from the interface.

#### Why?

With the AccountInterface refractoring of https://github.com/sulu/sulu/pull/3942 its not longer possible to unset some fields on the account. Sadly this is a bc break, but think we need accept this bc break to fix this bug.

#### BC Breaks/Deprecations

AccountInterface changed.

#### To Do

- [x] Add breaking changes to UPGRADE.md
