### PR TITLE
Add coordinate fields to address for contact and accounts

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/index.js
@@ -190,6 +190,21 @@ initializer.addUpdateConfigHook('sulu_contact', (config: Object, initialized: bo
                             },
                             type: 'section',
                         },
+                        coordinates: {
+                            items: {
+                                latitude: {
+                                    label: translate('sulu_contact.latitude'),
+                                    colSpan: 6,
+                                    type: 'text_line',
+                                },
+                                longitude: {
+                                    label: translate('sulu_contact.longitude'),
+                                    colSpan: 6,
+                                    type: 'text_line',
+                                },
+                            },
+                            type: 'section',
+                        },
                         note: {
                             items: {
                                 note: {

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/index.js
@@ -195,12 +195,12 @@ initializer.addUpdateConfigHook('sulu_contact', (config: Object, initialized: bo
                                 latitude: {
                                     label: translate('sulu_contact.latitude'),
                                     colSpan: 6,
-                                    type: 'text_line',
+                                    type: 'number',
                                 },
                                 longitude: {
                                     label: translate('sulu_contact.longitude'),
                                     colSpan: 6,
-                                    type: 'text_line',
+                                    type: 'number',
                                 },
                             },
                             type: 'section',

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.de.json
@@ -70,5 +70,7 @@
     "sulu_contact.documents": "Dokumente",
     "sulu_contact.delete_media_warning_title": "Dokumentenzuweisung löschen?",
     "sulu_contact.delete_media_warning_text": "Diese Operation löscht die ausgewählten Dokumentzuweisungen. Das Dokument selbst wird nicht gelöscht. Wollen Sie wirklich fortfahren?",
-    "sulu_contact.add_contact_to_organization": "Person zu Organisation hinzufügen"
+    "sulu_contact.add_contact_to_organization": "Person zu Organisation hinzufügen",
+    "sulu_contact.latitude": "Längengrad",
+    "sulu_contact.longitude": "Breitengrad"
 }

--- a/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/ContactBundle/Resources/translations/admin.en.json
@@ -70,5 +70,7 @@
     "sulu_contact.documents": "Documents",
     "sulu_contact.delete_media_warning_title": "Remove document assignment?",
     "sulu_contact.delete_media_warning_text": "This operation removes the selected document assignments. The document itself will not be deleted. Do you really wish to proceed?",
-    "sulu_contact.add_contact_to_organization": "Add contact to organization"
+    "sulu_contact.add_contact_to_organization": "Add contact to organization",
+    "sulu_contact.latitude": "Latitude",
+    "sulu_contact.longitude": "Longitude"
 }

--- a/src/Sulu/Bundle/LocationBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/LocationBundle/Resources/translations/admin.de.json
@@ -1,6 +1,6 @@
 {
-    "sulu_location.latitude": "Länge",
-    "sulu_location.longitude": "Breite",
+    "sulu_location.latitude": "Längengrad",
+    "sulu_location.longitude": "Breitengrad",
     "sulu_location.zoom": "Zoom",
     "sulu_location.select_location": "Position auswählen",
     "sulu_location.additional_information": "Zusätzliche Adressinformationen",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds the coordinate (longitude and latitude) to the address overlay in contacts and accounts.

#### Why?

These fields existed in Sulu 1.6 but have disappeared in Sulu 2.0.