### PR TITLE
Fix no host in parse_url of PreviewRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG for Sulu
 ==================
 
+* release/1.6
+    * BUGFIX      #4800  [PreviewBundle]           Fix no host in parse_url of PreviewRenderer
+    * BUGFIX      #4672  [RouteBundle]             Add redirect to locale-prefix for partial match requests
+    * BUGFIX      #4669  [Component]               Fix reference-options doctrine extension
+
 * 1.6.28 (2019-08-08)
     * BUGFIX      #4644  [CustomUrlBundle]         Fix loading custom url list if creator has been deleted
     * BUGFIX      #4627  [WebsiteBundle]           Fix Routing when no prefix is Provided.

--- a/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/SearchManagerTest.php
+++ b/src/Sulu/Bundle/ContentBundle/Tests/Functional/Search/SearchManagerTest.php
@@ -11,6 +11,9 @@
 
 namespace Sulu\Bundle\ContentBundle\Tests\Functional\Search;
 
+use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\QueryHit;
+
 class SearchManagerTest extends BaseTestCase
 {
     /**
@@ -40,14 +43,13 @@ class SearchManagerTest extends BaseTestCase
         $result = $this->getSearchManager()->createSearch('Document')->locale('de')->index('page_sulu_io')->execute();
         $this->assertCount(6, $result);
 
-        $firstHit = reset($result);
+        $result->rewind();
+        /** @var QueryHit $firstHit */
+        $firstHit = $result->current();
+        $this->assertInstanceOf(QueryHit::class, $firstHit);
+        /** @var Document $document */
         $document = $firstHit->getDocument();
+        $this->assertInstanceOf(Document::class, $document);
         $this->assertEquals('page_sulu_io', $document->getIndex());
-
-        if (!$this->getContainer()->get('massive_search.adapter') instanceof \Massive\Bundle\SearchBundle\Search\Adapter\ZendLuceneAdapter) {
-            $this->markTestSkipped('Skipping zend lucene specific test');
-
-            return;
-        }
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -258,14 +258,24 @@ class PreviewRenderer implements PreviewRendererInterface
 
         $portalUrl = $scheme . '://' . $this->replacer->replaceHost($portalInformation->getUrl(), $host);
         $portalUrlParts = parse_url($portalUrl);
-        $prefixPath = isset($portalUrlParts['path']) ? $portalUrlParts['path'] : '';
 
-        $httpHost = $portalUrlParts['host'];
-        if (!in_array($port, [80, 443])) {
-            $httpHost .= ':' . $port;
+        $serverName = null;
+        $httpHost = null;
+        $prefixPath = '';
+
+        if (isset($portalUrlParts['path'])) {
+            $prefixPath = $portalUrlParts['path'];
         }
 
-        $server['SERVER_NAME'] = $portalUrlParts['host'];
+        if (isset($portalUrlParts['host'])) {
+            $serverName = $portalUrlParts['host'];
+            $httpHost = $serverName;
+            if (!in_array($port, [80, 443])) {
+                $httpHost .= ':' . $port;
+            }
+        }
+
+        $server['SERVER_NAME'] = $serverName;
         $server['SERVER_PORT'] = $port;
         $server['HTTP_HOST'] = $httpHost;
         $server['REQUEST_URI'] = $prefixPath . '/_sulu_preview';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix no host in parse_url of PreviewRenderer.

#### Why?

Accessing a bool as array will throw an error on php 7.4. See PreviewBundle in: https://travis-ci.org/sulu/sulu/jobs/595280938

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
