### PR TITLE
Set default type on existing entity without type

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -58,12 +58,13 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
 
         if (this.hasTypes) {
             // this will set the correct type from the server response after it has been loaded
-            if (this.resourceStore.id) {
-                when(
-                    () => !this.resourceStore.loading,
-                    (): void => this.setType(this.resourceStore.data[TYPE])
-                );
-            }
+            when(
+                () => !this.resourceStore.loading,
+                (): void => {
+                    const defaultType = Object.keys(this.types)[0]; // TODO get correct default type if available
+                    this.setType(this.resourceStore.data[TYPE] ? this.resourceStore.data[TYPE] : defaultType);
+                }
+            );
         }
 
         this.schemaDisposer = autorun(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -1179,3 +1179,66 @@ test('Set new type after copying from different locale', () => {
         });
     });
 });
+
+test('HasTypes return true when types are set', () => {
+    const schemaTypesPromise = Promise.resolve({
+        sidebar: {key: 'sidebar', title: 'Sidebar'},
+        footer: {key: 'footer', title: 'Footer'},
+    });
+
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const resourceStore = new ResourceStore('test', 5);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
+
+    return schemaTypesPromise.then(() => {
+        expect(resourceFormStore.hasTypes).toEqual(true);
+    });
+});
+
+test('HasTypes return false when types are not set', () => {
+    const schemaTypesPromise = Promise.resolve({});
+
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const resourceStore = new ResourceStore('test', 5);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
+
+    return schemaTypesPromise.then(() => {
+        expect(resourceFormStore.hasTypes).toEqual(false);
+    });
+});
+
+test('Set type to first one if data has no template set', () => {
+    const schemaTypesPromise = Promise.resolve({
+        sidebar: {key: 'sidebar', title: 'Sidebar'},
+        footer: {key: 'footer', title: 'Footer'},
+    });
+
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const resourceStore = new ResourceStore('test', 5);
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
+
+    return schemaTypesPromise.then(() => {
+        expect(resourceFormStore.type).toEqual('sidebar');
+    });
+});
+
+test('Set type to the template value if set', () => {
+    const schemaTypesPromise = Promise.resolve({
+        sidebar: {key: 'sidebar', title: 'Sidebar'},
+        footer: {key: 'footer', title: 'Footer'},
+    });
+
+    metadataStore.getSchemaTypes.mockReturnValue(schemaTypesPromise);
+
+    const resourceStore = new ResourceStore('test', 5);
+    resourceStore.data = observable({template: 'footer'});
+
+    const resourceFormStore = new ResourceFormStore(resourceStore, 'snippets');
+
+    return schemaTypesPromise.then(() => {
+        expect(resourceFormStore.type).toEqual('footer');
+    });
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -26,7 +26,6 @@ jest.mock('../../../../containers/Form', () => ({
         }
 
         changeType = jest.fn();
-        setType = jest.fn();
     },
 }));
 
@@ -94,57 +93,6 @@ test('Return item config with loading select', () => {
         options: [],
         value: 'homepage',
     }));
-});
-
-test('Do not set the first value as default if nothing is given but data has not been loaded yet', () => {
-    const typeToolbarAction = createTypeToolbarAction();
-    typeToolbarAction.resourceFormStore.resourceStore.id = 5;
-    typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.types = {
-        default: {
-            key: 'default',
-            title: 'Default',
-        },
-        homepage: {
-            key: 'homepage',
-            title: 'Homepage',
-        },
-    };
-
-    const toolbarItemConfig = typeToolbarAction.getToolbarItemConfig();
-
-    if (toolbarItemConfig.type !== 'select') {
-        throw new Error(
-            'The returned toolbar item must be of type "select", but "' + toolbarItemConfig.type + '" was given!'
-        );
-    }
-
-    expect(typeToolbarAction.resourceFormStore.setType).not.toBeCalled();
-});
-
-test('Set the first value as default if nothing is given', () => {
-    const typeToolbarAction = createTypeToolbarAction();
-    typeToolbarAction.resourceFormStore.typesLoading = false;
-    typeToolbarAction.resourceFormStore.types = {
-        default: {
-            key: 'default',
-            title: 'Default',
-        },
-        homepage: {
-            key: 'homepage',
-            title: 'Homepage',
-        },
-    };
-
-    const toolbarItemConfig = typeToolbarAction.getToolbarItemConfig();
-
-    if (toolbarItemConfig.type !== 'select') {
-        throw new Error(
-            'The returned toolbar item must be of type "select", but "' + toolbarItemConfig.type + '" was given!'
-        );
-    }
-
-    expect(typeToolbarAction.resourceFormStore.setType).toBeCalledWith('default');
 });
 
 test('Change the type of the FormStore when another type is selected', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -5,10 +5,6 @@ import AbstractFormToolbarAction from './AbstractFormToolbarAction';
 export default class TypeToolbarAction extends AbstractFormToolbarAction {
     getToolbarItemConfig(): ToolbarItemConfig {
         const formTypes = this.resourceFormStore.types;
-        const formKeys = Object.keys(formTypes);
-        if (!this.resourceFormStore.id && formKeys.length > 0 && !this.resourceFormStore.type) {
-            this.resourceFormStore.setType(formKeys[0]);
-        }
 
         if (!this.resourceFormStore.typesLoading && Object.keys(formTypes).length === 0) {
             throw new Error('The ToolbarAction for types only works with entities actually supporting types!');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | #4441 / #4485 (this still works but was the issue why the id was added in the TypeToolbarAction and cause my problem)
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix set of template type on exist entity when not set.

#### Why?

Currently if you have a entity and with an id which does not have yet content it will error and not show any form. Currently it is handled in the TypeToolbarAction which I think is also the false place this to handle it as maybe you don't want that ToolbarAction, so I moved this to the ResourceFormStore.
