### PR TITLE
Implement a command that downloads the current JS build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "symfony/finder": "^4.3",
         "symfony/form": "^4.3",
         "symfony/framework-bundle": "^4.3.1",
+        "symfony/http-client": "^4.3",
         "symfony/http-foundation": "^4.3",
         "symfony/http-kernel": "^4.3",
         "symfony/intl": "^4.3",

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Templating\Tests\Storage\FileStorageTest;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class DownloadBuildCommand extends Command
+{
+    protected static $defaultName = 'sulu:admin:download-build';
+
+    /**
+     * @var HttpClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @var string
+     */
+    private $suluVersion;
+
+    /**
+     * @var string
+     */
+    private $remoteRepository;
+
+    /**
+     * @var string
+     */
+    private $remoteArchive;
+
+    const ASSETS_DIR = DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR;
+
+    const BUILD_DIR = DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR . 'build' . DIRECTORY_SEPARATOR . 'admin';
+
+    const REPOSITORY_NAME = 'skeleton';
+
+    public function __construct(HttpClientInterface $httpClient, string $projectDir, string $suluVersion)
+    {
+        parent::__construct();
+
+        $this->httpClient = $httpClient;
+        $this->projectDir = $projectDir;
+        $this->suluVersion = $suluVersion;
+        $this->remoteRepository = 'https://raw.githubusercontent.com/sulu/skeleton/' . $suluVersion;
+        $this->remoteArchive = 'https://codeload.github.com/sulu/skeleton/zip/' . $suluVersion;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Downloads the current admin application build from the sulu/skeleton repository.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Checking for changed files...</info>');
+
+        $indexJs = static::ASSETS_DIR . 'index.js';
+        $packageJson = static::ASSETS_DIR . 'package.json';
+        $webpackConfigJs = static::ASSETS_DIR . 'webpack.config.js';
+
+        $localIndexJsHash = $this->getLocaleFileHash($indexJs);
+        $localPackageJsonHash = $this->getLocaleFileHash($packageJson);
+        $localWebpackConfigJsHash = $this->getLocaleFileHash($webpackConfigJs);
+
+        $remoteIndexJsHash = $this->getRemoteFileHash($indexJs);
+        $remotePackageJsonHash = $this->getRemoteFileHash($packageJson);
+        $remoteWebpackConfigJsHash = $this->getRemoteFileHash($webpackConfigJs);
+
+        if ($localIndexJsHash !== $remoteIndexJsHash
+            || $localPackageJsonHash !== $remotePackageJsonHash
+            || $localWebpackConfigJsHash !== $remoteWebpackConfigJsHash
+        ) {
+            throw new \Exception(
+                sprintf(
+                    'The files in the local "%s" folder do not match the ones in the remote repository "%s".' . PHP_EOL
+                    . 'Either the build has been modified, which means it has to be done manually with NPM or the files'
+                    . ' in your repository are outdated and have to be copied from the remote repository.',
+                    static::ASSETS_DIR,
+                    $this->remoteRepository
+                )
+            );
+        }
+
+        $tempDirectory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . static::REPOSITORY_NAME . uniqid(rand(), true);
+        $tempFileZip = $tempDirectory . '.zip';
+
+        $output->writeln('<info>Download remote repository...</info>');
+        $response = $this->httpClient->request('GET', $this->remoteArchive, [
+            'on_progress' => function(int $downloaded, int $size) {
+                /* echo $downloaded . '/' . $size . PHP_EOL; */
+            }
+        ]);
+
+        $filesystem = new Filesystem();
+
+        file_put_contents($tempFileZip, $response->getContent());
+
+        $zip = new \ZipArchive();
+        if ($zip->open($tempFileZip)) {
+            $output->writeln('<info>Extract ZIP archive...</info>');
+            $zip->extractTo($tempDirectory);
+            $zip->close();
+
+            $buildDir = $this->projectDir . static::BUILD_DIR;
+            $extractedFolderName = static::REPOSITORY_NAME . '-' .  $this->suluVersion;
+            $tempProjectDir = $tempDirectory . DIRECTORY_SEPARATOR . $extractedFolderName;
+
+            $output->writeln('<info>Delete old build folder...</info>');
+            $filesystem->remove(glob($buildDir . DIRECTORY_SEPARATOR . '*'));
+
+            $output->writeln('<info>Copy build folder from remote repository...</info>');
+            $filesystem->mirror(
+                $tempProjectDir . static::BUILD_DIR,
+                $buildDir
+            );
+
+            $filesystem->remove($tempDirectory);
+        } else {
+            $output->writeln('<error>Error when unpacking the ZIP archive</error>');
+        }
+
+        unlink($tempFileZip);
+    }
+
+    private function getLocaleFileHash(string $path)
+    {
+        return $this->hash(file_get_contents($this->projectDir . $path));
+    }
+
+    private function getRemoteFileHash(string $path)
+    {
+        $response = $this->httpClient->request('GET', $this->remoteRepository . $path);
+
+        return $this->hash($response->getContent());
+    }
+
+    private function hash($content)
+    {
+        return hash('sha256', $content);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -74,8 +74,9 @@ class DownloadBuildCommand extends Command
     {
         if (!preg_match(static::VERSION_REGEX, $this->suluVersion)) {
             throw new \Exception(
-                'This command only works for tagged sulu versions matching semantic versioning, not for branches etc.'
-                . ' Given version was "' . $this->suluVersion . '".'
+                'This command only works for tagged sulu versions matching semantic versioning, not for branches etc. '
+                . 'Given version was "' . $this->suluVersion . '".' . PHP_EOL
+                . 'You would have to run "npm install" and "npm run build" in your "assets/admin" folder on your own.'
             );
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Templating\Tests\Storage\FileStorageTest;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class DownloadBuildCommand extends Command
@@ -107,7 +106,7 @@ class DownloadBuildCommand extends Command
         $response = $this->httpClient->request('GET', $this->remoteArchive, [
             'on_progress' => function(int $downloaded, int $size) {
                 /* echo $downloaded . '/' . $size . PHP_EOL; */
-            }
+            },
         ]);
 
         $filesystem = new Filesystem();
@@ -121,7 +120,7 @@ class DownloadBuildCommand extends Command
             $zip->close();
 
             $buildDir = $this->projectDir . static::BUILD_DIR;
-            $extractedFolderName = static::REPOSITORY_NAME . '-' .  $this->suluVersion;
+            $extractedFolderName = static::REPOSITORY_NAME . '-' . $this->suluVersion;
             $tempProjectDir = $tempDirectory . DIRECTORY_SEPARATOR . $extractedFolderName;
 
             $output->writeln('<info>Delete old build folder...</info>');

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -52,6 +52,8 @@ class DownloadBuildCommand extends Command
 
     const REPOSITORY_NAME = 'skeleton';
 
+    const VERSION_REGEX = '/^\d+\.\d+\.\d+(-(alpha|beta|RC)\d+)?$/';
+
     public function __construct(HttpClientInterface $httpClient, string $projectDir, string $suluVersion)
     {
         parent::__construct();
@@ -70,6 +72,13 @@ class DownloadBuildCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!preg_match(static::VERSION_REGEX, $this->suluVersion)) {
+            throw new \Exception(
+                'This command only works for tagged sulu versions matching semantic versioning, not for branches etc.'
+                . ' Given version was "' . $this->suluVersion . '".'
+            );
+        }
+
         $output->writeln('<info>Checking for changed files...</info>');
 
         $indexJs = static::ASSETS_DIR . 'index.js';
@@ -103,11 +112,7 @@ class DownloadBuildCommand extends Command
         $tempFileZip = $tempDirectory . '.zip';
 
         $output->writeln('<info>Download remote repository...</info>');
-        $response = $this->httpClient->request('GET', $this->remoteArchive, [
-            'on_progress' => function(int $downloaded, int $size) {
-                /* echo $downloaded . '/' . $size . PHP_EOL; */
-            },
-        ]);
+        $response = $this->httpClient->request('GET', $this->remoteArchive);
 
         $filesystem = new Filesystem();
 

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadBuildCommand.php
@@ -101,8 +101,9 @@ class DownloadBuildCommand extends Command
             throw new \Exception(
                 sprintf(
                     'The files in the local "%s" folder do not match the ones in the remote repository "%s".' . PHP_EOL
-                    . 'Either the build has been modified, which means it has to be done manually with NPM or the files'
-                    . ' in your repository are outdated and have to be copied from the remote repository.',
+                    . 'Either bundles with custom JavaScript have been added, which means it has to be done manually '
+                    . 'with NPM, or the files in your repository are outdated and have to be copied from the remote '
+                    . 'repository.',
                     static::ASSETS_DIR,
                     $this->remoteRepository
                 )

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -156,5 +156,12 @@
             <argument type="service" id="translator"/>
             <tag name="jms_serializer.event_subscriber"/>
         </service>
+
+        <service id="sulu_admin.download_build_command" class="Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand">
+            <argument type="service" id="http_client" />
+            <argument>%kernel.project_dir%</argument>
+            <argument>%sulu.version%</argument>
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | TODO

#### What's in this PR?

This PR adds a command that downloads the JS build in the correct version for the developer.

#### Why?

Because that should make the update easier.

#### Example Usage

~~~bash
bin/console sulu:admin:download-build
~~~

#### To Do

- [ ] Create a documentation PR
