### PR TITLE
Allow to exclude templates in webspaces

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilder.php
@@ -123,6 +123,13 @@ class FormViewBuilder implements FormViewBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): FormViewBuilderInterface
+    {
+        $this->addRouterAttributesToFormMetadataToView($this->view, $routerAttributesToFormMetadata);
+
+        return $this;
+    }
+
     public function addMetadataRequestParameters(array $metadataRequestParameters): FormViewBuilderInterface
     {
         $this->addMetadataRequestParametersToView($this->view, $metadataRequestParameters);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderInterface.php
@@ -49,6 +49,8 @@ interface FormViewBuilderInterface extends ViewBuilderInterface
 
     public function setBackView(string $editView): self;
 
+    public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): self;
+
     public function addMetadataRequestParameters(array $metadataRequestParameters): self;
 
     public function setIdQueryParameter(string $idQueryParameter): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormViewBuilderTrait.php
@@ -87,6 +87,16 @@ trait FormViewBuilderTrait
         $view->setOption('routerAttributesToBackView', $newRouterAttributesToBackView);
     }
 
+    private function addRouterAttributesToFormMetadataToView(View $route, array $routerAttributesToFormMetadata): void
+    {
+        $oldRouterAttributesToFormMetadata = $route->getOption('routerAttributesToFormMetadata');
+        $newRouterAttributesToFormMetadata = $oldRouterAttributesToFormMetadata
+            ? array_merge($oldRouterAttributesToFormMetadata, $routerAttributesToFormMetadata)
+            : $routerAttributesToFormMetadata;
+
+        $route->setOption('routerAttributesToFormMetadata', $newRouterAttributesToFormMetadata);
+    }
+
     private function addMetadataRequestParametersToView(View $route, array $metadataRequestParameters): void
     {
         $oldMetadataRequestParameters = $route->getOption('metadataRequestParameters');

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilder.php
@@ -108,6 +108,21 @@ class PreviewFormViewBuilder implements PreviewFormViewBuilderInterface
         return $this;
     }
 
+    public function addRouterAttributesToFormMetadata(
+        array $routerAttributesToFormMetadata
+    ): PreviewFormViewBuilderInterface {
+        $this->addRouterAttributesToFormMetadataToView($this->view, $routerAttributesToFormMetadata);
+
+        return $this;
+    }
+
+    public function addMetadataRequestParameters(array $metadataRequestParameters): PreviewFormViewBuilderInterface
+    {
+        $this->addMetadataRequestParametersToView($this->view, $metadataRequestParameters);
+
+        return $this;
+    }
+
     public function setEditView(string $editView): PreviewFormViewBuilderInterface
     {
         $this->setEditViewToView($this->view, $editView);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/PreviewFormViewBuilderInterface.php
@@ -45,6 +45,8 @@ interface PreviewFormViewBuilderInterface extends ViewBuilderInterface
      */
     public function addRouterAttributesToEditView(array $routerAttributesToEditView): self;
 
+    public function addRouterAttributesToFormMetadata(array $routerAttributesToFormMetadata): self;
+
     public function setEditView(string $editView): self;
 
     public function setBackView(string $editView): self;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TypedFormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TypedFormMetadata.php
@@ -27,6 +27,11 @@ class TypedFormMetadata extends AbstractMetadata
         $this->forms[$key] = $form;
     }
 
