### PR TITLE
Prevent editor toolbar to overlap sulu header

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -1,5 +1,8 @@
 @import '../../containers/Application/colors.scss';
+@import '../../containers/Application/variables.scss';
 @import '../../components/Toolbar/variables.scss';
+@import '../../components/Snackbar/snackbar.scss';
+@import '../../components/Tabs/variables.scss';
 
 $textEditorFontSize: 12px;
 $textEditorButtonMinSize: 20px;
@@ -99,7 +102,7 @@ $textEditorUnpublishedLinkColor: $gold;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;
-            max-height: calc(40vh - $toolbarHeight);
+            max-height: calc(100vh - $toolbarHeight - $snackbarHeight - $tabMenuHeight - $viewPadding - 8px);
         }
 
         .ck-widget.table {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -1,4 +1,5 @@
 @import '../../containers/Application/colors.scss';
+@import '../../components/Toolbar/variables.scss';
 
 $textEditorFontSize: 12px;
 $textEditorButtonMinSize: 20px;
@@ -79,6 +80,17 @@ $textEditorUnpublishedLinkColor: $gold;
         .ck.ck-heading-dropdown .ck.ck-dropdown__button {
             border: 1px solid $textEditorDarkBorderColor;
         }
+
+        /**
+         * Move the sticky-toolbar below the SULU header.
+         * Still causes issues when snackbar is visible or when users scrolls whole page to top while editor with
+         * sticky-toolbar is active/visible.
+         */
+        .ck.ck-sticky-panel {
+            .ck.ck-sticky-panel__content_sticky {
+                top: calc($toolbarHeight);
+            }
+        }
     }
 
     .ck.ck-editor {
@@ -92,6 +104,11 @@ $textEditorUnpublishedLinkColor: $gold;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;
+
+            /**
+             * Make the editor so small, that it will not trigger the sticky-header of ck-editor in most cases.
+             */
+            max-height: 40vh;
         }
 
         .ck-widget.table {
@@ -129,6 +146,7 @@ $textEditorUnpublishedLinkColor: $gold;
             line-height: $textEditorFontSize;
             vertical-align: middle;
         }
+
         /* stylelint-enable */
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -88,6 +88,11 @@ $textEditorUnpublishedLinkColor: $gold;
             .ck.ck-sticky-panel__content_sticky {
                 position: static;
             }
+
+            .ck.ck-sticky-panel__placeholder {
+                max-height: 0px;
+                overflow: hidden;
+            }
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -1,8 +1,8 @@
 @import '../../containers/Application/colors.scss';
 @import '../../containers/Application/variables.scss';
-@import '../../components/Toolbar/variables.scss';
 @import '../../components/Snackbar/snackbar.scss';
 @import '../../components/Tabs/variables.scss';
+@import '../../components/Toolbar/variables.scss';
 
 $textEditorFontSize: 12px;
 $textEditorButtonMinSize: 20px;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -81,14 +81,9 @@ $textEditorUnpublishedLinkColor: $gold;
             border: 1px solid $textEditorDarkBorderColor;
         }
 
-        /**
-         * Move the sticky-toolbar below the SULU header.
-         * Still causes issues when snackbar is visible or when users scrolls whole page to top while editor with
-         * sticky-toolbar is active/visible.
-         */
         .ck.ck-sticky-panel {
             .ck.ck-sticky-panel__content_sticky {
-                top: calc($toolbarHeight);
+                position: static;
             }
         }
     }
@@ -104,11 +99,7 @@ $textEditorUnpublishedLinkColor: $gold;
             border-color: $textEditorBackgroundColor !important;
             line-height: 20px;
             min-height: 100px;
-
-            /**
-             * Make the editor so small, that it will not trigger the sticky-header of ck-editor in most cases.
-             */
-            max-height: 40vh;
+            max-height: calc(40vh - $toolbarHeight);
         }
 
         .ck-widget.table {
@@ -146,7 +137,6 @@ $textEditorUnpublishedLinkColor: $gold;
             line-height: $textEditorFontSize;
             vertical-align: middle;
         }
-
         /* stylelint-enable */
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/ckeditor5.scss
@@ -90,7 +90,7 @@ $textEditorUnpublishedLinkColor: $gold;
             }
 
             .ck.ck-sticky-panel__placeholder {
-                max-height: 0px;
+                max-height: 0;
                 overflow: hidden;
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | Yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

PR generally reduces the size of the editor so that the problem of overlapping (see "Why?" below) will only occur in rare cases. If it still happens, then the sticky-toolbar of ck editor will be positioned below the header inside the visible area of the editor.

#### Why?

CK Editors toolbar overlaps the SULU header when top of editor is below header after scrolling. This happens when a lot of lines are in content area.
