### PR TITLE
Use ResourceLocatorStrategy in UI based on webspace configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,24 @@
 
 ## dev-release/2.0
 
+### mode schemaOption in ResourceLocator
+
+The `resource_locator` field had a `mode` schema option, which could e.g. be used like this:
+
+
+```xml
+<property name="url" type="resource_locator" mandatory="true">
+    <params>
+        <param name="mode" value="full" />
+    </params>
+
+    <tag name="sulu.rlp"/>
+</property>
+```
+
+This option does not exist anymore. Instead you should set the correct `resource-locator-strategy` in your webspace
+configuration.
+
 ### Fix AccountInterface nullable setters/getter
 
 Setters and getter of nullable fields on the Account entity were fixed.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -8,7 +8,7 @@ import resourceLocatorStyles from './resourceLocator.scss';
 type Props = {|
     disabled: boolean,
     id?: string,
-    mode: 'full' | 'leaf',
+    mode: string,
     onBlur?: () => void,
     onChange: (value: ?string) => void,
     value: ?string,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -64,7 +64,6 @@ import {
     Number,
     PasswordConfirmation,
     Phone,
-    ResourceLocator,
     Selection,
     SingleSelect,
     SingleSelection,
@@ -114,7 +113,6 @@ const FIELD_TYPE_EMAIL = 'email';
 const FIELD_TYPE_NUMBER = 'number';
 const FIELD_TYPE_PASSWORD_CONFIRMATION = 'password_confirmation';
 const FIELD_TYPE_PHONE = 'phone';
-const FIELD_TYPE_RESOURCE_LOCATOR = 'resource_locator';
 const FIELD_TYPE_SELECT = 'select';
 const FIELD_TYPE_SINGLE_SELECT = 'single_select';
 const FIELD_TYPE_SMART_CONTENT = 'smart_content';
@@ -189,11 +187,6 @@ function registerFieldTypes(fieldTypeOptions) {
     fieldRegistry.add(FIELD_TYPE_NUMBER, Number);
     fieldRegistry.add(FIELD_TYPE_PASSWORD_CONFIRMATION, PasswordConfirmation);
     fieldRegistry.add(FIELD_TYPE_PHONE, Phone);
-    fieldRegistry.add(
-        FIELD_TYPE_RESOURCE_LOCATOR,
-        ResourceLocator,
-        {defaultMode: 'leaf', generationUrl: Config.endpoints.generateUrl, historyResourceKey: 'page_resourcelocators'}
-    );
     fieldRegistry.add(FIELD_TYPE_SMART_CONTENT, SmartContent);
     fieldRegistry.add(FIELD_TYPE_SINGLE_SELECT, SingleSelect);
     fieldRegistry.add(FIELD_TYPE_TEXT_AREA, TextArea);

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -33,6 +33,7 @@
                  class="Sulu\Bundle\PageBundle\EventListener\WebspaceSerializeEventSubscriber">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_core.webspace.url_provider"/>
+            <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument type="string">%kernel.environment%</argument>
 
             <tag name="jms_serializer.event_subscriber" />

--- a/src/Sulu/Bundle/PageBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/index.js
@@ -1,6 +1,6 @@
 // @flow
-import {initializer} from 'sulu-admin-bundle/services';
-import {fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
+import {initializer, Config} from 'sulu-admin-bundle/services';
+import {fieldRegistry, viewRegistry, ResourceLocator} from 'sulu-admin-bundle/containers';
 import {formToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import SearchResult from './containers/Form/fields/SearchResult';
 import TeaserSelection from './containers/Form/fields/TeaserSelection';
@@ -8,6 +8,7 @@ import {teaserProviderRegistry} from './containers/TeaserSelection';
 import PageSettingsNavigationSelect from './containers/Form/fields/PageSettingsNavigationSelect';
 import PageSettingsShadowLocaleSelect from './containers/Form/fields/PageSettingsShadowLocaleSelect';
 import PageSettingsVersions from './containers/Form/fields/PageSettingsVersions';
+import {loadResourceLocatorInputTypeByWebspace} from './utils/Webspace';
 import TemplateToolbarAction from './views/Form/toolbarActions/TemplateToolbarAction';
 import PageTabs from './views/PageTabs';
 import PageList from './views/PageList';
@@ -26,6 +27,16 @@ initializer.addUpdateConfigHook('sulu_page', (config: Object, initialized: boole
     fieldRegistry.add('page_settings_shadow_locale_select', PageSettingsShadowLocaleSelect);
     fieldRegistry.add('search_result', SearchResult);
     fieldRegistry.add('teaser_selection', TeaserSelection);
+
+    fieldRegistry.add(
+        'resource_locator',
+        ResourceLocator,
+        {
+            modeResolver: (props) => loadResourceLocatorInputTypeByWebspace(props.formInspector.options.webspace),
+            generationUrl: Config.endpoints.generateUrl,
+            historyResourceKey: 'page_resourcelocators',
+        }
+    );
 
     if (config.versioning) {
         fieldRegistry.add('page_settings_versions', PageSettingsVersions);

--- a/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/stores/webspaceStore/types.js
@@ -10,7 +10,12 @@ export type Webspace = {
     name: string,
     navigations: Array<Navigation>,
     portalInformation: Array<PortalInformation>,
+    resourceLocatorStrategy: ResourceLocatorStrategy,
     urls: Array<Url>,
+};
+
+export type ResourceLocatorStrategy = {
+    inputType: string,
 };
 
 export type Navigation = {

--- a/src/Sulu/Bundle/PageBundle/Resources/js/utils/Webspace/index.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/utils/Webspace/index.js
@@ -1,0 +1,6 @@
+// @flow
+import loadResourceLocatorInputTypeByWebspace from './loadResourceLocatorInputTypeByWebspace';
+
+export {
+    loadResourceLocatorInputTypeByWebspace,
+};

--- a/src/Sulu/Bundle/PageBundle/Resources/js/utils/Webspace/loadResourceLocatorInputTypeByWebspace.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/utils/Webspace/loadResourceLocatorInputTypeByWebspace.js
@@ -1,0 +1,9 @@
+// @flow
+import webspaceStore from '../../stores/webspaceStore';
+
+export default function loadResourceLocatorInputTypeByWebspace(webspaceKey: string) {
+    return webspaceStore.loadWebspace(webspaceKey)
+        .then((webspace) => {
+            return webspace.resourceLocatorStrategy.inputType;
+        });
+}

--- a/src/Sulu/Bundle/PageBundle/Resources/js/utils/Webspace/tests/loadResourceLocatorInputTypeByWebspace.test.js
+++ b/src/Sulu/Bundle/PageBundle/Resources/js/utils/Webspace/tests/loadResourceLocatorInputTypeByWebspace.test.js
@@ -1,0 +1,15 @@
+// @flow
+import loadResourceLocatorInputTypeByWebspace from '../loadResourceLocatorInputTypeByWebspace';
+import webspaceStore from '../../../stores/webspaceStore';
+
+jest.mock('../../../stores/webspaceStore', () => ({
+    loadWebspace: jest.fn(),
+}));
+
+test.each(['sulu', 'example'])('Load input type for resource locator by webspace', (webspaceKey) => {
+    webspaceStore.loadWebspace.mockReturnValue(Promise.resolve({resourceLocatorStrategy: {inputType: 'leaf'}}));
+    const inputType = loadResourceLocatorInputTypeByWebspace(webspaceKey);
+
+    expect(inputType).toEqual(inputType);
+    expect(webspaceStore.loadWebspace).toBeCalledWith(webspaceKey);
+});

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
@@ -48,5 +48,6 @@ class WebspaceControllerTest extends SuluTestCase
         $this->assertCount(2, $testWebspace['navigations']);
         $this->assertEquals('main', $testWebspace['navigations'][0]['key']);
         $this->assertEquals('footer', $testWebspace['navigations'][1]['key']);
+        $this->assertEquals('leaf', $testWebspace['resourceLocatorStrategy']['inputType']);
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/EventListener/WebspaceSerializeEventSubscriberTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/EventListener/WebspaceSerializeEventSubscriberTest.php
@@ -19,6 +19,7 @@ use JMS\Serializer\Visitor\SerializationVisitorInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sulu\Bundle\PageBundle\EventListener\WebspaceSerializeEventSubscriber;
+use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\CustomUrl;
 use Sulu\Component\Webspace\Environment;
@@ -35,7 +36,13 @@ class WebspaceSerializeEventSubscriberTest extends TestCase
     {
         $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
+        $resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
+        $subscriber = new WebspaceSerializeEventSubscriber(
+            $webspaceManager->reveal(),
+            $webspaceUrlProvider->reveal(),
+            $resourceLocatorStrategyPool->reveal(),
+            'prod'
+        );
 
         $events = $subscriber->getSubscribedEvents();
 
@@ -55,7 +62,13 @@ class WebspaceSerializeEventSubscriberTest extends TestCase
     {
         $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
+        $resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
+        $subscriber = new WebspaceSerializeEventSubscriber(
+            $webspaceManager->reveal(),
+            $webspaceUrlProvider->reveal(),
+            $resourceLocatorStrategyPool->reveal(),
+            'prod'
+        );
 
         $webspace = $this->prophesize(Webspace::class);
         $webspace->getKey()->willReturn('sulu_io');
@@ -98,7 +111,13 @@ class WebspaceSerializeEventSubscriberTest extends TestCase
 
         $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
+        $resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
+        $subscriber = new WebspaceSerializeEventSubscriber(
+            $webspaceManager->reveal(),
+            $webspaceUrlProvider->reveal(),
+            $resourceLocatorStrategyPool->reveal(),
+            'prod'
+        );
 
         $webspace = $this->prophesize(Webspace::class);
         $webspaceUrlProvider->getUrls($webspace->reveal(), 'prod')->willReturn($urls);
@@ -156,7 +175,13 @@ class WebspaceSerializeEventSubscriberTest extends TestCase
 
         $webspaceUrlProvider = $this->prophesize(WebspaceUrlProviderInterface::class);
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $subscriber = new WebspaceSerializeEventSubscriber($webspaceManager->reveal(), $webspaceUrlProvider->reveal(), 'prod');
+        $resourceLocatorStrategyPool = $this->prophesize(ResourceLocatorStrategyPoolInterface::class);
+        $subscriber = new WebspaceSerializeEventSubscriber(
+            $webspaceManager->reveal(),
+            $webspaceUrlProvider->reveal(),
+            $resourceLocatorStrategyPool->reveal(),
+            'prod'
+        );
 
         $context = $this->prophesize(Context::class);
         $navigator = $this->prophesize(GraphNavigatorInterface::class);

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/index.js
@@ -5,8 +5,10 @@ fieldRegistry.add(
     'route',
     ResourceLocator,
     {
-        defaultMode: 'full',
         historyResourceKey: 'routes',
+        modeResolver: () => {
+            return Promise.resolve('full');
+        },
         options: {history: true},
     }
 );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR makes use of the `resource-locator-strategy` configuration of the webspace xml.

#### Why?

Because previously this setting was ignored, and although the configuration said that the entire resource locator should be editable, it wasn't.

#### Example Usage

~~~xml
<resource-locator>
        <strategy>tree_full_edit</strategy>
    </resource-locator>
~~~

#### BC Breaks/Deprecations

The `mode` schema option of the `resource_locator` field type is gone now.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md