+    public function removeForm($key)
+    {
+        unset($this->forms[$key]);
+    }
+
     public function getForms(): array
     {
         return $this->forms;

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -97,6 +97,7 @@
         <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader">
             <argument type="service" id="sulu_page.structure.factory"/>
             <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%sulu_core.locales%</argument>
             <argument>%sulu.cache_dir%/form-structures</argument>
             <argument>%kernel.debug%</argument>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/Form.js
@@ -83,6 +83,7 @@ class Form extends React.Component<Props> {
                     formKey,
                     idQueryParameter,
                     resourceKey,
+                    routerAttributesToFormMetadata = {},
                     routerAttributesToFormRequest = {},
                     metadataRequestParameters = {},
                 },
@@ -122,11 +123,17 @@ class Form extends React.Component<Props> {
             this.resourceStore = resourceStore;
         }
 
+        const metadataOptions = this.buildMetadataOptions(
+            attributes,
+            routerAttributesToFormMetadata,
+            metadataRequestParameters
+        );
+
         this.resourceFormStore = new ResourceFormStore(
             this.resourceStore,
             formKey,
             formStoreOptions,
-            metadataRequestParameters
+            metadataOptions
         );
 
         if (this.resourceStore.locale) {
@@ -192,6 +199,24 @@ class Form extends React.Component<Props> {
         });
 
         return formStoreOptions;
+    }
+
+    buildMetadataOptions(
+        attributes: Object,
+        routerAttributesToFormMetadata: {[string | number]: string},
+        metadataRequestParameters: {[string | number]: string}
+    ) {
+        const metadataOptions = {...metadataRequestParameters};
+        routerAttributesToFormMetadata = toJS(routerAttributesToFormMetadata);
+
+        Object.keys(routerAttributesToFormMetadata).forEach((key) => {
+            const listOptionKey = routerAttributesToFormMetadata[key];
+            const attributeName = isNaN(key) ? key : routerAttributesToFormMetadata[key];
+
+            metadataOptions[listOptionKey] = attributes[attributeName];
+        });
+
+        return metadataOptions;
     }
 
     @action componentDidMount() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js
@@ -1893,6 +1893,64 @@ test('Should pass metadataRequestParameters options to Form View', () => {
     expect(formContainer.prop('store').metadataOptions).toEqual(metadataRequestParameters);
 });
 
+test('Should pass option to form metadata with routerAttribuesToFormMetadata', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
+    const metadataStore = require('../../../containers/Form/stores/metadataStore');
+
+    const route = {
+        options: {
+            formKey: 'snippets',
+            locales: [],
+            routerAttributesToFormMetadata: ['webspace'],
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {
+            webspace: 'sulu_io',
+        },
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route,
+    };
+    mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    expect(metadataStore.getSchemaTypes).toBeCalledWith('snippets', {webspace: 'sulu_io'});
+});
+
+test('Should pass options to Form metadata with mixed routerAttribuesToFormMetadata', () => {
+    const Form = require('../Form').default;
+    const ResourceStore = require('../../../stores/ResourceStore').default;
+    const resourceStore = new ResourceStore('snippet', 1, {locale: observable.box('de')});
+    const metadataStore = require('../../../containers/Form/stores/metadataStore');
+
+    const route = {
+        options: {
+            backView: 'test_route',
+            formKey: 'snippets',
+            locales: [],
+            routerAttributesToFormMetadata: {0: 'webspace', 'id': 'active'},
+            toolbarActions: [],
+        },
+    };
+    const router = {
+        addUpdateRouteHook: jest.fn(),
+        attributes: {
+            id: 4,
+            webspace: 'sulu_io',
+        },
+        bind: jest.fn(),
+        restore: jest.fn(),
+        route,
+    };
+    mount(<Form resourceStore={resourceStore} route={route} router={router} />);
+
+    expect(metadataStore.getSchemaTypes).toBeCalledWith('snippets', {active: 4, webspace: 'sulu_io'});
+});
+
 test('Should destroy the store on unmount', () => {
     const Form = require('../Form').default;
     const ResourceStore = require('../../../stores/ResourceStore').default;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/webspaces/sulu.io.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/webspaces/sulu.io.xml
@@ -22,6 +22,10 @@
         <default-template type="homepage">overview</default-template>
     </default-templates>
 
+    <excluded-templates>
+        <excluded-template>overview</excluded-template>
+    </excluded-templates>
+
     <navigation>
         <contexts>
             <context key="main">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -81,4 +81,19 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $typedForm = $this->structureFormMetadataLoader->getMetadata('does_not_exist', 'de');
         $this->assertNull($typedForm);
     }
+
+    public function testGetMetadataWithExcludedTemplates()
+    {
+        $typedForm = $this->structureFormMetadataLoader->getMetadata('page', 'de', ['webspace' => 'sulu_io']);
+        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
+        $this->assertCount(1, $typedForm->getForms());
+
+        $defaultForm = $typedForm->getForms()['default'];
+        $this->assertInstanceOf(FormMetadata::class, $defaultForm);
+        $this->assertEquals('default', $defaultForm->getName());
+        $this->assertEquals('Tiers', $defaultForm->getTitle());
+        $this->assertCount(5, $defaultForm->getItems());
+        $this->assertNotNull($defaultForm->getSchema());
+        $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormViewBuilderTest.php
@@ -51,6 +51,7 @@ class FormViewBuilderTest extends TestCase
                 'sulu_category.list',
                 null,
                 null,
+                null,
                 ['test1' => 'value1'],
             ],
             [
@@ -58,6 +59,7 @@ class FormViewBuilderTest extends TestCase
                 '/tags/:id',
                 'tags',
                 'tags',
+                null,
                 null,
                 null,
                 null,
@@ -80,6 +82,7 @@ class FormViewBuilderTest extends TestCase
                 'sulu_category.edit_form',
                 'sulu_category.list',
                 ['webspace'],
+                ['webspaceKey' => 'webspace'],
                 true,
                 null,
             ],
@@ -95,6 +98,7 @@ class FormViewBuilderTest extends TestCase
                 'sulu_category.edit_form',
                 'sulu_category.list',
                 ['webspace', 'id' => 'active'],
+                ['webspace'],
                 false,
                 null,
             ],
