### PR TITLE
Optimize image output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu
 ==================
 
 * release/1.6
+    * ENHANCEMENT #4812  [MediaBundle]             Optimize gif image output
     * BUGFIX      #4800  [PreviewBundle]           Fix no host in parse_url of PreviewRenderer
     * BUGFIX      #4672  [RouteBundle]             Add redirect to locale-prefix for partial match requests
     * BUGFIX      #4669  [Component]               Fix reference-options doctrine extension

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -395,6 +395,7 @@ class ImagineImageConverter implements ImageConverterInterface
         $options = [];
         if (count($image->layers()) > 1 && 'gif' == $imageExtension) {
             $options['animated'] = true;
+            $options['optimize'] = true;
         }
 
         return array_merge($options, $imagineOptions);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Optimize image output.

#### Why?

The output of gifs will be smaller. For resizing a gif [coalesce](https://www.php.net/manual/de/imagick.coalesceimages.php) for the layers is called. To optimize every layer again the optimize flag need to be set so not every layer contain again the whole image.

Strangely the memory usage was with an animated gif also reduced. I measured it with `\Imagick::getResource(\Imagick::RESOURCETYPE_MEMORY)` reduced from 870mb -> 811mb, memory_get_usage did stay the same. Still seems like a win-win situation smaller filesize and less memory usage.