### PR TITLE
Make getTestUser function static

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/TestUserTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestUserTrait.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\TestBundle\Testing;
 
-use Symfony\Component\Security\Core\User\UserInterface;
+use Sulu\Bundle\SecurityBundle\Entity\User;
 
 trait TestUserTrait
 {
@@ -19,11 +19,11 @@ trait TestUserTrait
      * Return the test user (which is provided / created
      * by the test_user_provider in this Bundle at runtime).
      *
-     * @return UserInterface
+     * @return User
      */
-    protected function getTestUser()
+    protected static function getTestUser()
     {
-        return $this->getContainer()->get('test_user_provider')->getUser();
+        return static::getContainer()->get('test_user_provider')->getUser();
     }
 
     /**
@@ -32,8 +32,8 @@ trait TestUserTrait
      *
      * @return int
      */
-    protected function getTestUserId()
+    protected static function getTestUserId()
     {
-        return $this->getTestUser()->getId();
+        return static::getTestUser()->getId();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Make getTestUser functions static

#### Why?

To make it possible to access the TestUser in a `setUpBeforeClass`.

#### Example Usage

~~~php
public static function setUpBeforeClass(): void
{
     self::getTestUserId();
}
~~~