### PR TITLE
Show better preview content block exception

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -165,6 +165,10 @@ class Preview implements PreviewInterface
     {
         $parts = explode(self::CONTENT_REPLACER, $html);
 
+        if (!isset($parts[2])) {
+            throw new \RuntimeException('The "{% block content %}" could not be found in the twig template.');
+        }
+
         return $parts[0] . self::CONTENT_REPLACER . $parts[2];
     }
 

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewKernel.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Renderer;
 
 use App\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Extends website-kernel from sulu-installation and override configuration.
@@ -33,11 +34,14 @@ class PreviewKernel extends Kernel
     {
         parent::registerContainerConfiguration($loader);
 
-        if (in_array($this->getEnvironment(), ['dev', 'test'])) {
-            $loader->load(
-                implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview_dev.yml'])
-            );
-        }
+        $loader->load(function(ContainerBuilder $container) use ($loader) {
+            // disable web_profiler toolbar in preview if the web_profiler extension exist
+            if ($container->hasExtension('web_profiler')) {
+                $loader->load(
+                    implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview_dev.yml'])
+                );
+            }
+        });
 
         $loader->load(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'config', 'config_preview.yml']));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4877
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Show better preview content block exception

#### Why?

The current code end up in an error without throwing a exception why it did happened.

#### Usage?

Remove the `block content` the following exception should then be shown.