### PR TITLE
Fix loading of unbuilt js files in chrome over http2 push

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,6 @@
         "symfony/translation": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
-        "symfony/web-link": "^4.3",
         "symfony/yaml": "^4.3",
         "toflar/psr6-symfony-http-cache-store": "^1.1 || ^2.0",
         "twig/twig": "^1.41 || ^2.0"

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -58,9 +58,6 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                             ],
                         ],
                     ],
-                    'web_link' => [
-                        'enabled' => true,
-                    ],
                     'translator' => [
                         'enabled' => true,
                     ],

--- a/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
+++ b/src/Sulu/Bundle/AdminBundle/Resources/views/Admin/main.html.twig
@@ -4,7 +4,9 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>SULU</title>
-        <link rel="stylesheet" href="{{ preload(asset('main.css', 'sulu_admin'), {as: 'style'}) }}">
+
+        {# We do not preload the files because of problems with big files on http push in Chrome #}
+        <link rel="stylesheet" href="{{ asset('main.css', 'sulu_admin') }}">
     </head>
     <body>
         <div id="application">
@@ -21,6 +23,8 @@
             });
             {% endautoescape %}
         </script>
-        <script src="{{ preload(asset('main.js', 'sulu_admin'), {as: 'script'})}}"></script>
+
+        {# We do not preload the files because of problems with big files on http push in Chrome #}
+        <script src="{{ asset('main.js', 'sulu_admin') }}"></script>
     </body>
 </html>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Remove the preload of the css and js files in main.html.twig.

#### Why?

Fix loading of unbuilt js files in chrome over https push.
Sometimes the Chrome cancel the request after only loading 6.6mb of the ~25mb file.

