### PR TITLE
Add MetadataRequestParameters to FormView and FormOverlayListView

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -186,9 +186,9 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
-    public function addFormMetadata(array $formMetadata): FormOverlayListViewBuilderInterface
+    public function addMetadataRequestParameters(array $formMetadata): FormOverlayListViewBuilderInterface
     {
-        $this->addFormMetadataToView($this->view, $formMetadata);
+        $this->addMetadataRequestParametersToView($this->view, $formMetadata);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -186,6 +186,13 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
+    public function addFormMetadata(array $routerAttributesToFormMetadata): FormOverlayListViewBuilderInterface
+    {
+        $this->addFormMetadataToView($this->view, $routerAttributesToFormMetadata);
+
+        return $this;
+    }
+
     public function getView(): View
     {
         if (!$this->view->getOption('resourceKey')) {

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -186,9 +186,9 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
-    public function addMetadataRequestParameters(array $formMetadata): FormOverlayListViewBuilderInterface
+    public function addMetadataRequestParameters(array $metadataRequestParameters): FormOverlayListViewBuilderInterface
     {
-        $this->addMetadataRequestParametersToView($this->view, $formMetadata);
+        $this->addMetadataRequestParametersToView($this->view, $metadataRequestParameters);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -186,9 +186,9 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
-    public function addFormMetadata(array $routerAttributesToFormMetadata): FormOverlayListViewBuilderInterface
+    public function addFormMetadata(array $formMetadata): FormOverlayListViewBuilderInterface
     {
-        $this->addFormMetadataToView($this->view, $routerAttributesToFormMetadata);
+        $this->addFormMetadataToView($this->view, $formMetadata);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -76,5 +76,5 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setOverlaySize(string $overlaySize): self;
 
-    public function addFormMetadata(array $formMetadata): self;
+    public function addMetadataRequestParameters(array $formMetadata): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -76,5 +76,5 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setOverlaySize(string $overlaySize): self;
 
-    public function addMetadataRequestParameters(array $formMetadata): self;
+    public function addMetadataRequestParameters(array $metadataRequestParameters): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -76,5 +76,5 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setOverlaySize(string $overlaySize): self;
 
-    public function addFormMetadata(array $routerAttributesToFormMetadata): self;
+    public function addFormMetadata(array $formMetadata): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -75,4 +75,6 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
     public function addResourceStorePropertiesToFormRequest(array $resourceStorePropertiesToFormRequest): self;
 
     public function setOverlaySize(string $overlaySize): self;
+
+    public function addFormMetadata(array $routerAttributesToFormMetadata): self;
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -123,9 +123,9 @@ class FormViewBuilder implements FormViewBuilderInterface
         return $this;
     }
 
-    public function addMetadataRequestParameters(array $formMetadata): FormViewBuilderInterface
+    public function addMetadataRequestParameters(array $metadataRequestParameters): FormViewBuilderInterface
     {
-        $this->addMetadataRequestParametersToView($this->view, $formMetadata);
+        $this->addMetadataRequestParametersToView($this->view, $metadataRequestParameters);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -123,6 +123,13 @@ class FormViewBuilder implements FormViewBuilderInterface
         return $this;
     }
 
+    public function addMetadataRequestParameters(array $formMetadata): FormViewBuilderInterface
+    {
+        $this->addMetadataRequestParametersToView($this->view, $formMetadata);
+
+        return $this;
+    }
+
     public function setIdQueryParameter(string $idQueryParameter): FormViewBuilderInterface
     {
         $this->setIdQueryParameterToView($this->view, $idQueryParameter);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
@@ -49,6 +49,8 @@ interface FormViewBuilderInterface extends ViewBuilderInterface
 
     public function setBackView(string $editView): self;
 
+    public function addMetadataRequestParameters(array $formMetadata): self;
+
     public function setIdQueryParameter(string $idQueryParameter): self;
 
     public function setTitleVisible(bool $titleVisible): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
@@ -49,7 +49,7 @@ interface FormViewBuilderInterface extends ViewBuilderInterface
 
     public function setBackView(string $editView): self;
 
-    public function addMetadataRequestParameters(array $formMetadata): self;
+    public function addMetadataRequestParameters(array $metadataRequestParameters): self;
 
     public function setIdQueryParameter(string $idQueryParameter): self;
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
@@ -89,9 +89,9 @@ trait FormViewBuilderTrait
 
     private function addMetadataRequestParametersToView(View $route, array $formMetadata): void
     {
-        $oldFormMetadata = $route->getOption('formMetadata');
+        $oldFormMetadata = $route->getOption('metadataRequestParameters');
         $newFormMetadata = $oldFormMetadata ? array_merge($oldFormMetadata, $formMetadata) : $formMetadata;
 
-        $route->setOption('formMetadata', $newFormMetadata);
+        $route->setOption('metadataRequestParameters', $newFormMetadata);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
@@ -87,11 +87,11 @@ trait FormViewBuilderTrait
         $view->setOption('routerAttributesToBackView', $newRouterAttributesToBackView);
     }
 
-    private function addMetadataRequestParametersToView(View $route, array $formMetadata): void
+    private function addMetadataRequestParametersToView(View $route, array $metadataRequestParameters): void
     {
-        $oldFormMetadata = $route->getOption('metadataRequestParameters');
-        $newFormMetadata = $oldFormMetadata ? array_merge($oldFormMetadata, $formMetadata) : $formMetadata;
+        $oldMetadataRequestParameters = $route->getOption('metadataRequestParameters');
+        $newMetadataRequestParameters = $oldMetadataRequestParameters ? array_merge($oldMetadataRequestParameters, $metadataRequestParameters) : $metadataRequestParameters;
 
-        $route->setOption('metadataRequestParameters', $newFormMetadata);
+        $route->setOption('metadataRequestParameters', $newMetadataRequestParameters);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
@@ -86,4 +86,12 @@ trait FormViewBuilderTrait
 
         $view->setOption('routerAttributesToBackView', $newRouterAttributesToBackView);
     }
+
+    private function addMetadataRequestParametersToView(View $route, array $formMetadata): void
+    {
+        $oldFormMetadata = $route->getOption('formMetadata');
+        $newFormMetadata = $oldFormMetadata ? array_merge($oldFormMetadata, $formMetadata) : $formMetadata;
+
+        $route->setOption('formMetadata', $newFormMetadata);
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -82,14 +82,12 @@ trait ListViewBuilderTrait
         $route->setOption('routerAttributesToListMetadata', $newRouterAttributesToListMetadata);
     }
 
-    private function addFormMetadataToView(View $route, array $routerAttributesToFormMetadata):void
+    private function addFormMetadataToView(View $route, array $formMetadata): void
     {
-        $oldRouterAttributesToFormMetadata = $route->getOption('formMetadata');
-        $newRouterAttributesToFormMetadata = $oldRouterAttributesToFormMetadata
-            ? array_merge($oldRouterAttributesToFormMetadata, $routerAttributesToFormMetadata)
-            : $routerAttributesToFormMetadata;
+        $oldFormMetadata = $route->getOption('formMetadata');
+        $newFormMetadata = $oldFormMetadata ? array_merge($oldFormMetadata, $formMetadata) : $formMetadata;
 
-        $route->setOption('formMetadata', $newRouterAttributesToFormMetadata);
+        $route->setOption('formMetadata', $newFormMetadata);
     }
 
     private function addLocalesToView(View $route, array $locales): void

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -82,6 +82,16 @@ trait ListViewBuilderTrait
         $route->setOption('routerAttributesToListMetadata', $newRouterAttributesToListMetadata);
     }
 
+    private function addFormMetadataToView(View $route, array $routerAttributesToFormMetadata):void
+    {
+        $oldRouterAttributesToFormMetadata = $route->getOption('formMetadata');
+        $newRouterAttributesToFormMetadata = $oldRouterAttributesToFormMetadata
+            ? array_merge($oldRouterAttributesToFormMetadata, $routerAttributesToFormMetadata)
+            : $routerAttributesToFormMetadata;
+
+        $route->setOption('formMetadata', $newRouterAttributesToFormMetadata);
+    }
+
     private function addLocalesToView(View $route, array $locales): void
     {
         $oldLocales = $route->getOption('locales');

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ListViewBuilderTrait.php
@@ -82,14 +82,6 @@ trait ListViewBuilderTrait
         $route->setOption('routerAttributesToListMetadata', $newRouterAttributesToListMetadata);
     }
 
-    private function addFormMetadataToView(View $route, array $formMetadata): void
-    {
-        $oldFormMetadata = $route->getOption('formMetadata');
-        $newFormMetadata = $oldFormMetadata ? array_merge($oldFormMetadata, $formMetadata) : $formMetadata;
-
-        $route->setOption('formMetadata', $newFormMetadata);
-    }
-
     private function addLocalesToView(View $route, array $locales): void
     {
         $oldLocales = $route->getOption('locales');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -24,13 +24,15 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     schemaDisposer: ?() => void;
     typeDisposer: ?() => void;
     updateFieldPathEvaluationsDisposer: ?() => void;
+    metadataOptions: ?Object;
 
-    constructor(resourceStore: ResourceStore, formKey: string, options: Object = {}) {
+    constructor(resourceStore: ResourceStore, formKey: string, options: Object = {}, metadataOptions: ?Object) {
         super();
 
         this.resourceStore = resourceStore;
         this.formKey = formKey;
         this.options = options;
+        this.metadataOptions = metadataOptions;
 
         metadataStore.getSchemaTypes(this.formKey)
             .then(this.handleSchemaTypeResponse);
@@ -72,7 +74,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
             }
 
             Promise.all([
-                metadataStore.getSchema(this.formKey, type),
+                metadataStore.getSchema(this.formKey, type, this.metadataOptions),
                 metadataStore.getJsonSchema(this.formKey, type),
             ]).then(this.handleSchemaResponse);
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -34,7 +34,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         this.options = options;
         this.metadataOptions = metadataOptions;
 
-        metadataStore.getSchemaTypes(this.formKey)
+        metadataStore.getSchemaTypes(this.formKey, this.metadataOptions)
             .then(this.handleSchemaTypeResponse);
     }
 
@@ -75,7 +75,7 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
             Promise.all([
                 metadataStore.getSchema(this.formKey, type, this.metadataOptions),
-                metadataStore.getJsonSchema(this.formKey, type),
+                metadataStore.getJsonSchema(this.formKey, type, this.metadataOptions),
             ]).then(this.handleSchemaResponse);
         });
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
@@ -26,8 +26,8 @@ class MetadataStore {
             });
     }
 
-    getSchema(formKey: string, type: ?string): Promise<RawSchema> {
-        return metadataStore.loadMetadata(FORM_TYPE, formKey)
+    getSchema(formKey: string, type: ?string, metadataOptions: ?Object): Promise<RawSchema> {
+        return metadataStore.loadMetadata(FORM_TYPE, formKey, metadataOptions)
             .then((configuration) => {
                 const typeConfiguration = this.getTypeConfiguration(configuration, type, formKey);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
@@ -5,8 +5,8 @@ import type {RawSchema, SchemaTypes} from '../types';
 const FORM_TYPE = 'form';
 
 class MetadataStore {
-    getSchemaTypes(formKey: string): Promise<SchemaTypes> {
-        return metadataStore.loadMetadata(FORM_TYPE, formKey)
+    getSchemaTypes(formKey: string, metadataOptions: ?Object): Promise<SchemaTypes> {
+        return metadataStore.loadMetadata(FORM_TYPE, formKey, metadataOptions)
             .then((configuration) => {
                 const {types} = configuration;
 
@@ -48,8 +48,8 @@ class MetadataStore {
             });
     }
 
-    getJsonSchema(formKey: string, type: ?string): Promise<Object> {
-        return metadataStore.loadMetadata(FORM_TYPE, formKey)
+    getJsonSchema(formKey: string, type: ?string, metadataOptions: ?Object): Promise<Object> {
+        return metadataStore.loadMetadata(FORM_TYPE, formKey, metadataOptions)
             .then((configuration) => {
                 const typeConfiguration = this.getTypeConfiguration(configuration, type, formKey);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
@@ -176,10 +176,10 @@ test('Throw if a schema for a type is requested, but the given resourceKey does 
     const snippetPromise = Promise.resolve(snippetMetadata);
     generalMetadataStore.loadMetadata.mockReturnValue(snippetPromise);
 
-    const snippetFieldsPromise = metadataStore.getJsonSchema('snippets', 'sidebar');
+    const snippetFieldsPromise = metadataStore.getJsonSchema('snippets', 'sidebar', undefined);
 
     return snippetFieldsPromise.catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('does not support types'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
         done();
@@ -255,7 +255,7 @@ test('Throw exception if no schema for given resourceKey are available', () => {
     generalMetadataStore.loadMetadata.mockReturnValue(contactPromise);
 
     return metadataStore.getJsonSchema('contacts').catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'contacts');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'contacts', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('"contacts"'));
     });
 });
@@ -289,7 +289,7 @@ test('Throw exception if no form fields for given resourceKey and type are avail
     generalMetadataStore.loadMetadata.mockReturnValue(snippetPromise);
 
     return metadataStore.getJsonSchema('snippets', 'default').catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('no json schema'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
         expect(error.toString()).toEqual(expect.stringContaining('"default"'));
@@ -309,7 +309,7 @@ test('Return available types for given resourceKey', () => {
     generalMetadataStore.loadMetadata.mockReturnValue(snippetPromise);
 
     const snippetTypesPromise = metadataStore.getSchemaTypes('snippets');
-    expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+    expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
 
     return snippetTypesPromise.then((snippetTypes) => {
         expect(snippetTypes).toMatchSnapshot();
@@ -324,7 +324,7 @@ test('Return empty object as available types for given resourceKey if types are 
     generalMetadataStore.loadMetadata.mockReturnValue(snippetPromise);
 
     const snippetTypesPromise = metadataStore.getSchemaTypes('snippets');
-    expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+    expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
 
     return snippetTypesPromise.then((snippetTypes) => {
         expect(snippetTypes).toEqual({});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MetadataStore.test.js
@@ -158,7 +158,7 @@ test('Throw if a type is requested, but the given resourceKey does not have type
     const snippetFieldsPromise = metadataStore.getSchema('snippets', 'sidebar');
 
     return snippetFieldsPromise.catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('does not support types'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
         done();
@@ -204,7 +204,7 @@ test('Throw if a type is omitted, but the given reosurceKey has type support', (
     const snippetSchemaPromise = metadataStore.getSchema('snippets');
 
     return snippetSchemaPromise.catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('requires a type'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
         done();
@@ -229,7 +229,7 @@ test('Throw if a type is omitted when loading the JSON Schema, but the given reo
     const snippetSchemaPromise = metadataStore.getSchema('snippets');
 
     return snippetSchemaPromise.catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('requires a type'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
         done();
@@ -243,7 +243,7 @@ test('Throw exception if no form fields for given resourceKey are available', ()
     generalMetadataStore.loadMetadata.mockReturnValue(contactPromise);
 
     return metadataStore.getSchema('contacts').catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'contacts');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'contacts', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('"contacts"'));
     });
 });
@@ -271,7 +271,7 @@ test('Throw exception if no form fields for given resourceKey and type are avail
     generalMetadataStore.loadMetadata.mockReturnValue(snippetPromise);
 
     return metadataStore.getSchema('snippets', 'default').catch((error) => {
-        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets');
+        expect(generalMetadataStore.loadMetadata).toBeCalledWith('form', 'snippets', undefined);
         expect(error.toString()).toEqual(expect.stringContaining('no form schema'));
         expect(error.toString()).toEqual(expect.stringContaining('"snippets"'));
         expect(error.toString()).toEqual(expect.stringContaining('"default"'));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -122,7 +122,12 @@ class Form extends React.Component<Props> {
             this.resourceStore = resourceStore;
         }
 
-        this.resourceFormStore = new ResourceFormStore(this.resourceStore, formKey, formStoreOptions, metadataRequestParameters);
+        this.resourceFormStore = new ResourceFormStore(
+            this.resourceStore,
+            formKey,
+            formStoreOptions,
+            metadataRequestParameters
+        );
 
         if (this.resourceStore.locale) {
             router.bind('locale', this.resourceStore.locale);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -84,6 +84,7 @@ class Form extends React.Component<Props> {
                     idQueryParameter,
                     resourceKey,
                     routerAttributesToFormRequest = {},
+                    metadataRequestParameters = {},
                 },
             },
         } = router;
@@ -121,7 +122,7 @@ class Form extends React.Component<Props> {
             this.resourceStore = resourceStore;
         }
 
-        this.resourceFormStore = new ResourceFormStore(this.resourceStore, formKey, formStoreOptions);
+        this.resourceFormStore = new ResourceFormStore(this.resourceStore, formKey, formStoreOptions, metadataRequestParameters);
 
         if (this.resourceStore.locale) {
             router.bind('locale', this.resourceStore.locale);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -4,6 +4,7 @@ import {observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import {findWithHighOrderFunction} from '../../../utils/TestHelper';
 import AbstractFormToolbarAction from '../toolbarActions/AbstractFormToolbarAction';
+import ResourceFormStore from "../../../containers/Form/stores/ResourceFormStore";
 
 jest.mock('../../../services/initializer', () => jest.fn());
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
@@ -1860,6 +1861,39 @@ test('Should pass router, store and schema handler to FormContainer', () => {
     expect(formContainer.prop('store').resourceStore).toEqual(resourceStore);
     expect(formContainer.prop('onSubmit')).toBeInstanceOf(Function);
 });
+
+test('Should pass metadataRequestParameters options to Form View', () => {
+    const metadataRequestParameters = {
+        'testParam': 'testValue',
+    };
+
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippets', 12);
+
+    const route = {
+        options: {
+            formKey: 'snippets',
+            locales: [],
+            toolbarActions: [],
+            metadataRequestParameters: metadataRequestParameters,
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        bind: jest.fn(),
+        navigate: jest.fn(),
+        route,
+        attributes: {},
+    };
+
+    const form = mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    const formContainer = form.find('Form').at(1);
+    expect(formContainer.prop('store').resourceStore).toEqual(resourceStore);
+    expect(formContainer.prop('store').metadataOptions).toEqual(metadataRequestParameters);
+});
+
 
 test('Should destroy the store on unmount', () => {
     const Form = require('../Form').default;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -4,7 +4,6 @@ import {observable} from 'mobx';
 import {mount, shallow} from 'enzyme';
 import {findWithHighOrderFunction} from '../../../utils/TestHelper';
 import AbstractFormToolbarAction from '../toolbarActions/AbstractFormToolbarAction';
-import ResourceFormStore from "../../../containers/Form/stores/ResourceFormStore";
 
 jest.mock('../../../services/initializer', () => jest.fn());
 jest.mock('../../../containers/Toolbar/withToolbar', () => jest.fn((Component) => Component));
@@ -1893,7 +1892,6 @@ test('Should pass metadataRequestParameters options to Form View', () => {
     expect(formContainer.prop('store').resourceStore).toEqual(resourceStore);
     expect(formContainer.prop('store').metadataOptions).toEqual(metadataRequestParameters);
 });
-
 
 test('Should destroy the store on unmount', () => {
     const Form = require('../Form').default;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -85,7 +85,7 @@ class FormOverlayList extends React.Component<Props> {
                         resourceKey,
                         routerAttributesToFormRequest = {},
                         resourceStorePropertiesToFormRequest = {},
-                        formMetadata = {},
+                        metadataRequestParameters = {},
                     },
                 },
             },
@@ -108,7 +108,7 @@ class FormOverlayList extends React.Component<Props> {
         );
 
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
-        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, formMetadata);
+        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, metadataRequestParameters);
     };
 
     @action destroyFormOverlay = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -108,7 +108,7 @@ class FormOverlayList extends React.Component<Props> {
         );
 
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
-        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, toJS(formMetadata));
+        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, formMetadata);
     };
 
     @action destroyFormOverlay = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -106,11 +106,9 @@ class FormOverlayList extends React.Component<Props> {
             routerAttributesToFormRequest,
             resourceStorePropertiesToFormRequest
         );
-
-        const metadataOptions = formMetadata;
-
+        
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
-        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, metadataOptions);
+        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, formMetadata);
     };
 
     @action destroyFormOverlay = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -85,6 +85,7 @@ class FormOverlayList extends React.Component<Props> {
                         resourceKey,
                         routerAttributesToFormRequest = {},
                         resourceStorePropertiesToFormRequest = {},
+                        formMetadata = {},
                     },
                 },
             },
@@ -105,8 +106,11 @@ class FormOverlayList extends React.Component<Props> {
             routerAttributesToFormRequest,
             resourceStorePropertiesToFormRequest
         );
+
+        const metadataOptions = formMetadata;
+
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
-        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions);
+        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, metadataOptions);
     };
 
     @action destroyFormOverlay = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -106,9 +106,9 @@ class FormOverlayList extends React.Component<Props> {
             routerAttributesToFormRequest,
             resourceStorePropertiesToFormRequest
         );
-        
+
         const resourceStore = new ResourceStore(resourceKey, itemId, observableOptions, formStoreOptions);
-        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, formMetadata);
+        this.formStore = new ResourceFormStore(resourceStore, formKey, formStoreOptions, toJS(formMetadata));
     };
 
     @action destroyFormOverlay = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -38,9 +38,10 @@ jest.mock('../../../stores/ResourceStore', () => jest.fn(
     }
 ));
 jest.mock('../../../containers/Form/stores/ResourceFormStore', () => jest.fn(
-    (resourceStore) => {
+    (resourceStore, formKey, options, metadataOptions) => {
         return {
             id: resourceStore.id,
+            metadataOptions: metadataOptions,
         };
     }
 ));
@@ -148,7 +149,7 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
         parentId: 'test-id',
         webspace: 'test-webspace',
         dimensionId: 'test-dimension',
-    });
+    }, {});
 });
 
 test('Should construct ResourceStore and ResourceFormStore with correct parameters on item-click callback', () => {
@@ -192,7 +193,38 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
         parentId: 'test-id',
         webspace: 'test-webspace',
         dimensionId: 'test-dimension',
-    });
+    }, {});
+});
+
+test('Should pass formMetadata options to Form View', () => {
+    const formMetadata = {
+        'entity-class': 'testClass',
+    };
+
+    const route: Route = ({}: any);
+    const router: Router = ({
+        attributes: {
+            id: 'test-id',
+            category: 'category-id',
+        },
+        route: {
+            options: {
+                formKey: 'test-form-key',
+                resourceKey: 'test-resource-key',
+                formMetadata: formMetadata,
+            },
+        },
+    }: any);
+
+    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+
+    formOverlayList.instance().locale = observable.box('en');
+    formOverlayList.find(List).props().onItemAdd();
+
+    expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {}, formMetadata);
+
+    const formStore = formOverlayList.instance().formStore;
+    expect(formStore.metadataOptions).toEqual(formMetadata);
 });
 
 test('Should open Overlay with correct props when List fires the item-add callback', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -196,9 +196,9 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
     }, {});
 });
 