@@ -116,6 +120,7 @@ class FormViewBuilderTest extends TestCase
         ?string $editView,
         ?string $backView,
         ?array $routerAttributesToBackView,
+        ?array $routerAttributesToFormMetadata,
         ?bool $titleVisible,
         ?array $requestParameters
     ) {
@@ -151,6 +156,10 @@ class FormViewBuilderTest extends TestCase
             $viewBuilder->addRouterAttributesToBackView($routerAttributesToBackView);
         }
 
+        if ($routerAttributesToFormMetadata) {
+            $viewBuilder->addRouterAttributesToFormMetadata($routerAttributesToFormMetadata);
+        }
+
         if (null !== $titleVisible) {
             $viewBuilder->setTitleVisible($titleVisible);
         }
@@ -172,6 +181,7 @@ class FormViewBuilderTest extends TestCase
         $this->assertSame($editView, $view->getOption('editView'));
         $this->assertSame($backView, $view->getOption('backView'));
         $this->assertSame($routerAttributesToBackView, $view->getOption('routerAttributesToBackView'));
+        $this->assertSame($routerAttributesToFormMetadata, $view->getOption('routerAttributesToFormMetadata'));
         $this->assertSame($titleVisible, $view->getOption('titleVisible'));
         $this->assertSame($requestParameters, $view->getOption('requestParameters'));
         $this->assertNull($view->getParent());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/PreviewFormViewBuilderTest.php
@@ -52,6 +52,7 @@ class PreviewFormViewBuilderTest extends TestCase
                 false,
                 ['test1' => 'value1'],
                 true,
+                null,
             ],
             [
                 'sulu_tag.edit_form',
@@ -67,6 +68,7 @@ class PreviewFormViewBuilderTest extends TestCase
                 true,
                 null,
                 false,
+                ['webspace'],
             ],
         ];
     }
@@ -87,7 +89,8 @@ class PreviewFormViewBuilderTest extends TestCase
         ?string $backView,
         ?bool $titleVisible,
         ?array $requestParameters,
-        bool $disablePreviewWebspaceChooser
+        ?bool $disablePreviewWebspaceChooser,
+        ?array $routerAttributesToFormMetadata
     ) {
         $viewBuilder = (new PreviewFormViewBuilder($name, $path))
             ->setResourceKey($resourceKey)
@@ -129,6 +132,10 @@ class PreviewFormViewBuilderTest extends TestCase
             $viewBuilder->disablePreviewWebspaceChooser();
         }
 
+        if ($routerAttributesToFormMetadata) {
+            $viewBuilder->addRouterAttributesToFormMetadata($routerAttributesToFormMetadata);
+        }
+
         $view = $viewBuilder->getView();
 
         $this->assertSame($name, $view->getName());
