### PR TITLE
Show proper error message when not available default type is set on a block

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/complex.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/complex.xml
@@ -35,8 +35,8 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <block name="block1" 
-               default-type="editor"
+        <block name="block1"
+               default-type="default"
                minOccurs="2"
                maxOccurs="10"
                mandatory="true">

--- a/src/Sulu/Component/Content/Exception/InvalidBlockDefaultTypeException.php
+++ b/src/Sulu/Component/Content/Exception/InvalidBlockDefaultTypeException.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Exception;
+
+class InvalidBlockDefaultTypeException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $defaultType;
+
+    /**
+     * @var string[]
+     */
+    private $availableTypes;
+
+    /**
+     * @param string[] $availableTypes
+     */
+    public function __construct(string $name, string $defaultType, array $availableTypes)
+    {
+        parent::__construct(sprintf(
+            'Block "%s" has invalid default-type "%s". Available types are %s',
+            $name,
+            $defaultType,
+            implode(
+                ', ',
+                array_map(function($availableType) {
+                    return '"' . $availableType . '"';
+                }, $availableTypes),
+            )
+        ));
+        $this->name = $name;
+        $this->defaultType = $defaultType;
+        $this->availableTypes = $availableTypes;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDefaultType(): string
+    {
+        return $this->defaultType;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAvailableTypes(): array
+    {
+        return $this->availableTypes;
+    }
+}

--- a/src/Sulu/Component/Content/Exception/InvalidBlockDefaultTypeException.php
+++ b/src/Sulu/Component/Content/Exception/InvalidBlockDefaultTypeException.php
@@ -41,7 +41,7 @@ class InvalidBlockDefaultTypeException extends \Exception
                 ', ',
                 array_map(function($availableType) {
                     return '"' . $availableType . '"';
-                }, $availableTypes),
+                }, $availableTypes)
             )
         ));
         $this->name = $name;

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Content\Metadata\Parser;
 
+use Sulu\Component\Content\Exception\InvalidBlockDefaultTypeException;
 use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\ComponentMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
@@ -166,6 +167,14 @@ class PropertiesXmlParser
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
         $result['meta'] = $this->loadMeta($xpath, $node);
         $result['types'] = $this->loadTypes($tags, $xpath, $node);
+
+        $typeNames = array_map(function($type) {
+            return $type['name'];
+        }, $result['types']);
+
+        if (!in_array($result['default-type'], $typeNames)) {
+            throw new InvalidBlockDefaultTypeException($result['name'], $result['default-type'], $typeNames);
+        }
 
         return $result;
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Exception\InvalidBlockDefaultTypeException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredPropertyNameNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredTagNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\StructureXmlLoader;
@@ -256,6 +257,14 @@ class StructureXmlLoaderTest extends TestCase
         $properties = $result->getProperties();
 
         $this->assertCount(2, $properties);
+    }
+
+    public function testLoadFormWithInvalidBlockDefaultType()
+    {
+        $this->expectException(InvalidBlockDefaultTypeException::class);
+        $this->expectExceptionMessage('Block "blocks" has invalid default-type "test". Available types are "editor", "images"');
+
+        $this->load('template_with_invalid_block_default_type.xml');
     }
 
     private function load($name, $type = null)

--- a/tests/Resources/DataFixtures/Page/template_with_invalid_block_default_type.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_invalid_block_default_type.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>template_with_invalid_block_default_type</key>
+
+    <view>page.html.twig</view>
+    <controller>SuluPageBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true" colspan="6"/>
+
+        <property name="url" type="text_line">
+            <tag name="sulu.rlp" />
+        </property>
+
+        <block name="blocks" default-type="test" minOccurs="0">
+            <meta>
+                <title lang="de">Inhalte</title>
+                <title lang="en">Content</title>
+            </meta>
+            <types>
+                <type name="editor">
+                    <properties>
+                        <property name="article" type="text_editor"/>
+                    </properties>
+                </type>
+                <type name="images">
+                    <properties>
+                        <property name="images" type="media_selection" colspan="3"/>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR throws a proper exception when a block is defined in a XML template without an existing `default-type`.

#### Why?

Because when you are configuring this in a wrong way at the moment, then the XML template is interepreted without any error, but when a new block is added in the UI, it will show a strange error like this:

```
FieldBlocks.js:76 Uncaught TypeError: Cannot read property 'form' of undefined
```

This is very confusing, and does not really help.

#### Example Usage

Try to use the following template and add a new block in the UI.

~~~xml
<?xml version="1.0" ?>
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">

    <key>template_with_invalid_block_default_type</key>

    <view>page.html.twig</view>
    <controller>SuluPageBundle:Default:index</controller>
    <cacheLifetime>2400</cacheLifetime>

    <properties>
        <property name="title" type="text_line" mandatory="true" colspan="6"/>

        <property name="url" type="text_line">
            <tag name="sulu.rlp" />
        </property>

        <block name="blocks" default-type="test" minOccurs="0">
            <meta>
                <title lang="de">Inhalte</title>
                <title lang="en">Content</title>
            </meta>
            <types>
                <type name="editor">
                    <properties>
                        <property name="article" type="text_editor"/>
                    </properties>
                </type>
                <type name="images">
                    <properties>
                        <property name="images" type="media_selection" colspan="3"/>
                    </properties>
                </type>
            </types>
        </block>
    </properties>
</template>
~~~