### PR TITLE
Add possibility to filter by types in Selection component for snippets

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -23,6 +23,27 @@ public function setPlaceOfJurisdiction(?string $placeOfJurisdiction): AccountInt
 public function setNote(?string $note): AccountInterface;
 ```
 
+### SnippetSelection type param
+
+Previously the `snippet_selection` field type accepted a `snippetType` param, which filtered the assignable snippets.
+This param was renamed to `types`, in order to make it consistent with e.g. the `media_selection`.
+
+```xml
+<!-- before -->
+<property name="snippets" type="snippet_selection">
+    <params>
+        <param name="snippetType" value="default" />
+    </params>
+</property>
+
+<!-- after -->
+<property name="snippets" type="snippet_selection">
+    <params>
+        <param name="types" value="default" />
+    </params>
+</property>
+```
+
 ### Sitemap Provider changed
 
 As a sitemap is always domain specific and a domain can have multiple webspaces and portal

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -155,6 +155,23 @@ export default class Selection extends React.Component<Props> {
             value,
         } = this.props;
 
+        const {schemaOptions} = this.props;
+
+        const {
+            types: {
+                value: types,
+            } = {},
+        } = schemaOptions;
+
+        if (types !== undefined && typeof types !== 'string') {
+            throw new Error('The "types" schema option must be a string if given!');
+        }
+
+        const options = {};
+        if (types) {
+            options.types = types;
+        }
+
         if (!adapter) {
             throw new Error('The selection field needs a "adapter" option to work properly');
         }
@@ -170,6 +187,7 @@ export default class Selection extends React.Component<Props> {
                 listKey={listKey || resourceKey}
                 locale={this.locale}
                 onChange={this.handleMultiSelectionChange}
+                options={options}
                 overlayTitle={translate(overlayTitle)}
                 resourceKey={resourceKey}
                 value={value || []}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -80,6 +80,12 @@ test('Should pass props correctly to selection component', () => {
         },
     };
 
+    const schemaOptions = {
+        types: {
+            value: 'test',
+        },
+    };
+
     const locale = observable.box('en');
 
     const formInspector = new FormInspector(
@@ -96,6 +102,7 @@ test('Should pass props correctly to selection component', () => {
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
             onFinish={jest.fn()}
+            schemaOptions={schemaOptions}
             value={value}
         />
     );
@@ -110,6 +117,7 @@ test('Should pass props correctly to selection component', () => {
         label: 'sulu_snippet.selection_label',
         locale,
         resourceKey: 'snippets',
+        options: {types: 'test'},
         overlayTitle: 'sulu_snippet.selection_overlay_title',
         value,
     }));
@@ -347,6 +355,26 @@ test('Should call onChange and onFinish callback when selection overlay is confi
 
     expect(changeSpy).toBeCalledWith([1, 2, 3]);
     expect(finishSpy).toBeCalledWith();
+});
+
+test('Should throw an error if "types" schema option is not a string', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+
+    expect(() => shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={{types: {value: []}}}
+        />
+    )).toThrowError(/"types"/);
 });
 
 test('Should throw an error if no "resource_key" option is passed in fieldOptions', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -20,6 +20,7 @@ type Props = {|
     listKey: string,
     locale?: ?IObservableValue<string>,
     onChange: (selectedIds: Array<string | number>) => void,
+    options: Object,
     overlayTitle: string,
     resourceKey: string,
     value: Array<string | number>,
@@ -32,6 +33,7 @@ class MultiSelection extends React.Component<Props> {
         disabledIds: [],
         displayProperties: [],
         icon: 'su-plus',
+        options: {},
         value: [],
     };
 
@@ -113,6 +115,7 @@ class MultiSelection extends React.Component<Props> {
             label,
             locale,
             resourceKey,
+            options,
             overlayTitle,
         } = this.props;
 
@@ -156,6 +159,7 @@ class MultiSelection extends React.Component<Props> {
                     onClose={this.handleOverlayClose}
                     onConfirm={this.handleOverlayConfirm}
                     open={this.overlayOpen}
+                    options={options}
                     preSelectedItems={items}
                     resourceKey={resourceKey}
                     title={overlayTitle}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js
@@ -117,6 +117,22 @@ test('Pass locale to MultiListOverlay', () => {
     expect(selection.find('MultiListOverlay').prop('locale').get()).toEqual('de');
 });
 
+test('Pass options to MultiListOverlay', () => {
+    const options = {types: 'test'};
+    const selection = mount(
+        <MultiSelection
+            adapter="table"
+            listKey="snippets"
+            onChange={jest.fn()}
+            options={options}
+            overlayTitle="Selection"
+            resourceKey="snippets"
+        />
+    );
+
+    expect(selection.find('MultiListOverlay').prop('options')).toEqual(options);
+});
+
 test('Pass disabledIds to MultiListOverlay', () => {
     const disabledIds = [1, 2, 4];
 

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -147,6 +147,11 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         // if the type parameter is falsy, assign NULL to $type
         $types = $request->query->get('types', null) ?: null;
 
+        if (false !== strpos($types, ',')) {
+            // TODO Implement filtering by multiple types
+            throw new \Exception('Filtering by multiple types at once is currently not supported!');
+        }
+
         $idsString = $request->get('ids');
 
         if ($idsString) {

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -145,7 +145,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         $locale = $this->getLocale($request);
 
         // if the type parameter is falsy, assign NULL to $type
-        $type = $request->query->get('type', null) ?: null;
+        $types = $request->query->get('types', null) ?: null;
 
         $idsString = $request->get('ids');
 
@@ -156,7 +156,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
         } else {
             $snippets = $this->snippetRepository->getSnippets(
                 $locale,
-                $type,
+                $types,
                 $this->listRestHelper->getOffset(),
                 $this->listRestHelper->getLimit(),
                 $this->listRestHelper->getSearchPattern(),
@@ -166,7 +166,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
 
             $total = $this->snippetRepository->getSnippetsAmount(
                 $locale,
-                $type,
+                $types,
                 $this->listRestHelper->getSearchPattern(),
                 $this->listRestHelper->getSortColumn(),
                 $this->listRestHelper->getSortOrder()

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -168,13 +168,13 @@ class SnippetControllerTest extends SuluTestCase
             ],
             [
                 [
-                    'type' => 'car',
+                    'types' => 'car',
                 ],
                 4,
             ],
             [
                 [
-                    'type' => 'hotel',
+                    'types' => 'hotel',
                 ],
                 2,
             ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | sulu/sulu-docs#457

#### What's in this PR?

This PR adds the possibility to use a `types` schema option in the XML for selection fields, in order to only list elements of a certain type.

#### Why?

Because this was already possible in the old UI, and enables the developer to make sure that e.g. the right type of snippet is assigned in a `snippet_selection`.

#### BC Breaks/Deprecations

The parameter is now called `types` instead of `snippetType`.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
