### PR TITLE
Remove unused code from NavigationItems

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,19 @@
 # Upgrade
 
+## release/2.0
+
+### NavigationItem
+
+The `NavigationItem` class used in the `Admin` classes still had some properties that are not used anymore in Sulu 2.0.
+In order to avoid confusion these properties and their corresponding getters and setters have been removed. This affects
+the following properties:
+
+- event
+- eventArguments
+- headerTitle
+- headerIcon
+- hasSettings
+
 ## 2.0.1
 
 ### mode schemaOption in ResourceLocator

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -50,20 +50,6 @@ class NavigationItem implements \Iterator
     protected $childViews = [];
 
     /**
-     * Will be used for a custom behaviour of the navigation item.
-     *
-     * @var string
-     */
-    private $event;
-
-    /**
-     * The event arguments.
-     *
-     * @var string
-     */
-    private $eventArguments;
-
-    /**
      * Contains the children of this item, which are other NavigationItems.
      *
      * @var array
@@ -71,32 +57,11 @@ class NavigationItem implements \Iterator
     protected $children = [];
 
     /**
-     * The title of the head area of the NavigationItem.
-     *
-     * @var string
-     */
-    protected $headerTitle;
-
-    /**
-     * The icon of the header are of the NavigationItem.
-     *
-     * @var string
-     */
-    protected $headerIcon;
-
-    /**
      * The current position of the iterator.
      *
      * @var int
      */
     protected $position;
-
-    /**
-     * Defines if this menu item has settings.
-     *
-     * @var bool
-     */
-    protected $hasSettings;
 
     /**
      * Describes how the navigation item should be shown in husky.
@@ -220,38 +185,6 @@ class NavigationItem implements \Iterator
     }
 
     /**
-     * @return string
-     */
-    public function getEvent()
-    {
-        return $this->event;
-    }
-
-    /**
-     * @param string $event
-     */
-    public function setEvent($event)
-    {
-        $this->event = $event;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEventArguments()
-    {
-        return $this->event;
-    }
-
-    /**
-     * @param string $event
-     */
-    public function setEventArguments($eventArguments)
-    {
-        $this->eventArguments = $eventArguments;
-    }
-
-    /**
      * Adds a child to the navigation item.
      *
      * @param NavigationItem $child
@@ -269,46 +202,6 @@ class NavigationItem implements \Iterator
     public function getChildren()
     {
         return $this->children;
-    }
-
-    /**
-     * Sets the icon of the header.
-     *
-     * @param string $headerIcon
-     */
-    public function setHeaderIcon($headerIcon)
-    {
-        $this->headerIcon = $headerIcon;
-    }
-
-    /**
-     * Returns the icon of the header.
-     *
-     * @return string
-     */
-    public function getHeaderIcon()
-    {
-        return $this->headerIcon;
-    }
-
-    /**
-     * Sets the title of the header.
-     *
-     * @param string $headerTitle The title of the header
-     */
-    public function setHeaderTitle($headerTitle)
-    {
-        $this->headerTitle = $headerTitle;
-    }
-
-    /**
-     * Returns the title of the header.
-     *
-     * @return string The title of the header
-     */
-    public function getHeaderTitle()
-    {
-        return $this->headerTitle;
     }
 
     /**
@@ -338,22 +231,6 @@ class NavigationItem implements \Iterator
     }
 
     /**
-     * @param bool $hasSettings
-     */
-    public function setHasSettings($hasSettings)
-    {
-        $this->hasSettings = $hasSettings;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getHasSettings()
-    {
-        return $this->hasSettings;
-    }
-
-    /**
      * @param bool $disabled
      */
     public function setDisabled($disabled)
@@ -379,13 +256,8 @@ class NavigationItem implements \Iterator
         $new = $this->copyWithName();
         $new->setView($this->getView());
         $new->setChildViews($this->getChildViews());
-        $new->setEvent($this->getEvent());
-        $new->setEventArguments($this->getEventArguments());
         $new->setIcon($this->getIcon());
-        $new->setHeaderIcon($this->getHeaderIcon());
-        $new->setHeaderTitle($this->getHeaderTitle());
         $new->setId($this->getId());
-        $new->setHasSettings($this->getHasSettings());
         $new->setPosition($this->getPosition());
         $new->setLabel($this->getLabel());
 
@@ -527,22 +399,12 @@ class NavigationItem implements \Iterator
             'label' => $this->getLabel(),
             'icon' => $this->getIcon(),
             'view' => $this->getView(),
-            'event' => $this->getEvent(),
-            'eventArguments' => $this->getEventArguments(),
-            'hasSettings' => $this->getHasSettings(),
             'disabled' => $this->getDisabled(),
             'id' => (null != $this->getId()) ? $this->getId() : str_replace('.', '', uniqid('', true)), //FIXME don't use uniqid()
         ];
 
         if (count($this->getChildViews()) > 0) {
             $array['childViews'] = $this->getChildViews();
-        }
-
-        if (null != $this->getHeaderIcon() || null != $this->getHeaderTitle()) {
-            $array['header'] = [
-                'title' => $this->getHeaderTitle(),
-                'logo' => $this->getHeaderIcon(),
-            ];
         }
 
         $children = $this->getChildren();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
@@ -36,8 +36,6 @@ class NavigationItemTest extends TestCase
         $this->navigationItem = new NavigationItem('NavigationItem');
 
         $this->item1 = new NavigationItem('Root');
-        $this->item1->setHeaderIcon('logo');
-        $this->item1->setHeaderTitle('title');
 
         $portalItem1 = new NavigationItem('Portals');
         $this->item1->addChild($portalItem1);
@@ -87,14 +85,6 @@ class NavigationItemTest extends TestCase
         $this->assertEquals($child, $this->navigationItem->getChildren()[0]);
     }
 
-    public function testHeader()
-    {
-        $this->navigationItem->setHeaderIcon('icon');
-        $this->navigationItem->setHeaderTitle('title');
-        $this->assertEquals('icon', $this->navigationItem->getHeaderIcon());
-        $this->assertEquals('title', $this->navigationItem->getHeaderTitle());
-    }
-
     public function testSearch()
     {
         $this->assertEquals('Globals', $this->item2->find(new NavigationItem('Globals'))->getName());
@@ -112,8 +102,6 @@ class NavigationItemTest extends TestCase
         $copy = $this->item1->copyChildless();
 
         $this->assertEquals($this->item1->getIcon(), $copy->getIcon());
-        $this->assertEquals($this->item1->getHeaderIcon(), $copy->getHeaderIcon());
-        $this->assertEquals($this->item1->getHeaderTitle(), $copy->getHeaderTitle());
         $this->assertEquals($this->item1->getId(), $copy->getId());
     }
 
@@ -134,8 +122,6 @@ class NavigationItemTest extends TestCase
         $array = $this->item1->toArray();
 
         $this->assertEquals('Root', $array['title']);
-        $this->assertEquals('logo', $array['header']['logo']);
-        $this->assertEquals('title', $array['header']['title']);
 
         $this->assertContains('Portals', [$array['items'][0]['title'], $array['items'][1]['title']]);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR removes code that is not used anymore.

#### Why?

Because these methods will confuse people, when they are trying to use, and nothing at all happens.