### PR TITLE
Fix templating error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
         "symfony/security": "^4.3",
         "symfony/security-bundle": "^4.3",
         "symfony/swiftmailer-bundle": "^3.1.4",
+        "symfony/templating": "^4.3",
         "symfony/translation": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

The FOSRest bundle removed a dependency (`symfony/templating`), which we were still prepending a configuration. We have to add the dependency on our own now, because otherwise Symfony will complain that this configuration does not exist.