### PR TITLE
Fix getContainer and initPhpCr for tests

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/ContainerTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/ContainerTrait.php
@@ -18,8 +18,7 @@ trait ContainerTrait
     /**
      * @internal The "getContainer" function is deprecated use self::$container variable instead.
      *
-     * This function exist to keep a compatibility between symfony versions.
-     * Can be removed when Symfony <4.1 is not longer supported.
+     * This function exist to keep compatibility to oldtests.
      */
     protected static function getContainer(): ContainerInterface
     {

--- a/src/Sulu/Bundle/TestBundle/Testing/ContainerTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/ContainerTrait.php
@@ -23,54 +23,10 @@ trait ContainerTrait
      */
     protected static function getContainer(): ContainerInterface
     {
-        if (static::$container) {
-            return static::$container;
-        }
-
-        if (!self::$kernel) {
-            // Boot kernel if container is not yet available to keep backward compatibility for tests.
+        if (!static::$container) {
             static::bootKernel();
-
-            if (static::$container) {
-                return static::$container;
-            }
         }
-
-        // Get the container from kernel to keep compatibility for symfony <4.1
-        $container = static::$kernel->getContainer();
-
-        if (!$container) {
-            // If the kernel was not booted the container is empty so we need to boot it
-            static::bootKernel();
-
-            $container = static::$kernel->getContainer();
-
-            if (!$container) {
-                throw new \RuntimeException('Could not boot kernel with container for test.');
-            }
-        }
-
-        static::$container = $container;
 
         return static::$container;
-    }
-
-    protected static function bootKernel(array $options = [])
-    {
-        $kernel = parent::bootKernel($options);
-
-        if (!static::$container) {
-            // In symfony <4.1 container is not set to a static::$container this is here to keep compatibility
-            static::$container = static::$kernel->getContainer();
-        }
-
-        return $kernel;
-    }
-
-    protected static function ensureKernelShutdown()
-    {
-        parent::ensureKernelShutdown();
-        // In symfony <4.1 container is not set to null on ensureKernelShutdown this keep compatibility
-        static::$container = null;
     }
 }

--- a/src/Sulu/Bundle/TestBundle/Testing/PhpCrInitTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/PhpCrInitTrait.php
@@ -15,6 +15,7 @@ use PHPCR\ImportUUIDBehaviorInterface;
 use PHPCR\SessionInterface;
 use PHPCR\Util\NodeHelper;
 use Sulu\Bundle\DocumentManagerBundle\Initializer\Initializer;
+use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -110,13 +111,21 @@ trait PhpCrInitTrait
      */
     private static function getInitializerDumpFilePath(string $workspace): string
     {
+        if (!static::$kernel instanceof SuluKernel) {
+            throw new \TypeError(
+                'Expected that Kernel is "%s" but "%s" given.',
+                SuluKernel::class,
+                get_class(static::$kernel)
+            );
+        }
+
         switch ($workspace) {
             case 'live':
-                return static::$kernel->getCacheDir() . '/initial_live.xml';
+                return static::$kernel->getCommonCacheDir() . '/initial_live.xml';
 
                 break;
             case 'default':
-                return static::$kernel->getCacheDir() . '/initial.xml';
+                return static::$kernel->getCommonCacheDir() . '/initial.xml';
 
                 break;
             default:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

The container accidently resonses sometimes the real container instead of test container because symfony does not reset `static::$kernel` to null after 

#### Why?

The correct test container is again available and initPhpCr does not error if a WebtestCase is run as first test.

Most of the `ContainerTrait` could be removed because of the Symfony 4.3 upgrade.

#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
