### PR TITLE
Show error when deleting parent account

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade
 
-## unreleased
+## dev-release/2.0
 
 ### Sitemap Provider changed
 
@@ -58,6 +58,39 @@ sulu_website:
 # after
 parameters:
     router.request_context.host: 'localhost'
+```
+
+### DeleteToolbarAction with conflict
+
+The `DeleteToolbarAction` asks for confirmation if e.g. a page that is being tried to deleted is linked on other pages.
+The delete action of the controller now also has to return the ID that was trying to be deleted, in order for the
+application to know what was tried to be deleted.
+
+```
+# Before
+{
+    "items": [
+        {
+            "name": "Test1"
+        },
+        {
+            "name": "Test2"
+        }
+    ]
+}
+
+# After
+{
+    "id": "page-uuid",
+    "items": [
+        {
+            "name": "Test1"
+        },
+        {
+            "name": "Test2"
+        }
+    ]
+}
 ```
 
 ## 2.0.0

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/Dialog.js
@@ -11,12 +11,12 @@ import Button from '../Button';
 import dialogStyles from './dialog.scss';
 
 type Props = {|
-    cancelText: string,
+    cancelText?: string,
     children: Node,
     confirmDisabled: boolean,
     confirmLoading: boolean,
     confirmText: string,
-    onCancel: () => void,
+    onCancel?: () => void,
     onConfirm: () => void,
     open: boolean,
     size?: 'small' | 'large',
@@ -41,10 +41,6 @@ class Dialog extends React.Component<Props> {
         this.open = open;
         this.visible = open;
     }
-
-    close = () => {
-        this.props.onCancel();
-    };
 
     @action componentDidUpdate(prevProps: Props) {
         const {open} = this.props;
@@ -114,9 +110,6 @@ class Dialog extends React.Component<Props> {
                                         {children}
                                     </article>
                                     <footer>
-                                        <Button onClick={onCancel} skin="secondary">
-                                            {cancelText}
-                                        </Button>
                                         <Button
                                             disabled={confirmDisabled}
                                             loading={confirmLoading}
@@ -125,6 +118,11 @@ class Dialog extends React.Component<Props> {
                                         >
                                             {confirmText}
                                         </Button>
+                                        {onCancel && cancelText &&
+                                            <Button onClick={onCancel} skin="secondary">
+                                                {cancelText}
+                                            </Button>
+                                        }
                                     </footer>
                                 </section>
                             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/README.md
@@ -28,3 +28,27 @@ const onCancel = () => {
     </Dialog>
 </div>
 ```
+
+The `onCancel` and `cancelText` properties are optional, so that you can also use this component to show a message that
+just need acknowleding.
+
+```
+initialState = {open: false};
+
+const onConfirm = () => {
+    /* do confirm things */
+    setState({open: false});
+};
+
+<div>
+    <button onClick={() => setState({open: true})}>Open dialog</button>
+    <Dialog
+        title="Question?"
+        onConfirm={onConfirm}
+        confirmText="Yes"
+        open={state.open}>
+        You've got a question in here.
+        Yes or no?
+    </Dialog>
+</div>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/dialog.scss
@@ -86,5 +86,6 @@ $transitionDuration: 300ms;
         padding: 30px;
         display: flex;
         justify-content: space-between;
+        flex-direction: row-reverse;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/Dialog.test.js
@@ -32,6 +32,25 @@ test('The component should render in body when open', () => {
     expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
 });
 
+test('The component should render in body without cancel button', () => {
+    const body = document.body;
+    const onConfirm = jest.fn();
+    const view = mount(
+        <Dialog
+            confirmText="Confirm"
+            onConfirm={onConfirm}
+            open={true}
+            title="My dialog title"
+        >
+            <div>My dialog content</div>
+        </Dialog>
+    );
+
+    expect(view.find('Backdrop')).toHaveLength(1);
+    expect(view.find('Backdrop').prop('open')).toEqual(true);
+    expect(pretty(body ? body.innerHTML : '')).toMatchSnapshot();
+});
+
 test('The component should render in body with disabled confirm button', () => {
     const body = document.body;
     const onCancel = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Dialog/tests/__snapshots__/Dialog.test.js.snap
@@ -14,7 +14,7 @@ exports[`The component should render in body when open 1`] = `
         <article>
           <div>My dialog content</div>
         </article>
