### PR TITLE
Resolve persistence-bundle entities in references option of doctrine schemas

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/doctrine.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/doctrine.xml
@@ -5,6 +5,8 @@
     <services>
         <service id="sulu_core.doctrine.references" class="Sulu\Component\Doctrine\ReferencesOption">
             <argument type="service" id="doctrine"/>
+            <!-- the $targetEntityMapping argument is set by the ResolveTargetEntitiesPass -->
+            <argument key="$targetEntityMapping" type="collection" />
 
             <tag name="doctrine.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/doctrine.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/doctrine.xml
@@ -6,7 +6,7 @@
         <service id="sulu_core.doctrine.references" class="Sulu\Component\Doctrine\ReferencesOption">
             <argument type="service" id="doctrine"/>
             <!-- the $targetEntityMapping argument is set by the ResolveTargetEntitiesPass -->
-            <argument key="$targetEntityMapping" type="collection" />
+            <argument type="collection" />
 
             <tag name="doctrine.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
@@ -60,8 +60,8 @@ class ResolveTargetEntitiesPass implements CompilerPassInterface
         // update $targetEntityMapping argument of ReferencesOption service
         // this is needed to allow for using interfaces when using a "references" option in a doctrine schema
         $doctrineReference = $container->findDefinition('sulu_core.doctrine.references');
-        $oldTargetEntityMapping = $doctrineReference->getArgument('$targetEntityMapping');
-        $doctrineReference->setArgument('$targetEntityMapping', array_merge($oldTargetEntityMapping, $interfaceMapping));
+        $oldTargetEntityMapping = $doctrineReference->getArgument(1);
+        $doctrineReference->replaceArgument(1, array_merge($oldTargetEntityMapping, $interfaceMapping));
     }
 
     /**

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
@@ -59,9 +59,11 @@ class ResolveTargetEntitiesPass implements CompilerPassInterface
 
         // update $targetEntityMapping argument of ReferencesOption service
         // this is needed to allow for using interfaces when using a "references" option in a doctrine schema
-        $doctrineReference = $container->findDefinition('sulu_core.doctrine.references');
-        $oldTargetEntityMapping = $doctrineReference->getArgument(1);
-        $doctrineReference->replaceArgument(1, array_merge($oldTargetEntityMapping, $interfaceMapping));
+        if ($container->hasDefinition('sulu_core.doctrine.references')) {
+            $doctrineReference = $container->findDefinition('sulu_core.doctrine.references');
+            $oldTargetEntityMapping = $doctrineReference->getArgument(1);
+            $doctrineReference->replaceArgument(1, array_merge($oldTargetEntityMapping, $interfaceMapping));
+        }
     }
 
     /**

--- a/src/Sulu/Component/Doctrine/ReferencesOption.php
+++ b/src/Sulu/Component/Doctrine/ReferencesOption.php
@@ -63,9 +63,15 @@ class ReferencesOption implements EventSubscriber
      */
     private $managerRegistry;
 
-    public function __construct(ManagerRegistry $managerRegistry)
+    /**
+     * @var array
+     */
+    private $targetEntityMapping;
+
+    public function __construct(ManagerRegistry $managerRegistry, array $targetEntityMapping)
     {
         $this->managerRegistry = $managerRegistry;
+        $this->targetEntityMapping = $targetEntityMapping;
     }
 
     /**
@@ -153,10 +159,16 @@ class ReferencesOption implements EventSubscriber
 
             $localColumnName = $classMetadata->getColumnName($fieldName);
 
+            // we need to use the actual class if the entity is an interface that is mapped by the SuluPersistenceBundle
+            $targetEntity = $referencesOptions['entity'];
+            if (array_key_exists($targetEntity, $this->targetEntityMapping)) {
+                $targetEntity = $this->targetEntityMapping[$targetEntity];
+            }
+
             /** @var ObjectManager $manager */
-            $manager = $this->managerRegistry->getManagerForClass($referencesOptions['entity']);
+            $manager = $this->managerRegistry->getManagerForClass($targetEntity);
             /** @var ClassMetadata $foreignClassMetadata */
-            $foreignClassMetadata = $manager->getClassMetadata($referencesOptions['entity']);
+            $foreignClassMetadata = $manager->getClassMetadata($targetEntity);
 
             $foreignTable = $foreignClassMetadata->getTableName();
             $foreignColumnName = $foreignClassMetadata->getColumnName($referencesOptions['field']);


### PR DESCRIPTION


| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR enhances the `ResolveTargetEntitiesPass` to pass a target-entity mapping to the `ReferencesOption` service.

#### Why?

To allow for using interfaces in a `references` option inside of a doctrine schema.

#### Example Usage

~~~xml
        <field name="userId" column="userId" type="integer" unique="true" nullable="false">
            <options>
                <option name="references">
                    <option name="entity">Sulu\Component\Security\Authentication\UserInterface</option>
                    <option name="field">id</option>
                    <option name="onDelete">CASCADE</option>
                    <option name="onUpdate">CASCADE</option>
                </option>
            </options>
        </field>
~~~
