### PR TITLE
Show history URL for custom urls

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
@@ -96,7 +96,7 @@ class ResourceLocatorHistory extends React.Component<Props> {
                                 <Table.Body>
                                     {historyRoutes.map((historyRoute) => (
                                         <Table.Row id={historyRoute.id} key={historyRoute.id}>
-                                            <Table.Cell>{historyRoute.path}</Table.Cell>
+                                            <Table.Cell>{historyRoute.resourcelocator}</Table.Cell>
                                             <Table.Cell>{(new Date(historyRoute.created)).toLocaleString()}</Table.Cell>
                                         </Table.Row>
                                     ))}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
@@ -51,12 +51,12 @@ test('Show history routes in overlay', () => {
     resourceListStore.data = [
         {
             id: 3,
-            path: 'sulu.io/test',
+            resourcelocator: 'sulu.io/test',
             created: '2019-04-10T13:06:16',
         },
         {
             id: 6,
-            path: 'sulu.io/testing',
+            resourcelocator: 'sulu.io/testing',
             created: '2019-04-10T16:01:12',
         },
     ];
@@ -120,7 +120,7 @@ test('Do not delete if confirmation dialog is cancelled', () => {
     resourceListStore.data = [
         {
             id: 3,
-            path: 'sulu.io/test',
+            resourcelocator: 'sulu.io/test',
             created: '2019-04-10T13:06:16',
         },
     ];
@@ -155,7 +155,7 @@ test('Delete if confirmation dialog is confirmed', () => {
     resourceListStore.data = [
         {
             id: 3,
-            path: 'sulu.io/test',
+            resourcelocator: 'sulu.io/test',
             created: '2019-04-10T13:06:16',
         },
     ];

--- a/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
@@ -100,7 +100,7 @@ class ResourceLocatorRepository implements ResourceLocatorRepositoryInterface
 
             $result[] = [
                 'id' => $url->getId(),
-                'path' => $url->getResourceLocator(),
+                'resourcelocator' => $url->getResourceLocator(),
                 'created' => $url->getCreated(),
                 '_links' => [
                     'delete' => $this->getBasePath(null, 0) . $deleteParameter,

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -1074,8 +1074,8 @@ class PageControllerTest extends SuluTestCase
         );
         $response = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->assertEquals('/a2', $response['_embedded']['page_resourcelocators'][0]['path']);
-        $this->assertEquals('/a1', $response['_embedded']['page_resourcelocators'][1]['path']);
+        $this->assertEquals('/a2', $response['_embedded']['page_resourcelocators'][0]['resourcelocator']);
+        $this->assertEquals('/a1', $response['_embedded']['page_resourcelocators'][1]['resourcelocator']);
     }
 
     public function testTreeGetTillId()

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -215,7 +215,7 @@ class PageResourcelocatorControllerTest extends SuluTestCase
 
         $this->assertEquals(1, count($result['_embedded']['page_resourcelocators']));
         $this->assertEquals(1, $result['total']);
-        $this->assertEquals('/news', $result['_embedded']['page_resourcelocators'][0]['path']);
+        $this->assertEquals('/news', $result['_embedded']['page_resourcelocators'][0]['resourcelocator']);
     }
 
     public function testDelete()

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Repository/ResourceLocatorRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Repository/ResourceLocatorRepositoryTest.php
@@ -61,7 +61,8 @@ class ResourceLocatorRepositoryTest extends TestCase
         $this->resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
         $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
 
-        $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey(Argument::any())->willReturn($this->resourceLocatorStrategy->reveal());
+        $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey(Argument::any())
+             ->willReturn($this->resourceLocatorStrategy->reveal());
 
         $this->repository = new ResourceLocatorRepository(
             $this->resourceLocatorStrategyPool->reveal(),
@@ -87,11 +88,12 @@ class ResourceLocatorRepositoryTest extends TestCase
         ]);
         $this->structureManager->getStructure($template)->willReturn($structure->reveal());
 
-        $path = '/parent/news-football';
-        $this->resourceLocatorStrategy->generate('news-football', $parentUuid, $webspace, $locale, null)->willReturn($path);
+        $resourcelocator = '/parent/news-football';
+        $this->resourceLocatorStrategy->generate('news-football', $parentUuid, $webspace, $locale, null)
+             ->willReturn($resourcelocator);
 
         $result = $this->repository->generate($parts, $parentUuid, $webspace, $locale, $template);
-        $this->assertEquals($result['resourceLocator'], $path);
+        $this->assertEquals($result['resourceLocator'], $resourcelocator);
     }
 
     public function testGenerate()
@@ -111,11 +113,12 @@ class ResourceLocatorRepositoryTest extends TestCase
         ]);
         $this->structureManager->getStructure($template)->willReturn($structure->reveal());
 
-        $path = '/news-football';
-        $this->resourceLocatorStrategy->generate('news-football', null, $webspace, $locale, null)->willReturn($path);
+        $resourcelocator = '/news-football';
+        $this->resourceLocatorStrategy->generate('news-football', null, $webspace, $locale, null)
+             ->willReturn($resourcelocator);
 
         $result = $this->repository->generate($parts, null, $webspace, $locale, $template);
-        $this->assertEquals($result['resourceLocator'], $path);
+        $this->assertEquals($result['resourceLocator'], $resourcelocator);
     }
 
     public function testGetHistory()
@@ -133,28 +136,28 @@ class ResourceLocatorRepositoryTest extends TestCase
         $result = $this->repository->getHistory($uuid, $webspace, $locale);
         $this->assertEquals(3, $result['total']);
         $this->assertEquals(3, count($result['_embedded']['page_resourcelocators']));
-        $this->assertEquals('/test1', $result['_embedded']['page_resourcelocators'][0]['path']);
-        $this->assertEquals('/test3', $result['_embedded']['page_resourcelocators'][2]['path']);
+        $this->assertEquals('/test1', $result['_embedded']['page_resourcelocators'][0]['resourcelocator']);
+        $this->assertEquals('/test3', $result['_embedded']['page_resourcelocators'][2]['resourcelocator']);
     }
 
     public function testDelete()
     {
-        $path = '/test';
+        $resourcelocator = '/test';
         $webspace = 'sulu_io';
         $locale = 'en';
 
-        $this->resourceLocatorStrategy->deleteById($path, $locale, null)->shouldBeCalled();
-        $this->repository->delete($path, $webspace, $locale);
+        $this->resourceLocatorStrategy->deleteById($resourcelocator, $locale, null)->shouldBeCalled();
+        $this->repository->delete($resourcelocator, $webspace, $locale);
     }
 
     public function testDeleteWithSegment()
     {
-        $path = '/test';
+        $resourcelocator = '/test';
         $webspace = 'sulu_io';
         $locale = 'en';
         $segment = 'live';
 
-        $this->resourceLocatorStrategy->deleteById($path, $locale, $segment)->shouldBeCalled();
-        $this->repository->delete($path, $webspace, $locale, $segment);
+        $this->resourceLocatorStrategy->deleteById($resourcelocator, $locale, $segment)->shouldBeCalled();
+        $this->repository->delete($resourcelocator, $webspace, $locale, $segment);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the history button of the custom urls.

#### Why?

Because the history url was always shown as empty.
#### BC Breaks/Deprecations

Yes, and not totally sure if we should do them, or already start having multiple paths in our code. BC breaks are in the `ResourceLocatorHistory` JS component (using the `resourcelocator` field instead of `path`), and in the `PageResourcelocatorController` (returns a `resourcelocator` field instead of `path`).

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
- [ ] Clarify BC breaks