@@ -145,6 +152,7 @@ class PreviewFormViewBuilderTest extends TestCase
         $this->assertSame($requestParameters, $view->getOption('requestParameters'));
         $this->assertNull($view->getParent());
         $this->assertSame('sulu_admin.preview_form', $view->getType());
+        $this->assertSame($routerAttributesToFormMetadata, $view->getOption('routerAttributesToFormMetadata'));
 
         if ($disablePreviewWebspaceChooser) {
             $this->assertFalse($view->getOption('previewWebspaceChooser'));

--- a/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
+++ b/src/Sulu/Bundle/PageBundle/Admin/PageAdmin.php
@@ -157,6 +157,7 @@ class PageAdmin extends Admin
         ];
 
         $routerAttributesToFormRequest = ['parentId', 'webspace'];
+        $routerAttributesToFormMetdata = ['webspace'];
 
         $previewCondition = 'nodeType == 1';
 
@@ -199,6 +200,7 @@ class PageAdmin extends Admin
                     ->addRouterAttributesToEditView(['webspace'])
                     ->addToolbarActions($formToolbarActionsWithType)
                     ->addRouterAttributesToFormRequest($routerAttributesToFormRequest)
+                    ->addRouterAttributesToFormMetadata($routerAttributesToFormMetdata)
                     ->setParent(static::ADD_FORM_VIEW)
             );
             $viewCollection->add(
@@ -222,6 +224,7 @@ class PageAdmin extends Admin
                     ->setTabCondition('nodeType == 1 && shadowOn == false')
                     ->addToolbarActions($formToolbarActionsWithType)
                     ->addRouterAttributesToFormRequest($routerAttributesToFormRequest)
+                    ->addRouterAttributesToFormMetadata($routerAttributesToFormMetdata)
                     ->setPreviewCondition($previewCondition)
                     ->setTabOrder(1024)
                     ->setParent(static::EDIT_FORM_VIEW)

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader11.php
@@ -38,6 +38,8 @@ class XmlFileLoader11 extends XmlFileLoader10
             $webspace->setResourceLocatorStrategy('tree_leaf_edit');
         }
 
+        $this->generateExcludedTemplates($webspace);
+
         return $webspace;
     }
 
@@ -86,6 +88,24 @@ class XmlFileLoader11 extends XmlFileLoader10
             $template = $templateNode->nodeValue;
             $type = $templateNode->attributes->getNamedItem('type')->nodeValue;
             $webspace->addTemplate($type, $template);
+        }
+
+        return $webspace;
+    }
+
+    /**
+     * Adds the excluded-templates as described in the XML document.
+     *
+     * @param Webspace $webspace
+     *
+     * @return Webspace
+     */
+    protected function generateExcludedTemplates(Webspace $webspace)
+    {
+        foreach ($this->xpath->query('/x:webspace/x:excluded-templates/x:excluded-template') as $excludedTemplateNode) {
+            /* @var \DOMNode $excludedTemplateNode */
+            $excludedTemplate = $excludedTemplateNode->nodeValue;
+            $webspace->addExcludedTemplate($excludedTemplate);
         }
 
         return $webspace;

--- a/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
+++ b/src/Sulu/Component/Webspace/Loader/schema/webspace/webspace-1.1.xsd
@@ -19,6 +19,7 @@
             <xs:element type="xs:string" name="theme" minOccurs="0" maxOccurs="1"/>
             <xs:element type="defaultTemplatesType" name="default-templates" minOccurs="1" maxOccurs="1"/>
             <xs:element type="templatesType" name="templates" minOccurs="0" maxOccurs="1"/>
+            <xs:element type="excludedTemplatesType" name="excluded-templates" minOccurs="0" maxOccurs="1"/>
             <xs:element type="navigationType" name="navigation"/>
             <xs:element type="resource-locatorType" name="resource-locator" maxOccurs="1" minOccurs="0"/>
             <xs:element type="portalsType" name="portals"/>
@@ -140,6 +141,16 @@
             <xs:extension base="xs:string">
                 <xs:attribute name="type" type="xs:string" use="required"/>
             </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="excludedTemplatesType">
+        <xs:sequence>
+            <xs:element type="excludedTemplateType" name="excluded-template" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="excludedTemplateType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string"/>
         </xs:simpleContent>
     </xs:complexType>
     <xs:complexType name="environmentsType">

--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -71,6 +71,8 @@ class {{ cache_class }} extends {{ base_class }}
 {% endfor %}
 {% for type,template in webspace.defaultTemplates %}        $webspace->addDefaultTemplate('{{ type }}', '{{ template }}');
 {% endfor %}
+{% for template in webspace.excludedTemplates %}        $webspace->addExcludedTemplate('{{ template }}');
+{% endfor %}
 
         // add navigation
         $navigation = new Navigation();

--- a/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
@@ -71,6 +71,8 @@ class XmlFileLoader11Test extends WebspaceTestCase
         $this->assertEquals(null, $webspace->getLocalizations()[1]->getShadow());
         $this->assertEquals(true, $webspace->getLocalizations()[1]->isDefault());
 
+        $this->assertEquals(['template1', 'template2'], $webspace->getExcludedTemplates());
+
         $this->assertEquals('de_at', $webspace->getDefaultLocalization()->getLocale());
 
         $this->assertEquals('sulu', $webspace->getTheme());

--- a/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/WebspaceTest.php
@@ -82,6 +82,7 @@ class WebspaceTest extends TestCase
             ],
             'templates' => [],
             'defaultTemplates' => [],
