### PR TITLE
Add path prefix to media url

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
@@ -203,11 +203,12 @@ class S3StorageTest extends TestCase
         $client->getEndpoint()->willReturn('http://aws.com');
         $adapter->getClient()->willReturn($client->reveal());
         $adapter->getBucket()->willReturn('test');
+        $adapter->applyPathPrefix('1/test.jpg')->willReturn('xxx/1/test.jpg');
 
         $storage = new S3Storage($flysystem->reveal(), 1);
 
         $path = $storage->getPath(['segment' => '1', 'fileName' => 'test.jpg']);
-        $this->assertEquals('http://aws.com/test/1/test.jpg', $path);
+        $this->assertEquals('http://aws.com/test/xxx/1/test.jpg', $path);
     }
 
     public function testGetType(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/461

#### What's in this PR?

This PR fixes the media original download.

#### Why?

The path prefix is missing there.