### PR TITLE
Add autowiring of LocalizationManagerInterface

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/localization.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/localization.xml
@@ -11,6 +11,7 @@
 
     <services>
         <service id="sulu.core.localization_manager" class="%sulu.core.localization_manager.class%" public="true"/>
+        <service id="Sulu\Component\Localization\Manager\LocalizationManagerInterface" alias="sulu.core.localization_manager"/>
 
         <service id="sulu_core.localization_controller"
                  class="Sulu\Bundle\CoreBundle\Controller\LocalizationController"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Add autowiring of LocalizationManagerInterface

#### Why?

So you can get easier the localizations for a Admin class in a project.