### PR TITLE
Add branch aliases for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,5 +103,12 @@
         "psr-0": {
             "Sulu\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-release/1.6": "1.6.x-dev",
+            "dev-release/2.0": "2.0.x-dev",
+            "dev-master": "2.1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add branch aliases for development

#### Why?

Allow to use @dev for specific version.

#### Example Usage

~~~json
"sulu/sulu": "^2.0@dev"
~~~

