### PR TITLE
Display indicators for internal and external links in page list

### DIFF
--- a/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
+++ b/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
@@ -97,7 +97,7 @@ class SerializerEventListener implements EventSubscriberInterface
             $linked = 'internal';
         }
 
-        if (!$linked) {
+        if ($linked) {
             $visitor->visitProperty(
                 new StaticPropertyMetadata('', 'linked', $linked),
                 $linked


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR reintroduces the `linked` property on the page list response.

#### Why?

Because otherwise the content manager won't be able to easily see if the page is an internal or external link.