### PR TITLE
Add possibility to restrict SingleMediaSelection by type

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/MediaSelection.js
@@ -68,7 +68,7 @@ class MediaSelection extends React.Component<FieldTypeProps<Value>> {
         const displayOptionValues = convertDisplayOptionsFromParams(displayOptions);
 
         if (mediaTypes !== undefined && mediaTypes !== null && typeof mediaTypes !== 'string') {
-            throw new Error('The "mediaTypes" option has to be a string if set.');
+            throw new Error('The "types" option has to be a string if set.');
         }
 
         const mediaTypeValues = convertMediaTypesFromParams(mediaTypes);

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/fields/SingleMediaSelection.js
@@ -4,7 +4,11 @@ import {observer} from 'mobx-react';
 import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 import userStore from 'sulu-admin-bundle/stores/userStore';
 import {observable} from 'mobx';
-import {convertDisplayOptionsFromParams, validateDisplayOption} from '../../../utils/MediaSelectionHelper';
+import {
+    convertDisplayOptionsFromParams,
+    convertMediaTypesFromParams,
+    validateDisplayOption,
+} from '../../../utils/MediaSelectionHelper';
 import SingleMediaSelectionComponent from '../../SingleMediaSelection';
 import type {Value} from '../../SingleMediaSelection';
 
@@ -50,6 +54,9 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
             displayOptions: {
                 value: displayOptions,
             } = {},
+            types: {
+                value: mediaTypes,
+            } = {},
         } = schemaOptions;
         const locale = formInspector.locale ? formInspector.locale : observable.box(userStore.contentLocale);
 
@@ -59,12 +66,19 @@ class SingleMediaSelection extends React.Component<FieldTypeProps<Value>> {
 
         const displayOptionValues = convertDisplayOptionsFromParams(displayOptions);
 
+        if (mediaTypes !== undefined && mediaTypes !== null && typeof mediaTypes !== 'string') {
+            throw new Error('The "types" option has to be a string if set.');
+        }
+
+        const mediaTypeValues = convertMediaTypesFromParams(mediaTypes);
+
         return (
             <SingleMediaSelectionComponent
                 disabled={!!disabled}
                 displayOptions={displayOptionValues}
                 locale={locale}
                 onChange={this.handleChange}
+                types={mediaTypeValues}
                 valid={!error}
                 value={value ? value : undefined}
             />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js
@@ -97,6 +97,31 @@ test('Set default display option if no value is passed', () => {
     expect(changeSpy).toBeCalledWith({displayOption: 'left', ids: []});
 });
 
+test('Set types on MultiMediaSelection', () => {
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        types: {value: 'image,video'},
+    };
+
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {}),
+            'test'
+        )
+    );
+
+    const mediaSelection = shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(mediaSelection.find(MultiMediaSelection).props().types).toEqual(['image', 'video']);
+});
+
 test('Do not set default display option if value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
@@ -201,4 +226,21 @@ test('Should throw an error if displayOptions schemaOption is given but contains
             schemaOptions={{displayOptions: {value: [{name: 'test', value: true}]}}}
         />
     )).toThrow(/"test"/);
+});
+
+test('Should throw an error if types schemaOption is given but not an array', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    expect(() => shallow(
+        <MediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={{types: {value: true}}}
+        />
+    )).toThrow(/"types"/);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js
@@ -73,6 +73,31 @@ test('Pass content-locale of user to SingleMediaSelection if locale is not prese
     expect(mediaSelection.find(SingleMediaSelectionComponent).props().locale.get()).toEqual('userContentLocale');
 });
 
+test('Set types on SingleMediaSelectionComponent', () => {
+    const changeSpy = jest.fn();
+    const schemaOptions = {
+        types: {value: 'image,video'},
+    };
+
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    const singleMediaSelection = shallow(
+        <SingleMediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    expect(singleMediaSelection.find(SingleMediaSelectionComponent).props().types).toEqual(['image', 'video']);
+});
+
 test('Set default display option if no value is passed', () => {
     const changeSpy = jest.fn();
     const schemaOptions = {
@@ -186,4 +211,21 @@ test('Should throw an error if displayOptions schemaOption is given but not an a
             schemaOptions={{displayOptions: {value: [{name: 'test', value: true}]}}}
         />
     )).toThrow(/"displayOptions"/);
+});
+
+test('Should throw an error if types schemaOption is given but not an array', () => {
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            new ResourceStore('test', undefined, {locale: observable.box('en')}),
+            'test'
+        )
+    );
+
+    expect(() => shallow(
+        <SingleMediaSelection
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={{types: {value: true}}}
+        />
+    )).toThrow(/"types"/);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/SingleMediaSelection.js
@@ -18,6 +18,7 @@ type Props = {|
     displayOptions: Array<DisplayOption>,
     locale: IObservableValue<string>,
     onChange: (selectedId: Value, media: ?Media) => void,
+    types: Array<string>,
     valid: boolean,
     value: Value,
 |}
@@ -30,6 +31,7 @@ class SingleMediaSelection extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         displayOptions: [],
+        types: [],
         valid: true,
         value: {displayOption: undefined, id: undefined},
     };
