### PR TITLE
Fix missing webspace when page is deleted in form

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -37,6 +37,7 @@ jest.mock('../../../../containers/Form', () => ({
 }));
 
 jest.mock('../../../../services/Router', () => jest.fn(function() {
+    this.attributes = {};
     this.restore = jest.fn();
     this.route = {
         options: {},
@@ -173,6 +174,72 @@ test('Call delete when dialog is confirmed', () => {
     return deletePromise.then(() => {
         element = mount(deleteToolbarAction.getNode());
         expect(deleteToolbarAction.router.restore).toBeCalledWith('sulu_test.list', {locale: 'en'});
+        expect(element.at(0).instance().props).toEqual(expect.objectContaining({
+            open: false,
+        }));
+    });
+});
+
+test('Call delete when dialog is confirmed with router_attributes_to_back_view option as array', () => {
+    const deleteToolbarAction = createDeleteToolbarAction({router_attributes_to_back_view: ['webspace']});
+    deleteToolbarAction.resourceFormStore.resourceStore.id = 3;
+    deleteToolbarAction.router.attributes.webspace = 'example';
+    deleteToolbarAction.router.route.options.backView = 'sulu_test.list';
+
+    const deletePromise = Promise.resolve();
+    deleteToolbarAction.resourceFormStore.delete.mockReturnValue(deletePromise);
+
+    const toolbarItemConfig = deleteToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+    toolbarItemConfig.onClick();
+
+    let element = mount(deleteToolbarAction.getNode());
+    expect(element.at(0).instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    element.find('Button[skin="primary"]').simulate('click');
+    expect(deleteToolbarAction.resourceFormStore.delete).toBeCalledWith();
+
+    return deletePromise.then(() => {
+        element = mount(deleteToolbarAction.getNode());
+        expect(deleteToolbarAction.router.restore)
+            .toBeCalledWith('sulu_test.list', {locale: 'en', webspace: 'example'});
+        expect(element.at(0).instance().props).toEqual(expect.objectContaining({
+            open: false,
+        }));
+    });
+});
+
+test('Call delete when dialog is confirmed with router_attributes_to_back_view option as object', () => {
+    const deleteToolbarAction = createDeleteToolbarAction({router_attributes_to_back_view: {webspaceKey: 'webspace'}});
+    deleteToolbarAction.resourceFormStore.resourceStore.id = 3;
+    deleteToolbarAction.router.attributes.webspaceKey = 'example';
+    deleteToolbarAction.router.route.options.backView = 'sulu_test.list';
+
+    const deletePromise = Promise.resolve();
+    deleteToolbarAction.resourceFormStore.delete.mockReturnValue(deletePromise);
+
+    const toolbarItemConfig = deleteToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
+    toolbarItemConfig.onClick();
+
+    let element = mount(deleteToolbarAction.getNode());
+    expect(element.at(0).instance().props).toEqual(expect.objectContaining({
+        open: true,
+    }));
+
+    element.find('Button[skin="primary"]').simulate('click');
+    expect(deleteToolbarAction.resourceFormStore.delete).toBeCalledWith();
+
+    return deletePromise.then(() => {
+        element = mount(deleteToolbarAction.getNode());
+        expect(deleteToolbarAction.router.restore)
+            .toBeCalledWith('sulu_test.list', {locale: 'en', webspace: 'example'});
         expect(element.at(0).instance().props).toEqual(expect.objectContaining({
             open: false,
         }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -37,7 +37,7 @@ jest.mock('../../../../containers/Form', () => ({
 }));
 
 jest.mock('../../../../services/Router', () => jest.fn(function() {
-    this.navigate = jest.fn();
+    this.restore = jest.fn();
     this.route = {
         options: {},
     };
@@ -172,7 +172,7 @@ test('Call delete when dialog is confirmed', () => {
 
     return deletePromise.then(() => {
         element = mount(deleteToolbarAction.getNode());
-        expect(deleteToolbarAction.router.navigate).toBeCalledWith('sulu_test.list', {locale: 'en'});
+        expect(deleteToolbarAction.router.restore).toBeCalledWith('sulu_test.list', {locale: 'en'});
         expect(element.at(0).instance().props).toEqual(expect.objectContaining({
             open: false,
         }));
@@ -207,7 +207,7 @@ test('Call delete with force when dialog is confirmed twice', (done) => {
 
     setTimeout(() => {
         element = mount(deleteToolbarAction.getNode());
-        expect(deleteToolbarAction.router.navigate).toBeCalledTimes(0);
+        expect(deleteToolbarAction.router.restore).toBeCalledTimes(0);
         expect(element.at(0).prop('open')).toEqual(false);
         expect(element.at(1).prop('open')).toEqual(true);
         expect(element.at(1).find('li')).toHaveLength(2);
@@ -220,7 +220,7 @@ test('Call delete with force when dialog is confirmed twice', (done) => {
         element.find('Button[skin="primary"]').simulate('click');
 
         setTimeout(() => {
-            expect(deleteToolbarAction.router.navigate).toBeCalledWith('sulu_test.list', {locale: 'en'});
+            expect(deleteToolbarAction.router.restore).toBeCalledWith('sulu_test.list', {locale: 'en'});
             expect(element.at(0).instance().props).toEqual(expect.objectContaining({
                 open: false,
             }));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -68,7 +68,7 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
     navigateBack = () => {
         const {backView} = this.router.route.options;
         const {locale} = this.resourceFormStore;
-        this.router.navigate(backView, {locale: locale ? locale.get() : undefined});
+        this.router.restore(backView, {locale: locale ? locale.get() : undefined});
     };
 
     @action handleCancel = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -66,9 +66,33 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
     }
 
     navigateBack = () => {
-        const {backView} = this.router.route.options;
+        const {attributes, route} = this.router;
+        const {backView} = route.options;
         const {locale} = this.resourceFormStore;
-        this.router.restore(backView, {locale: locale ? locale.get() : undefined});
+
+        const {
+            router_attributes_to_back_view: routerAttributesToBackView,
+        } = this.options;
+
+        const backViewAttributes = {locale: locale ? locale.get() : undefined};
+        if (routerAttributesToBackView) {
+            if (typeof routerAttributesToBackView !== 'object') {
+                throw new Error('The "router_attributes_to_back_view" option must be an object!');
+            }
+
+            Object.keys(routerAttributesToBackView).forEach((key) => {
+                const attributeKey = routerAttributesToBackView[key];
+                const attributeName = isNaN(key) ? key : routerAttributesToBackView[key];
+
+                if (typeof attributeKey !== 'string') {
+                    throw new Error('The value of the "router_attributes_to_back_view" option must be a string!');
+                }
+
+                backViewAttributes[attributeKey] = attributes[attributeName];
+            });
+        }
+
+        this.router.restore(backView, backViewAttributes);
     };
 
     @action handleCancel = () => {

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -123,6 +123,7 @@ class PageAdmin extends Admin
                 'sulu_admin.delete',
                 [
                     'display_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                    'router_attributes_to_back_view' => ['webspace'],
                 ]
             ),
             new DropdownToolbarAction(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR uses `restore` when going back to the list after deleting an item in the form.

#### Why?

That avoids an error when a webspace is missing after deleting a page, if the webspace has never been chosen manually. If this is done before the fix, then the webspace select is empty.