### PR TITLE
Add path_prefix config for s3 and google-cloud media-storage

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -210,6 +210,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('key_file_path')->isRequired()->end()
                         ->scalarNode('bucket_name')->isRequired()->end()
+                        ->scalarNode('path_prefix')->defaultNull()->end()
                         ->scalarNode('segments')->defaultValue(10)->end()
                     ->end()
                 ->end();
@@ -225,6 +226,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('secret')->isRequired()->end()
                         ->scalarNode('region')->isRequired()->end()
                         ->scalarNode('bucket_name')->isRequired()->end()
+                        ->scalarNode('path_prefix')->defaultNull()->end()
                         ->scalarNode('version')->defaultValue('latest')->end()
                         ->scalarNode('endpoint')->defaultNull()->end()
                         ->scalarNode('segments')->defaultValue(10)->end()

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_google_cloud.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_google_cloud.xml
@@ -18,6 +18,7 @@
                  class="Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter">
             <argument type="service" id="sulu_media.storage.google_cloud.client"/>
             <argument type="service" id="sulu_media.storage.google_cloud.bucket"/>
+            <argument type="string">%sulu_media.media.storage.google_cloud.path_prefix%</argument>
         </service>
 
         <service id="sulu_media.storage.google_cloud.filesystem" class="League\Flysystem\Filesystem">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_s3.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_storage_s3.xml
@@ -17,6 +17,7 @@
         <service id="sulu_media.storage.s3.adapter" class="League\Flysystem\AwsS3v3\AwsS3Adapter">
             <argument type="service" id="sulu_media.storage.s3.client"/>
             <argument type="string">%sulu_media.media.storage.s3.bucket_name%</argument>
+            <argument type="string">%sulu_media.media.storage.s3.path_prefix%</argument>
         </service>
 
         <service id="sulu_media.storage.s3.filesystem" class="League\Flysystem\Filesystem">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a configuration for a path-prefix in aws s3 and google-cloud adapter.

#### Why?

If you want to reuse a bucket you can specifiy a path-prefix to use sub paths inside of the bucket.

#### Example Usage

~~~yaml
sulu_media:
    storage: s3
    storages:
        s3:
            key: '%env(resolve:S3_KEY)%'
            secret: '%env(resolve:S3_SECRET)%'
            region: '%env(resolve:S3_REGION)%'
            bucket_name: '%env(resolve:S3_BUCKET_NAME)%'
            path_prefix: '%env(resolve:S3_PATH_PREFIX)%'
            endpoint: '%env(resolve:S3_ENDPOINT)%'
~~~

#### BC Breaks/Deprecations

None
