### PR TITLE
Fix SingleAccountSelection ContentType

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
@@ -11,14 +11,15 @@
 
 namespace Sulu\Bundle\ContactBundle\Content\Types;
 
+use PHPCR\NodeInterface;
 use Sulu\Bundle\ContactBundle\Api\Account;
 use Sulu\Bundle\ContactBundle\Contact\AccountManager;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
-use Sulu\Component\Content\SimpleContentType;
 
-class SingleAccountSelection extends SimpleContentType implements PreResolvableContentTypeInterface
+class SingleAccountSelection extends ComplexContentType implements PreResolvableContentTypeInterface
 {
     /**
      * @var AccountManager
@@ -36,19 +37,59 @@ class SingleAccountSelection extends SimpleContentType implements PreResolvableC
     ) {
         $this->accountManager = $accountManager;
         $this->accountReferenceStore = $accountReferenceStore;
+    }
 
-        parent::__construct('SingleAccount');
+    public function read(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
+    {
+        $account = null;
+        if ($node->hasProperty($property->getName())) {
+            $account = $this->accountManager->getById(
+                $node->getPropertyValue($property->getName()),
+                $property->getStructure()->getLanguageCode()
+            );
+        }
+
+        $property->setValue(
+            [
+                'id' => $account->getId(),
+                'name' => $account->getName(),
+            ]
+        );
+    }
+
+    public function write(
+        NodeInterface $node,
+        PropertyInterface $property,
+        $userId,
+        $webspaceKey,
+        $languageCode,
+        $segmentKey
+    ) {
+        $account = $property->getValue();
+        if (null != $account) {
+            $node->setProperty($property->getName(), $account['id']);
+        } else {
+            $this->remove($node, $property, $webspaceKey, $languageCode, $segmentKey);
+        }
+    }
+
+    public function remove(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
+    {
+        // if exist remove property of node
+        if ($node->hasProperty($property->getName())) {
+            $node->getProperty($property->getName())->remove();
+        }
     }
 
     public function getContentData(PropertyInterface $property): ?Account
     {
-        $id = $property->getValue();
+        $account = $property->getValue();
 
-        if (!$id) {
+        if (!isset($account['id'])) {
             return null;
         }
 
-        return $this->accountManager->getById($id, $property->getStructure()->getLanguageCode());
+        return $this->accountManager->getById($account['id'], $property->getStructure()->getLanguageCode());
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
+use Sulu\Component\Rest\Exception\EntityNotFoundException;
 
 class SingleAccountSelection extends ComplexContentType implements PreResolvableContentTypeInterface
 {
@@ -41,20 +42,24 @@ class SingleAccountSelection extends ComplexContentType implements PreResolvable
 
     public function read(NodeInterface $node, PropertyInterface $property, $webspaceKey, $languageCode, $segmentKey)
     {
-        $account = null;
+        $value = null;
         if ($node->hasProperty($property->getName())) {
-            $account = $this->accountManager->getById(
-                $node->getPropertyValue($property->getName()),
-                $property->getStructure()->getLanguageCode()
-            );
+            try {
+                $account = $this->accountManager->getById(
+                    $node->getPropertyValue($property->getName()),
+                    $property->getStructure()->getLanguageCode()
+                );
+
+                $value = [
+                    'id' => $account->getId(),
+                    'name' => $account->getName(),
+                ];
+            } catch (EntityNotFoundException $e) {
+                $value = null;
+            }
         }
 
-        $property->setValue(
-            [
-                'id' => $account->getId(),
-                'name' => $account->getName(),
-            ]
-        );
+        $property->setValue($value);
     }
 
     public function write(

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleAccountSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleAccountSelectionTest.php
@@ -74,15 +74,34 @@ class SingleAccountSelectionTest extends TestCase
         $this->node->hasProperty('account')->willReturn(true);
         $this->node->getPropertyValue('account')->willReturn(1);
 
+        $structure = $this->prophesize(StructureInterface::class);
+        $structure->getLanguageCode()->willReturn('de');
+
+        $property = new Property('account', [], 'single_account_selection');
+        $property->setValue(['id' => 1]);
+        $property->setStructure($structure);
+
+        $this->account->getId()->willReturn(1);
+        $this->account->getName()->willReturn('Sulu');
+
+        $this->accountManager
+             ->getById(1, $property->getStructure()->getLanguageCode())
+             ->willReturn($this->account->reveal())->shouldBeCalled();
+
+        $this->singleAccountSelection->read(
+            $this->node->reveal(),
+            $property,
+            'sulu',
+            'de',
+            ''
+        );
+
         $this->assertEquals(
-            1,
-            $this->singleAccountSelection->read(
-                $this->node->reveal(),
-                new Property('account', [], 'single_account_selection'),
-                'sulu',
-                'de',
-                ''
-            )
+            [
+                'id' => 1,
+                'name' => 'Sulu',
+            ],
+            $property->getValue()
         );
     }
 
@@ -90,7 +109,7 @@ class SingleAccountSelectionTest extends TestCase
     {
         $this->node->setProperty('account', 1)->shouldBeCalled();
         $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(1);
+        $property->setValue(['id' => 1]);
 
         $this->singleAccountSelection->write(
             $this->node->reveal(),
@@ -160,10 +179,12 @@ class SingleAccountSelectionTest extends TestCase
         $structure->getLanguageCode()->willReturn('de');
 
         $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(1);
+        $property->setValue(['id' => 1]);
         $property->setStructure($structure);
 
-        $this->accountManager->getById(1, $property->getStructure()->getLanguageCode())->willReturn($this->account->reveal())->shouldBeCalled();
+        $this->accountManager
+             ->getById(1, $property->getStructure()->getLanguageCode())
+             ->willReturn($this->account->reveal())->shouldBeCalled();
 
         $this->assertEquals($this->account->reveal(), $this->singleAccountSelection->getContentData($property));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR fixes the type mismatch between the `single_account_selection` field type and the ´SingleAccountSelection` content type.

#### Why?

Because otherwise the `single_account_selection` field type throws an error when used on a page.