-test('Should pass formMetadata options to Form View', () => {
-    const formMetadata = {
-        'entity-class': 'testClass',
+test('Should pass metadataRequestParameters options to Form View', () => {
+    const metadataRequestParameters = {
+        'testParam': 'testValue',
     };
 
     const route: Route = ({}: any);
@@ -211,7 +211,7 @@ test('Should pass formMetadata options to Form View', () => {
             options: {
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
-                formMetadata: formMetadata,
+                metadataRequestParameters: metadataRequestParameters,
             },
         },
     }: any);
@@ -221,10 +221,10 @@ test('Should pass formMetadata options to Form View', () => {
     formOverlayList.instance().locale = observable.box('en');
     formOverlayList.find(List).props().onItemAdd();
 
-    expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {}, formMetadata);
+    expect(ResourceFormStore).toBeCalledWith(expect.anything(), 'test-form-key', {}, metadataRequestParameters);
 
     const formStore = formOverlayList.instance().formStore;
-    expect(formStore.metadataOptions).toEqual(formMetadata);
+    expect(formStore.metadataOptions).toEqual(metadataRequestParameters);
 });
 
 test('Should open Overlay with correct props when List fires the item-add callback', () => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Adds the possibility to add custom metadata to the form of the FormOverlay and the FormView.

#### Why?

Because we want the possibility to add custom metadata to views.

#### Example Usage

##### ViewBuilder
~~~php
        $formOverlayListViewBuilder->setResourceKey(Example::RESOURCE_KEY)
            ->setListKey(Example::RESOURCE_KEY)
            ->setFormKey('example_details')
            ->addListAdapters(['table'])
            ->addMetadataRequestParameters(['test-data' => $data]);
~~~

##### CustomMetadataLoader
~~~php
class CustomMetadataLoader implements FormMetadataLoaderInterface
{
    public function getMetadata(string $key, string $locale, array $metadataOptions): ?MetadataInterface
    {
       //do something with the metadata
       $testData = $metadataOptions['test-data'];
       //...
   }
}
~~~