### PR TITLE
Fix image width calculation problems with float values

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Scaler/Scaler.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Scaler/Scaler.php
@@ -52,7 +52,7 @@ class Scaler implements ScalerInterface
      * @param $size
      * @param $mode
      *
-     * @return array
+     * @return int[]
      */
     private function getHeightWidth($x, $y, $retina, $forceRatio, $size, $mode)
     {
@@ -96,7 +96,7 @@ class Scaler implements ScalerInterface
             }
         }
 
-        return [$newWidth, $newHeight];
+        return [(int) round($newWidth), (int) round($newHeight)];
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Scaler/ScalerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/Scaler/ScalerTest.php
@@ -87,4 +87,16 @@ class ScalerTest extends SuluTestCase
         $this->assertEquals(400, $image->getSize()->getWidth());
         $this->assertEquals(400, $image->getSize()->getHeight());
     }
+
+    public function testScaleWithFloatWidth()
+    {
+        $imagine = new Imagine();
+        $imageBox = new Box(220, 442);
+        $image = $imagine->create($imageBox);
+
+        $image = $this->scaler->scale($image, 1273, null, ImageInterface::THUMBNAIL_OUTBOUND);
+
+        $this->assertEquals(220, $image->getSize()->getWidth());
+        $this->assertEquals(442, $image->getSize()->getHeight());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Return a rounded int value in the scaler width height calculation.

#### Why?

A image in the following format:

```xml
    <format key="1273x">
        <scale x="1273"/>
    </format>
```

And original image in the format `220x442` will result in `219x442` because the float is converted falsely from `220.0` -> `219`. The round does fix this problem.


#### To Do

- [ ] ~~Create a documentation PR~~
- [ ] ~~Add breaking changes to UPGRADE.md~~
