### PR TITLE
Fix infinite loader in ChangelogLine when user was deleted

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ChangelogLine.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ChangelogLine.js
@@ -32,9 +32,17 @@ class ChangelogLine extends React.Component<FieldTypeProps<typeof undefined>> {
             return;
         }
 
-        ResourceRequester.get('users', {id: this.changerId}).then(action((changer) => {
-            this.setChanger(changer);
-        }));
+        ResourceRequester.get('users', {id: this.changerId})
+            .then(action((changer) => {
+                this.setChanger(changer);
+            }))
+            .catch(action((error) => {
+                if (error.status !== 404) {
+                    return Promise.reject(error);
+                }
+
+                this.setChanger(undefined);
+            }));
     };
 
     loadCreator = () => {
@@ -43,9 +51,17 @@ class ChangelogLine extends React.Component<FieldTypeProps<typeof undefined>> {
             return;
         }
 
-        ResourceRequester.get('users', {id: this.creatorId}).then(action((creator) => {
-            this.setCreator(creator);
-        }));
+        ResourceRequester.get('users', {id: this.creatorId})
+            .then(action((creator) => {
+                this.setCreator(creator);
+            }))
+            .catch(action((error) => {
+                if (error.status !== 404) {
+                    return Promise.reject(error);
+                }
+
+                this.setCreator(undefined);
+            }));
     };
 
     @action setChanger(changer: ?Object) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -325,7 +325,7 @@ test('Cancel delete conflict occured with the allowConflictDeletion option set t
 
     setTimeout(() => {
         element = mount(deleteToolbarAction.getNode());
-        expect(deleteToolbarAction.router.navigate).toBeCalledTimes(0);
+        expect(deleteToolbarAction.router.restore).toBeCalledTimes(0);
         expect(element.at(0).prop('open')).toEqual(false);
         expect(element.at(1).prop('open')).toEqual(true);
         expect(element.at(1).find('li')).toHaveLength(2);
@@ -338,7 +338,7 @@ test('Cancel delete conflict occured with the allowConflictDeletion option set t
         element.find('Button[skin="primary"]').simulate('click');
 
         setTimeout(() => {
-            expect(deleteToolbarAction.router.navigate).not.toBeCalled();
+            expect(deleteToolbarAction.router.restore).not.toBeCalled();
             expect(deleteToolbarAction.resourceFormStore.delete).toBeCalledTimes(1);
             expect(element.at(0).instance().props).toEqual(expect.objectContaining({
                 open: false,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4845 
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR sets the creator and changer to a value of `undefined` if the user has been deleted in the mean time.

#### Why?

Because if we don't handle this case, an infinite loader appears.