### PR TITLE
Remove templating requirement

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,34 @@
 # Upgrade
 
+## dev-release/2.0
+
+When upgrading also have a look at the changes in the
+[sulu skeleton](https://github.com/sulu/skeleton/compare/2.0.2...2.0.3).
+
+### Symfony/templating requirement removed
+
+Sulu does not longer need the `symfony/templating` package which is deprecated.
+
+If you depend on `symfony/templating` you need to require it in your project:
+
+```bash
+composer require symfony/templating
+```
+
+If you want to remove it also from your project you need to change the include syntax:
+
+**Before**
+
+```twig
+{% include "SuluWebsiteBundle:Extension:seo.html.twig" %}
+```
+
+**After**
+
+```twig
+{% include "@SuluWebsite/Extension/seo.html.twig" %}
+```
+
 ## 2.0.2
 
 ### RouteManagerInterface / RouteRepositoryInterface changed

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "friendsofsymfony/http-cache": "^2.5",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "friendsofsymfony/jsrouting-bundle": "^2.3",
-        "friendsofsymfony/rest-bundle": "^2.5",
+        "friendsofsymfony/rest-bundle": "^2.6",
         "gedmo/doctrine-extensions": "^2.4",
         "goodby/csv": "^1.3",
         "guzzlehttp/guzzle": "^6.2",

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,6 @@
         "symfony/security": "^4.3",
         "symfony/security-bundle": "^4.3",
         "symfony/swiftmailer-bundle": "^3.1.4",
-        "symfony/templating": "^4.3",
         "symfony/translation": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -212,7 +212,7 @@ class AdminController
         ];
 
         return new Response($this->engine->render(
-            '@SuluAdmin\Admin\main.html.twig',
+            '@SuluAdmin/Admin/main.html.twig',
             [
                 'translations' => $this->translations,
                 'fallback_locale' => $this->fallbackLocale,

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -103,23 +103,13 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                     'serializer' => [
                         'serialize_null' => true,
                     ],
+                    'service' => [
+                        'templating' => 'twig',
+                    ],
                     'view' => [
                         'formats' => [
                             'json' => true,
                             'csv' => true,
-                        ],
-                    ],
-                ]
-            );
-        }
-
-        if ($container->hasExtension('framework')) {
-            $container->prependExtensionConfig(
-                'framework',
-                [
-                    'templating' => [
-                        'engines' => [
-                            'twig',
                         ],
                     ],
                 ]

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/Controller/SearchController.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/Controller/SearchController.php
@@ -36,7 +36,7 @@ class SearchController
 
         $hits = $this->searchManager->createSearch($q)->locale('de')->index('content');
 
-        return $this->render('TestBundle:Search:query.html.twig', [
+        return $this->render('@Test/Search/query.html.twig', [
             'hits' => $hits,
         ]);
     }

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -63,7 +63,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->scalarNode('template')
                                     ->cannotBeEmpty()
-                                    ->defaultValue('SuluSecurityBundle:mail_templates:reset_password.html.twig')
+                                    ->defaultValue('@SuluSecurity/mail_templates/reset_password.html.twig')
                                 ->end()
                                 ->scalarNode('translation_domain')
                                     ->cannotBeEmpty()

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -418,7 +418,7 @@ class ResettingControllerTest extends SuluTestCase
             [],
             \Symfony\Component\Routing\Router::ABSOLUTE_URL
         );
-        $body = $this->getContainer()->get('templating')->render($template, [
+        $body = $this->getContainer()->get('twig')->render($template, [
             'user' => $user,
             'reset_url' => $resetUrl . '#/?forgotPasswordToken=' . $user->getPasswordResetToken(),
             'translation_domain' => $this->getContainer()->getParameter('sulu_security.reset_password.mail.translation_domain'),

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -136,7 +136,7 @@ abstract class WebsiteController extends AbstractController
         $parameters['previewParentTemplate'] = $view;
         $parameters['previewContentReplacer'] = Preview::CONTENT_REPLACER;
 
-        return parent::renderView('SuluWebsiteBundle:Preview:preview.html.twig', $parameters);
+        return parent::renderView('@SuluWebsite/Preview/preview.html.twig', $parameters);
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
@@ -135,7 +135,7 @@ class AppendAnalyticsListener
     protected function generateAnalyticsContent(array $analyticsContent, Analytics $analytics)
     {
         foreach (array_keys(self::$positions) as $position) {
-            $template = 'SuluWebsiteBundle:Analytics:' . $analytics->getType() . '/' . $position . '.html.twig';
+            $template = '@SuluWebsite/Analytics/' . $analytics->getType() . '/' . $position . '.html.twig';
 
             if (!$this->engine->getLoader()->exists($template)) {
                 continue;

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRenderer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRenderer.php
@@ -50,7 +50,7 @@ class XmlSitemapRenderer implements XmlSitemapRendererInterface
         }
 
         return $this->render(
-            'SuluWebsiteBundle:Sitemap:sitemap-index.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap-index.xml.twig',
             ['sitemaps' => $this->sitemapProviderPool->getIndex($scheme, $host), 'domain' => $host, 'scheme' => $scheme]
         );
     }
@@ -72,7 +72,7 @@ class XmlSitemapRenderer implements XmlSitemapRendererInterface
         $entries = $provider->build($page, $scheme, $host);
 
         return $this->render(
-            'SuluWebsiteBundle:Sitemap:sitemap.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap.xml.twig',
             [
                 'domain' => $host,
                 'scheme' => $scheme,

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListenerTest.php
@@ -129,20 +129,20 @@ class AppendAnalyticsListenerTest extends TestCase
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google/head-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google/head-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:google/head-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/google/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google/body-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google/body-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google/body-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
         $response->getContent()->willReturn('<html><head><title>Test</title></head><body><h1>Title</h1></body></html>');
@@ -189,20 +189,20 @@ class AppendAnalyticsListenerTest extends TestCase
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google/head-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/head-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google/head-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:google/head-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/google/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google/body-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/body-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google/body-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google/body-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
         $response->getContent()->willReturn('<html><head><title>Test</title></head><body><h1>Title</h1></body></html>');
@@ -248,20 +248,20 @@ class AppendAnalyticsListenerTest extends TestCase
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-open.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/head-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google_tag_manager/head-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/google_tag_manager/head-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/head-close.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/head-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google_tag_manager/head-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google_tag_manager/head-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/body-open.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/body-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google_tag_manager/body-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/google_tag_manager/body-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<noscript><div>Blabla</div></noscript>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:google_tag_manager/body-close.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:google_tag_manager/body-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/google_tag_manager/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/google_tag_manager/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
         $response->getContent()
@@ -307,20 +307,20 @@ class AppendAnalyticsListenerTest extends TestCase
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
-        $loader->exists('SuluWebsiteBundle:Analytics:piwik/head-open.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:piwik/head-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/piwik/head-open.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/piwik/head-open.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
-        $loader->exists('SuluWebsiteBundle:Analytics:piwik/head-close.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:piwik/head-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/piwik/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/piwik/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var i = 0;</script>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:piwik/body-open.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:piwik/body-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/piwik/body-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/piwik/body-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<noscript><div>Blabla</div></noscript>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:piwik/body-close.html.twig')->shouldBeCalled()->willReturn(false);
-        $engine->render('SuluWebsiteBundle:Analytics:piwik/body-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/piwik/body-close.html.twig')->shouldBeCalled()->willReturn(false);
+        $engine->render('@SuluWebsite/Analytics/piwik/body-close.html.twig', ['analytics' => $analytics])
             ->shouldNotBeCalled();
 
         $response->getContent()
@@ -366,20 +366,20 @@ class AppendAnalyticsListenerTest extends TestCase
         $loader = $this->prophesize(FilesystemLoader::class);
         $engine->getLoader()->shouldBeCalled()->willReturn($loader->reveal());
 
-        $loader->exists('SuluWebsiteBundle:Analytics:custom/head-open.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:custom/head-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/custom/head-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/custom/head-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('<script>var nice_var = false;</script>');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:custom/head-close.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:custom/head-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/custom/head-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/custom/head-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:custom/body-open.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:custom/body-open.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/custom/body-open.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/custom/body-open.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('');
 
-        $loader->exists('SuluWebsiteBundle:Analytics:custom/body-close.html.twig')->shouldBeCalled()->willReturn(true);
-        $engine->render('SuluWebsiteBundle:Analytics:custom/body-close.html.twig', ['analytics' => $analytics])
+        $loader->exists('@SuluWebsite/Analytics/custom/body-close.html.twig')->shouldBeCalled()->willReturn(true);
+        $engine->render('@SuluWebsite/Analytics/custom/body-close.html.twig', ['analytics' => $analytics])
             ->shouldBeCalled()->willReturn('');
 
         $response->getContent()

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sulu/Bundle/WebsiteBundle/Sitemap/XmlSitemapRendererTest.php
@@ -61,7 +61,7 @@ class XmlSitemapRendererTest extends TestCase
         $this->providerPoolInterface->getIndex('http', 'sulu.io')->willReturn($sitemaps);
 
         $this->engine->render(
-            'SuluWebsiteBundle:Sitemap:sitemap-index.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap-index.xml.twig',
             ['sitemaps' => $sitemaps]
         )->willReturn('<html/>');
 
@@ -79,7 +79,7 @@ class XmlSitemapRendererTest extends TestCase
         $this->providerPoolInterface->getIndex('http', 'sulu.io')->willReturn($sitemaps);
 
         $this->engine->render(
-            'SuluWebsiteBundle:Sitemap:sitemap-index.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap-index.xml.twig',
             ['sitemaps' => $sitemaps, 'domain' => 'sulu.io', 'scheme' => 'http']
         )->willReturn('<html/>');
 
@@ -100,7 +100,7 @@ class XmlSitemapRendererTest extends TestCase
         $this->providerPoolInterface->getIndex('http', 'sulu.io')->willReturn($sitemaps);
 
         $this->engine->render(
-            'SuluWebsiteBundle:Sitemap:sitemap-index.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap-index.xml.twig',
             ['sitemaps' => $sitemaps, 'domain' => 'sulu.io', 'scheme' => 'http']
         )->willReturn('<html/>');
 
@@ -121,7 +121,7 @@ class XmlSitemapRendererTest extends TestCase
         $this->providerPoolInterface->getIndex('http', 'sulu.io')->willReturn($sitemaps);
 
         $this->engine->render(
-            'SuluWebsiteBundle:Sitemap:sitemap-index.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap-index.xml.twig',
             ['sitemaps' => $sitemaps, 'domain' => 'sulu.io', 'scheme' => 'http']
         )->willReturn('<html/>');
 
@@ -148,7 +148,7 @@ class XmlSitemapRendererTest extends TestCase
         $portal->getXDefaultLocalization()->willReturn(new Localization('de'));
 
         $this->engine->render(
-            'SuluWebsiteBundle:Sitemap:sitemap.xml.twig',
+            '@SuluWebsite/Sitemap/sitemap.xml.twig',
             [
                 'domain' => 'sulu.io',
                 'scheme' => 'http',

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Seo/SeoTwigExtension.php
@@ -73,7 +73,7 @@ class SeoTwigExtension extends AbstractExtension
         array $urls,
         $shadowBaseLocale
     ) {
-        $template = 'SuluWebsiteBundle:Extension:seo.html.twig';
+        $template = '@SuluWebsite/Extension/seo.html.twig';
 
         @trigger_error(sprintf(
             'This twig extension is deprecated and should not be used anymore, include the "%s".',

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% block meta %}
-        {% include "SuluWebsiteBundle:Extension:seo.html.twig" with {
+        {% include "@SuluWebsite/Extension/seo.html.twig" with {
             "seo": extension.seo|default([]),
             "content": content|default([]),
             "urls": urls|default([]),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | Symfony 5 compatibility #4798
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove templating requirement and use new template reference syntax.

#### Why?

The templating bridge is deprecated and should not longer be used.