-        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button></footer>
+        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button></footer>
       </section>
     </div>
   </div>
@@ -33,7 +33,7 @@ exports[`The component should render in body with a large class 1`] = `
         <article>
           <div>My dialog content</div>
         </article>
-        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button></footer>
+        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button></footer>
       </section>
     </div>
   </div>
@@ -52,7 +52,7 @@ exports[`The component should render in body with disabled confirm button 1`] = 
         <article>
           <div>My dialog content</div>
         </article>
-        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button><button class=\\"button primary\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button></footer>
+        <footer><button class=\\"button primary\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button></footer>
       </section>
     </div>
   </div>
@@ -71,13 +71,32 @@ exports[`The component should render in body with loader instead of confirm butt
         <article>
           <div>My dialog content</div>
         </article>
-        <footer><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button><button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span>
+        <footer><button class=\\"button primary loading\\" disabled=\\"\\" type=\\"button\\"><span class=\\"text\\">Confirm</span>
             <div class=\\"loader\\">
               <div class=\\"spinner\\" style=\\"width: 25px; height: 25px;\\">
                 <div class=\\"doubleBounce1\\"></div>
                 <div class=\\"doubleBounce2\\"></div>
               </div>
-            </div></button></footer>
+            </div></button><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">Cancel</span></button></footer>
+      </section>
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`The component should render in body without cancel button 1`] = `
+"<div>
+  <div class=\\"backdrop visible fixed\\" role=\\"button\\"></div>
+</div>
+<div>
+  <div class=\\"dialogContainer open\\">
+    <div class=\\"dialog\\">
+      <section class=\\"content\\">
+        <header>My dialog title</header>
+        <article>
+          <div>My dialog content</div>
+        </article>
+        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">Confirm</span></button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js
@@ -5,7 +5,7 @@ import pretty from 'pretty';
 import GhostDialog from '../GhostDialog';
 
 jest.mock('../../../utils/Translator', () => ({
-    translate: jest.fn(),
+    translate: jest.fn((key) => key),
 }));
 
 afterEach(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -8,10 +8,10 @@ exports[`Should render a Dialog 1`] = `
   <div class=\\"dialogContainer open\\">
     <div class=\\"dialog\\">
       <section class=\\"content\\">
-        <header></header>
+        <header>sulu_admin.ghost_dialog_title</header>
         <article>
           <div class=\\"ghostDialog\\">
-            <p></p><label class=\\"label\\"></label>
+            <p>sulu_admin.ghost_dialog_description</p><label class=\\"label\\">sulu_admin.choose_language</label>
             <div class=\\"localeSelect\\">
               <div class=\\"select\\"><button class=\\"displayValue default\\" type=\\"button\\">
                   <div aria-label=\\"en\\" class=\\"croppedText\\" title=\\"en\\">
