### PR TITLE
removed storageOptions param in getFormats call

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -650,7 +650,6 @@ class CollectionManager implements CollectionManagerInterface
         $mediaFormats = $this->formatManager->getFormats(
             $mediaId,
             $fileVersion->getName(),
-            $fileVersion->getStorageOptions(),
             $fileVersion->getVersion(),
             $fileVersion->getSubVersion(),
             $fileVersion->getMimeType()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4827 
| Related issues/PRs | #4024 
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR removes the storage options parameter in the call to FormatManager->getFormats() from the CollectionManager.