+            'excludedTemplates' => [],
             'portals' => [
                 ['one'],
             ],

--- a/src/Sulu/Component/Webspace/Webspace.php
+++ b/src/Sulu/Component/Webspace/Webspace.php
@@ -111,6 +111,11 @@ class Webspace implements ArrayableInterface
     private $defaultTemplates = [];
 
     /**
+     * @var string[]
+     */
+    private $excludedTemplates = [];
+
+    /**
      * The url generation strategy for this portal.
      *
      * @var string
@@ -523,6 +528,24 @@ class Webspace implements ArrayableInterface
     }
 
     /**
+     * Add a new template for given type.
+     *
+     * @param string $excludedTemplate
+     */
+    public function addExcludedTemplate($excludedTemplate)
+    {
+        $this->excludedTemplates[] = $excludedTemplate;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExcludedTemplates()
+    {
+        return $this->excludedTemplates;
+    }
+
+    /**
      * Set resource-locator strategy.
      *
      * @param string $resourceLocatorStrategy
@@ -553,6 +576,7 @@ class Webspace implements ArrayableInterface
         $res['localizations'] = [];
         $res['templates'] = $this->getTemplates();
         $res['defaultTemplates'] = $this->getDefaultTemplates();
+        $res['excludedTemplates'] = $this->getExcludedTemplates();
         $res['resourceLocator']['strategy'] = $this->getResourceLocatorStrategy();
 
         foreach ($this->getLocalizations() as $localization) {

--- a/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
+++ b/tests/Resources/DataFixtures/Webspace/valid/sulu.io.xml
@@ -22,6 +22,11 @@
         <default-template type="homepage">overview</default-template>
     </default-templates>
 
+    <excluded-templates>
+        <excluded-template>template1</excluded-template>
+        <excluded-template>template2</excluded-template>
+    </excluded-templates>
+
     <navigation>
         <contexts>
             <context key="main">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | ---
| License | MIT
| Documentation PR | sulu/sulu-docs#462

#### What's in this PR?

This PR allows to exclude certain templates in webspaces.

#### Why?

Because some templates might not be allowed in all webspaces.

#### Example Usage

~~~xml
<?xml version="1.0" encoding="utf-8"?>                                                                                                                                                                                                                                          
<webspace xmlns="http://schemas.sulu.io/webspace/webspace"                                                                                                                                                                                                                      
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"                                                                                                                                                                                                                 
          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
    <!-- ... -->
    <excluded-templates>                                            
        <excluded-template>default</excluded-template>
    </excluded-templates>
    <!-- ... -->
</webspace>                                
~~~

#### To Do

- [ ] Create a documentation PR