### PR TITLE
Use category_root parameter of SmartContent

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -98,6 +98,9 @@ export default class SmartContent extends React.Component<Props> {
             disabled,
             label,
             schemaOptions: {
+                category_root: {
+                    value: categoryRootKey,
+                } = {},
                 present_as: {
                     value: schemaPresentations = [],
                 } = {},
@@ -108,6 +111,10 @@ export default class SmartContent extends React.Component<Props> {
             throw new Error(
                 'The "present_as" schemaOption must be a string, but received ' + typeof schemaPresentations + '!'
             );
+        }
+
+        if (categoryRootKey !== undefined && typeof categoryRootKey !== 'string') {
+            throw new Error('The "category_root" option must a string if set!');
         }
 
         const presentations = schemaPresentations.map((presentation) => {
@@ -129,6 +136,7 @@ export default class SmartContent extends React.Component<Props> {
 
         return (
             <SmartContentComponent
+                categoryRootKey={categoryRootKey}
                 disabled={!!disabled}
                 fieldLabel={label}
                 presentations={presentations}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -110,6 +110,9 @@ test('Pass correct props to SmartContent component', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 
     const schemaOptions = {
+        category_root: {
+            value: 'test1',
+        },
         provider: {
             value: 'media',
         },
@@ -131,6 +134,7 @@ test('Pass correct props to SmartContent component', () => {
         />
     );
 
+    expect(smartContent.find('SmartContent').prop('categoryRootKey')).toEqual('test1');
     expect(smartContent.find('SmartContent').prop('presentations')).toEqual([
         {name: 'one', value: 'One column'},
         {name: 'two', value: 'Two column'},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/FilterOverlay.js
@@ -15,7 +15,8 @@ import SmartContentStore from './stores/SmartContentStore';
 import type {Conjunction, SortOrder} from './types';
 import filterOverlayStyles from './filterOverlay.scss';
 
-type Props = {
+type Props = {|
+    categoryRootKey: ?string,
     dataSourceAdapter: ?string,
     dataSourceListKey: ?string,
     dataSourceResourceKey: ?string,
@@ -26,7 +27,7 @@ type Props = {
     smartContentStore: SmartContentStore,
     sortings: {[key: string]: string},
     title: string,
-};
+|};
 
 @observer
 class FilterOverlay extends React.Component<Props> {
@@ -199,6 +200,7 @@ class FilterOverlay extends React.Component<Props> {
 
     render() {
         const {
+            categoryRootKey,
             dataSourceAdapter,
             dataSourceListKey,
             dataSourceResourceKey,
@@ -398,6 +400,7 @@ class FilterOverlay extends React.Component<Props> {
                         onClose={this.handleCloseCategoryDialog}
                         onConfirm={this.handleConfirmCategoryDialog}
                         open={this.showCategoryDialog}
+                        options={{rootKey: categoryRootKey}}
                         overlayType="dialog"
                         preSelectedItems={this.categories || []}
                         resourceKey="categories"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/SmartContent.js
@@ -11,6 +11,7 @@ import SmartContentItem from './SmartContentItem';
 import type {Presentation, SmartContentConfig} from './types';
 
 type Props = {|
+    categoryRootKey?: string,
     disabled: boolean,
     fieldLabel: string,
     presentations: Array<Presentation>,
@@ -104,7 +105,7 @@ class SmartContent extends React.Component<Props> {
     };
 
     render() {
-        const {disabled, fieldLabel, store} = this.props;
+        const {categoryRootKey, disabled, fieldLabel, store} = this.props;
 
         const presentations = this.props.presentations.reduce((presentations, presentation) => {
             presentations[presentation.name] = presentation.value;
@@ -130,6 +131,7 @@ class SmartContent extends React.Component<Props> {
                     ))}
                 </MultiItemSelection>
                 <FilterOverlay
+                    categoryRootKey={categoryRootKey}
                     dataSourceAdapter={this.config.datasourceAdapter}
                     dataSourceListKey={this.config.datasourceListKey}
                     dataSourceResourceKey={this.config.datasourceResourceKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js
@@ -21,6 +21,7 @@ test('Do not display if open is set to false', () => {
     const smartContentStore = new SmartContentStore('content');
     const filterOverlay = shallow(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter="table"
             dataSourceListKey="snippets"
             dataSourceResourceKey="snippets"
@@ -37,6 +38,31 @@ test('Do not display if open is set to false', () => {
     expect(filterOverlay.find('Overlay').prop('open')).toEqual(false);
 });
 
+test('Pass rootKey for categories to options for category list', () => {
+    const smartContentStore = new SmartContentStore('content');
+    // $FlowFixMe
+    smartContentStore.loading = false;
+
+    const filterOverlay = shallow(
+        <FilterOverlay
+            categoryRootKey="test1"
+            dataSourceAdapter="table"
+            dataSourceListKey="snippets"
+            dataSourceResourceKey="snippets"
+            onClose={jest.fn()}
+            open={false}
+            presentations={{}}
+            sections={['categories']}
+            smartContentStore={smartContentStore}
+            sortings={{}}
+            title="Test"
+        />
+    );
+
+    expect(filterOverlay.find(MultiListOverlay).find('[resourceKey="categories"]').prop('options'))
+        .toEqual({rootKey: 'test1'});
+});
+
 test('Render with ListOverlays if smartContentStore is loaded', () => {
     const smartContentStore = new SmartContentStore('content');
     // $FlowFixMe
@@ -44,6 +70,7 @@ test('Render with ListOverlays if smartContentStore is loaded', () => {
 
     const filterOverlay = shallow(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter="table"
             dataSourceListKey="snippets"
             dataSourceResourceKey="snippets"
@@ -68,6 +95,7 @@ test('Render without ListOverlays if smartContentStore is not loaded', () => {
 
     const filterOverlay = mount(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter={undefined}
             dataSourceListKey={undefined}
             dataSourceResourceKey={undefined}
@@ -88,6 +116,7 @@ test('Render with all fields', () => {
     const smartContentStore = new SmartContentStore('content');
     const filterOverlay = mount(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter={undefined}
             dataSourceListKey={undefined}
             dataSourceResourceKey={undefined}
@@ -107,6 +136,7 @@ test('Render with no fields', () => {
     const smartContentStore = new SmartContentStore('content');
     const filterOverlay = mount(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter={undefined}
             dataSourceListKey={undefined}
             dataSourceResourceKey={undefined}
@@ -128,6 +158,7 @@ test('Fill all fields using and update SmartContentStore on confirm', () => {
 
     const filterOverlay = mount(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter="table"
             dataSourceListKey="pages_list"
             dataSourceResourceKey="pages"
@@ -251,6 +282,7 @@ test('Prefill all fields with correct values', () => {
 
     const filterOverlay = mount(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter="table"
             dataSourceListKey="pages"
             dataSourceResourceKey="pages"
@@ -312,6 +344,7 @@ test('Reset all fields when reset action is clicked', () => {
 
     const filterOverlay = mount(
         <FilterOverlay
+            categoryRootKey={undefined}
             dataSourceAdapter="table"
             dataSourceListKey="pages"
             dataSourceResourceKey="pages"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js
@@ -85,9 +85,15 @@ test('Pass correct sections prop with other values', () => {
 
     const smartContentStore = new SmartContentStore('content');
     const smartContent = shallow(
-        <SmartContent fieldLabel="Test" presentations={presentations} store={smartContentStore} />
+        <SmartContent
+            categoryRootKey="test1"
+            fieldLabel="Test"
+            presentations={presentations}
+            store={smartContentStore}
+        />
     );
 
+    expect(smartContent.find('FilterOverlay').prop('categoryRootKey')).toEqual('test1');
     expect(smartContent.find('FilterOverlay').prop('dataSourceListKey')).toEqual('pages_list');
     expect(smartContent.find('FilterOverlay').prop('dataSourceResourceKey')).toEqual('pages');
     expect(smartContent.find('FilterOverlay').prop('sections'))


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the possibility to use the `category_root` parameter in the xml templates in order to choose where selecting a category starts in the SmartContent.

#### Why?

Because this was already possible in the 1.x version, and is documented in the [documentation](http://docs.sulu.io/en/2.0/reference/content-types/smart_content.html).

#### Example Usage

~~~xml
<property name="smart" type="smart_content">
    <params>
        <param name="category_root" value="test1"/>
    </params>
</property>
~~~
