### PR TITLE
Fix symfony 4 4 compatibility

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -253,7 +253,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $script = $this->twig->render('SuluAudienceTargetingBundle:Template:hit-script.html.twig', [
+        $script = $this->twig->render('@SuluAudienceTargeting/Template/hit-script.html.twig', [
             'url' => $this->targetGroupHitUrl,
             'urlHeader' => $this->urlHeader,
             'refererHeader' => $this->referrerHeader,

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
@@ -424,7 +424,7 @@ class TargetGroupSubscriberTest extends TestCase
         $response->headers->set('Content-Type', 'text/html');
         $event->getResponse()->willReturn($response);
 
-        $this->twig->render('SuluAudienceTargetingBundle:Template:hit-script.html.twig', [
+        $this->twig->render('@SuluAudienceTargeting/Template/hit-script.html.twig', [
             'url' => $targetGroupHitUrl,
             'urlHeader' => $forwardedUrlHeader,
             'refererHeader' => $forwardedRefererHeader,

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -31,7 +31,7 @@ use Sulu\Component\DocumentManager\DocumentManager;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManager;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
@@ -75,7 +75,7 @@ class ContentMapperTest extends SuluTestCase
     private $extensionManager;
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     private $tokenStorage;
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ExceptionController.php
@@ -69,10 +69,12 @@ class ExceptionController
 
     /**
      * {@see BaseExceptionController::showAction()}.
+     *
+     * @param FlattenException $exception
      */
     public function showAction(
         Request $request,
-        FlattenException $exception,
+        $exception,
         DebugLoggerInterface $logger = null
     ) {
         $code = $exception->getStatusCode();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ExceptionControllerTest.php
@@ -88,7 +88,7 @@ class ExceptionControllerTest extends TestCase
     {
         $request = new Request();
         $request->setRequestFormat($retrievedFormat);
-        $exception = FlattenException::create(new \Exception(), 400);
+        $exception = $this->createFlattenException(new \Exception(), 400);
 
         $webspace = new Webspace();
         $webspace->addTemplate('error-400', 'error400');
@@ -146,7 +146,7 @@ class ExceptionControllerTest extends TestCase
     public function testShowActionErrorTemplate($templates, $errorCode, $expectedTemplate)
     {
         $request = new Request();
-        $exception = FlattenException::create(new \Exception(), $errorCode);
+        $exception = $this->createFlattenException(new \Exception(), $errorCode);
 
         $webspace = new Webspace();
         foreach ($templates as $type => $template) {
@@ -165,5 +165,10 @@ class ExceptionControllerTest extends TestCase
         $request->headers->add(['X-Php-Ob-Level' => 1]);
 
         $this->exceptionController->showAction($request, $exception);
+    }
+
+    private function createFlattenException($exception, $statusCode)
+    {
+        return FlattenException::createFromThrowable($exception, $statusCode);
     }
 }

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Events;
 use Sulu\Component\Persistence\Model\UserBlameInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -34,7 +34,7 @@ class UserBlameSubscriber implements EventSubscriber
     const CREATOR_FIELD = 'creator';
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     private $tokenStorage;
 
@@ -44,10 +44,10 @@ class UserBlameSubscriber implements EventSubscriber
     private $userClass;
 
     /**
-     * @param TokenStorage $tokenStorage
+     * @param TokenStorageInterface $tokenStorage
      * @param string $userClass
      */
-    public function __construct(TokenStorage $tokenStorage = null, $userClass)
+    public function __construct(TokenStorageInterface $tokenStorage = null, $userClass)
     {
         $this->tokenStorage = $tokenStorage;
         $this->userClass = $userClass;

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
@@ -21,7 +21,7 @@ use Prophecy\Argument;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Persistence\EventSubscriber\ORM\UserBlameSubscriber;
 use Sulu\Component\Security\Authentication\UserInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
@@ -73,7 +73,7 @@ class UserBlameSubscriberTest extends TestCase
     private $token;
 
     /**
-     * @var TokenStorage
+     * @var TokenStorageInterface
      */
     private $tokenStorage;
 
@@ -96,7 +96,7 @@ class UserBlameSubscriberTest extends TestCase
         $this->entityManager = $this->prophesize('Doctrine\ORM\EntityManager');
         $this->user = $this->prophesize('Sulu\Component\Security\Authentication\UserInterface');
         $this->token = $this->prophesize('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $this->tokenStorage = $this->prophesize('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage');
+        $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
 
         $this->unitOfWork = $this->getMockBuilder(UnitOfWork::class)->disableOriginalConstructor()->getMock();
 
@@ -260,7 +260,7 @@ class UserBlameSubscriberTest extends TestCase
     {
         $symfonyUser = $this->prophesize(SymfonyUserInterface::class);
         $token = $this->prophesize(TokenInterface::class);
-        $tokenStorage = $this->prophesize(TokenStorage::class);
+        $tokenStorage = $this->prophesize(TokenStorageInterface::class);
         $tokenStorage->getToken()->willReturn($token->reveal());
         $token->getUser()->willReturn($symfonyUser->reveal());
         $subscriber = new UserBlameSubscriber($tokenStorage->reveal(), User::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove the deprecated syntax for twig templates in AudienceTargetingBundle and fix symfony 4 4 compatibility to TokenStorageInterface.

#### Why?

Keep kompatibility to symfony 4.4.
