### PR TITLE
Fix branch aliases for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -182,12 +182,6 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.6-dev",
-            "dev-develop": "2.0-dev"
-        }
-    },
-    "extra": {
-        "branch-alias": {
             "dev-release/1.6": "1.6.x-dev",
             "dev-release/2.0": "2.0.x-dev",
             "dev-master": "2.1.x-dev"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs |-
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fix branch aliases for development.

#### Why?

Seems like a merge conflict didn't happened or was not resolved correctly when merging 1.6 to 2.0.
