### PR TITLE
Fix pre-resolve for single-account-selection

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
+++ b/src/Sulu/Bundle/ContactBundle/Content/Types/SingleAccountSelection.php
@@ -102,11 +102,11 @@ class SingleAccountSelection extends ComplexContentType implements PreResolvable
      */
     public function preResolve(PropertyInterface $property)
     {
-        $id = $property->getValue();
-        if (!$id) {
+        $account = $property->getValue();
+        if (!$account || !array_key_exists('id', $account)) {
             return;
         }
 
-        $this->accountReferenceStore->add($id);
+        $this->accountReferenceStore->add($account['id']);
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleAccountSelectionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/SingleAccountSelectionTest.php
@@ -230,10 +230,20 @@ class SingleAccountSelectionTest extends TestCase
         $this->singleAccountSelection->preResolve($property);
     }
 
+    public function testPreResolveEmptyArray()
+    {
+        $property = new Property('account', [], 'single_account_selection');
+        $property->setValue([]);
+
+        $this->accountReferenceStore->add(Argument::any())->shouldNotBeCalled();
+
+        $this->singleAccountSelection->preResolve($property);
+    }
+
     public function testPreResolve()
     {
         $property = new Property('account', [], 'single_account_selection');
-        $property->setValue(22);
+        $property->setValue(['id' => 22]);
 
         $this->accountReferenceStore->add(22)->shouldBeCalled();
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR fixes the pre-resolve for tags-cache purging.