### PR TITLE
Reset SingleSelection to null if the selected item was deleted

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -100,7 +100,7 @@ export default class SingleSelection extends React.Component<Props>
             value,
         } = this.props;
 
-        if (typeof value === 'object') {
+        if (value !== null && typeof value === 'object') {
             // TODO implement object value support for overlay type
             throw new Error(
                 'The "list_overlay" type of the SingleSelection field type supports only an ID value until now.'

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -172,6 +172,37 @@ test('Pass correct props with schema-options type to SingleAutoComplete', () => 
     }));
 });
 
+test('Pass null as value to SingleSelection for list_overlay', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const value = null;
+
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'accounts',
+        types: {
+            list_overlay: {
+                adapter: 'table',
+                display_properties: ['name'],
+                empty_text: 'sulu_contact.nothing',
+                icon: 'su-account',
+                overlay_title: 'sulu_contact.overlay_title',
+            },
+        },
+    };
+
+    const singleSelection = shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            disabled={true}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            value={null}
+        />
+    );
+
+    expect(singleSelection.find('SingleSelection').prop('value')).toEqual(expect.objectContaining(value));
+});
+
 test('Call onChange and onFinish when SingleAutoComplete changes', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
     const changeSpy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -45,7 +45,9 @@ class SingleSelection extends React.Component<Props> {
 
         this.singleSelectionStore = new SingleSelectionStore(resourceKey, value, locale, detailOptions);
         this.changeDisposer = reaction(
-            () => (this.singleSelectionStore.item ? this.singleSelectionStore.item.id : undefined),
+            () => !this.singleSelectionStore.item
+                ? this.singleSelectionStore.item
+                : this.singleSelectionStore.item.id,
             (loadedItemId: ?string | number) => {
                 const {onChange, value} = this.props;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/SingleSelection.js
@@ -45,9 +45,11 @@ class SingleSelection extends React.Component<Props> {
 
         this.singleSelectionStore = new SingleSelectionStore(resourceKey, value, locale, detailOptions);
         this.changeDisposer = reaction(
-            () => !this.singleSelectionStore.item
-                ? this.singleSelectionStore.item
-                : this.singleSelectionStore.item.id,
+            () => this.singleSelectionStore.item === undefined
+                ? undefined // this value is returned if nothing was assigned
+                : this.singleSelectionStore.item === null
+                    ? null // this value is returned if something was assigned but was deleted
+                    : this.singleSelectionStore.item.id,
             (loadedItemId: ?string | number) => {
                 const {onChange, value} = this.props;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js
@@ -226,6 +226,29 @@ test('Should not open an overlay on button-click when disabled', () => {
     expect(singleSelection.find(SingleListOverlay).prop('open')).toEqual(false);
 });
 
+test('Should call the onChange callback with null if the current item does not exist and set to null', () => {
+    const changeSpy = jest.fn();
+
+    const singleSelection = mount(
+        <SingleSelection
+            adapter="table"
+            disabledIds={[]}
+            displayProperties={[]}
+            emptyText="Nothing"
+            icon="su-test"
+            listKey="test"
+            onChange={changeSpy}
+            overlayTitle="Test"
+            resourceKey="test"
+            value={3}
+        />
+    );
+
+    singleSelection.instance().singleSelectionStore.item = null;
+
+    expect(changeSpy).toBeCalledWith(null, null);
+});
+
 test('Should call the onChange callback if a new item was selected', () => {
     const changeSpy = jest.fn();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SingleSelectionStore/SingleSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SingleSelectionStore/SingleSelectionStore.js
@@ -43,13 +43,23 @@ export default class SingleSelectionStore<T, U: {id: T} = Object> {
         }
 
         this.setLoading(true);
-        return ResourceRequester.get(this.resourceKey, {
-            ...this.options,
-            id: itemId,
-            locale: this.locale ? this.locale.get() : undefined,
-        }).then(action((data) => {
-            this.item = data;
-            this.setLoading(false);
-        }));
+        return ResourceRequester
+            .get(this.resourceKey, {
+                ...this.options,
+                id: itemId,
+                locale: this.locale ? this.locale.get() : undefined,
+            })
+            .then(action((data) => {
+                this.item = data;
+                this.setLoading(false);
+            }))
+            .catch(action((error) => {
+                if (error.status !== 404) {
+                    return Promise.reject(error);
+                }
+
+                this.item = null;
+                this.setLoading(false);
+            }));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SingleSelectionStore/tests/SingleSelectionStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/SingleSelectionStore/tests/SingleSelectionStore.test.js
@@ -29,6 +29,32 @@ test('Should load item when being constructed', () => {
     });
 });
 
+test('Should set item to null when 404 is returned', (done) => {
+    const getPromise = Promise.reject({
+        status: 404,
+    });
+
+    ResourceRequester.get.mockReturnValue(getPromise);
+
+    const singleSelectionStore = new SingleSelectionStore('snippets', 1, observable.box('en'));
+
+    expect(ResourceRequester.get).toBeCalledWith(
+        'snippets',
+        {
+            id: 1,
+            locale: 'en',
+        }
+    );
+
+    expect(toJS(singleSelectionStore.loading)).toEqual(true);
+
+    setTimeout(() => {
+        expect(toJS(singleSelectionStore.item)).toEqual(null);
+        expect(toJS(singleSelectionStore.loading)).toEqual(false);
+        done();
+    });
+});
+
 test('Should load item when being constructed with additional options', () => {
     const getPromise = Promise.resolve({
         id: 1,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4808
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes the current selection in a `SingleSelection` if the selected item does not exist anymore.