### PR TITLE
Use exclude_duplicates parameter of SmartContent

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -47,7 +47,7 @@ class SmartContent extends React.Component<Props> {
             formInspector,
             schemaOptions: {
                 exclude_duplicates: {
-                    value: excludeDuplicates,
+                    value: excludeDuplicates = false,
                 } = {},
                 provider: {
                     value: provider,
@@ -60,6 +60,10 @@ class SmartContent extends React.Component<Props> {
             throw new Error('The "provider" schemaOption must be a string, but received ' + typeof provider + '!');
         }
 
+        if (typeof excludeDuplicates !== 'boolean') {
+            throw new Error('The "exclude_duplicates" schemaOption must be a boolean if set!');
+        }
+
         const datasourceResourceKey = smartContentConfigStore.getConfig(provider).datasourceResourceKey;
 
         this.smartContentStore = new SmartContentStore(
@@ -70,7 +74,7 @@ class SmartContent extends React.Component<Props> {
             formInspector.resourceKey === provider ? formInspector.id : undefined
         );
 
-        smartContentStorePool.add(this.smartContentStore);
+        smartContentStorePool.add(this.smartContentStore, excludeDuplicates);
 
         this.filterCriteriaChangeDisposer = autorun(this.handleFilterCriteriaChange);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -72,6 +72,8 @@ class SmartContent extends React.Component<Props> {
         if (!excludeDuplicates || this.previousSmartContentStores.length === 0) {
             this.smartContentStore.start();
         } else {
+            // If duplicates are excluded wait with loading the smart content until all previous ones have been loaded
+            // Otherwise it is not known which ids to exclude for the initial request and has to be done a second time
             when(
                 () => this.previousSmartContentStores.every((store) => !store.itemsLoading),
                 (): void => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -28,16 +28,7 @@ class SmartContent extends React.Component<Props> {
     filterCriteriaChangeDisposer: () => void;
 
     @computed get previousSmartContentStores() {
-        const previousSmartContentStores = [];
-        for (const smartContentStore of smartContentStorePool.stores) {
-            if (smartContentStore === this.smartContentStore) {
-                break;
-            }
-
-            previousSmartContentStores.push(smartContentStore);
-        }
-
-        return previousSmartContentStores;
+        return smartContentStorePool.findPreviousStores(this.smartContentStore);
     }
 
     constructor(props: Props) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/smartContentStorePool.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/smartContentStorePool.js
@@ -1,16 +1,20 @@
 // @flow
-import {action, observable, when} from 'mobx';
+import {action, computed, observable, when} from 'mobx';
 import {SmartContentStore} from '../../SmartContent';
 
 class SmartContentStorePool {
-    @observable stores: Array<SmartContentStore>;
+    @observable entries: Array<{store: SmartContentStore}>;
+
+    @computed get stores(): Array<SmartContentStore> {
+        return this.entries.map((entry) => entry.store);
+    }
 
     constructor() {
         this.clear();
     }
 
     clear() {
-        this.stores = [];
+        this.entries = [];
     }
 
     @action add(store: SmartContentStore) {
@@ -18,11 +22,11 @@ class SmartContentStorePool {
             throw new Error('Cannot add a SmartContentStore twice!');
         }
 
-        this.stores.push(store);
+        this.entries.push({store});
     }
 
     @action remove(store: SmartContentStore) {
-        this.stores.splice(this.stores.indexOf(store), 1);
+        this.entries.splice(this.stores.indexOf(store), 1);
     }
 
     updateExcludedIds = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/smartContentStorePool.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/smartContentStorePool.js
@@ -37,6 +37,23 @@ class SmartContentStorePool {
         this.updateRecursiveExcludedIds(this.stores);
     };
 
+    findPreviousStores(store: SmartContentStore) {
+        const previousStores = [];
+        for (const otherStore of this.stores) {
+            if (otherStore === store) {
+                break;
+            }
+
+            if (otherStore.provider !== store.provider) {
+                continue;
+            }
+
+            previousStores.push(otherStore);
+        }
+
+        return previousStores;
+    }
+
     updateRecursiveExcludedIds = (stores: Array<SmartContentStore>) => {
         if (stores.length === 0) {
             return;
@@ -54,14 +71,7 @@ class SmartContentStorePool {
             return;
         }
 
-        const previousStores = [];
-        for (const otherStore of this.stores) {
-            if (otherStore === store) {
-                break;
-            }
-
-            previousStores.push(otherStore);
-        }
+        const previousStores = this.findPreviousStores(store);
 
         if (previousStores.length === 0) {
             this.updateRecursiveExcludedIds(stores.slice(1));

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/smartContentStorePool.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/smartContentStorePool.js
@@ -1,0 +1,69 @@
+// @flow
+import {action, observable, when} from 'mobx';
+import {SmartContentStore} from '../../SmartContent';
+
+class SmartContentStorePool {
+    @observable stores: Array<SmartContentStore>;
+
+    constructor() {
+        this.clear();
+    }
+
+    clear() {
+        this.stores = [];
+    }
+
+    @action add(store: SmartContentStore) {
+        if (this.stores.includes(store)) {
+            throw new Error('Cannot add a SmartContentStore twice!');
+        }
+
+        this.stores.push(store);
+    }
+
+    @action remove(store: SmartContentStore) {
+        this.stores.splice(this.stores.indexOf(store), 1);
+    }
+
+    updateExcludedIds = () => {
+        this.updateRecursiveExcludedIds(this.stores);
+    };
+
+    updateRecursiveExcludedIds = (stores: Array<SmartContentStore>) => {
+        if (stores.length === 0) {
+            return;
+        }
+
+        const store = stores[0];
+        const previousStores = [];
+        for (const otherStore of this.stores) {
+            if (otherStore === store) {
+                break;
+            }
+
+            previousStores.push(otherStore);
+        }
+
+        if (previousStores.length === 0) {
+            this.updateRecursiveExcludedIds(stores.slice(1));
+            return;
+        }
+
+        when(
+            () => previousStores.every((store) => !store.itemsLoading),
+            (): void => {
+                const excludedIds = previousStores
+                    .reduce((ids, smartContentStore) => {
+                        ids.push(...smartContentStore.items.map((item) => item.id));
+                        return ids;
+                    }, []);
+
+                store.setExcludedIds(excludedIds);
+
+                this.updateRecursiveExcludedIds(stores.slice(1));
+            }
+        );
+    };
+}
+
+export default new SmartContentStorePool();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -40,6 +40,7 @@ jest.mock('../../../SmartContent/stores/smartContentConfigStore', () => ({
 
 jest.mock('../../fields/smartContentStorePool', () => ({
     add: jest.fn(),
+    findPreviousStores: jest.fn().mockReturnValue([]),
     stores: [],
     remove: jest.fn(),
     updateExcludedIds: jest.fn(),
@@ -120,8 +121,7 @@ test('Defer start of smartContentStore until all previous stores have loaded the
     smartContentStore1.itemsLoading = true;
     const smartContentStore2 = new SmartContentStore('pages');
     smartContentStore2.itemsLoading = true;
-    // $FlowFixMe
-    smartContentStorePool.stores = [smartContentStore1, smartContentStore2];
+    smartContentStorePool.findPreviousStores.mockReturnValue([smartContentStore1, smartContentStore2]);
 
     const schemaOptions = {
         exclude_duplicates: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -82,12 +82,36 @@ test('Should correctly initialize SmartContentStore', () => {
 
     expect(smartContentStore.start).toBeCalledWith();
 
-    expect(smartContentStorePool.add).toBeCalledWith(smartContentStore);
+    expect(smartContentStorePool.add).toBeCalledWith(smartContentStore, false);
     expect(smartContentConfigStore.getConfig).toBeCalledWith('media');
     expect(SmartContentStore).toBeCalledWith('media', value, undefined, 'collections', undefined);
 
     smartContent.unmount();
     expect(smartContentStorePool.remove).toBeCalledWith(smartContentStore);
+});
+
+test('Should correctly initialize SmartContentStore with a negative exclude_duplicates values', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test', 1), 'test'));
+    smartContentConfigStore.getConfig.mockReturnValue({datasourceResourceKey: 'collections'});
+
+    const schemaOptions = {
+        exclude_duplicates: {
+            value: true,
+        },
+    };
+
+    const smartContent = shallow(
+        <SmartContent
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    const smartContentStore = smartContent.instance().smartContentStore;
+
+    expect(smartContentStore.start).toBeCalledWith();
+    expect(smartContentStorePool.add).toBeCalledWith(smartContentStore, true);
 });
 
 test('Defer start of smartContentStore until all previous stores have loaded their items', () => {
@@ -96,6 +120,7 @@ test('Defer start of smartContentStore until all previous stores have loaded the
     smartContentStore1.itemsLoading = true;
     const smartContentStore2 = new SmartContentStore('pages');
     smartContentStore2.itemsLoading = true;
+    // $FlowFixMe
     smartContentStorePool.stores = [smartContentStore1, smartContentStore2];
 
     const schemaOptions = {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -91,7 +91,7 @@ test('Should correctly initialize SmartContentStore', () => {
     expect(smartContentStorePool.remove).toBeCalledWith(smartContentStore);
 });
 
-test('Should correctly initialize SmartContentStore with a negative exclude_duplicates values', () => {
+test('Should correctly initialize SmartContentStore with a exclude_duplicates value of false', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test', 1), 'test'));
     smartContentConfigStore.getConfig.mockReturnValue({datasourceResourceKey: 'collections'});
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/smartContentStorePool.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/smartContentStorePool.test.js
@@ -1,0 +1,90 @@
+// @flow
+import {extendObservable as mockExtendObservable} from 'mobx';
+import smartContentStorePool from '../../fields/smartContentStorePool';
+import SmartContentStore from '../../../SmartContent/stores/SmartContentStore';
+
+jest.mock('../../../SmartContent/stores/SmartContentStore', () => jest.fn(function() {
+    this.excludedIds = [];
+    this.setExcludedIds = jest.fn((excludedIds) => {
+        this.excludedIds = excludedIds;
+    });
+
+    mockExtendObservable(this, {itemsLoading: false});
+}));
+
+beforeEach(() => {
+    smartContentStorePool.clear();
+});
+
+test('Add and remove SmartContentStores', () => {
+    const smartContentStore1 = new SmartContentStore('pages');
+    const smartContentStore2 = new SmartContentStore('pages');
+
+    smartContentStorePool.add(smartContentStore1);
+    smartContentStorePool.add(smartContentStore2);
+
+    expect(smartContentStorePool.stores).toEqual([smartContentStore1, smartContentStore2]);
+
+    smartContentStorePool.remove(smartContentStore1);
+    expect(smartContentStorePool.stores).toEqual([smartContentStore2]);
+});
+
+test('Add same SmartContentStore twice should throw an error', () => {
+    const smartContentStore = new SmartContentStore('pages');
+
+    smartContentStorePool.add(smartContentStore);
+
+    expect(() => smartContentStorePool.add(smartContentStore)).toThrow(/twice/);
+});
+
+test('Updated excluded ids', () => {
+    const smartContentStore1 = new SmartContentStore('pages');
+    const smartContentStore2 = new SmartContentStore('pages');
+    const smartContentStore3 = new SmartContentStore('pages');
+
+    smartContentStorePool.add(smartContentStore1);
+    smartContentStorePool.add(smartContentStore2);
+    smartContentStorePool.add(smartContentStore3);
+
+    smartContentStore1.items = [{id: 1}];
+    smartContentStore2.items = [{id: 2}, {id: 3}];
+
+    smartContentStorePool.updateExcludedIds();
+
+    expect(smartContentStore1.excludedIds).toEqual([]);
+    expect(smartContentStore2.excludedIds).toEqual([1]);
+    expect(smartContentStore3.excludedIds).toEqual([1, 2, 3]);
+});
+
+test('Updated excluded ids should wait if something is currently loading', () => {
+    const smartContentStore1 = new SmartContentStore('pages');
+    const smartContentStore2 = new SmartContentStore('pages');
+    const smartContentStore3 = new SmartContentStore('pages');
+
+    smartContentStore1.itemsLoading = true;
+    smartContentStore2.itemsLoading = true;
+    smartContentStore3.itemsLoading = true;
+
+    smartContentStorePool.add(smartContentStore1);
+    smartContentStorePool.add(smartContentStore2);
+    smartContentStorePool.add(smartContentStore3);
+
+    smartContentStore1.items = [{id: 1}];
+    smartContentStore2.items = [{id: 2}, {id: 3}];
+
+    smartContentStorePool.updateExcludedIds();
+
+    expect(smartContentStore1.excludedIds).toEqual([]);
+    expect(smartContentStore2.excludedIds).toEqual([]);
+    expect(smartContentStore3.excludedIds).toEqual([]);
+
+    smartContentStore1.itemsLoading = false;
+    expect(smartContentStore1.excludedIds).toEqual([]);
+    expect(smartContentStore2.excludedIds).toEqual([1]);
+    expect(smartContentStore3.excludedIds).toEqual([]);
+
+    smartContentStore2.itemsLoading = false;
+    expect(smartContentStore1.excludedIds).toEqual([]);
+    expect(smartContentStore2.excludedIds).toEqual([1]);
+    expect(smartContentStore3.excludedIds).toEqual([1, 2, 3]);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/smartContentStorePool.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/smartContentStorePool.test.js
@@ -8,6 +8,7 @@ jest.mock('../../../SmartContent/stores/SmartContentStore', () => jest.fn(functi
     this.setExcludedIds = jest.fn((excludedIds) => {
         this.excludedIds = excludedIds;
     });
+    this.items = [];
 
     mockExtendObservable(this, {itemsLoading: false});
 }));
@@ -20,8 +21,8 @@ test('Add and remove SmartContentStores', () => {
     const smartContentStore1 = new SmartContentStore('pages');
     const smartContentStore2 = new SmartContentStore('pages');
 
-    smartContentStorePool.add(smartContentStore1);
-    smartContentStorePool.add(smartContentStore2);
+    smartContentStorePool.add(smartContentStore1, true);
+    smartContentStorePool.add(smartContentStore2, true);
 
     expect(smartContentStorePool.stores).toEqual([smartContentStore1, smartContentStore2]);
 
@@ -32,19 +33,21 @@ test('Add and remove SmartContentStores', () => {
 test('Add same SmartContentStore twice should throw an error', () => {
     const smartContentStore = new SmartContentStore('pages');
 
-    smartContentStorePool.add(smartContentStore);
+    smartContentStorePool.add(smartContentStore, true);
 
-    expect(() => smartContentStorePool.add(smartContentStore)).toThrow(/twice/);
+    expect(() => smartContentStorePool.add(smartContentStore, true)).toThrow(/twice/);
 });
 
-test('Updated excluded ids', () => {
+test('Updated excluded ids only if excludedDuplicates is set to true', () => {
     const smartContentStore1 = new SmartContentStore('pages');
     const smartContentStore2 = new SmartContentStore('pages');
     const smartContentStore3 = new SmartContentStore('pages');
+    const smartContentStore4 = new SmartContentStore('pages');
 
-    smartContentStorePool.add(smartContentStore1);
-    smartContentStorePool.add(smartContentStore2);
-    smartContentStorePool.add(smartContentStore3);
+    smartContentStorePool.add(smartContentStore1, true);
+    smartContentStorePool.add(smartContentStore2, true);
+    smartContentStorePool.add(smartContentStore3, false);
+    smartContentStorePool.add(smartContentStore4, true);
 
     smartContentStore1.items = [{id: 1}];
     smartContentStore2.items = [{id: 2}, {id: 3}];
@@ -53,7 +56,8 @@ test('Updated excluded ids', () => {
 
     expect(smartContentStore1.excludedIds).toEqual([]);
     expect(smartContentStore2.excludedIds).toEqual([1]);
-    expect(smartContentStore3.excludedIds).toEqual([1, 2, 3]);
+    expect(smartContentStore3.excludedIds).toEqual([]);
+    expect(smartContentStore4.excludedIds).toEqual([1, 2, 3]);
 });
 
 test('Updated excluded ids should wait if something is currently loading', () => {
@@ -65,9 +69,9 @@ test('Updated excluded ids should wait if something is currently loading', () =>
     smartContentStore2.itemsLoading = true;
     smartContentStore3.itemsLoading = true;
 
-    smartContentStorePool.add(smartContentStore1);
-    smartContentStorePool.add(smartContentStore2);
-    smartContentStorePool.add(smartContentStore3);
+    smartContentStorePool.add(smartContentStore1, true);
+    smartContentStorePool.add(smartContentStore2, true);
+    smartContentStorePool.add(smartContentStore3, true);
 
     smartContentStore1.items = [{id: 1}];
     smartContentStore2.items = [{id: 2}, {id: 3}];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/stores/SmartContentStore.test.js
@@ -93,7 +93,8 @@ test('Load items if FilterCriteria is given with datasource', () => {
     const datasourcePromise = Promise.resolve({id: 3});
     ResourceRequester.get.mockReturnValue(datasourcePromise);
 
-    new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    smartContentStore.start();
 
     return datasourcePromise.then(() => {
         expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4&locale=en&dataSource=3');
@@ -123,7 +124,8 @@ test('Load items if FilterCriteria is given with categories', () => {
     });
     ResourceRequester.get.mockReturnValue(categoriesPromise);
 
-    new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    smartContentStore.start();
 
     return categoriesPromise.then(() => {
         expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4&locale=en&categories=1,5');
@@ -146,9 +148,33 @@ test('Load items if FilterCriteria is given with tags', () => {
         limitResult: undefined,
     };
 
-    new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    smartContentStore.start();
 
     expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4&locale=en&tags=Tag2');
+});
+
+test('Load items excluding given ids', () => {
+    const locale = observable.box('en');
+    const filterCriteria = {
+        dataSource: undefined,
+        includeSubFolders: undefined,
+        categories: undefined,
+        categoryOperator: undefined,
+        tags: undefined,
+        tagOperator: undefined,
+        audienceTargeting: undefined,
+        sortBy: undefined,
+        sortMethod: undefined,
+        presentAs: undefined,
+        limitResult: undefined,
+    };
+
+    const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    smartContentStore.setExcludedIds([1, 2, 6]);
+    smartContentStore.start();
+
+    expect(Requester.get).toBeCalledWith('/api/items?provider=content&excluded=4,1,2,6&locale=en');
 });
 
 test('Do not load items if FilterCriteria is given with empty categories and tags arrays', () => {
@@ -200,6 +226,7 @@ test('Load items and store them in the items variable', () => {
     });
     Requester.get.mockReturnValue(itemsPromise);
     const smartContentStore = new SmartContentStore('content', filterCriteria, locale, 'pages', 4);
+    smartContentStore.start();
 
     expect(Requester.get).toHaveBeenLastCalledWith(
         '/api/items?provider=content&excluded=4&locale=en&audienceTargeting=true&categoryOperator=and'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes use of the already existing `exclude_duplicates` parameter.

#### Why?

Because the preview in the admin showed the correct entries including this option, but the field itself in the form did not.

#### Example Usage

~~~xml
        <property name="smart" type="smart_content">
            <params>
                <param name="exclude_duplicates" value="true"/>
            </params>
        </property>

        <property name="smart2" type="smart_content">
            <params>
                <param name="exclude_duplicates" value="true"/>
            </params>
        </property>

        <property name="smart3" type="smart_content">
            <params>
                <param name="exclude_duplicates" value="true"/>
            </params>
        </property>

        <property name="smart4" type="smart_content">
            <params>
                <param name="exclude_duplicates" value="true"/>
            </params>
        </property>
~~~

#### To Do

- [x] Check if working without `exclude_duplicates` as well
- [x] Check if mixed providers are working (e.g. some contact and some media smart contents)
- [x] Maybe replace `previousSmartContentStore` in `smart_content` field with a more general function in `smartContentStorePool`