@@ -102,7 +104,7 @@ class SingleMediaSelection extends React.Component<Props> {
     };
 
     render() {
-        const {disabled, displayOptions, locale, valid, value} = this.props;
+        const {disabled, displayOptions, locale, types, valid, value} = this.props;
         const {loading, item: media} = this.singleMediaSelectionStore;
 
         const rightButton = displayOptions.length > 0
@@ -156,6 +158,7 @@ class SingleMediaSelection extends React.Component<Props> {
                     onClose={this.handleOverlayClose}
                     onConfirm={this.handleOverlayConfirm}
                     open={this.overlayOpen}
+                    types={types}
                 />
             </Fragment>
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js
@@ -99,6 +99,19 @@ test('Component should render with selected media without thumbnails with MimeTy
     expect(singleMediaSelection.render()).toMatchSnapshot();
 });
 
+test('Component should pass types to SingleMediaSelectionOverlay', () => {
+    const singleMediaSelection = shallow(
+        <SingleMediaSelection
+            locale={observable.box('en')}
+            onChange={jest.fn()}
+            types={['image', 'video']}
+            value={undefined}
+        />
+    );
+
+    expect(singleMediaSelection.find(SingleMediaSelectionOverlay).prop('types')).toEqual(['image', 'video']);
+});
+
 test('Click on media-button should open an overlay', () => {
     const singleMediaSelection = mount(
         <SingleMediaSelection locale={observable.box('en')} onChange={jest.fn()} value={undefined} />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/SingleMediaSelectionOverlay.js
@@ -12,12 +12,14 @@ type Props = {|
     onClose: () => void,
     onConfirm: (selectedMedia: Object) => void,
     open: boolean,
+    types: Array<string>,
 |};
 
 @observer
 class SingleMediaSelectionOverlay extends React.Component<Props> {
     static defaultProps = {
         excludedIds: [],
+        types: [],
     };
 
     collectionId: IObservableValue<?string | number> = observable.box();
@@ -35,7 +37,8 @@ class SingleMediaSelectionOverlay extends React.Component<Props> {
         this.mediaListStore = MediaSelectionOverlay.createMediaListStore(
             this.collectionId,
             excludedIds,
-            this.props.locale
+            this.props.locale,
+            this.props.types
         );
         this.collectionListStore = MediaSelectionOverlay.createCollectionListStore(
             this.collectionId,

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js
@@ -38,7 +38,8 @@ test('Should create list-stores with correct locale and excluded-ids', () => {
     expect(MediaSelectionOverlay.createMediaListStore).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        locale
+        locale,
+        []
     );
     expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual([66, 55]);
     expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
@@ -58,7 +59,30 @@ test('Should create list-stores without excluded-ids', () => {
     expect(MediaSelectionOverlay.createMediaListStore).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        locale
+        locale,
+        []
+    );
+    expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual(undefined);
+    expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);
+});
+
+test('Should create list-stores with types', () => {
+    const locale = mockObservable.box('en');
+    shallow(
+        <SingleMediaSelectionOverlay
+            locale={locale}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+            types={['image', 'video']}
+        />
+    ).render();
+
+    expect(MediaSelectionOverlay.createMediaListStore).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        locale,
+        ['image', 'video']
     );
     expect(MediaSelectionOverlay.createMediaListStore.mock.calls[0][1].get()).toEqual(undefined);
     expect(MediaSelectionOverlay.createCollectionListStore).toHaveBeenCalledWith(expect.anything(), locale);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to restrict the selectable media types in a `SingleMediaSelection`.

#### Why?

Because this was already possible in the old UI.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
