### PR TITLE
Remove symfony.lock file from gitignore after create-project

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Sulu/Bundle/CoreBundle/Composer/ScriptHandler.php
@@ -30,6 +30,7 @@ class ScriptHandler
 
         $gitignore = file_get_contents(static::GIT_IGNORE_FILE);
         $gitignore = str_replace("composer.lock\n", '', $gitignore);
+        $gitignore = str_replace("symfony.lock\n", '', $gitignore);
         file_put_contents(static::GIT_IGNORE_FILE, $gitignore);
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Rule/PageRuleTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Rule/PageRuleTest.php
@@ -11,8 +11,8 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Unit\Rule;
 
-use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Sulu\Bundle\PageBundle\Rule\PageRule;
 use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyInterface;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Remove the `symfony.lock` file when a new project is created.

#### Why?

Because we also remove the `composer.lock` file :slightly_smiling_face: 