@@ -23,7 +23,7 @@ exports[`Should render a Dialog 1`] = `
             </div>
           </div>
         </article>
-        <footer><button class=\\"button secondary\\" type=\\"button\\"></button><button class=\\"button primary\\" type=\\"button\\"></button></footer>
+        <footer><button class=\\"button primary\\" type=\\"button\\"><span class=\\"text\\">sulu_admin.yes</span></button><button class=\\"button secondary\\" type=\\"button\\"><span class=\\"text\\">sulu_admin.no</span></button></footer>
       </section>
     </div>
   </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/List.js
@@ -599,7 +599,10 @@ class List extends React.Component<Props> {
                             cancelText={translate('sulu_admin.cancel')}
                             confirmLoading={store.deleting}
                             confirmText={translate('sulu_admin.ok')}
-                            onCancel={this.handleDeleteDialogCancelClick}
+                            onCancel={this.allowConflictDeletion
+                                ? this.handleDeleteDialogCancelClick
+                                : undefined
+                            }
                             onConfirm={this.allowConflictDeletion
                                 ? this.handleDeleteDialogConfirmClick
                                 : this.handleDeleteDialogCancelClick

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -430,11 +430,17 @@ export default class ListStore {
             );
         });
 
-        return Promise.all(deletePromises).then(action(() => {
-            this.selectionIds.forEach(this.remove);
-            this.clearSelection();
-            this.deletingSelection = false;
-        }));
+        return Promise.all(deletePromises)
+            .then(action(() => {
+                this.selectionIds.forEach(this.remove);
+                this.clearSelection();
+                this.deletingSelection = false;
+            }))
+            .catch(action((error) => {
+                this.deletingSelection = false;
+
+                return Promise.reject(error);
+            }));
     };
 
     remove = (identifier: string | number): void => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -922,6 +922,97 @@ test('ListStore should not delete linked item when onRequestItemDelete callback 
     });
 });
 
+test('ListStore should delete linked item when called with allowConflictDeletion value of true', (done) => {
+    const jsonDeletePromise = Promise.resolve({id: 5, items: [{name: 'Item 1'}, {name: 'Item 2'}]});
+    const deletePromise = Promise.reject({
+        json: jest.fn().mockReturnValue(jsonDeletePromise),
+        status: 409,
+    });
+
+    listAdapterRegistry.get.mockReturnValue(TableAdapter);
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    // $FlowFixMe
+    listStore.deleteSelection.mockReturnValueOnce(deletePromise);
+    listStore.selectionIds.push(5);
+    mockStructureStrategyData = [
+        {id: 1},
+        {id: 2},
+        {id: 3},
+    ];
+    const list = mount(<List adapters={['table']} store={listStore} />);
+
+    list.instance().requestSelectionDelete(true);
+    list.update();
+    expect(list.find('Dialog').at(0).prop('open')).toEqual(true);
+
+    list.find('Dialog').at(0).prop('onConfirm')();
+
+    setTimeout(() => {
+        list.update();
+        expect(list.find('Dialog').at(0).prop('open')).toEqual(false);
+        expect(list.find('Dialog').at(1).prop('open')).toEqual(false);
+        expect(list.find('Dialog').at(2).prop('open')).toEqual(true);
+
+        const deletePromise = Promise.resolve();
+        // $FlowFixMe
+        listStore.delete.mockReturnValueOnce(deletePromise);
+        list.find('Dialog').at(2).prop('onConfirm')();
+
+        setTimeout(() => {
+            expect(listStore.delete).toBeCalledWith(5, {force: true});
+            list.update();
+            expect(list.find('Dialog').at(0).prop('open')).toEqual(false);
+            expect(list.find('Dialog').at(1).prop('open')).toEqual(false);
+            expect(list.find('Dialog').at(2).prop('open')).toEqual(false);
+            done();
+        });
+    });
+});
+
+test('ListStore should not delete linked item when called with allowConflictDeletion value of false', (done) => {
+    const jsonDeletePromise = Promise.resolve({id: 5, items: [{name: 'Item 1'}, {name: 'Item 2'}]});
+    const deletePromise = Promise.reject({
+        json: jest.fn().mockReturnValue(jsonDeletePromise),
+        status: 409,
+    });
+
+    listAdapterRegistry.get.mockReturnValue(TableAdapter);
+    const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});
+    // $FlowFixMe
+    listStore.deleteSelection.mockReturnValueOnce(deletePromise);
+    listStore.selectionIds.push(5);
+    mockStructureStrategyData = [
+        {id: 1},
+        {id: 2},
+        {id: 3},
+    ];
+    const list = mount(<List adapters={['table']} store={listStore} />);
+
+    list.instance().requestSelectionDelete(false);
+    list.update();
+    expect(list.find('Dialog').at(0).prop('open')).toEqual(true);
+
+    list.find('Dialog').at(0).prop('onConfirm')();
+
+    setTimeout(() => {
+        list.update();
+        expect(list.find('Dialog').at(0).prop('open')).toEqual(false);
+        expect(list.find('Dialog').at(1).prop('open')).toEqual(false);
+        expect(list.find('Dialog').at(2).prop('open')).toEqual(true);
+
+        list.find('Dialog').at(2).prop('onConfirm')();
+
+        setTimeout(() => {
+            expect(listStore.delete).not.toBeCalledWith(5, {force: true});
+            list.update();
+            expect(list.find('Dialog').at(0).prop('open')).toEqual(false);
+            expect(list.find('Dialog').at(1).prop('open')).toEqual(false);
+            expect(list.find('Dialog').at(2).prop('open')).toEqual(false);
+            done();
+        });
+    });
+});
+
 test('Order warning should just disappear when onRequestItemOrder callback is called and overlay is cancelled', () => {
     listAdapterRegistry.get.mockReturnValue(TableAdapter);
     const listStore = new ListStore('test', 'test', 'list_test', {page: observable.box(1)});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js
@@ -824,7 +824,7 @@ test('ListStore should delete item when onRequestItemDelete callback is called a
 });
 
 test('ListStore should delete linked item when onRequestItemDelete callback is is confirmed twice', (done) => {
-    const jsonDeletePromise = Promise.resolve({items: [{name: 'Item 1'}, {name: 'Item 2'}]});
+    const jsonDeletePromise = Promise.resolve({id: 5, items: [{name: 'Item 1'}, {name: 'Item 2'}]});
     const deletePromise = Promise.reject({
         json: jest.fn().mockReturnValue(jsonDeletePromise),
         status: 409,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -1776,7 +1776,11 @@ test('Should delete all selected items', () => {
     listStore.select({id: 1});
     listStore.select({id: 2});
 
+    expect(listStore.deletingSelection).toEqual(false);
+
     const deletePromise = listStore.deleteSelection();
+
+    expect(listStore.deletingSelection).toEqual(true);
 
     return deletePromise.then(() => {
         expect(ResourceRequester.delete).toHaveBeenCalledTimes(2);
@@ -1785,6 +1789,7 @@ test('Should delete all selected items', () => {
         expect(structureStrategy.remove).toBeCalledWith(1);
         expect(structureStrategy.remove).toBeCalledWith(2);
         expect(listStore.selections).toEqual([]);
+        expect(listStore.deletingSelection).toEqual(false);
     });
 });
 
@@ -1824,9 +1829,15 @@ test('Should crash when deleting all selected items and one request fails with a
     listStore.select({id: 1});
     listStore.select({id: 2});
 
+    expect(listStore.deletingSelection).toEqual(false);
+
     const deletePromise = listStore.deleteSelection();
+
+    expect(listStore.deletingSelection).toEqual(true);
+
     deletePromise.catch((error) => {
         expect(error.status).toEqual(500);
+        expect(listStore.deletingSelection).toEqual(false);
         done();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -35,7 +35,7 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
                     cancelText={translate('sulu_admin.cancel')}
                     confirmLoading={this.resourceFormStore.deleting}
                     confirmText={translate('sulu_admin.ok')}
-                    onCancel={this.handleLinkCancel}
+                    onCancel={this.allowConflictDeletion ? this.handleLinkCancel : undefined}
                     onConfirm={this.handleLinkConfirm}
                     open={this.showLinkedDialog}
                     title={this.allowConflictDeletion

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/List.js
@@ -142,6 +142,7 @@ class List extends React.Component<Props> {
         router.bind('search', this.listStore.searchTerm);
         router.bind('limit', this.listStore.limit, DEFAULT_LIMIT);
     }
+
     buildMetadataOptions(
         attributes: Object,
         routerAttributesToListMetadata: {[string | number]: string}
@@ -290,12 +291,12 @@ class List extends React.Component<Props> {
         router.navigate(editView, {id: itemId, locale: this.locale.get()});
     };
 
-    requestSelectionDelete = () => {
+    requestSelectionDelete = (allowConflictDelete: boolean = true) => {
         if (!this.list) {
             throw new Error('List not created yet.');
         }
 
-        this.list.requestSelectionDelete();
+        this.list.requestSelectionDelete(allowConflictDelete);
     };
 
     reload = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js
@@ -1311,6 +1311,36 @@ test('Should delete selected items when delete button is clicked', () => {
     expect(list.find('Dialog').at(0).prop('open')).toEqual(true);
 });
 
+test('Should pass allowConflictDeletion correctly to List component', () => {
+    const List = require('../List').default;
+    const listToolbarActionRegistry = require('../registries/listToolbarActionRegistry').default;
+    const DeleteToolbarAction = require('../toolbarActions/DeleteToolbarAction').default;
+    listToolbarActionRegistry.add('sulu_admin.delete', DeleteToolbarAction);
+    const router = {
+        bind: jest.fn(),
+        route: {
+            options: {
+                adapters: ['table'],
+                listKey: 'test',
+                resourceKey: 'test',
+                toolbarActions: [
+                    {type: 'sulu_admin.delete', options: {}},
+                ],
+            },
+        },
+    };
+
+    const list = mount(<List router={router} />);
+    const listStore = list.instance().listStore;
+    listStore.selectionIds.push(1, 4, 6);
+    list.instance().requestSelectionDelete(false);
+
+    list.update();
+    expect(list.find('Dialog').at(0).prop('open')).toEqual(true);
+
+    expect(list.find('List').at(1).instance().allowConflictDeletion).toEqual(false);
+});
+
 test('Should make move overlay disappear if cancel is clicked', () => {
     function getMoveItem() {
         return toolbarFunction.call(list.instance()).items.find((item) => item.label === 'Move selected');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -1,0 +1,75 @@
+// @flow
+import {observable} from 'mobx';
+import ListStore from '../../../../containers/List/stores/ListStore';
+import Router from '../../../../services/Router';
+import ResourceStore from '../../../../stores/ResourceStore';
+import List from '../../../../views/List';
+import DeleteToolbarAction from '../../toolbarActions/DeleteToolbarAction';
+
+jest.mock('../../../../utils/Translator', () => ({
+    translate: jest.fn((key) => key),
+}));
+
+jest.mock('../../../../containers/List/stores/ListStore', () => jest.fn(function() {
+    this.selectionIds = [];
+    this.deletingSelection = false;
+}));
+
+jest.mock('../../../../views/List/List', () => jest.fn(function() {
+    this.requestSelectionDelete = jest.fn();
+}));
+
+jest.mock('../../../../services/Router/Router', () => jest.fn());
+
+function createDeleteToolbarAction(options = {}) {
+    const router = new Router({});
+    const listStore = new ListStore('test', 'test', 'test', {page: observable.box(1)});
+    const list = new List({
+        route: router.route,
+        router,
+    });
+    const locales = [];
+    const resourceStore = new ResourceStore('test');
+
+    return new DeleteToolbarAction(listStore, list, router, locales, resourceStore, options);
+}
+
+test('Return config for toolbar item', () => {
+    const deleteToolbarAction = createDeleteToolbarAction();
+
+    expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        icon: 'su-trash-alt',
+        label: 'sulu_admin.delete',
+        loading: false,
+        type: 'button',
+    }));
+});
+
+test('Return config for toolbar item with selection and currently deleting', () => {
+    const deleteToolbarAction = createDeleteToolbarAction();
+
+    deleteToolbarAction.listStore.selectionIds.push(1);
+    deleteToolbarAction.listStore.deletingSelection = true;
+
+    expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: false,
+        icon: 'su-trash-alt',
+        label: 'sulu_admin.delete',
+        loading: true,
+        type: 'button',
+    }));
+});
+
+test.each([
+    true,
+    false,
+])('Call requestSelectionDelete of list with an allowConflictDeletion value of %s', (allowConflictDeletion) => {
+    const deleteToolbarAction = createDeleteToolbarAction({allow_conflict_deletion: allowConflictDeletion});
+
+    deleteToolbarAction.listStore.selectionIds.push(1);
+
+    deleteToolbarAction.getToolbarItemConfig().onClick();
+
+    expect(deleteToolbarAction.list.requestSelectionDelete).toBeCalledWith(allowConflictDeletion);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/DeleteToolbarAction.js
@@ -9,8 +9,18 @@ export default class DeleteToolbarAction extends AbstractListToolbarAction {
             icon: 'su-trash-alt',
             label: translate('sulu_admin.delete'),
             loading: this.listStore.deletingSelection,
-            onClick: this.list.requestSelectionDelete,
+            onClick: this.handleClick,
             type: 'button',
         };
     }
+
+    handleClick = () => {
+        const {allow_conflict_deletion: allowConflictDeletion = true} = this.options;
+
+        if (allowConflictDeletion !== undefined && typeof allowConflictDeletion !== 'boolean') {
+            throw new Error('The "allow_conflict_deletion" option must have a boolean value!');
+        }
+
+        this.list.requestSelectionDelete(allowConflictDeletion);
+    };
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -64,6 +64,8 @@
     "sulu_admin.delete_linked_warning_title": "Löschen bestätigen",
     "sulu_admin.delete_linked_warning_text": "Dieser Eintrag wird von folgenden anderen Einträgen referenziert, sind Sie sich sicher, dass sie diesen Eintrag löschen wollen?",
     "sulu_admin.delete_selection_warning_text": "Diese Operation löscht {count} {count, plural, =1 {Datensatz} other {Datensätze}} und kann nicht rückgängig gemacht werden. Wollen Sie wirklich fortfahren?",
+    "sulu_admin.item_not_deletable": "Eintrag nicht löschbar",
+    "sulu_admin.delete_linked_abort_text": "Dieser Eintrag kann nicht gelöscht werden, solange er noch von anderen Einträgen referenziert wird. Bitte löschen Sie die folgenden referenzierenden Einträge oder entfernen sie die Relation",
     "sulu_admin.ghost_dialog_title": "Sprachvariante kopieren?",
     "sulu_admin.ghost_dialog_description": "Diese Seite existiert nicht in dieser Sprache. Wollen Sie den Inhalt aus einer anderen Sprache kopieren?",
     "sulu_admin.choose_language": "Sprache wählen",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -64,6 +64,8 @@
     "sulu_admin.delete_linked_warning_title": "Confirm deletion",
     "sulu_admin.delete_linked_warning_text": "This item is referenced by the following items, are you sure you want to delete it?",
     "sulu_admin.delete_selection_warning_text": "This operation deletes {count} {count, plural, =1 {item} other {items}} and cannot be undone. Do you really wish to proceed?",
+    "sulu_admin.item_not_deletable": "Item cannot be deleted",
+    "sulu_admin.delete_linked_abort_text": "This item cannot be deleted as long as it has sub items. Delete the following sub items or remove the relation:",
     "sulu_admin.ghost_dialog_title": "Copy language?",
     "sulu_admin.ghost_dialog_description": "This page does not exist in this language. Do you want to copy content from another language?",
     "sulu_admin.choose_language": "Choose language",

--- a/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
+++ b/src/Sulu/Bundle/ContactBundle/Admin/ContactAdmin.php
@@ -194,8 +194,14 @@ class ContactAdmin extends Admin
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-                $accountFormToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-                $accountListToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+                $accountFormToolbarActions[] = new ToolbarAction(
+                    'sulu_admin.delete',
+                    ['allow_conflict_deletion' => false]
+                );
+                $accountListToolbarActions[] = new ToolbarAction(
+                    'sulu_admin.delete',
+                    ['allow_conflict_deletion' => false]
+                );
             }
 
             if ($this->securityChecker->hasPermission(static::CONTACT_SECURITY_CONTEXT, PermissionTypes::VIEW)) {

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -775,6 +775,20 @@ class AccountController extends AbstractRestController implements ClassResourceI
      */
     public function deleteAction($id, Request $request)
     {
+        $children = $this->accountRepository->findChildAccounts($id);
+        if (count($children) > 0) {
+                $data = [
+                    'id' => $id,
+                    'items' => [],
+                ];
+
+                foreach ($children as $child) {
+                    $data['items'][] = ['name' => $child->getName()];
+                }
+
+                return $this->handleView($this->view($data, 409));
+        }
+
         $delete = function($id) use ($request) {
             $account = $this->accountRepository->findAccountByIdAndDelete($id);
 
@@ -814,6 +828,8 @@ class AccountController extends AbstractRestController implements ClassResourceI
      * @param Request $request
      *
      * @return Response
+     *
+     * TODO remove?
      */
     public function multipledeleteinfoAction(Request $request)
     {

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -777,16 +777,16 @@ class AccountController extends AbstractRestController implements ClassResourceI
     {
         $children = $this->accountRepository->findChildAccounts($id);
         if (count($children) > 0) {
-                $data = [
-                    'id' => $id,
-                    'items' => [],
-                ];
+            $data = [
+                'id' => $id,
+                'items' => [],
+            ];
 
-                foreach ($children as $child) {
-                    $data['items'][] = ['name' => $child->getName()];
-                }
+            foreach ($children as $child) {
+                $data['items'][] = ['name' => $child->getName()];
+            }
 
-                return $this->handleView($this->view($data, 409));
+            return $this->handleView($this->view($data, 409));
         }
 
         $delete = function($id) use ($request) {

--- a/src/Sulu/Bundle/ContactBundle/Entity/AccountRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AccountRepository.php
@@ -331,6 +331,24 @@ class AccountRepository extends NestedTreeRepository implements DataProviderRepo
     }
 
     /**
+     * @return AccountInterface[]
+     */
+    public function findChildAccounts(int $id): array
+    {
+        try {
+            $qb = $this->createQueryBuilder('account')
+                ->where('account.parent = :accountId');
+
+            $query = $qb->getQuery();
+            $query->setParameter('accountId', $id);
+
+            return $query->getResult();
+        } catch (NoResultException $ex) {
+            return null;
+        }
+    }
+
+    /**
      * Append joins to query builder for "findByFilters" function.
      */
     protected function appendJoins(QueryBuilder $queryBuilder, $alias, $locale)

--- a/src/Sulu/Bundle/ContactBundle/Entity/AccountRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AccountRepository.php
@@ -344,7 +344,7 @@ class AccountRepository extends NestedTreeRepository implements DataProviderRepo
 
             return $query->getResult();
         } catch (NoResultException $ex) {
-            return null;
+            return [];
         }
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -1328,6 +1328,23 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $client->getResponse());
     }
 
+    public function testDeleteParentById()
+    {
+        $parentAccount = $this->createAccount('Parent Company');
+        $childAccount = $this->createAccount('Company', $parentAccount);
+        $this->em->flush();
+
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('DELETE', '/api/accounts/' . $parentAccount->getId());
+        $this->assertHttpStatusCode(409, $client->getResponse());
+
+        $response = json_decode($client->getResponse()->getContent());
+
+        $this->assertEquals($parentAccount->getId(), $response->id);
+        $this->assertEquals('Company', $response->items[0]->name);
+    }
+
     public function testAccountAddresses()
     {
         $addressType = $this->createAddressType('Private');

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -367,6 +367,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
 
             if (count($references) > 0) {
                 $data = [
+                    'id' => $id,
                     'items' => [],
                 ];
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -1909,6 +1909,7 @@ class PageControllerTest extends SuluTestCase
         $this->client->request('DELETE', '/api/pages/' . $linkedDocument->getUuid() . '?webspace=sulu_io&language=en');
         $this->assertHttpStatusCode(409, $this->client->getResponse());
         $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertEquals($linkedDocument->getUuid(), $response['id']);
         $this->assertCount(1, $response['items'][0]);
         $this->assertEquals('test2', $response['items'][0]['name']);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR introduces an error message when an account which is the parent of another account is trying to be deleted.

#### Why?

Because we don't want to delete the child accounts when a parent account is deleted. What should happen instead is not completely clear, and this way the user can decide how to resolve this conflict.

And it is the same behavior as in Sulu 1.6.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
