### PR TITLE
Improve assert http status for client phpstan return type

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
@@ -26,8 +26,10 @@ trait AssertHttpStatusCodeTrait
      * The $debugLength argument limits the number of lines included from the
      * response body in case of failure.
      */
-    protected static function assertHttpStatusCode(int $code, Response $response, int $debugLength = 50): void
+    protected static function assertHttpStatusCode(int $code, $response, int $debugLength = 50): void
     {
+        self::assertInstanceOf(Response::class, $response);
+
         $httpCode = $response->getStatusCode();
 
         $message = '';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs

#### What's in this PR?

Avoid the instanceOf checks for $client->getResponse() 

#### Why?

Which problem does the PR fix? (remove this section if you linked an issue above)

#### Example Usage

This avoids a check in project code for phpstan if $response is really from class Response.

~~~php
$this->assertHttpStatusCode(200, $response));
~~~

