### PR TITLE
Fix exception message in ViewNotFoundException

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Exception/ViewNotFoundException.php
+++ b/src/Sulu/Bundle/AdminBundle/Exception/ViewNotFoundException.php
@@ -12,24 +12,24 @@
 namespace Sulu\Bundle\AdminBundle\Exception;
 
 /**
- * An instance of this exception signals that no route with given name was found.
+ * An instance of this exception signals that no view with given name was found.
  */
 class ViewNotFoundException extends \Exception
 {
     /**
      * @var string
      */
-    private $route;
+    private $view;
 
-    public function __construct(string $route)
+    public function __construct(string $view)
     {
-        parent::__construct(sprintf('The route with the name "%s" does not exist.', $route));
+        parent::__construct(sprintf('The view with the name "%s" does not exist.', $view));
 
-        $this->route = $route;
+        $this->view = $view;
     }
 
-    public function getRoute(): string
+    public function getView(): string
     {
-        return $this->route;
+        return $this->view;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix exception message in ViewNotFoundException.

#### Why?

Route where renamed to View and so the exception message does not make any sense now.
